### PR TITLE
Rebuild the iOS keyboard's dictation view as one morphing bar

### DIFF
--- a/.github/workflows/android-beta.yml
+++ b/.github/workflows/android-beta.yml
@@ -23,6 +23,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # The release notes step walks back to the previous beta tag, which
+          # needs the tags and the history connecting them.
+          fetch-depth: 0
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
@@ -52,9 +56,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           cp android/app/build/outputs/apk/release/local-flow-release.apk local-flow.apk
+
+          # --generate-notes lists the pull requests merged since the previous
+          # beta. It will choose that starting point on its own, but naming the
+          # tag explicitly keeps the range right for a tag cut from anywhere
+          # other than the tip of main. An empty result is the first beta ever,
+          # where letting it pick means "everything", which is correct.
+          previous_tag="$(git describe --tags --abbrev=0 --match 'v*-beta*' "$GITHUB_REF_NAME^" 2>/dev/null || true)"
+          notes_range=()
+          if [ -n "$previous_tag" ]; then
+            notes_range=(--notes-start-tag "$previous_tag")
+          fi
+
+          # --notes is prepended to the generated list, so the install
+          # instructions stay at the top where a beta tester looks first.
           gh release create "$GITHUB_REF_NAME" \
             local-flow.apk \
             --repo "$GITHUB_REPOSITORY" \
             --title "Local Flow Android $GITHUB_REF_NAME" \
             --prerelease \
+            --generate-notes \
+            "${notes_range[@]}" \
             --notes "Release-signed APK covering every ABI (arm64-v8a, armeabi-v7a, x86_64) and all Android 13+ devices. Install with \`adb install local-flow.apk\` or open the APK on the device."

--- a/ios/LocalFlow.xcodeproj/project.pbxproj
+++ b/ios/LocalFlow.xcodeproj/project.pbxproj
@@ -10,18 +10,22 @@
 		0145D55B523EB13827B27AC4 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799A203DEDA091866FFBA4E /* TextInsertion.swift */; };
 		058BC439CA6C261AE5922069 /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4D700966610E77B503A6E8 /* KeyboardStatus.swift */; };
 		06B3991D6C5E2AD404A8D3A6 /* GatewayClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E50ACD74CADDD0BB62D1222 /* GatewayClient.swift */; };
+		071A3B76B9A9898F013BBBFA /* DictationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3DC0671915A7EE93CC93158 /* DictationBarView.swift */; };
 		09F4AAAEDA5288F98A21F5BB /* QuickDictationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119E8C9BE1BEB7517D444CD /* QuickDictationAvailability.swift */; };
 		0AD5017F623BBA820A437FDA /* PairingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D16BA539DADFFDC84CA902 /* PairingPayload.swift */; };
 		167F067DE708255E6CC96F90 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F29134B8035F91ACA991D5 /* AudioRecorder.swift */; };
 		18AB100760A33EAD802AF6C5 /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37BD648DCFB7D3452241CE1 /* GatewayEndpoint.swift */; };
 		191C781D0F219B2787D8923D /* FinishRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5A612D9FCE236CFDF42011 /* FinishRecordingIntent.swift */; };
+		193F876B9DBE611E631B41A8 /* DictationBarComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9BBA3D3A833425AFDB329A /* DictationBarComponents.swift */; };
 		21ADF5A5E85E3736552E28B0 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799A203DEDA091866FFBA4E /* TextInsertion.swift */; };
 		26C0719CEC4DDCB0BA08AAC4 /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4D700966610E77B503A6E8 /* KeyboardStatus.swift */; };
+		27AEA8655C49D5A993330098 /* DictationBarStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB1E7B1BF357F0FB620CCBC /* DictationBarStyle.swift */; };
 		2B31542654F871DCD77744DA /* SessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13384D76D40D7BBB5882E472 /* SessionRecord.swift */; };
 		2BE3127F30D991B02C70C5D9 /* PairingPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4344F731096BD514A985FFCA /* PairingPayloadTests.swift */; };
 		2D56C9A5CE35FF4853A3219E /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4D700966610E77B503A6E8 /* KeyboardStatus.swift */; };
 		2DD59385E1E2FE40DA6D12B5 /* KeyGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AD7CA27F30AE6D9A5375898 /* KeyGridView.swift */; };
 		2EFD17B37B8F0B12A4D02D71 /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0971907F8807AF4111357EAA /* LiveActivityManager.swift */; };
+		2FFACFDCAF2A2C308075C416 /* DictationBarLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF392D84438885719810A3E /* DictationBarLayoutTests.swift */; };
 		36D030A4745EC041A8576C57 /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = A360AC1ABD0B65D97947A185 /* KeyboardPreferences.swift */; };
 		3D9F43741DE7FD79F1D7BBD4 /* PairingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D16BA539DADFFDC84CA902 /* PairingPayload.swift */; };
 		40F7DEDC700B2C334FC86C17 /* LocalFlowApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6FBCD6D0BA52C87B1D6F01 /* LocalFlowApp.swift */; };
@@ -29,6 +33,7 @@
 		438B7DBF85706EAA0D4FAB47 /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D89402A128DB78CAA390D8 /* SharedStore.swift */; };
 		465471C98F093574D3D9E064 /* SessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13384D76D40D7BBB5882E472 /* SessionRecord.swift */; };
 		4CA5ACE8C47B723822AAEAD9 /* QuickDictationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119E8C9BE1BEB7517D444CD /* QuickDictationAvailability.swift */; };
+		52E35CCF918FCDE6532C5CA7 /* DictationPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8055049DFA0E4417BA11820 /* DictationPresentationTests.swift */; };
 		5337C61ADB62FF8D06454585 /* KeyLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE771351D7769E816A9351D /* KeyLayout.swift */; };
 		5337F224DF24B3587A6BD5C0 /* KeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3527B7F09F5339E5E0D465D7 /* KeyboardViewController.swift */; };
 		5481E85AFB3FB78892EA4594 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703439CBBE8F06E5A7449339 /* AppConfiguration.swift */; };
@@ -36,6 +41,7 @@
 		55A87E5D7B3D89547BAFE49E /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29431D5C04702EAC4660679 /* SettingsView.swift */; };
 		5893F51719CDEA9DF4483C26 /* AudioCapturePipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E21137C2267571197E0DE15 /* AudioCapturePipeline.swift */; };
 		6483777493E40A89BE5D96EF /* KeyGridLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2D93BC8D9A8F925C00A507 /* KeyGridLayoutTests.swift */; };
+		67A1532CBC8769AEAFA597DA /* DictationPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345682E82E48581DCA250E9D /* DictationPresentation.swift */; };
 		6A657FBECD134398B05227AE /* LocalFlowKeyboard.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 6CBCE898A23F47628C1183DA /* LocalFlowKeyboard.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		6B69DBBB69638883C42042CC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714EAEF5499752246C9E5FBA /* ContentView.swift */; };
 		7100CDA1673010769D5E7CF5 /* LocalFlowLiveActivity.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 5B71284AEFECD863402492DB /* LocalFlowLiveActivity.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -52,6 +58,7 @@
 		A51E936B352F336F6DC3E5C4 /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37BD648DCFB7D3452241CE1 /* GatewayEndpoint.swift */; };
 		A85EC9BE7705E8D58222B60A /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703439CBBE8F06E5A7449339 /* AppConfiguration.swift */; };
 		A907BA2F465E61A41742F991 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799A203DEDA091866FFBA4E /* TextInsertion.swift */; };
+		A91FC489EC86C8867D6E238C /* DictationBarComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9BBA3D3A833425AFDB329A /* DictationBarComponents.swift */; };
 		A9483EF6A5B7DC48524556EE /* PairingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D16BA539DADFFDC84CA902 /* PairingPayload.swift */; };
 		ADEF8CAFC4B716BE8AA943D9 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703439CBBE8F06E5A7449339 /* AppConfiguration.swift */; };
 		B1E3C93E42A9D6EA60E6D71F /* QuickDictationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119E8C9BE1BEB7517D444CD /* QuickDictationAvailability.swift */; };
@@ -67,9 +74,12 @@
 		D3878F197D933401251E56DA /* KeyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D98CCDF1DA1FD5C8C4213DEB /* KeyView.swift */; };
 		D86C0451167701407A48DBCB /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D89402A128DB78CAA390D8 /* SharedStore.swift */; };
 		DEA1AA9E14DB93DBC2951D89 /* QuickDictationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119E8C9BE1BEB7517D444CD /* QuickDictationAvailability.swift */; };
+		DF60F08E1FCC3495066672B8 /* DictationBarStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB1E7B1BF357F0FB620CCBC /* DictationBarStyle.swift */; };
+		E2577194DA1495BFCF41D367 /* DictationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3DC0671915A7EE93CC93158 /* DictationBarView.swift */; };
 		E53E4617EAC4024DE1C82257 /* LocalFlowActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEB8F53F67E6A3A30BFBB99B /* LocalFlowActivityAttributes.swift */; };
 		E6D3025060DEDF10EC45635D /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703439CBBE8F06E5A7449339 /* AppConfiguration.swift */; };
 		E988413867B75066073B32E4 /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37BD648DCFB7D3452241CE1 /* GatewayEndpoint.swift */; };
+		EA5040DEBFDC6E94F32E61A6 /* DictationPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345682E82E48581DCA250E9D /* DictationPresentation.swift */; };
 		EA6504A14AD3928A969FC631 /* SetupChecklist.swift in Sources */ = {isa = PBXBuildFile; fileRef = C521D43922FDDC9DE93B9117 /* SetupChecklist.swift */; };
 		EBAC4D63FB9EFE4E2920FEF6 /* RecordingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB93D3AEE8AC75CF9783740 /* RecordingCoordinator.swift */; };
 		F1757844C110E137D8959C4A /* KeyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D98CCDF1DA1FD5C8C4213DEB /* KeyView.swift */; };
@@ -121,6 +131,7 @@
 		2C43220C98C2F3DADD48D714 /* LocalFlowKeyboard.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LocalFlowKeyboard.entitlements; sourceTree = "<group>"; };
 		2EE35659190071F646E5F538 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		32903D1AECF2E8F3A4EB8DB6 /* AudioCaptureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCaptureTests.swift; sourceTree = "<group>"; };
+		345682E82E48581DCA250E9D /* DictationPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationPresentation.swift; sourceTree = "<group>"; };
 		3527B7F09F5339E5E0D465D7 /* KeyboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardViewController.swift; sourceTree = "<group>"; };
 		3B6FBCD6D0BA52C87B1D6F01 /* LocalFlowApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFlowApp.swift; sourceTree = "<group>"; };
 		3D5D36117A0F57109452184B /* KeyboardURLLauncher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KeyboardURLLauncher.m; sourceTree = "<group>"; };
@@ -129,6 +140,7 @@
 		547EF78AB18AB0C5D0561123 /* TranscriptHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptHistoryView.swift; sourceTree = "<group>"; };
 		5B71284AEFECD863402492DB /* LocalFlowLiveActivity.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = LocalFlowLiveActivity.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		608A526CA60F83A070052A01 /* KeyboardURLLauncher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeyboardURLLauncher.h; sourceTree = "<group>"; };
+		6B9BBA3D3A833425AFDB329A /* DictationBarComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarComponents.swift; sourceTree = "<group>"; };
 		6CBCE898A23F47628C1183DA /* LocalFlowKeyboard.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = LocalFlowKeyboard.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		703439CBBE8F06E5A7449339 /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
 		7149F16802909BA09B07B761 /* SessionRecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRecordTests.swift; sourceTree = "<group>"; };
@@ -147,12 +159,16 @@
 		A6FDBFE79701D7096F59E9B7 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
 		B1C36285B8875EB38D290483 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		B29431D5C04702EAC4660679 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		BDB1E7B1BF357F0FB620CCBC /* DictationBarStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarStyle.swift; sourceTree = "<group>"; };
 		BEB8F53F67E6A3A30BFBB99B /* LocalFlowActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFlowActivityAttributes.swift; sourceTree = "<group>"; };
 		C521D43922FDDC9DE93B9117 /* SetupChecklist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupChecklist.swift; sourceTree = "<group>"; };
 		D43B3D04FBB29DBBD85F1544 /* LocalFlowTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = LocalFlowTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D61154C673CC42F46B10E76D /* LocalFlowLiveActivity.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LocalFlowLiveActivity.entitlements; sourceTree = "<group>"; };
+		D8055049DFA0E4417BA11820 /* DictationPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationPresentationTests.swift; sourceTree = "<group>"; };
 		D98CCDF1DA1FD5C8C4213DEB /* KeyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyView.swift; sourceTree = "<group>"; };
 		DBE771351D7769E816A9351D /* KeyLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyLayout.swift; sourceTree = "<group>"; };
+		E3DC0671915A7EE93CC93158 /* DictationBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarView.swift; sourceTree = "<group>"; };
+		EDF392D84438885719810A3E /* DictationBarLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarLayoutTests.swift; sourceTree = "<group>"; };
 		F37BD648DCFB7D3452241CE1 /* GatewayEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayEndpoint.swift; sourceTree = "<group>"; };
 		FB2D93BC8D9A8F925C00A507 /* KeyGridLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyGridLayoutTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -225,6 +241,8 @@
 			isa = PBXGroup;
 			children = (
 				32903D1AECF2E8F3A4EB8DB6 /* AudioCaptureTests.swift */,
+				EDF392D84438885719810A3E /* DictationBarLayoutTests.swift */,
+				D8055049DFA0E4417BA11820 /* DictationPresentationTests.swift */,
 				FB2D93BC8D9A8F925C00A507 /* KeyGridLayoutTests.swift */,
 				4344F731096BD514A985FFCA /* PairingPayloadTests.swift */,
 				7149F16802909BA09B07B761 /* SessionRecordTests.swift */,
