### PR TITLE
fix: stop the bubble from showing live streaming partials

### DIFF
--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/overlay/BubbleController.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/overlay/BubbleController.kt
@@ -175,12 +175,13 @@ class BubbleController(
 
     private fun render(state: DictationState) {
         val view = root ?: return
+        // Streaming partials are deliberately not shown here. They rewrite
+        // themselves as the model catches up and only settle after the gateway's
+        // post-processing, so a live preview next to the text field the user is
+        // dictating into is noise — and wrong often enough to be distracting.
         status?.text = when {
             state.approachingLimit && state.phase == DictationPhase.LISTENING ->
                 "Listening — one minute left"
-
-            state.phase == DictationPhase.LISTENING && state.partialTranscript.isNotEmpty() ->
-                state.partialTranscript.takeLast(PARTIAL_PREVIEW_CHARACTERS)
 
             else -> state.statusText
         }
@@ -319,6 +320,5 @@ class BubbleController(
 
     private companion object {
         const val SNOOZE_MILLIS = 15 * 60 * 1000L
-        const val PARTIAL_PREVIEW_CHARACTERS = 48
     }
 }

--- a/android/app/src/main/res/layout/view_bubble.xml
+++ b/android/app/src/main/res/layout/view_bubble.xml
@@ -30,7 +30,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="10dp"
-        android:ellipsize="start"
+        android:ellipsize="end"
         android:maxWidth="180dp"
         android:maxLines="1"
         android:textColor="#FFFFFFFF"


### PR DESCRIPTION
## What

While recording, the floating dictation bubble replaced its `Listening` status with the last 48 characters of the streaming partial transcript. This removes that preview — the bubble now shows the phase status for the whole session, whether it negotiated streaming or fell back to batch.

## Why

Partials rewrite themselves as the model catches up and only settle once the gateway has post-processed them. The preview therefore churned right next to the text field being dictated into, frequently showing text that was about to change. Distracting at exactly the moment the user is trying to speak, and misleading about what will actually be inserted.

## Changes

- `BubbleController.render()` — drop the `partialTranscript` branch, keeping `Listening` / `Listening — one minute left`. Removes the now-unused `PARTIAL_PREVIEW_CHARACTERS`.
- `view_bubble.xml` — `ellipsize` moves from `start` to `end`. Start-anchored truncation existed to keep the tail of a scrolling partial visible; it reads backwards for a status label or a failure message.

## Notes

- The companion app's Dictate screen still shows the live partial under its explicit `· streaming` label, where a preview is the point rather than noise.
- Streaming and batch now render identically in the bubble. Batch never produced partials, so gating on `state.streaming` would have been a distinction without a difference.
- `DictationController` still tracks `partialTranscript` in state; only the bubble stopped reading it.

## Testing

`compileDebugKotlin` and `testDebugUnitTest` pass. Not exercised on device: the test gateway reports `streaming_supported: false`, so a Pixel run only covers the batch path, which never showed a partial either way.