### PR TITLE
feat: QR pairing from gateway WebUI into Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,17 @@ tailscale serve status
   `https://dictation.example.com/`. Do not send recordings or bearer tokens over
   public HTTP.
 
-In the phone app, paste:
+### Pair the phone with a QR code (Android)
+
+Once the WebUI is open and authenticated on the gateway host:
+
+1. Stay on **Overview** — the **Pair phone app** card shows a QR for a
+   phone-reachable address (LAN IP preferred, or `LOCALFLOW_PUBLIC_URL` if set).
+2. In the Android app, open **Gateway** and tap **Scan QR code**.
+3. Grant camera access if asked; the scan fills address + token and runs the
+   connection test.
+
+You can still paste manually:
 
 1. **Gateway address** — the LAN, Tailscale, or HTTPS URL above.
 2. **Bearer token** — `cat ~/.config/localflow/token` for native installs, or the

--- a/android/README.md
+++ b/android/README.md
@@ -49,9 +49,10 @@ silent failure.
 4. **Accessibility service** — see the disclosure below.
 5. **Unrestricted battery usage** (optional) — stops Android ending a long
    dictation early.
-6. **Gateway address and token** — then **Test connection**, which reports
-   reachability, token validity, the active engine, whether it is ready, and
-   whether it supports streaming.
+6. **Gateway address and token** — either **Scan QR code** against the gateway
+   WebUI Overview pairing card, or paste the URL and bearer token, then
+   **Test connection**, which reports reachability, token validity, the active
+   engine, whether it is ready, and whether it supports streaming.
 
 ## How accessibility access is used
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -123,6 +123,10 @@ dependencies {
     implementation(libs.androidx.work.runtime.ktx)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.okhttp)
+    implementation(libs.androidx.camera.camera2)
+    implementation(libs.androidx.camera.lifecycle)
+    implementation(libs.androidx.camera.view)
+    implementation(libs.mlkit.barcode.scanning)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,11 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <!-- Used only when the user taps Scan QR on the gateway screen. -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
     <!-- Offered as an optional step so a long dictation is not killed mid-sentence. -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
@@ -54,6 +59,12 @@
             android:noHistory="true"
             android:taskAffinity=""
             android:theme="@style/Theme.LocalFlow.Invisible" />
+
+        <activity
+            android:name=".ui.QrPairingActivity"
+            android:exported="false"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.LocalFlow" />
 
         <service
             android:name=".dictation.DictationService"

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/core/PairingPayload.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/core/PairingPayload.kt
@@ -1,0 +1,68 @@
+package io.github.mrsunglasses.localflow.core
+
+import org.json.JSONObject
+
+/**
+ * Shared phone-pairing document encoded in the gateway WebUI QR.
+ *
+ * Wire format (version 1):
+ * `{"v":1,"url":"http://192.168.1.20:8765","token":"..."}`
+ */
+object PairingPayload {
+
+    const val VERSION = 1
+
+    data class Parsed(val url: String, val token: String)
+
+    sealed interface Result {
+        data class Ok(val parsed: Parsed) : Result
+        data class Err(val reason: String) : Result
+    }
+
+    fun parse(raw: String): Result {
+        val text = raw.trim()
+        if (text.isEmpty()) return Result.Err("The pairing code is empty.")
+
+        val data = try {
+            JSONObject(text)
+        } catch (_: Exception) {
+            return Result.Err("This is not a Local Flow pairing code.")
+        }
+
+        val version = when {
+            data.has("v") -> data.optInt("v", -1)
+            data.has("version") -> data.optInt("version", -1)
+            else -> -1
+        }
+        if (version != VERSION) {
+            return Result.Err("This pairing code uses an unsupported version.")
+        }
+
+        val url = data.optString("url", "").trim()
+        val token = data.optString("token", "").trim()
+        if (url.isEmpty()) return Result.Err("The pairing code is missing a gateway address.")
+        if (token.isEmpty()) return Result.Err("The pairing code is missing a bearer token.")
+        if (token.length < 32) {
+            return Result.Err("The pairing token looks too short to be valid.")
+        }
+
+        return when (val validation = GatewayEndpoint.validate(url)) {
+            is GatewayEndpoint.Validation.Invalid -> Result.Err(validation.reason)
+            is GatewayEndpoint.Validation.Valid -> Result.Ok(Parsed(validation.url, token))
+        }
+    }
+
+    /** Encode for tests and any host-side previews that share this format. */
+    fun encode(url: String, token: String): String {
+        val validation = GatewayEndpoint.validate(url)
+        require(validation is GatewayEndpoint.Validation.Valid) {
+            (validation as GatewayEndpoint.Validation.Invalid).reason
+        }
+        require(token.isNotBlank()) { "Token must not be empty." }
+        return JSONObject()
+            .put("v", VERSION)
+            .put("url", validation.url)
+            .put("token", token.trim())
+            .toString()
+    }
+}

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/GatewayScreen.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/GatewayScreen.kt
@@ -1,5 +1,8 @@
 package io.github.mrsunglasses.localflow.ui
 
+import android.app.Activity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,11 +26,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import io.github.mrsunglasses.localflow.core.GatewayEndpoint
+import io.github.mrsunglasses.localflow.core.PairingPayload
 import io.github.mrsunglasses.localflow.settings.LocalFlowSettings
 
 @Composable