@@ -251,6 +269,10 @@
 		CD8C3F708CDF322D2F943D01 /* LocalFlowKeyboard */ = {
 			isa = PBXGroup;
 			children = (
+				6B9BBA3D3A833425AFDB329A /* DictationBarComponents.swift */,
+				BDB1E7B1BF357F0FB620CCBC /* DictationBarStyle.swift */,
+				E3DC0671915A7EE93CC93158 /* DictationBarView.swift */,
+				345682E82E48581DCA250E9D /* DictationPresentation.swift */,
 				B1C36285B8875EB38D290483 /* Info.plist */,
 				608A526CA60F83A070052A01 /* KeyboardURLLauncher.h */,
 				3D5D36117A0F57109452184B /* KeyboardURLLauncher.m */,
@@ -445,6 +467,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				ADEF8CAFC4B716BE8AA943D9 /* AppConfiguration.swift in Sources */,
+				A91FC489EC86C8867D6E238C /* DictationBarComponents.swift in Sources */,
+				27AEA8655C49D5A993330098 /* DictationBarStyle.swift in Sources */,
+				E2577194DA1495BFCF41D367 /* DictationBarView.swift in Sources */,
+				67A1532CBC8769AEAFA597DA /* DictationPresentation.swift in Sources */,
 				F9FA851C5711B43FF64B0C2D /* GatewayEndpoint.swift in Sources */,
 				CBE8836AA904870938B18FE0 /* KeyGridView.swift in Sources */,
 				558EBF1861328F42ED3B5C07 /* KeyLayout.swift in Sources */,
@@ -468,6 +494,12 @@
 				5481E85AFB3FB78892EA4594 /* AppConfiguration.swift in Sources */,
 				C9D54338613F090FA032FC5F /* AudioCapturePipeline.swift in Sources */,
 				F778A5B91B15F1447918FC5D /* AudioCaptureTests.swift in Sources */,
+				193F876B9DBE611E631B41A8 /* DictationBarComponents.swift in Sources */,
+				2FFACFDCAF2A2C308075C416 /* DictationBarLayoutTests.swift in Sources */,
+				DF60F08E1FCC3495066672B8 /* DictationBarStyle.swift in Sources */,
+				071A3B76B9A9898F013BBBFA /* DictationBarView.swift in Sources */,
+				EA5040DEBFDC6E94F32E61A6 /* DictationPresentation.swift in Sources */,
+				52E35CCF918FCDE6532C5CA7 /* DictationPresentationTests.swift in Sources */,
 				E988413867B75066073B32E4 /* GatewayEndpoint.swift in Sources */,
 				6483777493E40A89BE5D96EF /* KeyGridLayoutTests.swift in Sources */,
 				2DD59385E1E2FE40DA6D12B5 /* KeyGridView.swift in Sources */,

--- a/ios/LocalFlowKeyboard/DictationBarComponents.swift
+++ b/ios/LocalFlowKeyboard/DictationBarComponents.swift
@@ -1,0 +1,374 @@
+import UIKit
+
+/// A scrolling level meter. Replaces the fixed decorative pattern that used to
+/// be scaled by a single number, which moved identically whether the user was
+/// whispering or shouting.
+///
+/// Bars enter at the trailing edge and slide out of the leading one, so the view
+/// shows the last few seconds of speech rather than one instant of it.
+final class WaveformView: UIView {
+    /// `nil` puts the view to sleep: no display link, no redraws. Ordinary
+    /// typing is the common case and it must not pay for animation.
+    var mode: WaveformMode? {
+        didSet {
+            guard mode != oldValue else { return }
+            if mode == .indeterminate { phase = -0.25 }
+            updateAnimation()
+            setNeedsDisplay()
+        }
+    }
+
+    var color: UIColor = .systemBlue {
+        didSet { setNeedsDisplay() }
+    }
+
+    private static let barWidth: CGFloat = 3
+    private static let barGap: CGFloat = 2.5
+    /// New bars per second. Slow enough to read as speech, fast enough that a
+    /// short utterance still fills the view.
+    private static let barsPerSecond: CGFloat = 14
+
+    private var levels: [CGFloat] = []
+    private var smoothedLevel: CGFloat = 0
+    private var targetLevel: CGFloat = 0
+    private var advanceProgress: CGFloat = 0
+    private var phase: CGFloat = -0.25
+    private var displayLink: CADisplayLink?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        isOpaque = false
+        // Bars leave through the leading edge rather than drawing over the
+        // status indicator beside them.
+        clipsToBounds = true
+        isAccessibilityElement = true
+        accessibilityLabel = "Voice level"
+        accessibilityTraits = [.updatesFrequently]
+        updateAccessibilityValue()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// The newest microphone level, published by the app roughly four times a
+    /// second. Rendering interpolates between these so the meter does not step.
+    func push(level: Float) {
+        targetLevel = min(max(CGFloat(level), 0), 1)
+        updateAccessibilityValue()
+        // Reduce Motion, an offscreen keyboard, anything that stops the display
+        // link: with nothing else advancing the meter, each published level has
+        // to become a bar itself rather than leaving a frozen line.
+        guard displayLink == nil, mode == .live else { return }
+        smoothedLevel = targetLevel
+        appendBar(smoothedLevel)
+        setNeedsDisplay()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        resizeBuffer()
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        updateAnimation()
+    }
+
+    override func draw(_ rect: CGRect) {
+        guard !levels.isEmpty, bounds.height > 0 else { return }
+        let step = Self.barWidth + Self.barGap
+        let offset = mode == .indeterminate ? 0 : advanceProgress * step
+        let radius = Self.barWidth / 2
+
+        for (index, stored) in levels.enumerated() {
+            let value = mode == .indeterminate ? pulseValue(at: index) : stored
+            let height = max(Self.barWidth, value * bounds.height)
+            let bar = CGRect(
+                x: CGFloat(index) * step - offset,
+                y: bounds.midY - height / 2,
+                width: Self.barWidth,
+                height: height
+            )
+            color.withAlphaComponent(alpha(at: index)).setFill()
+            UIBezierPath(roundedRect: bar, cornerRadius: radius).fill()
+        }
+    }
+
+    // MARK: - Rendering values
+
+    /// Older bars fade out, which gives the meter a direction of travel without
+    /// needing a gradient layer over the top of it.
+    private func alpha(at index: Int) -> CGFloat {
+        guard mode != .indeterminate else { return 0.85 }
+        let position = CGFloat(index) / CGFloat(max(levels.count - 1, 1))
+        return 0.24 + 0.76 * position
+    }
+
+    /// A soft bump travelling from the leading edge to the trailing one. Shaped
+    /// deliberately unlike speech so a wait is never read as recorded audio.
+    private func pulseValue(at index: Int) -> CGFloat {
+        let position = CGFloat(index) / CGFloat(max(levels.count - 1, 1))
+        let distance = (position - phase) / 0.16
+        return 0.1 + 0.8 * exp(-distance * distance)
+    }
+
+    private func appendBar(_ value: CGFloat) {
+        guard !levels.isEmpty else { return }
+        levels.removeFirst()
+        levels.append(value)
+    }
+
+    private func resizeBuffer() {
+        let step = Self.barWidth + Self.barGap
+        // One extra bar covers the slot that is part-way through scrolling in.
+        let count = max(0, Int(((bounds.width + step) / step).rounded(.down)))
+        guard count != levels.count else { return }
+        if count < levels.count {
+            levels.removeFirst(levels.count - count)
+        } else {
+            levels.insert(contentsOf: [CGFloat](repeating: 0, count: count - levels.count), at: 0)
+        }
+    }
+
+    // MARK: - Animation
+
+    private var reduceMotion: Bool {
+        UIAccessibility.isReduceMotionEnabled
+    }
+
+    /// A display link retains its target and is itself retained by the run
+    /// loop, so leaving the window has to tear it down; there is no `deinit`
+    /// that could reach it once the cycle exists.
+    private func updateAnimation() {
+        let wantsLink = mode != nil && window != nil && !reduceMotion
+        guard wantsLink else {
+            displayLink?.invalidate()
+            displayLink = nil
+            if mode == nil {
+                levels = levels.map { _ in 0 }
+                smoothedLevel = 0
+                advanceProgress = 0
+            }
+            return
+        }
+        guard displayLink == nil else { return }
+        let link = CADisplayLink(target: self, selector: #selector(step))
+        // Half the usual rate is plenty for bars this narrow, and a keyboard
+        // extension has little headroom to spare.
+        link.preferredFrameRateRange = CAFrameRateRange(minimum: 20, maximum: 30, preferred: 30)
+        link.add(to: .main, forMode: .common)
+        displayLink = link
+    }
+
+    @objc private func step(_ link: CADisplayLink) {
+        let elapsed = max(link.targetTimestamp - link.timestamp, 1.0 / 120)
+        switch mode {
+        case .live:
+            smoothedLevel += (targetLevel - smoothedLevel) * 0.3
+            advanceProgress += Self.barsPerSecond * CGFloat(elapsed)
+            while advanceProgress >= 1 {
+                advanceProgress -= 1
+                appendBar(smoothedLevel)
+            }
+        case .indeterminate:
+            phase += CGFloat(elapsed) * 0.75
+            if phase > 1.25 { phase = -0.25 }
+        case nil:
+            return
+        }
+        setNeedsDisplay()
+    }
+
+    private func updateAccessibilityValue() {
+        switch mode {
+        case .live: accessibilityValue = "\(Int(targetLevel * 100)) percent"
+        case .indeterminate: accessibilityValue = "Working"
+        case nil: accessibilityValue = "Not recording"
+        }
+    }
+}
+
+/// The dot beside the status title. Small, but it is the only element that keeps
+/// moving while the user waits, so it carries the "still alive" signal.
+final class StatusIndicatorView: UIView {
+    var pulse: DictationPulse = .steady {
+        didSet {
+            guard pulse != oldValue else { return }
+            applyAnimation()
+        }
+    }
+
+    var color: UIColor = .systemBlue {
+        didSet {
+            core.backgroundColor = color.cgColor
+            ring.borderColor = color.cgColor
+        }
+    }
+
+    private let core = CALayer()
+    private let ring = CALayer()
+    private static let coreDiameter: CGFloat = 9
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isAccessibilityElement = false
+        ring.borderWidth = 1.5
+        ring.opacity = 0
+        layer.addSublayer(ring)
+        layer.addSublayer(core)
+        color = .systemBlue
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: 22, height: 22)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let size = Self.coreDiameter
+        let rect = CGRect(
+            x: (bounds.width - size) / 2,
+            y: (bounds.height - size) / 2,
+            width: size,
+            height: size
+        )
+        // Frame changes would otherwise animate implicitly and fight the pulse.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        core.frame = rect
+        core.cornerRadius = size / 2
+        ring.frame = rect
+        ring.cornerRadius = size / 2
+        CATransaction.commit()
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        applyAnimation()
+    }
+
+    private func applyAnimation() {
+        core.removeAllAnimations()
+        ring.removeAllAnimations()
+        ring.opacity = 0
+        core.transform = CATransform3DIdentity
+        guard window != nil, !UIAccessibility.isReduceMotionEnabled else { return }
+
+        switch pulse {
+        case .steady:
+            return
+        case .listening:
+            let scale = CABasicAnimation(keyPath: "transform.scale")
+            scale.fromValue = 1
+            scale.toValue = 2.7
+            let fade = CABasicAnimation(keyPath: "opacity")
+            fade.fromValue = 0.5
+            fade.toValue = 0
+            let group = CAAnimationGroup()
+            group.animations = [scale, fade]
+            group.duration = 1.5
+            group.repeatCount = .infinity
+            group.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            ring.add(group, forKey: "localflow.ring")
+        case .working:
+            let breathe = CABasicAnimation(keyPath: "transform.scale")
+            breathe.fromValue = 0.78
+            breathe.toValue = 1.18
+            breathe.duration = 0.7
+            breathe.autoreverses = true
+            breathe.repeatCount = .infinity
+            breathe.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            core.add(breathe, forKey: "localflow.breathe")
+        }
+    }
+}
+
+/// The bar's primary action. A gradient fill and a tinted shadow are what
+/// separate it from the flat system-blue control it replaces, and the press
+/// scale gives the tap the same feedback the keys have.
+final class GradientButton: UIButton {
+    /// The gradient rides on a subview rather than on the button's own layer.
+    /// Assigning a `UIButton.Configuration` rebuilds the internal view hierarchy
+    /// on top of any layer added in `init`, which hid the title behind the fill.
+    private let fillView = UIView()
+    private let gradient = CAGradientLayer()
+
+    var fillColors: [UIColor] = [] {
+        didSet { applyFill() }
+    }
+
+    override var isEnabled: Bool {
+        didSet { applyFill() }
+    }
+
+    override var isHighlighted: Bool {
+        didSet {
+            guard isHighlighted != oldValue else { return }
+            let collapse = isHighlighted
+            UIView.animate(
+                withDuration: collapse ? 0.09 : 0.22,
+                delay: 0,
+                usingSpringWithDamping: 0.7,
+                initialSpringVelocity: 0,
+                options: [.allowUserInteraction, .beginFromCurrentState]
+            ) {
+                self.transform = collapse
+                    ? CGAffineTransform(scaleX: 0.955, y: 0.955)
+                    : .identity
+            }
+        }
+    }
+
+    init() {
+        super.init(frame: .zero)
+        gradient.startPoint = CGPoint(x: 0, y: 0)
+        gradient.endPoint = CGPoint(x: 1, y: 1)
+        fillView.isUserInteractionEnabled = false
+        fillView.layer.addSublayer(gradient)
+        addSubview(fillView)
+        layer.shadowOffset = CGSize(width: 0, height: 3)
+        layer.shadowRadius = 7
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Every configuration change can re-order the subviews, so the fill is
+        // pushed back down on each pass rather than only once.
+        sendSubviewToBack(fillView)
+        fillView.frame = bounds
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        gradient.frame = bounds
+        gradient.cornerRadius = bounds.height / 2
+        CATransaction.commit()
+        layer.shadowPath = UIBezierPath(
+            roundedRect: bounds,
+            cornerRadius: bounds.height / 2
+        ).cgPath
+    }
+
+    private func applyFill() {
+        guard let first = fillColors.first else { return }
+        // Muted enough to read as unavailable, solid enough to keep the white
+        // label above it legible.
+        let resolved = isEnabled
+            ? fillColors
+            : fillColors.map { $0.withAlphaComponent(0.7) }
+        gradient.colors = resolved.map(\.cgColor)
+        layer.shadowColor = first.cgColor
+        layer.shadowOpacity = isEnabled ? 0.34 : 0
+    }
+}

--- a/ios/LocalFlowKeyboard/DictationBarStyle.swift
+++ b/ios/LocalFlowKeyboard/DictationBarStyle.swift
@@ -1,0 +1,145 @@
+import UIKit
+
+/// Concrete colours for the bar, resolved eagerly for one appearance exactly as
+/// the key colours are, so a dark field inside a light app still gets a dark bar.
+extension KeyboardPalette {
+    /// Two stops per accent. A flat fill reads as a stock system control; the
+    /// slight hue travel is what makes the primary button look deliberate.
+    func gradient(for accent: DictationAccent) -> [UIColor] {
+        switch accent {
+        case .brand:
+            isDark
+                ? [rgb(0.36, 0.54, 1), rgb(0.55, 0.47, 1)]
+                : [rgb(0.16, 0.42, 0.96), rgb(0.42, 0.35, 0.95)]
+        case .handoff:
+            isDark
+                ? [rgb(0.51, 0.47, 1), rgb(0.68, 0.45, 0.99)]
+                : [rgb(0.35, 0.33, 0.87), rgb(0.53, 0.34, 0.93)]
+        case .listening:
+            isDark
+                ? [rgb(1, 0.34, 0.4), rgb(1, 0.42, 0.62)]
+                : [rgb(0.93, 0.2, 0.29), rgb(0.97, 0.32, 0.52)]
+        case .working:
+            isDark
+                ? [rgb(1, 0.62, 0.24), rgb(1, 0.76, 0.29)]
+                : [rgb(0.96, 0.51, 0.09), rgb(0.98, 0.68, 0.18)]
+        case .ready:
+            isDark
+                ? [rgb(0.19, 0.82, 0.5), rgb(0.16, 0.83, 0.71)]
+                : [rgb(0.09, 0.68, 0.4), rgb(0.1, 0.72, 0.6)]
+        case .alert:
+            isDark
+                ? [rgb(1, 0.36, 0.36), rgb(1, 0.47, 0.34)]
+                : [rgb(0.87, 0.19, 0.22), rgb(0.94, 0.33, 0.24)]
+        case .locked:
+            isDark
+                ? [rgb(0.45, 0.46, 0.51), rgb(0.53, 0.54, 0.59)]
+                : [rgb(0.53, 0.54, 0.58), rgb(0.61, 0.62, 0.66)]
+        }
+    }
+
+    /// The single colour used for the status dot, the waveform and any accented
+    /// text — the gradient's first stop, which is its most saturated end.
+    func tint(for accent: DictationAccent) -> UIColor {
+        gradient(for: accent)[0]
+    }
+
+    var barBackground: UIColor {
+        isDark
+            ? UIColor(red: 0.135, green: 0.145, blue: 0.17, alpha: 1)
+            : UIColor(red: 0.985, green: 0.99, blue: 1, alpha: 1)
+    }
+
+    var chipBackground: UIColor {
+        isDark
+            ? UIColor.white.withAlphaComponent(0.1)
+            : UIColor.black.withAlphaComponent(0.045)
+    }
+
+    var secondaryControl: UIColor {
+        isDark
+            ? UIColor.white.withAlphaComponent(0.13)
+            : UIColor.black.withAlphaComponent(0.06)
+    }
+
+    private func rgb(_ red: CGFloat, _ green: CGFloat, _ blue: CGFloat) -> UIColor {
+        UIColor(red: red, green: green, blue: blue, alpha: 1)
+    }
+}
+
+/// Geometry for one rendering of the bar. Everything scales with the traits so
+/// landscape and iPad stop inheriting portrait iPhone sizing.
+struct DictationBarMetrics: Equatable {
+    var collapsedHeight: CGFloat
+    var expandedHeight: CGFloat
+    var horizontalInset: CGFloat
+    var verticalInset: CGFloat
+    var titleFontSize: CGFloat
+    var bodyFontSize: CGFloat
+    var controlHeight: CGFloat
+    var waveformHeight: CGFloat
+    var primaryWidth: CGFloat
+    var primaryHeight: CGFloat
+    var secondaryDiameter: CGFloat
+    var cornerRadius: CGFloat
+    /// A transcript preview is worth two lines where there is room for them.
+    var messageLineLimit: Int
+
+    func height(expanded: Bool) -> CGFloat {
+        expanded ? expandedHeight : collapsedHeight
+    }
+
+    static func resolved(for traits: UITraitCollection) -> DictationBarMetrics {
+        if traits.horizontalSizeClass == .regular, traits.verticalSizeClass == .regular {
+            return DictationBarMetrics(
+                collapsedHeight: 82,
+                expandedHeight: 96,
+                horizontalInset: 16,
+                verticalInset: 12,
+                titleFontSize: 17,
+                bodyFontSize: 14,
+                controlHeight: 34,
+                waveformHeight: 40,
+                primaryWidth: 138,
+                primaryHeight: 50,
+                secondaryDiameter: 40,
+                cornerRadius: 24,
+                messageLineLimit: 2
+            )
+        }
+        if traits.verticalSizeClass == .compact {
+            // Landscape phones have almost no height to spare, so the bar gives
+            // up its breathing room before the keys give up theirs.
+            return DictationBarMetrics(
+                collapsedHeight: 58,
+                expandedHeight: 58,
+                horizontalInset: 11,
+                verticalInset: 6,
+                titleFontSize: 13,
+                bodyFontSize: 11,
+                controlHeight: 24,
+                waveformHeight: 20,
+                primaryWidth: 98,
+                primaryHeight: 36,
+                secondaryDiameter: 28,
+                cornerRadius: 17,
+                messageLineLimit: 1
+            )
+        }
+        return DictationBarMetrics(
+            collapsedHeight: 72,
+            expandedHeight: 84,
+            horizontalInset: 13,
+            verticalInset: 9,
+            titleFontSize: 15,
+            bodyFontSize: 12.5,
+            controlHeight: 30,
+            waveformHeight: 34,
+            primaryWidth: 116,
+            primaryHeight: 44,
+            secondaryDiameter: 34,
+            cornerRadius: 21,
+            messageLineLimit: 2
+        )
+    }
+}

--- a/ios/LocalFlowKeyboard/DictationBarView.swift
+++ b/ios/LocalFlowKeyboard/DictationBarView.swift
@@ -1,0 +1,612 @@
+import UIKit
+
+@MainActor
+protocol DictationBarViewDelegate: AnyObject {
+    func dictationBar(_ bar: DictationBarView, didTrigger action: DictationAction)
+    /// The language and style pickers write straight to the shared preferences,
+    /// so the controller only needs to know that a re-render is due.
+    func dictationBarDidChangePreferences(_ bar: DictationBarView)
+}
+
+/// The dictation chrome above the keys: one container that morphs between
+/// states rather than a fixed status card stacked on a fixed toolbar.
+///
+/// The two rows it replaces cost 117pt whether or not anything was happening.
+/// This bar spends 72pt while idle and 84pt while a session is live, and the
+/// difference goes to the keys.
+final class DictationBarView: UIView {
+    weak var delegate: (any DictationBarViewDelegate)?
+
+    var metrics: DictationBarMetrics {
+        didSet {
+            guard metrics != oldValue else { return }
+            applyMetrics()
+        }
+    }
+
+    var palette: KeyboardPalette {
+        didSet {
+            guard palette != oldValue else { return }
+            applyPalette()
+        }
+    }
+
+    private let indicator = StatusIndicatorView()
+    private let titleLabel = UILabel()
+    private let timerLabel = UILabel()
+    private let headlineStack = UIStackView()
+
+    private let bodyContainer = UIView()
+    private let controlsStack = UIStackView()
+    private let languageButton = UIButton(type: .system)
+    private let styleButton = UIButton(type: .system)
+    private let waveform = WaveformView()
+    private let messageLabel = UILabel()
+
+    private let actionStack = UIStackView()
+    private let secondaryStack = UIStackView()
+    private let primaryButton = GradientButton()
+    private var secondaryButtons: [UIButton] = []
+    private var secondaryActions: [DictationAction] = []
+
+    private var renderedModel: DictationBarModel?
+    private var renderedLanguage: TranscriptionLanguage?
+    private var renderedStyle: WritingStyle?
+    private var visibleBodyView: UIView?
+    private var flashWork: DispatchWorkItem?
+    private var isFlashing = false
+
+    private var horizontalInsets: [NSLayoutConstraint] = []
+    private var topInset: NSLayoutConstraint?
+    private var bottomInset: NSLayoutConstraint?
+    private var primaryWidthConstraint: NSLayoutConstraint?
+    private var primaryHeightConstraint: NSLayoutConstraint?
+    private var waveformHeightConstraint: NSLayoutConstraint?
+    private var controlHeights: [NSLayoutConstraint] = []
+    private var secondarySizes: [NSLayoutConstraint] = []
+
+    private static let flashDuration: TimeInterval = 2.6
+    /// Two is all the states ever ask for, so they are built once instead of
+    /// being created and thrown away as the session moves.
+    private static let secondaryCapacity = 2
+
+    init(metrics: DictationBarMetrics, palette: KeyboardPalette) {
+        self.metrics = metrics
+        self.palette = palette
+        super.init(frame: .zero)
+        configureSubviews()
+        configureLayout()
+        applyMetrics()
+        applyPalette()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layer.shadowPath = UIBezierPath(
+            roundedRect: bounds,
+            cornerRadius: metrics.cornerRadius
+        ).cgPath
+    }
+
+    // MARK: - Rendering
+
+    /// `render` runs on every poll tick, so an unchanged model must cost
+    /// nothing: rebuilding button configurations four times a second churned
+    /// allocations and re-laid out the whole bar for state that had not moved.
+    func apply(_ model: DictationBarModel, animated: Bool) {
+        defer { renderedModel = model }
+        updatePreferenceControls()
+        guard model != renderedModel else { return }
+        let accentChanged = model.accent != renderedModel?.accent
+
+        if titleLabel.text != model.title {
+            crossfade(titleLabel, animated: animated) { self.titleLabel.text = model.title }
+        }
+        timerLabel.isHidden = !model.showsElapsedTime
+        indicator.pulse = model.pulse
+        if accentChanged {
+            applyAccent(model.accent, animated: animated)
+        }
+        // A transient message holds the slot against repeated renders of the same
+        // state, but never against a real change: "Starting with Quick
+        // Dictation…" must not still be covering the meter once recording has
+        // actually begun.
+        if !isFlashing || model.body != renderedModel?.body {
+            endFlash()
+            setBody(model.body, animated: animated)
+        }
+        configurePrimary(model.primary, animated: animated)
+        configureSecondaries(model.secondaries)
+    }
+
+    /// The most recent microphone level. Kept separate from `apply` because it
+    /// changes on every tick while the model does not.
+    func push(meterLevel: Float) {
+        waveform.push(level: meterLevel)
+    }
+
+    func setElapsed(_ interval: TimeInterval?) {
+        let text = interval.map { DictationBarModel.elapsedText($0) }
+        guard timerLabel.text != text else { return }
+        timerLabel.text = text
+        timerLabel.accessibilityLabel = text.map { "Recording time \($0)" }
+    }
+
+    /// A message that outlives the next poll tick. Direct writes to the status
+    /// label used to be erased a quarter of a second later, so the guidance the
+    /// user needed most was the guidance they never got to read.
+    func flash(_ message: String) {
+        endFlash()
+        isFlashing = true
+        setBody(.message(message), animated: true)
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            isFlashing = false
+            if let body = renderedModel?.body { setBody(body, animated: true) }
+        }
+        flashWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.flashDuration, execute: work)
+    }
+
+    private func endFlash() {
+        flashWork?.cancel()
+        flashWork = nil
+        isFlashing = false
+    }
+
+    // MARK: - Body
+
+    private func setBody(_ body: DictationBody, animated: Bool) {
+        if case let .message(text) = body, messageLabel.text != text {
+            let sameView = visibleBodyView === messageLabel
+            crossfade(messageLabel, animated: animated && sameView) {
+                self.messageLabel.text = text
+                self.messageLabel.accessibilityLabel = text
+            }
+        }
+        if case let .waveform(mode) = body {
+            waveform.mode = mode
+        } else {
+            waveform.mode = nil
+        }
+
+        let target: UIView = switch body {
+        case .controls: controlsStack
+        case .waveform: waveform
+        case .message: messageLabel
+        }
+        guard target !== visibleBodyView else { return }
+        let previous = visibleBodyView
+        visibleBodyView = target
+        target.isHidden = false
+        guard animated else {
+            target.alpha = 1
+            previous?.alpha = 0
+            previous?.isHidden = true
+            return
+        }
+        UIView.animate(withDuration: 0.24, delay: 0, options: [.beginFromCurrentState]) {
+            target.alpha = 1
+            previous?.alpha = 0
+        } completion: { _ in
+            // A second change may have overtaken this animation.
+            if previous !== self.visibleBodyView { previous?.isHidden = true }
+        }
+    }
+
+    // MARK: - Buttons
+
+    private func configurePrimary(_ button: DictationButton, animated: Bool) {
+        let changed = renderedModel?.primary != button
+        primaryButton.isEnabled = button.isEnabled
+        primaryButton.accessibilityLabel = button.title
+        primaryButton.accessibilityHint = button.hint
+        guard changed || primaryButton.configuration == nil else { return }
+        let titleSize = metrics.titleFontSize
+        let update = { [primaryButton] in
+            var configuration = UIButton.Configuration.plain()
+            configuration.title = button.title
+            configuration.image = UIImage(
+                systemName: button.symbol,
+                withConfiguration: UIImage.SymbolConfiguration(
+                    pointSize: titleSize - 2,
+                    weight: .semibold
+                )
+            )
+            configuration.imagePadding = 6
+            configuration.contentInsets = .zero
+            configuration.baseForegroundColor = .white
+            // UIKit dims a disabled button's own colours towards grey, which on
+            // the muted fill left the label barely legible. The label and glyph
+            // stay white in every state and the fill alone carries "disabled".
+            configuration.imageColorTransformer = UIConfigurationColorTransformer { _ in .white }
+            configuration.titleTextAttributesTransformer =
+                UIConfigurationTextAttributesTransformer { incoming in
+                    var outgoing = incoming
+                    outgoing.font = .systemFont(ofSize: titleSize - 1, weight: .semibold)
+                    outgoing.foregroundColor = UIColor.white
+                    return outgoing
+                }
+            primaryButton.configuration = configuration
+        }
+        crossfade(primaryButton, animated: animated && changed, changes: update)
+    }
+
+    private func configureSecondaries(_ items: [DictationButton]) {
+        guard items != renderedModel?.secondaries || secondaryActions.isEmpty else { return }
+        secondaryActions = items.map(\.action)
+        for (index, button) in secondaryButtons.enumerated() {
+            guard index < items.count else {
+                button.isHidden = true
+                continue
+            }
+            let item = items[index]
+            button.isHidden = false
+            button.accessibilityLabel = item.title
+            button.accessibilityHint = item.hint
+            var configuration = UIButton.Configuration.plain()
+            configuration.image = UIImage(
+                systemName: item.symbol,
+                withConfiguration: UIImage.SymbolConfiguration(
+                    pointSize: metrics.bodyFontSize + 1,
+                    weight: .semibold
+                )
+            )
+            configuration.contentInsets = .zero
+            configuration.cornerStyle = .capsule
+            configuration.background.backgroundColor = palette.secondaryControl
+            configuration.baseForegroundColor = palette.secondaryLabel
+            button.configuration = configuration
+        }
+        secondaryStack.isHidden = items.isEmpty
+    }
+
+    @objc private func primaryTapped() {
+        guard let action = renderedModel?.primary.action else { return }
+        delegate?.dictationBar(self, didTrigger: action)
+    }
+
+    @objc private func secondaryTapped(_ sender: UIButton) {
+        guard sender.tag < secondaryActions.count else { return }
+        delegate?.dictationBar(self, didTrigger: secondaryActions[sender.tag])
+    }
+
+    // MARK: - Preference controls
+
+    private func updatePreferenceControls() {
+        let language = KeyboardPreferences.transcriptionLanguage
+        if renderedLanguage != language {
+            renderedLanguage = language
+            languageButton.menu = UIMenu(
+                title: "Transcription language",
+                children: TranscriptionLanguage.allCases.map { option in
+                    UIAction(
+                        title: option.displayName,
+                        image: UIImage(systemName: "globe"),
+                        state: option == language ? .on : .off
+                    ) { [weak self] _ in
+                        guard let self else { return }
+                        KeyboardPreferences.transcriptionLanguage = option
+                        delegate?.dictationBarDidChangePreferences(self)
+                    }
+                }
+            )
+            applyChipConfiguration(
+                to: languageButton,
+                title: language.shortLabel,
+                symbol: "globe"
+            )
+            languageButton.accessibilityValue = language.displayName
+        }
+
+        let style = KeyboardPreferences.writingStyle
+        guard renderedStyle != style else { return }
+        renderedStyle = style
+        styleButton.menu = UIMenu(
+            title: "Writing style",
+            children: WritingStyle.allCases.map { option in
+                UIAction(
+                    title: option.displayName,
+                    image: UIImage(systemName: option.symbolName),
+                    state: option == style ? .on : .off
+                ) { [weak self] _ in
+                    guard let self else { return }
+                    KeyboardPreferences.writingStyle = option
+                    delegate?.dictationBarDidChangePreferences(self)
+                }
+            }
+        )
+        applyChipConfiguration(
+            to: styleButton,
+            title: style.displayName,
+            symbol: style.symbolName
+        )
+        styleButton.accessibilityValue = style.displayName
+    }
+
+    private func applyChipConfiguration(to button: UIButton, title: String, symbol: String) {
+        var configuration = UIButton.Configuration.plain()
+        configuration.title = title
+        configuration.image = UIImage(
+            systemName: symbol,
+            withConfiguration: UIImage.SymbolConfiguration(
+                pointSize: metrics.bodyFontSize - 0.5,
+                weight: .semibold
+            )
+        )
+        configuration.imagePadding = 5
+        configuration.cornerStyle = .capsule
+        configuration.titleLineBreakMode = .byTruncatingTail
+        // The chevron says these open a menu, which the old flat pills did not.
+        configuration.indicator = .popup
+        configuration.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: 8,
+            bottom: 0,
+            trailing: 6
+        )
+        configuration.background.backgroundColor = palette.chipBackground
+        configuration.baseForegroundColor = palette.tint(for: .brand)
+        let titleSize = metrics.bodyFontSize
+        configuration.titleTextAttributesTransformer =
+            UIConfigurationTextAttributesTransformer { incoming in
+                var outgoing = incoming
+                outgoing.font = .systemFont(ofSize: titleSize, weight: .semibold)
+                return outgoing
+            }
+        button.configuration = configuration
+    }
+
+    // MARK: - Appearance
+
+    /// The colour change is what carries a state transition, so it is animated
+    /// at the layer level rather than through a whole-bar dissolve, which would
+    /// have fought the label and button transitions running at the same time.
+    private func applyAccent(_ accent: DictationAccent, animated: Bool) {
+        let tint = palette.tint(for: accent)
+        // Standalone sublayers animate their colour implicitly; the bar's own
+        // backing layer does not, so its border is animated by hand.
+        primaryButton.fillColors = palette.gradient(for: accent)
+        indicator.color = tint
+        waveform.color = tint
+        crossfade(timerLabel, animated: animated) { self.timerLabel.textColor = tint }
+
+        // A live session tints the outline; at rest the bar keeps the neutral
+        // border the keys sit inside.
+        let border = accent == .brand
+            ? palette.cardBorder.cgColor
+            : tint.withAlphaComponent(0.3).cgColor
+        guard animated, !UIAccessibility.isReduceMotionEnabled else {
+            layer.borderColor = border
+            return
+        }
+        let fade = CABasicAnimation(keyPath: "borderColor")
+        fade.fromValue = layer.borderColor
+        fade.toValue = border
+        fade.duration = 0.24
+        layer.borderColor = border
+        layer.add(fade, forKey: "localflow.border")
+    }
+
+    private func applyPalette() {
+        backgroundColor = palette.barBackground
+        layer.borderColor = palette.cardBorder.cgColor
+        titleLabel.textColor = palette.label
+        messageLabel.textColor = palette.secondaryLabel
+        // Colours are baked into the button configurations, so every cached
+        // rendering has to be discarded before the next apply.
+        renderedModel = nil
+        renderedLanguage = nil
+        renderedStyle = nil
+    }
+
+    private func applyMetrics() {
+        for constraint in horizontalInsets {
+            constraint.constant = constraint.firstAttribute == .leading
+                ? metrics.horizontalInset
+                : -metrics.horizontalInset
+        }
+        topInset?.constant = metrics.verticalInset
+        bottomInset?.constant = -metrics.verticalInset
+        primaryWidthConstraint?.constant = metrics.primaryWidth
+        primaryHeightConstraint?.constant = metrics.primaryHeight
+        waveformHeightConstraint?.constant = metrics.waveformHeight
+        controlHeights.forEach { $0.constant = metrics.controlHeight }
+        secondarySizes.forEach { $0.constant = metrics.secondaryDiameter }
+
+        layer.cornerRadius = metrics.cornerRadius
+        titleLabel.font = .systemFont(ofSize: metrics.titleFontSize, weight: .semibold)
+        timerLabel.font = .monospacedDigitSystemFont(
+            ofSize: metrics.titleFontSize - 2,
+            weight: .medium
+        )
+        messageLabel.font = .systemFont(ofSize: metrics.bodyFontSize, weight: .regular)
+        messageLabel.numberOfLines = metrics.messageLineLimit
+        renderedModel = nil
+        renderedLanguage = nil
+        renderedStyle = nil
+        setNeedsLayout()
+    }
+
+    /// Colour and label changes snapping between states is what made the old
+    /// card feel mechanical; every one of them dissolves instead.
+    private func crossfade(_ view: UIView, animated: Bool, changes: @escaping () -> Void) {
+        guard animated, !UIAccessibility.isReduceMotionEnabled else {
+            changes()
+            return
+        }
+        UIView.transition(
+            with: view,
+            duration: 0.22,
+            options: [.transitionCrossDissolve, .allowUserInteraction, .beginFromCurrentState],
+            animations: changes
+        )
+    }
+
+    // MARK: - Construction
+
+    private func configureSubviews() {
+        layer.cornerCurve = .continuous
+        layer.borderWidth = 0.5
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.07
+        layer.shadowRadius = 4
+        layer.shadowOffset = CGSize(width: 0, height: 2)
+
+        titleLabel.adjustsFontSizeToFitWidth = true
+        titleLabel.minimumScaleFactor = 0.8
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        timerLabel.setContentHuggingPriority(.required, for: .horizontal)
+        timerLabel.isHidden = true
+
+        headlineStack.axis = .horizontal
+        headlineStack.alignment = .center
+        headlineStack.spacing = 6
+        [indicator, titleLabel, timerLabel].forEach(headlineStack.addArrangedSubview)
+
+        messageLabel.lineBreakMode = .byTruncatingTail
+        messageLabel.isAccessibilityElement = true
+        // Two lines of transcript preview must not spill over the keys below.
+        bodyContainer.clipsToBounds = true
+
+        languageButton.showsMenuAsPrimaryAction = true
+        languageButton.accessibilityLabel = "Transcription language"
+        styleButton.showsMenuAsPrimaryAction = true
+        styleButton.accessibilityLabel = "Writing style"
+        controlsStack.axis = .horizontal
+        controlsStack.alignment = .center
+        controlsStack.spacing = 5
+        [languageButton, styleButton].forEach(controlsStack.addArrangedSubview)
+        [languageButton, styleButton].forEach {
+            $0.setContentHuggingPriority(.required, for: .horizontal)
+        }
+        // A chip squeezed even a point below its natural width used to wrap its
+        // title onto a second line. The language label is short enough to always
+        // hold its ground; the longest style name gives way and truncates, which
+        // only happens in the one state that also offers Undo.
+        languageButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+        styleButton.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+
+        // Only one body view is visible at a time; the others stay in place at
+        // zero alpha so a change is a dissolve rather than a re-layout.
+        for view in [controlsStack, waveform, messageLabel] as [UIView] {
+            view.alpha = 0
+            view.isHidden = true
+            bodyContainer.addSubview(view)
+        }
+
+        primaryButton.addTarget(self, action: #selector(primaryTapped), for: .touchUpInside)
+        secondaryStack.axis = .horizontal
+        secondaryStack.alignment = .center
+        secondaryStack.spacing = 6
+        for index in 0..<Self.secondaryCapacity {
+            let button = UIButton(type: .system)
+            button.tag = index
+            button.isHidden = true
+            button.addTarget(self, action: #selector(secondaryTapped), for: .touchUpInside)
+            secondaryButtons.append(button)
+            secondaryStack.addArrangedSubview(button)
+        }
+        actionStack.axis = .horizontal
+        actionStack.alignment = .center
+        actionStack.spacing = 6
+        [secondaryStack, primaryButton].forEach(actionStack.addArrangedSubview)
+
+        [headlineStack, bodyContainer, actionStack].forEach(addSubview)
+    }
+
+    private func configureLayout() {
+        [headlineStack, bodyContainer, actionStack, controlsStack, waveform, messageLabel]
+            .forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
+
+        let headlineLeading = headlineStack.leadingAnchor.constraint(
+            equalTo: leadingAnchor,
+            constant: metrics.horizontalInset
+        )
+        let bodyLeading = bodyContainer.leadingAnchor.constraint(
+            equalTo: leadingAnchor,
+            constant: metrics.horizontalInset
+        )
+        let actionTrailing = actionStack.trailingAnchor.constraint(
+            equalTo: trailingAnchor,
+            constant: -metrics.horizontalInset
+        )
+        horizontalInsets = [headlineLeading, bodyLeading, actionTrailing]
+
+        let top = headlineStack.topAnchor.constraint(
+            equalTo: topAnchor,
+            constant: metrics.verticalInset
+        )
+        let bottom = bodyContainer.bottomAnchor.constraint(
+            equalTo: bottomAnchor,
+            constant: -metrics.verticalInset
+        )
+        topInset = top
+        bottomInset = bottom
+
+        let width = primaryButton.widthAnchor.constraint(equalToConstant: metrics.primaryWidth)
+        let height = primaryButton.heightAnchor.constraint(equalToConstant: metrics.primaryHeight)
+        primaryWidthConstraint = width
+        primaryHeightConstraint = height
+
+        let controlsTrailing = controlsStack.trailingAnchor.constraint(
+            lessThanOrEqualTo: bodyContainer.trailingAnchor
+        )
+
+        let meter = waveform.heightAnchor.constraint(equalToConstant: metrics.waveformHeight)
+        // The bar's own height is fixed from outside, so the meter yields rather
+        // than breaking the layout when the two disagree.
+        meter.priority = .defaultHigh
+        waveformHeightConstraint = meter
+
+        controlHeights = [languageButton, styleButton].map {
+            let constraint = $0.heightAnchor.constraint(equalToConstant: metrics.controlHeight)
+            constraint.priority = .defaultHigh
+            return constraint
+        }
+        secondarySizes = secondaryButtons.flatMap { button in
+            [
+                button.widthAnchor.constraint(equalToConstant: metrics.secondaryDiameter),
+                button.heightAnchor.constraint(equalToConstant: metrics.secondaryDiameter),
+            ]
+        }
+
+        NSLayoutConstraint.activate([
+            headlineLeading,
+            top,
+            headlineStack.trailingAnchor.constraint(
+                lessThanOrEqualTo: actionStack.leadingAnchor,
+                constant: -10
+            ),
+            bodyLeading,
+            bottom,
+            bodyContainer.topAnchor.constraint(equalTo: headlineStack.bottomAnchor, constant: 4),
+            bodyContainer.trailingAnchor.constraint(
+                equalTo: actionStack.leadingAnchor,
+                constant: -10
+            ),
+            actionTrailing,
+            actionStack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            width,
+            height,
+            meter,
+            waveform.leadingAnchor.constraint(equalTo: bodyContainer.leadingAnchor),
+            waveform.trailingAnchor.constraint(equalTo: bodyContainer.trailingAnchor),
+            waveform.centerYAnchor.constraint(equalTo: bodyContainer.centerYAnchor),
+            waveform.heightAnchor.constraint(lessThanOrEqualTo: bodyContainer.heightAnchor),
+            controlsStack.leadingAnchor.constraint(equalTo: bodyContainer.leadingAnchor),
+            controlsStack.centerYAnchor.constraint(equalTo: bodyContainer.centerYAnchor),
+            messageLabel.leadingAnchor.constraint(equalTo: bodyContainer.leadingAnchor),
+            messageLabel.trailingAnchor.constraint(equalTo: bodyContainer.trailingAnchor),
+            messageLabel.centerYAnchor.constraint(equalTo: bodyContainer.centerYAnchor),
+            controlsTrailing,
+        ] + controlHeights + secondarySizes)
+    }
+}

--- a/ios/LocalFlowKeyboard/DictationPresentation.swift
+++ b/ios/LocalFlowKeyboard/DictationPresentation.swift
@@ -1,0 +1,355 @@
+import UIKit
+
+/// What a dictation-bar button does when it is tapped.
+///
+/// The bar renders from a model that names its own actions, so the mapping from
+/// session state to interface lives in exactly one place. Deriving the action a
+/// second time inside the tap handler is what let the prominent button in the
+/// recoverable-failure states quietly discard the preserved recording.
+enum DictationAction: Equatable {
+    case start
+    case finish
+    case insert
+    case insertHere
+    case openApp
+    case retry
+    case cancel
+    case undo
+}
+
+/// A button as the bar should currently present it. Secondary buttons render as
+/// icons only, so `title` doubles as their accessibility label.
+struct DictationButton: Equatable {
+    let title: String
+    let symbol: String
+    let action: DictationAction
+    var isEnabled = true
+    var hint: String?
+
+    static let cancel = DictationButton(
+        title: "Cancel dictation",
+        symbol: "xmark",
+        action: .cancel,
+        hint: "Discards this dictation."
+    )
+
+    static let undo = DictationButton(
+        title: "Undo insert",
+        symbol: "arrow.uturn.backward",
+        action: .undo,
+        hint: "Removes the transcript that was just inserted."
+    )
+}
+
+/// Colour families the bar cycles through. Kept symbolic so the palette decides
+/// the actual values per appearance, the way the key colours already do.
+enum DictationAccent: Equatable {
+    case brand
+    case handoff
+    case listening
+    case working
+    case ready
+    case alert
+    case locked
+}
+
+/// Motion applied to the status indicator, which is the bar's cheapest signal
+/// that something is still happening while the user waits.
+enum DictationPulse: Equatable {
+    case steady
+    case listening
+    case working
+}
+
+enum WaveformMode: Equatable {
+    /// Driven by the microphone levels the app publishes.
+    case live
+    /// A travelling pulse, used while work is happening off-device and there is
+    /// no level to show. It must not be mistaken for audio.
+    case indeterminate
+}
+
+/// The single slot beneath the headline. Only one of these is meaningful at a
+/// time, which is what let the old card's stacked subtitle, meter and toolbar
+/// collapse into one bar.
+enum DictationBody: Equatable {
+    /// Language and writing-style pickers, shown only when no session owns the
+    /// bar — which is exactly when changing them still affects the next
+    /// dictation.
+    case controls
+    case waveform(WaveformMode)
+    case message(String)
+}
+
+/// Everything the bar needs to draw itself for one moment in a session.
+struct DictationBarModel: Equatable {
+    var title: String
+    var body: DictationBody
+    var accent: DictationAccent
+    var pulse: DictationPulse
+    var primary: DictationButton
+    var secondaries: [DictationButton]
+    var showsElapsedTime: Bool
+    /// A live session earns the taller bar; an idle one gives the height back
+    /// to the keys.
+    var isExpanded: Bool
+}
+
+/// The inputs the model is derived from. A struct rather than a long parameter
+/// list so a test can vary one fact at a time.
+struct DictationContext: Equatable {
+    var state: SessionState = .idle
+    var hasFullAccess = true
+    var transcript: String?
+    var errorMessage: String?
+    var autoInsertsTranscripts = false
+    var canRetry = false
+    var canUndo = false
+}
+
+extension DictationBarModel {
+    static func make(_ context: DictationContext) -> DictationBarModel {
+        guard context.hasFullAccess else { return locked }
+        switch context.state {
+        case .idle, .completed, .canceled, .expired:
+            return resting(context)
+        case .launchingApp, .awaitingReturn:
+            return handoff
+        case .recording:
+            return listening
+        case .finalizing, .uploading, .transcribing:
+            return working(context.state)
+        case .readyToInsert:
+            return ready(context)
+        case .targetContextChanged:
+            return waitingForField(context)
+        case .inserting, .inserted:
+            return inserting
+        case .serverUnavailable, .uploadFailedRecoverable, .transcriptionFailedRecoverable:
+            return recoverableFailure(context)
+        case .permissionDenied:
+            return permissionDenied
+        case .transcriptionFailedPermanent:
+            return permanentFailure(context)
+        }
+    }
+
+    private static let locked = DictationBarModel(
+        title: "Full Access needed",
+        body: .message("Turn it on in Settings › General › Keyboard › Local Flow."),
+        accent: .locked,
+        pulse: .steady,
+        primary: DictationButton(
+            title: "Locked",
+            symbol: "lock.fill",
+            action: .start,
+            isEnabled: false
+        ),
+        secondaries: [],
+        showsElapsedTime: false,
+        isExpanded: true
+    )
+
+    private static func resting(_ context: DictationContext) -> DictationBarModel {
+        DictationBarModel(
+            title: context.state == .completed ? "Text inserted" : "Ready to dictate",
+            body: .controls,
+            accent: context.state == .completed ? .ready : .brand,
+            pulse: .steady,
+            primary: DictationButton(
+                title: "Dictate",
+                symbol: "mic.fill",
+                action: .start,
+                hint: "Opens Local Flow and starts private dictation."
+            ),
+            secondaries: context.canUndo ? [.undo] : [],
+            showsElapsedTime: false,
+            isExpanded: false
+        )
+    }
+
+    private static let handoff = DictationBarModel(
+        title: "Opening Local Flow",
+        body: .message("Start speaking as soon as the app appears."),
+        accent: .handoff,
+        pulse: .working,
+        primary: DictationButton(
+            title: "Open app",
+            symbol: "arrow.up.forward.app.fill",
+            action: .openApp,
+            hint: "Opens Local Flow to continue."
+        ),
+        secondaries: [.cancel],
+        showsElapsedTime: false,
+        isExpanded: true
+    )
+
+    private static let listening = DictationBarModel(
+        title: "Listening",
+        body: .waveform(.live),
+        accent: .listening,
+        pulse: .listening,
+        primary: DictationButton(
+            title: "Finish",
+            symbol: "stop.fill",
+            action: .finish,
+            hint: "Stops recording and starts transcription."
+        ),
+        secondaries: [.cancel],
+        showsElapsedTime: true,
+        isExpanded: true
+    )
+
+    private static func working(_ state: SessionState) -> DictationBarModel {
+        DictationBarModel(
+            title: state == .transcribing ? "Transcribing on your Mac" : "Sending to your Mac",
+            body: .waveform(.indeterminate),
+            accent: .working,
+            pulse: .working,
+            primary: DictationButton(
+                title: "Working",
+                symbol: "waveform",
+                action: .finish,
+                isEnabled: false
+            ),
+            secondaries: [.cancel],
+            showsElapsedTime: false,
+            isExpanded: true
+        )
+    }
+
+    private static func ready(_ context: DictationContext) -> DictationBarModel {
+        let fallback = context.autoInsertsTranscripts
+            ? "Inserting automatically…"
+            : "Tap Insert to place the text."
+        return DictationBarModel(
+            title: "Transcript ready",
+            body: .message(quoted(context.transcript) ?? fallback),
+            accent: .ready,
+            pulse: .steady,
+            primary: DictationButton(
+                title: "Insert",
+                symbol: "text.badge.plus",
+                action: .insert,
+                hint: "Inserts the transcript at the cursor."
+            ),
+            secondaries: [.cancel],
+            showsElapsedTime: false,
+            isExpanded: true
+        )
+    }
+
+    private static func waitingForField(_ context: DictationContext) -> DictationBarModel {
+        DictationBarModel(
+            title: "Waiting for its own field",
+            body: .message(
+                quoted(context.transcript) ?? "Return to that field, or insert it here."
+            ),
+            accent: .working,
+            pulse: .steady,
+            primary: DictationButton(
+                title: "Insert here",
+                symbol: "text.badge.plus",
+                action: .insertHere,
+                hint: "Inserts the waiting transcript into this field instead."
+            ),
+            secondaries: [.cancel],
+            showsElapsedTime: false,
+            isExpanded: true
+        )
+    }
+
+    private static let inserting = DictationBarModel(
+        title: "Inserting",
+        body: .message("Placing the transcript at the cursor."),
+        accent: .ready,
+        pulse: .working,
+        primary: DictationButton(
+            title: "Inserting",
+            symbol: "text.badge.checkmark",
+            action: .insert,
+            isEnabled: false
+        ),
+        secondaries: [],
+        showsElapsedTime: false,
+        isExpanded: true
+    )
+
+    /// The recording survived, so retrying it is the prominent action. It used
+    /// to be a small icon beside a prominent "New", which threw the preserved
+    /// audio away on the very tap most people reached for.
+    private static func recoverableFailure(_ context: DictationContext) -> DictationBarModel {
+        let primary = context.canRetry
+            ? DictationButton(
+                title: "Retry",
+                symbol: "arrow.clockwise",
+                action: .retry,
+                hint: "Sends the preserved recording again."
+            )
+            : DictationButton(title: "Dictate", symbol: "mic.fill", action: .start)
+        return DictationBarModel(
+            title: context.state == .serverUnavailable
+                ? "Gateway unavailable"
+                : "Transcription paused",
+            body: .message(context.errorMessage ?? "Your recording is preserved."),
+            accent: .alert,
+            pulse: .steady,
+            primary: primary,
+            // Cancelling returns the bar to Ready with Dictate already in place,
+            // so a separate "new recording" button only crowded the title out.
+            secondaries: [.cancel],
+            showsElapsedTime: false,
+            isExpanded: true
+        )
+    }
+
+    private static let permissionDenied = DictationBarModel(
+        title: "Microphone access needed",
+        body: .message("Allow the microphone in Local Flow, then dictate again."),
+        accent: .alert,
+        pulse: .steady,
+        primary: DictationButton(
+            title: "Open app",
+            symbol: "gear",
+            action: .start,
+            hint: "Opens Local Flow so the microphone prompt can be answered."
+        ),
+        secondaries: [],
+        showsElapsedTime: false,
+        isExpanded: true
+    )
+
+    private static func permanentFailure(_ context: DictationContext) -> DictationBarModel {
+        DictationBarModel(
+            title: "Transcription failed",
+            body: .message(context.errorMessage ?? "Please make a new recording."),
+            accent: .alert,
+            pulse: .steady,
+            primary: DictationButton(
+                title: "Try again",
+                symbol: "arrow.clockwise",
+                action: .start,
+                hint: "Starts a new recording."
+            ),
+            secondaries: [],
+            showsElapsedTime: false,
+            isExpanded: true
+        )
+    }
+
+    /// A one-line rendering of the transcript, so the user can see what they are
+    /// about to insert instead of trusting an unlabelled button.
+    static func quoted(_ transcript: String?, limit: Int = 96) -> String? {
+        guard let transcript else { return nil }
+        let collapsed = transcript.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        guard !collapsed.isEmpty else { return nil }
+        guard collapsed.count > limit else { return "“\(collapsed)”" }
+        let clipped = collapsed.prefix(limit).trimmingCharacters(in: .whitespaces)
+        return "“\(clipped)…”"
+    }
+
+    static func elapsedText(_ interval: TimeInterval) -> String {
+        let seconds = max(0, Int(interval))
+        return String(format: "%d:%02d", seconds / 60, seconds % 60)
+    }
+}

--- a/ios/LocalFlowKeyboard/KeyboardViewController.swift
+++ b/ios/LocalFlowKeyboard/KeyboardViewController.swift
@@ -7,14 +7,15 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     private var appLaunchFallbackTask: Task<Void, Never>?
     private var lastInsertedText: String?
     private var isPerformingInsertion = false
-    private var renderedStyle: WritingStyle?
-    private var renderedStyleEnabled: Bool?
-    private var renderedLanguage: TranscriptionLanguage?
-    private var renderedLanguageEnabled: Bool?
-    private var renderedPrimary: (
-        title: String, symbol: String, color: UIColor, enabled: Bool
-    )?
     private var lastSpaceInsertedAt: Date?
+    /// Observed by this keyboard instance rather than read from the record: the
+    /// record's timestamps cover the whole session, including the hand-off to
+    /// the app, which is not what the user is watching tick up.
+    private var recordingStartedAt: Date?
+    private var lastRenderedState: SessionState?
+    private var hasRendered = false
+    private var announcesStateChanges = false
+    private var isBarExpanded = false
     private var lastDocumentID: String?
     /// The document the active session inserts into, as observed by this
     /// keyboard instance. iOS issues a fresh `documentIdentifier` when the
@@ -22,7 +23,6 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// session record is only comparable while the instance that captured it
     /// is still alive; each instance records its own target.
     private var sessionTargetDocumentID: String?
-    private var hasActiveSession = false
     private var palette = KeyboardPalette(isDark: false)
 
     private var currentDocumentID: String? {
@@ -38,25 +38,16 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         return identifier.uuidString
     }
 
-    private let statusLabel = UILabel()
-    private let meterView = VoiceMeterView()
-    private let primaryButton = UIButton(type: .system)
-    private let cancelButton = UIButton(type: .system)
-    private let retryButton = UIButton(type: .system)
-    private let undoButton = UIButton(type: .system)
-    private let languageLabel = UILabel()
-    private let styleButton = UIButton(type: .system)
-    private let transcriptionLanguageButton = UIButton(type: .system)
-    private let dictationCard = UIView()
-    private let recordingDot = UIView()
-    private let toolbarStack = UIStackView()
+    private lazy var dictationBar = DictationBarView(
+        metrics: DictationBarMetrics.resolved(for: traitCollection),
+        palette: palette
+    )
     private lazy var keyGrid = KeyGridView(
         metrics: KeyboardMetrics.resolved(for: traitCollection),
         palette: palette
     )
     private var keyboardHeightConstraint: NSLayoutConstraint?
-    private var cardHeightConstraint: NSLayoutConstraint?
-    private var toolbarHeightConstraint: NSLayoutConstraint?
+    private var barHeightConstraint: NSLayoutConstraint?
     private var gridHeightConstraint: NSLayoutConstraint?
 
     var enableInputClicksWhenVisible: Bool { true }
@@ -88,6 +79,14 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         refresh()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // A session found before the keyboard is on screen is work already in
+        // flight being restored, not something that just happened to the user,
+        // and it must not arrive as a buzz in their hand.
+        announcesStateChanges = true
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         pollingTimer?.invalidate()
@@ -111,42 +110,57 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         updateAutomaticShift()
     }
 
