### PR TITLE
feat: add French to Android transcription languages (apply sort)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ versioned session state with the keyboard, and inserts through
 minutes so most later dictations skip another app switch.
 
 On Android, your own keyboard stays put. A floating bubble starts and stops
-dictation and inserts at the focused field, with the same styles, languages, and
-gateway as iOS.
+dictation and inserts at the focused field, with the same styles and gateway as
+iOS.
 
 Both clients send recoverable audio to the same private gateway and insert the
 final transcript at the active cursor.
@@ -89,9 +89,10 @@ limits, Android accessibility consent, and what the bubble will never touch
 - Native SwiftUI app and UIKit keyboard with Start, Finish, Cancel, Retry, Undo,
   language/style status, next-keyboard control, and direct insertion
 - Native Kotlin/Compose Android client that keeps your own keyboard and dictates
-  through a floating bubble, with the same styles, languages, and gateway
-- Eight selectable transcription languages plus Automatic, shared by the app
-  and keyboard, and four writing styles: Formal, Casual, Very Casual, and Excited
+  through a floating bubble, with the same styles and gateway as the keyboard
+- 11 selectable transcription languages plus Automatic on Android (9 on iOS,
+  pending French and German), and four writing styles: Formal, Casual, Very
+  Casual, and Excited
 - Automatic microphone routing or an explicit iPhone Microphone preference,
   with the input currently in use shown in the app
 - A bounded Quick Dictation window with persistent background input, a Live

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/core/TranscriptionLanguage.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/core/TranscriptionLanguage.kt
@@ -5,8 +5,8 @@ package io.github.mrsunglasses.localflow.core
  * first as the default; the rest are alphabetical by [displayName].
  */
 enum class TranscriptionLanguage(val wireValue: String) {
-    ARABIC("ar"),
     AUTOMATIC("auto"),
+    ARABIC("ar"),
     ENGLISH("en"),
     FRENCH("fr"),
     GERMAN("de"),
@@ -24,6 +24,7 @@ enum class TranscriptionLanguage(val wireValue: String) {
             ARABIC -> "Arabic"
             ENGLISH -> "English"
             FRENCH -> "French"
+            GERMAN -> "German"
             JAPANESE -> "Japanese"
             KOREAN -> "Korean"
             MANDARIN_CHINESE -> "Mandarin Chinese"
@@ -31,7 +32,6 @@ enum class TranscriptionLanguage(val wireValue: String) {
             SPANISH -> "Spanish"
             UKRAINIAN -> "Ukrainian"
             VIETNAMESE -> "Vietnamese"
-            GERMAN -> "German"
         }
 
     val shortLabel: String

--- a/android/app/src/main/java/io/github/mrsunglasses/localflow/core/TranscriptionLanguage.kt
+++ b/android/app/src/main/java/io/github/mrsunglasses/localflow/core/TranscriptionLanguage.kt
@@ -1,33 +1,35 @@
 package io.github.mrsunglasses.localflow.core
 
 /**
- * Mirrors the gateway's accepted `language` values and the iOS client's
- * `TranscriptionLanguage`, in the same order.
+ * Mirrors the gateway's accepted `language` values. Automatic is pinned
+ * first as the default; the rest are alphabetical by [displayName].
  */
 enum class TranscriptionLanguage(val wireValue: String) {
+    ARABIC("ar"),
     AUTOMATIC("auto"),
     ENGLISH("en"),
-    SPANISH("es"),
-    ARABIC("ar"),
+    FRENCH("fr"),
+    GERMAN("de"),
     JAPANESE("ja"),
     KOREAN("ko"),
     MANDARIN_CHINESE("zh"),
-    UKRAINIAN("uk"),
     RUSSIAN("ru"),
-    VIETNAMESE("vi"),
-    GERMAN("de");
+    SPANISH("es"),
+    UKRAINIAN("uk"),
+    VIETNAMESE("vi");
 
     val displayName: String
         get() = when (this) {
             AUTOMATIC -> "Automatic"
-            ENGLISH -> "English"
-            SPANISH -> "Spanish"
             ARABIC -> "Arabic"
+            ENGLISH -> "English"
+            FRENCH -> "French"
             JAPANESE -> "Japanese"
             KOREAN -> "Korean"
             MANDARIN_CHINESE -> "Mandarin Chinese"
-            UKRAINIAN -> "Ukrainian"
             RUSSIAN -> "Russian"
+            SPANISH -> "Spanish"
+            UKRAINIAN -> "Ukrainian"
             VIETNAMESE -> "Vietnamese"
             GERMAN -> "German"
         }

--- a/android/app/src/test/java/io/github/mrsunglasses/localflow/core/WireValuesTest.kt
+++ b/android/app/src/test/java/io/github/mrsunglasses/localflow/core/WireValuesTest.kt
@@ -20,7 +20,7 @@ class WireValuesTest {
     @Test
     fun `languages match the server literals in order`() {
         assertEquals(
-            listOf("auto", "en", "es", "ar", "ja", "ko", "zh", "uk", "ru", "vi", "de"),
+            listOf("auto", "ar", "en", "fr", "de", "ja", "ko", "zh", "ru", "es", "uk", "vi"),
             TranscriptionLanguage.entries.map { it.wireValue },
         )
     }


### PR DESCRIPTION
**Transcription language updates:**

* Changed the order of `TranscriptionLanguage` enum values so that `AUTOMATIC` is first (as the default), and the rest are listed alphabetically by their `displayName`.
* Added a new language, `FRENCH`, to the enum with corresponding `wireValue` and display name.
* Ensured that all enum values have a matching entry in the `displayName` property, improving consistency.
* Updated the class documentation to reflect the new ordering and clarify the relationship to the gateway's accepted values.