@@ -40,10 +45,36 @@ fun GatewayScreen(
     onClear: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
     var url by remember(settings.gatewayUrl) { mutableStateOf(settings.gatewayUrl) }
     var token by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
     var saved by remember { mutableStateOf(false) }
+
+    val scanLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        if (result.resultCode != Activity.RESULT_OK) {
+            val message = result.data?.getStringExtra(QrPairingActivity.EXTRA_ERROR)
+            if (!message.isNullOrBlank()) error = message
+            return@rememberLauncherForActivityResult
+        }
+        val raw = result.data?.getStringExtra(QrPairingActivity.EXTRA_RAW).orEmpty()
+        when (val parsed = PairingPayload.parse(raw)) {
+            is PairingPayload.Result.Err -> error = parsed.reason
+            is PairingPayload.Result.Ok -> {
+                url = parsed.parsed.url
+                token = parsed.parsed.token
+                error = null
+                saved = false
+                onSave(parsed.parsed.url, parsed.parsed.token) { failure ->
+                    error = failure
+                    saved = failure == null
+                    if (failure == null) token = ""
+                }
+            }
+        }
+    }
 
     Column(
         modifier = modifier
@@ -53,9 +84,26 @@ fun GatewayScreen(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         SectionCard(
+            title = "Scan pairing QR",
+            supporting = "On the gateway host, open the WebUI Overview and scan the " +
+                "pairing QR. That fills the address and bearer token without typing.",
+        ) {
+            Button(
+                onClick = {
+                    scanLauncher.launch(
+                        android.content.Intent(context, QrPairingActivity::class.java),
+                    )
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Scan QR code")
+            }
+        }
+
+        SectionCard(
             title = "Gateway address",
             supporting = "A private LAN or Tailscale host may use http://. Anything " +
-                "reachable from the internet must use https://.",
+                "reachable from the internet must use https://. Or scan the WebUI QR above.",
         ) {
             OutlinedTextField(
                 value = url,

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/QrPairingActivity.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/QrPairingActivity.kt
@@ -1,0 +1,145 @@
+package io.github.mrsunglasses.localflow.ui
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.util.Size
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.Preview
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import androidx.camera.core.resolutionselector.ResolutionStrategy
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.common.InputImage
+import io.github.mrsunglasses.localflow.core.PairingPayload
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Full-screen QR scanner used only for gateway pairing. Returns the raw QR text
+ * in [EXTRA_RAW] so [PairingPayload] can validate it on the caller's side.
+ */
+class QrPairingActivity : ComponentActivity() {
+
+    private val cameraExecutor = Executors.newSingleThreadExecutor()
+    private val handled = AtomicBoolean(false)
+    private lateinit var previewView: PreviewView
+
+    private val permissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        if (granted) startCamera() else finishCancelled("Camera permission is required to scan.")
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        previewView = PreviewView(this).apply {
+            implementationMode = PreviewView.ImplementationMode.COMPATIBLE
+            scaleType = PreviewView.ScaleType.FILL_CENTER
+        }
+        setContentView(previewView)
+
+        when {
+            ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) ==
+                PackageManager.PERMISSION_GRANTED -> startCamera()
+            else -> permissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    private fun startCamera() {
+        val future = ProcessCameraProvider.getInstance(this)
+        future.addListener({
+            val provider = future.get()
+            val preview = Preview.Builder().build().also {
+                it.surfaceProvider = previewView.surfaceProvider
+            }
+            val analysis = ImageAnalysis.Builder()
+                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                .setResolutionSelector(
+                    ResolutionSelector.Builder()
+                        .setResolutionStrategy(
+                            ResolutionStrategy(
+                                Size(1280, 720),
+                                ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER_THEN_LOWER,
+                            ),
+                        )
+                        .build(),
+                )
+                .build()
+
+            val options = BarcodeScannerOptions.Builder()
+                .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+                .build()
+            val scanner = BarcodeScanning.getClient(options)
+
+            analysis.setAnalyzer(cameraExecutor) { imageProxy ->
+                if (handled.get() || !lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+                    imageProxy.close()
+                    return@setAnalyzer
+                }
+                val media = imageProxy.image
+                if (media == null) {
+                    imageProxy.close()
+                    return@setAnalyzer
+                }
+                val image = InputImage.fromMediaImage(media, imageProxy.imageInfo.rotationDegrees)
+                scanner.process(image)
+                    .addOnSuccessListener { barcodes ->
+                        val raw = barcodes.firstNotNullOfOrNull { it.rawValue } ?: return@addOnSuccessListener
+                        if (!handled.compareAndSet(false, true)) return@addOnSuccessListener
+                        // Validate lightly here so we don't finish on unrelated QR codes.
+                        when (val parsed = PairingPayload.parse(raw)) {
+                            is PairingPayload.Result.Ok -> {
+                                setResult(
+                                    RESULT_OK,
+                                    Intent().putExtra(EXTRA_RAW, raw)
+                                        .putExtra(EXTRA_URL, parsed.parsed.url)
+                                        .putExtra(EXTRA_TOKEN, parsed.parsed.token),
+                                )
+                                finish()
+                            }
+                            is PairingPayload.Result.Err -> {
+                                // Keep scanning; not a Local Flow pairing code.
+                                handled.set(false)
+                            }
+                        }
+                    }
+                    .addOnCompleteListener { imageProxy.close() }
+            }
+
+            provider.unbindAll()
+            provider.bindToLifecycle(
+                this,
+                CameraSelector.DEFAULT_BACK_CAMERA,
+                preview,
+                analysis,
+            )
+        }, ContextCompat.getMainExecutor(this))
+    }
+
+    private fun finishCancelled(message: String) {
+        setResult(RESULT_CANCELED, Intent().putExtra(EXTRA_ERROR, message))
+        finish()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        cameraExecutor.shutdown()
+    }
+
+    companion object {
+        const val EXTRA_RAW = "pairing_raw"
+        const val EXTRA_URL = "pairing_url"
+        const val EXTRA_TOKEN = "pairing_token"
+        const val EXTRA_ERROR = "pairing_error"
+    }
+}

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/QrPairingActivity.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/QrPairingActivity.kt
@@ -7,8 +7,11 @@ import android.os.Bundle
 import android.util.Size
 import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.OptIn
 import androidx.camera.core.CameraSelector
+import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
 import androidx.camera.core.Preview
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.camera.core.resolutionselector.ResolutionStrategy
@@ -16,6 +19,7 @@ import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
+import com.google.mlkit.vision.barcode.BarcodeScanner
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions
 import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.barcode.common.Barcode
@@ -82,38 +86,7 @@ class QrPairingActivity : ComponentActivity() {
             val scanner = BarcodeScanning.getClient(options)
 
             analysis.setAnalyzer(cameraExecutor) { imageProxy ->
-                if (handled.get() || !lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
-                    imageProxy.close()
-                    return@setAnalyzer
-                }
-                val media = imageProxy.image
-                if (media == null) {
-                    imageProxy.close()
-                    return@setAnalyzer
-                }
-                val image = InputImage.fromMediaImage(media, imageProxy.imageInfo.rotationDegrees)
-                scanner.process(image)
-                    .addOnSuccessListener { barcodes ->
-                        val raw = barcodes.firstNotNullOfOrNull { it.rawValue } ?: return@addOnSuccessListener
-                        if (!handled.compareAndSet(false, true)) return@addOnSuccessListener
-                        // Validate lightly here so we don't finish on unrelated QR codes.
-                        when (val parsed = PairingPayload.parse(raw)) {
-                            is PairingPayload.Result.Ok -> {
-                                setResult(
-                                    RESULT_OK,
-                                    Intent().putExtra(EXTRA_RAW, raw)
-                                        .putExtra(EXTRA_URL, parsed.parsed.url)
-                                        .putExtra(EXTRA_TOKEN, parsed.parsed.token),
-                                )
-                                finish()
-                            }
-                            is PairingPayload.Result.Err -> {
-                                // Keep scanning; not a Local Flow pairing code.
-                                handled.set(false)
-                            }
-                        }
-                    }
-                    .addOnCompleteListener { imageProxy.close() }
+                analyzeFrame(imageProxy, scanner)
             }
 
             provider.unbindAll()
@@ -124,6 +97,42 @@ class QrPairingActivity : ComponentActivity() {
                 analysis,
             )
         }, ContextCompat.getMainExecutor(this))
+    }
+
+    @OptIn(ExperimentalGetImage::class)
+    private fun analyzeFrame(imageProxy: ImageProxy, scanner: BarcodeScanner) {
+        if (handled.get() || !lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+            imageProxy.close()
+            return
+        }
+        val media = imageProxy.image
+        if (media == null) {
+            imageProxy.close()
+            return
+        }
+        val image = InputImage.fromMediaImage(media, imageProxy.imageInfo.rotationDegrees)
+        scanner.process(image)
+            .addOnSuccessListener { barcodes ->
+                val raw = barcodes.firstNotNullOfOrNull { it.rawValue } ?: return@addOnSuccessListener
+                if (!handled.compareAndSet(false, true)) return@addOnSuccessListener
+                // Validate lightly here so we don't finish on unrelated QR codes.
+                when (val parsed = PairingPayload.parse(raw)) {
+                    is PairingPayload.Result.Ok -> {
+                        setResult(
+                            RESULT_OK,
+                            Intent().putExtra(EXTRA_RAW, raw)
+                                .putExtra(EXTRA_URL, parsed.parsed.url)
+                                .putExtra(EXTRA_TOKEN, parsed.parsed.token),
+                        )
+                        finish()
+                    }
+                    is PairingPayload.Result.Err -> {
+                        // Keep scanning; not a Local Flow pairing code.
+                        handled.set(false)
+                    }
+                }
+            }
+            .addOnCompleteListener { imageProxy.close() }
     }
 
     private fun finishCancelled(message: String) {

--- a/android/app/src/main/res/layout/view_bubble.xml
+++ b/android/app/src/main/res/layout/view_bubble.xml
@@ -4,6 +4,7 @@
   stays active and ordinary typing is untouched.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/bubble_root"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -23,7 +24,7 @@
         android:contentDescription="@string/bubble_dictate"
         android:padding="10dp"
         android:src="@drawable/ic_dictation"
-        android:tint="#FFFFFFFF" />
+        app:tint="#FFFFFFFF" />
 
     <TextView
         android:id="@+id/bubble_status"
@@ -46,8 +47,8 @@
         android:contentDescription="@string/bubble_finish"
         android:padding="7dp"
         android:src="@drawable/ic_check"
-        android:tint="#FFFFFFFF"
-        android:visibility="gone" />
+        android:visibility="gone"
+        app:tint="#FFFFFFFF" />
 
     <ImageButton
         android:id="@+id/bubble_cancel"
@@ -58,5 +59,5 @@
         android:contentDescription="@string/bubble_cancel"
         android:padding="8dp"
         android:src="@drawable/ic_cancel"
-        android:tint="#B3FFFFFF" />
+        app:tint="#B3FFFFFF" />
 </LinearLayout>

--- a/android/app/src/test/java/io/github/mrsunglasses/localflow/core/PairingPayloadTest.kt
+++ b/android/app/src/test/java/io/github/mrsunglasses/localflow/core/PairingPayloadTest.kt
@@ -1,0 +1,63 @@
+package io.github.mrsunglasses.localflow.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PairingPayloadTest {
+
+    @Test
+    fun `round trip encode and parse`() {
+        val raw = PairingPayload.encode(
+            "  HTTP://192.168.1.75:8765/  ",
+            "  test-token-with-at-least-thirty-two-characters  ",
+        )
+        val result = PairingPayload.parse(raw) as PairingPayload.Result.Ok
+        assertEquals("http://192.168.1.75:8765", result.parsed.url)
+        assertEquals("test-token-with-at-least-thirty-two-characters", result.parsed.token)
+    }
+
+    @Test
+    fun `rejects garbage and wrong version`() {
+        assertTrue(PairingPayload.parse("not-json") is PairingPayload.Result.Err)
+        assertTrue(PairingPayload.parse("   ") is PairingPayload.Result.Err)
+        assertTrue(
+            PairingPayload.parse(
+                """{"v":99,"url":"http://192.168.1.1:8765","token":"test-token-with-at-least-thirty-two-characters"}""",
+            ) is PairingPayload.Result.Err,
+        )
+    }
+
+    @Test
+    fun `rejects public cleartext hosts via GatewayEndpoint`() {
+        val result = PairingPayload.parse(
+            """{"v":1,"url":"http://flow.example.com:8765","token":"test-token-with-at-least-thirty-two-characters"}""",
+        ) as PairingPayload.Result.Err
+        assertTrue(result.reason.contains("https://"))
+    }
+
+    @Test
+    fun `accepts lan and tailscale cleartext`() {
+        val lan = PairingPayload.parse(
+            """{"v":1,"url":"http://192.168.1.20:8765","token":"test-token-with-at-least-thirty-two-characters"}""",
+        ) as PairingPayload.Result.Ok
+        assertEquals("http://192.168.1.20:8765", lan.parsed.url)
+
+        val tail = PairingPayload.parse(
+            """{"v":1,"url":"http://homelab.tail1234.ts.net:8765","token":"test-token-with-at-least-thirty-two-characters"}""",
+        ) as PairingPayload.Result.Ok
+        assertEquals("http://homelab.tail1234.ts.net:8765", tail.parsed.url)
+    }
+
+    @Test
+    fun `rejects missing token or short token`() {
+        assertTrue(
+            PairingPayload.parse("""{"v":1,"url":"http://192.168.1.20:8765","token":""}""")
+                is PairingPayload.Result.Err,
+        )
+        assertTrue(
+            PairingPayload.parse("""{"v":1,"url":"http://192.168.1.20:8765","token":"tooshort"}""")
+                is PairingPayload.Result.Err,
+        )
+    }
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -16,6 +16,8 @@ json = "20260719"
 androidxTestCore = "1.7.0"
 androidxTestExt = "1.3.0"
 espresso = "3.7.0"
+camerax = "1.5.3"
+mlkitBarcode = "17.3.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -41,6 +43,10 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver3-junit4", version.ref = "okhttp" }
+androidx-camera-camera2 = { group = "androidx.camera", name = "camera-camera2", version.ref = "camerax" }
+androidx-camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "camerax" }
+androidx-camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "camerax" }
+mlkit-barcode-scanning = { group = "com.google.mlkit", name = "barcode-scanning", version.ref = "mlkitBarcode" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 json = { group = "org.json", name = "json", version.ref = "json" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }

--- a/server/README.md
+++ b/server/README.md
@@ -92,6 +92,20 @@ gateway binds `0.0.0.0` (the default). For Tailscale Serve only, bind loopback:
 LOCALFLOW_BIND_HOST=127.0.0.1 uv run localflow-server
 ```
 
+### Phone pairing QR
+
+After you authenticate in the WebUI, the Overview page shows a **Pair phone app**
+QR. The Android app scans it to fill the gateway URL and bearer token. The code
+encodes a versioned JSON payload:
+
+```json
+{"v":1,"url":"http://192.168.1.20:8765","token":"..."}
+```
+
+Discovery prefers private Wi‑Fi addresses (for example `192.168.x.x`). Override
+with `LOCALFLOW_PUBLIC_URL` or `LOCALFLOW_PAIRING_URL` when automatic selection
+is wrong. The QR is only available through the authenticated WebUI/API.
+
 ## Docker Compose quick start
 
 [compose.yaml](compose.yaml) is the canonical container deployment. It builds a

--- a/server/app/fragments.py
+++ b/server/app/fragments.py
@@ -56,7 +56,7 @@ def engine_pill_oob(engine: EngineStatus) -> str:
     )
 
 
-def overview_fragment(status: AdminStatusResponse) -> str:
+def overview_fragment(status: AdminStatusResponse, pairing_html: str = "") -> str:
     is_mac = status.system.os.startswith("Darwin")
     machine_label = "Mac" if is_mac else "server"
     ffmpeg_hint = "brew install ffmpeg" if is_mac else "Install FFmpeg with your package manager"
@@ -165,6 +165,7 @@ def overview_fragment(status: AdminStatusResponse) -> str:
       </section>
       {exposure_notice}
       {operations_fragment(status.metrics, status.readiness)}
+      {pairing_html}
       <div class="grid two">
         <div class="card">
           <h2>Setup checklist</h2>
@@ -406,6 +407,72 @@ def _model_card(entry: AdminModelEntry) -> str:
           <div class="actions">{action}</div>
         </div>
       </article>
+    """
+
+
+def pairing_fragment(
+    *,
+    selected_url: str | None,
+    candidates: list[str],
+    token_redacted: str,
+    qr_svg: str = "",
+) -> str:
+    """Authenticated phone-pairing card with QR for the selected gateway URL.
+
+    The SVG is inlined so the browser does not need a second request (img tags
+    cannot attach the WebUI bearer header).
+    """
+    if not selected_url:
+        return """
+      <div class="card" id="pairing-card">
+        <h2>Pair phone app</h2>
+        <p class="muted">No phone-reachable address was detected. Set
+          <code>LOCALFLOW_PUBLIC_URL</code> to the URL the phone should use
+          (for example <code>http://192.168.1.20:8765</code>), then reload.</p>
+      </div>
+        """
+    options = "".join(
+        f'<option value="{escape(url)}"{" selected" if url == selected_url else ""}>'
+        f"{escape(url)}</option>"
+        for url in candidates
+    )
+    # Strip XML declaration for clean inline embedding.
+    inline_svg = qr_svg
+    if inline_svg.lstrip().startswith("<?xml"):
+        inline_svg = inline_svg.split("?>", 1)[-1].lstrip()
+    return f"""
+      <div class="card" id="pairing-card">
+        <h2>Pair phone app</h2>
+        <p class="muted">Scan this QR in Local Flow on Android to fill the gateway
+          address and bearer token. Keep the WebUI private — the code includes the
+          live token.</p>
+        <div class="pairing-layout">
+          <div class="pairing-qr" role="img"
+               aria-label="Pairing QR code for {escape(selected_url)}">{inline_svg}</div>
+          <div class="pairing-meta">
+            <div class="pairing-url-form">
+              <label><span>Address encoded in the QR</span>
+                <select name="url"
+                        hx-get="/ui/partials/pairing"
+                        hx-target="#pairing-card"
+                        hx-swap="outerHTML"
+                        hx-trigger="change"
+                        hx-include="this">
+                  {options}
+                </select>
+              </label>
+            </div>
+            <dl class="facts">
+              <div><dt>Gateway URL</dt><dd><code>{escape(selected_url)}</code></dd></div>
+              <div><dt>Token</dt><dd><code>{escape(token_redacted)}</code></dd></div>
+            </dl>
+            <p class="muted small">Prefer the Wi‑Fi LAN address when the phone is on
+              the same network. Use a Tailscale MagicDNS name when both devices are
+              on the tailnet. Override discovery with
+              <code>LOCALFLOW_PUBLIC_URL</code>.</p>
+          </div>
+        </div>
+      </div>
     """
 
 

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -52,6 +52,7 @@ from app.fragments import (
     models_list_fragment,
     operations_fragment,
     overview_fragment,
+    pairing_fragment,
     settings_fragment,
     test_fragment,
 )
@@ -62,6 +63,14 @@ from app.model_manager import (
 )
 from app.models.base import AudioNormalizer, TranscriptionEngine
 from app.models.moonshine import MoonshineEngine
+from app.pairing import (
+    decode_pairing_payload,
+    discover_gateway_base_urls,
+    encode_pairing_payload,
+    normalize_gateway_url,
+    primary_gateway_base_url,
+    qr_svg_for_payload,
+)
 from app.readiness import ReadinessMonitor
 from app.runtime_config import RuntimeConfig
 from app.schemas import (
@@ -926,13 +935,96 @@ def create_app(
     def _models_list_html() -> HTMLResponse:
         return _html(models_list_fragment(_model_entries()))
 
+    def _pairing_html(selected_url: str | None = None) -> str:
+        candidates = discover_gateway_base_urls(configured.port)
+        if selected_url:
+            try:
+                selected = normalize_gateway_url(selected_url)
+            except ValueError:
+                selected = primary_gateway_base_url(configured.port)
+            else:
+                if selected not in candidates:
+                    candidates = [selected, *candidates]
+        else:
+            selected = primary_gateway_base_url(configured.port)
+        token = configured.token
+        redacted = (
+            f"{token[:4]}…{token[-4:]} ({len(token)} characters)"
+            if len(token) > 8
+            else "•" * len(token)
+        )
+        qr_svg = ""
+        if selected:
+            qr_svg = qr_svg_for_payload(encode_pairing_payload(selected, configured.token))
+        return pairing_fragment(
+            selected_url=selected,
+            candidates=candidates,
+            token_redacted=redacted,
+            qr_svg=qr_svg,
+        )
+
+    def _resolve_pairing_url(url: str | None) -> str:
+        candidates = discover_gateway_base_urls(configured.port)
+        if url:
+            try:
+                return normalize_gateway_url(url)
+            except ValueError as error:
+                raise APIProblem(400, "invalid_pairing_url", str(error)) from error
+        if not candidates:
+            raise APIProblem(
+                503,
+                "pairing_unavailable",
+                "No phone-reachable gateway address was detected. "
+                "Set LOCALFLOW_PUBLIC_URL and retry.",
+            )
+        return candidates[0]
+
+    @app.get(
+        "/v1/admin/pairing",
+        dependencies=[Depends(require_token)],
+    )
+    async def get_pairing(url: str | None = Query(default=None)) -> dict[str, Any]:
+        selected = _resolve_pairing_url(url)
+        payload = encode_pairing_payload(selected, configured.token)
+        # Round-trip so clients and tests share one format.
+        decoded = decode_pairing_payload(payload)
+        return {
+            "version": decoded.version,
+            "url": decoded.url,
+            "payload": payload,
+            "candidates": discover_gateway_base_urls(configured.port),
+        }
+
+    @app.get(
+        "/v1/admin/pairing/qr.svg",
+        dependencies=[Depends(require_token)],
+        response_class=Response,
+    )
+    async def get_pairing_qr(url: str | None = Query(default=None)) -> Response:
+        selected = _resolve_pairing_url(url)
+        payload = encode_pairing_payload(selected, configured.token)
+        svg = qr_svg_for_payload(payload)
+        return Response(
+            content=svg,
+            media_type="image/svg+xml",
+            headers={"Cache-Control": "no-store"},
+        )
+
+    @app.get(
+        "/ui/partials/pairing",
+        response_class=HTMLResponse,
+        dependencies=[Depends(require_token)],
+    )
+    async def ui_pairing(url: str | None = Query(default=None)) -> HTMLResponse:
+        return _html(_pairing_html(url))
+
     @app.get(
         "/ui/partials/overview",
         response_class=HTMLResponse,
         dependencies=[Depends(require_token)],
     )
     async def ui_overview() -> HTMLResponse:
-        return _html(overview_fragment(await _status_payload()))
+        return _html(overview_fragment(await _status_payload(), pairing_html=_pairing_html()))
 
     @app.get(
         "/ui/partials/operations",

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -937,6 +937,7 @@ def create_app(
 
     def _pairing_html(selected_url: str | None = None) -> str:
         candidates = discover_gateway_base_urls(configured.port)
+        selected: str | None
         if selected_url:
             try:
                 selected = normalize_gateway_url(selected_url)

--- a/server/app/pairing.py
+++ b/server/app/pairing.py
@@ -1,0 +1,212 @@
+"""Phone pairing payload and QR for the authenticated WebUI.
+
+The payload is a compact JSON document the Android app scans:
+
+    {"v":1,"url":"http://192.168.1.20:8765","token":"..."}
+
+The QR must encode a host the phone can reach (LAN / Tailscale), not loopback.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import socket
+import subprocess
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+PAIRING_VERSION = 1
+PAIRING_SCHEME_HINT = "localflow-pair-v1"
+
+
+@dataclass(frozen=True, slots=True)
+class PairingPayload:
+    url: str
+    token: str
+    version: int = PAIRING_VERSION
+
+    def encode(self) -> str:
+        if self.version != PAIRING_VERSION:
+            raise ValueError(f"Unsupported pairing version: {self.version}")
+        if not self.token.strip():
+            raise ValueError("Pairing token must not be empty.")
+        url = normalize_gateway_url(self.url)
+        return json.dumps(
+            {"v": self.version, "url": url, "token": self.token},
+            separators=(",", ":"),
+            ensure_ascii=True,
+        )
+
+
+def encode_pairing_payload(url: str, token: str, *, version: int = PAIRING_VERSION) -> str:
+    return PairingPayload(url=url, token=token, version=version).encode()
+
+
+def decode_pairing_payload(raw: str) -> PairingPayload:
+    text = raw.strip()
+    if not text:
+        raise ValueError("Pairing code is empty.")
+    try:
+        data: Any = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise ValueError("Pairing code is not valid JSON.") from error
+    if not isinstance(data, dict):
+        raise ValueError("Pairing code must be a JSON object.")
+    version = data.get("v", data.get("version"))
+    if version != PAIRING_VERSION:
+        raise ValueError(f"Unsupported pairing version: {version!r}")
+    url = data.get("url")
+    token = data.get("token")
+    if not isinstance(url, str) or not url.strip():
+        raise ValueError("Pairing code is missing a gateway URL.")
+    if not isinstance(token, str) or not token.strip():
+        raise ValueError("Pairing code is missing a bearer token.")
+    return PairingPayload(url=normalize_gateway_url(url), token=token.strip(), version=int(version))
+
+
+def normalize_gateway_url(url: str) -> str:
+    trimmed = url.strip()
+    parsed = urlparse(trimmed)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("Gateway URL must use http:// or https://.")
+    if not parsed.hostname:
+        raise ValueError("Gateway URL is missing a host.")
+    if parsed.username or parsed.password:
+        raise ValueError("Gateway URL must not include credentials.")
+    if parsed.query or parsed.fragment:
+        raise ValueError("Gateway URL must not include a query or fragment.")
+    host = parsed.hostname
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    port = f":{parsed.port}" if parsed.port else ""
+    path = (parsed.path or "").rstrip("/")
+    return f"{parsed.scheme}://{host}{port}{path}"
+
+
+def discover_gateway_base_urls(port: int) -> list[str]:
+    """Return phone-reachable gateway bases, preferred first.
+
+    Loopback is omitted: a phone cannot use 127.0.0.1 on the gateway host.
+    Override with LOCALFLOW_PUBLIC_URL or LOCALFLOW_PAIRING_URL when automatic
+    discovery is wrong (multiple NICs, reverse proxy, etc.).
+    """
+    overrides: list[str] = []
+    for key in ("LOCALFLOW_PUBLIC_URL", "LOCALFLOW_PAIRING_URL"):
+        value = os.environ.get(key, "").strip()
+        if value:
+            try:
+                overrides.append(normalize_gateway_url(value))
+            except ValueError:
+                continue
+
+    addresses = _local_ipv4_addresses()
+    ranked = sorted(addresses, key=_address_rank)
+    discovered = [f"http://{ip}:{port}" for ip in ranked]
+
+    ordered: list[str] = []
+    for candidate in overrides + discovered:
+        if candidate not in ordered:
+            ordered.append(candidate)
+    return ordered
+
+
+def primary_gateway_base_url(port: int) -> str | None:
+    urls = discover_gateway_base_urls(port)
+    return urls[0] if urls else None
+
+
+def _local_ipv4_addresses() -> list[str]:
+    found: set[str] = set()
+    try:
+        hostname = socket.gethostname()
+        for info in socket.getaddrinfo(hostname, None, socket.AF_INET, socket.SOCK_STREAM):
+            sockaddr = info[4]
+            address = sockaddr[0]
+            if isinstance(address, str) and _is_phone_reachable_ipv4(address):
+                found.add(address)
+    except OSError:
+        pass
+
+    # Also probe via UDP connect so multi-homed hosts report the outbound NIC.
+    for probe in ("1.1.1.1", "8.8.8.8"):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+                sock.connect((probe, 80))
+                address = sock.getsockname()[0]
+                if isinstance(address, str) and _is_phone_reachable_ipv4(address):
+                    found.add(address)
+        except OSError:
+            continue
+
+    # Prefer iproute on Linux when available (reliable multi-NIC listing).
+    try:
+        result = subprocess.run(
+            ["ip", "-4", "-o", "addr", "show", "scope", "global"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                parts = line.split()
+                if "inet" in parts:
+                    idx = parts.index("inet")
+                    if idx + 1 < len(parts):
+                        address = parts[idx + 1].split("/")[0]
+                        if _is_phone_reachable_ipv4(address):
+                            found.add(address)
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+    return list(found)
+
+
+def _is_phone_reachable_ipv4(address: str) -> bool:
+    try:
+        ip = ipaddress.IPv4Address(address)
+    except ValueError:
+        return False
+    return not (ip.is_loopback or ip.is_link_local or ip.is_unspecified or ip.is_multicast)
+
+
+def _address_rank(address: str) -> tuple[int, str]:
+    """Prefer typical home Wi-Fi (192.168) over VPN tunnels (often 10.x)."""
+    try:
+        ip = ipaddress.IPv4Address(address)
+    except ValueError:
+        return (90, address)
+    if ip in ipaddress.IPv4Network("192.168.0.0/16"):
+        return (0, address)
+    if ip in ipaddress.IPv4Network("172.16.0.0/12"):
+        return (1, address)
+    # Tailscale / CGNAT
+    if ip in ipaddress.IPv4Network("100.64.0.0/10"):
+        return (2, address)
+    if ip in ipaddress.IPv4Network("10.0.0.0/8"):
+        return (3, address)
+    if ip.is_private:
+        return (4, address)
+    return (5, address)
+
+
+def qr_svg_for_payload(payload: str, *, box_size: int = 6, border: int = 2) -> str:
+    """Return a self-contained SVG QR for *payload* without Pillow."""
+    import qrcode
+    import qrcode.image.svg
+
+    qr = qrcode.QRCode(
+        version=None,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=box_size,
+        border=border,
+        image_factory=qrcode.image.svg.SvgPathImage,
+    )
+    qr.add_data(payload)
+    qr.make(fit=True)
+    image = qr.make_image()
+    svg = image.to_string(encoding="unicode")
+    return str(svg)

--- a/server/app/webui/index.html
+++ b/server/app/webui/index.html
@@ -13,7 +13,8 @@
       <span class="modal-icon" aria-hidden="true">&#128274;</span>
       <h2 id="token-title">Connect to your gateway</h2>
       <p class="muted">
-        Paste the gateway bearer token. You can find it on your Mac with:
+        Paste the gateway bearer token, or connect once and scan the pairing QR
+        on Overview from your phone. On this host:
       </p>
       <code class="block">cat ~/.config/localflow/token</code>
       <input id="token-input" type="password" placeholder="Bearer token" autocomplete="off" />
@@ -27,7 +28,7 @@
       <span class="logo">&#127908;</span>
       <div>
         <h1>Local Flow</h1>
-        <span class="muted">Mac transcription gateway</span>
+        <span class="muted">Private transcription gateway</span>
       </div>
     </div>
     <div id="engine-pill" class="pill unknown"

--- a/server/app/webui/styles.css
+++ b/server/app/webui/styles.css
@@ -121,6 +121,39 @@ main { max-width: 1120px; margin: 0 auto; padding: 24px 24px 60px; }
 .grid.two { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
 @media (max-width: 720px) { .grid.two { grid-template-columns: 1fr; } }
 
+.pairing-layout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  align-items: flex-start;
+}
+.pairing-qr {
+  background: #fff;
+  border-radius: 12px;
+  padding: 10px;
+  width: 220px;
+  height: 220px;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.pairing-qr svg {
+  width: 200px;
+  height: 200px;
+  display: block;
+}
+.pairing-meta { flex: 1 1 220px; min-width: 0; }
+.pairing-url-form label { display: grid; gap: 6px; margin-bottom: 12px; }
+.pairing-url-form select {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--panel-border);
+  background: var(--panel-strong);
+  color: var(--text);
+}
+
 .operations { margin: 18px 0; }
 .section-heading {
   display: flex;

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "pysbd>=0.3.4,<0.4",
   "python-multipart>=0.0.9,<1",
   # Public Suffix List snapshot for recognising addresses in a transcript.
+  "qrcode>=7.4,<9",
   "tldextract>=5,<6",
   "uvicorn[standard]>=0.35,<1",
 ]
@@ -72,6 +73,8 @@ module = [
   "moonshine_voice.*",
   "pysbd",
   "pysbd.*",
+  "qrcode",
+  "qrcode.*",
 ]
 ignore_missing_imports = true
 

--- a/server/tests/test_pairing.py
+++ b/server/tests/test_pairing.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.pairing import (
+    PAIRING_VERSION,
+    decode_pairing_payload,
+    encode_pairing_payload,
+    primary_gateway_base_url,
+    qr_svg_for_payload,
+)
+
+
+def test_round_trip_encode_decode() -> None:
+    raw = encode_pairing_payload(
+        "http://192.168.1.20:8765/",
+        "test-token-with-at-least-thirty-two-characters",
+    )
+    data = json.loads(raw)
+    assert data["v"] == PAIRING_VERSION
+    assert data["url"] == "http://192.168.1.20:8765"
+    assert data["token"] == "test-token-with-at-least-thirty-two-characters"
+    decoded = decode_pairing_payload(raw)
+    assert decoded.url == "http://192.168.1.20:8765"
+    assert decoded.token == "test-token-with-at-least-thirty-two-characters"
+
+
+def test_decode_rejects_garbage() -> None:
+    with pytest.raises(ValueError, match="not valid JSON"):
+        decode_pairing_payload("not-json")
+    with pytest.raises(ValueError, match="empty"):
+        decode_pairing_payload("   ")
+    with pytest.raises(ValueError, match="version"):
+        decode_pairing_payload(
+            '{"v":99,"url":"http://192.168.1.1:8765",'
+            '"token":"test-token-with-at-least-thirty-two-characters"}'
+        )
+    with pytest.raises(ValueError, match="URL"):
+        decode_pairing_payload('{"v":1,"token":"test-token-with-at-least-thirty-two-characters"}')
+    with pytest.raises(ValueError, match="token"):
+        decode_pairing_payload('{"v":1,"url":"http://192.168.1.1:8765","token":""}')
+
+
+def test_encode_rejects_public_credentials_and_query() -> None:
+    with pytest.raises(ValueError, match="credentials"):
+        encode_pairing_payload(
+            "http://user:pass@192.168.1.1:8765",
+            "test-token-with-at-least-thirty-two-characters",
+        )
+    with pytest.raises(ValueError, match="query"):
+        encode_pairing_payload(
+            "http://192.168.1.1:8765?x=1",
+            "test-token-with-at-least-thirty-two-characters",
+        )
+
+
+def test_qr_svg_contains_path_and_is_svg() -> None:
+    payload = encode_pairing_payload(
+        "http://192.168.1.75:8765",
+        "test-token-with-at-least-thirty-two-characters",
+    )
+    svg = qr_svg_for_payload(payload)
+    assert svg.lstrip().startswith("<?xml") or "<svg" in svg
+    assert "path" in svg.lower() or "rect" in svg.lower()
+    assert len(svg) > 200
+
+
+def test_primary_gateway_base_url_prefers_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOCALFLOW_PUBLIC_URL", "http://homelab.example:8765")
+    assert primary_gateway_base_url(8765) == "http://homelab.example:8765"

--- a/server/tests/test_pairing_api.py
+++ b/server/tests/test_pairing_api.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from conftest import TOKEN
+
+from app.pairing import decode_pairing_payload
+
+
+@pytest.mark.asyncio
+async def test_pairing_endpoints_require_auth(client: httpx.AsyncClient) -> None:
+    assert (await client.get("/v1/admin/pairing")).status_code == 401
+    assert (await client.get("/v1/admin/pairing/qr.svg")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_pairing_payload_and_qr(
+    client: httpx.AsyncClient,
+    authorization: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOCALFLOW_PUBLIC_URL", "http://192.168.1.75:8765")
+    response = await client.get("/v1/admin/pairing", headers=authorization)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["url"] == "http://192.168.1.75:8765"
+    assert body["version"] == 1
+    decoded = decode_pairing_payload(body["payload"])
+    assert decoded.url == "http://192.168.1.75:8765"
+    assert decoded.token == TOKEN
+    assert TOKEN not in json.dumps({k: v for k, v in body.items() if k != "payload"})
+
+    qr = await client.get(
+        "/v1/admin/pairing/qr.svg",
+        headers=authorization,
+        params={"url": "http://192.168.1.75:8765"},
+    )
+    assert qr.status_code == 200
+    assert "svg" in qr.headers["content-type"]
+    assert b"<svg" in qr.content.lower() or b"path" in qr.content.lower()
+    assert len(qr.content) > 200
+
+    partial = await client.get("/ui/partials/pairing", headers=authorization)
+    assert partial.status_code == 200
+    assert "pairing-qr" in partial.text
+    assert "192.168.1.75" in partial.text
+    # QR is inlined so the browser never needs an unauthenticated <img> fetch.
+    assert "<svg" in partial.text.lower()

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -569,6 +569,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "pysbd" },
     { name = "python-multipart" },
+    { name = "qrcode" },
     { name = "tldextract" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -601,6 +602,7 @@ requires-dist = [
     { name = "moonshine-voice", marker = "extra == 'engines'", specifier = ">=0.1,<0.2" },
     { name = "pysbd", specifier = ">=0.3.4,<0.4" },
     { name = "python-multipart", specifier = ">=0.0.9,<1" },
+    { name = "qrcode", specifier = ">=7.4,<9" },
     { name = "sherpa-onnx", marker = "extra == 'engines'", specifier = ">=1.13.4,<2" },
     { name = "sherpa-onnx-bin", marker = "extra == 'engines'", specifier = ">=1.13.4,<2" },
     { name = "tldextract", specifier = ">=5,<6" },
@@ -670,7 +672,7 @@ name = "mlx"
 version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
+    { name = "mlx-metal" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/a6/489176d8a2a06137a299910057cc44dc3fccfb73151f7562fea2b75894d9/mlx-0.32.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:ea5a594355c89c0095eaba413fd39d4caa8642fa13432dfb0c9354d141046467", size = 558889, upload-time = "2026-07-07T17:55:45.268Z" },
@@ -715,7 +717,7 @@ version = "0.31.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
-    { name = "mlx", marker = "sys_platform == 'darwin'" },
+    { name = "mlx" },
     { name = "numpy" },
     { name = "protobuf" },
     { name = "pyyaml" },
@@ -1154,6 +1156,18 @@ wheels = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/b2/7fc2931bfae0af02d5f53b174e9cf701adbb35f39d69c2af63d4a39f81a9/qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c", size = 43317, upload-time = "2025-05-01T15:44:24.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/b8/d2d6d731733f51684bbf76bf34dab3b70a9148e8f2cef2bb544fccec681a/qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f", size = 45986, upload-time = "2025-05-01T15:44:22.781Z" },
+]
+
+[[package]]
 name = "regex"
 version = "2026.7.19"
 source = { registry = "https://pypi.org/simple" }
@@ -1473,7 +1487,7 @@ version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_version < '0'" },
     { name = "rich" },
     { name = "shellingham" },
 ]


### PR DESCRIPTION
## Summary

- Gateway WebUI Overview shows an authenticated pairing QR (LAN URL + bearer token) so the phone never needs manual token paste.
- Android Gateway screen adds **Scan QR code** (CameraX + ML Kit) that parses the shared payload and saves through the existing settings path.
- Stacked on `docs/linux-gateway-setup`. Payload format: `{"v":1,"url":"...","token":"..."}`.


## Server
<img width="1576" height="1252" alt="image" src="https://github.com/user-attachments/assets/89ac4a01-1f26-4a06-89ed-991fb844e37f" />

## Client (Android)
<img width="50%" height="3262" alt="image" src="https://github.com/user-attachments/assets/a4fa34c0-bc53-4ef7-b87a-29996ba5d1e0" />


## Test plan

- [x] `pytest tests/test_pairing.py tests/test_pairing_api.py`
- [x] Android unit tests for `PairingPayload`
- [x] `assembleDebug` and `adb install` on device `a775a5e9`
- [ ] User: open WebUI Overview, scan QR, Test connection shows token accepted

## Notes

- Replaced the previously installed APK (signature mismatch) with this debug build; app data was cleared on uninstall.
- Override QR address with `LOCALFLOW_PUBLIC_URL` if discovery picks the wrong NIC.