-    @objc private func primaryTapped() {
+    // MARK: - Dictation actions
+
+    /// Each action arrives already decided by the rendered model, so a button
+    /// can only ever do what its own label promised.
+    private func perform(_ action: DictationAction) {
         UIImpactFeedbackGenerator(style: .soft).impactOccurred()
-        guard hasFullAccess else {
-            statusLabel.text = "Enable Full Access for Local Flow in Keyboard Settings."
-            return
-        }
-        guard let id = activeSessionID,
-              var record = try? store.load(id)
-        else {
-            startSession()
-            return
-        }
-        switch record.state {
-        case .recording:
-            transition(&record, to: .finalizing)
-        case .readyToInsert:
-            insert(&record)
-        case .targetContextChanged:
-            // Tapping Insert is an explicit request for the transcript in
-            // whatever field the cursor is in now, so the guard is bypassed
-            // rather than leaving the transcript unreachable.
-            transition(&record, to: .readyToInsert)
-            insert(&record, force: true)
-        case .launchingApp, .awaitingReturn:
-            openContainingApp(for: record)
-        default:
-            startSession()
+        switch action {
+        case .start: startSession()
+        case .finish: finishRecording()
+        case .insert: insertTranscript(force: false)
+        case .insertHere: insertTranscript(force: true)
+        case .openApp: resumeHandoff()
+        case .retry: retryTranscription()
+        case .cancel: cancelSession()
+        case .undo: undoInsertion()
         }
     }
 
-    @objc private func cancelTapped() {
+    private func finishRecording() {
+        guard let id = activeSessionID,
+              var record = try? store.load(id),
+              record.state == .recording
+        else { return }
+        transition(&record, to: .finalizing)
+    }
+
+    private func insertTranscript(force: Bool) {
+        guard let id = activeSessionID, var record = try? store.load(id) else { return }
+        // Tapping "Insert here" is an explicit request for the transcript in
+        // whatever field the cursor is in now, so the target guard is bypassed
+        // rather than leaving the transcript unreachable.
+        if force, record.state == .targetContextChanged {
+            transition(&record, to: .readyToInsert)
+        }
+        insert(&record, force: force)
+    }
+
+    private func resumeHandoff() {
+        guard let id = activeSessionID, let record = try? store.load(id) else {
+            startSession()
+            return
+        }
+        openContainingApp(for: record)
+    }
+
+    private func cancelSession() {
         guard let id = activeSessionID, var record = try? store.load(id) else { return }
         transition(&record, to: .canceled)
     }
 
-    @objc private func retryTapped() {
+    private func retryTranscription() {
         guard let id = activeSessionID,
               var record = try? store.load(id),
               record.canRetry
@@ -159,24 +173,25 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         openURLFromKeyboard(url) { [weak self] opened in
             DispatchQueue.main.async {
                 if !opened {
-                    self?.statusLabel.text = "Open Local Flow to retry the preserved recording."
+                    self?.dictationBar.flash("Open Local Flow to retry the preserved recording.")
                 }
             }
         }
     }
 
-    @objc private func undoTapped() {
+    private func undoInsertion() {
         guard let inserted = lastInsertedText,
               textDocumentProxy.documentContextBeforeInput?.hasSuffix(inserted) == true
         else {
-            statusLabel.text = "Cursor moved; undo is unavailable."
+            dictationBar.flash("The cursor moved, so undo is no longer available.")
+            lastInsertedText = nil
+            refresh()
             return
         }
         inserted.forEach { _ in textDocumentProxy.deleteBackward() }
         lastInsertedText = nil
-        undoButton.isEnabled = false
-        undoButton.isHidden = true
-        statusLabel.text = "Last insertion removed."
+        refresh()
+        dictationBar.flash("The last insertion was removed.")
     }
 
     // MARK: - Typing
@@ -260,8 +275,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
               textDocumentProxy.documentContextBeforeInput?.hasSuffix(inserted) != true
         else { return }
         lastInsertedText = nil
-        undoButton.isEnabled = false
-        undoButton.isHidden = true
+        refresh()
     }
 
     /// Starting a fresh dictation abandons a transcript the user chose not to
@@ -284,7 +298,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
     private func startSession() {
         guard hasFullAccess else {
-            statusLabel.text = "Enable Full Access for Local Flow in Keyboard Settings."
+            dictationBar.flash("Turn on Full Access for Local Flow in Keyboard settings.")
             return
         }
         discardParkedSession()
@@ -307,13 +321,13 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             if let availability = try? store.loadQuickDictationAvailability(),
                availability.isReady()
             {
-                statusLabel.text = "Starting with Quick Dictation…"
+                dictationBar.flash("Starting with Quick Dictation…")
                 scheduleContainingAppFallback(for: record)
             } else {
                 openContainingApp(for: record)
             }
         } catch {
-            statusLabel.text = "Could not create a shared session."
+            dictationBar.flash("Could not create a shared session.")
         }
     }
 
@@ -360,7 +374,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             sessionTargetDocumentID = nil
             render(record)
         } catch {
-            statusLabel.text = "Insertion was interrupted; text will not be inserted twice."
+            dictationBar.flash("Insertion was interrupted; text will not be inserted twice.")
         }
     }
 
@@ -373,22 +387,14 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         openURLFromKeyboard(url) { [weak self] opened in
             DispatchQueue.main.async {
                 guard let self else { return }
-                if opened {
-                    self.statusLabel.text = "Opening Local Flow…"
-                    return
-                }
+                if opened { return }
                 if var waiting = try? self.store.load(record.sessionID),
                    waiting.state == .launchingApp
                 {
                     self.transition(&waiting, to: .awaitingReturn)
                 }
-                self.statusLabel.text =
+                self.dictationBar.flash(
                     "Open Local Flow manually; the recording request is waiting."
-                self.setPrimaryButton(
-                    title: "Try again",
-                    symbol: "arrow.up.forward.app.fill",
-                    color: .systemIndigo,
-                    enabled: true
                 )
             }
         }
@@ -434,7 +440,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             try store.save(record)
             render(record)
         } catch {
-            statusLabel.text = "The session changed. Please try again."
+            dictationBar.flash("The session changed. Please try again.")
         }
     }
 
