### PR TITLE
docs: native Linux gateway setup and phone pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,20 @@ tests, and has not yet been exercised end to end on a physical Pixel.
 | Deployment | Best for | Speech engine | Expected performance |
 | --- | --- | --- | --- |
 | Native macOS | Daily use on an Apple silicon Mac | MLX Audio, WhisperKit, Handy, sherpa-onnx | Best with Apple-native MLX/Core ML engines |
-| Docker Compose | Linux home servers and reproducible deployment | sherpa-onnx INT8, faster-whisper INT8, Moonshine, or accelerated `whisper.cpp` | Portable CPU by default; optional native/CUDA/Vulkan profiles |
+| Native Linux | Daily use on a Linux desktop or home server | sherpa-onnx INT8, faster-whisper, Moonshine | Good CPU latency; optional CUDA/Vulkan via Docker profiles |
+| Docker Compose | Reproducible Linux images and multi-arch hosts | sherpa-onnx INT8, faster-whisper INT8, Moonshine, or accelerated `whisper.cpp` | Portable CPU by default; optional native/CUDA/Vulkan profiles |
 
 On an Apple silicon Mac, use the native gateway for the lowest virtualization
 overhead. MLX Audio runs directly on M-series unified memory/GPU, while
 WhisperKit uses Core ML; Local Flow keeps either selected model resident between
 dictations. The container deliberately uses portable Linux runtimes and cannot
 use macOS MLX or Core ML from inside Docker Desktop.
-Docker remains the recommended deployment for Linux home servers.
-Precise speed depends on the model, audio duration, and hardware; compare the
-same recording and model class before drawing benchmark conclusions.
+
+On Linux, prefer the native gateway when you already have Python 3.12+ and FFmpeg
+on the host. Use Docker when you want an isolated image, CUDA/Vulkan profiles, or
+a multi-architecture registry build. Precise speed depends on the model, audio
+duration, and hardware; compare the same recording and model class before drawing
+benchmark conclusions.
 
 See [deployment choices](docs/deployment.md) for the complete comparison and
 operational commands.
@@ -85,7 +89,46 @@ cd server
 ./scripts/install-launch-agent.sh
 ```
 
-### 2. Or start it with Docker Compose
+### 2. Or start the gateway natively on Linux
+
+Requires Python 3.12+, [uv](https://docs.astral.sh/uv/), and FFmpeg. On Debian or
+Ubuntu:
+
+```sh
+sudo apt install ffmpeg
+# Install uv if needed: curl -LsSf https://astral.sh/uv/install.sh | sh
+cd server
+uv sync --all-groups --extra engines
+uv run localflow-server
+```
+
+Omit the `apple` extra on Linux; MLX Audio and WhisperKit are macOS-only. The
+startup banner prints the WebUI URL and where the bearer token lives:
+
+```text
+Local Flow gateway listening on 0.0.0.0:8765
+WebUI (this host): http://127.0.0.1:8765/
+Network access: use this host's LAN or Tailscale IP with the same port
+Token: ~/.config/localflow/token
+  (cat ~/.config/localflow/token — enter that value in the phone app)
+```
+
+Open the WebUI, enter the token from `~/.config/localflow/token`, download a
+recommended model (SenseVoice Small INT8 or Parakeet TDT INT8 on CPU), select it,
+and confirm Overview shows **Ready for dictation**.
+
+To keep the gateway running after the terminal closes (systemd user unit):
+
+```sh
+cd server
+./scripts/install-systemd-user.sh
+# optional: survive logout
+loginctl enable-linger "$USER"
+```
+
+Logs: `journalctl --user -u com.example.localflow.gateway.service -f`.
+
+### 3. Or start it with Docker Compose
 
 The canonical Compose file is [server/compose.yaml](server/compose.yaml). It
 publishes the gateway only on host loopback by default and stores models,
@@ -113,18 +156,24 @@ curl --fail http://127.0.0.1:8765/health/ready
 Copy [server/.env.example](server/.env.example) if you prefer an editable
 template. Never commit the resulting `.env` file.
 
-### 3. Choose how the iPhone reaches the gateway
+### 4. Choose how the phone reaches the gateway
 
-The app accepts any valid `http://` or `https://` gateway URL. Choose one of
-these network arrangements:
+The iPhone and Android apps accept any valid `http://` or `https://` gateway URL.
+Choose one of these network arrangements:
 
