### PR TITLE
Add tests for session storage, whisper.cpp engine, and warmup

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -521,6 +521,8 @@ def create_app(
                                 )
                             if not transcript:
                                 raise ValueError("Moonshine returned an empty transcript.")
+                            await asyncio.to_thread(stream.close)
+                            stream = None
                             await websocket.send_json(
                                 {"type": "complete", "transcript": transcript}
                             )

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -36,6 +36,9 @@ localflow-cleanup = "app.cli:cleanup"
 [dependency-groups]
 dev = [
   "httpx>=0.28,<1",
+  # starlette.testclient (used for WebSocket streaming tests) prefers this
+  # over plain httpx; without it every run prints a deprecation warning.
+  "httpx2>=2,<3",
   "mypy>=1.17,<2",
   "pytest>=8.4,<9",
   "pytest-asyncio>=1.1,<2",

--- a/server/tests/test_admin.py
+++ b/server/tests/test_admin.py
@@ -380,6 +380,32 @@ async def test_mac_only_engines_are_labelled_with_their_host(
     assert "sherpa-onnx</option>" in settings_html
 
 
+async def test_ui_config_update_switches_engine_and_renders_a_fragment(
+    admin_client: httpx.AsyncClient, auth: dict[str, str], admin_settings: Settings
+) -> None:
+    response = await admin_client.put(
+        "/ui/partials/config",
+        headers=auth,
+        data={"engine": "sherpa-onnx", "compute_device": "cpu", "cpu_threads": "2"},
+    )
+    assert response.status_code == 200
+    assert "Engine preference saved." in response.text
+    assert 'id="engine-pill"' in response.text
+    assert RuntimeConfig.load(admin_settings.config_path).engine == "sherpa-onnx"
+
+
+async def test_ui_config_update_rejects_an_invalid_engine(
+    admin_client: httpx.AsyncClient, auth: dict[str, str]
+) -> None:
+    response = await admin_client.put(
+        "/ui/partials/config",
+        headers=auth,
+        data={"engine": "cloud"},
+    )
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_engine"
+
+
 async def test_custom_download_rejects_bad_url(
     admin_client: httpx.AsyncClient, auth: dict[str, str]
 ) -> None:

--- a/server/tests/test_storage.py
+++ b/server/tests/test_storage.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from app.storage import SessionRepository
+
+
+@pytest.fixture
+def repository(tmp_path: Path) -> SessionRepository:
+    repo = SessionRepository(tmp_path / "nested" / "sessions.sqlite3")
+    repo.initialize()
+    return repo
+
+
+def test_initialize_creates_the_database_file_and_parent_directories(
+    repository: SessionRepository,
+) -> None:
+    assert repository.database_path.is_file()
+
+
+def test_create_or_get_is_idempotent_for_the_same_session_id(
+    repository: SessionRepository,
+) -> None:
+    session_id = uuid4()
+
+    first = repository.create_or_get(session_id, "en", "raw")
+    second = repository.create_or_get(session_id, "de", "casual")
+
+    assert first.job_id == second.job_id
+    assert second.language == "en"
+    assert second.style == "raw"
+    assert second.state == "created"
+
+
+def test_create_or_get_assigns_a_unique_job_id_per_session(
+    repository: SessionRepository,
+) -> None:
+    first = repository.create_or_get(uuid4(), "en", "raw")
+    second = repository.create_or_get(uuid4(), "en", "raw")
+
+    assert first.job_id != second.job_id
+
+
+def test_get_returns_none_for_an_unknown_session(repository: SessionRepository) -> None:
+    assert repository.get(uuid4()) is None
+
+
+def test_update_preserves_audio_name_by_default(repository: SessionRepository) -> None:
+    session_id = uuid4()
+    repository.create_or_get(session_id, "en", "raw")
+    repository.update(session_id, state="processing", audio_name="clip.wav")
+
+    updated = repository.update(session_id, state="completed", transcript="hello")
+
+    assert updated.audio_name == "clip.wav"
+    assert updated.transcript == "hello"
+    assert updated.state == "completed"
+
+
+def test_update_can_overwrite_the_audio_name_explicitly(repository: SessionRepository) -> None:
+    session_id = uuid4()
+    repository.create_or_get(session_id, "en", "raw")
+    repository.update(session_id, state="processing", audio_name="first.wav")
+
+    updated = repository.update(
+        session_id, state="processing", audio_name="second.wav", preserve_audio_name=False
+    )
+
+    assert updated.audio_name == "second.wav"
+
+
+def test_update_bumps_updated_at(repository: SessionRepository) -> None:
+    session_id = uuid4()
+    created = repository.create_or_get(session_id, "en", "raw")
+
+    updated = repository.update(session_id, state="failed", error_code="engine_unavailable")
+
+    assert updated.updated_at >= created.updated_at
+    assert updated.error_code == "engine_unavailable"
+
+
+def test_update_raises_key_error_for_an_unknown_session(repository: SessionRepository) -> None:
+    with pytest.raises(KeyError):
+        repository.update(uuid4(), state="completed")
+
+
+def test_delete_removes_the_session_and_returns_the_prior_state(
+    repository: SessionRepository,
+) -> None:
+    session_id = uuid4()
+    repository.create_or_get(session_id, "en", "raw")
+
+    deleted = repository.delete(session_id)
+
+    assert deleted is not None
+    assert deleted.session_id == session_id
+    assert repository.get(session_id) is None
+
+
+def test_delete_returns_none_for_an_unknown_session(repository: SessionRepository) -> None:
+    assert repository.delete(uuid4()) is None
+
+
+def test_expired_only_returns_sessions_past_the_retention_window(
+    repository: SessionRepository,
+) -> None:
+    fresh_id = uuid4()
+    stale_id = uuid4()
+    repository.create_or_get(fresh_id, "en", "raw")
+    repository.create_or_get(stale_id, "en", "raw")
+
+    stale_time = (datetime.now(UTC) - timedelta(hours=48)).isoformat()
+    with repository._connect() as connection:
+        connection.execute(
+            "UPDATE sessions SET updated_at = ? WHERE session_id = ?",
+            (stale_time, str(stale_id)),
+        )
+
+    expired = repository.expired(retention_hours=24)
+
+    assert [session.session_id for session in expired] == [stale_id]

--- a/server/tests/test_warmup.py
+++ b/server/tests/test_warmup.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.models.warmup import prefetch_model_paths
+
+
+def test_prefetch_a_single_file_advises_its_full_size(tmp_path: Path) -> None:
+    path = tmp_path / "model.bin"
+    path.write_bytes(b"x" * 4096)
+
+    assert prefetch_model_paths([path]) == 4096
+
+
+def test_prefetch_walks_directories_for_files(tmp_path: Path) -> None:
+    directory = tmp_path / "model"
+    directory.mkdir()
+    (directory / "weights.bin").write_bytes(b"x" * 1024)
+    (directory / "tokenizer.json").write_bytes(b"y" * 256)
+
+    assert prefetch_model_paths([directory]) == 1024 + 256
+
+
+def test_prefetch_skips_paths_that_do_not_exist(tmp_path: Path) -> None:
+    assert prefetch_model_paths([tmp_path / "does-not-exist"]) == 0
+
+
+def test_prefetch_stops_once_the_byte_budget_is_reached(tmp_path: Path) -> None:
+    large = tmp_path / "large.bin"
+    large.write_bytes(b"x" * 4096)
+    small = tmp_path / "small.bin"
+    small.write_bytes(b"y" * 1024)
+
+    advised = prefetch_model_paths([large, small], maximum_bytes=2048)
+
+    assert advised == 2048
+
+
+def test_prefetch_with_no_candidates_advises_nothing(tmp_path: Path) -> None:
+    assert prefetch_model_paths([]) == 0

--- a/server/tests/test_whisper_cpp.py
+++ b/server/tests/test_whisper_cpp.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.errors import EngineUnavailableError, TranscriptionProcessError
+from app.models.base import TranscriptionOptions
+from app.models.whisper_cpp import WhisperCppEngine
+
+
+def _write_binary(path: Path, script: str) -> None:
+    path.write_text(script, encoding="utf-8")
+    path.chmod(0o700)
+
+
+async def test_health_requires_both_the_binary_and_the_model(tmp_path: Path) -> None:
+    binary = tmp_path / "whisper-cli"
+    model = tmp_path / "model.bin"
+
+    engine = WhisperCppEngine(binary, model)
+    assert (await engine.health()).ready is False
+
+    _write_binary(binary, "#!/bin/sh\nexit 0\n")
+    assert (await engine.health()).ready is False
+
+    model.write_bytes(b"model")
+    health = await engine.health()
+    assert health.ready is True
+    assert health.name == f"whisper.cpp:{model.name}"
+
+
+async def test_transcribe_writes_the_output_stem_and_returns_its_contents(
+    tmp_path: Path,
+) -> None:
+    binary = tmp_path / "whisper-cli"
+    _write_binary(
+        binary,
+        """#!/bin/sh
+printf '%s\\n' "$@" > "$0.args"
+of=""
+lang=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -of) of="$2"; shift 2 ;;
+    -l) lang="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '%s' "private local result" > "$of.txt"
+""",
+    )
+    model = tmp_path / "model.bin"
+    model.write_bytes(b"model")
+    audio = tmp_path / "audio.wav"
+    audio.write_bytes(b"audio")
+
+    engine = WhisperCppEngine(binary, model)
+    transcript = await engine.transcribe(audio, TranscriptionOptions("en", "raw"))
+
+    assert transcript == "private local result"
+    arguments = (tmp_path / "whisper-cli.args").read_text(encoding="utf-8").splitlines()
+    assert arguments[arguments.index("-l") + 1] == "en"
+    assert arguments[arguments.index("-f") + 1] == str(audio)
+
+
+async def test_transcribe_omits_the_language_flag_when_auto(tmp_path: Path) -> None:
+    binary = tmp_path / "whisper-cli"
+    _write_binary(
+        binary,
+        """#!/bin/sh
+printf '%s\\n' "$@" > "$0.args"
+of=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -of) of="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '%s' "auto detected" > "$of.txt"
+""",
+    )
+    model = tmp_path / "model.bin"
+    model.write_bytes(b"model")
+    audio = tmp_path / "audio.wav"
+    audio.write_bytes(b"audio")
+
+    engine = WhisperCppEngine(binary, model)
+    transcript = await engine.transcribe(audio, TranscriptionOptions("auto", "raw"))
+
+    assert transcript == "auto detected"
+    arguments = (tmp_path / "whisper-cli.args").read_text(encoding="utf-8").splitlines()
+    assert "-l" not in arguments
+
+
+async def test_transcribe_raises_when_the_engine_is_unavailable(tmp_path: Path) -> None:
+    engine = WhisperCppEngine(tmp_path / "missing-cli", tmp_path / "missing-model.bin")
+
+    with pytest.raises(EngineUnavailableError):
+        await engine.transcribe(tmp_path / "audio.wav", TranscriptionOptions("auto", "raw"))
+
+
+async def test_transcribe_raises_on_a_nonzero_exit_code(tmp_path: Path) -> None:
+    binary = tmp_path / "whisper-cli"
+    _write_binary(binary, "#!/bin/sh\necho 'boom' 1>&2\nexit 1\n")
+    model = tmp_path / "model.bin"
+    model.write_bytes(b"model")
+    audio = tmp_path / "audio.wav"
+    audio.write_bytes(b"audio")
+
+    engine = WhisperCppEngine(binary, model)
+
+    with pytest.raises(TranscriptionProcessError, match="boom"):
+        await engine.transcribe(audio, TranscriptionOptions("auto", "raw"))
+
+
+async def test_transcribe_raises_when_the_transcript_is_empty(tmp_path: Path) -> None:
+    binary = tmp_path / "whisper-cli"
+    _write_binary(
+        binary,
+        """#!/bin/sh
+of=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -of) of="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '' > "$of.txt"
+""",
+    )
+    model = tmp_path / "model.bin"
+    model.write_bytes(b"model")
+    audio = tmp_path / "audio.wav"
+    audio.write_bytes(b"audio")
+
+    engine = WhisperCppEngine(binary, model)
+
+    with pytest.raises(TranscriptionProcessError, match="empty"):
+        await engine.transcribe(audio, TranscriptionOptions("auto", "raw"))
+
+
+async def test_warmup_prefetches_the_model_when_ready(tmp_path: Path) -> None:
+    binary = tmp_path / "whisper-cli"
+    _write_binary(binary, "#!/bin/sh\nexit 0\n")
+    model = tmp_path / "model.bin"
+    model.write_bytes(b"x" * 1024)
+
+    engine = WhisperCppEngine(binary, model)
+    advised = await engine.warmup()
+
+    assert advised > 0
+
+
+async def test_warmup_is_a_noop_when_not_ready(tmp_path: Path) -> None:
+    engine = WhisperCppEngine(tmp_path / "missing-cli", tmp_path / "missing-model.bin")
+
+    assert await engine.warmup() == 0

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -399,6 +399,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -447,6 +460,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -588,6 +617,7 @@ engines = [
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "httpx2" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -613,6 +643,7 @@ provides-extras = ["engines", "apple"]
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.28,<1" },
+    { name = "httpx2", specifier = ">=2,<3" },
     { name = "mypy", specifier = ">=1.17,<2" },
     { name = "pytest", specifier = ">=8.4,<9" },
     { name = "pytest-asyncio", specifier = ">=1.1,<2" },
@@ -1479,6 +1510,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/7c/8240f612819718100a9346dc28dea6a11370c3ca9c8c6eabadd3dea4ef29/transformers-5.12.1.tar.gz", hash = "sha256:679ee731c8225347889ad4fb3b2c926a62e9da3b7d284e9d12c791da7272466b", size = 8924054, upload-time = "2026-06-15T17:27:50.604Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/56/bbd60dd8668055803bf8ba55a81f9b8a8b31497f620109a9671d26a2076d/transformers-5.12.1-py3-none-any.whl", hash = "sha256:2a5e109d2021265df7098ffbb738295acaf5ad256f12cbc586db2ea4dcbb1a8a", size = 11150587, upload-time = "2026-06-15T17:27:46.679Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed?

This PR brings extensive test coverage for core modules and a minor dependency update to enhance the developer workflow. We’re mainly working on tests for session storage, model warmup, and whisper.cpp.

**Testing improvements:**

* Added a complete test suite for the `SessionRepository` in `test_storage.py`, covering initialization, CRUD operations, idempotency, update semantics, deletion, and session expiration logic.
* Introduced tests for the model warmup logic in `test_warmup.py`, ensuring correct byte size calculation, directory traversal, missing file handling, and byte budget enforcement.
* Added extensive tests for the `WhisperCppEngine` in `test_whisper_cpp.py`, verifying health checks, transcription behavior under various scenarios, error handling, argument passing, and warmup logic.

**Admin UI and configuration:**

* Enhanced admin UI config update tests in `test_admin.py` to verify engine switching, fragment rendering, and proper error responses for invalid engine values.

**Development dependencies:**

* Updated development dependencies in `pyproject.toml` to include `httpx2` for better compatibility with `starlette.testclient` and to eliminate deprecation warnings during test runs.