@@ -499,269 +505,70 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
     private func render(_ record: SessionRecord?) {
         updatePolling(for: record)
-        // An idle keyboard does not need a meter or a subtitle, and the space
-        // they used to occupy is better spent on the keys.
-        let isSessionActive = record.map { !$0.state.isTerminal } ?? false
-        if isSessionActive != hasActiveSession {
-            hasActiveSession = isSessionActive
-            applyLayoutMetrics()
-        }
-        let selectedStyle = record.flatMap { WritingStyle(rawValue: $0.style) }
-            ?? KeyboardPreferences.writingStyle
-        let selectedLanguage = record.flatMap { TranscriptionLanguage(rawValue: $0.language) }
-            ?? KeyboardPreferences.transcriptionLanguage
-        guard hasFullAccess else {
-            meterView.level = 0
-            meterView.isActive = false
-            languageLabel.text = "Full Access required"
-            configureStyleButton(selected: selectedStyle, enabled: false)
-            configureLanguageButton(selected: selectedLanguage, enabled: false)
-            retryButton.isHidden = true
-            cancelButton.isHidden = true
-            undoButton.isEnabled = false
-            undoButton.isHidden = true
-            statusLabel.text = "Keyboard access needed"
-            recordingDot.backgroundColor = .systemGray
-            updateRecordingPulse(active: false)
-            setPrimaryButton(
-                title: "Locked",
-                symbol: "lock.fill",
-                color: .systemGray,
-                enabled: false
+        let state = record?.state ?? .idle
+        let model = DictationBarModel.make(
+            DictationContext(
+                state: state,
+                hasFullAccess: hasFullAccess,
+                transcript: record?.transcript,
+                errorMessage: record?.error?.message,
+                autoInsertsTranscripts: KeyboardPreferences.autoInsertTranscripts,
+                canRetry: record?.canRetry == true,
+                // Undo is offered only while the transcript is still the tail of
+                // the document, and only once the session it came from is over.
+                canUndo: lastInsertedText != nil
             )
+        )
+
+        // An idle keyboard needs no meter and no subtitle, and the height they
+        // would occupy is better spent on the keys.
+        if model.isExpanded != isBarExpanded {
+            isBarExpanded = model.isExpanded
+            applyLayoutMetrics(animated: hasRendered)
+        }
+        updateElapsedTime(for: state)
+        if state == .recording {
+            dictationBar.push(meterLevel: record?.meterLevel ?? 0)
+        }
+        dictationBar.apply(model, animated: hasRendered)
+        announceStateChange(to: state)
+        hasRendered = true
+    }
+
+    private func updateElapsedTime(for state: SessionState) {
+        guard state == .recording else {
+            recordingStartedAt = nil
+            dictationBar.setElapsed(nil)
             return
         }
+        let start = recordingStartedAt ?? Date()
+        recordingStartedAt = start
+        dictationBar.setElapsed(Date().timeIntervalSince(start))
+    }
 
-        let state = record?.state ?? .idle
-        meterView.level = record?.meterLevel ?? 0
-        meterView.isActive = state == .recording
-        configureStyleButton(
-            selected: selectedStyle,
-            enabled: record == nil || state.isTerminal
-        )
-        configureLanguageButton(
-            selected: selectedLanguage,
-            enabled: record == nil || state.isTerminal
-        )
-        retryButton.isHidden = record?.canRetry != true
-        cancelButton.isHidden = ![
-            .launchingApp, .awaitingReturn, .recording, .finalizing, .uploading,
-            .targetContextChanged,
-        ].contains(state)
-        undoButton.isEnabled = lastInsertedText != nil
-        undoButton.isHidden = lastInsertedText == nil || (record != nil && !state.isTerminal)
-        updateRecordingPulse(active: state == .recording)
-
+    /// The keyboard is often not the view the user is looking at while a
+    /// transcript is being produced, so the milestones announce themselves.
+    private func announceStateChange(to state: SessionState) {
+        guard state != lastRenderedState else { return }
+        lastRenderedState = state
+        guard announcesStateChanges, hasFullAccess else { return }
         switch state {
-        case .idle, .completed, .canceled, .expired:
-            statusLabel.text = state == .completed ? "Text inserted" : "Ready"
-            languageLabel.text = state == .completed
-                ? "Undo is available below"
-                : "\(selectedLanguage.displayName) · private model"
-            recordingDot.backgroundColor = state == .completed ? .systemGreen : .systemBlue
-            meterView.activeColor = state == .completed ? .systemGreen : .systemBlue
-            setPrimaryButton(
-                title: "Dictate",
-                symbol: "mic.fill",
-                color: .systemBlue,
-                enabled: true
-            )
-        case .launchingApp, .awaitingReturn:
-            statusLabel.text = "Opening Local Flow…"
-            languageLabel.text = "Get ready to speak"
-            recordingDot.backgroundColor = .systemIndigo
-            meterView.activeColor = .systemIndigo
-            setPrimaryButton(
-                title: "Open app",
-                symbol: "arrow.up.forward.app.fill",
-                color: .systemIndigo,
-                enabled: true
-            )
         case .recording:
-            statusLabel.text = "Listening…"
-            languageLabel.text = "Tap Finish when you’re done"
-            recordingDot.backgroundColor = .systemRed
-            meterView.activeColor = .systemRed
-            setPrimaryButton(
-                title: "Finish",
-                symbol: "stop.fill",
-                color: .systemRed,
-                enabled: true
-            )
-        case .finalizing, .uploading, .transcribing:
-            statusLabel.text = state == .transcribing ? "Transcribing on Mac…" : "Sending to Mac…"
-            languageLabel.text = state == .transcribing
-                ? "Using your private local model"
-                : "Your recording stays private"
-            recordingDot.backgroundColor = .systemOrange
-            meterView.activeColor = .systemOrange
-            setPrimaryButton(
-                title: "Working…",
-                symbol: "waveform",
-                color: .systemOrange,
-                enabled: false
-            )
+            UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
         case .readyToInsert:
-            statusLabel.text = "Transcript ready"
-            languageLabel.text = KeyboardPreferences.autoInsertTranscripts
-                ? "Inserting automatically…"
-                : "Tap Insert to place the text"
-            recordingDot.backgroundColor = .systemGreen
-            meterView.activeColor = .systemGreen
-            setPrimaryButton(
-                title: "Insert",
-                symbol: "text.badge.plus",
-                color: .systemGreen,
-                enabled: true
-            )
-        case .serverUnavailable, .uploadFailedRecoverable, .transcriptionFailedRecoverable:
-            statusLabel.text = state == .serverUnavailable
-                ? "Gateway unavailable"
-                : "Transcription paused"
-            languageLabel.text = "Recording preserved · Retry when ready"
-            recordingDot.backgroundColor = .systemOrange
-            meterView.activeColor = .systemOrange
-            setPrimaryButton(
-                title: "New",
-                symbol: "mic.fill",
-                color: .systemBlue,
-                enabled: true
-            )
-        case .permissionDenied:
-            statusLabel.text = "Microphone access needed"
-            languageLabel.text = "Allow access in Local Flow Settings"
-            recordingDot.backgroundColor = .systemRed
-            meterView.activeColor = .systemRed
-            setPrimaryButton(
-                title: "Open app",
-                symbol: "gear",
-                color: .systemRed,
-                enabled: true
-            )
-        case .targetContextChanged:
-            statusLabel.text = "Transcript is waiting"
-            languageLabel.text = "Return to that field, or insert it here"
-            recordingDot.backgroundColor = .systemOrange
-            meterView.activeColor = .systemOrange
-            setPrimaryButton(
-                title: "Insert here",
-                symbol: "text.badge.plus",
-                color: .systemGreen,
-                enabled: true
-            )
-        case .inserting, .inserted:
-            statusLabel.text = "Finishing insertion…"
-            languageLabel.text = "Placing the transcript at the cursor"
-            recordingDot.backgroundColor = .systemGreen
-            meterView.activeColor = .systemGreen
-            setPrimaryButton(
-                title: "Inserting…",
-                symbol: "text.badge.checkmark",
-                color: .systemGreen,
-                enabled: false
-            )
-        case .transcriptionFailedPermanent:
-            statusLabel.text = "Transcription failed"
-            languageLabel.text = record?.error?.message ?? "Please make a new recording"
-            recordingDot.backgroundColor = .systemRed
-            meterView.activeColor = .systemRed
-            setPrimaryButton(
-                title: "Try again",
-                symbol: "arrow.clockwise",
-                color: .systemRed,
-                enabled: true
-            )
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        case .permissionDenied, .serverUnavailable, .uploadFailedRecoverable,
+             .transcriptionFailedRecoverable, .transcriptionFailedPermanent:
+            UINotificationFeedbackGenerator().notificationOccurred(.error)
+        default:
+            break
         }
     }
 
     private func configureUI() {
-        statusLabel.font = .systemFont(ofSize: 17, weight: .semibold)
-        statusLabel.textAlignment = .left
-        statusLabel.numberOfLines = 1
-        statusLabel.adjustsFontSizeToFitWidth = true
-        statusLabel.minimumScaleFactor = 0.78
-        statusLabel.lineBreakMode = .byTruncatingTail
-        languageLabel.font = .systemFont(ofSize: 12, weight: .regular)
-        languageLabel.textColor = .secondaryLabel
-        languageLabel.textAlignment = .left
-        languageLabel.adjustsFontSizeToFitWidth = true
-        languageLabel.minimumScaleFactor = 0.82
-
-        styleButton.showsMenuAsPrimaryAction = true
-        styleButton.accessibilityLabel = "Writing style"
-        transcriptionLanguageButton.showsMenuAsPrimaryAction = true
-        transcriptionLanguageButton.accessibilityLabel = "Transcription language"
-
-        recordingDot.layer.cornerRadius = 5
-        recordingDot.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            recordingDot.widthAnchor.constraint(equalToConstant: 10),
-            recordingDot.heightAnchor.constraint(equalToConstant: 10),
-        ])
-
-        meterView.translatesAutoresizingMaskIntoConstraints = false
-        meterView.heightAnchor.constraint(equalToConstant: 9).isActive = true
-
-        primaryButton.addTarget(self, action: #selector(primaryTapped), for: .touchUpInside)
-        primaryButton.accessibilityLabel = "Start or finish private dictation"
-        configureUtilityButton(cancelButton, title: "Cancel", symbol: "xmark")
-        cancelButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
-        configureUtilityButton(retryButton, title: "Retry", symbol: "arrow.clockwise")
-        retryButton.addTarget(self, action: #selector(retryTapped), for: .touchUpInside)
-        configureUtilityButton(undoButton, title: "Undo insert", symbol: "arrow.uturn.backward")
-        undoButton.addTarget(self, action: #selector(undoTapped), for: .touchUpInside)
-
-        let titleRow = UIStackView(arrangedSubviews: [recordingDot, statusLabel])
-        titleRow.axis = .horizontal
-        titleRow.alignment = .center
-        titleRow.spacing = 8
-        languageLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        let statusStack = UIStackView(arrangedSubviews: [titleRow, languageLabel, meterView])
-        statusStack.axis = .vertical
-        statusStack.spacing = 4
-        let cardRow = UIStackView(arrangedSubviews: [statusStack, primaryButton])
-        cardRow.axis = .horizontal
-        cardRow.alignment = .center
-        cardRow.spacing = 10
-        cardRow.translatesAutoresizingMaskIntoConstraints = false
-
-        dictationCard.layer.cornerRadius = 18
-        dictationCard.layer.cornerCurve = .continuous
-        dictationCard.layer.shadowColor = UIColor.black.cgColor
-        dictationCard.layer.shadowOpacity = 0.08
-        dictationCard.layer.shadowRadius = 3
-        dictationCard.layer.shadowOffset = CGSize(width: 0, height: 1.5)
-        dictationCard.layer.borderWidth = 0.5
-        dictationCard.addSubview(cardRow)
-        NSLayoutConstraint.activate([
-            cardRow.leadingAnchor.constraint(equalTo: dictationCard.leadingAnchor, constant: 14),
-            cardRow.trailingAnchor.constraint(equalTo: dictationCard.trailingAnchor, constant: -11),
-            cardRow.topAnchor.constraint(equalTo: dictationCard.topAnchor, constant: 10),
-            cardRow.bottomAnchor.constraint(equalTo: dictationCard.bottomAnchor, constant: -10),
-            dictationCard.heightAnchor.constraint(equalToConstant: 76),
-            primaryButton.widthAnchor.constraint(equalToConstant: 112),
-            primaryButton.heightAnchor.constraint(equalToConstant: 48),
-        ])
-
-        let toolbarSpacer = UIView()
-        toolbarSpacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        toolbarStack.addArrangedSubview(transcriptionLanguageButton)
-        toolbarStack.addArrangedSubview(styleButton)
-        toolbarStack.addArrangedSubview(toolbarSpacer)
-        toolbarStack.addArrangedSubview(cancelButton)
-        toolbarStack.addArrangedSubview(retryButton)
-        toolbarStack.addArrangedSubview(undoButton)
-        toolbarStack.axis = .horizontal
-        toolbarStack.alignment = .center
-        toolbarStack.spacing = 6
-        styleButton.setContentHuggingPriority(.required, for: .horizontal)
-        transcriptionLanguageButton.setContentHuggingPriority(.required, for: .horizontal)
-        cancelButton.isHidden = true
-        retryButton.isHidden = true
-        undoButton.isHidden = true
-
+        dictationBar.delegate = self
         keyGrid.delegate = self
-        let stack = UIStackView(arrangedSubviews: [dictationCard, toolbarStack, keyGrid])
+        let stack = UIStackView(arrangedSubviews: [dictationBar, keyGrid])
         stack.axis = .vertical
         stack.spacing = Self.chromeSpacing
         stack.translatesAutoresizingMaskIntoConstraints = false
@@ -770,13 +577,14 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         view.clipsToBounds = false
         view.addSubview(stack)
 
-        let cardHeight = dictationCard.heightAnchor.constraint(equalToConstant: 76)
-        let toolbarHeight = toolbarStack.heightAnchor.constraint(equalToConstant: 34)
+        let barMetrics = DictationBarMetrics.resolved(for: traitCollection)
+        let barHeight = dictationBar.heightAnchor.constraint(
+            equalToConstant: barMetrics.height(expanded: false)
+        )
         let gridHeight = keyGrid.heightAnchor.constraint(equalToConstant: 202)
         let keyboardHeight = view.heightAnchor.constraint(equalToConstant: 326)
         keyboardHeight.priority = UILayoutPriority(999)
-        cardHeightConstraint = cardHeight
-        toolbarHeightConstraint = toolbarHeight
+        barHeightConstraint = barHeight
         gridHeightConstraint = gridHeight
         keyboardHeightConstraint = keyboardHeight
 
@@ -791,8 +599,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
                 lessThanOrEqualTo: view.bottomAnchor,
                 constant: -Self.chromeInset
             ),
-            cardHeight,
-            toolbarHeight,
+            barHeight,
             gridHeight,
             keyboardHeight,
         ])
@@ -806,28 +613,37 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     private static let chromeInset: CGFloat = 6
 
     /// Sizes everything from the current traits instead of a single portrait
-    /// iPhone constant, and gives the status card only as much room as the
+    /// iPhone constant, and gives the dictation bar only as much room as the
     /// current state actually needs.
-    private func applyLayoutMetrics() {
+    private func applyLayoutMetrics(animated: Bool = false) {
         let metrics = KeyboardMetrics.resolved(for: traitCollection)
+        let barMetrics = DictationBarMetrics.resolved(for: traitCollection)
         keyGrid.metrics = metrics
+        dictationBar.metrics = barMetrics
 
-        let isCompactHeight = traitCollection.verticalSizeClass == .compact
-        let cardHeight: CGFloat = isCompactHeight ? 46 : (hasActiveSession ? 76 : 54)
-        let toolbarHeight: CGFloat = isCompactHeight ? 30 : 34
-        let showsDetail = cardHeight >= 70
-        meterView.isHidden = !showsDetail
-        languageLabel.isHidden = !showsDetail
-
-        cardHeightConstraint?.constant = cardHeight
-        toolbarHeightConstraint?.constant = toolbarHeight
+        let barHeight = barMetrics.height(expanded: isBarExpanded)
+        barHeightConstraint?.constant = barHeight
         gridHeightConstraint?.constant = metrics.gridHeight
         keyboardHeightConstraint?.constant = 2 * Self.chromeInset
-            + cardHeight
-            + toolbarHeight
+            + barHeight
             + metrics.gridHeight
-            + 2 * Self.chromeSpacing
-        view.setNeedsLayout()
+            + Self.chromeSpacing
+
+        guard animated, !UIAccessibility.isReduceMotionEnabled else {
+            view.setNeedsLayout()
+            return
+        }
+        // The host app resizes around the keyboard, so the expansion has to be
+        // a settle rather than a jump.
+        UIView.animate(
+            withDuration: 0.34,
+            delay: 0,
+            usingSpringWithDamping: 0.9,
+            initialSpringVelocity: 0,
+            options: [.beginFromCurrentState, .allowUserInteraction]
+        ) {
+            self.view.layoutIfNeeded()
+        }
     }
 
     /// Mirrors the traits of the field being typed into. Without this the
@@ -877,158 +693,6 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         }
     }
 
