### PR TITLE
feat: filter the models dashboard to installed-only

### DIFF
--- a/server/app/fragments.py
+++ b/server/app/fragments.py
@@ -313,9 +313,17 @@ def models_fragment(entries: list[AdminModelEntry]) -> str:
             <h2>Available models</h2>
             <p class="muted">Recommendations are matched to this server's hardware.</p>
           </div>
-          <button type="button" class="ghost small no-margin"
-                  hx-get="/ui/partials/models-list"
-                  hx-target="#models-list" hx-swap="innerHTML">Refresh</button>
+          <div class="models-toolbar-actions">
+            <label class="filter-toggle" for="installed-only-toggle">
+              <input type="checkbox" id="installed-only-toggle" name="installed_only"
+                     value="true" class="sr-only" hx-get="/ui/partials/models-list"
+                     hx-target="#models-list" hx-swap="innerHTML" hx-trigger="change" />
+              Installed only
+            </label>
+            <button type="button" class="ghost small no-margin"
+                    hx-get="/ui/partials/models-list" hx-include="#installed-only-toggle"
+                    hx-target="#models-list" hx-swap="innerHTML">Refresh</button>
+          </div>
         </div>
         <div id="models-list" aria-live="polite">
           {models_list_fragment(entries)}
@@ -325,7 +333,8 @@ def models_fragment(entries: list[AdminModelEntry]) -> str:
         <h2>Bring your own Whisper model</h2>
         <p class="muted">Paste a direct HTTPS link to a compatible <code>.bin</code> or
           <code>.gguf</code> file. It will run through the standalone engine.</p>
-        <form hx-post="/ui/partials/models/custom" hx-target="#models-list" hx-swap="innerHTML">
+        <form hx-post="/ui/partials/models/custom" hx-include="#installed-only-toggle"
+              hx-target="#models-list" hx-swap="innerHTML">
           <div class="row">
             <input name="url" type="url" required
                    placeholder="https://huggingface.co/&hellip;/resolve/main/model.gguf" />