-- **Trusted LAN:** bind/publish the gateway on the LAN and enter a URL such as
-  `http://homelabone:8765/`. HTTP is unencrypted, so use this only on a network
-  you trust and never forward that port to the internet.
+- **Trusted LAN:** the native gateway listens on all interfaces by default. On
+  the same Wi‑Fi, enter `http://<host-lan-ip>:8765` (for example
+  `http://192.168.1.75:8765`). Find the IP with `hostname -I` or
+  `ip -4 addr`. HTTP is unencrypted, so use this only on a network you trust and
+  never forward that port to the internet. For Docker, set
+  `LOCALFLOW_PUBLISH_HOST=0.0.0.0` in `server/.env` and protect the port with the
+  host firewall.
 - **Tailscale:** keep the gateway on loopback and let Tailscale Serve provide
   tailnet-only HTTPS:
 
 ```sh
+# optional: bind loopback only when using Serve
+# LOCALFLOW_BIND_HOST=127.0.0.1 uv run localflow-server
 tailscale serve --bg 8765
 tailscale serve status
 ```
@@ -134,11 +183,18 @@ tailscale serve status
   `https://dictation.example.com/`. Do not send recordings or bearer tokens over
   public HTTP.
 
-Tailscale is recommended for a private personal deployment, but it is not
-mandatory. Follow [deployment](docs/deployment.md) and the optional
+In the phone app, paste:
+
+1. **Gateway address** — the LAN, Tailscale, or HTTPS URL above.
+2. **Bearer token** — `cat ~/.config/localflow/token` for native installs, or the
+   `LOCALFLOW_TOKEN` value from `server/.env` for Docker.
+
+Then use **Save and test** / **Test connection**. Tailscale is recommended for a
+private personal deployment, but it is not mandatory. Follow
+[deployment](docs/deployment.md) and the optional
 [Tailscale guide](docs/tailscale.md) for the relevant host configuration.
 
-### 4. Configure and install the iPhone app
+### 5. Configure and install the iPhone app
 
 Before signing under your own Apple account, replace these placeholders
 consistently in the Xcode project configuration and entitlements:
@@ -160,17 +216,21 @@ Then:
 
 Complete the physical-device checklist in [device setup](docs/device-setup.md).
 
-### 5. Or install the Android app
+### 6. Or install the Android app
 
 Android keeps your existing keyboard and dictates through a floating bubble
 instead. Build and install the APK, then follow the guided setup in the app:
 
 ```sh
 cd android
-export ANDROID_HOME="$HOME/Library/Android/sdk"
+# macOS default; on Linux try $HOME/Android/Sdk
+export ANDROID_HOME="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
 ./gradlew assembleDebug
 adb install -r app/build/outputs/apk/debug/local-flow-debug.apk
 ```
+
+In the app: grant microphone, notifications, overlay, and accessibility; then
+enter the gateway address and bearer token from step 4 and run **Test connection**.
 
 The same placeholder application ID, `com.example.localflow.android`, should be
 replaced before you distribute a build. See the
@@ -183,7 +243,8 @@ Gateway checks:
 
 ```sh
 cd server
-uv sync --all-groups --extra engines --extra apple
+# On macOS add --extra apple for MLX / WhisperKit tooling in the dev environment.
+uv sync --all-groups --extra engines
 uv run ruff check .
 uv run ruff format --check .
 uv run mypy app
@@ -195,7 +256,7 @@ Android checks:
 
 ```sh
 cd android
-export ANDROID_HOME="$HOME/Library/Android/sdk"
+export ANDROID_HOME="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
 ./gradlew assembleDebug testDebugUnitTest lintDebug
 ```
 

--- a/android/README.md
+++ b/android/README.md
@@ -21,7 +21,8 @@ accessibility disclosure and consent Play requires are present from the start.
 
 ```sh
 cd android
