### PR TITLE
docs: cover LOCALFLOW_NETWORK_MODE=host in every LAN-access doc path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ server/.venv/
 server/.pytest_cache/
 server/.ruff_cache/
 server/.mypy_cache/
+server/.omo/
 server/data/
 server/*.db
 server/*.sqlite

--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ operational commands.
 
 ### 1. Start the gateway natively on macOS
 
-Install the tools and launch the server:
+Install the tools (FFmpeg, plus the WhisperKit and `whisper.cpp` CLIs) and
+launch the server:
 
 ```sh
-brew install ffmpeg whisperkit-cli
+brew install ffmpeg whisperkit-cli whisper-cpp
 cd server
 uv sync --all-groups --extra engines --extra apple
 uv run localflow-server
@@ -168,7 +169,11 @@ Choose one of these network arrangements:
   `ip -4 addr`. HTTP is unencrypted, so use this only on a network you trust and
   never forward that port to the internet. For Docker, set
   `LOCALFLOW_PUBLISH_HOST=0.0.0.0` in `server/.env` and protect the port with the
-  host firewall.
+  host firewall. The container's own address auto-discovery (used by the
+  pairing QR) can't see the host's LAN IP under the default bridge network
+  either; on Linux Docker Engine, set `LOCALFLOW_NETWORK_MODE=host` in
+  `server/.env` instead so discovery finds it directly — see
+  [server/README.md](server/README.md#configuration).
 - **Tailscale:** keep the gateway on loopback and let Tailscale Serve provide
   tailnet-only HTTPS:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,7 +44,8 @@ not only end-to-end time.
 ### Install and run
 
 ```sh
-brew install ffmpeg whisperkit-cli
+# ffmpeg (required), WhisperKit CLI, and the whisper.cpp CLI
+brew install ffmpeg whisperkit-cli whisper-cpp
 cd server
 uv sync --all-groups --extra engines --extra apple
 uv run localflow-server
@@ -255,6 +256,24 @@ iPhone, and use a URL such as `http://homelabone:8765/`. Approve Local Network
 access when iOS asks. Plain HTTP exposes recordings and the bearer token to
 anyone who can inspect the network, so use it only on a trusted LAN or encrypted
 VPN and never forward it from a router.
+
+With the default bridge network, the container only ever sees its own private
+bridge address (for example `172.19.0.2`), never the host's real Wi-Fi/Ethernet
+interface — so the pairing card's auto-discovered candidate list won't include
+a `192.168.x.x` address even after the change above. On Linux Docker Engine
+(not Docker Desktop on macOS/Windows), share the host's network namespace
+instead so discovery sees the real LAN IP directly:
+
+```dotenv
+LOCALFLOW_NETWORK_MODE=host
+```
+
+`LOCALFLOW_PUBLISH_HOST`/`LOCALFLOW_PUBLISH_PORT` are ignored in this mode —
+Compose discards the `ports:` mapping and the container binds straight onto the
+host per `LOCALFLOW_BIND_HOST` (`0.0.0.0` by default) and `LOCALFLOW_PORT`
+(`8765` by default). That means the host firewall is now the only thing
+standing between port 8765 and every interface on the box, including any
+public one — lock it down before enabling this.
 
 ### Tailscale Serve
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -159,6 +159,14 @@ docker compose up --detach
 Keep the host firewall enabled. Do not use this LAN configuration to expose port
 8765 directly to the internet; use an HTTPS reverse proxy for a VPS.
 
+If the pairing QR itself shows no LAN address to pick from (or only shows a
+`172.x`/bridge address), that's the same root cause: the container's default
+bridge network only exposes its own private interface to address
+auto-discovery, never the host's real LAN NIC. On Linux Docker Engine (not
+Docker Desktop), set `LOCALFLOW_NETWORK_MODE=host` in `server/.env` instead so
+the container shares the host's network namespace and discovery finds the
+`192.168.x.x` address directly. See [deployment.md](deployment.md#trusted-local-network).
+
 ## 401 unauthorized
 
 If this device was paired with its own token, open the WebUI Settings tab and

--- a/server/README.md
+++ b/server/README.md
@@ -154,6 +154,16 @@ Tailscale Serve. To intentionally allow direct LAN access, set
 `LOCALFLOW_PUBLISH_HOST=0.0.0.0` in `.env` and protect the port with the host
 firewall. Never expose port 8765 to the public internet.
 
+The default bridge network also hides the host's real LAN address from the
+gateway's own address auto-discovery (used for the pairing QR): the container
+only ever sees its private bridge IP, not the host's Wi-Fi/Ethernet interface.
+On Linux Docker Engine (not Docker Desktop on macOS/Windows), set
+`LOCALFLOW_NETWORK_MODE=host` in `.env` instead so the container shares the
+host's network namespace and discovery finds the real `192.168.x.x` address.
+This ignores `LOCALFLOW_PUBLISH_HOST`/`PORT` — the container binds directly on
+the host per `LOCALFLOW_BIND_HOST`/`LOCALFLOW_PORT`, so lock down port 8765
+with the host firewall first.
+
 ## WebUI
 
 The authenticated WebUI provides:
@@ -302,6 +312,7 @@ Compose-specific variables live in `server/.env`:
 | --- | --- | --- |
 | `LOCALFLOW_PUBLISH_HOST` | `127.0.0.1` | Host interface published by Docker |
 | `LOCALFLOW_PUBLISH_PORT` | `8765` | Host port published by Docker |
+| `LOCALFLOW_NETWORK_MODE` | `bridge` | Set to `host` on Linux Docker Engine to share the host's network namespace (ignores `LOCALFLOW_PUBLISH_HOST`/`PORT`); not supported by Docker Desktop |
 | `LOCALFLOW_IMAGE` | `localflow-gateway:local` | Local or registry image tag |
 
 Use [`.env.example`](.env.example) as a template and never commit the populated


### PR DESCRIPTION
## Summary
- Documents the `LOCALFLOW_NETWORK_MODE=host` opt-in (added in #11) in every place that already talks about direct LAN access, so it isn't only discoverable from one doc: root `README.md`, `server/README.md` (including the config table), `docs/deployment.md`, and `docs/troubleshooting.md`'s "LAN hostname does not connect" section.
- Ignores `server/.omo/` in `.gitignore` (local scratch directory, not project output).

## Why
The pairing-QR address auto-discovery only sees the container's private bridge IP under default Compose networking, never the host's real LAN interface — `LOCALFLOW_NETWORK_MODE=host` (Linux Docker Engine only) fixes that by sharing the host's network namespace. That was documented in one place after #11 merged but not carried through to the other docs that cover the same LAN-access scenario.

## Test plan
- [x] Reviewed each doc section for consistency with the existing `LOCALFLOW_PUBLISH_HOST`/`PORT` guidance
- [x] `docker compose config` validated with `LOCALFLOW_NETWORK_MODE=host` (from the earlier #11 change, unaffected here)