-    private func configureUtilityButton(_ button: UIButton, title: String, symbol: String) {
-        var configuration = UIButton.Configuration.filled()
-        configuration.title = title
-        configuration.image = UIImage(systemName: symbol)
-        configuration.imagePadding = 5
-        configuration.cornerStyle = .capsule
-        configuration.contentInsets = NSDirectionalEdgeInsets(
-            top: 5,
-            leading: 10,
-            bottom: 5,
-            trailing: 10
-        )
-        configuration.baseBackgroundColor = palette.toolbarControl
-        configuration.baseForegroundColor = .label
-        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer {
-            incoming in
-            var outgoing = incoming
-            outgoing.font = .systemFont(ofSize: 13, weight: .semibold)
-            return outgoing
-        }
-        button.configuration = configuration
-        button.heightAnchor.constraint(equalToConstant: 34).isActive = true
-    }
-
-    private func configureStyleButton(selected: WritingStyle, enabled: Bool) {
-        // `render` runs on every poll tick. Rebuilding the menu and button
-        // configuration each time churns allocations and re-lays out the toolbar
-        // for state that almost never changes.
-        guard renderedStyle != selected || renderedStyleEnabled != enabled else { return }
-        renderedStyle = selected
-        renderedStyleEnabled = enabled
-        let actions = WritingStyle.allCases.map { style in
-            UIAction(
-                title: style.displayName,
-                image: UIImage(systemName: style.symbolName),
-                state: style == selected ? .on : .off
-            ) { [weak self] _ in
-                KeyboardPreferences.writingStyle = style
-                self?.refresh()
-            }
-        }
-        styleButton.menu = UIMenu(title: "Writing style", children: actions)
-
-        var configuration = UIButton.Configuration.filled()
-        configuration.title = selected.displayName
-        configuration.image = UIImage(systemName: selected.symbolName)
-        configuration.imagePadding = 5
-        configuration.cornerStyle = .capsule
-        configuration.contentInsets = NSDirectionalEdgeInsets(
-            top: 5,
-            leading: 10,
-            bottom: 5,
-            trailing: 10
-        )
-        configuration.baseBackgroundColor = palette.toolbarControl
-        configuration.baseForegroundColor = .systemBlue
-        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer {
-            incoming in
-            var outgoing = incoming
-            outgoing.font = .systemFont(ofSize: 13, weight: .semibold)
-            return outgoing
-        }
-        styleButton.configuration = configuration
-        styleButton.isEnabled = enabled
-        styleButton.accessibilityValue = selected.displayName
-    }
-
-    private func configureLanguageButton(
-        selected: TranscriptionLanguage,
-        enabled: Bool
-    ) {
-        guard renderedLanguage != selected || renderedLanguageEnabled != enabled else { return }
-        renderedLanguage = selected
-        renderedLanguageEnabled = enabled
-        let actions = TranscriptionLanguage.allCases.map { language in
-            UIAction(
-                title: language.displayName,
-                image: UIImage(systemName: "globe"),
-                state: language == selected ? .on : .off
-            ) { [weak self] _ in
-                KeyboardPreferences.transcriptionLanguage = language
-                self?.refresh()
-            }
-        }
-        transcriptionLanguageButton.menu = UIMenu(
-            title: "Transcription language",
-            children: actions
-        )
-
-        var configuration = UIButton.Configuration.filled()
-        configuration.title = selected.shortLabel
-        configuration.image = UIImage(systemName: "globe")
-        configuration.imagePadding = 4
-        configuration.cornerStyle = .capsule
-        configuration.contentInsets = NSDirectionalEdgeInsets(
-            top: 5,
-            leading: 9,
-            bottom: 5,
-            trailing: 9
-        )
-        configuration.baseBackgroundColor = palette.toolbarControl
-        configuration.baseForegroundColor = .systemBlue
-        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer {
-            incoming in
-            var outgoing = incoming
-            outgoing.font = .systemFont(ofSize: 13, weight: .semibold)
-            return outgoing
-        }
-        transcriptionLanguageButton.configuration = configuration
-        transcriptionLanguageButton.isEnabled = enabled
-        transcriptionLanguageButton.accessibilityValue = selected.displayName
-    }
-
-    private func setPrimaryButton(
-        title: String,
-        symbol: String,
-        color: UIColor,
-        enabled: Bool
-    ) {
-        defer { primaryButton.accessibilityValue = statusLabel.text }
-        guard renderedPrimary?.title != title
-            || renderedPrimary?.symbol != symbol
-            || renderedPrimary?.color != color
-            || renderedPrimary?.enabled != enabled
-        else { return }
-        renderedPrimary = (title, symbol, color, enabled)
-        var configuration = UIButton.Configuration.filled()
-        configuration.title = title
-        configuration.image = UIImage(systemName: symbol)
-        configuration.imagePadding = 7
-        configuration.cornerStyle = .capsule
-        configuration.baseBackgroundColor = color
-        configuration.baseForegroundColor = .white
-        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer {
-            incoming in
-            var outgoing = incoming
-            outgoing.font = .systemFont(ofSize: 15, weight: .semibold)
-            return outgoing
-        }
-        primaryButton.configuration = configuration
-        primaryButton.isEnabled = enabled
-        primaryButton.accessibilityLabel = title
-        primaryButton.accessibilityHint = switch title {
-        case "Dictate": "Opens Local Flow and starts private dictation."
-        case "Finish": "Stops recording and starts transcription."
-        case "Insert": "Inserts the transcript at the cursor."
-        case "Insert here": "Inserts the waiting transcript into this field instead."
-        case "Open app": "Opens Local Flow to continue."
-        default: nil
-        }
-    }
-
     /// Fields can request a dark keyboard inside a light app, so the appearance
     /// comes from the document first and only falls back to the system trait.
     private var prefersDarkAppearance: Bool {
@@ -1043,32 +707,8 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         palette = KeyboardPalette(isDark: prefersDarkAppearance)
         view.backgroundColor = palette.background
         inputView?.backgroundColor = palette.background
-        dictationCard.backgroundColor = palette.card
-        dictationCard.layer.borderColor = palette.cardBorder.cgColor
-        statusLabel.textColor = palette.label
-        languageLabel.textColor = palette.secondaryLabel
+        dictationBar.palette = palette
         keyGrid.palette = palette
-        renderedStyle = nil
-        renderedLanguage = nil
-        renderedPrimary = nil
-    }
-
-    private func updateRecordingPulse(active: Bool) {
-        let animationKey = "localflow.recordingPulse"
-        guard active else {
-            recordingDot.layer.removeAnimation(forKey: animationKey)
-            recordingDot.layer.opacity = 1
-            return
-        }
-        guard recordingDot.layer.animation(forKey: animationKey) == nil else { return }
-        let pulse = CABasicAnimation(keyPath: "opacity")
-        pulse.fromValue = 1
-        pulse.toValue = 0.32
-        pulse.duration = 0.78
-        pulse.autoreverses = true
-        pulse.repeatCount = .infinity
-        pulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-        recordingDot.layer.add(pulse, forKey: animationKey)
     }
 
     /// Autocapitalization follows the field's own request. A username or URL
