### PR TITLE
docs: rebrand README around the vocaphone story

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.cursor/
 __pycache__/
 *.py[cod]
 .mypy_cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing
 
-Thanks for helping improve Local Flow. Changes should preserve its privacy-first
-architecture, documented network-exposure controls, and iOS keyboard constraints.
+Thanks for helping improve vocaphone. (The working name in code is still Local
+Flow.) Changes should keep the privacy-first architecture, the documented
+network-exposure controls, and the iOS keyboard constraints intact.
 
 ## Development setup
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,88 @@
-# Local Flow
+<div align="center">
 
-Local Flow is privacy-first dictation backed by speech models running on hardware
-you control. On iPhone it is a keyboard that coordinates recording through its
-containing app; on Android it is a floating bubble that leaves your own keyboard
-alone. Both send recoverable audio to the same private gateway and insert the
-final transcript directly at the active cursor.
+# vocaphone
 
-The complete keyboard handoff, background recording, private Tailscale
-transcription, and direct text-insertion flow has been exercised on a physical
-iPhone 14 Pro. The [Android client](android/README.md) builds, passes its unit
-tests, and has not yet been exercised end to end on a physical Pixel.
+**Voice dictation for iPhone and Android.**
+
+[![Status: in development](https://img.shields.io/badge/status-in%20development-yellow)](#status)
+[![Platform: iOS + Android](https://img.shields.io/badge/platform-iOS%20%2B%20Android-lightgrey)](#how-it-works)
+[![Privacy: self-hosted](https://img.shields.io/badge/privacy-self--hosted%20%2F%20no%20cloud%20STT-success)](#privacy-and-platform-boundaries)
+[![Part of VocaHQ](https://img.shields.io/badge/family-VocaHQ-1a7f4e)](https://github.com/VocaHQ)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+
+Speak into your phone. Text shows up where you're typing. Transcription runs on
+hardware you control, not a cloud speech service.
+
+</div>
+
+---
+
+**vocaphone** is the phone side of the [Voca](https://github.com/VocaHQ) family:
+the same privacy-first dictation idea that already runs on Linux
+([VocaLinux](https://github.com/VocaHQ/vocalinux)) and macOS
+([VocaMac](https://github.com/VocaHQ/vocamac)), with Windows coming later.
+
+Longer term the goal is straightforward: set Voca up once and use it across
+whatever machines you own. Desktop plus phone is what makes that real.
+
+Dictate from an iPhone keyboard or an Android floating bubble. Audio goes to a
+gateway on your Mac, Linux box, or home server. Local speech models turn it into
+text, and the transcript lands at your cursor. No accounts, no cloud STT, and no
+subscription.
+
+> Working name in code and binaries is still **Local Flow**
+> (`localflow-server`, `com.example.localflow`, ...). Product name in prose and
+> on GitHub is **vocaphone**. Bundle IDs and package names will catch up before
+> a public release.
+
+## Status
+
+| Client | State |
+| --- | --- |
+| **iOS** | End-to-end flow exercised on a physical iPhone 14 Pro: keyboard handoff, background recording, private Tailscale transcription, direct insertion |
+| **Android** | Builds and passes unit tests; floating-bubble client not yet exercised end to end on a physical Pixel |
+| **Gateway** | Runs natively on macOS/Linux or via Docker Compose, with multiple local engine adapters |
+
+No open-source license has been selected yet. Until one is added, the
+repository is source-available for review but does not grant permission to copy,
+modify, or redistribute the code.
+
+## How it works
+
+On iPhone, vocaphone is a custom keyboard plus a containing app. iOS keyboard
+extensions cannot access the microphone, so the app records, shares only
+versioned session state with the keyboard, and inserts through
+`UITextDocumentProxy`. Quick Dictation can keep the app ready for up to 10
+minutes so most later dictations skip another app switch.
+
+On Android, your own keyboard stays put. A floating bubble starts and stops
+dictation and inserts at the focused field, with the same styles, languages, and
+gateway as iOS.
+
+Both clients send recoverable audio to the same private gateway and insert the
+final transcript at the active cursor.
 
 > [!IMPORTANT]
-> iOS keyboard extensions cannot access the microphone. Local Flow records in
+> iOS keyboard extensions cannot access the microphone. vocaphone records in
 > the containing app, shares only versioned session state with the keyboard, and
 > then inserts through `UITextDocumentProxy`. Quick Dictation can keep that app
 > ready for up to 10 minutes so most later dictations do not require another app
 > switch.
+
+## Why vocaphone
+
+Most phone dictation means either a cloud API listening to every utterance, or
+an app that only works inside itself. vocaphone is built differently.
+
+Transcription runs on a Mac, Linux desktop, or home server you already own, not
+a vendor's GPU farm. You pick the network path: trusted LAN, private Tailscale,
+or HTTPS behind your own reverse proxy. Bearer tokens are per device. There is
+no analytics SDK and no third-party transcription.
+
+Same privacy stance as VocaLinux and VocaMac: free, offline first, and meant to
+stay that way. We also document the awkward platform bits honestly: iOS keyboard
+limits, Android accessibility consent, and what the bubble will never touch
+(password fields, payment screens, apps you exclude).
 
 ## Highlights
 
@@ -33,16 +99,27 @@ tests, and has not yet been exercised end to end on a physical Pixel.
 - FastAPI gateway with bounded uploads, SQLite idempotency, FFmpeg normalization,
   silence detection, retention cleanup, and stable error responses
 - VocaMac, Handy, WhisperKit, Apple-native MLX Audio, persistent `sherpa-onnx`
-  and `faster-whisper`, multilingual Moonshine, and `whisper.cpp` adapters —
-  the VocaMac and Handy desktop apps are optional, Mac-only, and reuse the
+  and `faster-whisper`, multilingual Moonshine, and `whisper.cpp` adapters.
+  The VocaMac and Handy desktop apps are optional, Mac-only, and reuse the
   models they already downloaded
 - Operational dashboard with hardware detection, queue/outcome counters,
   pipeline benchmarks, real-time factor, peak memory, and warmup state
 - CPU/OpenBLAS, host-native CPU, NVIDIA CUDA, and Vulkan Compose profiles
 - Bearer authentication with named per-device tokens and revocation, iOS
   Keychain storage, configurable HTTP/HTTPS gateway access, optional private
-  Tailscale HTTPS, no analytics, and no third-party
-  transcription
+  Tailscale HTTPS, no analytics, and no third-party transcription
+
+## Part of VocaHQ
+
+| Platform | Project | Repo | Status |
+| --- | --- | --- | --- |
+| Linux | VocaLinux | [VocaHQ/vocalinux](https://github.com/VocaHQ/vocalinux) | Stable |
+| macOS | VocaMac | [VocaHQ/vocamac](https://github.com/VocaHQ/vocamac) | Beta |
+| Windows | VocaWin | [VocaHQ/vocawin](https://github.com/VocaHQ/vocawin) | Coming soon |
+| iOS / Android | vocaphone | [VocaHQ/vocaphone](https://github.com/VocaHQ/vocaphone) | In development |
+
+Org: [github.com/VocaHQ](https://github.com/VocaHQ). Contact:
+[hello@vocahq.com](mailto:hello@vocahq.com)
 
 ## Choose a gateway deployment
 
@@ -54,7 +131,7 @@ tests, and has not yet been exercised end to end on a physical Pixel.
 
 On an Apple silicon Mac, use the native gateway for the lowest virtualization
 overhead. MLX Audio runs directly on M-series unified memory/GPU, while
-WhisperKit uses Core ML; Local Flow keeps either selected model resident between
+WhisperKit uses Core ML; the gateway keeps either selected model resident between
 dictations. The container deliberately uses portable Linux runtimes and cannot
 use macOS MLX or Core ML from inside Docker Desktop.
 
@@ -234,9 +311,9 @@ Then:
 1. Generate/open `ios/LocalFlow.xcodeproj` and select your Apple development team.
 2. Register the same App Group for the app, keyboard, and Live Activity targets.
 3. Install the containing app on the iPhone and grant microphone permission.
-4. Add Local Flow under **Settings → General → Keyboard → Keyboards** and enable
+4. Add the keyboard under **Settings → General → Keyboard → Keyboards** and enable
    Full Access.
-5. In Local Flow, enter the reachable HTTP/HTTPS gateway URL and bearer token,
+5. In the app, enter the reachable HTTP/HTTPS gateway URL and bearer token,
    then use **Save and test**. Approve Local Network access when using a LAN host.
 
 Complete the physical-device checklist in [device setup](docs/device-setup.md).
@@ -342,7 +419,8 @@ Plan-Android.md         Android implementation plan and acceptance criteria
 - Operational metrics contain counts and timings only and reset when the gateway
   restarts.
 - iOS does not provide a public API to reopen an arbitrary previously active app.
-  If Quick Dictation expires, Local Flow must open and the user returns manually.
+  If Quick Dictation expires, the containing app must open and the user returns
+  manually.
 - Secure fields and apps that disable third-party keyboards remain iOS platform
   limitations.
 - On Android, accessibility access is used only to identify the focused editable

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,17 +3,18 @@
 ## Supported version
 
 The latest code on `main` is the only version currently receiving security and
-privacy fixes. Local Flow has not had a public production release.
+privacy fixes. vocaphone has not had a public production release.
 
 ## Reporting a vulnerability
 
 Do not open a public issue for suspected vulnerabilities involving microphone
-access, recordings, transcripts, App Group data, bearer tokens, the Mac gateway,
-or Tailscale exposure.
+access, recordings, transcripts, App Group data, bearer tokens, the Mac/Linux
+gateway, or Tailscale exposure.
 
 Use GitHub's private vulnerability reporting option in the repository's
-**Security** tab when it is available. Otherwise, contact the repository owner
-through the GitHub profile and request a private channel before sharing details.
+**Security** tab when it is available. Otherwise, contact
+[hello@vocahq.com](mailto:hello@vocahq.com) or the maintainers through GitHub
+and request a private channel before sharing details.
 
 Include the affected component, reproduction steps, impact, and any suggested
 mitigation. Do not include real recordings, transcripts, tokens, private

--- a/android/README.md
+++ b/android/README.md
@@ -1,18 +1,21 @@
-# Local Flow for Android
+# vocaphone for Android
 
-A native Android dictation client for the same self-hosted Local Flow gateway the
+A native Android dictation client for the same self-hosted vocaphone gateway the
 iPhone app uses. Unlike iOS, it does **not** replace your keyboard. Gboard,
-Samsung Keyboard or whatever you already use stays active, and Local Flow shows a
+Samsung Keyboard or whatever you already use stays active, and vocaphone shows a
 floating bubble over eligible text fields, inserting the transcript at your
 cursor when you finish.
 
 Distributed as a private APK. Google Play publication is deferred, but the
 accessibility disclosure and consent Play requires are present from the start.
 
+> In-code package and APK names still use the Local Flow working name
+> (`local-flow-debug.apk`, `com.example.localflow.android`).
+
 ## Requirements
 
 - Android 13 (API 33) or newer. Google Pixel is the baseline device.
-- A reachable Local Flow gateway — see the [root README](../README.md).
+- A reachable vocaphone gateway. See the [root README](../README.md).
 - To build: JDK 17+ (the JDK bundled with Android Studio works) and the Android
   SDK. Everything else is pinned in `gradle/libs.versions.toml` and fetched by
   the Gradle wrapper.
@@ -56,7 +59,7 @@ silent failure.
 
 ## How accessibility access is used
 
-Local Flow is not an accessibility tool, so it states plainly what it does with
+vocaphone is not an accessibility tool, so it states plainly what it does with
 the service, and the app asks for separate consent before the checklist step:
 
 - To tell whether the focused text field can be dictated into, so the bubble

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -6,7 +6,7 @@ These are changeable implementation defaults, not confirmed product decisions:
 
 | Choice | Current assumption | Why |
 | --- | --- | --- |
-| Product name | Local Flow | Codename from `Plan.md` |
+| Product name | **vocaphone** (prose / GitHub); Local Flow still used in code, binaries, and placeholders | Product name chosen for the Voca family; code identifiers catch up before public release |
 | Minimum iOS | iOS 17.0 | Supports the chosen SwiftUI and audio APIs |
 | App bundle ID | `com.example.localflow` | Placeholder that builds unsigned |
 | Keyboard bundle ID | `com.example.localflow.keyboard` | Placeholder |
@@ -24,7 +24,8 @@ These are changeable implementation defaults, not confirmed product decisions:
 
 ## Must be confirmed before physical-device acceptance
 
-- Final product name, bundle identifiers, Apple team, and App Group
+- Bundle identifiers, Apple team, and App Group (product name is **vocaphone**;
+  migrate off `localflow` / `com.example.localflow` placeholders)
 - Whether iOS 17.0 is the desired minimum
 - Mac availability and sleep policy
 - Whether mixed Hindi/English should be added through a separate multilingual model

--- a/server/README.md
+++ b/server/README.md
@@ -1,9 +1,12 @@
-# Local Flow gateway
+# vocaphone gateway
 
-The gateway accepts bounded recordings from the Local Flow iPhone app,
-normalizes them with FFmpeg, invokes a local speech engine, and returns an
+The gateway accepts bounded recordings from the vocaphone iPhone and Android
+apps, normalizes them with FFmpeg, invokes a local speech engine, and returns an
 idempotent transcript. It includes an authenticated HTMX WebUI for setup, model
 management, engine selection, microphone testing, and operational status.
+
+> CLI entry points, env vars, and config paths still use the Local Flow working
+> name (`localflow-server`, `LOCALFLOW_*`, `~/.config/localflow/`).
 
 ## Deployment summary
 
@@ -29,7 +32,7 @@ Requires [Homebrew](https://brew.sh/), Python 3.12+, and
 - `whisper-cpp` — provides `whisper-cli` for GGML `whisper.cpp` models,
   including the Handy model family, which runs without the Handy app
 
-The [VocaMac](https://github.com/jatinkrmalik/vocamac) and
+The [VocaMac](https://github.com/VocaHQ/vocamac) and
 [Handy](https://handy.computer) desktop apps are **optional and Mac-only**:
 VocaMac needs an Apple silicon Mac, Handy needs macOS. Install neither and the
 gateway downloads and runs its own models; install either and the gateway can


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Updates the root README and nearby docs so the project reads as vocaphone within the Voca family.
- Keeps Local Flow as the in-code working name for binaries, env vars, and placeholders.

## Verification

- [x] Documentation-only change
- [ ] `uv run ruff check .`
- [ ] `uv run ruff format --check .`
- [ ] `uv run mypy app`
- [ ] `uv run pytest`
- [ ] Compose validation/container build, if deployment files changed
- [ ] iOS simulator build/tests
- [ ] Physical-device test, if keyboard, microphone, background audio, or insertion changed

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for product naming / contact only (no data-flow changes)


