### PR TITLE
feat: add QR pairing to iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,13 +183,14 @@ tailscale serve status
   `https://dictation.example.com/`. Do not send recordings or bearer tokens over
   public HTTP.
 
-### Pair the phone with a QR code (Android)
+### Pair the phone with a QR code (iPhone or Android)
 
 Once the WebUI is open and authenticated on the gateway host:
 
 1. Stay on **Overview** — the **Pair phone app** card shows a QR for a
    phone-reachable address (LAN IP preferred, or `LOCALFLOW_PUBLIC_URL` if set).
-2. In the Android app, open **Gateway** and tap **Scan QR code**.
+2. In the iPhone app, open **Settings** and tap **Scan pairing QR code**. On
+   Android, open **Gateway** and tap **Scan QR code**.
 3. Grant camera access if asked; the scan fills address + token and runs the
    connection test.
 

--- a/docs/device-setup.md
+++ b/docs/device-setup.md
@@ -25,7 +25,9 @@ and on-device installation have been exercised with the current checkout.
    shows Quick Dictation as Ready and iOS displays its microphone indicator.
 3. Enter the configured HTTP/HTTPS gateway URL and bearer token. This may be a
    trusted LAN URL such as `http://homelabone:8765/`, a Tailscale Serve URL, or
-   an HTTPS VPS/reverse-proxy URL. Approve Local Network access for LAN hosts.
+   an HTTPS VPS/reverse-proxy URL. Or open **Settings**, tap **Scan pairing QR
+   code**, and scan the gateway WebUI Overview card. Approve camera and Local
+   Network access when prompted.
 4. Confirm that Save and test reports both gateway and model ready and shows the
    expected active model.
 5. Choose Automatic microphone routing or iPhone Microphone, connect any AirPods

--- a/ios/LocalFlow.xcodeproj/project.pbxproj
+++ b/ios/LocalFlow.xcodeproj/project.pbxproj
@@ -11,16 +11,19 @@
 		058BC439CA6C261AE5922069 /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4D700966610E77B503A6E8 /* KeyboardStatus.swift */; };
 		06B3991D6C5E2AD404A8D3A6 /* GatewayClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E50ACD74CADDD0BB62D1222 /* GatewayClient.swift */; };
 		09F4AAAEDA5288F98A21F5BB /* QuickDictationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119E8C9BE1BEB7517D444CD /* QuickDictationAvailability.swift */; };
+		0AD5017F623BBA820A437FDA /* PairingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D16BA539DADFFDC84CA902 /* PairingPayload.swift */; };
 		167F067DE708255E6CC96F90 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F29134B8035F91ACA991D5 /* AudioRecorder.swift */; };
 		18AB100760A33EAD802AF6C5 /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37BD648DCFB7D3452241CE1 /* GatewayEndpoint.swift */; };
 		191C781D0F219B2787D8923D /* FinishRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5A612D9FCE236CFDF42011 /* FinishRecordingIntent.swift */; };
 		21ADF5A5E85E3736552E28B0 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799A203DEDA091866FFBA4E /* TextInsertion.swift */; };
 		26C0719CEC4DDCB0BA08AAC4 /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4D700966610E77B503A6E8 /* KeyboardStatus.swift */; };
 		2B31542654F871DCD77744DA /* SessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13384D76D40D7BBB5882E472 /* SessionRecord.swift */; };
+		2BE3127F30D991B02C70C5D9 /* PairingPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4344F731096BD514A985FFCA /* PairingPayloadTests.swift */; };
 		2D56C9A5CE35FF4853A3219E /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4D700966610E77B503A6E8 /* KeyboardStatus.swift */; };
 		2DD59385E1E2FE40DA6D12B5 /* KeyGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AD7CA27F30AE6D9A5375898 /* KeyGridView.swift */; };
 		2EFD17B37B8F0B12A4D02D71 /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0971907F8807AF4111357EAA /* LiveActivityManager.swift */; };
 		36D030A4745EC041A8576C57 /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = A360AC1ABD0B65D97947A185 /* KeyboardPreferences.swift */; };