@@ -1104,75 +744,12 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
 extension KeyboardViewController: KeyGridViewDelegate {}
 
-private final class VoiceMeterView: UIView {
-    var level: Float = 0 {
-        didSet {
-            updateAccessibilityValue()
-            setNeedsDisplay()
-        }
+extension KeyboardViewController: DictationBarViewDelegate {
+    func dictationBar(_ bar: DictationBarView, didTrigger action: DictationAction) {
+        perform(action)
     }
 
-    var isActive = false {
-        didSet {
-            updateAccessibilityValue()
-            setNeedsDisplay()
-        }
-    }
-
-    var activeColor: UIColor = .systemBlue {
-        didSet { setNeedsDisplay() }
-    }
-
-    override var intrinsicContentSize: CGSize {
-        CGSize(width: 120, height: 9)
-    }
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        backgroundColor = .clear
-        isOpaque = false
-        isAccessibilityElement = true
-        accessibilityLabel = "Voice level"
-        accessibilityTraits = [.updatesFrequently]
-        updateAccessibilityValue()
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func draw(_ rect: CGRect) {
-        let pattern: [CGFloat] = [
-            0.28, 0.46, 0.72, 0.42, 0.86, 0.58, 1, 0.7, 0.48,
-            0.9, 0.62, 0.38, 0.76, 0.52, 0.88, 0.44, 0.66, 0.3,
-        ]
-        let gap: CGFloat = 2.2
-        let totalGaps = gap * CGFloat(pattern.count - 1)
-        let barWidth = max(1.5, (bounds.width - totalGaps) / CGFloat(pattern.count))
-        let normalizedLevel = min(max(CGFloat(level), 0), 1)
-        let energy = isActive ? max(0.16, normalizedLevel) : 0.09
-        let color = activeColor.withAlphaComponent(isActive ? 0.88 : 0.22)
-        color.setFill()
-
-        for (index, value) in pattern.enumerated() {
-            let scaledEnergy = min(1, energy * (0.55 + value * 0.85))
-            let height = max(2, bounds.height * scaledEnergy)
-            let x = CGFloat(index) * (barWidth + gap)
-            let bar = CGRect(
-                x: x,
-                y: bounds.midY - height / 2,
-                width: barWidth,
-                height: height
-            )
-            UIBezierPath(roundedRect: bar, cornerRadius: barWidth / 2).fill()
-        }
-    }
-
-    private func updateAccessibilityValue() {
-        let normalizedLevel = min(max(level, 0), 1)
-        accessibilityValue = isActive
-            ? "\(Int(normalizedLevel * 100)) percent"
-            : "Not recording"
+    func dictationBarDidChangePreferences(_ bar: DictationBarView) {
+        refresh()
     }
 }

--- a/ios/LocalFlowTests/DictationBarLayoutTests.swift
+++ b/ios/LocalFlowTests/DictationBarLayoutTests.swift
@@ -1,0 +1,109 @@
+import Testing
+import UIKit
+
+@MainActor
+struct DictationBarLayoutTests {
+    private static let referenceWidth: CGFloat = 393 - 12
+
+    private static func makeBar(
+        _ model: DictationBarModel,
+        traits: UITraitCollection = UITraitCollection { $0.verticalSizeClass = .regular },
+        isDark: Bool = false
+    ) -> DictationBarView {
+        let metrics = DictationBarMetrics.resolved(for: traits)
+        let bar = DictationBarView(metrics: metrics, palette: KeyboardPalette(isDark: isDark))
+        bar.frame = CGRect(
+            x: 0,
+            y: 0,
+            width: referenceWidth,
+            height: metrics.height(expanded: model.isExpanded)
+        )
+        bar.apply(model, animated: false)
+        bar.layoutIfNeeded()
+        return bar
+    }
+
+    private static func model(_ state: SessionState, transcript: String? = nil) -> DictationBarModel {
+        DictationBarModel.make(DictationContext(state: state, transcript: transcript))
+    }
+
+    private static func descendants(of view: UIView) -> [UIView] {
+        view.subviews + view.subviews.flatMap(descendants)
+    }
+
+    /// Anything that is drawing has to be inside the bar. The previous card left
+    /// its subtitle and meter to be clipped whenever the status text grew.
+    @Test func nothingVisibleEscapesTheBar() {
+        for state in SessionState.allCases {
+            let bar = Self.makeBar(Self.model(state, transcript: String(repeating: "long ", count: 40)))
+            for view in Self.descendants(of: bar) where !view.isHidden && view.alpha > 0 {
+                let frame = view.convert(view.bounds, to: bar)
+                guard frame.width > 0, frame.height > 0 else { continue }
+                #expect(frame.minX >= -0.5)
+                #expect(frame.maxX <= bar.bounds.width + 0.5)
+            }
+        }
+    }
+
+    /// The headline and the body share the space the action buttons leave, so a
+    /// long title must never end up drawn underneath the primary button.
+    @Test func theActionButtonsKeepTheirColumnClear() {
+        let bar = Self.makeBar(Self.model(.recording))
+        let primary = Self.descendants(of: bar).first { $0 is GradientButton }
+        let waveform = Self.descendants(of: bar).first { $0 is WaveformView }
+        #expect(primary != nil)
+        #expect(waveform != nil)
+        guard let primary, let waveform else { return }
+        let primaryFrame = primary.convert(primary.bounds, to: bar)
+        let waveformFrame = waveform.convert(waveform.bounds, to: bar)
+        #expect(waveformFrame.maxX <= primaryFrame.minX)
+        #expect(primaryFrame.maxX <= bar.bounds.width)
+        #expect(waveformFrame.width > 0)
+    }
+
+    /// The body views all stay in place at zero alpha so a state change
+    /// dissolves instead of re-laying out — which means only the one the model
+    /// asked for may be on screen.
+    @Test func onlyTheModelsOwnBodyViewIsVisible() {
+        let bar = Self.makeBar(Self.model(.idle))
+        let waveforms = Self.descendants(of: bar).compactMap { $0 as? WaveformView }
+        #expect(waveforms.count == 1)
+
+        for state in SessionState.allCases {
+            let model = Self.model(state)
+            bar.apply(model, animated: false)
+            bar.layoutIfNeeded()
+            let showsMeter = waveforms.contains { !$0.isHidden && $0.alpha > 0 }
+            let wantsMeter = switch model.body {
+            case .waveform: true
+            case .controls, .message: false
+            }
+            #expect(showsMeter == wantsMeter)
+        }
+    }
+
+    @Test func theBarSurvivesRepeatedRendersOfTheSameState() {
+        let bar = Self.makeBar(Self.model(.recording))
+        let before = Self.descendants(of: bar).count
+        for _ in 0..<20 {
+            bar.apply(Self.model(.recording), animated: false)
+            bar.push(meterLevel: 0.6)
+        }
+        bar.layoutIfNeeded()
+        // A poll tick that changes nothing must not accumulate views.
+        #expect(Self.descendants(of: bar).count == before)
+    }
+
+    @Test func bothAppearancesResolveEveryAccent() {
+        for isDark in [true, false] {
+            let palette = KeyboardPalette(isDark: isDark)
+            let accents: [DictationAccent] = [
+                .brand, .handoff, .listening, .working, .ready, .alert, .locked,
+            ]
+            for accent in accents {
+                #expect(palette.gradient(for: accent).count == 2)
+                #expect(palette.tint(for: accent) == palette.gradient(for: accent)[0])
+            }
+        }
+    }
+}

--- a/ios/LocalFlowTests/DictationPresentationTests.swift
+++ b/ios/LocalFlowTests/DictationPresentationTests.swift
@@ -1,0 +1,169 @@
+import Testing
+import UIKit
+
+@MainActor
+struct DictationPresentationTests {
+    private static func model(
+        _ state: SessionState,
+        transcript: String? = nil,
+        errorMessage: String? = nil,
+        autoInsert: Bool = false,
+        canRetry: Bool = false,
+        canUndo: Bool = false,
+        hasFullAccess: Bool = true
+    ) -> DictationBarModel {
+        DictationBarModel.make(
+            DictationContext(
+                state: state,
+                hasFullAccess: hasFullAccess,
+                transcript: transcript,
+                errorMessage: errorMessage,
+                autoInsertsTranscripts: autoInsert,
+                canRetry: canRetry,
+                canUndo: canUndo
+            )
+        )
+    }
+
+    @Test func everyStateOffersALabelledPrimaryButton() {
+        for state in SessionState.allCases {
+            let model = Self.model(state)
+            #expect(!model.title.isEmpty)
+            #expect(!model.primary.title.isEmpty)
+            #expect(!model.primary.symbol.isEmpty)
+        }
+    }
+
+    /// The prominent button in the recoverable-failure states used to start a
+    /// fresh session, and starting one cancels the parked record — so the tap
+    /// most people reached for threw away the recording the state had just
+    /// promised to preserve.
+    @Test func recoverableFailuresPromoteRetryOverANewRecording() {
+        let states: [SessionState] = [
+            .serverUnavailable, .uploadFailedRecoverable, .transcriptionFailedRecoverable,
+        ]
+        for state in states {
+            let model = Self.model(state, canRetry: true)
+            #expect(model.primary.action == .retry)
+            #expect(model.secondaries.contains { $0.action == .cancel })
+        }
+    }
+
+    @Test func anUnretryableFailureFallsBackToStartingOver() {
+        let model = Self.model(.serverUnavailable, canRetry: false)
+        #expect(model.primary.action == .start)
+    }
+
+    @Test func aReadyTranscriptIsShownBeforeItIsInserted() {
+        let model = Self.model(.readyToInsert, transcript: "Ship the beta on Friday")
+        #expect(model.body == .message("“Ship the beta on Friday”"))
+        #expect(model.primary.action == .insert)
+    }
+
+    @Test func anEmptyTranscriptFallsBackToGuidance() {
+        let model = Self.model(.readyToInsert, transcript: "   \n ")
+        #expect(model.body == .message("Tap Insert to place the text."))
+    }
+
+    @Test func autoInsertionSaysSoWhenThereIsNoTranscriptYet() {
+        let model = Self.model(.readyToInsert, autoInsert: true)
+        #expect(model.body == .message("Inserting automatically…"))
+    }
+
+    @Test func aPreviewCollapsesWhitespaceAndTruncates() {
+        let long = String(repeating: "word ", count: 60)
+        let preview = DictationBarModel.quoted("  hello\n\n  there  ")
+        #expect(preview == "“hello there”")
+        #expect(DictationBarModel.quoted(long)?.hasSuffix("…”") == true)
+        #expect(DictationBarModel.quoted(long)!.count <= 100)
+        #expect(DictationBarModel.quoted(nil) == nil)
+        #expect(DictationBarModel.quoted(" \t ") == nil)
+    }
+
+    @Test func withoutFullAccessNothingIsActionable() {
+        let model = Self.model(.idle, canUndo: true, hasFullAccess: false)
+        #expect(model.accent == .locked)
+        #expect(!model.primary.isEnabled)
+        #expect(model.secondaries.isEmpty)
+    }
+
+    /// States that own no work and have nothing to explain. A terminal failure
+    /// is not one of them: it still has to say what went wrong.
+    private static let resting: Set<SessionState> = [.idle, .completed, .canceled, .expired]
+
+    /// The pickers change what the *next* dictation does, so they are offered
+    /// exactly when no session owns the bar.
+    @Test func thePickersAppearOnlyBetweenSessions() {
+        for state in SessionState.allCases {
+            #expect((Self.model(state).body == .controls) == Self.resting.contains(state))
+        }
+    }
+
+    @Test func undoIsOfferedOnlyOnceTheSessionIsOver() {
+        #expect(Self.model(.completed, canUndo: true).secondaries.contains { $0.action == .undo })
+        #expect(Self.model(.completed, canUndo: false).secondaries.isEmpty)
+        #expect(!Self.model(.recording, canUndo: true).secondaries.contains { $0.action == .undo })
+    }
+
+    /// Height is given back to the keys the moment nothing needs the space —
+    /// which includes a finished insertion, but not a failure the user has yet
+    /// to read.
+    @Test func theBarCollapsesOnlyWhenItHasNothingToSay() {
+        for state in SessionState.allCases {
+            #expect(Self.model(state).isExpanded == !Self.resting.contains(state))
+        }
+        #expect(Self.model(.permissionDenied).isExpanded)
+        #expect(Self.model(.transcriptionFailedPermanent).isExpanded)
+    }
+
+    /// A wait must never be drawn as though it were recorded audio.
+    @Test func theMeterIsLiveOnlyWhileRecording() {
+        #expect(Self.model(.recording).body == .waveform(.live))
+        #expect(Self.model(.recording).showsElapsedTime)
+        for state in [SessionState.finalizing, .uploading, .transcribing] {
+            #expect(Self.model(state).body == .waveform(.indeterminate))
+            #expect(!Self.model(state).showsElapsedTime)
+        }
+    }
+
+    @Test func everyLiveStateCanBeAbandoned() {
+        let live: [SessionState] = [
+            .launchingApp, .awaitingReturn, .recording, .finalizing, .uploading,
+            .transcribing, .readyToInsert, .targetContextChanged,
+        ]
+        for state in live {
+            #expect(Self.model(state).secondaries.contains { $0.action == .cancel })
+        }
+    }
+
+    @Test func aStrandedTranscriptCanBeRedirectedToTheCurrentField() {
+        let model = Self.model(.targetContextChanged, transcript: "Redirect me")
+        #expect(model.primary.action == .insertHere)
+        #expect(model.body == .message("“Redirect me”"))
+    }
+
+    @Test func elapsedTimeReadsAsMinutesAndSeconds() {
+        #expect(DictationBarModel.elapsedText(0) == "0:00")
+        #expect(DictationBarModel.elapsedText(7.9) == "0:07")
+        #expect(DictationBarModel.elapsedText(65) == "1:05")
+        #expect(DictationBarModel.elapsedText(600) == "10:00")
+        #expect(DictationBarModel.elapsedText(-4) == "0:00")
+    }
+
+    @Test func barHeightsLeaveMoreRoomForKeysThanTheCardAndToolbarDid() {
+        let portrait = DictationBarMetrics.resolved(
+            for: UITraitCollection { $0.verticalSizeClass = .regular }
+        )
+        // The card, the toolbar and the gap between them came to 117pt in every
+        // state, including the idle one.
+        #expect(portrait.collapsedHeight < 117)
+        #expect(portrait.expandedHeight < 117)
+        #expect(portrait.collapsedHeight < portrait.expandedHeight)
+
+        let landscape = DictationBarMetrics.resolved(
+            for: UITraitCollection { $0.verticalSizeClass = .compact }
+        )
+        #expect(landscape.expandedHeight < portrait.collapsedHeight)
+        #expect(landscape.messageLineLimit == 1)
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -72,6 +72,12 @@ targets:
       - path: LocalFlowKeyboard/KeyLayout.swift
       - path: LocalFlowKeyboard/KeyView.swift
       - path: LocalFlowKeyboard/KeyGridView.swift
+      # The state-to-interface mapping for the dictation bar is pure, so every
+      # session state can be checked without standing up the extension.
+      - path: LocalFlowKeyboard/DictationPresentation.swift
+      - path: LocalFlowKeyboard/DictationBarStyle.swift
+      - path: LocalFlowKeyboard/DictationBarView.swift
+      - path: LocalFlowKeyboard/DictationBarComponents.swift
       # The realtime capture path is the highest-risk code in the app.
       - path: LocalFlowApp/Audio/AudioCapturePipeline.swift
     settings:


### PR DESCRIPTION
## What

The dictation chrome above the keys was a fixed status card stacked on a fixed toolbar. It charged **117pt in every state**, including the idle one that had nothing to report, and its meter was a decorative pattern scaled by one number — it moved identically whether you whispered or shouted.

It is now a single bar that morphs with the session: **72pt at rest, 84pt while a session is live**, with the difference going back to the keys.

| | before | after |
| --- | --- | --- |
| idle | 117pt | 72pt |
| live session | 117pt | 84pt |
| landscape | 83pt | 58pt |

## Structure

`KeyboardViewController` drops from 1178 to 748 lines; the chrome moves into four files.

- **`DictationPresentation.swift`** — a pure `SessionState` → `DictationBarModel` mapping. Buttons carry their own `DictationAction`, so the state, the labels and the behaviour can no longer disagree, and every session state is testable without standing up the extension.
- **`DictationBarStyle.swift`** — accent gradients resolved per appearance (the way the key colours already are, so a dark field inside a light app still gets a dark bar) and the trait-resolved bar metrics.
- **`DictationBarComponents.swift`** — the scrolling `WaveformView`, the pulsing `StatusIndicatorView`, the `GradientButton`.
- **`DictationBarView.swift`** — one headline, one body slot holding either the pickers, the meter or a message, and one action column.

## Behaviour

- The meter is a real scrolling waveform driven by the published microphone levels. Work happening on the Mac draws a travelling pulse instead, shaped deliberately unlike speech so a wait cannot be mistaken for recorded audio.
- The transcript is shown before you insert it, rather than an unlabelled button.
- Recording counts up.
- States dissolve and settle instead of snapping.
- Haptics mark recording starting, a transcript arriving, and a failure.
- Reduce Motion is respected throughout: no display link, no pulses, no crossfades — and levels still advance the meter, one bar per sample.

## Two changes worth a second look

**Retry is now the prominent button after a recoverable failure.** It used to be "New", which calls `discardParkedSession()` and so threw away the recording that the state had just finished promising to preserve; retrying was left to a small icon beside it. Cancel now returns the bar to Ready with Dictate already in place, which is what "New" was reaching for.

**Transient guidance survives long enough to read.** Messages written straight to the status label were erased by the next poll tick a quarter of a second later. They now hold for 2.6s — but yield immediately to a real state change, so "Starting with Quick Dictation…" cannot still be covering the meter once recording has begun.

Also: restoring a session that was already in flight no longer fires the haptic that marks a recording actually starting.

## Testing

23 new tests (59 total, all passing on the iPhone 17 simulator) covering every session state, the retry-vs-discard regression above, transcript truncation, and bar layout.

Every state was also rendered offscreen in both appearances during development, which caught three defects invisible to both the compiler and the unit tests: a gradient layer covering its own button title, a chip wrapping "Auto" mid-word, and unreadable text on the disabled button.

**Not yet exercised on a physical iPhone.** Per CONTRIBUTING, the haptics, the display link under real memory pressure, and the keyboard-height animation as the host app resizes around it still need a device pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
