### PR TITLE
Add diagnostics export, per-device tokens, and new sherpa-onnx models

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ tests, and has not yet been exercised end to end on a physical Pixel.
 - Operational dashboard with hardware detection, queue/outcome counters,
   pipeline benchmarks, real-time factor, peak memory, and warmup state
 - CPU/OpenBLAS, host-native CPU, NVIDIA CUDA, and Vulkan Compose profiles
-- Bearer authentication, iOS Keychain storage, configurable HTTP/HTTPS gateway
-  access, optional private Tailscale HTTPS, no analytics, and no third-party
+- Bearer authentication with named per-device tokens and revocation, iOS
+  Keychain storage, configurable HTTP/HTTPS gateway access, optional private
+  Tailscale HTTPS, no analytics, and no third-party
   transcription
 
 ## Choose a gateway deployment
@@ -189,9 +190,15 @@ Once the WebUI is open and authenticated on the gateway host:
 
 1. Stay on **Overview** — the **Pair phone app** card shows a QR for a
    phone-reachable address (LAN IP preferred, or `LOCALFLOW_PUBLIC_URL` if set).
-2. In the iPhone app, open **Settings** and tap **Scan pairing QR code**. On
+2. To give this phone its own revocable credential instead of the shared
+   bootstrap token, use **Or pair a new device with its own token**: name the
+   device and the card immediately shows a QR for that device's token alone.
+   The **Token to encode** dropdown switches the QR between the bootstrap
+   token and any device token created this way; manage or revoke them later
+   from Settings → **Paired device tokens**.
+3. In the iPhone app, open **Settings** and tap **Scan pairing QR code**. On
    Android, open **Gateway** and tap **Scan QR code**.
-3. Grant camera access if asked; the scan fills address + token and runs the
+4. Grant camera access if asked; the scan fills address + token and runs the
    connection test.
 
 You can still paste manually:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,11 +67,19 @@ Apple silicon, and `WhisperCppEngine` is the portable CLI fallback. The service
 keeps the selected model resident and falls back to the one-shot CLI when an
 older WhisperKit build cannot serve. `FasterWhisperEngine` owns one persistent
 CTranslate2 model and uses CPU INT8 by default. `SherpaOnnxEngine` owns one
-portable INT8 recognizer for SenseVoice or Parakeet. `MLXAudioEngine` keeps one
+portable INT8 recognizer for SenseVoice, Parakeet, GigaAM, Canary, or a
+streaming Zipformer model, dispatching on the selected model's catalog
+`model_type` for both loading and decoding. `MLXAudioEngine` keeps one
 Apple-silicon-native model in unified memory. `MoonshineEngine` owns one
-persistent transcriber. It exposes the guarded `/v1/stream` path only when the
-selected architecture supports cached incremental inference; language-specific
-batch models use the same upload fallback as other batch engines. No
+persistent transcriber. Any engine can expose the guarded `/v1/stream` path by
+implementing the `StreamingEngine` protocol (`app/models/base.py`):
+`supports_streaming`, `streaming_lock`, and `create_stream()` returning an
+object with `add_listener`/`add_audio`/`stop`. Currently Moonshine's streaming
+architectures and sherpa-onnx's streaming Zipformer model do; `SherpaOnnxEngine`
+wraps sherpa-onnx's separate `OnlineRecognizer`/`OnlineStream` API in an adapter
+presenting that same surface, so the WebSocket handler itself has no
+engine-specific code. Every other model — including every other sherpa-onnx
+model — uses the same upload fallback as other batch engines. No
 engine-specific field is part of the stable session API
 response.
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -25,7 +25,10 @@ result needed for idempotent retry.
 
 - Configurable gateway binding, with loopback recommended for private deployments
 - Tailscale Serve private ingress over a loopback listener; no Funnel
-- Independent high-entropy bearer token
+- Independent high-entropy bearer token, with additional named per-device
+  tokens available so losing one phone means revoking that device's token
+  rather than rotating every paired device's credential (see "Per-device
+  tokens" below)
 - Token stored in an iPhone Keychain item and a mode-600 Mac file
 - Strict upload types, byte limits, duration limits, and one transcription slot
 - FFmpeg and `whisper.cpp` invoked with argument arrays, never a shell
@@ -42,8 +45,9 @@ The Compose source token is normally stored in the host-only `server/.env` file
 before Docker mounts it at `/run/secrets/localflow_token`. Keep that file at mode
 `600`, exclude it from backups shared with other people, and never commit it.
 
-Moonshine streaming uses the same bearer token and configured HTTP/HTTPS host as
-the batch API (`ws://` on trusted HTTP networks, `wss://` with HTTPS). The iPhone
+Streaming (Moonshine's streaming tiers, or sherpa-onnx's streaming Zipformer
+model) uses the same bearer token and configured HTTP/HTTPS host as the batch
+API (`ws://` on trusted HTTP networks, `wss://` with HTTPS). The iPhone
 continues writing the bounded WAV while streaming so a socket interruption can
 fall back without losing the dictation. Partial transcripts are not persisted by
 the gateway or written to ordinary logs.
@@ -74,10 +78,36 @@ app and the user's Mac. The extension does not record microphone audio, inspect
 unrelated keystrokes, or use clipboard insertion. iOS still controls whether a
 third-party keyboard is available in a field.
 
+## Per-device tokens
+
+`LOCALFLOW_TOKEN` (or its token file) remains a permanent bootstrap credential
+that always authenticates and cannot be revoked through the API — whoever
+controls that file or environment variable can already read or rotate it
+directly. The WebUI Settings tab and the Overview pairing card can both create
+named, independently revocable tokens for specific devices. Only a SHA-256
+digest of each is persisted (`app/tokens.py`); the plaintext is shown once, at
+creation. Creating a device token from the pairing card immediately shows a QR
+for it, so a new phone can scan its own credential instead of the shared
+bootstrap token. The plaintext also stays cached in memory (never written to
+disk) for the rest of that gateway process, so the pairing card's token
+dropdown can still regenerate that same device's QR at a different address
+without creating a duplicate token; a restart, or revoking the token, clears
+it from that cache. Revoking a device token immediately rejects further
+requests carrying it without affecting the bootstrap token or any other
+paired device.
+
+## Diagnostics export
+
+The authenticated WebUI Settings tab and `uv run localflow-diagnostics` can export a
+redacted snapshot for a bug report: version, engine/model status, hardware and
+dependency detection, setup checklist, in-memory operational counters, and
+persistent configuration. Filesystem paths under the operator's home directory are
+rewritten to `~`. It never includes the bearer token, recording audio, transcript
+text, or session identifiers — see `app/diagnostics.py`.
+
 ## Remaining threats before distribution
 
 - Review model and FFmpeg supply-chain provenance.
 - Add dependency vulnerability and secret scanning in CI.
 - Confirm tailnet ACLs restrict gateway access to the user's devices.
-- Review diagnostics export before implementing it.
 - Revisit transcript retention and lock-screen exposure with the user.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -92,9 +92,17 @@ bootstrap token. The plaintext also stays cached in memory (never written to
 disk) for the rest of that gateway process, so the pairing card's token
 dropdown can still regenerate that same device's QR at a different address
 without creating a duplicate token; a restart, or revoking the token, clears
-it from that cache. Revoking a device token immediately rejects further
-requests carrying it without affecting the bootstrap token or any other
-paired device.
+it from that cache.
+
+A gateway restart (a routine deploy/update, for example) never affects an
+already-paired device: its token is validated by hash and keeps authenticating
+exactly as before. The in-memory cache only controls whether *this session*
+can redisplay that secret as a QR — losing it after a restart is expected and
+harmless. Rotating a token (giving it a fresh secret so its QR can be shown
+again) is the one action that actually breaks that device's existing pairing,
+so treat it as opt-in, not routine maintenance. Revoking a device token
+immediately rejects further requests carrying it without affecting the
+bootstrap token or any other paired device.
 
 ## Diagnostics export
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -161,8 +161,11 @@ Keep the host firewall enabled. Do not use this LAN configuration to expose port
 
 ## 401 unauthorized
 
-Re-run `server/scripts/setup-token.sh`, copy the exact token into Local Flow, and
-save/test again. Never put the token in a URL or screenshot.
+If this device was paired with its own token, open the WebUI Settings tab and
+confirm it is still listed under **Paired device tokens** — revoking a token
+there immediately rejects it. Otherwise re-run `server/scripts/setup-token.sh`,
+copy the exact token into Local Flow, and save/test again. Never put the token
+in a URL or screenshot.
 
 ## 413, 415, or 422
 
@@ -195,3 +198,11 @@ Repeated Finish taps are safe, but they do not create a second server session.
 When reporting a failure, include the keyboard state shown before and after the
 tap, whether Local Flow was open in the background, and the gateway readiness
 response—never include the token or a private transcript.
+
+## Reporting a gateway bug
+
+Attach the redacted diagnostics bundle instead of manually describing gateway
+state: open the WebUI **Settings** tab and click **Download diagnostics**, or run
+`uv run localflow-diagnostics` on the gateway host. It contains version, engine
+and dependency status, hardware detection, and operational counters, and never
+includes the bearer token, recordings, transcripts, or session identifiers.

--- a/server/README.md
+++ b/server/README.md
@@ -106,6 +106,14 @@ Discovery prefers private Wi‑Fi addresses (for example `192.168.x.x`). Overrid
 with `LOCALFLOW_PUBLIC_URL` or `LOCALFLOW_PAIRING_URL` when automatic selection
 is wrong. The QR is only available through the authenticated WebUI/API.
 
+The same card can create a named per-device token and immediately show its own
+QR instead of the shared bootstrap token, and a **Token to encode** dropdown
+switches which one the QR (and the `/v1/admin/pairing` and
+`/v1/admin/pairing/qr.svg` JSON/SVG endpoints, via `?token_id=`) currently
+encodes. A device token's plaintext is cached in memory only for the life of
+the gateway process — long enough to regenerate its QR at a different address
+without creating a duplicate — and is dropped immediately on revoke.
+
 ## Docker Compose quick start
 
 [compose.yaml](compose.yaml) is the canonical container deployment. It builds a
@@ -154,6 +162,12 @@ The authenticated WebUI provides:
 - one-run or three-run microphone benchmarks with normalization, model-load,
   inference, real-time-factor, and peak-memory results
 - selected engine/model and readiness/warmup status
+- a redacted diagnostics export for bug reports (Settings tab or
+  `uv run localflow-diagnostics`); never includes the token, audio, transcripts,
+  or session identifiers
+- named, independently revocable per-device tokens (Settings tab), so losing
+  one phone means revoking that device's token instead of rotating everyone
+  else's; the bootstrap `LOCALFLOW_TOKEN` always keeps working alongside them
 
 Operational counters stay in process memory, contain no audio or transcript
 content, and reset when the gateway process restarts.