+		3D9F43741DE7FD79F1D7BBD4 /* PairingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D16BA539DADFFDC84CA902 /* PairingPayload.swift */; };
 		40F7DEDC700B2C334FC86C17 /* LocalFlowApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6FBCD6D0BA52C87B1D6F01 /* LocalFlowApp.swift */; };
 		42DF37B557FDD34042704FE7 /* SessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13384D76D40D7BBB5882E472 /* SessionRecord.swift */; };
 		438B7DBF85706EAA0D4FAB47 /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D89402A128DB78CAA390D8 /* SharedStore.swift */; };
@@ -37,6 +40,7 @@
 		6B69DBBB69638883C42042CC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714EAEF5499752246C9E5FBA /* ContentView.swift */; };
 		7100CDA1673010769D5E7CF5 /* LocalFlowLiveActivity.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 5B71284AEFECD863402492DB /* LocalFlowLiveActivity.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		7244C4C2BE3D7591D5BDB287 /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = A360AC1ABD0B65D97947A185 /* KeyboardPreferences.swift */; };
+		73145EB2911942AC53258699 /* PairingScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9484926C7BD805E7813BD0 /* PairingScannerView.swift */; };
 		7B2D2D7DA7C685DC1BBA898B /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = A360AC1ABD0B65D97947A185 /* KeyboardPreferences.swift */; };
 		7FADE222FD44945C19726566 /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D89402A128DB78CAA390D8 /* SharedStore.swift */; };
 		7FC7AE9008AF75BBD234A5F2 /* KeyboardURLLauncher.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D5D36117A0F57109452184B /* KeyboardURLLauncher.m */; };
@@ -48,11 +52,13 @@
 		A51E936B352F336F6DC3E5C4 /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37BD648DCFB7D3452241CE1 /* GatewayEndpoint.swift */; };
 		A85EC9BE7705E8D58222B60A /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703439CBBE8F06E5A7449339 /* AppConfiguration.swift */; };
 		A907BA2F465E61A41742F991 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799A203DEDA091866FFBA4E /* TextInsertion.swift */; };
+		A9483EF6A5B7DC48524556EE /* PairingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D16BA539DADFFDC84CA902 /* PairingPayload.swift */; };
 		ADEF8CAFC4B716BE8AA943D9 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703439CBBE8F06E5A7449339 /* AppConfiguration.swift */; };
 		B1E3C93E42A9D6EA60E6D71F /* QuickDictationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119E8C9BE1BEB7517D444CD /* QuickDictationAvailability.swift */; };
 		BB67C1C32DDD3B3CD47BE69D /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6FDBFE79701D7096F59E9B7 /* KeychainStore.swift */; };
 		C1C4D93A37B6DD6518B88853 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799A203DEDA091866FFBA4E /* TextInsertion.swift */; };
 		C2E67FA8A3749C07F7B066E8 /* SessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13384D76D40D7BBB5882E472 /* SessionRecord.swift */; };
+		C4E1E85C9B1318F072E5E263 /* PairingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D16BA539DADFFDC84CA902 /* PairingPayload.swift */; };
 		C9D54338613F090FA032FC5F /* AudioCapturePipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E21137C2267571197E0DE15 /* AudioCapturePipeline.swift */; };
 		CADE84CFE603159DE75478D3 /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = A360AC1ABD0B65D97947A185 /* KeyboardPreferences.swift */; };
 		CADEEDDCC7655AADD5A941CF /* LocalFlowLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764115ED713E3CD2933B2E9E /* LocalFlowLiveActivity.swift */; };
