### PR TITLE
fix: give Android onboarding a way forward and restyle its controls

### DIFF
--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/settings/SettingsRepository.kt
@@ -97,6 +97,9 @@ class SettingsRepository(private val context: Context) {
         }
     }
 
+    /** Corrects the address while leaving the sealed token exactly as it is. */
+    suspend fun setGatewayUrl(url: String) = put(Keys.GATEWAY_URL, url)
+
     suspend fun clearGateway() {
         context.dataStore.edit { preferences ->
             preferences.remove(Keys.GATEWAY_URL)

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/AppInfo.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/AppInfo.kt
@@ -1,0 +1,78 @@
+package io.github.mrsunglasses.localflow.ui
+
+import android.content.Context
+import android.os.Build
+import io.github.mrsunglasses.localflow.core.GatewayEndpoint
+import io.github.mrsunglasses.localflow.settings.LocalFlowSettings
+
+const val PROJECT_URL = "https://github.com/VocaHQ/vocaphone"
+
+/** What the About card shows, read once from the platform. */
+data class AppInfo(
+    val versionName: String = "",
+    val versionCode: Long = 0,
+    val packageName: String = "",
+    val installedFrom: String = "",
+    val androidRelease: String = "",
+    val sdkInt: Int = 0,
+    val device: String = "",
+)
+
+fun Context.readAppInfo(): AppInfo {
+    val info = runCatching { packageManager.getPackageInfo(packageName, 0) }.getOrNull()
+    return AppInfo(
+        versionName = info?.versionName.orEmpty(),
+        versionCode = info?.longVersionCode ?: 0,
+        packageName = packageName,
+        installedFrom = installerLabel(),
+        androidRelease = Build.VERSION.RELEASE.orEmpty(),
+        sdkInt = Build.VERSION.SDK_INT,
+        device = "${Build.MANUFACTURER} ${Build.MODEL}",
+    )
+}
+
+/**
+ * Which store, if any, vouched for this install. It is the same signal guided
+ * setup uses to predict a greyed-out accessibility switch, so it belongs in a
+ * bug report.
+ */
+private fun Context.installerLabel(): String = when (val installer = installerPackage()) {
+    null -> "sideloaded"
+    "com.android.vending" -> "Google Play"
+    "org.fdroid.fdroid" -> "F-Droid"
+    else -> installer
+}
+
+/**
+ * A block the user can paste into an issue. The gateway host name is
+ * deliberately left out — it is a LAN or tailnet address that identifies the
+ * user's own network — and the bearer token never leaves the Keystore at all.
+ */
+fun diagnosticsReport(
+    info: AppInfo,
+    settings: LocalFlowSettings,
+    setup: SetupStatus,
+): String = buildString {
+    appendLine("Local Flow ${info.versionName} (${info.versionCode})")
+    appendLine("Android ${info.androidRelease} (SDK ${info.sdkInt}) · ${info.device}")
+    appendLine("Installed from: ${info.installedFrom}")
+    appendLine("Gateway: ${gatewaySummary(settings)}")
+    appendLine("Engine: ${settings.lastEngine.ifEmpty { "unknown" }}" +
+        if (settings.lastEngineReady) " (ready)" else " (not ready)")
+    appendLine("Streaming: " + if (settings.lastStreamingSupported) "supported" else "batch upload")
+    append("Setup: ")
+    append(
+        if (setup.isReadyToDictate) {
+            "all steps done"
+        } else {
+            "missing ${setup.remainingSteps.joinToString { it.label }}"
+        }
+    )
+}
+
+/** Enough to debug a transport problem, without naming the host. */
+private fun gatewaySummary(settings: LocalFlowSettings): String = when {
+    !settings.isConfigured -> "not configured"
+    GatewayEndpoint.isCleartext(settings.gatewayUrl) -> "http:// (private host)"
+    else -> "https://"
+}

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/Components.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/Components.kt
@@ -6,13 +6,19 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -24,6 +30,82 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import io.github.mrsunglasses.localflow.R
+
+/**
+ * The app's two button weights, so every screen agrees on shape and height.
+ *
+ * Outlined buttons are deliberately absent: with dynamic dark colour their
+ * border all but vanishes against these cards, which left secondary actions
+ * looking like bare floating text.
+ */
+private val ButtonShape = RoundedCornerShape(16.dp)
+private val ButtonHeight = 48.dp
+
+@Composable
+fun PrimaryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    loading: Boolean = false,
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled && !loading,
+        shape = ButtonShape,
+        modifier = modifier.height(ButtonHeight),
+    ) {
+        ButtonLabel(text, loading)
+    }
+}
+
+@Composable
+fun SecondaryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    loading: Boolean = false,
+) {
+    FilledTonalButton(
+        onClick = onClick,
+        enabled = enabled && !loading,
+        shape = ButtonShape,
+        modifier = modifier.height(ButtonHeight),
+    ) {
+        ButtonLabel(text, loading)
+    }
+}
+
+@Composable
+private fun ButtonLabel(text: String, loading: Boolean) {
+    if (loading) {
+        CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp)
+    } else {
+        Text(text)
+    }
+}
+
+/** A label and its value on one line, for the About card. */
+@Composable
+fun InfoRow(label: String, value: String, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier.fillMaxWidth().padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            value,
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.End,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
 
 @Composable
 fun SectionCard(
@@ -91,7 +173,13 @@ fun ChecklistRow(
     }
 }
 
-/** A single-choice chip row, used for every enumerated setting. */
+/**
+ * A single-choice chip row, used for every enumerated setting.
+ *
+ * The chips carry their own fill rather than relying on an outline: the default
+ * chip border is invisible in a dynamic dark scheme, which made unselected
+ * options read as loose words rather than something you could tap.
+ */
 @Composable
 fun <T> ChipChoiceRow(
     options: List<T>,
@@ -103,13 +191,21 @@ fun <T> ChipChoiceRow(
     FlowRow(
         modifier = modifier.fillMaxWidth().selectableGroup(),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         options.forEach { option ->
             FilterChip(
                 selected = option == selected,
                 onClick = { onSelect(option) },
                 label = { Text(label(option)) },
+                shape = RoundedCornerShape(12.dp),
+                border = null,
+                colors = FilterChipDefaults.filterChipColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    labelColor = MaterialTheme.colorScheme.onSurface,
+                    selectedContainerColor = MaterialTheme.colorScheme.primary,
+                    selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                ),
             )
         }
     }

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/DictateScreen.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/DictateScreen.kt
@@ -9,10 +9,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -114,25 +112,31 @@ fun DictateScreen(
                 )
             }
 
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 when {
                     state.isRecording -> {
-                        Button(onClick = onFinish) { Text("Finish") }
-                        OutlinedButton(onClick = onCancel) { Text("Cancel") }
+                        PrimaryButton("Finish", onClick = onFinish, modifier = Modifier.weight(1f))
+                        SecondaryButton("Cancel", onClick = onCancel, modifier = Modifier.weight(1f))
                     }
 
-                    state.phase.isBusy -> OutlinedButton(onClick = onCancel) { Text("Cancel") }
+                    state.phase.isBusy ->
+                        SecondaryButton("Cancel", onClick = onCancel, modifier = Modifier.weight(1f))
 
                     state.canRetry -> {
-                        Button(onClick = { state.sessionId?.let { onRetry(it.toString()) } }) {
-                            Text("Retry")
-                        }
-                        OutlinedButton(onClick = onDismiss) { Text("Dismiss") }
+                        PrimaryButton(
+                            text = "Retry",
+                            onClick = { state.sessionId?.let { onRetry(it.toString()) } },
+                            modifier = Modifier.weight(1f),
+                        )
+                        SecondaryButton("Dismiss", onClick = onDismiss, modifier = Modifier.weight(1f))
                     }
 
-                    else -> Button(onClick = onStart, enabled = setup.isReadyToDictate) {
-                        Text("Start dictation")
-                    }
+                    else -> PrimaryButton(
+                        text = "Start dictation",
+                        onClick = onStart,
+                        enabled = setup.isReadyToDictate,
+                        modifier = Modifier.weight(1f),
+                    )
                 }
             }
 
