### PR TITLE
Allow custom Tailscale IP/hostname in phone pairing QR

### DIFF
--- a/server/app/fragments.py
+++ b/server/app/fragments.py
@@ -461,6 +461,15 @@ def pairing_fragment(
                   {options}
                 </select>
               </label>
+              <form hx-get="/ui/partials/pairing" hx-target="#pairing-card" hx-swap="outerHTML">
+                <label><span>Or enter your own address (e.g. Tailscale IP)</span>
+                  <div class="row">
+                    <input name="url" type="text"
+                           placeholder="100.101.102.103 or phone.tailnet-name.ts.net" />
+                    <button type="submit" class="ghost small">Use this address</button>
+                  </div>
+                </label>
+              </form>
             </div>
             <dl class="facts">
               <div><dt>Gateway URL</dt><dd><code>{escape(selected_url)}</code></dd></div>

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -67,6 +67,7 @@ from app.pairing import (
     decode_pairing_payload,
     discover_gateway_base_urls,
     encode_pairing_payload,
+    normalize_gateway_input,
     normalize_gateway_url,
     primary_gateway_base_url,
     qr_svg_for_payload,
@@ -940,7 +941,7 @@ def create_app(
         selected: str | None
         if selected_url:
             try:
-                selected = normalize_gateway_url(selected_url)
+                selected = normalize_gateway_input(selected_url, configured.port)
             except ValueError:
                 selected = primary_gateway_base_url(configured.port)
             else:
@@ -968,7 +969,7 @@ def create_app(
         candidates = discover_gateway_base_urls(configured.port)
         if url:
             try:
-                return normalize_gateway_url(url)
+                return normalize_gateway_input(url, configured.port)
             except ValueError as error:
                 raise APIProblem(400, "invalid_pairing_url", str(error)) from error
         if not candidates:

--- a/server/app/pairing.py
+++ b/server/app/pairing.py
@@ -86,6 +86,29 @@ def normalize_gateway_url(url: str) -> str:
     return f"{parsed.scheme}://{host}{port}{path}"
 
 
+def normalize_gateway_input(raw: str, default_port: int) -> str:
+    """Normalize free-text pairing input into a gateway URL.
+
+    Lets a user paste a bare address — a Tailscale IP (``100.x.x.x``), a
+    Tailscale MagicDNS name (``phone.tailnet-name.ts.net``), or a LAN IP —
+    without typing a scheme or port. A full ``http://`` / ``https://`` URL is
+    also accepted and passed through to :func:`normalize_gateway_url`.
+    """
+    trimmed = raw.strip()
+    if not trimmed:
+        raise ValueError("Address must not be empty.")
+    if "://" not in trimmed:
+        trimmed = f"http://{trimmed}"
+    parsed = urlparse(trimmed)
+    if parsed.hostname and parsed.port is None:
+        host = parsed.hostname
+        if ":" in host:
+            host = f"[{host}]"
+        path = parsed.path or ""
+        trimmed = f"{parsed.scheme}://{host}:{default_port}{path}"
+    return normalize_gateway_url(trimmed)
+
+
 def discover_gateway_base_urls(port: int) -> list[str]:
     """Return phone-reachable gateway bases, preferred first.
 

--- a/server/tests/test_pairing.py
+++ b/server/tests/test_pairing.py
@@ -8,6 +8,7 @@ from app.pairing import (
     PAIRING_VERSION,
     decode_pairing_payload,
     encode_pairing_payload,
+    normalize_gateway_input,
     primary_gateway_base_url,
     qr_svg_for_payload,
 )
@@ -70,3 +71,27 @@ def test_qr_svg_contains_path_and_is_svg() -> None:
 def test_primary_gateway_base_url_prefers_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LOCALFLOW_PUBLIC_URL", "http://homelab.example:8765")
     assert primary_gateway_base_url(8765) == "http://homelab.example:8765"
+
+
+def test_normalize_gateway_input_adds_scheme_and_default_port() -> None:
+    assert normalize_gateway_input("100.101.102.103", 8765) == "http://100.101.102.103:8765"
+
+
+def test_normalize_gateway_input_keeps_explicit_port() -> None:
+    assert normalize_gateway_input("100.101.102.103:9000", 8765) == "http://100.101.102.103:9000"
+
+
+def test_normalize_gateway_input_accepts_tailscale_hostname() -> None:
+    assert (
+        normalize_gateway_input("phone.tailnet-name.ts.net", 8765)
+        == "http://phone.tailnet-name.ts.net:8765"
+    )
+
+
+def test_normalize_gateway_input_passes_through_full_url() -> None:
+    assert normalize_gateway_input("http://192.168.1.5:8765", 8765) == "http://192.168.1.5:8765"
+
+
+def test_normalize_gateway_input_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        normalize_gateway_input("   ", 8765)

--- a/server/tests/test_pairing_api.py
+++ b/server/tests/test_pairing_api.py
@@ -48,3 +48,31 @@ async def test_pairing_payload_and_qr(
     assert "192.168.1.75" in partial.text
     # QR is inlined so the browser never needs an unauthenticated <img> fetch.
     assert "<svg" in partial.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_pairing_accepts_bare_tailscale_address(
+    client: httpx.AsyncClient,
+    authorization: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOCALFLOW_PUBLIC_URL", "http://192.168.1.75:8765")
+
+    partial = await client.get(
+        "/ui/partials/pairing",
+        headers=authorization,
+        params={"url": "100.101.102.103"},
+    )
+    assert partial.status_code == 200
+    assert "http://100.101.102.103:8765" in partial.text
+
+    api = await client.get(
+        "/v1/admin/pairing",
+        headers=authorization,
+        params={"url": "100.101.102.103"},
+    )
+    assert api.status_code == 200
+    body = api.json()
+    assert body["url"] == "http://100.101.102.103:8765"
+    decoded = decode_pairing_payload(body["payload"])
+    assert decoded.url == "http://100.101.102.103:8765"


### PR DESCRIPTION
## Summary
- Adds a free-text address field under the existing address dropdown on the "Pair phone app" WebUI card, so users can type their own Tailscale IP (`100.x.x.x`), Tailscale MagicDNS hostname (`phone.tailnet-name.ts.net`), or any other reachable address, and have it embedded directly in the pairing QR.
- Adds `normalize_gateway_input()` in `app/pairing.py` to accept bare IPs/hostnames (defaulting to `http://` and the gateway's configured port) alongside full `http(s)://` URLs, and wires it into the `/ui/partials/pairing`, `/v1/admin/pairing`, and `/v1/admin/pairing/qr.svg` routes.
- Previously users were limited to the auto-discovered LAN/Tailscale candidates; this covers cases where discovery misses the right interface or the phone is reached via a different tailnet address.

## Test plan
- [x] `pytest tests/test_pairing.py tests/test_pairing_api.py -q` — all pass, including new tests for bare IP, IP:port, Tailscale hostname, full URL passthrough, and empty-input rejection
- [x] `pytest -q` (full suite) — all pass
- [x] `mypy app/pairing.py app/main.py app/fragments.py` — no issues
- [ ] Manual check in a browser: load the WebUI pairing card, type a Tailscale IP into the new field, confirm the QR/Gateway URL update