-export ANDROID_HOME="$HOME/Library/Android/sdk"
+# macOS default SDK path; on Linux Android Studio usually uses $HOME/Android/Sdk
+export ANDROID_HOME="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
 ./gradlew assembleDebug
 adb install -r app/build/outputs/apk/debug/local-flow-debug.apk
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,32 +1,36 @@
 # Gateway deployment
 
-Local Flow uses the same HTTP API whether the gateway runs directly on macOS or
-inside its Linux container. The meaningful differences are the available speech
-engines, acceleration, isolation, and operational portability.
+Local Flow uses the same HTTP API whether the gateway runs directly on macOS,
+directly on Linux, or inside its Linux container. The meaningful differences are
+the available speech engines, acceleration, isolation, and operational
+portability.
 
 ## Which deployment should I choose?
 
-| Consideration | Native macOS | Docker Compose |
-| --- | --- | --- |
-| Recommended host | Apple silicon Mac | Linux `amd64` or `arm64` home server |
-| Engines | MLX Audio, WhisperKit, Handy, sherpa-onnx, `whisper.cpp` | sherpa-onnx, faster-whisper, Moonshine, `whisper.cpp` |
-| Acceleration | Apple-native MLX and WhisperKit/Core ML paths | INT8 ONNX/OpenBLAS CPU; native CPU, CUDA, or Vulkan profiles |
-| Mac performance | Recommended; no Linux VM | Usually slower and uses Docker Desktop resources |
-| Portability | macOS-specific service setup | Reproducible across supported Linux architectures |
-| Persistence | Files below `~/.local/share/localflow` | Named volume mounted at `/data` |
-| Updates | Pull code, sync dependencies, restart LaunchAgent | Pull/build image and recreate the service |
+| Consideration | Native macOS | Native Linux | Docker Compose |
+| --- | --- | --- | --- |
+| Recommended host | Apple silicon Mac | Linux desktop or home server | Linux `amd64`/`arm64` when you want an image |
+| Engines | MLX Audio, WhisperKit, Handy, sherpa-onnx, `whisper.cpp` | sherpa-onnx, faster-whisper, Moonshine, optional `whisper.cpp` | sherpa-onnx, faster-whisper, Moonshine, `whisper.cpp` |
+| Acceleration | Apple-native MLX and WhisperKit/Core ML paths | Host CPU (Python wheels); CUDA via Docker profiles | INT8 ONNX/OpenBLAS CPU; native CPU, CUDA, or Vulkan profiles |
+| Performance | Recommended on Mac; no Linux VM | No container overhead on Linux | Slightly more isolation cost; strong for CUDA images |
+| Portability | macOS LaunchAgent | systemd user unit | Reproducible across supported Linux architectures |
+| Persistence | Files below `~/.local/share/localflow` | Same as native macOS | Named volume mounted at `/data` |
+| Updates | Pull code, `uv sync`, restart LaunchAgent | Pull code, `uv sync`, restart systemd unit | Pull/build image and recreate the service |
 
 ### Recommendation
 
 - On an Apple silicon Mac, run natively and compare MLX Whisper Turbo 4-bit,
   MLX Parakeet, and WhisperKit on the same recording. These avoid Docker
   Desktop's Linux VM and keep the chosen Apple-native model resident.
-- On a Linux home server, start with SenseVoice Small INT8 for its supported
-  Asian languages plus English, or Parakeet TDT INT8 for 25 European languages.
-  Both use sherpa-onnx wheels on `amd64` and `arm64`; faster-whisper remains the
-  broad Whisper fallback.
-- Use Docker on a Mac when reproducibility and isolation matter more than the
-  lowest transcription latency.
+- On a Linux desktop or home server, run natively with
+  `uv sync --all-groups --extra engines` when you already trust the host Python
+  environment. Start with SenseVoice Small INT8 for its supported Asian languages
+  plus English, or Parakeet TDT INT8 for 25 European languages. Both use
+  sherpa-onnx wheels on `amd64` and `arm64`; faster-whisper remains the broad
+  Whisper fallback.
+- Use Docker on Linux when you want CUDA/Vulkan profiles, multi-arch images, or
+  stronger isolation. Use Docker on a Mac only when reproducibility matters more
+  than the lowest transcription latency.
 
 There is no honest fixed speed multiplier: model size, audio length, thermals,
 and host hardware all matter. For an apples-to-apples comparison, dictate the
