### PR TITLE
ci: split Quality workflow by path and cut redundant runs

### DIFF
--- a/.github/workflows/quality-android.yml
+++ b/.github/workflows/quality-android.yml
@@ -1,0 +1,41 @@
+name: Quality (Android)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'android/**'
+      - '.github/workflows/quality-android.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'android/**'
+      - '.github/workflows/quality-android.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          # Matches the JDK bundled with Android Studio, which is what the build
+          # has been verified against locally.
+          java-version: '25'
+      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+      - uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
+      - run: ./gradlew assembleDebug testDebugUnitTest lintDebug
+        working-directory: android
+      - name: Fail if the checked-in Room schema is stale
+        run: git diff --exit-code -- app/schemas
+        working-directory: android

--- a/.github/workflows/quality-ios.yml
+++ b/.github/workflows/quality-ios.yml
@@ -1,68 +1,26 @@
-name: Quality
+name: Quality (iOS)
 
 on:
   push:
+    branches: [main]
+    paths:
+      - 'ios/**'
+      - '.github/workflows/quality-ios.yml'
   pull_request:
+    branches: [main]
+    paths:
+      - 'ios/**'
+      - '.github/workflows/quality-ios.yml'
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: quality-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  server:
-    runs-on: macos-15
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-      - run: brew install ffmpeg
-      - run: uv sync --locked --all-groups
-        working-directory: server
-      - run: uv run ruff check .
-        working-directory: server
-      - run: uv run ruff format --check .
-        working-directory: server
-      - run: uv run mypy app
-        working-directory: server
-      - run: uv run pytest
-        working-directory: server
-
-  container:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - name: Validate Compose configuration
-        run: docker compose config --quiet
-        working-directory: server
-        env:
-          LOCALFLOW_TOKEN: test-token-with-at-least-thirty-two-characters
-      - name: Build gateway image
-        run: docker build --tag localflow-gateway:test .
-        working-directory: server
-
-  android:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
-        with:
-          distribution: temurin
-          # Matches the JDK bundled with Android Studio, which is what the build
-          # has been verified against locally.
-          java-version: '25'
-      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
-      - uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
-      - run: ./gradlew assembleDebug testDebugUnitTest lintDebug
-        working-directory: android
-      - name: Fail if the checked-in Room schema is stale
-        run: git diff --exit-code -- app/schemas
-        working-directory: android
-
   ios:
     runs-on: macos-15
     timeout-minutes: 20

--- a/.github/workflows/quality-server.yml
+++ b/.github/workflows/quality-server.yml
@@ -1,0 +1,63 @@
+name: Quality (server)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'server/**'
+      - '.github/workflows/quality-server.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/**'
+      - '.github/workflows/quality-server.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  server:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          working-directory: server
+          enable-cache: true
+      - run: sudo apt-get update && sudo apt-get install -y ffmpeg
+      - run: uv sync --locked --all-groups
+        working-directory: server
+      - run: uv run ruff check .
+        working-directory: server
+      - run: uv run ruff format --check .
+        working-directory: server
+      - run: uv run mypy app
+        working-directory: server
+      - run: uv run pytest
+        working-directory: server
+
+  container:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Validate Compose configuration
+        run: docker compose config --quiet
+        working-directory: server
+        env:
+          LOCALFLOW_TOKEN: test-token-with-at-least-thirty-two-characters
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Build gateway image
+        working-directory: server
+        run: |
+          docker buildx build \
+            --tag localflow-gateway:test \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            --load .


### PR DESCRIPTION
## Summary
- Split the single `quality.yml` (server, container, android, ios jobs, no path filtering) into `quality-server.yml`, `quality-android.yml`, `quality-ios.yml`, each triggered only by changes under its own directory. A docs-only or Android-only change no longer triggers an iOS build on a macOS runner, or vice versa.
- Restricted `push` to `main` in all three (was: every branch). Combined with `pull_request` already covering feature branches, this removes the duplicate run every push to an open PR branch was causing (verified in run history: `push` and `pull_request` fired within ~2 seconds of each other for the same commit, on a different `github.ref` each time, so nothing deduplicated them). Tag pushes (e.g. `v0.1.0-beta.1`) no longer trigger it either — that was never intentional.
- `server` job moved from `macos-15` to `ubuntu-24.04`: CI only installs the `dev` dependency group (ruff/mypy/pytest/httpx), never the `apple`/`engines` extras, so nothing it runs actually needs macOS. The one Darwin-specific test (`test_mlx_audio.py`) already mocks `platform.system()` rather than depending on the real OS.
- Added uv dependency caching to the server job.
- `container` job now builds with `docker buildx` + the GitHub Actions cache backend (`docker/setup-buildx-action`, SHA-pinned like the existing actions) instead of a cold `docker build` every run.
- Added `workflow_dispatch` to all three so they can still be run on demand without a matching file change.
- `android` and `ios` jobs are otherwise unchanged (Gradle already caches via `setup-gradle`).

Note: this repo is public, so GitHub doesn't meter Actions minutes against a quota regardless of runner OS — if "60% quota" is showing up somewhere, it's likely an org-wide pool shared with other repos, or a different limit (e.g. concurrent macOS job caps). Either way, not running CI that has nothing to do with the change is worth doing regardless of billing.

## Test plan
- [x] Validated all three workflow files with `actionlint` (byte-for-byte YAML + expression + inline shellcheck) — clean
- [x] Confirmed `main` has no branch protection / required status checks, so renaming the check names by splitting workflows can't silently block merges
- [x] Verified via `astral-sh/setup-uv`'s and `docker/setup-buildx-action`'s actual `action.yml` (fetched at the exact pinned commit) that the inputs used (`working-directory`, `enable-cache`) are real, rather than guessing
- [ ] Watching this PR's own Actions run as the real end-to-end check — my local sandbox's Docker has no network access, so I could not dry-run the Linux/apt/buildx changes locally; this PR's own CI run against the real GitHub-hosted runners is the actual verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)