### PR TITLE
ci: cut wasted CI minutes and split the container build out

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -1,0 +1,35 @@
+name: Set up the Android toolchain
+description: Installs the JDK, accepts the Android SDK licences, and wires up the Gradle cache.
+
+inputs:
+  cache-read-only:
+    description: >
+      Restore the Gradle cache without saving a new entry. Every branch that
+      saves gets its own copy, so only the default branch should write.
+    default: 'false'
+  cache-encryption-key:
+    description: >
+      Base64 key used to encrypt the cached configuration-cache entries. Gradle
+      refuses to cache them without one; leaving it empty keeps the rest of the
+      Gradle cache working and just skips that part.
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+      with:
+        distribution: temurin
+        # Matches the JDK bundled with Android Studio, which is what the build
+        # has been verified against locally.
+        java-version: '25'
+    - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+      with:
+        # The runner image already ships the command-line and platform tools, so
+        # the default package install is a redownload of what is on disk. The
+        # action still accepts the licences, which is the part the build needs.
+        packages: ''
+    - uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
+      with:
+        cache-read-only: ${{ inputs.cache-read-only }}
+        cache-encryption-key: ${{ inputs.cache-encryption-key }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+
+# Every action is pinned to a commit SHA, which is what keeps a compromised tag
+# from silently entering the build — and also what stops those pins from ever
+# moving on their own. One grouped pull request a month keeps them current
+# without turning into a queue of single-line updates that each cost a CI run.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns: ['*']
+    commit-message:
+      prefix: ci
+  # Composite actions are not covered by the entry above; they are found only
+  # through the directory that holds them.
+  - package-ecosystem: github-actions
+    directory: /.github/actions/setup-android
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns: ['*']
+    commit-message:
+      prefix: ci

--- a/.github/workflows/android-beta.yml
+++ b/.github/workflows/android-beta.yml
@@ -25,24 +25,29 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # The release notes step walks back to the previous beta tag, which
-          # needs the tags and the history connecting them.
+          # needs the tags and the history connecting them. Only the commits
+          # are needed, so skip fetching every blob in that history.
           fetch-depth: 0
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+          filter: blob:none
+          persist-credentials: false
+      - uses: ./.github/actions/setup-android
         with:
-          distribution: temurin
-          # Matches the JDK bundled with Android Studio, which is what the build
-          # has been verified against locally.
-          java-version: '25'
-      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
-      - uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
+          # A cache entry saved from a tag ref is scoped to that tag and can
+          # never be restored again, so this build reads main's and saves none.
+          cache-read-only: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       - name: Build signed release APK
         env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
           KEYSTORE_FILE: ${{ runner.temp }}/local-flow-release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
-          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > "$KEYSTORE_FILE"
+          set -euo pipefail
+          # Passed through the environment rather than interpolated into the
+          # script, so the keystore never becomes part of the command line.
+          printf '%s' "$KEYSTORE_BASE64" | base64 --decode > "$KEYSTORE_FILE"
           ./gradlew assembleRelease
         working-directory: android
       - name: Upload APK as workflow artifact
@@ -51,10 +56,16 @@ jobs:
           name: local-flow-apk
           path: android/app/build/outputs/apk/release/local-flow-release.apk
           if-no-files-found: error
+          # The release below is the durable copy. This one only covers the
+          # window before it is published, so it does not need 90 days of
+          # storage, and an APK is already a compressed archive.
+          retention-days: 7
+          compression-level: 0
       - name: Publish beta GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           cp android/app/build/outputs/apk/release/local-flow-release.apk local-flow.apk
 
           # --generate-notes lists the pull requests merged since the previous

--- a/.github/workflows/container-server.yml
+++ b/.github/workflows/container-server.yml
@@ -1,0 +1,56 @@
+name: Container (server)
+
+# Building the image compiles whisper.cpp from source, which is by far the most
+# expensive thing in CI. Nothing under server/app can break that build — the
+# runtime image only copies the package, it never imports it — so this runs on
+# the files that actually decide whether the image assembles: the Dockerfiles
+# and the dependency set they install.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'server/Dockerfile*'
+      - 'server/.dockerignore'
+      - 'server/pyproject.toml'
+      - 'server/uv.lock'
+      - '.github/workflows/container-server.yml'
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'server/Dockerfile*'
+      - 'server/.dockerignore'
+      - 'server/pyproject.toml'
+      - 'server/uv.lock'
+      - '.github/workflows/container-server.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  container:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Build gateway image
+        working-directory: server
+        run: |
+          # cacheonly skips exporting the assembled image to the local daemon.
+          # The question this job answers is whether the build succeeds, and
+          # nothing downstream runs the image.
+          docker buildx build \
+            --tag localflow-gateway:test \
+            --cache-from type=gha,scope=gateway \
+            --cache-to type=gha,mode=max,scope=gateway \
+            --output type=cacheonly \
+            .

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,44 @@
+name: Lint workflows
+
+# A typo in a workflow is only discovered when it runs, and by then it has
+# already claimed a runner — a macOS one at ten times the rate, in the worst
+# case. Twenty seconds on Linux catches it first.
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - name: Run actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+        run: |
+          set -euo pipefail
+          curl --fail --location --show-error --silent \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            | tar --extract --gzip actionlint
+          # The runner image ships shellcheck, so run: blocks get linted as
+          # shell as well as YAML.
+          ./actionlint -color

--- a/.github/workflows/quality-android.yml
+++ b/.github/workflows/quality-android.yml
@@ -5,11 +5,19 @@ on:
     branches: [main]
     paths:
       - 'android/**'
+      # Prose next to the code it documents cannot break the build.
+      - '!android/**.md'
+      - '.github/actions/setup-android/action.yml'
       - '.github/workflows/quality-android.yml'
   pull_request:
     branches: [main]
+    # A draft pull request is filtered out below; listing ready_for_review makes
+    # the checks start the moment it stops being a draft.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'android/**'
+      - '!android/**.md'
+      - '.github/actions/setup-android/action.yml'
       - '.github/workflows/quality-android.yml'
   workflow_dispatch:
 
@@ -18,22 +26,28 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # A superseded pull request push is wasted minutes, but a run on main is the
+  # record for a merged commit, so let that one finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   android:
+    # Work in progress re-runs the full build on every push. The checks that
+    # matter run when the author marks the pull request ready.
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
-          distribution: temurin
-          # Matches the JDK bundled with Android Studio, which is what the build
-          # has been verified against locally.
-          java-version: '25'
-      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
-      - uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
+          persist-credentials: false
+      - uses: ./.github/actions/setup-android
+        with:
+          # Branches read main's cache and never save their own, which keeps the
+          # 10 GB repository cache from filling with one Gradle copy per branch
+          # and evicting the entry everything else restores from.
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       - run: ./gradlew assembleDebug testDebugUnitTest lintDebug
         working-directory: android
       - name: Fail if the checked-in Room schema is stale

--- a/.github/workflows/quality-ios.yml
+++ b/.github/workflows/quality-ios.yml
@@ -5,11 +5,18 @@ on:
     branches: [main]
     paths:
       - 'ios/**'
+      # Prose next to the code it documents cannot break the build, and macOS
+      # minutes bill at ten times the Linux rate.
+      - '!ios/**.md'
       - '.github/workflows/quality-ios.yml'
   pull_request:
     branches: [main]
+    # A draft pull request is filtered out below; listing ready_for_review makes
+    # the checks start the moment it stops being a draft.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'ios/**'
+      - '!ios/**.md'
       - '.github/workflows/quality-ios.yml'
   workflow_dispatch:
 
@@ -18,26 +25,42 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # A superseded pull request push is wasted minutes, but a run on main is the
+  # record for a merged commit, so let that one finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  # Homebrew otherwise refreshes its whole formula index before installing, and
+  # cleans up afterwards, on a runner that is thrown away either way.
+  HOMEBREW_NO_AUTO_UPDATE: '1'
+  HOMEBREW_NO_INSTALL_CLEANUP: '1'
+  HOMEBREW_NO_ENV_HINTS: '1'
 
 jobs:
   ios:
+    # Work in progress re-runs the full build on every push. The checks that
+    # matter run when the author marks the pull request ready.
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: macos-15
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - run: brew install xcodegen
-      - run: xcodegen generate --spec project.yml
+      - name: Fail if the checked-in Xcode project is stale
         working-directory: ios
-      - run: git diff --exit-code -- LocalFlow.xcodeproj
-        working-directory: ios
-      - name: Run iOS unit tests
-        working-directory: ios
+        run: |
+          xcodegen generate --spec project.yml
+          git diff --exit-code -- LocalFlow.xcodeproj
+
+      - name: Pick an iOS simulator
+        id: simulator
         run: |
           set -euo pipefail
           # macos-15 images sometimes list no pre-created devices for
           # -showdestinations until simctl has materialized one. Prefer an
-          # available iPhone simulator; create and boot one if needed.
+          # available iPhone simulator; create one if there is none.
           udid=$(
             xcrun simctl list devices available \
               | sed -n 's/.*iPhone[^(]*(\([A-F0-9-]*\)).*/\1/p' \
@@ -64,12 +87,55 @@ jobs:
             udid=$(xcrun simctl create "LocalFlow-CI-iPhone" "${device_type}" "${runtime}")
           fi
           echo "Using simulator ${udid}"
-          xcrun simctl boot "${udid}" 2>/dev/null || true
-          xcrun simctl bootstatus "${udid}" -b
-          xcodebuild \
-            -project LocalFlow.xcodeproj \
-            -scheme LocalFlow \
-            -sdk iphonesimulator \
-            -destination "platform=iOS Simulator,id=${udid}" \
-            CODE_SIGNING_ALLOWED=NO \
-            test
+          echo "udid=${udid}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and run iOS unit tests
+        working-directory: ios
+        env:
+          UDID: ${{ steps.simulator.outputs.udid }}
+          DERIVED_DATA: ${{ runner.temp }}/DerivedData
+          RESULT_BUNDLE: ${{ runner.temp }}/LocalFlow.xcresult
+        run: |
+          set -euo pipefail
+
+          # First boot spends over a minute in data migration, and the build
+          # needs no device at all. Boot in the background so that minute
+          # overlaps compilation instead of running before it.
+          xcrun simctl bootstatus "${UDID}" -b &
+          boot=$!
+
+          # Shared flags. Index-while-building only feeds Xcode's editor, and
+          # there are no Swift packages to resolve, so both are pure overhead
+          # here.
+          common=(
+            -project LocalFlow.xcodeproj
+            -scheme LocalFlow
+            -sdk iphonesimulator
+            -destination "platform=iOS Simulator,id=${UDID}"
+            -derivedDataPath "${DERIVED_DATA}"
+            -disableAutomaticPackageResolution
+            CODE_SIGNING_ALLOWED=NO
+            COMPILER_INDEX_STORE_ENABLE=NO
+          )
+
+          # -quiet drops roughly 1500 lines of per-file compile commands while
+          # still printing warnings and errors. The test run below keeps its
+          # full output, which is short and carries the failed expectation.
+          xcodebuild "${common[@]}" -quiet build-for-testing
+
+          # Fails the step if the device never came up, which is a clearer
+          # signal than xcodebuild timing out against a half-booted simulator.
+          wait "${boot}"
+
+          xcodebuild "${common[@]}" \
+            -resultBundlePath "${RESULT_BUNDLE}" \
+            test-without-building
+
+      - name: Upload the test result bundle
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ios-test-results
+          path: ${{ runner.temp }}/LocalFlow.xcresult
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/quality-server.yml
+++ b/.github/workflows/quality-server.yml
@@ -5,11 +5,17 @@ on:
     branches: [main]
     paths:
       - 'server/**'
+      # Prose next to the code it documents cannot break the build.
+      - '!server/**.md'
       - '.github/workflows/quality-server.yml'
   pull_request:
     branches: [main]
+    # A draft pull request is filtered out below; listing ready_for_review makes
+    # the checks start the moment it stops being a draft.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'server/**'
+      - '!server/**.md'
       - '.github/workflows/quality-server.yml'
   workflow_dispatch:
 
@@ -18,19 +24,27 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # A superseded pull request push is wasted minutes, but a run on main is the
+  # record for a merged commit, so let that one finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   server:
+    # Work in progress re-runs the full suite on every push. The checks that
+    # matter run when the author marks the pull request ready.
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           working-directory: server
           enable-cache: true
-      - run: sudo apt-get update && sudo apt-get install -y ffmpeg
+      # tests/test_audio.py shells out to FFmpeg against real audio.
+      - run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends ffmpeg
       - run: uv sync --locked --all-groups
         working-directory: server
       - run: uv run ruff check .
@@ -41,23 +55,10 @@ jobs:
         working-directory: server
       - run: uv run pytest
         working-directory: server
-
-  container:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      # Parsing the Compose file costs nothing, so it stays on every server
+      # change even though building the image (container-server.yml) does not.
       - name: Validate Compose configuration
         run: docker compose config --quiet
         working-directory: server
         env:
           LOCALFLOW_TOKEN: test-token-with-at-least-thirty-two-characters
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - name: Build gateway image
-        working-directory: server
-        run: |
-          docker buildx build \
-            --tag localflow-gateway:test \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
-            --load .


### PR DESCRIPTION
## Summary

- **What changed?** The iOS job overlaps simulator boot with compilation instead of serialising them, the gateway image build moves to its own narrowly-triggered workflow, and documentation-only changes no longer start any job. Adds actionlint, Dependabot for the action pins, and a shared Android toolchain action.
- **Why is it needed?** macOS minutes bill at ten times the Linux rate, and the iOS job was the most expensive thing in CI at 6m44s — most of it waiting rather than working. The container job rebuilt whisper.cpp from source on every server change, documentation included.

### Where the time went

| Job | Before | Change |
| --- | --- | --- |
| `ios` (10× billing) | 6m44s | 79s of first-boot data migration now overlaps the ~110s build; index-while-building and package resolution switched off |
| `container` | 2m36s | No longer runs on ordinary server changes; `--output type=cacheonly` skips exporting an image nothing runs |
| docs-only PR | 2 × 2m45s | Skipped entirely |

Nothing under `server/app` can break the image build — the runtime image copies the package and never imports it — so the container workflow keys on the Dockerfiles and the dependency set they install. Compose parsing costs nothing and stays on every server change.

`-quiet` is on the build only. With it on the test run, a failure showed just the test name; without it you get `Expectation failed` with file and line, in a 167-line log.

## Verification

- [x] `actionlint` clean across all six workflows and the composite action (it caught one bug on its first run — a comment opening with `# shellcheck` parses as a directive)
- [x] iOS: `build-for-testing` → `wait` → `test-without-building` run against a clean `HEAD` worktree on a real simulator — 59 tests pass, both phases exit 0
- [x] iOS failure path: an injected failing expectation exits 65 with the assertion and source line visible; a compile error aborts before the test phase
- [x] `docker buildx build --output type=cacheonly` accepted
- [x] `docker compose config --quiet` still validates
- [x] Path filters checked against real history — PR #12 (five files, all prose) would now be skipped
- [ ] Android and server jobs confirmed green on this PR
- [ ] Physical-device test — not applicable, no app code changed

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Checkouts stop persisting credentials; the keystore secret reaches `base64` through the environment rather than the command line
- [x] Every action stays pinned to a commit SHA, and Dependabot now keeps those pins current

## Follow-up

`GRADLE_ENCRYPTION_KEY` is wired but unset. Gradle will not cache configuration-cache entries without it. It is a no-op while empty — the rest of the Gradle cache works — so it can be added whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)