@@ -110,6 +116,7 @@
 		0971907F8807AF4111357EAA /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
 		13384D76D40D7BBB5882E472 /* SessionRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRecord.swift; sourceTree = "<group>"; };
 		1E50ACD74CADDD0BB62D1222 /* GatewayClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayClient.swift; sourceTree = "<group>"; };
+		2A9484926C7BD805E7813BD0 /* PairingScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScannerView.swift; sourceTree = "<group>"; };
 		2AD7CA27F30AE6D9A5375898 /* KeyGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyGridView.swift; sourceTree = "<group>"; };
 		2C43220C98C2F3DADD48D714 /* LocalFlowKeyboard.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LocalFlowKeyboard.entitlements; sourceTree = "<group>"; };
 		2EE35659190071F646E5F538 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -117,6 +124,7 @@
 		3527B7F09F5339E5E0D465D7 /* KeyboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardViewController.swift; sourceTree = "<group>"; };
 		3B6FBCD6D0BA52C87B1D6F01 /* LocalFlowApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFlowApp.swift; sourceTree = "<group>"; };
 		3D5D36117A0F57109452184B /* KeyboardURLLauncher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KeyboardURLLauncher.m; sourceTree = "<group>"; };
+		4344F731096BD514A985FFCA /* PairingPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingPayloadTests.swift; sourceTree = "<group>"; };
 		47D89402A128DB78CAA390D8 /* SharedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStore.swift; sourceTree = "<group>"; };
 		547EF78AB18AB0C5D0561123 /* TranscriptHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptHistoryView.swift; sourceTree = "<group>"; };
 		5B71284AEFECD863402492DB /* LocalFlowLiveActivity.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = LocalFlowLiveActivity.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -135,6 +143,7 @@
 		95CB0C8B98437D563967E3A0 /* LocalFlowApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LocalFlowApp.entitlements; sourceTree = "<group>"; };
 		9BA93B9361CE2B8110A782AA /* LocalFlowKeyboard-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "LocalFlowKeyboard-Bridging-Header.h"; sourceTree = "<group>"; };
 		A360AC1ABD0B65D97947A185 /* KeyboardPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPreferences.swift; sourceTree = "<group>"; };
+		A3D16BA539DADFFDC84CA902 /* PairingPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingPayload.swift; sourceTree = "<group>"; };
 		A6FDBFE79701D7096F59E9B7 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
 		B1C36285B8875EB38D290483 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		B29431D5C04702EAC4660679 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -194,6 +203,7 @@
 			children = (
 				714EAEF5499752246C9E5FBA /* ContentView.swift */,
 				3B6FBCD6D0BA52C87B1D6F01 /* LocalFlowApp.swift */,
+				2A9484926C7BD805E7813BD0 /* PairingScannerView.swift */,
 				B29431D5C04702EAC4660679 /* SettingsView.swift */,
 				C521D43922FDDC9DE93B9117 /* SetupChecklist.swift */,
 				547EF78AB18AB0C5D0561123 /* TranscriptHistoryView.swift */,
@@ -216,6 +226,7 @@
 			children = (
 				32903D1AECF2E8F3A4EB8DB6 /* AudioCaptureTests.swift */,
 				FB2D93BC8D9A8F925C00A507 /* KeyGridLayoutTests.swift */,
+				4344F731096BD514A985FFCA /* PairingPayloadTests.swift */,
 				7149F16802909BA09B07B761 /* SessionRecordTests.swift */,
 			);
 			path = LocalFlowTests;
@@ -228,6 +239,7 @@
 				F37BD648DCFB7D3452241CE1 /* GatewayEndpoint.swift */,
 				A360AC1ABD0B65D97947A185 /* KeyboardPreferences.swift */,
 				8B4D700966610E77B503A6E8 /* KeyboardStatus.swift */,
+				A3D16BA539DADFFDC84CA902 /* PairingPayload.swift */,
 				9119E8C9BE1BEB7517D444CD /* QuickDictationAvailability.swift */,
 				13384D76D40D7BBB5882E472 /* SessionRecord.swift */,
 				47D89402A128DB78CAA390D8 /* SharedStore.swift */,