@@ -166,9 +180,13 @@ It also includes compact Whisper Medium,
 Whisper Large v3, and Breeze ASR builds from
 [Handy's documented model family](https://handy.computer/docs/models) that run
 directly through `whisper.cpp`; Handy does not need to be installed.
-SenseVoice and Parakeet now run independently of Handy through sherpa-onnx;
-Parakeet also has an Apple-native MLX option. GigaAM and Canary still require
-runtime adapters that Local Flow does not ship.
+SenseVoice, Parakeet, GigaAM, and Canary now all run independently of Handy
+through sherpa-onnx; Parakeet also has an Apple-native MLX option. GigaAM
+(Russian, CTC or RNNT) and Canary (English only in this build; the underlying
+model also covers German, French, and Spanish, but source/target language is
+fixed when the recognizer loads rather than per request) download individual
+files directly from their Hugging Face model repos rather than a packaged
+archive, since neither publishes one.
 
 ### Fast model guide
 
@@ -204,20 +222,23 @@ device and precision settings affect faster-whisper; sherpa models are already
 INT8 CPU exports. Use the Test tab's three-run benchmark after the first warm
 run.
 
-Moonshine's English Medium, Small, and Tiny Streaming tiers accept float32 PCM
-over an authenticated WebSocket while the iPhone records. Medium favors
-accuracy, Small is the balanced Linux default, and Tiny favors latency. The
-ordinary WAV is still retained during the request and automatically used by the
-batch API if streaming is unavailable or interrupted. Streaming support is
-negotiated on that socket to avoid an extra network round trip before every
-recording.
+Moonshine's English Medium, Small, and Tiny Streaming tiers, and the sherpa-onnx
+Streaming Zipformer English 20M INT8 model, accept float32 PCM over an
+authenticated WebSocket while the iPhone records — real incremental decoding
+with partial results, not a periodic re-transcription of the growing buffer.
+Moonshine Medium favors accuracy, Small is the balanced Linux default, and Tiny
+favors latency; the Zipformer model favors speed over accuracy at a fraction of
+the download size. The ordinary WAV is still retained during the request and
+automatically used by the batch API if streaming is unavailable or interrupted.
+Streaming support is negotiated on that socket to avoid an extra network round
+trip before every recording.
 
-The remaining Moonshine models use its fast batch path after recording. The
-server returns a structured unsupported response for those architectures, as it
-does for WhisperKit and faster-whisper, so the app immediately continues through
-the ordinary upload pipeline. In the iPhone app or keyboard, **Automatic** uses
-the active gateway model. Choosing a named language requires the active model to
-support that same language.
+Every other model — the remaining Moonshine tiers, WhisperKit, faster-whisper,
+and every other sherpa-onnx model above — uses its fast batch path after
+recording. The server returns a structured unsupported response for those, so
+the app immediately continues through the ordinary upload pipeline. In the
+iPhone app or keyboard, **Automatic** uses the active gateway model. Choosing a
+named language requires the active model to support that same language.
 
 Moonshine's English code and weights use the MIT license. Its non-English weights
 use the Moonshine Community License and are limited to non-commercial use; the
@@ -355,6 +376,9 @@ CPU there. The dashboard reports what devices the container can actually see.
 ```sh
 # Query the local backward-compatible health response
 uv run localflow-status
+
+# Download a redacted diagnostics bundle for a bug report
+uv run localflow-diagnostics
 
 # Remove sessions older than the configured retention window
 uv run localflow-cleanup

--- a/server/app/catalog.py
+++ b/server/app/catalog.py
@@ -187,15 +187,30 @@ def _sherpa_onnx(
     quality: str,
     minimum_ram_gb: float,
     *,
-    archive_url: str,
-    archive_root: str,
     required_files: tuple[str, ...],
     model_type: str,
     language_codes: tuple[str, ...],
     family: str,
     description: str,
     license_name: str,
+    archive_url: str | None = None,
+    archive_root: str | None = None,
+    huggingface_repo: str | None = None,
+    supports_streaming: bool = False,
 ) -> CatalogModel:
+    """Build a sherpa-onnx catalog entry from either download mechanism.
+
+    Most models ship as a `k2-fsa/sherpa-onnx` GitHub-release `.tar.bz2`
+    (`archive_url`/`archive_root`). Some model families (GigaAM, Canary) are
+    only published as individual files in a plain Hugging Face model repo with
+    no such archive; for those, pass `huggingface_repo` instead and the
+    gateway downloads exactly `required_files` from its root.
+    """
+    if archive_url is not None:
+        if archive_root is None:
+            raise ValueError(f"{key}: archive_url requires archive_root.")
+    elif huggingface_repo is None:
+        raise ValueError(f"{key}: provide either archive_url/archive_root or huggingface_repo.")
     return CatalogModel(
         id=f"{ENGINE_SHERPA_ONNX}:{key}",
         engine=ENGINE_SHERPA_ONNX,
@@ -207,6 +222,7 @@ def _sherpa_onnx(
         minimum_ram_gb=minimum_ram_gb,
         archive_url=archive_url,
         archive_root=archive_root,
+        huggingface_repo=huggingface_repo,
         required_files=required_files,
         family=family,
         description=description,
@@ -215,6 +231,7 @@ def _sherpa_onnx(
         model_type=model_type,
         language_codes=language_codes,
         license_name=license_name,
+        supports_streaming=supports_streaming,
     )
 
 
@@ -339,6 +356,87 @@ DEFAULT_CATALOG: tuple[CatalogModel, ...] = (
             "inference."
         ),
         license_name="CC BY 4.0",
+    ),
+    _sherpa_onnx(
+        "gigaam-v3-ctc-russian-int8",
+        "GigaAM v3 CTC Russian INT8",
+        225 * MB,
+        "Russian only",
+        "Fastest Russian ASR",
+        2,
+        huggingface_repo="csukuangfj/sherpa-onnx-nemo-ctc-giga-am-v3-russian-2025-12-16",
+        required_files=("model.int8.onnx", "tokens.txt"),
+        model_type="nemo_ctc",
+        language_codes=("ru",),
+        family="GigaAM",
+        description=(
+            "Sber's GigaAM CTC converted to INT8 ONNX for fast Russian-only CPU transcription."
+        ),
+        license_name="MIT",
+    ),
+    _sherpa_onnx(
+        "gigaam-v3-rnnt-russian-int8",
+        "GigaAM v3 RNNT Russian",
+        230 * MB,
+        "Russian only",
+        "Most accurate Russian ASR",
+        2,
+        huggingface_repo="csukuangfj/sherpa-onnx-nemo-transducer-giga-am-v3-russian-2025-12-16",
+        required_files=("encoder.int8.onnx", "decoder.onnx", "joiner.onnx", "tokens.txt"),
+        model_type="nemo_transducer",
+        language_codes=("ru",),
+        family="GigaAM",
+        description=(
+            "Sber's GigaAM RNNT converted to ONNX for the most accurate Russian-only CPU "
+            "transcription; only its encoder is INT8-quantized, so it is larger and slower "
+            "than the CTC variant."
+        ),
+        license_name="MIT",
+    ),
+    _sherpa_onnx(
+        "canary-180m-flash-en-int8",
+        "Canary 180M Flash English INT8",
+        210 * MB,
+        "English only in this build",
+        "Compact multilingual model, English transcription",
+        2,
+        huggingface_repo="csukuangfj/sherpa-onnx-nemo-canary-180m-flash-en-es-de-fr-int8",
+        required_files=("encoder.int8.onnx", "decoder.int8.onnx", "tokens.txt"),
+        model_type="nemo_canary",
+        language_codes=("en",),
+        family="Canary",
+        description=(
+            "NVIDIA's Canary 180M Flash converted to INT8 ONNX. The underlying model also "
+            "covers German, French, and Spanish, but its source/target language is fixed when "
+            "the recognizer loads rather than per request, so Local Flow loads it English-only "
+            "for now."
+        ),
+        license_name="CC BY 4.0",
+    ),
+    _sherpa_onnx(
+        "streaming-zipformer-en-20m-int8",
+        "Streaming Zipformer English 20M INT8",
+        44 * MB,
+        "English only",
+        "Fastest live streaming",
+        1,
+        huggingface_repo="csukuangfj/sherpa-onnx-streaming-zipformer-en-20M-2023-02-17",
+        required_files=(
+            "encoder-epoch-99-avg-1.int8.onnx",
+            "decoder-epoch-99-avg-1.int8.onnx",
+            "joiner-epoch-99-avg-1.int8.onnx",
+            "tokens.txt",
+        ),
+        model_type="streaming_zipformer",
+        language_codes=("en",),
+        family="Zipformer",
+        description=(
+            "A small streaming-capable zipformer transducer. Unlike the other sherpa-onnx "
+            "models above, this one decodes incrementally over /v1/stream with real partial "
+            "results, independent of Moonshine."
+        ),
+        license_name="Apache 2.0",
+        supports_streaming=True,
     ),
     _mlx_audio(
         "whisper-large-v3-turbo-4bit",

--- a/server/app/cli.py
+++ b/server/app/cli.py
@@ -52,6 +52,19 @@ def status() -> None:
     print(json.dumps(data, indent=2))
 
 
+def diagnostics() -> None:
+    settings = Settings.from_env()
+    url = f"{local_webui_url(settings.bind_host, settings.port)}v1/admin/diagnostics"
+    request = urllib.request.Request(url, headers={"Authorization": f"Bearer {settings.token}"})
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            data = json.load(response)
+    except Exception as error:
+        print(f"gateway unreachable or unauthorized: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
+    print(json.dumps(data, indent=2))
+
+
 def cleanup() -> None:
     settings = Settings.from_env()
     repository = SessionRepository(settings.data_dir / "sessions.sqlite3")

--- a/server/app/diagnostics.py
+++ b/server/app/diagnostics.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from app.schemas import AdminStatusResponse, ConfigResponse, DiagnosticsBundle, PathStatus
+
+NEVER_INCLUDED: tuple[str, ...] = (
+    "the bearer token",
+    "recording audio",
+    "transcript text",
+    "session identifiers",
+    "the local username in filesystem paths",
+)
+
+
+def redact_home_path(value: str) -> str:
+    """Replace an absolute home-directory prefix with `~` for safer sharing."""
+    home = str(Path.home())
+    if home and (value == home or value.startswith(home + "/")):
+        return "~" + value[len(home) :]
+    return value
+
+
+def _redact_optional_path(value: str | None) -> str | None:
+    return redact_home_path(value) if value is not None else None
+
+
+def build_diagnostics_bundle(
+    status: AdminStatusResponse, config: ConfigResponse
+) -> DiagnosticsBundle:
+    # whisper_model/whisperkit_model/faster_whisper_model hold absolute
+    # filesystem paths (set from `str(path)` in EngineManager.select_model),
+    # unlike moonshine_model/sherpa_model/mlx_audio_model, which are opaque
+    # catalog ids — redact only the fields that can actually contain one.
+    redacted_config = config.model_copy(
+        update={
+            "whisper_model": _redact_optional_path(config.whisper_model),
+            "whisperkit_model": _redact_optional_path(config.whisperkit_model),
+            "faster_whisper_model": _redact_optional_path(config.faster_whisper_model),
+        }
+    )
+    return DiagnosticsBundle(
+        generated_at=datetime.now(UTC),
+        version=status.version,
+        engine=status.engine,
+        system=status.system,
+        dependencies=status.dependencies,
+        paths=PathStatus(
+            data_dir=redact_home_path(status.paths.data_dir),
+            models_dir=redact_home_path(status.paths.models_dir),
+            config_file=redact_home_path(status.paths.config_file),
+            token_file=status.paths.token_file,
+        ),
+        bind_host=status.bind_host,
+        port=status.port,
+        setup=status.setup,
+        metrics=status.metrics,
+        readiness=status.readiness,
+        config=redacted_config,
+        never_included=list(NEVER_INCLUDED),
+    )

--- a/server/app/fragments.py
+++ b/server/app/fragments.py
@@ -430,11 +430,15 @@ def pairing_fragment(
     The SVG is inlined so the browser does not need a second request (img tags
     cannot attach the WebUI bearer header). `token_options` lists the bootstrap
     token plus every device token, marking ones this process cannot currently
-    display with "(rotate to view)" — only cached plaintexts can be encoded.
-    `token_status` explains why the shown token differs from what was asked
-    for: `stale` means the requested device token still exists but needs a
-    rotate to get a fresh, displayable secret; `unknown` means it no longer
-    exists at all (typically already revoked).
+    display for QR purposes — only cached plaintexts can be encoded. That
+    device's own pairing is completely unaffected either way: the phone keeps
+    authenticating with its already-scanned secret regardless of whether this
+    process can still show it. `token_status` explains why the shown token
+    differs from what was asked for: `stale` means the requested device token
+    still works fine but this process cannot redisplay its secret (typically
+    after a restart) — rotating is optional and only needed to get a fresh,
+    viewable QR, for example to re-pair a lost phone. `unknown` means it no
+    longer exists at all (typically already revoked).
     """
     if not selected_url:
         return """
@@ -462,17 +466,19 @@ def pairing_fragment(
     if token_status == "stale":
         stale_label = escape(requested_token_label or "That device token")
         unavailable_notice = f"""
-          <div class="callout warning compact">
-            <span>{stale_label}'s secret can't be displayed in this session. This usually
-              happens because the server restarted since it was created. Showing the
-              bootstrap token instead.</span>
+          <div class="callout compact">
+            <span><strong>{stale_label} is still paired and working normally.</strong> A server
+              restart just means this session can no longer redisplay its secret — by design,
+              it's never stored anywhere it could be recovered from. Showing the bootstrap
+              token instead; no action is needed unless you actually want a fresh QR (for
+              example, to re-pair a lost phone).</span>
             <form hx-post="/ui/partials/pairing/tokens/{quote(requested_token_id, safe="")}/rotate"
                   hx-target="#pairing-card" hx-swap="outerHTML">
               <input type="hidden" name="url" value="{escape(selected_url)}" />
-              <button type="submit" class="ghost small">Rotate &amp; show its QR</button>
+              <button type="submit" class="ghost small">Rotate &amp; show a new QR</button>
             </form>
-            <span class="muted small">Rotating replaces its secret immediately. Anything still
-              using the old one will need to re-pair.</span>
+            <span class="muted small">Only rotate if you need that: it immediately retires the
+              current secret, and the device using it will have to be paired again.</span>
           </div>
         """
     elif token_status == "unknown":

--- a/server/app/fragments.py
+++ b/server/app/fragments.py
@@ -477,7 +477,7 @@ def pairing_fragment(
                 hx-post="/ui/partials/pairing/tokens/{quote(requested_token_id, safe="")}/rotate"
                 hx-target="#pairing-card" hx-swap="outerHTML">
                 <input type="hidden" name="url" value="{escape(selected_url)}" />
-                <button type="submit" class="ghost small">Rotate &amp; show a new QR</button>
+                <button type="submit" class="primary small">Rotate &amp; show a new QR</button>
               </form>
               <span class="muted small">Only rotate if you need that: it immediately retires
                 the current secret, and the device using it will have to be paired again.</span>
@@ -564,7 +564,7 @@ def pairing_fragment(
                   <div class="row">
                     <input name="label" type="text" required maxlength="100"
                            placeholder="e.g. Kanishk&#39;s iPhone" />
-                    <button type="submit" class="ghost small">Create &amp; show QR</button>
+                    <button type="submit" class="primary small">Create &amp; show QR</button>
                   </div>
                 </label>
               </form>

--- a/server/app/fragments.py
+++ b/server/app/fragments.py
@@ -466,19 +466,22 @@ def pairing_fragment(
     if token_status == "stale":
         stale_label = escape(requested_token_label or "That device token")
         unavailable_notice = f"""
-          <div class="callout compact">
+          <div class="callout compact stacked">
             <span><strong>{stale_label} is still paired and working normally.</strong> A server
               restart just means this session can no longer redisplay its secret — by design,
               it's never stored anywhere it could be recovered from. Showing the bootstrap
               token instead; no action is needed unless you actually want a fresh QR (for
               example, to re-pair a lost phone).</span>
-            <form hx-post="/ui/partials/pairing/tokens/{quote(requested_token_id, safe="")}/rotate"
-                  hx-target="#pairing-card" hx-swap="outerHTML">
-              <input type="hidden" name="url" value="{escape(selected_url)}" />
-              <button type="submit" class="ghost small">Rotate &amp; show a new QR</button>
-            </form>
-            <span class="muted small">Only rotate if you need that: it immediately retires the
-              current secret, and the device using it will have to be paired again.</span>
+            <div class="callout-actions">
+              <form
+                hx-post="/ui/partials/pairing/tokens/{quote(requested_token_id, safe="")}/rotate"
+                hx-target="#pairing-card" hx-swap="outerHTML">
+                <input type="hidden" name="url" value="{escape(selected_url)}" />
+                <button type="submit" class="ghost small">Rotate &amp; show a new QR</button>
+              </form>
+              <span class="muted small">Only rotate if you need that: it immediately retires
+                the current secret, and the device using it will have to be paired again.</span>
+            </div>
           </div>
         """
     elif token_status == "unknown":

--- a/server/app/fragments.py
+++ b/server/app/fragments.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from html import escape
 from urllib.parse import quote
 
@@ -8,6 +9,7 @@ from app.schemas import (
     AdminModelEntry,
     AdminStatusResponse,
     ConfigResponse,
+    DeviceTokenEntry,
     EngineStatus,
     OperationalMetricsStatus,
     ReadinessStatus,
@@ -417,11 +419,22 @@ def pairing_fragment(
     token_redacted: str,
     qr_svg: str = "",
     saved_urls: list[str],
+    token_options: list[tuple[str, str]],
+    selected_token_id: str,
+    token_status: str = "ok",
+    requested_token_id: str = "",
+    requested_token_label: str | None = None,
 ) -> str:
     """Authenticated phone-pairing card with QR for the selected gateway URL.
 
     The SVG is inlined so the browser does not need a second request (img tags
-    cannot attach the WebUI bearer header).
+    cannot attach the WebUI bearer header). `token_options` lists the bootstrap
+    token plus every device token, marking ones this process cannot currently
+    display with "(rotate to view)" — only cached plaintexts can be encoded.
+    `token_status` explains why the shown token differs from what was asked
+    for: `stale` means the requested device token still exists but needs a
+    rotate to get a fresh, displayable secret; `unknown` means it no longer
+    exists at all (typically already revoked).
     """
     if not selected_url:
         return """
@@ -437,6 +450,40 @@ def pairing_fragment(
         f"{escape(url)}</option>"
         for url in candidates
     )
+    token_option_html = "".join(
+        f'<option value="{escape(token_id)}"{" selected" if token_id == selected_token_id else ""}>'
+        f"{escape(label)}</option>"
+        for token_id, label in token_options
+    )
+    selected_token_label = next(
+        (label for token_id, label in token_options if token_id == selected_token_id),
+        "Bootstrap token",
+    )
+    if token_status == "stale":
+        stale_label = escape(requested_token_label or "That device token")
+        unavailable_notice = f"""
+          <div class="callout warning compact">
+            <span>{stale_label}'s secret can't be displayed in this session. This usually
+              happens because the server restarted since it was created. Showing the
+              bootstrap token instead.</span>
+            <form hx-post="/ui/partials/pairing/tokens/{quote(requested_token_id, safe="")}/rotate"
+                  hx-target="#pairing-card" hx-swap="outerHTML">
+              <input type="hidden" name="url" value="{escape(selected_url)}" />
+              <button type="submit" class="ghost small">Rotate &amp; show its QR</button>
+            </form>
+            <span class="muted small">Rotating replaces its secret immediately. Anything still
+              using the old one will need to re-pair.</span>
+          </div>
+        """
+    elif token_status == "unknown":
+        unavailable_notice = """
+          <div class="callout warning compact">
+            <span>That device token no longer exists. It may have been revoked. Showing the
+              bootstrap token instead — create a new device token below for a fresh QR.</span>
+          </div>
+        """
+    else:
+        unavailable_notice = ""
     saved_rows = "".join(
         f"<li><code>{escape(url)}</code>"
         f'<button type="button" class="ghost small danger"'
@@ -469,6 +516,7 @@ def pairing_fragment(
           <div class="pairing-qr" role="img"
                aria-label="Pairing QR code for {escape(selected_url)}">{inline_svg}</div>
           <div class="pairing-meta">
+            {unavailable_notice}
             <div class="pairing-url-form">
               <label><span>Address encoded in the QR</span>
                 <select name="url"
@@ -476,11 +524,22 @@ def pairing_fragment(
                         hx-target="#pairing-card"
                         hx-swap="outerHTML"
                         hx-trigger="change"
-                        hx-include="this">
+                        hx-include="this,[name='token_id']">
                   {options}
                 </select>
               </label>
+              <label><span>Token to encode</span>
+                <select name="token_id"
+                        hx-get="/ui/partials/pairing"
+                        hx-target="#pairing-card"
+                        hx-swap="outerHTML"
+                        hx-trigger="change"
+                        hx-include="this,[name='url']">
+                  {token_option_html}
+                </select>
+              </label>
               <form hx-get="/ui/partials/pairing" hx-target="#pairing-card" hx-swap="outerHTML">
+                <input type="hidden" name="token_id" value="{escape(selected_token_id)}" />
                 <label><span>Or enter your own address (e.g. Tailscale IP)</span>
                   <div class="row">
                     <input name="url" type="text"
@@ -489,20 +548,102 @@ def pairing_fragment(
                   </div>
                 </label>
               </form>
+              <form hx-post="/ui/partials/pairing/tokens" hx-target="#pairing-card"
+                    hx-swap="outerHTML">
+                <input type="hidden" name="url" value="{escape(selected_url)}" />
+                <label><span>Or pair a new device with its own token</span>
+                  <div class="row">
+                    <input name="label" type="text" required maxlength="100"
+                           placeholder="e.g. Kanishk&#39;s iPhone" />
+                    <button type="submit" class="ghost small">Create &amp; show QR</button>
+                  </div>
+                </label>
+              </form>
               {saved_section}
             </div>
             <dl class="facts">
               <div><dt>Gateway URL</dt><dd><code>{escape(selected_url)}</code></dd></div>
-              <div><dt>Token</dt><dd><code>{escape(token_redacted)}</code></dd></div>
+              <div><dt>Token</dt>
+                <dd><code>{escape(token_redacted)}</code>
+                  ({escape(selected_token_label)})</dd></div>
             </dl>
             <p class="muted small">Prefer the Wi‑Fi LAN address when the phone is on
               the same network. Use a Tailscale MagicDNS name when both devices are
               on the tailnet. Override discovery with
-              <code>LOCALFLOW_PUBLIC_URL</code>.</p>
+              <code>LOCALFLOW_PUBLIC_URL</code>. Device tokens created here also appear
+              under Settings, where they can be revoked.</p>
           </div>
         </div>
       </div>
     """
+
+
+def tokens_fragment(
+    entries: list[DeviceTokenEntry], *, new_token: tuple[str, str] | None = None
+) -> str:
+    reveal = ""
+    if new_token is not None:
+        label, plaintext = new_token
+        reveal = f"""
+          <div class="callout success">
+            <strong>New secret for {escape(label)}</strong>
+            <span>Copy this token now &mdash; it will not be shown again. Paste it with the
+              gateway address into that device's manual "Gateway address and token" fields.</span>
+            <div class="row">
+              <code id="new-token-value">{escape(plaintext)}</code>
+              <button type="button" class="ghost small" id="copy-new-token">Copy</button>
+            </div>
+          </div>
+        """
+    rows = "".join(
+        "<tr>"
+        f"<td>{escape(entry.label)}</td>"
+        f"<td>{escape(_format_created(entry.created_at))}</td>"
+        "<td>"
+        + (
+            '<button type="button" class="ghost small"'
+            f' hx-post="/ui/partials/tokens/{quote(entry.id, safe="")}/rotate"'
+            ' hx-target="#tokens-card" hx-swap="outerHTML"'
+            f' hx-confirm="Give {escape(entry.label)} a new secret? Its previous token stops '
+            'working immediately.">Regenerate</button>'
+            '<button type="button" class="ghost small danger"'
+            f' hx-delete="/ui/partials/tokens/{quote(entry.id, safe="")}"'
+            ' hx-target="#tokens-card" hx-swap="outerHTML"'
+            f' hx-confirm="Revoke {escape(entry.label)}? Any device using only this token '
+            'loses access immediately.">Revoke</button>'
+            if entry.revocable
+            else '<span class="muted small">Not revocable here</span>'
+        )
+        + "</td></tr>"
+        for entry in entries
+    )
+    return f"""
+      <div class="card" id="tokens-card">
+        <h2>Paired device tokens</h2>
+        <p class="muted">Give each phone its own bearer token so losing one device only means
+          revoking that device's token instead of rotating everyone else's. Devices already
+          paired with the bootstrap token keep working until you re-pair them with one of
+          these.</p>
+        {reveal}
+        <div class="table-scroll">
+          <table class="table">
+            <thead><tr><th>Label</th><th>Created</th><th></th></tr></thead>
+            <tbody>{rows}</tbody>
+          </table>
+        </div>
+        <form hx-post="/ui/partials/tokens" hx-target="#tokens-card" hx-swap="outerHTML">
+          <div class="row">
+            <input name="label" type="text" required maxlength="100"
+                   placeholder="e.g. Kanishk&#39;s iPhone" />
+            <button type="submit" class="primary">Create token</button>
+          </div>
+        </form>
+      </div>
+    """
+
+
+def _format_created(value: datetime | None) -> str:
+    return "—" if value is None else value.strftime("%Y-%m-%d %H:%M UTC")
 
 
 def settings_fragment(
@@ -510,6 +651,7 @@ def settings_fragment(
     paths: list[tuple[str, str]],
     bind_host: str,
     port: int,
+    tokens_html: str,
 ) -> str:
     options = "".join(
         f'<option value="{escape(value)}"{" selected" if value == config.engine else ""}>'
@@ -589,6 +731,15 @@ def settings_fragment(
         <h2>Storage &amp; configuration</h2>
         <dl class="facts">{facts}</dl>
       </div>
+      <div class="card">
+        <h2>Diagnostics</h2>
+        <p class="muted">Download a redacted snapshot of this gateway's setup, dependencies,
+          hardware, and operational counters &mdash; useful when attaching to a bug report.
+          It never includes the bearer token, recordings, transcripts, or session
+          identifiers.</p>
+        <button id="download-diagnostics" type="button" class="ghost">Download diagnostics</button>
+      </div>
+      {tokens_html}
       <div class="card danger-zone">
         <h2>Connection</h2>
         <p class="muted">The WebUI stores the bearer token only in this browser.</p>

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -68,6 +68,7 @@ from app.pairing import (
     decode_pairing_payload,
     discover_gateway_base_urls,
     encode_pairing_payload,
+    is_ambient_lan_address,
     normalize_gateway_input,
     primary_gateway_base_url,
     qr_svg_for_payload,
@@ -1077,10 +1078,41 @@ def create_app(
         )
         return options
 
+    def _forget_stale_lan_addresses(discovered: list[str]) -> None:
+        """Drop any remembered LAN/tailnet IP no longer part of fresh discovery.
+
+        A bare LAN or Tailscale IP reflects whichever network the gateway was
+        on when it was picked; keeping it around after switching Wi-Fi just
+        clutters the address list and dropdown with a dead entry. Hostnames
+        (MagicDNS names, custom domains) and public IPs are never touched —
+        the user chose those deliberately and they aren't tied to one network.
+        """
+        if engine_manager is None:
+            return
+        changed = False
+        if (
+            pairing_config.pairing_url
+            and pairing_config.pairing_url not in discovered
+            and is_ambient_lan_address(pairing_config.pairing_url)
+        ):
+            pairing_config.pairing_url = None
+            changed = True
+        remaining = [
+            url
+            for url in pairing_config.pairing_urls
+            if url in discovered or not is_ambient_lan_address(url)
+        ]
+        if len(remaining) != len(pairing_config.pairing_urls):
+            pairing_config.pairing_urls = remaining
+            changed = True
+        if changed:
+            pairing_config.save(config_path)
+
     def _pairing_html(
         selected_url: str | None = None, token_id: str | None = None, *, persist: bool = False
     ) -> str:
         discovered = discover_gateway_base_urls(configured.port)
+        _forget_stale_lan_addresses(discovered)
         candidates = list(discovered)
         for saved in pairing_config.pairing_urls:
             if saved not in candidates:

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -36,6 +36,7 @@ from app.audio import (
 )
 from app.catalog import recommended_ids
 from app.config import Settings
+from app.diagnostics import build_diagnostics_bundle
 from app.engines import (
     EngineManager,
     EngineProvider,
@@ -55,14 +56,14 @@ from app.fragments import (
     pairing_fragment,
     settings_fragment,
     test_fragment,
+    tokens_fragment,
 )
 from app.model_manager import (
     DownloadInProgressError,
     ModelManager,
     UnknownModelError,
 )
-from app.models.base import AudioNormalizer, TranscriptionEngine
-from app.models.moonshine import MoonshineEngine
+from app.models.base import AudioNormalizer, StreamingEngine, TranscriptionEngine
 from app.pairing import (
     decode_pairing_payload,
     discover_gateway_base_urls,
@@ -82,6 +83,11 @@ from app.schemas import (
     CustomDownloadRequest,
     DeleteResponse,
     DependencyStatus,
+    DeviceTokenCreateRequest,
+    DeviceTokenCreateResponse,
+    DeviceTokenEntry,
+    DeviceTokenRevokeResponse,
+    DiagnosticsBundle,
     DownloadResponse,
     EngineStatus,
     ErrorDetail,
@@ -103,10 +109,12 @@ from app.service import TranscriptionService
 from app.storage import SessionRepository, StoredSession
 from app.system import detect_system
 from app.text_styles import apply_writing_style
+from app.tokens import TokenStore
 
 VERSION = "0.2.0"
 WEBUI_DIR = Path(__file__).parent / "webui"
 TOKEN_FILE_HINT = "~/.config/localflow/token"
+BOOTSTRAP_TOKEN_ID = "bootstrap"
 
 
 def create_app(
@@ -121,6 +129,7 @@ def create_app(
     repository = SessionRepository(configured.data_dir / "sessions.sqlite3")
     repository.initialize()
     manager = model_manager or ModelManager(configured.resolved_models_dir())
+    token_store = TokenStore(configured.data_dir / "device_tokens.json")
     config_path = configured.config_path
     if engine is not None:
         engine_provider: EngineProvider = StaticEngineProvider(engine)
@@ -201,6 +210,11 @@ def create_app(
         )
         return JSONResponse(status_code=problem.status_code, content=envelope.model_dump())
 
+    def _token_matches(supplied: str) -> bool:
+        if hmac.compare_digest(supplied, configured.token):
+            return True
+        return token_store.matches(supplied)
+
     def require_token(authorization: str | None = Header(default=None)) -> None:
         prefix = "Bearer "
         supplied = (
@@ -208,7 +222,7 @@ def create_app(
             if authorization and authorization.startswith(prefix)
             else ""
         )
-        if not hmac.compare_digest(supplied, configured.token):
+        if not _token_matches(supplied):
             raise APIProblem(401, "unauthorized", "A valid bearer token is required.")
 
     def token_is_valid(authorization: str | None) -> bool:
@@ -218,7 +232,7 @@ def create_app(
             if authorization and authorization.startswith(prefix)
             else ""
         )
-        return hmac.compare_digest(supplied, configured.token)
+        return _token_matches(supplied)
 
     # ---------------------------------------------------------------- WebUI
 
@@ -240,7 +254,7 @@ def create_app(
             engine=state.name,
             streaming_supported=(
                 state.ready
-                and isinstance(selected_engine, MoonshineEngine)
+                and isinstance(selected_engine, StreamingEngine)
                 and selected_engine.supports_streaming
             ),
         )
@@ -368,13 +382,19 @@ def create_app(
 
     @app.websocket("/v1/stream")
     async def stream_transcription(websocket: WebSocket) -> None:
-        """Experimental float32 PCM stream for a selected Moonshine engine."""
+        """Experimental float32 PCM stream for a streaming-capable engine.
+
+        Any engine exposing `supports_streaming` (True), `streaming_lock`, and
+        `create_stream()` returning an object with `add_listener`/`add_audio`/
+        `stop` works here — currently Moonshine and the sherpa-onnx streaming
+        zipformer model.
+        """
         if not token_is_valid(websocket.headers.get("authorization")):
             await websocket.close(code=4401, reason="Unauthorized")
             return
         selected_engine = engine_provider.current()
         if (
-            not isinstance(selected_engine, MoonshineEngine)
+            not isinstance(selected_engine, StreamingEngine)
             or not selected_engine.supports_streaming
         ):
             selected_health = await selected_engine.health()
@@ -431,7 +451,9 @@ def create_app(
                             lines[line_id] = str(text_value).strip()
 
                 await asyncio.to_thread(stream.add_listener, receive_event)
-                await websocket.send_json({"type": "ready", "engine": "moonshine"})
+                await websocket.send_json(
+                    {"type": "ready", "engine": selected_health.name.split(":", 1)[0]}
+                )
                 while True:
                     message = await websocket.receive()
                     if message.get("type") == "websocket.disconnect":
@@ -713,6 +735,90 @@ def create_app(
         return await _status_payload()
 
     @app.get(
+        "/v1/admin/diagnostics",
+        response_model=DiagnosticsBundle,
+        dependencies=[Depends(require_token)],
+    )
+    async def get_admin_diagnostics(response: Response) -> DiagnosticsBundle:
+        bundle = build_diagnostics_bundle(await _status_payload(), await get_config())
+        filename = f"localflow-diagnostics-{bundle.generated_at:%Y%m%dT%H%M%SZ}.json"
+        response.headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return bundle
+
+    def _token_entries() -> list[DeviceTokenEntry]:
+        entries = [
+            DeviceTokenEntry(
+                id=BOOTSTRAP_TOKEN_ID,
+                label="Bootstrap token (LOCALFLOW_TOKEN / token file)",
+                created_at=None,
+                revocable=False,
+            )
+        ]
+        entries.extend(
+            DeviceTokenEntry(
+                id=token.id, label=token.label, created_at=token.created_at, revocable=True
+            )
+            for token in token_store.all()
+        )
+        return entries
+
+    @app.get(
+        "/v1/admin/tokens",
+        response_model=list[DeviceTokenEntry],
+        dependencies=[Depends(require_token)],
+    )
+    async def list_admin_tokens() -> list[DeviceTokenEntry]:
+        return _token_entries()
+
+    @app.post(
+        "/v1/admin/tokens",
+        response_model=DeviceTokenCreateResponse,
+        dependencies=[Depends(require_token)],
+    )
+    async def create_admin_token(body: DeviceTokenCreateRequest) -> DeviceTokenCreateResponse:
+        record, plaintext = token_store.create(body.label)
+        return DeviceTokenCreateResponse(
+            id=record.id, label=record.label, token=plaintext, created_at=record.created_at
+        )
+
+    @app.delete(
+        "/v1/admin/tokens/{token_id}",
+        response_model=DeviceTokenRevokeResponse,
+        dependencies=[Depends(require_token)],
+    )
+    async def revoke_admin_token(token_id: str, response: Response) -> DeviceTokenRevokeResponse:
+        if token_id == BOOTSTRAP_TOKEN_ID:
+            raise APIProblem(
+                409,
+                "bootstrap_token_not_revocable",
+                "Rotate LOCALFLOW_TOKEN or its token file instead of revoking it here.",
+            )
+        revoked = token_store.revoke(token_id)
+        if not revoked:
+            response.status_code = 404
+        return DeviceTokenRevokeResponse(revoked=revoked)
+
+    @app.post(
+        "/v1/admin/tokens/{token_id}/rotate",
+        response_model=DeviceTokenCreateResponse,
+        dependencies=[Depends(require_token)],
+    )
+    async def rotate_admin_token(token_id: str) -> DeviceTokenCreateResponse:
+        if token_id == BOOTSTRAP_TOKEN_ID:
+            raise APIProblem(
+                409,
+                "bootstrap_token_not_rotatable",
+                "Rotate LOCALFLOW_TOKEN or its token file instead of rotating it here.",
+            )
+        rotated = token_store.rotate(token_id)
+        if rotated is None:
+            raise APIProblem(404, "token_not_found", "This device token no longer exists.")
+        record, plaintext = rotated
+        return DeviceTokenCreateResponse(
+            id=record.id, label=record.label, token=plaintext, created_at=record.created_at
+        )
+
+    @app.get(
         "/v1/admin/models",
         response_model=list[AdminModelEntry],
         dependencies=[Depends(require_token)],
@@ -937,7 +1043,43 @@ def create_app(
     def _models_list_html() -> HTMLResponse:
         return _html(models_list_fragment(_model_entries()))
 
-    def _pairing_html(selected_url: str | None = None, *, persist: bool = False) -> str:
+    def _resolve_pairing_token(
+        token_id: str | None,
+    ) -> tuple[str, str, Literal["ok", "stale", "unknown"], str | None]:
+        """Return (resolved_id, plaintext, status, requested_label).
+
+        `stale` means the token still exists (see it under Settings) but this
+        process never cached its plaintext — normally because it was created
+        before the gateway last restarted. `unknown` means no such token
+        exists at all (typically already revoked). Both fall back to the
+        bootstrap token for the QR actually shown; only `stale` can be fixed
+        by rotating the token to give it a fresh, displayable secret.
+        """
+        if token_id and token_id != BOOTSTRAP_TOKEN_ID:
+            cached = token_store.cached_plaintext(token_id)
+            if cached is not None:
+                return token_id, cached, "ok", None
+            existing = token_store.get(token_id)
+            if existing is not None:
+                return BOOTSTRAP_TOKEN_ID, configured.token, "stale", existing.label
+            return BOOTSTRAP_TOKEN_ID, configured.token, "unknown", None
+        return BOOTSTRAP_TOKEN_ID, configured.token, "ok", None
+
+    def _pairing_token_options() -> list[tuple[str, str]]:
+        cached_ids = {token.id for token in token_store.cached_entries()}
+        options = [(BOOTSTRAP_TOKEN_ID, "Bootstrap token")]
+        options.extend(
+            (
+                token.id,
+                token.label if token.id in cached_ids else f"{token.label} (rotate to view)",
+            )
+            for token in reversed(token_store.all())
+        )
+        return options
+
+    def _pairing_html(
+        selected_url: str | None = None, token_id: str | None = None, *, persist: bool = False
+    ) -> str:
         discovered = discover_gateway_base_urls(configured.port)
         candidates = list(discovered)
         for saved in pairing_config.pairing_urls:
@@ -964,7 +1106,7 @@ def create_app(
             selected = pairing_config.pairing_url or primary_gateway_base_url(configured.port)
             if selected and selected not in candidates:
                 candidates = [selected, *candidates]
-        token = configured.token
+        resolved_token_id, token, token_status, requested_label = _resolve_pairing_token(token_id)
         redacted = (
             f"{token[:4]}…{token[-4:]} ({len(token)} characters)"
             if len(token) > 8
@@ -972,13 +1114,18 @@ def create_app(
         )
         qr_svg = ""
         if selected:
-            qr_svg = qr_svg_for_payload(encode_pairing_payload(selected, configured.token))
+            qr_svg = qr_svg_for_payload(encode_pairing_payload(selected, token))
         return pairing_fragment(
             selected_url=selected,
             candidates=candidates,
             token_redacted=redacted,
             qr_svg=qr_svg,
             saved_urls=pairing_config.pairing_urls,
+            token_options=_pairing_token_options(),
+            selected_token_id=resolved_token_id,
+            token_status=token_status,
+            requested_token_id=token_id or "",
+            requested_token_label=requested_label,
         )
 
     def _forget_pairing_url(url: str) -> str:
@@ -1013,9 +1160,12 @@ def create_app(
         "/v1/admin/pairing",
         dependencies=[Depends(require_token)],
     )
-    async def get_pairing(url: str | None = Query(default=None)) -> dict[str, Any]:
+    async def get_pairing(
+        url: str | None = Query(default=None), token_id: str | None = Query(default=None)
+    ) -> dict[str, Any]:
         selected = _resolve_pairing_url(url)
-        payload = encode_pairing_payload(selected, configured.token)
+        _, token, _, _ = _resolve_pairing_token(token_id)
+        payload = encode_pairing_payload(selected, token)
         # Round-trip so clients and tests share one format.
         decoded = decode_pairing_payload(payload)
         return {
@@ -1030,9 +1180,12 @@ def create_app(
         dependencies=[Depends(require_token)],
         response_class=Response,
     )
-    async def get_pairing_qr(url: str | None = Query(default=None)) -> Response:
+    async def get_pairing_qr(
+        url: str | None = Query(default=None), token_id: str | None = Query(default=None)
+    ) -> Response:
         selected = _resolve_pairing_url(url)
-        payload = encode_pairing_payload(selected, configured.token)
+        _, token, _, _ = _resolve_pairing_token(token_id)
+        payload = encode_pairing_payload(selected, token)
         svg = qr_svg_for_payload(payload)
         return Response(
             content=svg,
@@ -1045,8 +1198,33 @@ def create_app(
         response_class=HTMLResponse,
         dependencies=[Depends(require_token)],
     )
-    async def ui_pairing(url: str | None = Query(default=None)) -> HTMLResponse:
-        return _html(_pairing_html(url, persist=True))
+    async def ui_pairing(
+        url: str | None = Query(default=None), token_id: str | None = Query(default=None)
+    ) -> HTMLResponse:
+        return _html(_pairing_html(url, token_id, persist=True))
+
+    @app.post(
+        "/ui/partials/pairing/tokens",
+        response_class=HTMLResponse,
+        dependencies=[Depends(require_token)],
+    )
+    async def ui_create_pairing_token(
+        label: str = Form(..., min_length=1, max_length=100), url: str | None = Form(default=None)
+    ) -> HTMLResponse:
+        record, _ = token_store.create(label)
+        return _html(_pairing_html(url, record.id, persist=True))
+
+    @app.post(
+        "/ui/partials/pairing/tokens/{token_id}/rotate",
+        response_class=HTMLResponse,
+        dependencies=[Depends(require_token)],
+    )
+    async def ui_rotate_pairing_token(
+        token_id: str, url: str | None = Form(default=None)
+    ) -> HTMLResponse:
+        rotated = token_store.rotate(token_id)
+        resolved_id = rotated[0].id if rotated is not None else token_id
+        return _html(_pairing_html(url, resolved_id, persist=True))
 
     @app.delete(
         "/ui/partials/pairing",
@@ -1216,7 +1394,66 @@ def create_app(
             ("WebUI config file", str(config_path)),
             ("Token file", TOKEN_FILE_HINT),
         ]
-        return _html(settings_fragment(config, paths, configured.bind_host, configured.port))
+        return _html(
+            settings_fragment(
+                config, paths, configured.bind_host, configured.port, _tokens_fragment_str()
+            )
+        )
+
+    def _tokens_fragment_str(*, new_token: tuple[str, str] | None = None) -> str:
+        return tokens_fragment(_token_entries(), new_token=new_token)
+
+    @app.get(
+        "/ui/partials/tokens",
+        response_class=HTMLResponse,
+        dependencies=[Depends(require_token)],
+    )
+    async def ui_tokens() -> HTMLResponse:
+        return _html(_tokens_fragment_str())
+
+    @app.post(
+        "/ui/partials/tokens",
+        response_class=HTMLResponse,
+        dependencies=[Depends(require_token)],
+    )
+    async def ui_create_token(
+        label: str = Form(..., min_length=1, max_length=100),
+    ) -> HTMLResponse:
+        record, plaintext = token_store.create(label)
+        return _html(_tokens_fragment_str(new_token=(record.label, plaintext)))
+
+    @app.delete(
+        "/ui/partials/tokens/{token_id}",
+        response_class=HTMLResponse,
+        dependencies=[Depends(require_token)],
+    )
+    async def ui_revoke_token(token_id: str) -> HTMLResponse:
+        if token_id == BOOTSTRAP_TOKEN_ID:
+            raise APIProblem(
+                409,
+                "bootstrap_token_not_revocable",
+                "Rotate LOCALFLOW_TOKEN or its token file instead of revoking it here.",
+            )
+        token_store.revoke(token_id)
+        return _html(_tokens_fragment_str())
+
+    @app.post(
+        "/ui/partials/tokens/{token_id}/rotate",
+        response_class=HTMLResponse,
+        dependencies=[Depends(require_token)],
+    )
+    async def ui_rotate_token(token_id: str) -> HTMLResponse:
+        if token_id == BOOTSTRAP_TOKEN_ID:
+            raise APIProblem(
+                409,
+                "bootstrap_token_not_rotatable",
+                "Rotate LOCALFLOW_TOKEN or its token file instead of rotating it here.",
+            )
+        rotated = token_store.rotate(token_id)
+        if rotated is None:
+            raise APIProblem(404, "token_not_found", "This device token no longer exists.")
+        record, plaintext = rotated
+        return _html(_tokens_fragment_str(new_token=(record.label, plaintext)))
 
     @app.put(
         "/ui/partials/config",

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1072,7 +1072,7 @@ def create_app(
         options.extend(
             (
                 token.id,
-                token.label if token.id in cached_ids else f"{token.label} (rotate to view)",
+                token.label if token.id in cached_ids else f"{token.label} (paired; no live QR)",
             )
             for token in reversed(token_store.all())
         )

--- a/server/app/model_manager.py
+++ b/server/app/model_manager.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 from app.catalog import (
     DEFAULT_CATALOG,
     ENGINE_MOONSHINE,
+    ENGINE_SHERPA_ONNX,
     ENGINE_WHISPER_CPP,
     ENGINE_WHISPERKIT,
     CatalogModel,
@@ -228,6 +229,9 @@ class ModelManager:
         if model.archive_url is not None:
             await self._run_archive_download(model, handle)
             return
+        if model.engine == ENGINE_SHERPA_ONNX and model.huggingface_repo is not None:
+            await self._run_sherpa_huggingface_download(model, handle)
+            return
         if model.huggingface_repo is not None:
             await self._run_huggingface_download(model, handle)
             return
@@ -284,6 +288,56 @@ class ModelManager:
         finally:
             archive_path.unlink(missing_ok=True)
             shutil.rmtree(extraction_dir, ignore_errors=True)
+            if handle.state.status != "completed":
+                shutil.rmtree(partial_dir, ignore_errors=True)
+
+    async def _run_sherpa_huggingface_download(
+        self, model: CatalogModel, handle: _DownloadHandle
+    ) -> None:
+        """Download exactly `required_files` from a plain Hugging Face model repo.
+
+        Unlike `_run_huggingface_download` (which mirrors an entire folder for
+        engines like MLX Audio and writes no marker), this fetches only the
+        named files a sherpa-onnx model actually needs and writes the same
+        `.localflow-model.json` marker `_run_archive_download` does, since
+        some model families (GigaAM, Canary) ship as bare Hugging Face repos
+        with no pre-packaged `.tar.bz2` release archive.
+        """
+        if not model.huggingface_repo or not model.required_files:
+            raise UnknownModelError(f"Hugging Face metadata is incomplete for {model.id}.")
+        final_dir = self.model_path(model)
+        partial_dir = final_dir.with_name(final_dir.name + ".partial")
+        shutil.rmtree(partial_dir, ignore_errors=True)
+        partial_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            available = dict(await asyncio.to_thread(_list_repo_folder, model.huggingface_repo, ""))
+            handle.state.total_bytes = sum(available.get(name, 0) for name in model.required_files)
+            for name in model.required_files:
+                if handle.cancel.is_set():
+                    raise DownloadCancelled
+                url = f"{HF_BASE_URL}/{model.huggingface_repo}/resolve/main/{name}"
+                await asyncio.to_thread(
+                    _download_file, url, partial_dir / name, handle.state, handle.cancel, name
+                )
+            missing = [name for name in model.required_files if not (partial_dir / name).is_file()]
+            if missing:
+                raise RuntimeError(f"Downloaded model is missing: {', '.join(missing)}.")
+            metadata = {
+                "model_id": model.id,
+                "model_type": model.model_type,
+                "language_codes": list(model.language_codes),
+                "required_files": list(model.required_files),
+            }
+            (partial_dir / ".localflow-model.json").write_text(
+                json.dumps(metadata, indent=2) + "\n", encoding="utf-8"
+            )
+            if handle.cancel.is_set():
+                raise DownloadCancelled
+            final_dir.parent.mkdir(parents=True, exist_ok=True)
+            shutil.rmtree(final_dir, ignore_errors=True)
+            partial_dir.replace(final_dir)
+            handle.state.status = "completed"
+        finally:
             if handle.state.status != "completed":
                 shutil.rmtree(partial_dir, ignore_errors=True)
 

--- a/server/app/models/base.py
+++ b/server/app/models/base.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol, runtime_checkable
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,3 +35,23 @@ class TranscriptionEngine(Protocol):
 
 class AudioNormalizer(Protocol):
     async def normalize(self, source: Path, destination: Path, maximum_seconds: int) -> Path: ...
+
+
+@runtime_checkable
+class StreamingEngine(Protocol):
+    """A `TranscriptionEngine` that can also decode incrementally.
+
+    `supports_streaming` still needs checking even when `isinstance` matches:
+    an engine can implement this interface while its *currently selected*
+    model doesn't stream (e.g. Moonshine with a batch-only language). See the
+    `/v1/stream` WebSocket handler in `main.py`, which is the only caller —
+    `create_stream()` must return an object exposing `add_listener(callback)`,
+    `add_audio(samples, sample_rate)`, and `stop()`.
+    """
+
+    supports_streaming: bool
+    streaming_lock: asyncio.Lock
+
+    async def health(self) -> EngineHealth: ...
+
+    async def create_stream(self) -> Any: ...

--- a/server/app/models/sherpa_onnx.py
+++ b/server/app/models/sherpa_onnx.py
@@ -6,6 +6,7 @@ import os
 import time
 import wave
 from array import array
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -14,10 +15,18 @@ from app.errors import EngineUnavailableError, TranscriptionProcessError
 from app.models.base import EngineHealth, EngineTranscription, TranscriptionOptions
 
 MODEL_METADATA = ".localflow-model.json"
+STREAMING_MODEL_TYPE = "streaming_zipformer"
 
 
 class SherpaOnnxEngine:
-    """Persistent CPU recognizer for compact sherpa-onnx model exports."""
+    """Persistent CPU recognizer for compact sherpa-onnx model exports.
+
+    Most catalog entries are offline (batch) models. One model type,
+    `streaming_zipformer`, is different: it loads an `OnlineRecognizer` and
+    exposes `create_stream()`/`supports_streaming`/`streaming_lock`, the same
+    surface `MoonshineEngine` already provides, so the `/v1/stream` WebSocket
+    handler in `main.py` works with either engine without engine-specific code.
+    """
 
     def __init__(
         self,
@@ -32,6 +41,15 @@ class SherpaOnnxEngine:
         self._recognizer: Any | None = None
         self._load_lock = asyncio.Lock()
         self._inference_lock = asyncio.Lock()
+        # The package owns mutable decoder state, so batch and streaming jobs
+        # must never share the persistent recognizer concurrently.
+        self.streaming_lock = self._inference_lock
+
+    @property
+    def supports_streaming(self) -> bool:
+        if self.catalog_model is None:
+            return False
+        return self.catalog_model.model_type == STREAMING_MODEL_TYPE
 
     async def health(self) -> EngineHealth:
         package_ready = importlib.util.find_spec("sherpa_onnx") is not None
@@ -55,6 +73,17 @@ class SherpaOnnxEngine:
         await self._ensure_recognizer()
         return _directory_size(self.model_root) if self.model_root else 0
 
+    async def create_stream(self) -> _SherpaOnnxStreamAdapter:
+        if not self.supports_streaming:
+            raise EngineUnavailableError("The selected sherpa-onnx model does not stream.")
+        if not (await self.health()).ready:
+            raise EngineUnavailableError(
+                "sherpa-onnx or its selected streaming model is unavailable."
+            )
+        recognizer, _ = await self._ensure_recognizer()
+        stream = await asyncio.to_thread(recognizer.create_stream)
+        return _SherpaOnnxStreamAdapter(recognizer, stream)
+
     async def transcribe(
         self, audio_path: Path, options: TranscriptionOptions
     ) -> EngineTranscription:
@@ -69,9 +98,10 @@ class SherpaOnnxEngine:
             recognizer, loaded_now = await self._ensure_recognizer()
             model_load_ms = _elapsed_ms(load_started) if loaded_now else 0
             inference_started = time.monotonic()
+            decode = _decode_wave_online if self.supports_streaming else _decode_wave
             try:
                 text = await asyncio.wait_for(
-                    asyncio.to_thread(_decode_wave, recognizer, audio_path),
+                    asyncio.to_thread(decode, recognizer, audio_path),
                     timeout=180,
                 )
             except TimeoutError as error:
@@ -114,14 +144,46 @@ class SherpaOnnxEngine:
                 provider="cpu",
             )
         if self.catalog_model.model_type == "nemo_transducer":
+            # Ordered (encoder, decoder, joiner, tokens) in the catalog entry: not every
+            # nemo_transducer export quantizes all three the same way GigaAM's decoder
+            # and joiner ship unquantized alongside an INT8 encoder, unlike Parakeet.
+            encoder_file, decoder_file, joiner_file, _ = self.catalog_model.required_files
             return sherpa_onnx.OfflineRecognizer.from_transducer(
-                encoder=str(self.model_root / "encoder.int8.onnx"),
-                decoder=str(self.model_root / "decoder.int8.onnx"),
-                joiner=str(self.model_root / "joiner.int8.onnx"),
+                encoder=str(self.model_root / encoder_file),
+                decoder=str(self.model_root / decoder_file),
+                joiner=str(self.model_root / joiner_file),
                 tokens=tokens,
                 num_threads=threads,
                 model_type="nemo_transducer",
                 provider="cpu",
+            )
+        if self.catalog_model.model_type == "nemo_ctc":
+            return sherpa_onnx.OfflineRecognizer.from_nemo_ctc(
+                model=str(self.model_root / "model.int8.onnx"),
+                tokens=tokens,
+                num_threads=threads,
+                provider="cpu",
+            )
+        if self.catalog_model.model_type == "nemo_canary":
+            # English-only for now: source/target language is fixed at load time, not
+            # per request, and the catalog currently only ships an English entry.
+            return sherpa_onnx.OfflineRecognizer.from_nemo_canary(
+                encoder=str(self.model_root / "encoder.int8.onnx"),
+                decoder=str(self.model_root / "decoder.int8.onnx"),
+                tokens=tokens,
+                num_threads=threads,
+                provider="cpu",
+            )
+        if self.catalog_model.model_type == STREAMING_MODEL_TYPE:
+            encoder_file, decoder_file, joiner_file, _ = self.catalog_model.required_files
+            return sherpa_onnx.OnlineRecognizer.from_transducer(
+                tokens=tokens,
+                encoder=str(self.model_root / encoder_file),
+                decoder=str(self.model_root / decoder_file),
+                joiner=str(self.model_root / joiner_file),
+                num_threads=threads,
+                provider="cpu",
+                enable_endpoint_detection=True,
             )
         raise EngineUnavailableError(
             f"Unsupported sherpa-onnx model type: {self.catalog_model.model_type}."
@@ -138,7 +200,7 @@ class SherpaOnnxEngine:
             )
 
 
-def _decode_wave(recognizer: Any, audio_path: Path) -> str:
+def _read_wave_samples(audio_path: Path) -> tuple[int, list[float]]:
     with wave.open(str(audio_path), "rb") as source:
         channels = source.getnchannels()
         sample_width = source.getsampwidth()
@@ -150,10 +212,103 @@ def _decode_wave(recognizer: Any, audio_path: Path) -> str:
     samples.frombytes(frames)
     if channels > 1:
         samples = array("h", samples[::channels])
+    return sample_rate, [sample / 32768.0 for sample in samples]
+
+
+def _decode_wave(recognizer: Any, audio_path: Path) -> str:
+    sample_rate, floats = _read_wave_samples(audio_path)
     stream = recognizer.create_stream()
-    stream.accept_waveform(sample_rate, [sample / 32768.0 for sample in samples])
+    stream.accept_waveform(sample_rate, floats)
     recognizer.decode_stream(stream)
     return str(stream.result.text).strip()
+
+
+def _decode_wave_online(recognizer: Any, audio_path: Path) -> str:
+    """Batch fallback for a streaming-only model: feed the whole recording as
+    one continuous stream and read the final result off the recognizer,
+    rather than the stream itself (`OnlineStream` has no `.result`)."""
+    sample_rate, floats = _read_wave_samples(audio_path)
+    stream = recognizer.create_stream()
+    stream.accept_waveform(sample_rate, floats)
+    stream.input_finished()
+    while recognizer.is_ready(stream):
+        recognizer.decode_stream(stream)
+    return str(recognizer.get_result(stream)).strip()
+
+
+class _StreamLine:
+    def __init__(self, line_id: int, text: str) -> None:
+        self.line_id = line_id
+        self.text = text
+
+
+class _StreamEvent:
+    def __init__(self, line: _StreamLine | None) -> None:
+        self.line = line
+
+
+class _StopResult:
+    def __init__(self, lines: list[_StreamLine]) -> None:
+        self.lines = lines
+
+
+class _SherpaOnnxStreamAdapter:
+    """Adapts sherpa-onnx's `OnlineRecognizer`/`OnlineStream` to the
+    `add_listener`/`add_audio`/`stop` interface the `/v1/stream` WebSocket
+    handler already uses for Moonshine.
+
+    sherpa-onnx separates the persistent recognizer (the loaded model) from a
+    per-connection stream (decode state); the recognizer, not the stream,
+    drives decoding (`is_ready`/`decode_stream`) and reports results
+    (`get_result`/`is_endpoint`/`reset`). Each completed segment (an
+    endpoint) becomes one "line", numbered like Moonshine's, so multiple
+    segments across a long dictation join the same way.
+    """
+
+    def __init__(self, recognizer: Any, stream: Any) -> None:
+        self._recognizer = recognizer
+        self._stream = stream
+        self._listener: Callable[[object], None] | None = None
+        self._completed_lines: list[_StreamLine] = []
+        self._next_line_id = 0
+        self._last_partial = ""
+
+    def add_listener(self, listener: Callable[[object], None]) -> None:
+        self._listener = listener
+
+    def add_audio(self, samples: list[float], sample_rate: int) -> None:
+        self._stream.accept_waveform(sample_rate, samples)
+        self._drain()
+
+    def stop(self) -> _StopResult:
+        self._stream.input_finished()
+        self._drain()
+        trailing = str(self._recognizer.get_result(self._stream)).strip()
+        if trailing:
+            self._completed_lines.append(_StreamLine(self._next_line_id, trailing))
+        return _StopResult(list(self._completed_lines))
+
+    def _drain(self) -> None:
+        while self._recognizer.is_ready(self._stream):
+            self._recognizer.decode_stream(self._stream)
+        if self._recognizer.is_endpoint(self._stream):
+            text = str(self._recognizer.get_result(self._stream)).strip()
+            if text:
+                line = _StreamLine(self._next_line_id, text)
+                self._completed_lines.append(line)
+                self._notify(line)
+            self._next_line_id += 1
+            self._last_partial = ""
+            self._recognizer.reset(self._stream)
+            return
+        partial = str(self._recognizer.get_result(self._stream)).strip()
+        if partial and partial != self._last_partial:
+            self._last_partial = partial
+            self._notify(_StreamLine(self._next_line_id, partial))
+
+    def _notify(self, line: _StreamLine) -> None:
+        if self._listener is not None:
+            self._listener(_StreamEvent(line))
 
 
 def _language_code(value: str) -> str:

--- a/server/app/pairing.py
+++ b/server/app/pairing.py
@@ -109,6 +109,28 @@ def normalize_gateway_input(raw: str, default_port: int) -> str:
     return normalize_gateway_url(trimmed)
 
 
+_AMBIENT_LAN_NETWORKS = (
+    ipaddress.IPv4Network("100.64.0.0/10"),  # Tailscale / CGNAT, not flagged by is_private
+)
+
+
+def is_ambient_lan_address(url: str) -> bool:
+    """True when *url*'s host is a bare LAN-or-tailnet IPv4 address.
+
+    Such an address (a plain LAN or Tailscale IP, not a hostname) reflects
+    whichever network the gateway happens to be on right now, so it should
+    track fresh discovery rather than being remembered indefinitely — unlike
+    a MagicDNS name, custom domain, or public IP, which the user chose
+    deliberately and isn't tied to a particular Wi-Fi network.
+    """
+    host = urlparse(url).hostname or ""
+    try:
+        ip = ipaddress.IPv4Address(host)
+    except ValueError:
+        return False
+    return ip.is_private or any(ip in network for network in _AMBIENT_LAN_NETWORKS)
+
+
 def discover_gateway_base_urls(port: int) -> list[str]:
     """Return phone-reachable gateway bases, preferred first.
 

--- a/server/app/schemas.py
+++ b/server/app/schemas.py
@@ -171,6 +171,30 @@ class CustomDownloadRequest(BaseModel):
     url: str = Field(min_length=12, max_length=2000)
 
 
+class DeviceTokenEntry(BaseModel):
+    id: str
+    label: str
+    created_at: datetime | None
+    revocable: bool
+
+
+class DeviceTokenCreateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    label: str = Field(min_length=1, max_length=100)
+
+
+class DeviceTokenCreateResponse(BaseModel):
+    id: str
+    label: str
+    token: str
+    created_at: datetime
+
+
+class DeviceTokenRevokeResponse(BaseModel):
+    revoked: bool
+
+
 class DownloadResponse(BaseModel):
     model_id: str
     status: str
@@ -233,3 +257,26 @@ class ErrorDetail(BaseModel):
 
 class ErrorEnvelope(BaseModel):
     error: ErrorDetail
+
+
+class DiagnosticsBundle(BaseModel):
+    """A redacted operational snapshot, safe to attach to a bug report.
+
+    Never contains the bearer token, recording audio, transcript text, or
+    session identifiers — only setup, dependency, hardware, and counter data
+    already shown in the authenticated WebUI.
+    """
+
+    generated_at: datetime
+    version: str
+    engine: EngineStatus
+    system: SystemStatus
+    dependencies: list[DependencyStatus]
+    paths: PathStatus
+    bind_host: str
+    port: int
+    setup: SetupChecklist
+    metrics: OperationalMetricsStatus
+    readiness: ReadinessStatus
+    config: ConfigResponse
+    never_included: list[str]

--- a/server/app/tokens.py
+++ b/server/app/tokens.py
@@ -1,0 +1,172 @@
+"""Named, individually revocable bearer tokens for additional paired devices.
+
+`Settings.token` (from `LOCALFLOW_TOKEN` / the token file) remains a permanent
+bootstrap credential managed outside this store — whoever controls that file
+or environment variable can always read/rotate it directly, so trying to
+revoke it through the API would be theatre. Everything issued through
+`TokenStore` sits alongside it and can be revoked independently, so losing one
+phone means revoking one token rather than rotating everyone else's.
+
+Only a SHA-256 digest of each token is ever persisted; the plaintext is
+returned once, at creation, and is not recoverable afterward. To let a device
+token's own QR be regenerated (for example after changing the pairing
+address) without weakening that guarantee, the store also keeps an in-memory,
+never-persisted cache of recently created plaintexts, cleared on revoke and
+naturally gone on restart.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceToken:
+    id: str
+    label: str
+    token_hash: str
+    created_at: datetime
+
+
+def _hash_token(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+class TokenStore:
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._tokens: list[DeviceToken] = self._load(path)
+        self._plaintext_cache: dict[str, str] = {}
+
+    @staticmethod
+    def _load(path: Path) -> list[DeviceToken]:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return []
+        if not isinstance(payload, list):
+            return []
+        tokens: list[DeviceToken] = []
+        for entry in payload:
+            if not isinstance(entry, dict):
+                continue
+            token_id = entry.get("id")
+            label = entry.get("label")
+            token_hash = entry.get("token_hash")
+            created_at = entry.get("created_at")
+            if not (
+                isinstance(token_id, str)
+                and token_id
+                and isinstance(label, str)
+                and label
+                and isinstance(token_hash, str)
+                and token_hash
+                and isinstance(created_at, str)
+            ):
+                continue
+            try:
+                parsed_created_at = datetime.fromisoformat(created_at)
+            except ValueError:
+                continue
+            tokens.append(
+                DeviceToken(
+                    id=token_id, label=label, token_hash=token_hash, created_at=parsed_created_at
+                )
+            )
+        return tokens
+
+    def _save(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = [
+            {
+                "id": token.id,
+                "label": token.label,
+                "token_hash": token.token_hash,
+                "created_at": token.created_at.isoformat(),
+            }
+            for token in self._tokens
+        ]
+        descriptor, temporary_name = tempfile.mkstemp(
+            dir=self._path.parent, prefix=".device-tokens-", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2)
+                handle.write("\n")
+            os.replace(temporary_name, self._path)
+        except BaseException:
+            Path(temporary_name).unlink(missing_ok=True)
+            raise
+
+    def all(self) -> list[DeviceToken]:
+        return list(self._tokens)
+
+    def create(self, label: str) -> tuple[DeviceToken, str]:
+        plaintext = secrets.token_urlsafe(32)
+        record = DeviceToken(
+            id=secrets.token_hex(8),
+            label=label.strip() or "Unnamed device",
+            token_hash=_hash_token(plaintext),
+            created_at=datetime.now(UTC),
+        )
+        self._tokens.append(record)
+        self._save()
+        self._plaintext_cache[record.id] = plaintext
+        return record, plaintext
+
+    def get(self, token_id: str) -> DeviceToken | None:
+        return next((token for token in self._tokens if token.id == token_id), None)
+
+    def rotate(self, token_id: str) -> tuple[DeviceToken, str] | None:
+        """Replace *token_id*'s secret in place, keeping its id and label.
+
+        The previous plaintext stops working immediately (its hash is gone),
+        so this is only for a token whose plaintext can no longer be
+        displayed — for example after a restart cleared the cache below.
+        """
+        for index, token in enumerate(self._tokens):
+            if token.id != token_id:
+                continue
+            plaintext = secrets.token_urlsafe(32)
+            updated = DeviceToken(
+                id=token.id,
+                label=token.label,
+                token_hash=_hash_token(plaintext),
+                created_at=datetime.now(UTC),
+            )
+            self._tokens[index] = updated
+            self._save()
+            self._plaintext_cache[token.id] = plaintext
+            return updated, plaintext
+        return None
+
+    def revoke(self, token_id: str) -> bool:
+        remaining = [token for token in self._tokens if token.id != token_id]
+        if len(remaining) == len(self._tokens):
+            return False
+        self._tokens = remaining
+        self._save()
+        self._plaintext_cache.pop(token_id, None)
+        return True
+
+    def matches(self, candidate: str) -> bool:
+        if not candidate:
+            return False
+        candidate_hash = _hash_token(candidate)
+        return any(hmac.compare_digest(token.token_hash, candidate_hash) for token in self._tokens)
+
+    def cached_plaintext(self, token_id: str) -> str | None:
+        """The plaintext for *token_id*, if created (and not revoked) in this process."""
+        return self._plaintext_cache.get(token_id)
+
+    def cached_entries(self) -> list[DeviceToken]:
+        """Device tokens whose plaintext is still available for QR display."""
+        return [token for token in self._tokens if token.id in self._plaintext_cache]

--- a/server/app/webui/app.js
+++ b/server/app/webui/app.js
@@ -315,6 +315,45 @@
   });
 
   document.body.addEventListener("click", async (event) => {
+    if (event.target.id !== "download-diagnostics") return;
+    try {
+      const response = await fetch("/v1/admin/diagnostics", {
+        headers: { Authorization: `Bearer ${getToken()}` },
+      });
+      if (response.status === 401) {
+        localStorage.removeItem(TOKEN_KEY);
+        showOverlay("Your gateway session expired. Paste the current token.");
+        return;
+      }
+      const payload = await response.json();
+      if (!response.ok) throw new Error(payload.error?.message || "Diagnostics failed.");
+      const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `localflow-diagnostics-${payload.generated_at.replace(/[:.]/g, "-")}.json`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+      showToast("Diagnostics downloaded.", false);
+    } catch (error) {
+      showToast(error.message || "Could not download diagnostics.");
+    }
+  });
+
+  document.body.addEventListener("click", async (event) => {
+    if (event.target.id !== "copy-new-token") return;
+    const value = document.getElementById("new-token-value").textContent;
+    try {
+      await navigator.clipboard.writeText(value);
+      showToast("Token copied.", false);
+    } catch (_) {
+      showToast("Could not copy the token. Select it manually.");
+    }
+  });
+
+  document.body.addEventListener("click", async (event) => {
     if (event.target.id !== "copy-transcript") return;
     const transcript = document.getElementById("test-transcript").textContent;
     try {

--- a/server/app/webui/styles.css
+++ b/server/app/webui/styles.css
@@ -275,6 +275,9 @@ main { max-width: 1120px; margin: 0 auto; padding: 24px 24px 60px; }
 .callout.warning { border-color: rgba(224, 176, 64, 0.5); }
 .callout.warning strong { color: var(--warn); }
 .callout.compact { margin: 16px 0 0; }
+.callout.stacked { flex-direction: column; align-items: stretch; }
+.callout-actions { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.callout-actions form { display: contents; }
 .ready-message { display: flex; gap: 12px; align-items: flex-start; }
 .ready-message p { margin: 4px 0 0; }
 .ready-icon {

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -30,6 +30,7 @@ apple = [
 [project.scripts]
 localflow-server = "app.cli:serve"
 localflow-status = "app.cli:status"
+localflow-diagnostics = "app.cli:diagnostics"
 localflow-cleanup = "app.cli:cleanup"
 
 [dependency-groups]

--- a/server/tests/test_admin.py
+++ b/server/tests/test_admin.py
@@ -73,6 +73,8 @@ def auth() -> dict[str, str]:
 async def test_admin_endpoints_require_token(admin_client: httpx.AsyncClient) -> None:
     for path in (
         "/v1/admin/status",
+        "/v1/admin/diagnostics",
+        "/v1/admin/tokens",
         "/v1/admin/models",
         "/v1/admin/config",
         "/ui/partials/overview",
@@ -81,6 +83,82 @@ async def test_admin_endpoints_require_token(admin_client: httpx.AsyncClient) ->
     ):
         response = await admin_client.get(path)
         assert response.status_code == 401, path
+
+
+async def test_tokens_list_starts_with_only_the_bootstrap_entry(
+    admin_client: httpx.AsyncClient, auth: dict[str, str]
+) -> None:
+    response = await admin_client.get("/v1/admin/tokens", headers=auth)
+    assert response.status_code == 200
+    entries = response.json()
+    assert entries == [
+        {
+            "id": "bootstrap",
+            "label": "Bootstrap token (LOCALFLOW_TOKEN / token file)",
+            "created_at": None,
+            "revocable": False,
+        }
+    ]
+
+
+async def test_created_device_token_authenticates_and_can_be_revoked(
+    admin_client: httpx.AsyncClient, auth: dict[str, str]
+) -> None:
+    created = await admin_client.post("/v1/admin/tokens", headers=auth, json={"label": "Pixel 6a"})
+    assert created.status_code == 200
+    payload = created.json()
+    assert payload["label"] == "Pixel 6a"
+    device_auth = {"Authorization": f"Bearer {payload['token']}"}
+
+    # The new device token authenticates on its own, independent of the bootstrap token.
+    status = await admin_client.get("/v1/admin/status", headers=device_auth)
+    assert status.status_code == 200
+
+    listed = await admin_client.get("/v1/admin/tokens", headers=auth)
+    ids = {entry["id"]: entry for entry in listed.json()}
+    assert payload["id"] in ids
+    assert ids[payload["id"]]["revocable"] is True
+
+    revoked = await admin_client.delete(f"/v1/admin/tokens/{payload['id']}", headers=auth)
+    assert revoked.status_code == 200
+    assert revoked.json() == {"revoked": True}
+
+    # Revoking one device token never touches the bootstrap token or other clients.
+    still_ok = await admin_client.get("/v1/admin/status", headers=auth)
+    assert still_ok.status_code == 200
+    now_rejected = await admin_client.get("/v1/admin/status", headers=device_auth)
+    assert now_rejected.status_code == 401
+
+
+async def test_revoking_unknown_token_returns_404(
+    admin_client: httpx.AsyncClient, auth: dict[str, str]
+) -> None:
+    response = await admin_client.delete("/v1/admin/tokens/does-not-exist", headers=auth)
+    assert response.status_code == 404
+    assert response.json() == {"revoked": False}
+
+
+async def test_bootstrap_token_cannot_be_revoked(
+    admin_client: httpx.AsyncClient, auth: dict[str, str]
+) -> None:
+    response = await admin_client.delete("/v1/admin/tokens/bootstrap", headers=auth)
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "bootstrap_token_not_revocable"
+
+
+async def test_diagnostics_bundle_is_downloadable_and_redacted(
+    admin_client: httpx.AsyncClient, auth: dict[str, str]
+) -> None:
+    response = await admin_client.get("/v1/admin/diagnostics", headers=auth)
+    assert response.status_code == 200
+    assert response.headers["content-disposition"].startswith(
+        'attachment; filename="localflow-diagnostics-'
+    )
+    payload = response.json()
+    assert payload["engine"]["id"] == "auto"
+    assert payload["config"]["engine"] == "auto"
+    assert "never_included" in payload and payload["never_included"]
+    assert TOKEN not in response.text
 
 
 async def test_status_reports_system_and_setup(
@@ -238,6 +316,20 @@ async def test_partials_render_html(admin_client: httpx.AsyncClient, auth: dict[
     assert settings.status_code == 200
     assert "Speech engine" in settings.text
     assert "All-interface listener" in settings.text
+    assert "Paired device tokens" in settings.text
+    assert "Bootstrap token (LOCALFLOW_TOKEN / token file)" in settings.text
+
+    tokens = await admin_client.get("/ui/partials/tokens", headers=auth)
+    assert tokens.status_code == 200
+    assert 'id="tokens-card"' in tokens.text
+
+    created = await admin_client.post(
+        "/ui/partials/tokens", headers=auth, data={"label": "Kanishk's iPhone"}
+    )
+    assert created.status_code == 200
+    assert "New secret for Kanishk&#x27;s iPhone" in created.text
+    assert 'id="new-token-value"' in created.text
+    assert "Regenerate</button>" in created.text
 
     operations = await admin_client.get("/ui/partials/operations", headers=auth)
     assert operations.status_code == 200

--- a/server/tests/test_diagnostics.py
+++ b/server/tests/test_diagnostics.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.diagnostics import NEVER_INCLUDED, build_diagnostics_bundle, redact_home_path
+from app.schemas import (
+    AdminStatusResponse,
+    ConfigResponse,
+    DependencyStatus,
+    EngineStatus,
+    OperationalMetricsStatus,
+    PathStatus,
+    ReadinessStatus,
+    SetupChecklist,
+    SystemStatus,
+)
+
+
+def _status(paths: PathStatus) -> AdminStatusResponse:
+    return AdminStatusResponse(
+        version="0.2.0",
+        engine=EngineStatus(id="whisper.cpp", name="whisper.cpp:ggml-base.en.bin", ready=True),
+        system=SystemStatus(
+            os="Darwin",
+            arch="arm64",
+            chip="Apple M2",
+            ram_gb=16.0,
+            is_apple_silicon=True,
+            logical_cpus=8,
+            effective_cpus=8.0,
+            containerized=False,
+            accelerators=["CPU", "Metal/Core ML"],
+            cpu_features=[],
+        ),
+        dependencies=[DependencyStatus(name="FFmpeg", available=True, path="/usr/bin/ffmpeg")],
+        paths=paths,
+        bind_host="0.0.0.0",
+        port=8765,
+        setup=SetupChecklist(
+            token_configured=True,
+            ffmpeg_available=True,
+            engine_binary_available=True,
+            model_installed=True,
+            engine_ready=True,
+        ),
+        metrics=OperationalMetricsStatus(
+            uptime_seconds=42,
+            queue_depth=0,
+            active_transcriptions=0,
+            concurrency_limit=1,
+            successful_transcriptions=3,
+            failed_transcriptions=0,
+            rejected_transcriptions=0,
+            average_latency_ms=500,
+            last_latency_ms=500,
+        ),
+        readiness=ReadinessStatus(probe_age_seconds=1.0, warmup_state="complete", warmed_bytes=0),
+    )
+
+
+def _config() -> ConfigResponse:
+    return ConfigResponse(engine="auto", available_engines=["auto", "whisper.cpp"])
+
+
+def test_redact_home_path_replaces_home_prefix() -> None:
+    home = str(Path.home())
+    assert redact_home_path(f"{home}/.local/share/localflow") == "~/.local/share/localflow"
+    assert redact_home_path(home) == "~"
+
+
+def test_redact_home_path_leaves_other_paths_untouched() -> None:
+    assert redact_home_path("/data/models") == "/data/models"
+
+
+def test_build_diagnostics_bundle_redacts_paths_and_lists_exclusions() -> None:
+    home = str(Path.home())
+    status = _status(
+        PathStatus(
+            data_dir=f"{home}/.local/share/localflow",
+            models_dir=f"{home}/.local/share/localflow/models",
+            config_file=f"{home}/.config/localflow/config.json",
+            token_file="~/.config/localflow/token",
+        )
+    )
+    bundle = build_diagnostics_bundle(status, _config())
+    assert bundle.paths.data_dir == "~/.local/share/localflow"
+    assert bundle.paths.models_dir == "~/.local/share/localflow/models"
+    assert bundle.paths.config_file == "~/.config/localflow/config.json"
+    assert bundle.never_included == list(NEVER_INCLUDED)
+    dumped = bundle.model_dump_json()
+    assert home not in dumped
+    assert "Bearer" not in dumped
+
+
+def test_build_diagnostics_bundle_redacts_config_model_paths() -> None:
+    """whisper_model/whisperkit_model/faster_whisper_model are absolute paths
+    (set via `str(path)` in EngineManager.select_model), unlike
+    moonshine_model/sherpa_model/mlx_audio_model, which are opaque catalog
+    ids — both must survive the bundle, but only the paths get redacted."""
+    home = str(Path.home())
+    status = _status(
+        PathStatus(
+            data_dir=f"{home}/.local/share/localflow",
+            models_dir=f"{home}/.local/share/localflow/models",
+            config_file=f"{home}/.config/localflow/config.json",
+            token_file="~/.config/localflow/token",
+        )
+    )
+    config = ConfigResponse(
+        engine="whisper.cpp",
+        available_engines=["auto", "whisper.cpp"],
+        whisper_model=f"{home}/.local/share/localflow/models/whisper.cpp/ggml-base.en.bin",
+        whisperkit_model=f"{home}/.local/share/localflow/models/whisperkit/openai_whisper-tiny",
+        faster_whisper_model=f"{home}/.local/share/localflow/models/faster-whisper/tiny.en",
+        sherpa_model="sherpa-onnx:sensevoice-small-int8",
+    )
+
+    bundle = build_diagnostics_bundle(status, config)
+
+    assert (
+        bundle.config.whisper_model
+        == "~/.local/share/localflow/models/whisper.cpp/ggml-base.en.bin"
+    )
+    assert (
+        bundle.config.whisperkit_model
+        == "~/.local/share/localflow/models/whisperkit/openai_whisper-tiny"
+    )
+    assert (
+        bundle.config.faster_whisper_model
+        == "~/.local/share/localflow/models/faster-whisper/tiny.en"
+    )
+    assert bundle.config.sherpa_model == "sherpa-onnx:sensevoice-small-int8"
+    assert home not in bundle.model_dump_json()

--- a/server/tests/test_model_manager.py
+++ b/server/tests/test_model_manager.py
@@ -143,6 +143,77 @@ def test_catalog_includes_portable_and_apple_silicon_models() -> None:
     assert mlx_turbo.marker_file == "model.safetensors"
 
 
+def test_catalog_includes_gigaam_and_canary_models() -> None:
+    entries = {model.id: model for model in DEFAULT_CATALOG}
+
+    gigaam_ctc = entries["sherpa-onnx:gigaam-v3-ctc-russian-int8"]
+    assert gigaam_ctc.archive_url is None
+    assert (
+        gigaam_ctc.huggingface_repo
+        == "csukuangfj/sherpa-onnx-nemo-ctc-giga-am-v3-russian-2025-12-16"
+    )
+    assert gigaam_ctc.required_files == ("model.int8.onnx", "tokens.txt")
+    assert gigaam_ctc.model_type == "nemo_ctc"
+    assert gigaam_ctc.language_codes == ("ru",)
+    assert gigaam_ctc.license_name == "MIT"
+
+    gigaam_rnnt = entries["sherpa-onnx:gigaam-v3-rnnt-russian-int8"]
+    assert gigaam_rnnt.huggingface_repo == (
+        "csukuangfj/sherpa-onnx-nemo-transducer-giga-am-v3-russian-2025-12-16"
+    )
+    assert gigaam_rnnt.required_files == (
+        "encoder.int8.onnx",
+        "decoder.onnx",
+        "joiner.onnx",
+        "tokens.txt",
+    )
+    assert gigaam_rnnt.model_type == "nemo_transducer"
+    assert gigaam_rnnt.license_name == "MIT"
+
+    canary = entries["sherpa-onnx:canary-180m-flash-en-int8"]
+    assert (
+        canary.huggingface_repo == "csukuangfj/sherpa-onnx-nemo-canary-180m-flash-en-es-de-fr-int8"
+    )
+    assert canary.required_files == ("encoder.int8.onnx", "decoder.int8.onnx", "tokens.txt")
+    assert canary.model_type == "nemo_canary"
+    assert canary.language_codes == ("en",)
+    assert canary.license_name == "CC BY 4.0"
+
+    streaming = entries["sherpa-onnx:streaming-zipformer-en-20m-int8"]
+    assert (
+        streaming.huggingface_repo == "csukuangfj/sherpa-onnx-streaming-zipformer-en-20M-2023-02-17"
+    )
+    assert streaming.required_files == (
+        "encoder-epoch-99-avg-1.int8.onnx",
+        "decoder-epoch-99-avg-1.int8.onnx",
+        "joiner-epoch-99-avg-1.int8.onnx",
+        "tokens.txt",
+    )
+    assert streaming.model_type == "streaming_zipformer"
+    assert streaming.supports_streaming is True
+    assert streaming.license_name == "Apache 2.0"
+
+
+def test_sherpa_onnx_helper_requires_a_download_mechanism() -> None:
+    from app.catalog import _sherpa_onnx
+
+    with pytest.raises(ValueError, match="archive_url/archive_root or huggingface_repo"):
+        _sherpa_onnx(
+            "broken",
+            "Broken",
+            1,
+            "English",
+            "Fast",
+            1,
+            required_files=("model.onnx",),
+            model_type="nemo_ctc",
+            language_codes=("en",),
+            family="Broken",
+            description="",
+            license_name="MIT",
+        )
+
+
 @pytest.fixture
 def tiny_file_model(tmp_path: Path) -> CatalogModel:
     source = tmp_path / "source.bin"
@@ -303,6 +374,52 @@ async def test_archive_download_extracts_validated_model(tmp_path: Path) -> None
     assert '"model_type": "sense_voice"' in metadata
     assert '"language_codes": [' in metadata
     assert not (manager.models_dir / "sherpa-onnx" / "test-int8.download").exists()
+
+
+async def test_sherpa_huggingface_download_fetches_only_required_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    catalog_model = dataclasses.replace(
+        SHERPA_TEST,
+        id="sherpa-onnx:gigaam-test",
+        key="gigaam-test",
+        archive_url=None,
+        archive_root=None,
+        huggingface_repo="example/gigaam-repo",
+        required_files=("model.int8.onnx", "tokens.txt"),
+        model_type="nemo_ctc",
+    )
+    manager = ModelManager(tmp_path / "models", catalog=(catalog_model,))
+
+    mirror = tmp_path / "mirror"
+    folder = mirror / "example/gigaam-repo/resolve/main"
+    folder.mkdir(parents=True)
+    (folder / "model.int8.onnx").write_bytes(b"onnx-bytes")
+    (folder / "tokens.txt").write_text("token")
+    (folder / "README.md").write_text("not needed")
+    monkeypatch.setattr(model_manager, "HF_BASE_URL", mirror.as_uri())
+    monkeypatch.setattr(
+        model_manager,
+        "_list_repo_folder",
+        lambda repo, name: [
+            ("model.int8.onnx", 10),
+            ("tokens.txt", 5),
+            ("README.md", 999),
+        ],
+    )
+
+    state = manager.start_download(catalog_model.id)
+    await asyncio.wait_for(_wait_finished(manager, catalog_model.id), timeout=5)
+
+    assert state.status == "completed"
+    assert state.total_bytes == 15  # only required_files counted, not README.md
+    installed = manager.installed_path(catalog_model.id)
+    assert installed is not None
+    assert (installed / "model.int8.onnx").read_bytes() == b"onnx-bytes"
+    assert not (installed / "README.md").exists()
+    metadata = (installed / ".localflow-model.json").read_text(encoding="utf-8")
+    assert '"model_type": "nemo_ctc"' in metadata
+    assert not (manager.models_dir / "sherpa-onnx" / "gigaam-test.partial").exists()
 
 
 def test_archive_extractor_rejects_parent_paths(tmp_path: Path) -> None:

--- a/server/tests/test_pairing.py
+++ b/server/tests/test_pairing.py
@@ -8,10 +8,24 @@ from app.pairing import (
     PAIRING_VERSION,
     decode_pairing_payload,
     encode_pairing_payload,
+    is_ambient_lan_address,
     normalize_gateway_input,
     primary_gateway_base_url,
     qr_svg_for_payload,
 )
+
+
+def test_is_ambient_lan_address_matches_private_and_tailnet_ips() -> None:
+    assert is_ambient_lan_address("http://192.168.1.20:8765") is True
+    assert is_ambient_lan_address("http://10.0.0.5:8765") is True
+    assert is_ambient_lan_address("http://172.16.5.5:8765") is True
+    assert is_ambient_lan_address("http://100.101.102.103:8765") is True  # Tailscale/CGNAT
+
+
+def test_is_ambient_lan_address_leaves_hostnames_and_public_ips_alone() -> None:
+    assert is_ambient_lan_address("https://homelabone.tail1234.ts.net:8765") is False
+    assert is_ambient_lan_address("https://flow.example.com") is False
+    assert is_ambient_lan_address("http://8.8.8.8:8765") is False
 
 
 def test_round_trip_encode_decode() -> None:

--- a/server/tests/test_pairing_api.py
+++ b/server/tests/test_pairing_api.py
@@ -4,8 +4,10 @@ import json
 
 import httpx
 import pytest
-from conftest import TOKEN
+from conftest import TOKEN, FakeEngine, FakeNormalizer
 
+from app.config import Settings
+from app.main import create_app
 from app.pairing import decode_pairing_payload
 
 
@@ -48,6 +50,152 @@ async def test_pairing_payload_and_qr(
     assert "192.168.1.75" in partial.text
     # QR is inlined so the browser never needs an unauthenticated <img> fetch.
     assert "<svg" in partial.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_pairing_defaults_to_bootstrap_token_dropdown(
+    client: httpx.AsyncClient,
+    authorization: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOCALFLOW_PUBLIC_URL", "http://192.168.1.75:8765")
+    partial = await client.get("/ui/partials/pairing", headers=authorization)
+    assert partial.status_code == 200
+    assert '<option value="bootstrap" selected>Bootstrap token</option>' in partial.text
+    assert "Or pair a new device with its own token" in partial.text
+
+
+@pytest.mark.asyncio
+async def test_pairing_can_select_a_device_token_for_the_qr(
+    client: httpx.AsyncClient,
+    authorization: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOCALFLOW_PUBLIC_URL", "http://192.168.1.75:8765")
+    created = await client.post(
+        "/v1/admin/tokens", headers=authorization, json={"label": "Pixel 6a"}
+    )
+    assert created.status_code == 200
+    device = created.json()
+
+    api = await client.get(
+        "/v1/admin/pairing",
+        headers=authorization,
+        params={"url": "http://192.168.1.75:8765", "token_id": device["id"]},
+    )
+    assert api.status_code == 200
+    decoded = decode_pairing_payload(api.json()["payload"])
+    assert decoded.token == device["token"]
+    assert decoded.token != TOKEN
+
+    partial = await client.get(
+        "/ui/partials/pairing",
+        headers=authorization,
+        params={"token_id": device["id"]},
+    )
+    assert partial.status_code == 200
+    assert f'<option value="{device["id"]}" selected>Pixel 6a</option>' in partial.text
+    assert "no longer available" not in partial.text
+
+
+@pytest.mark.asyncio
+async def test_pairing_falls_back_to_bootstrap_for_revoked_or_unknown_token(
+    client: httpx.AsyncClient,
+    authorization: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOCALFLOW_PUBLIC_URL", "http://192.168.1.75:8765")
+    created = await client.post(
+        "/v1/admin/tokens", headers=authorization, json={"label": "Old phone"}
+    )
+    device_id = created.json()["id"]
+    await client.delete(f"/v1/admin/tokens/{device_id}", headers=authorization)
+
+    for missing_id in (device_id, "never-existed"):
+        api = await client.get(
+            "/v1/admin/pairing",
+            headers=authorization,
+            params={"url": "http://192.168.1.75:8765", "token_id": missing_id},
+        )
+        assert decode_pairing_payload(api.json()["payload"]).token == TOKEN
+
+        partial = await client.get(
+            "/ui/partials/pairing",
+            headers=authorization,
+            params={"token_id": missing_id},
+        )
+        assert "no longer exists" in partial.text
+        assert '<option value="bootstrap" selected>Bootstrap token</option>' in partial.text
+
+
+@pytest.mark.asyncio
+async def test_pairing_offers_to_rotate_a_stale_device_token(
+    settings: Settings,
+    fake_engine: FakeEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A token created before the gateway last restarted has no cached plaintext.
+
+    It should still appear in the dropdown (marked for rotation) instead of
+    silently vanishing, and rotating it should make it selectable again.
+    """
+    monkeypatch.setenv("LOCALFLOW_PUBLIC_URL", "http://192.168.1.75:8765")
+    auth = {"Authorization": f"Bearer {TOKEN}"}
+
+    first_app = create_app(settings, engine=fake_engine, normalizer=FakeNormalizer())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=first_app), base_url="http://test"
+    ) as first_client:
+        created = await first_client.post(
+            "/v1/admin/tokens", headers=auth, json={"label": "Kanishk's Iphone"}
+        )
+        device_id = created.json()["id"]
+
+    # A fresh app over the same data directory simulates a restart: the token
+    # still exists on disk, but no process has its plaintext cached anymore.
+    second_app = create_app(settings, engine=fake_engine, normalizer=FakeNormalizer())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=second_app), base_url="http://test"
+    ) as second_client:
+        partial = await second_client.get(
+            "/ui/partials/pairing", headers=auth, params={"token_id": device_id}
+        )
+        assert "Kanishk&#x27;s Iphone (rotate to view)" in partial.text
+        assert "can't be displayed in this session" in partial.text
+        assert f'hx-post="/ui/partials/pairing/tokens/{device_id}/rotate"' in partial.text
+        assert '<option value="bootstrap" selected>Bootstrap token</option>' in partial.text
+
+        rotated = await second_client.post(
+            f"/ui/partials/pairing/tokens/{device_id}/rotate",
+            headers=auth,
+            data={"url": "http://192.168.1.75:8765"},
+        )
+        assert rotated.status_code == 200
+        assert (
+            f'<option value="{device_id}" selected>Kanishk&#x27;s Iphone</option>' in rotated.text
+        )
+        assert "can't be displayed" not in rotated.text
+
+
+@pytest.mark.asyncio
+async def test_creating_a_pairing_token_shows_its_own_qr(
+    client: httpx.AsyncClient,
+    authorization: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOCALFLOW_PUBLIC_URL", "http://192.168.1.75:8765")
+    response = await client.post(
+        "/ui/partials/pairing/tokens",
+        headers=authorization,
+        data={"label": "Work iPad", "url": "http://192.168.1.75:8765"},
+    )
+    assert response.status_code == 200
+    assert '<option value="bootstrap">Bootstrap token</option>' in response.text
+    assert "selected>Work iPad</option>" in response.text
+
+    tokens = await client.get("/v1/admin/tokens", headers=authorization)
+    labels = {entry["label"] for entry in tokens.json()}
+    assert "Work iPad" in labels
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_pairing_api.py
+++ b/server/tests/test_pairing_api.py
@@ -163,8 +163,8 @@ async def test_pairing_offers_to_rotate_a_stale_device_token(
         partial = await second_client.get(
             "/ui/partials/pairing", headers=auth, params={"token_id": device_id}
         )
-        assert "Kanishk&#x27;s Iphone (rotate to view)" in partial.text
-        assert "can't be displayed in this session" in partial.text
+        assert "Kanishk&#x27;s Iphone (paired; no live QR)" in partial.text
+        assert "is still paired and working normally" in partial.text
         assert f'hx-post="/ui/partials/pairing/tokens/{device_id}/rotate"' in partial.text
         assert '<option value="bootstrap" selected>Bootstrap token</option>' in partial.text
 
@@ -177,7 +177,7 @@ async def test_pairing_offers_to_rotate_a_stale_device_token(
         assert (
             f'<option value="{device_id}" selected>Kanishk&#x27;s Iphone</option>' in rotated.text
         )
-        assert "can't be displayed" not in rotated.text
+        assert "still paired and working normally" not in rotated.text
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_pairing_api.py
+++ b/server/tests/test_pairing_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import httpx
 import pytest
@@ -8,7 +9,9 @@ from conftest import TOKEN, FakeEngine, FakeNormalizer
 
 from app.config import Settings
 from app.main import create_app
+from app.model_manager import ModelManager
 from app.pairing import decode_pairing_payload
+from app.runtime_config import RuntimeConfig
 
 
 @pytest.mark.asyncio
@@ -196,6 +199,44 @@ async def test_creating_a_pairing_token_shows_its_own_qr(
     tokens = await client.get("/v1/admin/tokens", headers=authorization)
     labels = {entry["label"] for entry in tokens.json()}
     assert "Work iPad" in labels
+
+
+@pytest.mark.asyncio
+async def test_switching_networks_forgets_the_old_lan_address(tmp_path: Path) -> None:
+    """Reproduces the reported bug: an old Wi-Fi's LAN IP lingered forever
+    alongside the new one instead of being superseded by fresh discovery."""
+    settings = Settings(
+        token=TOKEN,
+        data_dir=tmp_path,
+        whisper_binary=tmp_path / "whisper-cli",
+        whisper_model=tmp_path / "model.bin",
+        config_path=tmp_path / "config.json",
+    )
+    old_address = "http://192.168.1.20:8765"
+    hostname_address = "https://homelabone.tail1234.ts.net:8765"
+    runtime_config = RuntimeConfig(
+        pairing_url=old_address,
+        pairing_urls=[old_address, hostname_address],
+    )
+    app = create_app(
+        settings,
+        model_manager=ModelManager(tmp_path / "models"),
+        runtime_config=runtime_config,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        auth = {"Authorization": f"Bearer {TOKEN}"}
+        partial = await client.get("/ui/partials/pairing", headers=auth)
+        assert partial.status_code == 200
+        assert f'value="{old_address}"' not in partial.text
+        assert f'value="{hostname_address}"' in partial.text
+
+    # The stale ambient LAN IP is gone; the deliberately-typed hostname stayed.
+    assert old_address not in runtime_config.pairing_urls
+    assert hostname_address in runtime_config.pairing_urls
+    assert runtime_config.pairing_url != old_address
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_sherpa_onnx.py
+++ b/server/tests/test_sherpa_onnx.py
@@ -10,17 +10,22 @@ from pathlib import Path
 import pytest
 
 from app.catalog import CatalogModel
-from app.errors import TranscriptionProcessError
+from app.errors import EngineUnavailableError, TranscriptionProcessError
 from app.models.base import EngineTranscription, TranscriptionOptions
-from app.models.sherpa_onnx import SherpaOnnxEngine
+from app.models.sherpa_onnx import SherpaOnnxEngine, _SherpaOnnxStreamAdapter
 
 
-def _catalog(model_type: str = "sense_voice") -> CatalogModel:
-    files = (
-        ("model.int8.onnx", "tokens.txt")
-        if model_type == "sense_voice"
-        else ("encoder.int8.onnx", "decoder.int8.onnx", "joiner.int8.onnx", "tokens.txt")
-    )
+def _catalog(
+    model_type: str = "sense_voice", required_files: tuple[str, ...] | None = None
+) -> CatalogModel:
+    if required_files is not None:
+        files = required_files
+    elif model_type in ("sense_voice", "nemo_ctc"):
+        files = ("model.int8.onnx", "tokens.txt")
+    elif model_type == "nemo_canary":
+        files = ("encoder.int8.onnx", "decoder.int8.onnx", "tokens.txt")
+    else:
+        files = ("encoder.int8.onnx", "decoder.int8.onnx", "joiner.int8.onnx", "tokens.txt")
     return CatalogModel(
         id=f"sherpa-onnx:{model_type}",
         engine="sherpa-onnx",
@@ -105,6 +110,151 @@ async def test_sherpa_keeps_one_recognizer_loaded(
     assert constructions[0]["use_itn"] is True
 
 
+def _fake_recognizer_module(
+    factory_name: str,
+    constructions: list[dict[str, object]],
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    attr_name: str = "OfflineRecognizer",
+) -> None:
+    class Recognizer:
+        pass
+
+    def factory(cls: type[Recognizer], **kwargs: object) -> Recognizer:
+        constructions.append(kwargs)
+        return cls()
+
+    setattr(Recognizer, factory_name, classmethod(factory))
+    module = types.ModuleType("sherpa_onnx")
+    setattr(module, attr_name, Recognizer)
+    monkeypatch.setitem(sys.modules, "sherpa_onnx", module)
+
+
+def test_sherpa_nemo_ctc_loads_with_its_own_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    catalog_model = _catalog("nemo_ctc")
+    root = _model_root(tmp_path, catalog_model)
+    constructions: list[dict[str, object]] = []
+    _fake_recognizer_module("from_nemo_ctc", constructions, monkeypatch)
+    monkeypatch.setattr(
+        "app.models.sherpa_onnx.importlib.util.find_spec",
+        lambda _: importlib.machinery.ModuleSpec("sherpa_onnx", loader=None),
+    )
+
+    SherpaOnnxEngine(root, catalog_model)._load_recognizer_sync()
+
+    assert len(constructions) == 1
+    assert constructions[0]["model"] == str(root / "model.int8.onnx")
+    assert constructions[0]["tokens"] == str(root / "tokens.txt")
+
+
+def test_sherpa_nemo_canary_loads_english_only_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    catalog_model = _catalog("nemo_canary")
+    root = _model_root(tmp_path, catalog_model)
+    constructions: list[dict[str, object]] = []
+    _fake_recognizer_module("from_nemo_canary", constructions, monkeypatch)
+    monkeypatch.setattr(
+        "app.models.sherpa_onnx.importlib.util.find_spec",
+        lambda _: importlib.machinery.ModuleSpec("sherpa_onnx", loader=None),
+    )
+
+    SherpaOnnxEngine(root, catalog_model)._load_recognizer_sync()
+
+    assert len(constructions) == 1
+    assert constructions[0]["encoder"] == str(root / "encoder.int8.onnx")
+    assert constructions[0]["decoder"] == str(root / "decoder.int8.onnx")
+    assert constructions[0]["tokens"] == str(root / "tokens.txt")
+    # No src_lang/tgt_lang override: sherpa-onnx defaults both to "en", matching the
+    # English-only catalog entry this project currently ships for Canary.
+    assert "src_lang" not in constructions[0]
+    assert "tgt_lang" not in constructions[0]
+
+
+def test_sherpa_nemo_transducer_uses_each_files_own_quantization(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GigaAM's RNNT export ships an INT8 encoder but a non-quantized decoder/joiner."""
+    catalog_model = _catalog(
+        "nemo_transducer",
+        required_files=("encoder.int8.onnx", "decoder.onnx", "joiner.onnx", "tokens.txt"),
+    )
+    root = _model_root(tmp_path, catalog_model)
+    constructions: list[dict[str, object]] = []
+    _fake_recognizer_module("from_transducer", constructions, monkeypatch)
+    monkeypatch.setattr(
+        "app.models.sherpa_onnx.importlib.util.find_spec",
+        lambda _: importlib.machinery.ModuleSpec("sherpa_onnx", loader=None),
+    )
+
+    SherpaOnnxEngine(root, catalog_model)._load_recognizer_sync()
+
+    assert constructions[0]["encoder"] == str(root / "encoder.int8.onnx")
+    assert constructions[0]["decoder"] == str(root / "decoder.onnx")
+    assert constructions[0]["joiner"] == str(root / "joiner.onnx")
+
+
+def test_streaming_zipformer_loads_via_online_recognizer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    catalog_model = _catalog(
+        "streaming_zipformer",
+        required_files=("encoder.onnx", "decoder.onnx", "joiner.onnx", "tokens.txt"),
+    )
+    root = _model_root(tmp_path, catalog_model)
+    constructions: list[dict[str, object]] = []
+    _fake_recognizer_module(
+        "from_transducer", constructions, monkeypatch, attr_name="OnlineRecognizer"
+    )
+    monkeypatch.setattr(
+        "app.models.sherpa_onnx.importlib.util.find_spec",
+        lambda _: importlib.machinery.ModuleSpec("sherpa_onnx", loader=None),
+    )
+
+    SherpaOnnxEngine(root, catalog_model)._load_recognizer_sync()
+
+    assert constructions[0]["encoder"] == str(root / "encoder.onnx")
+    assert constructions[0]["decoder"] == str(root / "decoder.onnx")
+    assert constructions[0]["joiner"] == str(root / "joiner.onnx")
+    assert constructions[0]["tokens"] == str(root / "tokens.txt")
+    assert constructions[0]["enable_endpoint_detection"] is True
+
+
+async def test_create_stream_wraps_the_recognizers_stream(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    catalog_model = _catalog(
+        "streaming_zipformer",
+        required_files=("encoder.onnx", "decoder.onnx", "joiner.onnx", "tokens.txt"),
+    )
+    root = _model_root(tmp_path, catalog_model)
+    raw_stream = object()
+
+    class Recognizer:
+        @classmethod
+        def from_transducer(cls, **kwargs: object) -> Recognizer:
+            return cls()
+
+        def create_stream(self) -> object:
+            return raw_stream
+
+    module = types.ModuleType("sherpa_onnx")
+    module.OnlineRecognizer = Recognizer  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sherpa_onnx", module)
+    monkeypatch.setattr(
+        "app.models.sherpa_onnx.importlib.util.find_spec",
+        lambda _: importlib.machinery.ModuleSpec("sherpa_onnx", loader=None),
+    )
+
+    engine = SherpaOnnxEngine(root, catalog_model)
+    adapter = await engine.create_stream()
+
+    assert isinstance(adapter, _SherpaOnnxStreamAdapter)
+    assert adapter._stream is raw_stream
+
+
 async def test_sherpa_rejects_unsupported_language(tmp_path: Path) -> None:
     catalog_model = _catalog()
     engine = SherpaOnnxEngine(_model_root(tmp_path, catalog_model), catalog_model)
@@ -114,3 +264,184 @@ async def test_sherpa_rejects_unsupported_language(tmp_path: Path) -> None:
             tmp_path / "unused.wav",
             TranscriptionOptions("es", "casual"),
         )
+
+
+def test_decode_wave_online_reads_result_from_the_recognizer(tmp_path: Path) -> None:
+    from app.models.sherpa_onnx import _decode_wave_online
+
+    audio = tmp_path / "audio.wav"
+    _wave(audio)
+
+    class FakeStream:
+        def __init__(self) -> None:
+            self.waveform: tuple[int, list[float]] | None = None
+            self.finished = False
+
+        def accept_waveform(self, sample_rate: int, samples: list[float]) -> None:
+            self.waveform = (sample_rate, samples)
+
+        def input_finished(self) -> None:
+            self.finished = True
+
+    class FakeRecognizer:
+        def __init__(self) -> None:
+            self.stream = FakeStream()
+            self.ready_calls = 0
+
+        def create_stream(self) -> FakeStream:
+            return self.stream
+
+        def is_ready(self, stream: FakeStream) -> bool:
+            self.ready_calls += 1
+            return self.ready_calls == 1
+
+        def decode_stream(self, stream: FakeStream) -> None:
+            pass
+
+        def get_result(self, stream: FakeStream) -> str:
+            # OnlineRecognizer.get_result returns a plain str, unlike the
+            # offline result objects, which expose `.text`.
+            return " final streaming text "
+
+    recognizer = FakeRecognizer()
+    text = _decode_wave_online(recognizer, audio)
+
+    assert text == "final streaming text"
+    assert recognizer.stream.finished is True
+    assert recognizer.stream.waveform is not None
+
+
+def test_supports_streaming_only_for_the_streaming_model_type(tmp_path: Path) -> None:
+    streaming_model = _catalog(
+        "streaming_zipformer",
+        required_files=("encoder.onnx", "decoder.onnx", "joiner.onnx", "tokens.txt"),
+    )
+    batch_model = _catalog("sense_voice")
+
+    streaming_engine = SherpaOnnxEngine(_model_root(tmp_path, streaming_model), streaming_model)
+    batch_engine = SherpaOnnxEngine(_model_root(tmp_path, batch_model), batch_model)
+    no_model_engine = SherpaOnnxEngine(None, None)
+
+    assert streaming_engine.supports_streaming is True
+    assert batch_engine.supports_streaming is False
+    assert no_model_engine.supports_streaming is False
+
+
+async def test_create_stream_rejects_a_non_streaming_model(tmp_path: Path) -> None:
+    catalog_model = _catalog("sense_voice")
+    engine = SherpaOnnxEngine(_model_root(tmp_path, catalog_model), catalog_model)
+
+    with pytest.raises(EngineUnavailableError, match="does not stream"):
+        await engine.create_stream()
+
+
+class _FakeOnlineStream:
+    def __init__(self) -> None:
+        self.waveforms: list[tuple[int, list[float]]] = []
+        self.finished = False
+
+    def accept_waveform(self, sample_rate: int, samples: list[float]) -> None:
+        self.waveforms.append((sample_rate, list(samples)))
+
+    def input_finished(self) -> None:
+        self.finished = True
+
+
+class _FakeOnlineRecognizer:
+    """Lets a test script exactly what one `is_ready`/`decode_stream` drain sees."""
+
+    def __init__(self) -> None:
+        self.ready_remaining = 0
+        self.endpoint = False
+        self.text = ""
+        self.decode_calls = 0
+        self.reset_calls = 0
+
+    def is_ready(self, stream: object) -> bool:
+        if self.ready_remaining > 0:
+            self.ready_remaining -= 1
+            return True
+        return False
+
+    def decode_stream(self, stream: object) -> None:
+        self.decode_calls += 1
+
+    def is_endpoint(self, stream: object) -> bool:
+        return self.endpoint
+
+    def get_result(self, stream: object) -> str:
+        # OnlineRecognizer.get_result returns a plain str, unlike the offline
+        # result objects, which expose `.text`.
+        return self.text
+
+    def reset(self, stream: object) -> None:
+        self.reset_calls += 1
+        self.text = ""
+        self.endpoint = False
+
+
+def test_stream_adapter_reports_partial_then_completes_a_line() -> None:
+    recognizer = _FakeOnlineRecognizer()
+    stream = _FakeOnlineStream()
+    adapter = _SherpaOnnxStreamAdapter(recognizer, stream)
+    events: list[object] = []
+    adapter.add_listener(events.append)
+
+    recognizer.ready_remaining = 1
+    recognizer.text = "hello"
+    adapter.add_audio([0.1, 0.2], 16_000)
+    assert len(events) == 1
+    assert events[0].line.text == "hello"
+    assert events[0].line.line_id == 0
+
+    recognizer.ready_remaining = 1
+    recognizer.text = "hello world"
+    recognizer.endpoint = True
+    adapter.add_audio([0.3, 0.4], 16_000)
+    assert len(events) == 2
+    assert events[1].line.text == "hello world"
+    assert events[1].line.line_id == 0
+    assert recognizer.reset_calls == 1
+
+    result = adapter.stop()
+    assert [(line.line_id, line.text) for line in result.lines] == [(0, "hello world")]
+    assert stream.finished is True
+
+
+def test_stream_adapter_starts_a_new_line_after_each_endpoint() -> None:
+    recognizer = _FakeOnlineRecognizer()
+    stream = _FakeOnlineStream()
+    adapter = _SherpaOnnxStreamAdapter(recognizer, stream)
+
+    recognizer.ready_remaining = 1
+    recognizer.text = "first segment"
+    recognizer.endpoint = True
+    adapter.add_audio([0.1], 16_000)
+
+    recognizer.ready_remaining = 1
+    recognizer.text = "second segment"
+    recognizer.endpoint = True
+    adapter.add_audio([0.2], 16_000)
+
+    result = adapter.stop()
+    assert [(line.line_id, line.text) for line in result.lines] == [
+        (0, "first segment"),
+        (1, "second segment"),
+    ]
+
+
+def test_stream_adapter_does_not_repeat_identical_partial_text() -> None:
+    recognizer = _FakeOnlineRecognizer()
+    stream = _FakeOnlineStream()
+    adapter = _SherpaOnnxStreamAdapter(recognizer, stream)
+    events: list[object] = []
+    adapter.add_listener(events.append)
+
+    recognizer.ready_remaining = 1
+    recognizer.text = "hello"
+    adapter.add_audio([0.1], 16_000)
+    recognizer.ready_remaining = 1
+    recognizer.text = "hello"  # unchanged
+    adapter.add_audio([0.2], 16_000)
+
+    assert len(events) == 1

--- a/server/tests/test_streaming.py
+++ b/server/tests/test_streaming.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from array import array
 from pathlib import Path
 from types import SimpleNamespace
@@ -150,6 +151,55 @@ def test_batch_moonshine_gets_structured_stream_fallback(
 
     with TestClient(app) as client:
         assert client.get("/health").json()["streaming_supported"] is False
+
+
+class FakeStreamingEngine:
+    """A non-Moonshine engine implementing the StreamingEngine protocol.
+
+    Proves the /v1/stream handler generalized past isinstance(MoonshineEngine)
+    to any engine exposing supports_streaming/streaming_lock/create_stream.
+    """
+
+    def __init__(self, stream: FakeStream) -> None:
+        self._stream = stream
+        self.supports_streaming = True
+        self.streaming_lock = asyncio.Lock()
+
+    async def health(self) -> EngineHealth:
+        return EngineHealth(ready=True, name="sherpa-onnx:streaming-zipformer-en-20m-int8")
+
+    async def create_stream(self) -> FakeStream:
+        return self._stream
+
+
+def test_authenticated_sherpa_onnx_style_stream_returns_styled_transcript(tmp_path: Path) -> None:
+    settings = Settings(
+        token=TOKEN,
+        data_dir=tmp_path,
+        whisper_binary=tmp_path / "whisper-cli",
+        whisper_model=tmp_path / "model.bin",
+    )
+    stream = FakeStream()
+    engine = FakeStreamingEngine(stream)
+    app = create_app(settings, engine=engine)
+
+    with (
+        TestClient(app) as client,
+        client.websocket_connect(
+            "/v1/stream", headers={"Authorization": f"Bearer {TOKEN}"}
+        ) as websocket,
+    ):
+        websocket.send_json({"type": "start", "sample_rate": 16_000, "style": "formal"})
+        assert websocket.receive_json() == {"type": "ready", "engine": "sherpa-onnx"}
+        websocket.send_bytes(array("f", [0.1, -0.1]).tobytes())
+        assert websocket.receive_json() == {"type": "partial", "transcript": "hello"}
+        websocket.send_json({"type": "finish"})
+        assert websocket.receive_json() == {
+            "type": "complete",
+            "transcript": "Hello world.",
+        }
+
+    assert stream.closed is True
 
 
 def test_authenticated_batch_engine_gets_structured_stream_fallback(tmp_path: Path) -> None:

--- a/server/tests/test_tokens.py
+++ b/server/tests/test_tokens.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.tokens import TokenStore
+
+
+def test_create_returns_plaintext_once_and_matches_validates_it(tmp_path: Path) -> None:
+    store = TokenStore(tmp_path / "device_tokens.json")
+    record, plaintext = store.create("Kanishk's iPhone")
+    assert record.label == "Kanishk's iPhone"
+    assert store.matches(plaintext) is True
+    assert store.matches("wrong-token") is False
+    assert store.matches("") is False
+    # The plaintext is never persisted, only its hash.
+    assert plaintext not in (tmp_path / "device_tokens.json").read_text(encoding="utf-8")
+
+
+def test_revoke_removes_a_token(tmp_path: Path) -> None:
+    store = TokenStore(tmp_path / "device_tokens.json")
+    record, plaintext = store.create("Pixel 6a")
+    assert store.matches(plaintext) is True
+    assert store.revoke(record.id) is True
+    assert store.matches(plaintext) is False
+    assert store.revoke(record.id) is False
+
+
+def test_revoke_unknown_id_returns_false(tmp_path: Path) -> None:
+    store = TokenStore(tmp_path / "device_tokens.json")
+    assert store.revoke("does-not-exist") is False
+
+
+def test_tokens_persist_across_store_instances(tmp_path: Path) -> None:
+    path = tmp_path / "device_tokens.json"
+    first = TokenStore(path)
+    _, plaintext = first.create("Work laptop")
+
+    second = TokenStore(path)
+    assert len(second.all()) == 1
+    assert second.matches(plaintext) is True
+
+
+def test_missing_or_corrupt_file_yields_empty_store(tmp_path: Path) -> None:
+    missing = TokenStore(tmp_path / "does-not-exist.json")
+    assert missing.all() == []
+
+    corrupt_path = tmp_path / "corrupt.json"
+    corrupt_path.write_text("not json", encoding="utf-8")
+    corrupt = TokenStore(corrupt_path)
+    assert corrupt.all() == []
+
+
+def test_blank_label_defaults_to_unnamed_device(tmp_path: Path) -> None:
+    store = TokenStore(tmp_path / "device_tokens.json")
+    record, _ = store.create("   ")
+    assert record.label == "Unnamed device"
+
+
+def test_cached_plaintext_available_after_create_and_gone_after_revoke(tmp_path: Path) -> None:
+    store = TokenStore(tmp_path / "device_tokens.json")
+    record, plaintext = store.create("iPad")
+    assert store.cached_plaintext(record.id) == plaintext
+    assert [entry.id for entry in store.cached_entries()] == [record.id]
+
+    store.revoke(record.id)
+    assert store.cached_plaintext(record.id) is None
+    assert store.cached_entries() == []
+
+
+def test_cache_does_not_survive_a_fresh_store_instance(tmp_path: Path) -> None:
+    path = tmp_path / "device_tokens.json"
+    first = TokenStore(path)
+    record, _ = first.create("Old laptop")
+
+    second = TokenStore(path)
+    assert second.cached_plaintext(record.id) is None
+    assert second.cached_entries() == []


### PR DESCRIPTION
## Summary
- Redacted diagnostics export (WebUI Settings tab + `uv run localflow-diagnostics` CLI) for bug reports — version, engine/hardware status, operational counters, and config, with filesystem paths under the operator's home directory rewritten to `~`. Never includes the bearer token, audio, transcripts, or session identifiers.
- Named, individually revocable per-device bearer tokens alongside the permanent bootstrap token (`LOCALFLOW_TOKEN`). Losing one phone means revoking that device's token, not rotating everyone else's. The Overview pairing card can create a token and show its QR directly; a token dropdown lets you pick which credential to encode, with in-session rotation for a token whose plaintext can no longer be displayed (e.g. after a restart).
- GigaAM (CTC + RNNT, Russian, MIT license) and Canary (180M Flash, English in this build, CC BY 4.0) as new sherpa-onnx models, downloaded directly from their Hugging Face repos since neither publishes a packaged `.tar.bz2` archive like the existing SenseVoice/Parakeet models.
- True incremental streaming for sherpa-onnx via a new streaming Zipformer model (Apache 2.0). The `/v1/stream` WebSocket handler is generalized from a hardcoded Moonshine check to a `StreamingEngine` protocol, so any engine implementing `supports_streaming`/`streaming_lock`/`create_stream()` works there.

## Test plan
- [x] Full test suite, `ruff check`, `ruff format --check`, and `mypy` all green
- [x] Live end-to-end smoke tests against real downloads (not mocks): Canary model download + batch transcription; streaming Zipformer model download + real speech through both the batch and incremental streaming paths, producing an identical transcript with real partial/complete events
- [x] Self-reviewed the diff before opening this PR; found and fixed two issues: the diagnostics bundle wasn't redacting absolute model-file paths surfaced through `config.whisper_model`/`whisperkit_model`/`faster_whisper_model`, and the HTML token-creation forms were missing the server-side label length validation the JSON API already had

🤖 Generated with [Claude Code](https://claude.com/claude-code)