### PR TITLE
fix: recover from a silently revoked accessibility or overlay permission

### DIFF
--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/accessibility/LocalFlowAccessibilityService.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/accessibility/LocalFlowAccessibilityService.kt
@@ -41,6 +41,7 @@ class LocalFlowAccessibilityService : AccessibilityService(), TranscriptInserter
 
     override fun onServiceConnected() {
         super.onServiceConnected()
+        applyEventMask()
         val container = LocalFlowApplication.container(this)
         container.dictation.inserter = this
 
@@ -56,21 +57,27 @@ class LocalFlowAccessibilityService : AccessibilityService(), TranscriptInserter
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
-        when (event?.eventType) {
-            AccessibilityEvent.TYPE_VIEW_FOCUSED,
-            AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED,
-            // A WebView editor announces neither focus nor selection when the
-            // caret lands in it — the first thing it says is that its text
-            // changed. Without these two, focusing Gmail's compose body
-            // produced no event at all and the bubble never re-evaluated.
-            AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED,
-            AccessibilityEvent.TYPE_VIEW_CLICKED,
-            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
-            AccessibilityEvent.TYPE_WINDOWS_CHANGED,
-            -> refreshBubble()
+        val type = event?.eventType ?: return
+        if (type and EVENT_MASK != 0) refreshBubble()
+    }
 
-            else -> Unit
-        }
+    /**
+     * Re-declares which events this service wants, every time it connects.
+     *
+     * The same list is in `accessibility_service_config.xml`, but that file is
+     * only read when the service is enabled — an app update does not re-read
+     * it. Measured on a POCO F1: shipping a build that added two event types
+     * left the framework serving the *old* mask, so the newly handled fields
+     * stayed dead until the user toggled the service off and on. Every existing
+     * user would have updated into that. Asserting the mask here applies it on
+     * the connect that follows the update, so the XML only ever has to be right
+     * for a fresh install.
+     */
+    private fun applyEventMask() {
+        val info = serviceInfo ?: return
+        if (info.eventTypes == EVENT_MASK) return
+        info.eventTypes = EVENT_MASK
+        runCatching { serviceInfo = info }
     }
 
     override fun onInterrupt() = Unit
@@ -303,6 +310,26 @@ class LocalFlowAccessibilityService : AccessibilityService(), TranscriptInserter
 
     private fun isDeviceLocked(): Boolean =
         getSystemService(KeyguardManager::class.java)?.isKeyguardLocked ?: false