@@ -420,6 +432,7 @@
 				058BC439CA6C261AE5922069 /* KeyboardStatus.swift in Sources */,
 				E53E4617EAC4024DE1C82257 /* LocalFlowActivityAttributes.swift in Sources */,
 				CADEEDDCC7655AADD5A941CF /* LocalFlowLiveActivity.swift in Sources */,
+				A9483EF6A5B7DC48524556EE /* PairingPayload.swift in Sources */,
 				4CA5ACE8C47B723822AAEAD9 /* QuickDictationAvailability.swift in Sources */,
 				42DF37B557FDD34042704FE7 /* SessionRecord.swift in Sources */,
 				438B7DBF85706EAA0D4FAB47 /* SharedStore.swift in Sources */,
@@ -440,6 +453,7 @@
 				A39BD12BBDBA5AE380F363B0 /* KeyboardStatus.swift in Sources */,
 				7FC7AE9008AF75BBD234A5F2 /* KeyboardURLLauncher.m in Sources */,
 				5337F224DF24B3587A6BD5C0 /* KeyboardViewController.swift in Sources */,
+				C4E1E85C9B1318F072E5E263 /* PairingPayload.swift in Sources */,
 				B1E3C93E42A9D6EA60E6D71F /* QuickDictationAvailability.swift in Sources */,
 				C2E67FA8A3749C07F7B066E8 /* SessionRecord.swift in Sources */,
 				D0CB76085C400240A5C35E97 /* SharedStore.swift in Sources */,
@@ -461,6 +475,8 @@
 				F1757844C110E137D8959C4A /* KeyView.swift in Sources */,
 				7B2D2D7DA7C685DC1BBA898B /* KeyboardPreferences.swift in Sources */,
 				26C0719CEC4DDCB0BA08AAC4 /* KeyboardStatus.swift in Sources */,
+				0AD5017F623BBA820A437FDA /* PairingPayload.swift in Sources */,
+				2BE3127F30D991B02C70C5D9 /* PairingPayloadTests.swift in Sources */,
 				DEA1AA9E14DB93DBC2951D89 /* QuickDictationAvailability.swift in Sources */,
 				465471C98F093574D3D9E064 /* SessionRecord.swift in Sources */,
 				84871365FA21E67F105B0593 /* SessionRecordTests.swift in Sources */,
@@ -486,6 +502,8 @@
 				2EFD17B37B8F0B12A4D02D71 /* LiveActivityManager.swift in Sources */,
 				88E09EC724D66A3D8B62D866 /* LocalFlowActivityAttributes.swift in Sources */,
 				40F7DEDC700B2C334FC86C17 /* LocalFlowApp.swift in Sources */,
+				3D9F43741DE7FD79F1D7BBD4 /* PairingPayload.swift in Sources */,
+				73145EB2911942AC53258699 /* PairingScannerView.swift in Sources */,
 				09F4AAAEDA5288F98A21F5BB /* QuickDictationAvailability.swift in Sources */,
 				EBAC4D63FB9EFE4E2920FEF6 /* RecordingCoordinator.swift in Sources */,
 				2B31542654F871DCD77744DA /* SessionRecord.swift in Sources */,

