### PR TITLE
feat: guided setup checklist and whisper first-run reliability

### DIFF
--- a/ios/LocalFlowApp/App/ContentView.swift
+++ b/ios/LocalFlowApp/App/ContentView.swift
@@ -14,6 +14,8 @@ struct ContentView: View {
     @State private var keyboardStatus: KeyboardStatus?
     @State private var keyboardStepDetail = ContentView.keyboardSetupHint
     @State private var testText = ""
+    @State private var showsSettings = false
+    @State private var showsKeyboardSetup = false
 
     private static let keyboardSetupHint =
         "Enable Local Flow under Settings › General › Keyboards and allow Full "
@@ -23,7 +25,7 @@ struct ContentView: View {
         NavigationStack {
             List {
                 if !isSetupComplete {
-                    SetupChecklistView(steps: setupSteps, recheck: reloadKeyboardStatus)
+                    SetupChecklistView(steps: setupSteps, recheck: recheckSetup)
                 }
                 sessionSection
                 transcriptSection
@@ -40,17 +42,21 @@ struct ContentView: View {
                     .accessibilityLabel("Settings")
                 }
             }
+            .navigationDestination(isPresented: $showsSettings) {
+                SettingsView()
+            }
             .task {
-                reloadKeyboardStatus()
+                await recheckSetup()
                 await coordinator.recoverRecentSession()
                 coordinator.prepareQuickDictationIfEnabled()
-                await coordinator.refreshGatewayHealth()
             }
             .onChange(of: scenePhase) { previousPhase, currentPhase in
                 guard previousPhase != .active, currentPhase == .active else { return }
-                reloadKeyboardStatus()
-                Task { await coordinator.refreshGatewayHealth() }
+                Task { await recheckSetup() }
             }
+        }
+        .sheet(isPresented: $showsKeyboardSetup) {
+            KeyboardSetupGuide(verify: verifyKeyboardAccess)
         }
         .overlay {
             if showsKeyboardReturnGuide {
@@ -75,21 +81,25 @@ struct ContentView: View {
                 detail: gatewayEngineReady
                     ? "Gateway, token, and model are ready."
                     : "Add the gateway URL and pairing token in Settings, then tap Save and test.",
-                isComplete: gatewayEngineReady
+                isComplete: gatewayEngineReady,
+                actionTitle: "Set up gateway",
+                action: { showsSettings = true }
             ),
             SetupStep(
                 id: "microphone",
                 title: "Allow microphone access",
-                detail: coordinator.microphonePermissionGranted
-                    ? "Local Flow can record on this iPhone."
-                    : "Recording happens in this app; the keyboard only receives the transcript.",
-                isComplete: coordinator.microphonePermissionGranted
+                detail: coordinator.microphonePermissionState.setupDetail,
+                isComplete: coordinator.microphonePermissionGranted,
+                actionTitle: coordinator.microphonePermissionState.actionTitle,
+                action: microphoneSetupAction
             ),
             SetupStep(
                 id: "keyboard",
                 title: "Add the keyboard with Full Access",
                 detail: keyboardStepDetail,
-                isComplete: keyboardStatus?.hasFullAccess == true
+                isComplete: keyboardStatus?.hasFullAccess == true,
+                actionTitle: "Set up keyboard access",
+                action: { showsKeyboardSetup = true }
             ),
         ]
     }
@@ -101,12 +111,41 @@ struct ContentView: View {
     /// Date formatting is comparatively expensive and `body` re-evaluates
     /// often, so the string is built when the status actually changes.
     private func reloadKeyboardStatus() {
+        coordinator.refreshMicrophonePermission()
         let status = coordinator.keyboardStatus()
         keyboardStatus = status
-        keyboardStepDetail = status.map {
-            let seen = $0.lastSeenAt.formatted(date: .abbreviated, time: .shortened)
-            return "Keyboard last active \(seen)."
-        } ?? Self.keyboardSetupHint
+        switch status {
+        case let .some(status) where status.hasFullAccess:
+            let seen = status.lastSeenAt.formatted(date: .abbreviated, time: .shortened)
+            keyboardStepDetail = "Keyboard ready. Last opened \(seen)."
+        case .some:
+            keyboardStepDetail =
+                "The keyboard was added, but Full Access is still off. Enable it, then open the Local Flow keyboard once."
+        case .none:
+            keyboardStepDetail = Self.keyboardSetupHint
+        }
+    }
+
+    private func recheckSetup() async {
+        reloadKeyboardStatus()
+        await coordinator.refreshGatewayHealth()
+        reloadKeyboardStatus()
+    }
+
+    private func verifyKeyboardAccess() {
+        Task { await recheckSetup() }
+    }
+
+    private func microphoneSetupAction() {
+        switch coordinator.microphonePermissionState {
+        case .notDetermined:
+            coordinator.requestMicrophonePermission()
+        case .denied:
+            guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+            UIApplication.shared.open(url)
+        case .granted:
+            break
+        }
     }
 
     // MARK: - Sections
@@ -345,5 +384,108 @@ private struct KeyboardReturnGuide: View {
                 arrowOffset = 18
             }
         }
+    }
+}
+
+struct KeyboardSetupGuide: View {
+    @Environment(\.dismiss) private var dismiss
+    let verify: () -> Void
+    @State private var copiedSettingsPath = false
+
+    private let settingsPath =
+        "Settings → General → Keyboard → Keyboards → Local Flow → Allow Full Access"
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    Label(
+                        "The Local Flow keyboard can insert your transcript into any text field. It asks the Local Flow app to record because iOS does not allow keyboards to use the microphone.",
+                        systemImage: "keyboard.chevron.compact.down"
+                    )
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                }
+
+                Section("Add Local Flow") {
+                    setupRow(
+                        number: 1,
+                        title: "Open the Settings app",
+                        detail: "Apple does not provide a public link apps can use to open this specific screen."
+                    )
+                    setupRow(
+                        number: 2,
+                        title: "Go to General → Keyboard → Keyboards",
+                        detail: "Choose Add New Keyboard…"
+                    )
+                    setupRow(
+                        number: 3,
+                        title: "Choose Local Flow",
+                        detail: "Then tap Local Flow in the keyboard list and turn on Allow Full Access."
+                    )
+                }
+
+                Section {
+                    Button {
+                        UIPasteboard.general.string = settingsPath
+                        copiedSettingsPath = true
+                    } label: {
+                        Label(
+                            copiedSettingsPath ? "Settings path copied" : "Copy Settings path",
+                            systemImage: copiedSettingsPath ? "checkmark" : "doc.on.doc"
+                        )
+                    }
+                    Text(settingsPath)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                } header: {
+                    Text("Make it quicker")
+                } footer: {
+                    Text("After enabling Full Access, open Local Flow in any text field once so the app can confirm it.")
+                }
+
+                Section("Why Full Access?") {
+                    Text(
+                        "It lets the keyboard use the shared Local Flow session and send recordings to only the gateway you configure. The keyboard itself never records audio."
+                    )
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                }
+
+                Section {
+                    Button("I’ve enabled Full Access") {
+                        verify()
+                        dismiss()
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+            .navigationTitle("Set up keyboard")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    private func setupRow(number: Int, title: String, detail: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Text("\(number)")
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(.white)
+                .frame(width: 24, height: 24)
+                .background(.tint, in: Circle())
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title).font(.subheadline.weight(.semibold))
+                Text(detail)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .combine)
     }
 }

