### PR TITLE
feat: add Russian to iOS transcription languages

### DIFF
--- a/ios/LocalFlowShared/KeyboardPreferences.swift
+++ b/ios/LocalFlowShared/KeyboardPreferences.swift
@@ -74,6 +74,7 @@ enum TranscriptionLanguage: String, Codable, CaseIterable, Identifiable, Sendabl
     case korean = "ko"
     case mandarinChinese = "zh"
     case ukrainian = "uk"
+    case russian = "ru"
     case vietnamese = "vi"
 
     var id: String { rawValue }
@@ -88,6 +89,7 @@ enum TranscriptionLanguage: String, Codable, CaseIterable, Identifiable, Sendabl
         case .korean: "Korean"
         case .mandarinChinese: "Mandarin Chinese"
         case .ukrainian: "Ukrainian"
+        case .russian: "Russian"
         case .vietnamese: "Vietnamese"
         }
     }
@@ -102,6 +104,7 @@ enum TranscriptionLanguage: String, Codable, CaseIterable, Identifiable, Sendabl
         case .korean: "KO"
         case .mandarinChinese: "ZH"
         case .ukrainian: "UK"
+        case .russian: "RU"
         case .vietnamese: "VI"
         }
     }

--- a/ios/LocalFlowTests/SessionRecordTests.swift
+++ b/ios/LocalFlowTests/SessionRecordTests.swift
@@ -233,7 +233,7 @@ struct SessionRecordTests {
 
     @Test func transcriptionLanguagesHaveStableGatewayValues() {
         #expect(TranscriptionLanguage.allCases.map(\.rawValue) == [
-            "auto", "en", "es", "ar", "ja", "ko", "zh", "uk", "vi",
+            "auto", "en", "es", "ar", "ja", "ko", "zh", "uk", "ru", "vi",
         ])
         #expect(SessionRecord().language == TranscriptionLanguage.automatic.rawValue)
     }


### PR DESCRIPTION
Mirrors #23, which added Russian on Android. iOS was left behind, so a gateway running a Russian model could be selected from one client but not the other.

## Change

`TranscriptionLanguage` in `LocalFlowShared` gains `case russian = "ru"`, plus its `displayName` ("Russian") and `shortLabel` ("RU"). Both UI sites — the app's Settings picker and the keyboard's language menu — iterate `allCases`, so the enum is the only place that needed touching.

Ordered between Ukrainian and Vietnamese to match the Android enum, so both platforms send the same wire values in the same order. That ordering is exactly what the two wire-value tests exist to pin down, and `SessionRecordTests.transcriptionLanguagesHaveStableGatewayValues` is updated to match its Android counterpart.

## Gateway

No server change needed — `server/app/catalog.py` already registers models with `language_codes=("ru",)` and lists `"ru"` among supported codes.

## Verified

`xcodebuild test` against the iPhone 17 Pro simulator: **75 tests in 7 suites passed**, including the updated wire-value assertion.

`docs/decisions.md` already lists Russian — that row is shared across platforms and was updated by #23.