### PR TITLE
Fix gateway pairing crashes and blocked HTTP across devices

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -126,7 +126,7 @@ dependencies {
     implementation(libs.androidx.camera.camera2)
     implementation(libs.androidx.camera.lifecycle)
     implementation(libs.androidx.camera.view)
-    implementation(libs.mlkit.barcode.scanning)
+    implementation(libs.zxing.core)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/QrPairingActivity.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/QrPairingActivity.kt
@@ -7,9 +7,7 @@ import android.os.Bundle
 import android.util.Size
 import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.annotation.OptIn
 import androidx.camera.core.CameraSelector
-import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
 import androidx.camera.core.Preview
@@ -19,11 +17,13 @@ import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
-import com.google.mlkit.vision.barcode.BarcodeScanner
-import com.google.mlkit.vision.barcode.BarcodeScannerOptions
-import com.google.mlkit.vision.barcode.BarcodeScanning
-import com.google.mlkit.vision.barcode.common.Barcode
-import com.google.mlkit.vision.common.InputImage
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.DecodeHintType
+import com.google.zxing.PlanarYUVLuminanceSource
+import com.google.zxing.ReaderException
+import com.google.zxing.common.HybridBinarizer
+import com.google.zxing.qrcode.QRCodeReader
 import io.github.mrsunglasses.localflow.core.PairingPayload
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
@@ -31,11 +31,19 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * Full-screen QR scanner used only for gateway pairing. Returns the raw QR text
  * in [EXTRA_RAW] so [PairingPayload] can validate it on the caller's side.
+ *
+ * Decoding uses ZXing rather than ML Kit: ML Kit's barcode-scanning artifact
+ * fetches its model through Google Play Services at runtime, which is
+ * unavailable on GMS-less/microG ROMs and crashes there. ZXing decodes QR
+ * codes directly from camera frames, ships fully inside the APK, and needs
+ * no device services at all.
  */
 class QrPairingActivity : ComponentActivity() {
 
     private val cameraExecutor = Executors.newSingleThreadExecutor()
     private val handled = AtomicBoolean(false)
+    private val reader = QRCodeReader()
+    private val decodeHints = mapOf(DecodeHintType.POSSIBLE_FORMATS to listOf(BarcodeFormat.QR_CODE))
     private lateinit var previewView: PreviewView
 
     private val permissionLauncher = registerForActivityResult(
@@ -62,65 +70,62 @@ class QrPairingActivity : ComponentActivity() {
     private fun startCamera() {
         val future = ProcessCameraProvider.getInstance(this)
         future.addListener({
-            val provider = future.get()
-            val preview = Preview.Builder().build().also {
-                it.surfaceProvider = previewView.surfaceProvider
-            }
-            val analysis = ImageAnalysis.Builder()
-                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-                .setResolutionSelector(
-                    ResolutionSelector.Builder()
-                        .setResolutionStrategy(
-                            ResolutionStrategy(
-                                Size(1280, 720),
-                                ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER_THEN_LOWER,
-                            ),
-                        )
-                        .build(),
+            try {
+                val provider = future.get()
+                val preview = Preview.Builder().build().also {
+                    it.surfaceProvider = previewView.surfaceProvider
+                }
+                val analysis = ImageAnalysis.Builder()
+                    .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                    .setResolutionSelector(
+                        ResolutionSelector.Builder()
+                            .setResolutionStrategy(
+                                ResolutionStrategy(
+                                    Size(1280, 720),
+                                    ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER_THEN_LOWER,
+                                ),
+                            )
+                            .build(),
+                    )
+                    .build()
+
+                analysis.setAnalyzer(cameraExecutor, ::analyzeFrame)
+
+                // Some tablets/Chromebooks only have a front camera; fall back
+                // to it instead of failing outright on DEFAULT_BACK_CAMERA.
+                val selector = when {
+                    provider.hasCamera(CameraSelector.DEFAULT_BACK_CAMERA) -> CameraSelector.DEFAULT_BACK_CAMERA
+                    provider.hasCamera(CameraSelector.DEFAULT_FRONT_CAMERA) -> CameraSelector.DEFAULT_FRONT_CAMERA
+                    else -> throw IllegalStateException("No camera available on this device.")
+                }
+
+                provider.unbindAll()
+                provider.bindToLifecycle(this, selector, preview, analysis)
+            } catch (error: Exception) {
+                finishCancelled(
+                    "Couldn't start the camera on this device. Enter the gateway address manually instead.",
                 )
-                .build()
-
-            val options = BarcodeScannerOptions.Builder()
-                .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
-                .build()
-            val scanner = BarcodeScanning.getClient(options)
-
-            analysis.setAnalyzer(cameraExecutor) { imageProxy ->
-                analyzeFrame(imageProxy, scanner)
             }
-
-            provider.unbindAll()
-            provider.bindToLifecycle(
-                this,
-                CameraSelector.DEFAULT_BACK_CAMERA,
-                preview,
-                analysis,
-            )
         }, ContextCompat.getMainExecutor(this))
     }
 
-    @OptIn(ExperimentalGetImage::class)
-    private fun analyzeFrame(imageProxy: ImageProxy, scanner: BarcodeScanner) {
+    private fun analyzeFrame(imageProxy: ImageProxy) {
         if (handled.get() || !lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
             imageProxy.close()
             return
         }
-        val media = imageProxy.image
-        if (media == null) {
-            imageProxy.close()
-            return
-        }
-        val image = InputImage.fromMediaImage(media, imageProxy.imageInfo.rotationDegrees)
-        scanner.process(image)
-            .addOnSuccessListener { barcodes ->
-                val raw = barcodes.firstNotNullOfOrNull { it.rawValue } ?: return@addOnSuccessListener
-                if (!handled.compareAndSet(false, true)) return@addOnSuccessListener
-                // Validate lightly here so we don't finish on unrelated QR codes.
-                when (val parsed = PairingPayload.parse(raw)) {
+        try {
+            val width = imageProxy.width
+            val height = imageProxy.height
+            val luminance = extractLuminance(imageProxy.planes[0], width, height)
+            val source = PlanarYUVLuminanceSource(luminance, width, height, 0, 0, width, height, false)
+            val result = reader.decode(BinaryBitmap(HybridBinarizer(source)), decodeHints)
+            if (handled.compareAndSet(false, true)) {
+                when (val parsed = PairingPayload.parse(result.text)) {
                     is PairingPayload.Result.Ok -> {
                         setResult(
                             RESULT_OK,
-                            Intent().putExtra(EXTRA_RAW, raw)
+                            Intent().putExtra(EXTRA_RAW, result.text)
                                 .putExtra(EXTRA_URL, parsed.parsed.url)
                                 .putExtra(EXTRA_TOKEN, parsed.parsed.token),
                         )
@@ -132,7 +137,34 @@ class QrPairingActivity : ComponentActivity() {
                     }
                 }
             }
-            .addOnCompleteListener { imageProxy.close() }
+        } catch (_: ReaderException) {
+            // No QR code decoded in this frame; keep scanning.
+        } finally {
+            reader.reset()
+            imageProxy.close()
+        }
+    }
+
+    /** Copies the Y (luminance) plane into a packed, row-stride-free byte array. */
+    private fun extractLuminance(plane: ImageProxy.PlaneProxy, width: Int, height: Int): ByteArray {
+        val buffer = plane.buffer
+        val rowStride = plane.rowStride
+        val pixelStride = plane.pixelStride
+        if (pixelStride == 1 && rowStride == width) {
+            val data = ByteArray(width * height)
+            buffer.get(data)
+            return data
+        }
+        val data = ByteArray(width * height)
+        val row = ByteArray(rowStride)
+        for (y in 0 until height) {
+            buffer.position(y * rowStride)
+            buffer.get(row, 0, minOf(rowStride, buffer.remaining()))
+            for (x in 0 until width) {
+                data[y * width + x] = row[x * pixelStride]
+            }
+        }
+        return data
     }
 
     private fun finishCancelled(message: String) {

--- a/android/app/src/main/res/layout/view_bubble.xml
+++ b/android/app/src/main/res/layout/view_bubble.xml
@@ -4,7 +4,6 @@
   stays active and ordinary typing is untouched.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/bubble_root"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -24,7 +23,7 @@
         android:contentDescription="@string/bubble_dictate"
         android:padding="10dp"
         android:src="@drawable/ic_dictation"
-        app:tint="#FFFFFFFF" />
+        android:tint="#FFFFFFFF" />
 
     <TextView
         android:id="@+id/bubble_status"
@@ -48,7 +47,7 @@
         android:padding="7dp"
         android:src="@drawable/ic_check"
         android:visibility="gone"
-        app:tint="#FFFFFFFF" />
+        android:tint="#FFFFFFFF" />
 
     <ImageButton
         android:id="@+id/bubble_cancel"
@@ -59,5 +58,5 @@
         android:contentDescription="@string/bubble_cancel"
         android:padding="8dp"
         android:src="@drawable/ic_cancel"
-        app:tint="#B3FFFFFF" />
+        android:tint="#B3FFFFFF" />
 </LinearLayout>

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ androidxTestCore = "1.7.0"
 androidxTestExt = "1.3.0"
 espresso = "3.7.0"
 camerax = "1.5.3"
-mlkitBarcode = "17.3.0"
+zxing = "3.5.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -46,7 +46,7 @@ okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver3-
 androidx-camera-camera2 = { group = "androidx.camera", name = "camera-camera2", version.ref = "camerax" }
 androidx-camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "camerax" }
 androidx-camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "camerax" }
-mlkit-barcode-scanning = { group = "com.google.mlkit", name = "barcode-scanning", version.ref = "mlkitBarcode" }
+zxing-core = { group = "com.google.zxing", name = "core", version.ref = "zxing" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 json = { group = "org.json", name = "json", version.ref = "json" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }

--- a/ios/LocalFlowApp/Info.plist
+++ b/ios/LocalFlowApp/Info.plist
@@ -26,21 +26,14 @@
   <string>Local Flow connects to the transcription gateway you configure on your private network.</string>
   <key>NSAppTransportSecurity</key>
   <dict>
-    <key>NSAllowsLocalNetworking</key>
+    <!-- ATS has no CIDR-based exception, and neither NSAllowsLocalNetworking
+         nor an NSExceptionDomains entry for ts.net covers a bare Tailscale
+         CGNAT IP (100.64.0.0/10) or other private hosts typed by hand.
+         GatewayEndpoint.isPrivateNetworkHost is the real gate: it already
+         restricts plain-HTTP gateways to LAN/CGNAT/mDNS/tailnet hosts before
+         a request is ever made, matching the Android cleartext policy. -->
+    <key>NSAllowsArbitraryLoads</key>
     <true/>
-    <!-- Tailscale MagicDNS names are fully qualified, so ATS would refuse the
-         plain-HTTP gateways this app is built around. Traffic to *.ts.net only
-         travels inside the user's WireGuard-encrypted tailnet. -->
-    <key>NSExceptionDomains</key>
-    <dict>
-      <key>ts.net</key>
-      <dict>
-        <key>NSIncludesSubdomains</key>
-        <true/>
-        <key>NSExceptionAllowsInsecureHTTPLoads</key>
-        <true/>
-      </dict>
-    </dict>
   </dict>
   <key>NSSupportsLiveActivities</key>
   <true/>

--- a/server/app/fragments.py
+++ b/server/app/fragments.py
@@ -416,6 +416,7 @@ def pairing_fragment(
     candidates: list[str],
     token_redacted: str,
     qr_svg: str = "",
+    saved_urls: list[str],
 ) -> str:
     """Authenticated phone-pairing card with QR for the selected gateway URL.
 
@@ -435,6 +436,24 @@ def pairing_fragment(
         f'<option value="{escape(url)}"{" selected" if url == selected_url else ""}>'
         f"{escape(url)}</option>"
         for url in candidates
+    )
+    saved_rows = "".join(
+        f"<li><code>{escape(url)}</code>"
+        f'<button type="button" class="ghost small danger"'
+        f' hx-delete="/ui/partials/pairing?url={quote(url, safe="")}"'
+        f' hx-target="#pairing-card" hx-swap="outerHTML"'
+        f' hx-confirm="Remove {escape(url)} from saved addresses?">Remove</button></li>'
+        for url in saved_urls
+    )
+    saved_section = (
+        f"""
+            <div class="pairing-saved">
+              <span>Saved addresses</span>
+              <ul>{saved_rows}</ul>
+            </div>
+        """
+        if saved_urls
+        else ""
     )
     # Strip XML declaration for clean inline embedding.
     inline_svg = qr_svg
@@ -470,6 +489,7 @@ def pairing_fragment(
                   </div>
                 </label>
               </form>
+              {saved_section}
             </div>
             <dl class="facts">
               <div><dt>Gateway URL</dt><dd><code>{escape(selected_url)}</code></dd></div>

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -68,7 +68,6 @@ from app.pairing import (
     discover_gateway_base_urls,
     encode_pairing_payload,
     normalize_gateway_input,
-    normalize_gateway_url,
     primary_gateway_base_url,
     qr_svg_for_payload,
 )
@@ -126,6 +125,7 @@ def create_app(
     if engine is not None:
         engine_provider: EngineProvider = StaticEngineProvider(engine)
         engine_manager: EngineManager | None = None
+        pairing_config = RuntimeConfig()
     else:
         engine_manager = EngineManager(
             configured,
@@ -134,6 +134,7 @@ def create_app(
             manager,
         )
         engine_provider = engine_manager
+        pairing_config = engine_manager.runtime_config
     service = TranscriptionService(
         configured,
         repository,
@@ -936,19 +937,33 @@ def create_app(
     def _models_list_html() -> HTMLResponse:
         return _html(models_list_fragment(_model_entries()))
 
-    def _pairing_html(selected_url: str | None = None) -> str:
-        candidates = discover_gateway_base_urls(configured.port)
+    def _pairing_html(selected_url: str | None = None, *, persist: bool = False) -> str:
+        discovered = discover_gateway_base_urls(configured.port)
+        candidates = list(discovered)
+        for saved in pairing_config.pairing_urls:
+            if saved not in candidates:
+                candidates.append(saved)
         selected: str | None
         if selected_url:
             try:
                 selected = normalize_gateway_input(selected_url, configured.port)
             except ValueError:
-                selected = primary_gateway_base_url(configured.port)
+                selected = pairing_config.pairing_url or primary_gateway_base_url(configured.port)
             else:
                 if selected not in candidates:
                     candidates = [selected, *candidates]
+                if persist and engine_manager is not None:
+                    changed = pairing_config.pairing_url != selected
+                    if selected not in discovered and selected not in pairing_config.pairing_urls:
+                        pairing_config.pairing_urls.append(selected)
+                        changed = True
+                    if changed:
+                        pairing_config.pairing_url = selected
+                        pairing_config.save(config_path)
         else:
-            selected = primary_gateway_base_url(configured.port)
+            selected = pairing_config.pairing_url or primary_gateway_base_url(configured.port)
+            if selected and selected not in candidates:
+                candidates = [selected, *candidates]
         token = configured.token
         redacted = (
             f"{token[:4]}…{token[-4:]} ({len(token)} characters)"
@@ -963,7 +978,20 @@ def create_app(
             candidates=candidates,
             token_redacted=redacted,
             qr_svg=qr_svg,
+            saved_urls=pairing_config.pairing_urls,
         )
+
+    def _forget_pairing_url(url: str) -> str:
+        try:
+            normalized = normalize_gateway_input(url, configured.port)
+        except ValueError as error:
+            raise APIProblem(400, "invalid_pairing_url", str(error)) from error
+        if engine_manager is not None and normalized in pairing_config.pairing_urls:
+            pairing_config.pairing_urls.remove(normalized)
+            if pairing_config.pairing_url == normalized:
+                pairing_config.pairing_url = None
+            pairing_config.save(config_path)
+        return _pairing_html()
 
     def _resolve_pairing_url(url: str | None) -> str:
         candidates = discover_gateway_base_urls(configured.port)
@@ -1018,7 +1046,15 @@ def create_app(
         dependencies=[Depends(require_token)],
     )
     async def ui_pairing(url: str | None = Query(default=None)) -> HTMLResponse:
-        return _html(_pairing_html(url))
+        return _html(_pairing_html(url, persist=True))
+
+    @app.delete(
+        "/ui/partials/pairing",
+        response_class=HTMLResponse,
+        dependencies=[Depends(require_token)],
+    )
+    async def ui_forget_pairing(url: str = Query(...)) -> HTMLResponse:
+        return _html(_forget_pairing_url(url))
 
     @app.get(
         "/ui/partials/overview",

--- a/server/app/runtime_config.py
+++ b/server/app/runtime_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +34,8 @@ class RuntimeConfig:
     compute_device: str = "auto"
     compute_type: str = "auto"
     cpu_threads: int = 0
+    pairing_url: str | None = None
+    pairing_urls: list[str] = field(default_factory=list)
 
     @classmethod
     def load(cls, path: Path) -> RuntimeConfig:
@@ -52,6 +54,8 @@ class RuntimeConfig:
         compute_device = payload.get("compute_device")
         compute_type = payload.get("compute_type")
         cpu_threads = payload.get("cpu_threads")
+        pairing_url = payload.get("pairing_url")
+        pairing_urls = payload.get("pairing_urls")
         return cls(
             engine=engine if engine in VALID_ENGINES else "auto",
             whisper_model=whisper_model if isinstance(whisper_model, str) else None,
@@ -82,6 +86,12 @@ class RuntimeConfig:
             cpu_threads=(
                 cpu_threads if isinstance(cpu_threads, int) and 0 <= cpu_threads <= 256 else 0
             ),
+            pairing_url=pairing_url if isinstance(pairing_url, str) else None,
+            pairing_urls=(
+                [url for url in pairing_urls if isinstance(url, str)]
+                if isinstance(pairing_urls, list)
+                else []
+            ),
         )
 
     def save(self, path: Path) -> None:
@@ -98,6 +108,8 @@ class RuntimeConfig:
             "compute_device": self.compute_device,
             "compute_type": self.compute_type,
             "cpu_threads": self.cpu_threads,
+            "pairing_url": self.pairing_url,
+            "pairing_urls": self.pairing_urls,
         }
         descriptor, temporary_name = tempfile.mkstemp(
             dir=path.parent, prefix=".config-", suffix=".tmp"

--- a/server/app/webui/styles.css
+++ b/server/app/webui/styles.css
@@ -153,6 +153,21 @@ main { max-width: 1120px; margin: 0 auto; padding: 24px 24px 60px; }
   background: var(--panel-strong);
   color: var(--text);
 }
+.pairing-saved { margin-top: 12px; }
+.pairing-saved > span { display: block; margin-bottom: 6px; font-size: 12.5px; color: var(--muted); }
+.pairing-saved ul { list-style: none; margin: 0; padding: 0; display: grid; gap: 6px; }
+.pairing-saved li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--panel-border);
+  background: var(--panel-strong);
+}
+.pairing-saved li code { overflow-wrap: anywhere; }
+.pairing-saved li button { flex: 0 0 auto; }
 
 .operations { margin: 18px 0; }
 .section-heading {


### PR DESCRIPTION
## Summary
- **iOS**: `Info.plist` App Transport Security only allow-listed the `ts.net` hostname, so pairing over a bare Tailscale IP (`100.64.0.0/10`) was blocked at the OS level with "the App Transport Security policy requires the use of a secure connection", even though `GatewayEndpoint.isPrivateNetworkHost` already treats that range as trusted before ever making the request. Switched to `NSAllowsArbitraryLoads`, since the app's own private-host validation (not ATS) is the real gate on cleartext HTTP — matching the Android `network_security_config.xml` model.
- **Android**: tapping "Scan QR code" crashed with a `NullPointerException` on GMS-less/microG ROMs (reproduced on LineageOS 21). Root cause: `com.google.mlkit:barcode-scanning` fetches its model through Google Play Services at runtime and throws internally when that module isn't available. Replaced it with **ZXing** (`com.google.zxing:core`), a pure-Java QR decoder bundled fully in the APK with zero Play Services dependency, decoding CameraX's raw YUV frames directly. Also added a `hasCamera()` check that falls back from the back camera to the front camera, instead of only ever requesting the back camera.
- **Server**: added persistence for saved pairing addresses (`pairing_url` / `pairing_urls` in `RuntimeConfig`) so a manually entered gateway address (e.g. a custom Tailscale IP) survives a server restart, plus a WebUI control to remove a saved address.

## Test plan
- [x] iOS: `plutil -lint` on the updated `Info.plist`
- [x] Android: reproduced the crash on a real LineageOS 21 (microG) device via adb, confirmed the exact `BarcodeScanning.getClient()` NPE with R8 retrace against the release mapping file
- [x] Android: rebuilt with ZXing, reinstalled on the same device — camera opens, a real QR code decodes successfully, full pairing round-trip completes, zero `AndroidRuntime`/`FATAL EXCEPTION` in logcat
- [x] Android: `./gradlew testDebugUnitTest lintDebug` clean
- [x] Server: `pytest` (full suite, 219 tests) and `mypy` clean
- [ ] Manual: verify front-camera fallback on a front-camera-only device (none available to test)