--- a/ios/LocalFlowApp/App/SettingsView.swift
+++ b/ios/LocalFlowApp/App/SettingsView.swift
@@ -3,6 +3,7 @@ import UIKit
 
 struct SettingsView: View {
     @Environment(RecordingCoordinator.self) private var coordinator
+    @Environment(\.scenePhase) private var scenePhase
     @AppStorage("gatewayURL") private var gatewayURL = ""
     @AppStorage(GatewayStatusPreferences.healthMessageKey)
     private var healthMessage = "Not tested"
@@ -32,6 +33,7 @@ struct SettingsView: View {
     @State private var token = ""
     @State private var isTestingGateway = false
     @State private var isShowingPairingScanner = false
+    @State private var showsKeyboardSetup = false
 
     var body: some View {
         List {
@@ -45,13 +47,23 @@ struct SettingsView: View {
         }
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
-        .task { token = (try? KeychainStore.loadToken()) ?? "" }
+        .task {
+            token = (try? KeychainStore.loadToken()) ?? ""
+            coordinator.refreshMicrophonePermission()
+        }
+        .onChange(of: scenePhase) { _, phase in
+            guard phase == .active else { return }
+            coordinator.refreshMicrophonePermission()
+        }
         .sheet(isPresented: $isShowingPairingScanner) {
             PairingScannerView(
                 paired: applyPairing,
                 unavailable: handleScannerUnavailable
             )
             .ignoresSafeArea()
+        }
+        .sheet(isPresented: $showsKeyboardSetup) {
+            KeyboardSetupGuide(verify: coordinator.refreshMicrophonePermission)
         }
         .onChange(of: gatewayURL) {
             healthMessage = "Not tested"
@@ -242,17 +254,36 @@ struct SettingsView: View {
 
     private var permissionsSection: some View {
         Section("Permissions") {
-            Button("Request microphone permission") {
-                coordinator.requestMicrophonePermission()
+            LabeledContent("Microphone") {
+                switch coordinator.microphonePermissionState {
+                case .granted:
+                    Label("Allowed", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                case .notDetermined:
+                    Text("Not requested")
+                        .foregroundStyle(.secondary)
+                case .denied:
+                    Text("Off")
+                        .foregroundStyle(.red)
+                }
             }
-            Button("Open Keyboard Settings") {
-                guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
-                UIApplication.shared.open(url)
+            switch coordinator.microphonePermissionState {
+            case .notDetermined:
+                Button("Allow microphone") {
+                    coordinator.requestMicrophonePermission()
+                }
+            case .denied:
+                Button("Open Local Flow Settings") {
+                    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                    UIApplication.shared.open(url)
+                }
+            case .granted:
+                EmptyView()
             }
+            Button("Show keyboard setup steps") { showsKeyboardSetup = true }
             Text(
-                "Enable Local Flow under Keyboards and allow Full Access. "
-                    + "Full Access is used only for shared session state and communication "
-                    + "with your configured gateway."
+                "Full Access is managed under Settings → General → Keyboard → Keyboards. "
+                    + "It is used only for shared session state and communication with your configured gateway."
             )
             .font(.footnote)
             .foregroundStyle(.secondary)

--- a/ios/LocalFlowApp/App/SetupChecklist.swift
+++ b/ios/LocalFlowApp/App/SetupChecklist.swift
@@ -5,6 +5,8 @@ struct SetupStep: Identifiable {
     let title: String
     let detail: String
     let isComplete: Bool
+    let actionTitle: String?
+    let action: (() -> Void)?
 }
 
 /// The dominant failure mode for this app is an unfinished setup spread across
@@ -12,34 +14,74 @@ struct SetupStep: Identifiable {
 /// as a checklist beats burying it in prose.
 struct SetupChecklistView: View {
     let steps: [SetupStep]
-    let recheck: () -> Void
+    let recheck: @MainActor () async -> Void
+    @State private var isChecking = false
+    @State private var lastCheckedAt: Date?
 
     var body: some View {
         Section {
             ForEach(steps) { step in
-                HStack(alignment: .firstTextBaseline, spacing: 12) {
-                    Image(systemName: step.isComplete ? "checkmark.circle.fill" : "circle")
-                        .foregroundStyle(step.isComplete ? .green : .secondary)
-                        .font(.title3)
-                        .accessibilityHidden(true)
-                    VStack(alignment: .leading, spacing: 3) {
-                        Text(step.title)
-                            .font(.subheadline.weight(.semibold))
-                        Text(step.detail)
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(alignment: .firstTextBaseline, spacing: 12) {
+                        Image(systemName: step.isComplete ? "checkmark.circle.fill" : "circle")
+                            .foregroundStyle(step.isComplete ? .green : .secondary)
+                            .font(.title3)
+                            .accessibilityHidden(true)
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(step.title)
+                                .font(.subheadline.weight(.semibold))
+                            Text(step.detail)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityValue(step.isComplete ? "Done" : "Not done")
+
+                    if !step.isComplete,
+                       let actionTitle = step.actionTitle,
+                       let action = step.action
+                    {
+                        Button(actionTitle, action: action)
+                            .buttonStyle(.bordered)
                     }
                 }
-                .accessibilityElement(children: .combine)
-                .accessibilityValue(step.isComplete ? "Done" : "Not done")
             }
 
-            Button("Check again", action: recheck)
+            Button {
+                Task {
+                    isChecking = true
+                    await recheck()
+                    lastCheckedAt = Date()
+                    isChecking = false
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    if isChecking {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                    Text(isChecking ? "Checking setup…" : "Refresh setup status")
+                }
+            }
+            .disabled(isChecking)
+            .accessibilityHint("Checks the microphone, transcription gateway, and keyboard status.")
+
+            if let lastCheckedAt {
+                Label(
+                    "Status refreshed \(lastCheckedAt.formatted(date: .omitted, time: .shortened))",
+                    systemImage: "checkmark.circle"
+                )
                 .font(.footnote)
+                .foregroundStyle(.secondary)
+            }
         } header: {
             Text("Finish setup")
         } footer: {
-            Text("Local Flow needs all three before the keyboard can dictate.")
+            Text(
+                "Refresh checks the microphone and gateway immediately. Keyboard access is confirmed when you open the Local Flow keyboard once."
+            )
         }
     }
 }

--- a/ios/LocalFlowApp/Networking/GatewayClient.swift
+++ b/ios/LocalFlowApp/Networking/GatewayClient.swift
@@ -101,7 +101,10 @@ struct GatewayClient: Sendable {
     func finish(sessionID: UUID) async throws -> GatewaySession {
         var request = URLRequest(url: endpoint("v1/sessions/\(sessionID.uuidString.lowercased())/finish"))
         request.httpMethod = "POST"
-        request.timeoutInterval = 90
+        // Core ML engines deliberately process one recording at a time. Allow
+        // room for a queued recording plus its own inference rather than
+        // turning a normal wait into an avoidable retry.
+        request.timeoutInterval = 540
         return try await perform(request, as: GatewaySession.self)
     }
 

--- a/ios/LocalFlowApp/Sessions/RecordingCoordinator.swift
+++ b/ios/LocalFlowApp/Sessions/RecordingCoordinator.swift
@@ -1,6 +1,45 @@
+import AVFAudio
 import Foundation
 import SwiftUI
 import UIKit
+
+enum MicrophonePermissionState: Equatable, Sendable {
+    case notDetermined
+    case denied
+    case granted
+
+    init(_ permission: AVAudioApplication.recordPermission) {
+        switch permission {
+        case .undetermined:
+            self = .notDetermined
+        case .denied:
+            self = .denied
+        case .granted:
+            self = .granted
+        @unknown default:
+            self = .denied
+        }
+    }
+
+    var setupDetail: String {
+        switch self {
+        case .notDetermined:
+            "Local Flow needs the microphone in this app to record your dictation."
+        case .denied:
+            "Microphone access is off. Turn it on in Local Flow's Settings, then return here."
+        case .granted:
+            "Local Flow can record on this iPhone."
+        }
+    }
+
+    var actionTitle: String? {
+        switch self {
+        case .notDetermined: "Allow microphone"
+        case .denied: "Open Local Flow Settings"
+        case .granted: nil
+        }
+    }
+}
 
 @MainActor
 @Observable
@@ -9,6 +48,7 @@ final class RecordingCoordinator {
     private(set) var message: String?
     private(set) var quickDictationExpiresAt: Date?
     private(set) var currentMicrophoneName: String?
+    private(set) var microphonePermissionState: MicrophonePermissionState
     /// Kept separate from `activeRecord` so a level update several times a
     /// second invalidates only the views that draw the meter.
     private(set) var meterLevel: Float = 0
@@ -50,7 +90,7 @@ final class RecordingCoordinator {
         !recorder.isRecording && startingSessionID == nil
     }
     var microphonePermissionGranted: Bool {
-        recorder.recordPermission == .granted
+        microphonePermissionState == .granted
     }
 
     /// Setup progress the app cannot otherwise observe: iOS exposes no API for
@@ -79,6 +119,7 @@ final class RecordingCoordinator {
         // marker behind. The new app process is not warm until it arms audio.
         try? store.clearQuickDictationAvailability()
         recorder.microphonePreference = KeyboardPreferences.microphonePreference
+        microphonePermissionState = MicrophonePermissionState(recorder.recordPermission)
         recorder.onMeter = { [weak self] level in self?.persistMeter(level) }
         recorder.onMaximumDuration = { [weak self] in self?.requestFinish() }
         recorder.onInputRouteChanged = { [weak self] inputName in
@@ -115,8 +156,16 @@ final class RecordingCoordinator {
     }
 
     func requestMicrophonePermission() {
+        refreshMicrophonePermission()
+        guard microphonePermissionState == .notDetermined else {
+            message = microphonePermissionState == .granted
+                ? "Microphone access is already allowed."
+                : "Microphone access is off. Open Local Flow Settings to allow it."
+            return
+        }
         recorder.requestPermission { [weak self] granted in
             guard let self else { return }
+            self.refreshMicrophonePermission()
             if granted {
                 self.message = "Microphone permission granted."
                 if KeyboardPreferences.quickDictationEnabled {
@@ -126,6 +175,10 @@ final class RecordingCoordinator {
                 self.message = "Microphone permission denied."
             }
         }
+    }
+
+    func refreshMicrophonePermission() {
+        microphonePermissionState = MicrophonePermissionState(recorder.recordPermission)
     }
 
     func prepareQuickDictationIfEnabled() {
@@ -292,8 +345,8 @@ final class RecordingCoordinator {
     nonisolated func pruneSharedStorage() {
         let store = SharedStore.shared
         Task.detached(priority: .utility) {
-            try? store.pruneSessions()
-            try? store.pruneOrphanedAudio()
+            _ = try? store.pruneSessions()
+            _ = try? store.pruneOrphanedAudio()
         }
     }
 

--- a/server/README.md
+++ b/server/README.md
@@ -230,8 +230,10 @@ choice in the runtime configuration file.
 
 On Apple silicon, current WhisperKit CLIs expose a local `serve` mode. Local
 Flow starts it on a random `127.0.0.1` port during warmup and reuses the loaded
-Core ML model. If an older CLI does not support `serve`, transcription falls
-back to the compatible one-shot command rather than becoming unavailable.
+Core ML model. The first startup may take up to five minutes while Core ML
+compiles a newly downloaded model. If an older CLI does not support `serve`,
+transcription falls back to the compatible one-shot command rather than
+becoming unavailable.
 
 To force Handy from the environment:
 
@@ -267,6 +269,7 @@ uv run localflow-server
 | `LOCALFLOW_WHISPER_MODEL` | base model path | base model path | Fallback `whisper.cpp` model |
 | `LOCALFLOW_WHISPERKIT_BINARY` | `whisperkit-cli` | unavailable | WhisperKit executable |
 | `LOCALFLOW_RETENTION_HOURS` | `24` | `24` | Failed-session retry retention |
+| `LOCALFLOW_TRANSCRIPTION_QUEUE_WAIT_SECONDS` | `300` | `300` | How long a transcription waits for the single local-engine slot |
 | `LOCALFLOW_DELETE_SUCCESSFUL_AUDIO` | `true` | `true` | Delete source/normalized audio after success |
 
 Compose-specific variables live in `server/.env`:

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -44,6 +44,7 @@ class Settings:
     retention_hours: int = 24
     delete_successful_audio: bool = True
     maximum_concurrent_transcriptions: int = 1
+    transcription_queue_wait_seconds: int = 300
 
     def resolved_models_dir(self) -> Path:
         return self.models_dir if self.models_dir is not None else self.data_dir / "models"
@@ -107,6 +108,9 @@ class Settings:
             bind_host=os.environ.get("LOCALFLOW_BIND_HOST", "0.0.0.0"),
             port=int(os.environ.get("LOCALFLOW_PORT", "8765")),
             retention_hours=int(os.environ.get("LOCALFLOW_RETENTION_HOURS", "24")),
+            transcription_queue_wait_seconds=int(
+                os.environ.get("LOCALFLOW_TRANSCRIPTION_QUEUE_WAIT_SECONDS", "300")
+            ),
             delete_successful_audio=os.environ.get(
                 "LOCALFLOW_DELETE_SUCCESSFUL_AUDIO", "true"
             ).lower()

--- a/server/app/models/whisperkit.py
+++ b/server/app/models/whisperkit.py
@@ -28,6 +28,12 @@ class _PersistentServerUnavailable(Exception):
     """The installed CLI cannot start or reach its persistent local server."""
 
 
+# Core ML may compile a newly downloaded model before it accepts its first
+# connection. Sixty seconds routinely pushed WhisperKit into the much slower
+# one-shot fallback on an otherwise healthy Apple-silicon Mac.
+_SERVER_START_TIMEOUT_SECONDS = 300
+
+
 class WhisperKitEngine:
     """Persistent Apple-silicon WhisperKit adapter with a legacy CLI fallback."""
 
@@ -217,7 +223,7 @@ def _start_server(binary: str, model_path: Path) -> _WhisperKitServer:
         stderr=subprocess.DEVNULL,
     )
     server = _WhisperKitServer(process=process, port=port)
-    deadline = time.monotonic() + 60
+    deadline = time.monotonic() + _SERVER_START_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
         if process.poll() is not None:
             raise _PersistentServerUnavailable(

--- a/server/app/service.py
+++ b/server/app/service.py
@@ -198,13 +198,16 @@ class TranscriptionService:
     async def _acquire_transcription_slot(self) -> None:
         self.metrics.queued()
         try:
-            await asyncio.wait_for(self._transcription_slots.acquire(), timeout=0.05)
+            await asyncio.wait_for(
+                self._transcription_slots.acquire(),
+                timeout=self.settings.transcription_queue_wait_seconds,
+            )
         except TimeoutError as error:
             self.metrics.rejected()
             raise APIProblem(
                 503,
                 "engine_overloaded",
-                "The local transcription engine is busy.",
+                "The local transcription queue is full. Try again in a moment.",
                 recoverable=True,
             ) from error
         except BaseException:

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from uuid import uuid4
 
 import httpx
@@ -13,6 +14,25 @@ from app.models.base import EngineHealth
 class UnreadyEngine:
     async def health(self) -> EngineHealth:
         return EngineHealth(ready=False, name="missing-model")
+
+
+class BlockingEngine:
+    """Holds the first request so the test can prove the second one queues."""
+
+    def __init__(self) -> None:
+        self.first_started = asyncio.Event()
+        self.release_first = asyncio.Event()
+        self.calls = 0
+
+    async def health(self) -> EngineHealth:
+        return EngineHealth(ready=True, name="whisperkit:test-model")
+
+    async def transcribe(self, audio_path, options) -> str:
+        self.calls += 1
+        if self.calls == 1:
+            self.first_started.set()
+            await self.release_first.wait()
+        return "queued local transcript"
 
 
 async def test_health_is_public_and_separates_engine_readiness(
@@ -98,6 +118,58 @@ async def test_complete_flow_is_idempotent_and_deletes_successful_audio(
     assert finished.json()["transcript"] == "hello from the local model"
     assert finished_again.json()["transcript"] == finished.json()["transcript"]
     assert finished_again.json()["job_id"] == finished.json()["job_id"]
+
+
+async def test_second_transcription_waits_for_the_single_local_engine_slot(
+    tmp_path,
+    audio_bytes: bytes,
+) -> None:
+    settings = Settings(
+        token=TOKEN,
+        data_dir=tmp_path,
+        whisper_binary=tmp_path / "whisper-cli",
+        whisper_model=tmp_path / "model.bin",
+        maximum_upload_bytes=20_000,
+        transcription_queue_wait_seconds=1,
+    )
+    engine = BlockingEngine()
+    app = create_app(settings, engine=engine, normalizer=FakeNormalizer())
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as test_client:
+        session_ids = [uuid4(), uuid4()]
+        for session_id in session_ids:
+            created = await test_client.post(
+                "/v1/sessions",
+                headers=headers,
+                json={"client_session_id": str(session_id)},
+            )
+            assert created.status_code == 200
+            uploaded = await test_client.put(
+                f"/v1/sessions/{session_id}/audio",
+                headers={**headers, "Content-Type": "audio/wav"},
+                content=audio_bytes,
+            )
+            assert uploaded.status_code == 200
+
+        first = asyncio.create_task(
+            test_client.post(f"/v1/sessions/{session_ids[0]}/finish", headers=headers)
+        )
+        await asyncio.wait_for(engine.first_started.wait(), timeout=1)
+        second = asyncio.create_task(
+            test_client.post(f"/v1/sessions/{session_ids[1]}/finish", headers=headers)
+        )
+        await asyncio.sleep(0.1)
+        assert not second.done()
+
+        engine.release_first.set()
+        first_response, second_response = await asyncio.gather(first, second)
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert engine.calls == 2
 
 
 async def test_session_accepts_writing_styles_and_rejects_unknown_values(


### PR DESCRIPTION
## Summary
Improves the iOS onboarding checklist and makes the first WhisperKit transcription reliable.

## iOS
- **Actionable setup checklist**: each incomplete step (gateway, microphone, keyboard) now has its own action button, plus a manual "Refresh setup status".
- **New keyboard setup guide**: step-by-step Full Access walkthrough with a copyable Settings path.
- **Microphone permission state**: displayed live in Settings and the checklist; refreshes when the app returns to the foreground.
- **Finish timeout raised** from 90s to 540s so a queued recording behind a Core ML engine isn't retried prematurely.

## Server
- **WhisperKit serve start timeout**: 60s → 300s, so a freshly downloaded model survives Core ML compilation and is reused through the persistent server instead of dropping to the slow one-shot CLI.
- **Transcription queue**: wait up to 300s for the single engine slot (configurable via `LOCALFLOW_TRANSCRIPTION_QUEUE_WAIT_SECONDS`) instead of rejecting immediately when busy.
- Added a test covering the queued second transcription.

## Notes
Resolves the WebUI Test tab appearing stuck on "Transcribing…" for the first ~5 minutes while Core ML compiles a newly downloaded WhisperKit model.