### PR TITLE
feat: add German to Android transcription languages

### DIFF
--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/core/TranscriptionLanguage.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/core/TranscriptionLanguage.kt
@@ -14,7 +14,8 @@ enum class TranscriptionLanguage(val wireValue: String) {
     MANDARIN_CHINESE("zh"),
     UKRAINIAN("uk"),
     RUSSIAN("ru"),
-    VIETNAMESE("vi");
+    VIETNAMESE("vi"),
+    GERMAN("de");
 
     val displayName: String
         get() = when (this) {
@@ -28,6 +29,7 @@ enum class TranscriptionLanguage(val wireValue: String) {
             UKRAINIAN -> "Ukrainian"
             RUSSIAN -> "Russian"
             VIETNAMESE -> "Vietnamese"
+            GERMAN -> "German"
         }
 
     val shortLabel: String

--- a/android/app/src/test/java/io/github/mrsunglasses/localflow/core/WireValuesTest.kt
+++ b/android/app/src/test/java/io/github/mrsunglasses/localflow/core/WireValuesTest.kt
@@ -20,7 +20,7 @@ class WireValuesTest {
     @Test
     fun `languages match the server literals in order`() {
         assertEquals(
-            listOf("auto", "en", "es", "ar", "ja", "ko", "zh", "uk", "ru", "vi"),
+            listOf("auto", "en", "es", "ar", "ja", "ko", "zh", "uk", "ru", "vi", "de"),
             TranscriptionLanguage.entries.map { it.wireValue },
         )
     }


### PR DESCRIPTION
**Language Support Updates:**

* Added `GERMAN` as a new member to the `TranscriptionLanguage` enum with the wire value `"de"`.
* Updated the `displayName` property to return `"German"` for the new `GERMAN` enum value.