--- a/ios/LocalFlowApp/App/PairingScannerView.swift
+++ b/ios/LocalFlowApp/App/PairingScannerView.swift
@@ -1,0 +1,149 @@
+@preconcurrency import AVFoundation
+import SwiftUI
+import UIKit
+
+/// A native camera preview which only accepts the authenticated Local Flow QR
+/// document. Other QR codes are ignored so the user can keep scanning.
+struct PairingScannerView: UIViewControllerRepresentable {
+    let paired: (PairingPayload.Value) -> Void
+    let unavailable: (String) -> Void
+
+    func makeUIViewController(context: Context) -> PairingScannerViewController {
+        PairingScannerViewController(paired: paired, unavailable: unavailable)
+    }
+
+    func updateUIViewController(_ uiViewController: PairingScannerViewController, context: Context) {}
+}
+
+@MainActor
+final class PairingScannerViewController: UIViewController, @preconcurrency AVCaptureMetadataOutputObjectsDelegate {
+    private let captureSession = AVCaptureSession()
+    private let sessionQueue = DispatchQueue(label: "io.github.mrsunglasses.localflow.pairing-camera")
+    private let paired: (PairingPayload.Value) -> Void
+    private let unavailable: (String) -> Void
+    private var hasPaired = false
+    private var isCameraConfigured = false
+
+    init(
+        paired: @escaping (PairingPayload.Value) -> Void,
+        unavailable: @escaping (String) -> Void
+    ) {
+        self.paired = paired
+        self.unavailable = unavailable
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+        configureCamera()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        guard isCameraConfigured else { return }
+        let captureSession = captureSession
+        sessionQueue.async {
+            guard !captureSession.isRunning else { return }
+            captureSession.startRunning()
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        let captureSession = captureSession
+        sessionQueue.async {
+            guard captureSession.isRunning else { return }
+            captureSession.stopRunning()
+        }
+    }
+
+    private func configureCamera() {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            installCamera()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    granted ? self.installCamera() : self.reportUnavailable(
+                        "Camera access is required to scan the pairing QR code."
+                    )
+                }
+            }
+        case .denied, .restricted:
+            reportUnavailable("Camera access is required to scan the pairing QR code.")
+        @unknown default:
+            reportUnavailable("This device cannot grant camera access for QR pairing.")
+        }
+    }
+
+    private func installCamera() {
+        guard captureSession.inputs.isEmpty else { return }
+        guard let camera = AVCaptureDevice.default(for: .video) else {
+            reportUnavailable("No camera is available to scan the pairing QR code.")
+            return
+        }
+
+        do {
+            let input = try AVCaptureDeviceInput(device: camera)
+            guard captureSession.canAddInput(input) else {
+                reportUnavailable("The camera could not be configured for QR pairing.")
+                return
+            }
+            captureSession.addInput(input)
+
+            let output = AVCaptureMetadataOutput()
+            guard captureSession.canAddOutput(output) else {
+                reportUnavailable("The camera could not be configured for QR pairing.")
+                return
+            }
+            captureSession.addOutput(output)
+            // The controller is main-actor isolated (like UIViewController),
+            // so deliver metadata there before updating its state or SwiftUI.
+            output.setMetadataObjectsDelegate(self, queue: .main)
+            output.metadataObjectTypes = [.qr]
+            isCameraConfigured = true
+
+            let preview = AVCaptureVideoPreviewLayer(session: captureSession)
+            preview.frame = view.bounds
+            preview.videoGravity = .resizeAspectFill
+            view.layer.addSublayer(preview)
+            let captureSession = captureSession
+            sessionQueue.async {
+                guard !captureSession.isRunning else { return }
+                captureSession.startRunning()
+            }
+        } catch {
+            reportUnavailable("The camera could not be opened for QR pairing.")
+        }
+    }
+
+    func metadataOutput(
+        _ output: AVCaptureMetadataOutput,
+        didOutput metadataObjects: [AVMetadataObject],
+        from connection: AVCaptureConnection
+    ) {
+        guard !hasPaired,
+              let readable = metadataObjects.compactMap({ $0 as? AVMetadataMachineReadableCodeObject })
+                  .first(where: { $0.type == .qr }),
+              let text = readable.stringValue,
+              case let .success(value) = PairingPayload.parse(text)
+        else { return }
+
+        hasPaired = true
+        captureSession.stopRunning()
+        DispatchQueue.main.async { [weak self] in
+            self?.paired(value)
+        }
+    }
+
+    private func reportUnavailable(_ message: String) {
+        unavailable(message)
+    }
+}

--- a/ios/LocalFlowApp/App/SettingsView.swift
+++ b/ios/LocalFlowApp/App/SettingsView.swift
@@ -31,6 +31,7 @@ struct SettingsView: View {
     ) private var microphonePreferenceRawValue = MicrophonePreference.automatic.rawValue
     @State private var token = ""
     @State private var isTestingGateway = false