@@ -71,6 +75,52 @@ launchctl print "gui/$(id -u)/com.example.localflow.gateway"
 Logs are written to `~/Library/Logs/LocalFlow/gateway.log` and
 `gateway-error.log`. Re-run the installer after changing the checkout location
 or gateway executable.
+
+## Native Linux deployment
+
+### Install and run
+
+```sh
+# Debian / Ubuntu example
+sudo apt install ffmpeg
+# https://docs.astral.sh/uv/ — curl -LsSf https://astral.sh/uv/install.sh | sh
+cd server
+uv sync --all-groups --extra engines
+uv run localflow-server
+```
+
+Omit `--extra apple` on Linux. The default listener is `0.0.0.0:8765`. When
+Tailscale Serve is the only desired ingress, override the listener:
+
+```sh
+LOCALFLOW_BIND_HOST=127.0.0.1 uv run localflow-server
+```
+
+Token, models, and config paths match the macOS native layout:
+
+- token: `~/.config/localflow/token`
+- models: `~/.local/share/localflow/models`
+- config: `~/.config/localflow/config.json`
+
+Phone clients need the bearer token (`cat ~/.config/localflow/token`) and a
+reachable URL such as `http://192.168.1.20:8765` on a trusted LAN.
+
+### Run as a systemd user service
+
+```sh
+cd server
+./scripts/install-systemd-user.sh
+systemctl --user status com.example.localflow.gateway.service
+journalctl --user -u com.example.localflow.gateway.service -f
+```
+
+To keep the unit after logout:
+
+```sh
+loginctl enable-linger "$USER"
+```
+
+Re-run the installer after moving the checkout or recreating `.venv`.
 
 ## Docker Compose deployment
 

--- a/docs/tailscale.md
+++ b/docs/tailscale.md
@@ -11,11 +11,12 @@ network. Never use Funnel for this project.
 
 ## Prerequisites
 
-- Install and sign in to Tailscale on both the Mac and iPhone.
+- Install and sign in to Tailscale on the gateway host and on the phone (iPhone
+  or Android).
 - Confirm both devices appear in the same tailnet.
 - Start or publish the gateway on host loopback and verify liveness locally.
 
-For a native macOS process:
+For a native macOS or Linux process:
 
 ```sh
 cd server
@@ -42,8 +43,8 @@ tailscale serve --bg 8765
 tailscale serve status
 ```
 
-Use the private HTTPS URL shown by `tailscale serve status` in the iPhone app.
-Do not use the local HTTP address from the phone.
+Use the private HTTPS URL shown by `tailscale serve status` in the iPhone or
+Android app. Do not use the local HTTP address from the phone.
 
 The HTTPS endpoint can be live while transcription readiness is still `503`.
 After downloading/selecting a model in the WebUI, verify both paths:
@@ -59,9 +60,9 @@ To reverse the Serve configuration:
 tailscale serve reset
 ```
 
-Apply a restrictive tailnet policy so only the user's iPhone and administrative
-devices can reach the Mac. Tailscale identity is an additional network layer;
-the Local Flow bearer token is still required.
+Apply a restrictive tailnet policy so only the user's phone and administrative
+devices can reach the gateway host. Tailscale identity is an additional network
+layer; the Local Flow bearer token is still required.
 
 Command syntax was checked against the current
 [Tailscale Serve CLI reference](https://tailscale.com/docs/reference/tailscale-cli/serve).

--- a/server/README.md
+++ b/server/README.md
@@ -10,7 +10,8 @@ management, engine selection, microphone testing, and operational status.
 | Mode | Engines | Recommended use |
 | --- | --- | --- |
 | Native macOS | MLX Audio, WhisperKit, Handy, sherpa-onnx, `whisper.cpp` | Best performance on Apple silicon |
-| Docker Compose | sherpa-onnx INT8, faster-whisper INT8, Moonshine, `whisper.cpp` | Linux `amd64`/`arm64` home servers |
+| Native Linux | sherpa-onnx INT8, faster-whisper, Moonshine, optional `whisper.cpp` | Linux desktop or home server without Docker |
+| Docker Compose | sherpa-onnx INT8, faster-whisper INT8, Moonshine, `whisper.cpp` | Reproducible Linux `amd64`/`arm64` images |
 
 Native MLX Audio and WhisperKit are the accelerated choices on Apple silicon.
 Docker Desktop runs the portable Linux image in a VM, so it cannot use the
@@ -45,6 +46,50 @@ Docker. Standalone `whisper.cpp` is also supported:
 
 ```sh
 brew install ffmpeg whisper-cpp