@@ -155,14 +159,11 @@ fun DictateScreen(
                 modifier = Modifier.fillMaxWidth().height(220.dp),
                 label = { Text("Your text") },
             )
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedButton(
-                    onClick = { scratchpad = TextFieldValue() },
-                    enabled = scratchpad.text.isNotEmpty(),
-                ) {
-                    Text("Clear")
-                }
-            }
+            SecondaryButton(
+                text = "Clear",
+                onClick = { scratchpad = TextFieldValue() },
+                enabled = scratchpad.text.isNotEmpty(),
+            )
         }
     }
 }

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/GatewayScreen.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/GatewayScreen.kt
@@ -11,13 +11,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -25,12 +27,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import io.github.mrsunglasses.localflow.R
 import io.github.mrsunglasses.localflow.core.GatewayEndpoint
 import io.github.mrsunglasses.localflow.core.PairingPayload
 import io.github.mrsunglasses.localflow.settings.LocalFlowSettings
@@ -40,16 +46,26 @@ fun GatewayScreen(
     settings: LocalFlowSettings,
     connection: ConnectionReport?,
     testing: Boolean,
+    inOnboarding: Boolean,
     onSave: (String, String, (String?) -> Unit) -> Unit,
     onTest: () -> Unit,
     onClear: () -> Unit,
+    onDone: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
+    val focusManager = LocalFocusManager.current
     var url by remember(settings.gatewayUrl) { mutableStateOf(settings.gatewayUrl) }
     var token by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
-    var saved by remember { mutableStateOf(false) }
+
+    val submit = {
+        focusManager.clearFocus()
+        onSave(url, token) { failure ->
+            error = failure
+            if (failure == null) token = ""
+        }
+    }
 
     val scanLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult(),
@@ -66,156 +82,253 @@ fun GatewayScreen(
                 url = parsed.parsed.url
                 token = parsed.parsed.token
                 error = null
-                saved = false
                 onSave(parsed.parsed.url, parsed.parsed.token) { failure ->
                     error = failure
-                    saved = failure == null
                     if (failure == null) token = ""
                 }
             }
         }
     }
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        SectionCard(
-            title = "Scan pairing QR",
-            supporting = "On the gateway host, open the WebUI Overview and scan the " +
-                "pairing QR. That fills the address and bearer token without typing.",
+    Column(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+                .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            Button(
-                onClick = {
-                    scanLauncher.launch(
-                        android.content.Intent(context, QrPairingActivity::class.java),
-                    )
-                },
-                modifier = Modifier.fillMaxWidth(),
+            SectionCard(
+                title = "Scan pairing QR",
+                supporting = "On the gateway host, open the WebUI Overview and scan the " +
+                    "pairing QR. That fills the address and bearer token without typing.",
             ) {
-                Text("Scan QR code")
-            }
-        }
-
-        SectionCard(
-            title = "Gateway address",
-            supporting = "A private LAN or Tailscale host may use http://. Anything " +
-                "reachable from the internet must use https://. Or scan the WebUI QR above.",
-        ) {
-            OutlinedTextField(
-                value = url,
-                onValueChange = {
-                    url = it
-                    error = null
-                    saved = false
-                },
-                label = { Text("Address") },
-                placeholder = { Text("http://homelabone.local:8765") },
-                singleLine = true,
-                isError = error != null,
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Uri,
-                    imeAction = ImeAction.Next,
-                ),
-                modifier = Modifier.fillMaxWidth(),
-            )
-            OutlinedTextField(
-                value = token,
-                onValueChange = {
-                    token = it
-                    error = null
-                    saved = false
-                },
-                label = { Text(if (settings.hasToken) "Replace bearer token" else "Bearer token") },
-                supportingText = {
-                    Text(
-                        if (settings.hasToken) {
-                            "A token is stored, encrypted by the Android Keystore. " +
-                                "Leave blank to keep it."
-                        } else {
-                            "Printed by your gateway on first run at ~/.config/localflow/token."
-                        }
-                    )
-                },
-                singleLine = true,
-                visualTransformation = PasswordVisualTransformation(),
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Password,
-                    imeAction = ImeAction.Done,
-                ),
-                modifier = Modifier.fillMaxWidth(),
-            )
-
-            if (url.isNotBlank() && GatewayEndpoint.isCleartext(url.trim())) {
-                Text(
-                    "This gateway is unencrypted. Your token and transcripts travel " +
-                        "in the clear over this network — only use it on a network you trust.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
-            error?.let {
-                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
-            }
-            if (saved) {
-                Text(
-                    "Saved.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-            }
-
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Button(
+                PrimaryButton(
+                    text = "Scan QR code",
                     onClick = {
-                        onSave(url, token) { failure ->
-                            error = failure
-                            saved = failure == null
-                            if (failure == null) token = ""
-                        }
+                        scanLauncher.launch(
+                            android.content.Intent(context, QrPairingActivity::class.java),
+                        )
                     },
-                    enabled = url.isNotBlank() && (token.isNotBlank() || settings.hasToken),
-                ) {
-                    Text("Save")
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            SectionCard(
+                title = "Gateway address",
+                supporting = "A private LAN or Tailscale host may use http://. Anything " +
+                    "reachable from the internet must use https://. Or scan the WebUI QR above.",
+            ) {
+                OutlinedTextField(
+                    value = url,
+                    onValueChange = {
+                        url = it
+                        error = null
+                    },
+                    label = { Text("Address") },
+                    placeholder = { Text("http://homelabone.local:8765") },
+                    singleLine = true,
+                    isError = error != null,
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Uri,
+                        imeAction = ImeAction.Next,
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = token,
+                    onValueChange = {
+                        token = it
+                        error = null
+                    },
+                    label = { Text(if (settings.hasToken) "Replace bearer token" else "Bearer token") },
+                    supportingText = {
+                        Text(
+                            if (settings.hasToken) {
+                                "A token is stored, encrypted by the Android Keystore. " +
+                                    "Leave blank to keep it."
+                            } else {
+                                "Printed by your gateway on first run at ~/.config/localflow/token."
+                            }
+                        )
+                    },
+                    singleLine = true,
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Password,
+                        imeAction = ImeAction.Done,
+                    ),
+                    // The keyboard's Done key saves, so finishing the token is not a
+                    // dead end that leaves the user hunting for a button.
+                    keyboardActions = KeyboardActions(onDone = { submit() }),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                if (url.isNotBlank() && GatewayEndpoint.isCleartext(url.trim())) {
+                    Text(
+                        "This gateway is unencrypted. Your token and transcripts travel " +
+                            "in the clear over this network — only use it on a network you trust.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
                 }
-                OutlinedButton(onClick = onTest, enabled = settings.isConfigured && !testing) {
-                    if (testing) {
-                        CircularProgressIndicator(Modifier.size(16.dp), strokeWidth = 2.dp)
+                error?.let {
+                    Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+                }
+
+                // Saving is confirmed by the footer, which reports the connection
+                // test it kicks off rather than just that bytes hit the disk.
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    PrimaryButton(
+                        text = "Save",
+                        onClick = submit,
+                        enabled = url.isNotBlank() && (token.isNotBlank() || settings.hasToken),
+                        modifier = Modifier.weight(1f),
+                    )
+                    SecondaryButton(
+                        text = "Test connection",
+                        onClick = onTest,
+                        enabled = settings.isConfigured,
+                        loading = testing,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+
+            connection?.let { report ->
+                SectionCard(title = "Connection") {
+                    StatusLine("Reachable", report.reachable)
+                    StatusLine("Token accepted", report.tokenValid)
+                    StatusLine("Engine ready", report.engineReady)
+                    Text(
+                        "Engine: ${report.engine.ifEmpty { "unknown" }}",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(
+                        "Streaming: " + when (report.streamingSupported) {
+                            true -> "supported by the active engine"
+                            false -> "not supported — batch upload will be used"
+                            null -> "not reported by this gateway"
+                        },
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(report.message, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+
+            if (settings.isConfigured) {
+                TextButton(onClick = onClear) { Text("Remove gateway and delete stored token") }
+            }
+        }
+
+        GatewayNextStepBar(
+            configured = settings.isConfigured,
+            inOnboarding = inOnboarding,
+            testing = testing,
+            connection = connection,
+            onDone = onDone,
+        )
+    }
+}
+
+/** What the footer says, so the wording and its icon cannot drift apart. */
+private enum class NextStep { PENDING, CHECKING, WARNING, READY }
+
+/**
+ * Pinned below the form so this screen always states what happens next. Saving a
+ * token used to leave the user on a page whose only exit was the system back
+ * gesture, with nothing on screen saying setup was waiting behind it.
+ */
+@Composable
+private fun GatewayNextStepBar(
+    configured: Boolean,
+    inOnboarding: Boolean,
+    testing: Boolean,
+    connection: ConnectionReport?,
+    onDone: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val step = when {
+        !configured -> NextStep.PENDING
+        testing -> NextStep.CHECKING
+        connection == null -> NextStep.READY
+        !connection.reachable || !connection.tokenValid -> NextStep.WARNING
+        !connection.engineReady -> NextStep.WARNING
+        else -> NextStep.READY
+    }
+    val hint = when {
+        !configured && inOnboarding -> "Nothing saved yet — setup is waiting behind this screen."
+        !configured -> "Nothing saved yet."
+        testing -> "Checking your gateway…"
+        connection == null -> "Address and token saved on this device."
+        !connection.reachable || !connection.tokenValid -> connection.message
+        !connection.engineReady -> "Connected. Load a model on the gateway when you get a chance."
+        else -> "Connected and ready."
+    }
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        shadowElevation = 12.dp,
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 18.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                NextStepIndicator(step)
+                Text(
+                    hint,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (step == NextStep.WARNING) {
+                        MaterialTheme.colorScheme.error
                     } else {
-                        Text("Test connection")
-                    }
-                }
-            }
-        }
-
-        connection?.let { report ->
-            SectionCard(title = "Connection") {
-                StatusLine("Reachable", report.reachable)
-                StatusLine("Token accepted", report.tokenValid)
-                StatusLine("Engine ready", report.engineReady)
-                Text(
-                    "Engine: ${report.engine.ifEmpty { "unknown" }}",
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                Text(
-                    "Streaming: " + when (report.streamingSupported) {
-                        true -> "supported by the active engine"
-                        false -> "not supported — batch upload will be used"
-                        null -> "not reported by this gateway"
+                        MaterialTheme.colorScheme.onSurfaceVariant
                     },
-                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f),
                 )
-                Text(report.message, style = MaterialTheme.typography.bodyMedium)
             }
-        }
-
-        if (settings.isConfigured) {
-            TextButton(onClick = onClear) { Text("Remove gateway and delete stored token") }
+            if (configured) {
+                PrimaryButton(
+                    text = if (inOnboarding) "Continue setup" else "Done",
+                    onClick = onDone,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            } else {
+                SecondaryButton(
+                    text = if (inOnboarding) "Back to setup" else "Back",
+                    onClick = onDone,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
         }
     }
+}
+
+@Composable
+private fun NextStepIndicator(step: NextStep, modifier: Modifier = Modifier) {
+    if (step == NextStep.CHECKING) {
+        CircularProgressIndicator(
+            modifier = modifier.size(20.dp),
+            strokeWidth = 2.dp,
+        )
+        return
+    }
+    val (icon, tint) = when (step) {
+        NextStep.READY -> R.drawable.ic_step_done to MaterialTheme.colorScheme.primary
+        NextStep.WARNING -> R.drawable.ic_warning to MaterialTheme.colorScheme.error
+        else -> R.drawable.ic_step_pending to MaterialTheme.colorScheme.outline
+    }
+    Icon(
+        painter = painterResource(icon),
+        contentDescription = null,
+        tint = tint,
+        modifier = modifier.size(20.dp),
+    )
 }
 
 @Composable

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/HistoryScreen.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/HistoryScreen.kt
@@ -11,9 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -97,15 +95,19 @@ private fun HistoryRow(
             Text(record.transcript.orEmpty(), style = MaterialTheme.typography.bodyMedium)
         }
 
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             if (failed && record.recoverable && record.audioPath != null) {
-                Button(onClick = onRetry) { Text("Retry") }
+                PrimaryButton("Retry", onClick = onRetry, modifier = Modifier.weight(1f))
             }
             record.transcript?.takeIf { it.isNotEmpty() }?.let { transcript ->
                 // Explicit only: Local Flow never writes to the clipboard on its own.
-                OutlinedButton(onClick = { onCopy(transcript) }) { Text("Copy") }
+                SecondaryButton(
+                    text = "Copy",
+                    onClick = { onCopy(transcript) },
+                    modifier = Modifier.weight(1f),
+                )
             }
-            TextButton(onClick = onDelete) { Text("Delete") }
+            TextButton(onClick = onDelete, modifier = Modifier.weight(1f)) { Text("Delete") }
         }
     }
 }

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/LocalFlowViewModel.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/LocalFlowViewModel.kt
@@ -80,11 +80,19 @@ class LocalFlowViewModel(application: Application) : AndroidViewModel(applicatio
         when (val validation = GatewayEndpoint.validate(url)) {
             is GatewayEndpoint.Validation.Invalid -> onResult(validation.reason)
             is GatewayEndpoint.Validation.Valid -> viewModelScope.launch {
-                if (token.isBlank()) {
+                val trimmed = token.trim()
+                if (trimmed.isEmpty() && !container.settings.current().hasToken) {
                     onResult("Enter the bearer token your gateway printed on first run.")
                     return@launch
                 }
-                container.settings.setGateway(validation.url, token.trim())
+                // A blank token with one already stored means "keep it", which is
+                // what the field promises. Correcting a typo in the address should
+                // not require digging the secret out again.
+                if (trimmed.isEmpty()) {
+                    container.settings.setGatewayUrl(validation.url)
+                } else {
+                    container.settings.setGateway(validation.url, trimmed)
+                }
                 refreshSetup()
                 testConnection()
                 onResult(null)

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/MainActivity.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
@@ -87,6 +88,18 @@ fun LocalFlowApp(viewModel: LocalFlowViewModel = viewModel()) {
                         }
                     )
                 },
+                navigationIcon = {
+                    // The gateway screen is pushed on top of setup, so it needs a
+                    // visible way back; the system gesture alone is not discoverable.
+                    if (showingGateway) {
+                        IconButton(onClick = { showingGateway = false }) {
+                            Icon(
+                                painterResource(R.drawable.ic_back),
+                                contentDescription = "Back",
+                            )
+                        }
+                    }
+                },
             )
         },
         bottomBar = {
@@ -110,17 +123,20 @@ fun LocalFlowApp(viewModel: LocalFlowViewModel = viewModel()) {
                 settings = settings,
                 connection = connection,
                 testing = testing,
+                inOnboarding = !settings.onboardingComplete,
                 onSave = viewModel::saveGateway,
                 onTest = viewModel::testConnection,
                 onClear = {
                     viewModel.clearGateway()
                     showingGateway = false
                 },
+                onDone = { showingGateway = false },
                 modifier = content,
             )
 
             showSetup -> SetupScreen(
                 status = setup,
+                settings = settings,
                 onOpenGateway = { showingGateway = true },
                 onAcceptDisclosure = { viewModel.setDisclosureAccepted(true) },
                 onFinish = { viewModel.setOnboardingComplete(true) },

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/SettingsScreen.kt
@@ -1,5 +1,10 @@
 package io.github.mrsunglasses.localflow.ui
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -14,11 +19,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -45,6 +50,7 @@ fun SettingsScreen(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
+    val appInfo = remember { context.readAppInfo() }
     LaunchedEffect(Unit) { onLoadApps() }
 
     Column(
@@ -68,7 +74,7 @@ fun SettingsScreen(
                 },
                 style = MaterialTheme.typography.bodyMedium,
             )
-            OutlinedButton(onClick = onOpenGateway) { Text("Gateway settings") }
+            SecondaryButton("Gateway settings", onClick = onOpenGateway)
         }
 
         SectionCard("Transcription language", supporting = settings.language.detail) {
@@ -121,15 +127,16 @@ fun SettingsScreen(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
                 )
-                OutlinedButton(onClick = {
-                    if (!setup.overlay) {
-                        context.openOverlaySettings()
-                    } else {
-                        context.openAccessibilitySettings()
-                    }
-                }) {
-                    Text("Repair")
-                }
+                SecondaryButton(
+                    text = "Repair",
+                    onClick = {
+                        if (!setup.overlay) {
+                            context.openOverlaySettings()
+                        } else {
+                            context.openAccessibilitySettings()
+                        }
+                    },
+                )
             }
         }
 
@@ -180,7 +187,62 @@ fun SettingsScreen(
                 style = MaterialTheme.typography.bodyMedium,
             )
         }
+
+        SectionCard(
+            title = "About",
+            supporting = "Local Flow ${appInfo.versionName} (${appInfo.versionCode})",
+        ) {
+            InfoRow("Android", "${appInfo.androidRelease} (SDK ${appInfo.sdkInt})")
+            InfoRow("Device", appInfo.device)
+            InfoRow("Installed from", appInfo.installedFrom)
+            InfoRow("Package", appInfo.packageName)
+            InfoRow(
+                "Engine",
+                settings.lastEngine.ifEmpty { "unknown" } +
+                    if (settings.lastEngineReady) " (ready)" else " (not ready)",
+            )
+            InfoRow(
+                "Setup",
+                if (setup.isReadyToDictate) {
+                    "complete"
+                } else {
+                    "${setup.completedStepCount} of ${setup.stepCount} steps"
+                },
+            )
+            Text(
+                "Diagnostics leave out your gateway's host name and never include " +
+                    "the token, so they are safe to paste into a public issue.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                SecondaryButton(
+                    text = "Copy diagnostics",
+                    onClick = {
+                        context.copyDiagnostics(
+                            diagnosticsReport(appInfo, settings, setup)
+                        )
+                    },
+                    modifier = Modifier.weight(1f),
+                )
+                SecondaryButton(
+                    text = "Project page",
+                    onClick = { context.openUrl(PROJECT_URL) },
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
     }
+}
+
+private fun Context.copyDiagnostics(text: String) {
+    val clipboard = getSystemService(ClipboardManager::class.java) ?: return
+    clipboard.setPrimaryClip(ClipData.newPlainText("Local Flow diagnostics", text))
+}
+
+/** No browser is a plausible state on a stripped-down ROM, so failure is silent. */
+private fun Context.openUrl(url: String) {
+    runCatching { startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url))) }
 }
 
 @Composable

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/SetupScreen.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/SetupScreen.kt
@@ -15,13 +15,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import io.github.mrsunglasses.localflow.settings.LocalFlowSettings
 
 /**
  * Guided setup. Every step states what Local Flow does with the access it asks
@@ -31,6 +32,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun SetupScreen(
     status: SetupStatus,
+    settings: LocalFlowSettings,
     onOpenGateway: () -> Unit,
     onAcceptDisclosure: () -> Unit,
     onFinish: () -> Unit,
@@ -56,6 +58,8 @@ fun SetupScreen(
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+
+        SetupProgress(status)
 
         AccessibilityDisclosureCard(
             accepted = status.disclosureAccepted,
@@ -110,23 +114,54 @@ fun SetupScreen(
         SectionCard("Gateway", supporting = "Your self-hosted Local Flow server.") {
             ChecklistRow(
                 title = "Address and token",
-                detail = "A LAN, Tailscale or HTTPS gateway you control.",
+                // Echoing the saved address back is the confirmation that the
+                // gateway screen took what was typed into it.
+                detail = if (status.gatewayConfigured) {
+                    settings.gatewayUrl
+                } else {
+                    "A LAN, Tailscale or HTTPS gateway you control."
+                },
                 satisfied = status.gatewayConfigured,
                 actionLabel = "Set up",
                 onAction = onOpenGateway,
             )
             if (status.gatewayConfigured) {
-                TextButton(onClick = onOpenGateway) { Text("Change gateway") }
+                TextButton(onClick = onOpenGateway) { Text("Change or test gateway") }
             }
         }
 
-        Button(
+        PrimaryButton(
+            text = "Start dictating",
             onClick = onFinish,
             enabled = status.isReadyToDictate,
             modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text(if (status.isReadyToDictate) "Start dictating" else "Finish the steps above")
+        )
+        if (!status.isReadyToDictate) {
+            Text(
+                "Still to do: " + status.remainingSteps.joinToString { it.label },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
+    }
+}
+
+/** How far through the checklist the user is, so the list has a visible end. */
+@Composable
+private fun SetupProgress(status: SetupStatus, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            "${status.completedStepCount} of ${status.stepCount} steps done",
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        LinearProgressIndicator(
+            progress = { status.completedStepCount.toFloat() / status.stepCount },
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }
 
@@ -165,7 +200,7 @@ fun AccessibilityDisclosureCard(
                 color = MaterialTheme.colorScheme.primary,
             )
         } else {
-            Button(onClick = onAccept) { Text("I understand") }
+            PrimaryButton("I understand", onClick = onAccept, modifier = Modifier.fillMaxWidth())
         }
     }
 }
@@ -206,9 +241,17 @@ fun RestrictedSettingsCard(
                 "on — it will work this time.",
             style = MaterialTheme.typography.bodyMedium,
         )
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Button(onClick = onOpenAccessibilitySettings) { Text("1. Accessibility") }
-            Button(onClick = onOpenAppInfo) { Text("2. App info") }
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            PrimaryButton(
+                text = "1. Accessibility",
+                onClick = onOpenAccessibilitySettings,
+                modifier = Modifier.weight(1f),
+            )
+            SecondaryButton(
+                text = "2. App info",
+                onClick = onOpenAppInfo,
+                modifier = Modifier.weight(1f),
+            )
         }
         Text(
             "On Samsung phones running One UI 8.5, \"Allow restricted " +

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/SetupStatus.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/SetupStatus.kt
@@ -11,6 +11,20 @@ import androidx.core.content.ContextCompat
 import io.github.mrsunglasses.localflow.accessibility.LocalFlowAccessibilityService
 import io.github.mrsunglasses.localflow.core.RestrictedSettingsPolicy
 
+/**
+ * A step guided setup requires before dictation can work, in the order the
+ * checklist presents them. Battery is deliberately absent: it is offered,
+ * never required.
+ */
+enum class SetupStep(val label: String) {
+    DISCLOSURE("Accessibility disclosure"),
+    MICROPHONE("Microphone"),
+    NOTIFICATIONS("Notifications"),
+    OVERLAY("Display over other apps"),
+    ACCESSIBILITY("Accessibility service"),
+    GATEWAY("Gateway"),
+}
+
 /** Everything guided setup checks, re-read every time the app is resumed. */
 data class SetupStatus(
     val microphone: Boolean = false,
@@ -23,10 +37,25 @@ data class SetupStatus(
     /** The accessibility switch is probably greyed out; see [RestrictedSettingsPolicy]. */
     val restrictedSettingsGuidance: Boolean = false,
 ) {
-    /** Battery is deliberately excluded: it is offered, never required. */
+    fun isSatisfied(step: SetupStep): Boolean = when (step) {
+        SetupStep.DISCLOSURE -> disclosureAccepted
+        SetupStep.MICROPHONE -> microphone
+        SetupStep.NOTIFICATIONS -> notifications
+        SetupStep.OVERLAY -> overlay
+        SetupStep.ACCESSIBILITY -> accessibility
+        SetupStep.GATEWAY -> gatewayConfigured
+    }
+
+    /** What the checklist still wants, in checklist order, for a plain-English prompt. */
+    val remainingSteps: List<SetupStep>
+        get() = SetupStep.entries.filterNot(::isSatisfied)
+
+    val stepCount: Int get() = SetupStep.entries.size
+
+    val completedStepCount: Int get() = stepCount - remainingSteps.size
+
     val isReadyToDictate: Boolean
-        get() = microphone && notifications && overlay && accessibility &&
-            gatewayConfigured && disclosureAccepted
+        get() = remainingSteps.isEmpty()
 
     companion object {
         fun read(context: Context, gatewayConfigured: Boolean, disclosureAccepted: Boolean): SetupStatus {
@@ -53,7 +82,7 @@ data class SetupStatus(
  * Null covers both an install that recorded no originator and a read that
  * failed outright; either way the app cannot claim it came from a store.
  */
-private fun Context.installerPackage(): String? = runCatching {
+internal fun Context.installerPackage(): String? = runCatching {
     packageManager.getInstallSourceInfo(packageName).installingPackageName
 }.getOrNull()
 

--- a/android/app/src/main/res/drawable/ic_back.xml
+++ b/android/app/src/main/res/drawable/ic_back.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:autoMirrored="true"
+    android:tint="?android:attr/colorForeground">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z" />
+</vector>

--- a/android/app/src/test/java/io/github/mrsunglasses/localflow/ui/DiagnosticsReportTest.kt
+++ b/android/app/src/test/java/io/github/mrsunglasses/localflow/ui/DiagnosticsReportTest.kt
@@ -1,0 +1,79 @@
+package io.github.mrsunglasses.localflow.ui
+
+import io.github.mrsunglasses.localflow.settings.LocalFlowSettings
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DiagnosticsReportTest {
+
+    private val info = AppInfo(
+        versionName = "0.1.0-beta.3",
+        versionCode = 3,
+        packageName = "io.github.mrsunglasses.localflow",
+        installedFrom = "sideloaded",
+        androidRelease = "14",
+        sdkInt = 34,
+        device = "Google Pixel 6a",
+    )
+
+    private val configured = LocalFlowSettings(
+        gatewayUrl = "http://homelabone.local:8765",
+        hasToken = true,
+        lastEngine = "moonshine:en",
+        lastEngineReady = true,
+        lastStreamingSupported = true,
+    )
+
+    private val ready = SetupStatus(
+        microphone = true,
+        notifications = true,
+        overlay = true,
+        accessibility = true,
+        gatewayConfigured = true,
+        disclosureAccepted = true,
+    )
+
+    @Test
+    fun `report carries the version, platform and engine`() {
+        val report = diagnosticsReport(info, configured, ready)
+
+        assertTrue(report.contains("Local Flow 0.1.0-beta.3 (3)"))
+        assertTrue(report.contains("Android 14 (SDK 34)"))
+        assertTrue(report.contains("Google Pixel 6a"))
+        assertTrue(report.contains("sideloaded"))
+        assertTrue(report.contains("moonshine:en (ready)"))
+        assertTrue(report.contains("Streaming: supported"))
+        assertTrue(report.contains("Setup: all steps done"))
+    }
+
+    @Test
+    fun `the gateway host name never reaches the report`() {
+        val report = diagnosticsReport(info, configured, ready)
+
+        assertFalse(report.contains("homelabone"))
+        assertFalse(report.contains("8765"))
+        assertTrue(report.contains("http:// (private host)"))
+    }
+
+    @Test
+    fun `an https gateway is reported as encrypted`() {
+        val settings = configured.copy(gatewayUrl = "https://voice.example.com")
+
+        val report = diagnosticsReport(info, settings, ready)
+
+        assertFalse(report.contains("example.com"))
+        assertTrue(report.contains("Gateway: https://"))
+    }
+
+    @Test
+    fun `an unconfigured install names the steps still outstanding`() {
+        val report = diagnosticsReport(info, LocalFlowSettings(), SetupStatus())
+
+        assertTrue(report.contains("Gateway: not configured"))
+        assertTrue(report.contains("Engine: unknown (not ready)"))
+        assertTrue(report.contains("Streaming: batch upload"))
+        assertTrue(report.contains("Setup: missing"))
+        assertTrue(report.contains(SetupStep.MICROPHONE.label))
+    }
+}

--- a/android/app/src/test/java/io/github/mrsunglasses/localflow/ui/SetupStatusTest.kt
+++ b/android/app/src/test/java/io/github/mrsunglasses/localflow/ui/SetupStatusTest.kt
@@ -1,0 +1,50 @@
+package io.github.mrsunglasses.localflow.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SetupStatusTest {
+
+    private val complete = SetupStatus(
+        microphone = true,
+        notifications = true,
+        overlay = true,
+        accessibility = true,
+        gatewayConfigured = true,
+        disclosureAccepted = true,
+    )
+
+    @Test
+    fun `every required step satisfied is ready to dictate`() {
+        assertTrue(complete.isReadyToDictate)
+        assertTrue(complete.remainingSteps.isEmpty())
+        assertEquals(complete.stepCount, complete.completedStepCount)
+    }
+
+    @Test
+    fun `battery is offered, never required`() {
+        assertFalse(complete.batteryUnrestricted)
+        assertTrue(complete.isReadyToDictate)
+        assertTrue(complete.copy(batteryUnrestricted = true).isReadyToDictate)
+    }
+
+    @Test
+    fun `remaining steps name what is left, in checklist order`() {
+        val status = complete.copy(disclosureAccepted = false, gatewayConfigured = false)
+
+        assertFalse(status.isReadyToDictate)
+        assertEquals(listOf(SetupStep.DISCLOSURE, SetupStep.GATEWAY), status.remainingSteps)
+        assertEquals(status.stepCount - 2, status.completedStepCount)
+    }
+
+    @Test
+    fun `a fresh install has nothing done`() {
+        val status = SetupStatus()
+
+        assertFalse(status.isReadyToDictate)
+        assertEquals(SetupStep.entries, status.remainingSteps)
+        assertEquals(0, status.completedStepCount)
+    }
+}


### PR DESCRIPTION
## Summary

**What changed?**

Entering the gateway token during Android setup left the user stranded. `GatewayScreen` had no back affordance in the top bar and no next action, so the only exit was the system back gesture — with nothing on screen saying the setup checklist was waiting behind it.

- Back arrow in the top bar whenever the gateway screen is showing.
- A pinned footer on the gateway screen that reports connection state (pending / checking / warning / ready) and offers **Continue setup** during onboarding or **Done** afterwards. When nothing is saved it degrades to **Back to setup** so the screen never traps anyone.
- The token field's IME **Done** key now saves and dismisses the keyboard.
- The setup checklist shows progress ("4 of 6 steps done") and names what is left — "Still to do: Microphone, Gateway" — instead of "Finish the steps above". The gateway row echoes the saved address back.
- Editing only the address with the token field left blank now keeps the stored token, which is what the field already promised. Previously this was rejected outright, so fixing a typo in the address meant digging the secret out again.

Separately, controls across the app used `OutlinedButton` and the default chip border. Both are all but invisible under a dynamic dark colour scheme, so secondary actions and unselected chips rendered as loose floating text. Shared `PrimaryButton` / `SecondaryButton` replace every outlined button, and `ChipChoiceRow` gives chips their own fill — which fixes transcription language, writing style, bubble behaviour and audio retention in one place.

Finally, Settings gains an **About** card: version and code, Android release/SDK, device, install source (store vs sideloaded — the same signal that predicts a greyed-out accessibility switch), package, engine, and setup progress. Plus **Copy diagnostics** and **Project page**.

**Why is it needed?**

The token step was the point where first-run setup dead-ended. The control styling made the rest of the app read as unfinished, and there was no way to report a bug with version or platform detail attached.

## Verification

- [ ] `uv run ruff check .` — not run, no gateway changes
- [ ] `uv run ruff format --check .` — not run, no gateway changes
- [ ] `uv run mypy app` — not run, no gateway changes
- [ ] `uv run pytest` — not run, no gateway changes
- [ ] Compose validation/container build — not applicable
- [ ] iOS simulator build/tests — not run, no iOS changes
- [x] Android: `:app:assembleRelease`, `:app:testDebugUnitTest`, `:app:lintDebug` all pass (84 unit tests, 8 new)
- [x] Physical-device test — see below

### Physical device

Xiaomi POCO F1, Android 14 (SDK 34), release APK installed with `adb install -r`:

- Settings → Gateway settings: back arrow returns to Settings; footer shows "Address and token saved on this device" with **Done**.
- **Test connection** against a live gateway: footer transitions to "Connected and ready" with the check indicator; the Connection card populates (reachable / token accepted / engine ready, `moonshine:en`, streaming supported).
- **Done** returns to Settings.
- Chip rows, button rows and the About card render as intended.
- **Copy diagnostics** pasted back into the scratchpad to confirm the exact clipboard content.

Not verified on device: the first-run onboarding path itself, since that device has onboarding complete and walking it means wiping app data (destroying the saved token and history). The onboarding-specific behaviour is confined to the `inOnboarding` label and hint branches.

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for data-flow, permission, retention, or network changes — none needed; no data-flow, permission, retention or network behaviour changed

The diagnostics report is the only new outbound data path, and it is user-initiated to the clipboard. It deliberately omits the gateway host name — a LAN or tailnet address identifying the user's own network — reporting `http:// (private host)` or `https://` instead, and the bearer token never leaves the Keystore. `DiagnosticsReportTest` asserts the host name and port never appear in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)