### PR TITLE
ci: generate beta release notes from the merged pull requests

### DIFF
--- a/.github/workflows/android-beta.yml
+++ b/.github/workflows/android-beta.yml
@@ -23,6 +23,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # The release notes step walks back to the previous beta tag, which
+          # needs the tags and the history connecting them.
+          fetch-depth: 0
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
@@ -52,9 +56,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           cp android/app/build/outputs/apk/release/local-flow-release.apk local-flow.apk
+
+          # --generate-notes lists the pull requests merged since the previous
+          # beta. It will choose that starting point on its own, but naming the
+          # tag explicitly keeps the range right for a tag cut from anywhere
+          # other than the tip of main. An empty result is the first beta ever,
+          # where letting it pick means "everything", which is correct.
+          previous_tag="$(git describe --tags --abbrev=0 --match 'v*-beta*' "$GITHUB_REF_NAME^" 2>/dev/null || true)"
+          notes_range=()
+          if [ -n "$previous_tag" ]; then
+            notes_range=(--notes-start-tag "$previous_tag")
+          fi
+
+          # --notes is prepended to the generated list, so the install
+          # instructions stay at the top where a beta tester looks first.
           gh release create "$GITHUB_REF_NAME" \
             local-flow.apk \
             --repo "$GITHUB_REPOSITORY" \
             --title "Local Flow Android $GITHUB_REF_NAME" \
             --prerelease \
+            --generate-notes \
+            "${notes_range[@]}" \
             --notes "Release-signed APK covering every ABI (arm64-v8a, armeabi-v7a, x86_64) and all Android 13+ devices. Install with \`adb install local-flow.apk\` or open the APK on the device."


### PR DESCRIPTION
## What

Beta releases published the same hardcoded sentence about ABIs and `adb install` every time, so the notes never said what changed between one prerelease and the next. This makes the workflow generate the changelog from the pull requests merged since the previous beta tag.

The install instructions stay — `gh` prepends `--notes` to the generated list, so they remain at the top where a tester looks first.

## Changes

- `--generate-notes` on `gh release create`, producing the `## What's Changed` list plus a full-changelog link.
- The starting tag is named explicitly (`git describe --match 'v*-beta*'` against the tag's parent) rather than left to the API to infer, so the range is right even for a tag cut from somewhere other than the tip of `main`. No earlier tag — the first beta ever — falls back to letting the API pick, which generates from the beginning of history.
- `fetch-depth: 0` on checkout, which walking back to the previous tag requires.

## Testing

- Generated notes for the `v0.1.0-beta.3..v0.1.0-beta.4` range through `repos/.../releases/generate-notes`; the output matches the six PRs (#9–#14) that actually landed in that window.
- Ran the publish step locally with `gh` stubbed to print its arguments. The normal path resolves `--notes-start-tag v0.1.0-beta.3`; the first-release path emits no `--notes-start-tag` at all.
- Workflow YAML parses, and the extracted step is `bash -n` and `shellcheck` clean.

## Note

The already-published [v0.1.0-beta.4](https://github.com/VocaHQ/vocaphone/releases/tag/v0.1.0-beta.4) notes were written by hand and are already live — this only changes what future tags produce.