+```
+
+## Native Linux quick start
+
+Requires Python 3.12+, [uv](https://docs.astral.sh/uv/), and FFmpeg on the host.
+
+```sh
+# Debian / Ubuntu
+sudo apt install ffmpeg
+# Install uv if needed: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+cd server
+uv sync --all-groups --extra engines
+uv run localflow-server
+```
+
+Do not pass `--extra apple` on Linux. The first run creates
+`~/.config/localflow/token` with mode `600`. The banner prints the WebUI URL and
+token path; show the secret with `cat ~/.config/localflow/token`. Open
+`http://127.0.0.1:8765/`, enter the token, download a recommended model
+(SenseVoice Small INT8 or Parakeet TDT INT8 on CPU), select it, and confirm
+**Ready for dictation**.
+
+To keep the gateway running after the terminal closes:
+
+```sh
+./scripts/install-systemd-user.sh
+# optional: keep the user session (and unit) after logout
+loginctl enable-linger "$USER"
+```
+
+```sh
+systemctl --user status com.example.localflow.gateway.service
+journalctl --user -u com.example.localflow.gateway.service -f
+```
+
+The unit uses the checkout's `.venv`. Re-run the installer after moving the
+repository or recreating the virtualenv.
+
+Phone clients on the same LAN can use `http://<host-lan-ip>:8765` while the
+gateway binds `0.0.0.0` (the default). For Tailscale Serve only, bind loopback:
+
+```sh
+LOCALFLOW_BIND_HOST=127.0.0.1 uv run localflow-server
 ```
 
 ## Docker Compose quick start
@@ -227,8 +272,8 @@ The native default listener is `0.0.0.0:8765`; the startup banner and WebUI show
 that listener separately from the local browser URL. An all-interface listener
 is reachable from connected networks, so keep the host firewall enabled.
 
-The iPhone app accepts ordinary HTTP and HTTPS gateway URLs; a Tailscale hostname
-is not mandatory. Supported arrangements include:
+The iPhone and Android apps accept ordinary HTTP and HTTPS gateway URLs; a
+Tailscale hostname is not mandatory. Supported arrangements include:
 
 - a trusted LAN hostname such as `http://homelabone:8765/`; for Docker, set
   `LOCALFLOW_PUBLISH_HOST=0.0.0.0` and protect the port with the host firewall
@@ -246,8 +291,8 @@ tailscale serve --bg 8765
 tailscale serve status
 ```
 
-Use the reported private HTTPS URL in the iPhone app. Do not use Funnel. See
-[deployment.md](../docs/deployment.md) for LAN/VPS alternatives and
+Use the reported private HTTPS URL in the iPhone or Android app. Do not use
+Funnel. See [deployment.md](../docs/deployment.md) for LAN/VPS alternatives and
 [tailscale.md](../docs/tailscale.md) for the private Serve setup.
 
 ## Health and readiness
@@ -300,8 +345,11 @@ uv run localflow-status
 # Remove sessions older than the configured retention window
 uv run localflow-cleanup
 
-# Follow the native LaunchAgent logs
+# Follow the native macOS LaunchAgent logs
 tail -f ~/Library/Logs/LocalFlow/gateway.log
+
+# Follow the native Linux systemd user unit logs
+journalctl --user -u com.example.localflow.gateway.service -f
 
 # Follow container logs
 docker compose logs --follow gateway
@@ -319,7 +367,8 @@ model, configuration file, and stored session is intentional.
 ## Development checks
 
 ```sh