+    @State private var isShowingPairingScanner = false
 
     var body: some View {
         List {
@@ -45,6 +46,13 @@ struct SettingsView: View {
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
         .task { token = (try? KeychainStore.loadToken()) ?? "" }
+        .sheet(isPresented: $isShowingPairingScanner) {
+            PairingScannerView(
+                paired: applyPairing,
+                unavailable: handleScannerUnavailable
+            )
+            .ignoresSafeArea()
+        }
         .onChange(of: gatewayURL) {
             healthMessage = "Not tested"
             gatewayEngine = ""
@@ -54,6 +62,19 @@ struct SettingsView: View {
 
     private var gatewaySection: some View {
         Section("Transcription gateway") {
+            Button {
+                isShowingPairingScanner = true
+            } label: {
+                Label("Scan pairing QR code", systemImage: "qrcode.viewfinder")
+            }
+
+            Text(
+                "Open Overview in the gateway WebUI, then scan its Pair phone app QR "
+                    + "to fill the address and bearer token automatically."
+            )
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+
             TextField(
                 "http://homelabone:8765 or https://dictation.example.com",
                 text: $gatewayURL
@@ -262,6 +283,22 @@ struct SettingsView: View {
 
     private var validatedGatewayURL: URL? {
         GatewayEndpoint.validatedURL(from: gatewayURL)
+    }
+
+    @MainActor
+    private func applyPairing(_ pairing: PairingPayload.Value) {
+        isShowingPairingScanner = false
+        gatewayURL = pairing.url.absoluteString
+        token = pairing.token
+        Task { await saveAndTestGateway() }
+    }
+
+    @MainActor
+    private func handleScannerUnavailable(_ message: String) {
+        isShowingPairingScanner = false
+        healthMessage = message
+        gatewayEngine = ""
+        gatewayEngineReady = false
     }
 
     @MainActor

--- a/ios/LocalFlowApp/Info.plist
+++ b/ios/LocalFlowApp/Info.plist
@@ -20,6 +20,8 @@
   <true/>
   <key>NSMicrophoneUsageDescription</key>
   <string>Local Flow records dictation for your configured transcription gateway and, when Quick Dictation is enabled, keeps microphone input ready for up to 10 minutes. Standby audio is discarded.</string>
+  <key>NSCameraUsageDescription</key>
+  <string>Local Flow uses the camera only when you choose to scan the gateway pairing QR code.</string>
   <key>NSLocalNetworkUsageDescription</key>
   <string>Local Flow connects to the transcription gateway you configure on your private network.</string>
   <key>NSAppTransportSecurity</key>

--- a/ios/LocalFlowShared/GatewayEndpoint.swift
+++ b/ios/LocalFlowShared/GatewayEndpoint.swift
@@ -21,4 +21,53 @@ enum GatewayEndpoint {
     static func usesUnencryptedHTTP(_ url: URL) -> Bool {
         url.scheme?.lowercased() == "http"
     }
+
+    /// Cleartext pairing is restricted to networks the user controls. This
+    /// matches the Android pairing contract; a bearer token must never be
+    /// accepted from a QR code pointing to public HTTP.
+    static func isPrivateNetworkHost(_ host: String) -> Bool {
+        let name = host
+            .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+            .lowercased()
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+        guard !name.isEmpty else { return false }
+        if name == "localhost" || isPrivateIPv4(name) || isPrivateIPv6(name) {
+            return true
+        }
+        if looksLikeIPv4(name) || name.contains(":") { return false }
+        if name.hasSuffix(".local") || name.hasSuffix(".internal") || name.hasSuffix(".home.arpa") {
+            return true
+        }
+        if name == "ts.net" || name.hasSuffix(".ts.net") { return true }
+        return !name.contains(".")
+    }
+
+    private static func looksLikeIPv4(_ host: String) -> Bool {
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        return parts.count == 4 && parts.allSatisfy { !$0.isEmpty && $0.allSatisfy(\.isNumber) }
+    }
+
+    private static func isPrivateIPv4(_ host: String) -> Bool {
+        guard looksLikeIPv4(host) else { return false }
+        let octets = host.split(separator: ".").compactMap { Int($0) }
+        guard octets.count == 4, octets.allSatisfy({ (0...255).contains($0) }) else { return false }
+        switch (octets[0], octets[1]) {
+        case (127, _), (10, _), (192, 168), (169, 254), (100, 64...127):
+            return true
+        case (172, 16...31):
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isPrivateIPv6(_ host: String) -> Bool {
+        let name = host.lowercased().split(separator: "%", maxSplits: 1).first ?? ""
+        guard name.contains(":"), name != "::1" else { return name == "::1" }
+        let firstGroup = name.split(separator: ":", omittingEmptySubsequences: false).first ?? ""
+        let paddedGroup = String(repeating: "0", count: max(0, 4 - firstGroup.count))
+            + String(firstGroup)
+        guard let prefix = Int(paddedGroup, radix: 16) else { return false }
+        return (0xfc00...0xfdff).contains(prefix) || (0xfe80...0xfebf).contains(prefix)
+    }
 }

--- a/ios/LocalFlowShared/PairingPayload.swift
+++ b/ios/LocalFlowShared/PairingPayload.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// The versioned document encoded in the gateway WebUI's phone-pairing QR.
+///
+/// Version 1 wire format:
+/// `{"v":1,"url":"http://192.168.1.20:8765","token":"..."}`
+enum PairingPayload {
+    static let version = 1
+
+    struct Value: Equatable {
+        let url: URL
+        let token: String
+    }
+
+    enum Result: Equatable {
+        case success(Value)
+        case failure(String)
+    }
+
+    static func parse(_ rawValue: String) -> Result {
+        let rawValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawValue.isEmpty else {
+            return .failure("The pairing code is empty.")
+        }
+
+        let document: Document
+        do {
+            document = try JSONDecoder().decode(Document.self, from: Data(rawValue.utf8))
+        } catch {
+            return .failure("This is not a Local Flow pairing code.")
+        }
+
+        guard document.supportedVersion == version else {
+            return .failure("This pairing code uses an unsupported version.")
+        }
+
+        let urlString = document.url.trimmingCharacters(in: .whitespacesAndNewlines)
+        let token = document.token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !urlString.isEmpty else {
+            return .failure("The pairing code is missing a gateway address.")
+        }
+        guard !token.isEmpty else {
+            return .failure("The pairing code is missing a bearer token.")
+        }
+        guard token.count >= 32 else {
+            return .failure("The pairing token looks too short to be valid.")
+        }
+        guard let url = GatewayEndpoint.validatedURL(from: urlString) else {
+            return .failure("The pairing code has an invalid gateway address.")
+        }
+        if GatewayEndpoint.usesUnencryptedHTTP(url),
+           !GatewayEndpoint.isPrivateNetworkHost(url.host ?? "")
+        {
+            let host = url.host ?? "This host"
+            return .failure(
+                "\(host) is reachable from the public internet, so it needs https://."
+            )
+        }
+
+        return .success(Value(url: url, token: token))
+    }
+}
+
+private extension PairingPayload {
+    struct Document: Decodable {
+        let v: Int?
+        let legacyVersion: Int?
+        let url: String
+        let token: String
+
+        enum CodingKeys: String, CodingKey {
+            case v
+            case legacyVersion = "version"
+            case url
+            case token
+        }
+
+        var supportedVersion: Int? { v ?? legacyVersion }
+    }
+}

--- a/ios/LocalFlowTests/PairingPayloadTests.swift
+++ b/ios/LocalFlowTests/PairingPayloadTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+
+struct PairingPayloadTests {
+    @Test func parsesVersionOneGatewayDocument() {
+        let result = PairingPayload.parse(
+            """
+            {"v":1,"url":"  http://192.168.1.75:8765/  ","token":"  test-token-with-at-least-thirty-two-characters  "}
+            """
+        )
+
+        #expect(
+            result == .success(
+                .init(
+                    url: URL(string: "http://192.168.1.75:8765/")!,
+                    token: "test-token-with-at-least-thirty-two-characters"
+                )
+            )
+        )
+    }
+
+    @Test func acceptsLegacyVersionKey() {
+        let result = PairingPayload.parse(
+            """
+            {"version":1,"url":"https://dictation.example.com","token":"test-token-with-at-least-thirty-two-characters"}
+            """
+        )
+
+        guard case let .success(value) = result else {
+            Issue.record("Expected a valid pairing document")
+            return
+        }
+        #expect(value.url == URL(string: "https://dictation.example.com")!)
+    }
+
+    @Test func rejectsInvalidPairingDocuments() {
+        let shortToken = "{\"v\":1,\"url\":\"http://192.168.1.20:8765\",\"token\":\"too-short\"}"
+        let wrongVersion = "{\"v\":99,\"url\":\"http://192.168.1.20:8765\",\"token\":\"test-token-with-at-least-thirty-two-characters\"}"
+        let publicHTTP = "{\"v\":1,\"url\":\"http://flow.example.com:8765\",\"token\":\"test-token-with-at-least-thirty-two-characters\"}"
+
+        for value in ["", "not-json", shortToken, wrongVersion, publicHTTP] {
+            guard case .failure = PairingPayload.parse(value) else {
+                Issue.record("Expected invalid pairing document: \(value)")
+                continue
+            }
+        }
+    }
+}

--- a/server/README.md
+++ b/server/README.md
@@ -95,8 +95,8 @@ LOCALFLOW_BIND_HOST=127.0.0.1 uv run localflow-server
 ### Phone pairing QR
 
 After you authenticate in the WebUI, the Overview page shows a **Pair phone app**
-QR. The Android app scans it to fill the gateway URL and bearer token. The code
-encodes a versioned JSON payload:
+QR. The iPhone and Android apps scan it to fill the gateway URL and bearer token.
+The code encodes a versioned JSON payload:
 
 ```json
 {"v":1,"url":"http://192.168.1.20:8765","token":"..."}

--- a/server/app/fragments.py
+++ b/server/app/fragments.py
@@ -443,7 +443,7 @@ def pairing_fragment(
     return f"""
       <div class="card" id="pairing-card">
         <h2>Pair phone app</h2>
-        <p class="muted">Scan this QR in Local Flow on Android to fill the gateway
+        <p class="muted">Scan this QR in Local Flow on iPhone or Android to fill the gateway
           address and bearer token. Keep the WebUI private — the code includes the
           live token.</p>
         <div class="pairing-layout">

--- a/server/app/pairing.py
+++ b/server/app/pairing.py
@@ -1,6 +1,6 @@
 """Phone pairing payload and QR for the authenticated WebUI.
 
-The payload is a compact JSON document the Android app scans:
+The payload is a compact JSON document the iPhone and Android apps scan:
 
     {"v":1,"url":"http://192.168.1.20:8765","token":"..."}
 


### PR DESCRIPTION
## Summary
- add a native iOS camera QR scanner in Settings for the gateway WebUI pairing code
- validate the versioned URL/token payload, reject unsafe public HTTP pairing targets, store the token in Keychain, and immediately test the connection
- declare camera usage and update the Xcode project, test coverage, WebUI copy, and setup documentation for iPhone support

## Verification
- `xcodebuild -project ios/LocalFlow.xcodeproj -scheme LocalFlow -configuration Debug -destination "platform=iOS,id=C5C66FC9-13EC-5AE9-87DE-2520D3A884D6" build -quiet`
- `xcodebuild -project ios/LocalFlow.xcodeproj -scheme LocalFlow -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 16 Pro" test -only-testing:LocalFlowTests/PairingPayloadTests -quiet`
- `uv run pytest tests/test_pairing.py tests/test_pairing_api.py -q` (7 passed)
- `plutil -lint ios/LocalFlowApp/Info.plist`

Physical-device QR scanning remains to be exercised with a live gateway pairing code.