+
+    private companion object {
+        /**
+         * Everything that can mean "the field under the cursor may have
+         * changed". Mirrored in `accessibility_service_config.xml` for the
+         * first connection of a fresh install; [applyEventMask] is what keeps
+         * an updated install honest.
+         *
+         * Text-changed and clicked are here for editors that announce nothing
+         * else: focusing Gmail's compose body reports neither focus nor
+         * selection, so without them the bubble never re-evaluated at all.
+         */
+        const val EVENT_MASK =
+            AccessibilityEvent.TYPE_VIEW_FOCUSED or
+                AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED or
+                AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED or
+                AccessibilityEvent.TYPE_VIEW_CLICKED or
+                AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED or
+                AccessibilityEvent.TYPE_WINDOWS_CHANGED
+    }
 }
 
 /**

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/accessibility/LocalFlowAccessibilityService.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/accessibility/LocalFlowAccessibilityService.kt
@@ -127,18 +127,18 @@ class LocalFlowAccessibilityService : AccessibilityService(), TranscriptInserter
      * The focused text field, however the app's UI toolkit chooses to describe
      * one.
      *
-     * `findFocus(FOCUS_INPUT)` alone only answers for classic View hierarchies.
-     * Measured on a Compose toolbar it hands back the non-editable wrapper
-     * around the real field — a bare `android.view.View` reporting `isFocused`
-     * as false — so the whole of Firefox's address bar, and every Compose text
-     * field, was a silent dead end. Hence: take the framework's answer when it
-     * is usable, and otherwise search for the node that claims focus itself.
+     * `findFocus(FOCUS_INPUT)` alone only answers for classic View hierarchies,
+     * and it fails in two different directions. On a Compose toolbar it hands
+     * back the non-editable wrapper around the real field — a bare
+     * `android.view.View` reporting `isFocused` as false. Inside a WebView
+     * editor it returns null outright. Firefox's address bar and Gmail's
+     * compose body were both silent dead ends for those reasons.
      *
-     * Known gap: a WebView editor is still not reached. Gmail's compose body
-     * answers `findFocus` with null *and* reports a null root on its own
-     * active, focused window, so there is nothing here to search. uiautomator
-     * reads that same tree fine from its own connection, so the content is
-     * retrievable in principle — the way in has not been found yet.
+     * So: take the framework's answer when it is usable, then look inside it
+     * for the field a wrapper is hiding, and failing that ask the windows
+     * directly for the node that claims focus itself. Both routes are needed —
+     * the wrapper descent is what recovers Compose, the window search is what
+     * recovers WebView.
      */
     private fun focusedEditableNode(): AccessibilityNodeInfo? {
         val reported = findFocus(AccessibilityNodeInfo.FOCUS_INPUT)

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/accessibility/LocalFlowAccessibilityService.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/accessibility/LocalFlowAccessibilityService.kt
@@ -59,6 +59,12 @@ class LocalFlowAccessibilityService : AccessibilityService(), TranscriptInserter
         when (event?.eventType) {
             AccessibilityEvent.TYPE_VIEW_FOCUSED,
             AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED,
+            // A WebView editor announces neither focus nor selection when the
+            // caret lands in it — the first thing it says is that its text
+            // changed. Without these two, focusing Gmail's compose body
+            // produced no event at all and the bubble never re-evaluated.
+            AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED,
+            AccessibilityEvent.TYPE_VIEW_CLICKED,
             AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
             AccessibilityEvent.TYPE_WINDOWS_CHANGED,
             -> refreshBubble()
@@ -117,16 +123,58 @@ class LocalFlowAccessibilityService : AccessibilityService(), TranscriptInserter
     private fun classify(node: AccessibilityNodeInfo): FieldEligibility =
         FieldClassifier.classify(node.toSignals(), excludedPackages)
 
+    /**
+     * The focused text field, however the app's UI toolkit chooses to describe
+     * one.
+     *
+     * `findFocus(FOCUS_INPUT)` alone only answers for classic View hierarchies.
+     * Measured on a Compose toolbar it hands back the non-editable wrapper
+     * around the real field — a bare `android.view.View` reporting `isFocused`
+     * as false — so the whole of Firefox's address bar, and every Compose text
+     * field, was a silent dead end. Hence: take the framework's answer when it
+     * is usable, and otherwise search for the node that claims focus itself.
+     *
+     * Known gap: a WebView editor is still not reached. Gmail's compose body
+     * answers `findFocus` with null *and* reports a null root on its own
+     * active, focused window, so there is nothing here to search. uiautomator
+     * reads that same tree fine from its own connection, so the content is
+     * retrievable in principle — the way in has not been found yet.
+     */
     private fun focusedEditableNode(): AccessibilityNodeInfo? {
-        val focused = findFocus(AccessibilityNodeInfo.FOCUS_INPUT) ?: return null
-        // The framework can hand back a node from a window that no longer
-        // exists; refresh proves it is still alive, still focused, and still
-        // editable before anything trusts it.
-        if (!focused.refresh() || !focused.isEditable || !focused.isFocused) {
-            focused.recycleCompat()
-            return null
+        val reported = findFocus(AccessibilityNodeInfo.FOCUS_INPUT)
+        if (reported != null) {
+            // The framework can hand back a node from a window that no longer
+            // exists; refresh proves it is still alive before anything trusts it.
+            if (reported.refresh() && reported.isUsableTarget) return reported
+            // A wrapper: the field Compose actually draws is inside it.
+            reported.focusedTargetInSubtree()?.let { found ->
+                reported.recycleCompat()
+                return found
+            }
+            reported.recycleCompat()
         }
-        return focused
+        // Not rootInActiveWindow alone: it comes back null often enough that a
+        // single source would be its own dead end, so every window is asked.
+        // The IME's own window is skipped — its keys are editable-looking nodes
+        // and none of them is the user's field.
+        val budget = intArrayOf(SEARCH_NODE_BUDGET)
+        for (root in searchableRoots()) {
+            val found = root.focusedTargetInSubtree(budget)
+            if (found != null) {
+                if (found !== root) root.recycleCompat()
+                return found
+            }
+            root.recycleCompat()
+        }
+        return null
+    }
+
+    private fun searchableRoots(): List<AccessibilityNodeInfo> = buildList {
+        rootInActiveWindow?.let { add(it) }
+        runCatching { windows }.getOrNull().orEmpty().forEach { window ->
+            if (window.type == AccessibilityWindowInfo.TYPE_INPUT_METHOD) return@forEach
+            runCatching { window.root }.getOrNull()?.let { add(it) }
+        }
     }
 
     // ----------------------------------------------------------- insertion
@@ -257,8 +305,47 @@ class LocalFlowAccessibilityService : AccessibilityService(), TranscriptInserter
         getSystemService(KeyguardManager::class.java)?.isKeyguardLocked ?: false
 }
 
+/**
+ * Whether this node is the field the user is typing in and can be written to.
+ *
+ * `isEditable` is not required on its own: a WebView editor or a Compose text
+ * field can advertise [AccessibilityNodeInfo.ACTION_SET_TEXT] — which is the
+ * capability insertion actually uses — without setting the editable flag.
+ */
+internal val AccessibilityNodeInfo.isUsableTarget: Boolean
+    get() = isFocused && isEnabled && isVisibleToUser && acceptsText
+
+internal val AccessibilityNodeInfo.acceptsText: Boolean
+    get() = isEditable || actionList.any { it.id == AccessibilityNodeInfo.ACTION_SET_TEXT }
+
+/**
+ * Depth-first search for the node that reports itself focused. Bounded because
+ * this runs on every accessibility event, and an unbounded walk of a large web
+ * page would be paid on each one.
+ */
+internal fun AccessibilityNodeInfo.focusedTargetInSubtree(
+    budget: IntArray = intArrayOf(SEARCH_NODE_BUDGET),
+    depth: Int = 0,
+): AccessibilityNodeInfo? {
+    if (depth > SEARCH_MAX_DEPTH || budget[0] <= 0) return null
+    budget[0]--
+
+    if (isUsableTarget) return this
+
+    for (index in 0 until childCount) {
+        val child = runCatching { getChild(index) }.getOrNull() ?: continue
+        val found = child.focusedTargetInSubtree(budget, depth + 1)
+        if (found != null) return found
+        child.recycleCompat()
+    }
+    return null
+}
+
+private const val SEARCH_NODE_BUDGET = 600
+private const val SEARCH_MAX_DEPTH = 40
+
 internal fun AccessibilityNodeInfo.toSignals() = FieldSignals(
-    editable = isEditable,
+    editable = acceptsText,
     visibleToUser = isVisibleToUser,
     enabled = isEnabled,
     password = isPassword,

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/core/OverlayNoticePolicy.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/core/OverlayNoticePolicy.kt
@@ -1,0 +1,40 @@
+package io.github.mrsunglasses.localflow.core
+
+/**
+ * Whether to tell the user that the bubble was blocked by a missing
+ * "Display over other apps" permission.
+ *
+ * Losing that permission is silent and total: every upstream check can pass —
+ * the field is eligible, [BubblePolicy] says SHOW — and the overlay simply
+ * never reaches the screen. A fresh install is the common way in, since the
+ * permission is not carried across an uninstall. The user is typing in someone
+ * else's app when it happens, so the in-app checklist cannot reach them; a
+ * notification is the only surface that can.
+ *
+ * Consulted only at the moment the bubble was supposed to appear, so a user who
+ * has switched the bubble off, snoozed it, or simply is not typing never hears
+ * about it. One notification per blocked episode: re-posting on the next
+ * keystroke after the user has swiped it away is nagging, and swiping it away
+ * is an explicit "I have seen this". The episode ends when the permission comes
+ * back, which re-arms the notice against a later regression.
+ */
+object OverlayNoticePolicy {
+
+    enum class Action {
+        /** Tell the user the bubble is blocked. */
+        POST,
+
+        /** The permission is back; clear a notice that is no longer true. */
+        CANCEL,
+
+        NOTHING,
+    }
+
+    fun decide(overlayGranted: Boolean, alreadyPosted: Boolean): Action = when {
+        overlayGranted && alreadyPosted -> Action.CANCEL
+        overlayGranted -> Action.NOTHING
+        // Already told them, and they have not fixed it yet.
+        alreadyPosted -> Action.NOTHING
+        else -> Action.POST
+    }
+}

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/overlay/BubbleController.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/overlay/BubbleController.kt
@@ -35,6 +35,7 @@ class BubbleController(
     private val windowManager = context.getSystemService(WindowManager::class.java)
     private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop
     private val longPressTimeout = ViewConfiguration.getLongPressTimeout().toLong()
+    private val overlayNotice = OverlayPermissionNotice(context)
 
     private var root: View? = null
     private var status: TextView? = null
@@ -99,7 +100,14 @@ class BubbleController(
     fun show() {
         if (root != null) return
         if (isSnoozed || dismissed) return
-        if (!Settings.canDrawOverlays(context)) return
+        // The one failure the user cannot see from here: they are typing in
+        // another app, so the only way to explain the missing bubble is to
+        // notify. See OverlayNoticePolicy.
+        if (!Settings.canDrawOverlays(context)) {
+            overlayNotice.onBubbleBlocked()
+            return
+        }
+        overlayNotice.onOverlayAvailable()
 
         val view = LayoutInflater.from(context).inflate(R.layout.view_bubble, null, false)
         status = view.findViewById(R.id.bubble_status)

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/overlay/OverlayPermissionNotice.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/overlay/OverlayPermissionNotice.kt
@@ -1,0 +1,106 @@
+package io.github.mrsunglasses.localflow.overlay
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.core.app.NotificationCompat
+import io.github.mrsunglasses.localflow.R
+import io.github.mrsunglasses.localflow.core.OverlayNoticePolicy
+
+/**
+ * The notification that explains a bubble which never arrived. See
+ * [OverlayNoticePolicy] for when it fires and why it is a notification rather
+ * than something in the app.
+ */
+class OverlayPermissionNotice(private val context: Context) {
+
+    private var posted = false
+
+    /** The bubble was wanted and the overlay permission refused it. */
+    fun onBubbleBlocked() = apply(overlayGranted = false)
+
+    /** The bubble is about to be shown, so the permission is evidently back. */
+    fun onOverlayAvailable() = apply(overlayGranted = true)
+
+    private fun apply(overlayGranted: Boolean) {
+        when (OverlayNoticePolicy.decide(overlayGranted, posted)) {
+            OverlayNoticePolicy.Action.POST -> {
+                android.util.Log.d("LocalFlow", "bubble blocked: no overlay permission")
+                if (post()) posted = true
+            }
+
+            OverlayNoticePolicy.Action.CANCEL -> {
+                runCatching { manager()?.cancel(NOTIFICATION_ID) }
+                posted = false
+            }
+
+            OverlayNoticePolicy.Action.NOTHING -> Unit
+        }
+    }
+
+    /**
+     * False when the post did not land — most often notifications are denied
+     * too, in which case nothing is marked as told and a later attempt can
+     * still succeed.
+     */
+    private fun post(): Boolean {
+        val manager = manager() ?: return false
+        createChannel(manager)
+
+        val settings = Intent(
+            Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+            Uri.fromParts("package", context.packageName, null),
+        ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        val tap = PendingIntent.getActivity(
+            context,
+            REQUEST_CODE,
+            settings,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_warning)
+            .setContentTitle("Local Flow can't show the bubble")
+            .setContentText("\"Display over other apps\" is off. Tap to turn it back on.")
+            .setStyle(
+                NotificationCompat.BigTextStyle().bigText(
+                    "Local Flow needs \"Display over other apps\" to draw the " +
+                        "dictation bubble. Android switches it off on a fresh " +
+                        "install, so dictation into other apps stays unavailable " +
+                        "until it is granted again. Tap to open the setting.",
+                )
+            )
+            .setCategory(NotificationCompat.CATEGORY_ERROR)
+            .setAutoCancel(true)
+            .setContentIntent(tap)
+            .build()
+
+        // Notifications may be denied outright; a blocked bubble is not worth
+        // crashing the accessibility service over.
+        return runCatching { manager.notify(NOTIFICATION_ID, notification) }.isSuccess
+    }
+
+    private fun createChannel(manager: NotificationManager) {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Bubble unavailable",
+            NotificationManager.IMPORTANCE_DEFAULT,
+        ).apply {
+            description = "Shown when a permission stops the dictation bubble appearing."
+            setShowBadge(false)
+        }
+        manager.createNotificationChannel(channel)
+    }
+
+    private fun manager() = context.getSystemService(NotificationManager::class.java)
+
+    private companion object {
+        const val CHANNEL_ID = "localflow.bubble_blocked"
+        const val NOTIFICATION_ID = 4102
+        const val REQUEST_CODE = 2
+    }
+}

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/DictateScreen.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/DictateScreen.kt
@@ -41,6 +41,8 @@ fun DictateScreen(
     onCancel: () -> Unit,
     onRetry: (String) -> Unit,
     onDismiss: () -> Unit,
+    onOpenGateway: () -> Unit,
+    onAcceptDisclosure: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var scratchpad by remember { mutableStateOf(TextFieldValue()) }
@@ -142,12 +144,20 @@ fun DictateScreen(
 
             if (!setup.isReadyToDictate) {
                 Text(
-                    "Finish setup before dictating.",
+                    "Dictation is paused — see below.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
                 )
             }
         }
+
+        // Directly under the disabled button rather than at the foot of the
+        // screen: this is the answer to why the button will not press.
+        SetupRepairCard(
+            status = setup,
+            onOpenGateway = onOpenGateway,
+            onAcceptDisclosure = onAcceptDisclosure,
+        )
 
         SectionCard(
             title = "Scratchpad",

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/MainActivity.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/MainActivity.kt
@@ -152,6 +152,8 @@ fun LocalFlowApp(viewModel: LocalFlowViewModel = viewModel()) {
                 onCancel = viewModel::cancelDictation,
                 onRetry = viewModel::retry,
                 onDismiss = viewModel::dismissDictation,
+                onOpenGateway = { showingGateway = true },
+                onAcceptDisclosure = { viewModel.setDisclosureAccepted(true) },
                 modifier = content,
             )
 

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/SetupRepair.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/SetupRepair.kt
@@ -1,0 +1,133 @@
+package io.github.mrsunglasses.localflow.ui
+
+import android.Manifest
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+
+/**
+ * The way back when a step that was satisfied once stops being satisfied.
+ *
+ * Force stop is the usual cause and by far the least obvious: Android drops an
+ * app out of `ENABLED_ACCESSIBILITY_SERVICES` whenever the user force stops it,
+ * and no manifest flag or API opts out of that. Onboarding has long since
+ * completed by then, so the checklist that would have explained any of this is
+ * gated off for good — without this card the bubble simply stops appearing and
+ * nothing on screen says why, or what to do about it.
+ *
+ * It deliberately repeats the setup screen's actions rather than sending the
+ * user back into onboarding: only one step is usually broken, and re-running a
+ * six-step wizard to repair it reads as though the app has forgotten them.
+ *
+ * The `when` below is exhaustive on purpose: a new [SetupStep] has to be given a
+ * repair route here before this compiles, rather than silently going missing.
+ */
+@Composable
+fun SetupRepairCard(
+    status: SetupStatus,
+    onOpenGateway: () -> Unit,
+    onAcceptDisclosure: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val missing = status.remainingSteps
+    if (missing.isEmpty()) return
+
+    // Consent, not a checkbox: the disclosure gets its own full card below, so
+    // repairing it cannot become a one-tap accept next to unrelated rows. Held
+    // out of the checklist here as well, so a disclosure-only repair does not
+    // render a headed card with nothing inside it.
+    val rows = missing.filterNot { it == SetupStep.DISCLOSURE }
+
+    val context = LocalContext.current
+    val requestPermission = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { }
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        if (rows.isNotEmpty()) {
+            SectionCard(
+                title = if (missing.size == 1) {
+                    "One thing needs fixing"
+                } else {
+                    "${missing.size} things need fixing"
+                },
+                supporting = "Dictation stays paused until these are back.",
+            ) {
+                rows.forEach { step ->
+                    when (step) {
+                        // Filtered out above; kept so the `when` stays exhaustive.
+                        SetupStep.DISCLOSURE -> Unit
+
+                        SetupStep.MICROPHONE -> ChecklistRow(
+                            title = "Microphone",
+                            detail = "Records only while you are dictating.",
+                            satisfied = false,
+                            actionLabel = "Grant",
+                            onAction = {
+                                requestPermission.launch(Manifest.permission.RECORD_AUDIO)
+                            },
+                        )
+
+                        SetupStep.NOTIFICATIONS -> ChecklistRow(
+                            title = "Notifications",
+                            detail = "Shows the ongoing recording notification Android requires.",
+                            satisfied = false,
+                            actionLabel = "Grant",
+                            onAction = {
+                                requestPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+                            },
+                        )
+
+                        SetupStep.OVERLAY -> ChecklistRow(
+                            title = "Display over other apps",
+                            detail = "Draws the dictation bubble above the app you are typing in.",
+                            satisfied = false,
+                            actionLabel = "Open",
+                            onAction = { context.openOverlaySettings() },
+                        )
+
+                        SetupStep.ACCESSIBILITY -> ChecklistRow(
+                            title = "Accessibility service",
+                            detail = "Finds the focused field and inserts your transcript. " +
+                                "Force stopping Local Flow always switches this off — " +
+                                "Android does that to every app with an accessibility " +
+                                "service, and only you can switch it back on.",
+                            satisfied = false,
+                            actionLabel = "Open",
+                            onAction = { context.openAccessibilitySettings() },
+                        )
+
+                        SetupStep.GATEWAY -> ChecklistRow(
+                            title = "Gateway",
+                            detail = "The self-hosted Local Flow server that transcribes " +
+                                "your speech.",
+                            satisfied = false,
+                            actionLabel = "Set up",
+                            onAction = onOpenGateway,
+                        )
+                    }
+                }
+            }
+        }
+
+        if (SetupStep.DISCLOSURE in missing) {
+            AccessibilityDisclosureCard(accepted = false, onAccept = onAcceptDisclosure)
+        }
+
+        if (status.restrictedSettingsGuidance) {
+            RestrictedSettingsCard(
+                onOpenAccessibilitySettings = { context.openAccessibilitySettings() },
+                onOpenAppInfo = { context.openAppSettings() },
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/SetupScreen.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/ui/SetupScreen.kt
@@ -9,7 +9,6 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -241,16 +240,19 @@ fun RestrictedSettingsCard(
                 "on — it will work this time.",
             style = MaterialTheme.typography.bodyMedium,
         )
-        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        // Stacked rather than side by side: at a large display size two weighted
+        // buttons clip their labels to "1." and "2. App", which loses precisely
+        // the ordering the numbered steps above are asking the user to follow.
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             PrimaryButton(
-                text = "1. Accessibility",
+                text = "1. Accessibility settings",
                 onClick = onOpenAccessibilitySettings,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.fillMaxWidth(),
             )
             SecondaryButton(
                 text = "2. App info",
                 onClick = onOpenAppInfo,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.fillMaxWidth(),
             )
         }
         Text(

--- a/android/app/src/main/res/xml/accessibility_service_config.xml
+++ b/android/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
-    android:accessibilityEventTypes="typeViewFocused|typeViewTextSelectionChanged|typeWindowStateChanged|typeWindowsChanged"
+    android:accessibilityEventTypes="typeViewFocused|typeViewTextSelectionChanged|typeViewTextChanged|typeViewClicked|typeWindowStateChanged|typeWindowsChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
     android:accessibilityFlags="flagDefault|flagIncludeNotImportantViews|flagRetrieveInteractiveWindows"
     android:canRetrieveWindowContent="true"

--- a/android/app/src/test/java/io/github/mrsunglasses/localflow/core/OverlayNoticePolicyTest.kt
+++ b/android/app/src/test/java/io/github/mrsunglasses/localflow/core/OverlayNoticePolicyTest.kt
@@ -1,0 +1,61 @@
+package io.github.mrsunglasses.localflow.core
+
+import io.github.mrsunglasses.localflow.core.OverlayNoticePolicy.Action
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OverlayNoticePolicyTest {
+
+    @Test
+    fun `tells the user the first time the bubble is blocked`() {
+        assertEquals(
+            Action.POST,
+            OverlayNoticePolicy.decide(overlayGranted = false, alreadyPosted = false),
+        )
+    }
+
+    @Test
+    fun `does not re-post on every keystroke while it stays broken`() {
+        // refreshBubble runs on every accessibility event, so the un-posted
+        // state is the only thing standing between the user and a flood.
+        assertEquals(
+            Action.NOTHING,
+            OverlayNoticePolicy.decide(overlayGranted = false, alreadyPosted = true),
+        )
+    }
+
+    @Test
+    fun `clears the notice once the permission is granted again`() {
+        assertEquals(
+            Action.CANCEL,
+            OverlayNoticePolicy.decide(overlayGranted = true, alreadyPosted = true),
+        )
+    }
+
+    @Test
+    fun `stays quiet when the bubble works and nothing was ever posted`() {
+        assertEquals(
+            Action.NOTHING,
+            OverlayNoticePolicy.decide(overlayGranted = true, alreadyPosted = false),
+        )
+    }
+
+    @Test
+    fun `re-arms after a repair so a later regression is reported again`() {
+        var posted = false
+        fun step(granted: Boolean): Action =
+            OverlayNoticePolicy.decide(granted, posted).also { action ->
+                when (action) {
+                    Action.POST -> posted = true
+                    Action.CANCEL -> posted = false
+                    Action.NOTHING -> Unit
+                }
+            }
+
+        assertEquals(Action.POST, step(granted = false))
+        assertEquals(Action.NOTHING, step(granted = false))
+        assertEquals(Action.CANCEL, step(granted = true))
+        // Permission revoked a second time: the user hears about it again.
+        assertEquals(Action.POST, step(granted = false))
+    }
+}


### PR DESCRIPTION
## The bug

After a force stop, the bubble stops working and the user has to grant accessibility again — with nothing on screen explaining why or how.

The revocation itself is Android, not us. `AccessibilityManagerService`'s package monitor removes the component from `mEnabledServices` and persists the emptied list on force stop. There is no manifest flag or API that opts out — an accessibility service auto-rebinds forever, so revoking the grant is the only way the platform can honour "force stop".

Confirmed on the Pixel 6a (Android 17 / API 37):

```
before: io.github.mrsunglasses.localflow/...LocalFlowAccessibilityService
after:  null          # accessibility_enabled also flipped 1 → 0
```

## What was actually broken on our side

Detection was already fine — `SetupStatus` reads `Settings.Secure` directly and re-reads on every `ON_RESUME`. The problem was recovery:

- `onboardingComplete` is persisted and untouched by a force stop, so `showSetup` stays `false` and the checklist never returns.
- The Dictate screen showed only *"Finish setup before dictating."* — no action, no indication of which step.
- The one working repair button was three sections deep in Settings → Floating bubble.
- `restrictedSettingsGuidance` was computed correctly but only rendered on the setup screen. A sideloaded user hitting the greyed-out "Restricted setting" switch a second time had the explanation unreachable.

## Change

`SetupRepairCard` (new, `ui/SetupRepair.kt`) lists the steps actually missing from `SetupStatus.remainingSteps`, each with the action that repairs it, plus the restricted-settings guidance when it applies. Rendered on the Dictate screen directly under the disabled button.

The `when` over `SetupStep` is exhaustive with no `else`, so a new step must be given a repair route before this compiles. The disclosure is held out of the checklist and shown as its own full card — a one-tap accept beside unrelated rows would undercut the prominent-disclosure requirement.

Also stacks the restricted-settings buttons rather than weighting them side by side: at a large display size the labels clipped to **"1."** and **"2. App"**, losing the ordering the numbered steps depend on. Pre-existing, but this change puts that card in front of more users.

## Verified on device

| | |
|---|---|
| Full setup, all granted | No repair card, "Start dictation" enabled |
| Force stop → reopen | "One thing needs fixing" → Accessibility service + explanation + Open |
| Restricted-settings card | Now reachable post-onboarding |
| "Open" | Launches `Settings$AccessibilitySettingsActivity` |
| "2. App info" | Launches App info |
| Re-grant → resume | Card clears, button re-enables, service rebinds |

Gateway round-trip against the real server reported "Connected and ready". `testDebugUnitTest` and `lintDebug` pass.

## Not in scope

`LocalFlowAccessibilityService.onUnbind` cancels its `CoroutineScope`. It works today — `AccessibilityService` doesn't override `onUnbind`, so it returns `false` and the instance is destroyed and recreated — but `onDestroy` is the correct hook if the service ever gains another binding path. Left alone; unrelated to this bug.