-uv sync --all-groups --extra engines --extra apple
+# On macOS add --extra apple when you need MLX / WhisperKit in the dev environment.
+uv sync --all-groups --extra engines
 uv run ruff check .
 uv run ruff format --check .
 uv run mypy app

--- a/server/app/cli.py
+++ b/server/app/cli.py
@@ -20,10 +20,12 @@ def serve() -> None:
     host = settings.bind_host
     token_source = "(from LOCALFLOW_TOKEN)" if _token_from_env() else "~/.config/localflow/token"
     print(f"Local Flow gateway listening on {format_host_port(host, settings.port)}")
-    print(f"WebUI (this Mac): {local_webui_url(host, settings.port)}")
+    print(f"WebUI (this host): {local_webui_url(host, settings.port)}")
     if host in WILDCARD_BIND_HOSTS:
-        print("Network access: use this Mac's LAN or Tailscale IP with the same port")
+        print("Network access: use this host's LAN or Tailscale IP with the same port")
     print(f"Token: {token_source}")
+    if not _token_from_env():
+        print("  (cat ~/.config/localflow/token — enter that value in the phone app)")
     uvicorn.run(
         create_app(settings),
         host=host,

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -16,7 +16,7 @@ def format_host_port(host: str, port: int) -> str:
 
 
 def local_webui_url(host: str, port: int) -> str:
-    """Return the loopback URL that opens a listener from the same Mac."""
+    """Return the loopback URL that opens a listener from the same host."""
     if host == "0.0.0.0":
         host = "127.0.0.1"
     elif host == "::":

--- a/server/app/fragments.py
+++ b/server/app/fragments.py
@@ -63,7 +63,7 @@ def overview_fragment(status: AdminStatusResponse) -> str:
     engine_hint = (
         "brew install whisper-cpp or whisperkit-cli"
         if is_mac
-        else "Use the Docker image or install whisper.cpp"
+        else "Install localflow-gateway[engines] (sherpa-onnx / faster-whisper) or use Docker"
     )
     checks = [
         ("Gateway token configured", status.setup.token_configured, ""),
@@ -122,7 +122,7 @@ def overview_fragment(status: AdminStatusResponse) -> str:
             <span class="ready-icon" aria-hidden="true">✓</span>
             <div><strong>The gateway is ready for dictation.</strong>
               <p class="muted">Use the Test tab for a quick microphone check, then connect
-                the iPhone using this server's Tailscale address.</p></div>
+                the phone app with this host's LAN or Tailscale URL and bearer token.</p></div>
           </div>
         """
     else:
@@ -132,7 +132,9 @@ def overview_fragment(status: AdminStatusResponse) -> str:
         if not status.setup.engine_binary_available:
             pending_steps.append(f"{escape(engine_hint)}.")
         if not status.setup.model_installed:
-            pending_steps.append("Open Models and download a model recommended for this Mac.")
+            pending_steps.append(
+                f"Open Models and download a model recommended for this {machine_label}."
+            )
         if not status.setup.engine_ready:
             pending_steps.append("Select an installed model and confirm that the engine is ready.")
         next_steps = (
@@ -140,10 +142,11 @@ def overview_fragment(status: AdminStatusResponse) -> str:
         )
     exposure_notice = ""
     if status.bind_host in WILDCARD_BIND_HOSTS:
-        exposure_notice = """
+        firewall_hint = "Keep macOS Firewall on" if is_mac else "Keep the host firewall enabled"
+        exposure_notice = f"""
           <div class="callout warning">
             <strong>Available on every network interface</strong>
-            <span>The private API still requires the bearer token. Keep macOS Firewall on,
+            <span>The private API still requires the bearer token. {firewall_hint},
               use Tailscale for remote access, and do not expose this port to the internet.</span>
           </div>
         """
@@ -157,7 +160,7 @@ def overview_fragment(status: AdminStatusResponse) -> str:
         </div>
         <dl class="connection-facts">
           <div><dt>Listener</dt><dd>{escape(listener)}</dd></div>
-          <div><dt>Open on this Mac</dt><dd>{escape(local_url)}</dd></div>
+          <div><dt>Open on this host</dt><dd>{escape(local_url)}</dd></div>
         </dl>
       </section>
       {exposure_notice}
@@ -482,7 +485,7 @@ def settings_fragment(
         <h2>Network</h2>
         <dl class="facts">
           <dt>Listener</dt><dd>{listener}</dd>
-          <dt>Open on this Mac</dt><dd>{local_url}</dd>
+          <dt>Open on this host</dt><dd>{local_url}</dd>
         </dl>
         {exposure_notice}
       </div>

--- a/server/scripts/com.example.localflow.gateway.service
+++ b/server/scripts/com.example.localflow.gateway.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Local Flow transcription gateway
+Documentation=file://__REPOSITORY__/server/README.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=__REPOSITORY__/server
+ExecStart=__REPOSITORY__/server/.venv/bin/localflow-server
+Restart=on-failure
+RestartSec=3
+# Keep the usual user PATH so FFmpeg and optional tools resolve without a login shell.
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+# Uncomment to bind loopback only (pair with Tailscale Serve):
+# Environment=LOCALFLOW_BIND_HOST=127.0.0.1
+
+[Install]
+WantedBy=default.target

--- a/server/scripts/install-systemd-user.sh
+++ b/server/scripts/install-systemd-user.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Install a systemd --user unit that keeps the native Linux gateway running.
+# Requires: uv sync already done in server/ (creates .venv/bin/localflow-server).
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repository=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+unit_name="com.example.localflow.gateway.service"
+template="$script_dir/$unit_name"
+program="$repository/server/.venv/bin/localflow-server"
+unit_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+destination="$unit_dir/$unit_name"
+
+if [ ! -x "$program" ]; then
+  printf 'Gateway executable not found at %s\nRun: cd server && uv sync --all-groups --extra engines\n' \
+    "$program" >&2
+  exit 1
+fi
+
+if ! command -v systemctl >/dev/null 2>&1; then
+  printf 'systemctl not found; this helper needs systemd.\n' >&2
+  exit 1
+fi
+
+mkdir -p "$unit_dir"
+escaped_repository=$(printf '%s' "$repository" | sed 's/[\/&]/\\&/g')
+temporary=$(mktemp "${TMPDIR:-/tmp}/localflow-systemd.XXXXXX")
+trap 'rm -f "$temporary"' EXIT
+sed -e "s/__REPOSITORY__/$escaped_repository/g" "$template" > "$temporary"
+mv "$temporary" "$destination"
+trap - EXIT
+
+systemctl --user daemon-reload
+systemctl --user enable --now "$unit_name"
+
+printf 'Installed and started %s\n' "$destination"
+printf 'Status:  systemctl --user status %s\n' "$unit_name"
+printf 'Logs:    journalctl --user -u %s -f\n' "$unit_name"
+printf 'Stop:    systemctl --user stop %s\n' "$unit_name"
+printf '\nTo keep the gateway running after logout, once per user:\n'
+printf '  loginctl enable-linger %s\n' "$(id -un)"


### PR DESCRIPTION
## Summary

- Documents running the gateway natively on Linux (`uv sync --extra engines`, FFmpeg, no Apple extras).
- Adds a systemd user unit installer as the Linux counterpart to the macOS LaunchAgent.
- Clarifies how phone apps get the gateway URL and bearer token (LAN or Tailscale).
- Softens a few Mac-only WebUI/CLI strings so Linux hosts read as "this host".

## Test plan

- [x] Started gateway on Ubuntu with `uv run localflow-server`
- [x] Downloaded SenseVoice Small INT8 and confirmed `/health/ready`
- [x] Verified listen on `0.0.0.0:8765` for LAN access
- [x] Phone **Test connection** with LAN URL + token from `~/.config/localflow/token`
- [ ] Optional: `./scripts/install-systemd-user.sh` and `systemctl --user status com.example.localflow.gateway.service`