@@ -336,7 +345,7 @@ def models_fragment(entries: list[AdminModelEntry]) -> str:
     """
 
 
-def models_list_fragment(entries: list[AdminModelEntry]) -> str:
+def models_list_fragment(entries: list[AdminModelEntry], installed_only: bool = False) -> str:
     groups: dict[str, list[AdminModelEntry]] = {}
     for entry in entries:
         groups.setdefault(entry.engine, []).append(entry)
@@ -349,7 +358,14 @@ def models_list_fragment(entries: list[AdminModelEntry]) -> str:
             f"<h3>{title}</h3><span>{len(items)} models</span></div>"
             f'<div class="model-grid">{cards}</div></section>'
         )
-    return "".join(parts) or '<p class="empty-state">No models are available.</p>'
+    if parts:
+        return "".join(parts)
+    if installed_only:
+        return (
+            '<p class="empty-state">No models downloaded yet. '
+            "Turn off &ldquo;Installed only&rdquo; to browse the catalog.</p>"
+        )
+    return '<p class="empty-state">No models are available.</p>'
 
 
 def _model_card(entry: AdminModelEntry) -> str:
@@ -374,6 +390,7 @@ def _model_card(entry: AdminModelEntry) -> str:
             f'<span class="muted small progress-copy">'
             f"{percent}% · {downloaded} / {total}</span>"
             f'<button class="ghost small" hx-post="/ui/partials/models/{encoded_id}/cancel"'
+            f' hx-include="#installed-only-toggle"'
             f' hx-target="#models-list" hx-swap="innerHTML">Cancel</button>'
         )
     elif entry.state == "installed":
@@ -383,6 +400,7 @@ def _model_card(entry: AdminModelEntry) -> str:
             else (
                 f'<button class="primary small"'
                 f' hx-post="/ui/partials/models/{encoded_id}/select"'
+                f' hx-include="#installed-only-toggle"'
                 f' hx-target="#models-list" hx-swap="innerHTML">Select</button>'
             )
         )
@@ -390,6 +408,7 @@ def _model_card(entry: AdminModelEntry) -> str:
             f"{select_button}"
             f'<button class="ghost small danger"'
             f' hx-delete="/ui/partials/models/{encoded_id}"'
+            f' hx-include="#installed-only-toggle"'
             f' hx-confirm="Delete {escape(entry.label)} from this server?"'
             f' hx-target="#models-list" hx-swap="innerHTML">Delete</button>'
         )
@@ -403,6 +422,7 @@ def _model_card(entry: AdminModelEntry) -> str:
             f"{note}"
             f'<button class="primary small"'
             f' hx-post="/ui/partials/models/{encoded_id}/download"'
+            f' hx-include="#installed-only-toggle"'
             f' hx-target="#models-list" hx-swap="innerHTML">Download</button>'
         )
 

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -874,8 +874,11 @@ def create_app(
         response_model=list[AdminModelEntry],
         dependencies=[Depends(require_token)],
     )
-    async def get_admin_models() -> list[AdminModelEntry]:
-        return _model_entries()
+    async def get_admin_models(installed_only: bool = False) -> list[AdminModelEntry]:
+        entries = _model_entries()
+        if installed_only:
+            entries = [entry for entry in entries if entry.state == "installed"]
+        return entries
 
     def _active_model_path() -> Path | None:
         if engine_manager is None:
@@ -1094,8 +1097,11 @@ def create_app(
     def _html(content: str) -> HTMLResponse:
         return HTMLResponse(content)
 
-    def _models_list_html() -> HTMLResponse:
-        return _html(models_list_fragment(_model_entries()))
+    def _models_list_html(installed_only: bool = False) -> HTMLResponse:
+        entries = _model_entries()
+        if installed_only:
+            entries = [entry for entry in entries if entry.state == "installed"]
+        return _html(models_list_fragment(entries, installed_only))
 
     def _resolve_pairing_token(
         token_id: str | None,
@@ -1370,15 +1376,15 @@ def create_app(
         response_class=HTMLResponse,
         dependencies=[Depends(require_token)],
     )
-    async def ui_models_list() -> HTMLResponse:
-        return _models_list_html()
+    async def ui_models_list(installed_only: bool = False) -> HTMLResponse:
+        return _models_list_html(installed_only)
 
     @app.post(
         "/ui/partials/models/{model_id}/download",
         response_class=HTMLResponse,
         dependencies=[Depends(require_token)],
     )
-    async def ui_start_download(model_id: str) -> HTMLResponse:
+    async def ui_start_download(model_id: str, installed_only: bool = Form(False)) -> HTMLResponse:
         try:
             manager.start_download(model_id)
         except UnknownModelError as error:
@@ -1387,37 +1393,39 @@ def create_app(
             raise APIProblem(
                 409, "download_in_progress", "This model is already downloading."
             ) from error
-        return _models_list_html()
+        return _models_list_html(installed_only)
 
     @app.post(
         "/ui/partials/models/custom",
         response_class=HTMLResponse,
         dependencies=[Depends(require_token)],
     )
-    async def ui_custom_download(url: str = Form(...)) -> HTMLResponse:
+    async def ui_custom_download(
+        url: str = Form(...), installed_only: bool = Form(False)
+    ) -> HTMLResponse:
         try:
             manager.start_custom_download(url)
         except ValueError as error:
             raise APIProblem(422, "invalid_model_url", str(error)) from error
         except DownloadInProgressError as error:
             raise APIProblem(409, "download_in_progress", str(error)) from error
-        return _models_list_html()
+        return _models_list_html(installed_only)
 
     @app.post(
         "/ui/partials/models/{model_id}/cancel",
         response_class=HTMLResponse,
         dependencies=[Depends(require_token)],
     )
-    async def ui_cancel_download(model_id: str) -> HTMLResponse:
+    async def ui_cancel_download(model_id: str, installed_only: bool = Form(False)) -> HTMLResponse:
         manager.cancel_download(model_id)
-        return _models_list_html()
+        return _models_list_html(installed_only)
 
     @app.delete(
         "/ui/partials/models/{model_id}",
         response_class=HTMLResponse,
         dependencies=[Depends(require_token)],
     )
-    async def ui_delete_model(model_id: str) -> HTMLResponse:
+    async def ui_delete_model(model_id: str, installed_only: bool = Form(False)) -> HTMLResponse:
         try:
             if engine_manager is not None:
                 engine_manager.forget_if_active(model_id)
@@ -1426,14 +1434,16 @@ def create_app(
             raise APIProblem(
                 409, "download_in_progress", "Cancel the download before deleting."
             ) from error
-        return _models_list_html()
+        return _models_list_html(installed_only)
 
     @app.post(
         "/ui/partials/models/{model_id}/select",
         response_class=HTMLResponse,
         dependencies=[Depends(require_token)],
     )
-    async def ui_select_model(model_id: str) -> HTMLResponse:
+    async def ui_select_model(
+        model_id: str, installed_only: bool = Form(False)
+    ) -> HTMLResponse:
         if engine_manager is None:
             raise APIProblem(
                 409, "engine_locked", "The engine was fixed at startup and cannot switch."
@@ -1446,8 +1456,11 @@ def create_app(
             ) from error
         await readiness.warmup()
         state = await readiness.probe()
+        entries = _model_entries()
+        if installed_only:
+            entries = [entry for entry in entries if entry.state == "installed"]
         return _html(
-            models_list_fragment(_model_entries())
+            models_list_fragment(entries, installed_only)
             + engine_pill_oob(
                 EngineStatus(
                     id=engine_manager.runtime_config.engine, name=state.name, ready=state.ready

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1441,9 +1441,7 @@ def create_app(
         response_class=HTMLResponse,
         dependencies=[Depends(require_token)],
     )
-    async def ui_select_model(
-        model_id: str, installed_only: bool = Form(False)
-    ) -> HTMLResponse:
+    async def ui_select_model(model_id: str, installed_only: bool = Form(False)) -> HTMLResponse:
         if engine_manager is None:
             raise APIProblem(
                 409, "engine_locked", "The engine was fixed at startup and cannot switch."

--- a/server/app/webui/styles.css
+++ b/server/app/webui/styles.css
@@ -318,6 +318,36 @@ main { max-width: 1120px; margin: 0 auto; padding: 24px 24px 60px; }
 .model-stats strong { color: var(--text); font-size: 20px; line-height: 1.1; }
 .models-toolbar { margin-bottom: 18px; }
 .models-toolbar h2, .models-toolbar p { margin-bottom: 0; }
+.models-toolbar-actions { display: flex; align-items: center; gap: 14px; }
+.filter-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  font: inherit;
+  font-size: 13px;
+  border-radius: 8px;
+  border: 1px solid var(--panel-border);
+  color: var(--muted);
+  background: none;
+  padding: 5px 12px;
+}
+.filter-toggle:hover { color: var(--text); }
+.filter-toggle:has(input:checked) { color: var(--accent); border-color: var(--accent); }
+.filter-toggle:has(input:focus-visible) { outline: 2px solid var(--accent); outline-offset: 2px; }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 button.no-margin { margin-left: 0; }
 .model-group + .model-group { margin-top: 28px; }
 .model-group-heading {

--- a/server/tests/test_admin.py
+++ b/server/tests/test_admin.py
@@ -267,6 +267,63 @@ async def test_download_select_and_delete_flow(
     assert saved.whisper_model is None
 
 
+async def test_models_list_installed_only_filter(
+    admin_client: httpx.AsyncClient, auth: dict[str, str]
+) -> None:
+    model_id = "whisper.cpp:ggml-tiny.bin"
+
+    before = await admin_client.get(
+        "/v1/admin/models", params={"installed_only": "true"}, headers=auth
+    )
+    assert before.status_code == 200
+    assert model_id not in {entry["id"] for entry in before.json()}
+
+    started = await admin_client.post(f"/v1/admin/models/{model_id}/download", headers=auth)
+    assert started.status_code == 200
+
+    for _ in range(200):
+        filtered = {
+            entry["id"]: entry
+            for entry in (
+                await admin_client.get(
+                    "/v1/admin/models", params={"installed_only": "true"}, headers=auth
+                )
+            ).json()
+        }
+        if model_id in filtered:
+            break
+        await asyncio.sleep(0.02)
+    assert filtered[model_id]["state"] == "installed"
+    assert all(entry["state"] == "installed" for entry in filtered.values())
+
+
+async def test_ui_select_preserves_installed_only_filter(
+    admin_client: httpx.AsyncClient, auth: dict[str, str]
+) -> None:
+    model_id = "whisper.cpp:ggml-tiny.bin"
+
+    await admin_client.post(f"/v1/admin/models/{model_id}/download", headers=auth)
+    entries: dict[str, dict[str, object]] = {}
+    for _ in range(200):
+        entries = {
+            entry["id"]: entry
+            for entry in (await admin_client.get("/v1/admin/models", headers=auth)).json()
+        }
+        if entries[model_id]["state"] == "installed":
+            break
+        await asyncio.sleep(0.02)
+    assert entries[model_id]["state"] == "installed"
+
+    selected = await admin_client.post(
+        f"/ui/partials/models/{model_id}/select",
+        headers=auth,
+        data={"installed_only": "true"},
+    )
+    assert selected.status_code == 200
+    assert 'class="model-card"' in selected.text
+    assert "No models downloaded yet" not in selected.text
+
+
 async def test_unknown_model_download_404(
     admin_client: httpx.AsyncClient, auth: dict[str, str]
 ) -> None:


### PR DESCRIPTION
## What changed?

Add an "Installed only" toggle to the Models panel, styled as a ghost-pill button to match Refresh. The filter now survives every action (download, cancel, delete, select) instead of resetting after each one, and the JSON admin API gained the same ?installed_only query param for parity.