### PR TITLE
fix: guard Local Flow → vocaphone upgrades against silent token remint

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,16 +330,17 @@ cd android
 # macOS default; on Linux try $HOME/Android/Sdk
 export ANDROID_HOME="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
 ./gradlew assembleDebug
+# Uninstall any pre-rename Local Flow build first — application IDs differ, so
+# `adb install -r` will side-install next to io.github.mrsunglasses.localflow.
+adb uninstall io.github.mrsunglasses.localflow 2>/dev/null || true
 adb install -r app/build/outputs/apk/debug/vocaphone-debug.apk
 ```
 
 In the app: grant microphone, notifications, overlay, and accessibility; then
 enter the gateway address and bearer token from step 4 and run **Test connection**.
 
-The same application ID, `com.vocahq.vocaphone`, should be
-replaced before you distribute a build. See the
-[Android client guide](android/README.md) for permissions, the accessibility
-disclosure, and the supported gateway address forms.
+See the [Android client guide](android/README.md) for permissions, the
+accessibility disclosure, and the supported gateway address forms.
 
 ## Build and test
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -27,8 +27,11 @@ identifiers. The following are the final identifiers in use:
 Apple Developer portal registration of these bundle identifiers and App Group
 under the existing team is a required follow-up.
 
-See [deployment.md](deployment.md#migrating-from-the-local-flow-working-name-v030)
-for the full migration guide.
+Native gateway startups migrate a missing vocaphone bootstrap token (and
+WebUI config) from the Local Flow paths once, and the LaunchAgent/systemd
+install helpers remove the obsolete Local Flow units. Everything else remains
+a documented hard cutover — see
+[deployment.md](deployment.md#migrating-from-the-local-flow-working-name-v030).
 
 ## Implemented assumptions
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -301,24 +301,48 @@ over the public internet.
 ## Migrating from the Local Flow working name (v0.3.0)
 
 The v0.3.0 release replaced the **Local Flow** working name with **vocaphone**
-across all identifiers. This is a hard cutover — no compatibility aliases are
-provided. If you are upgrading from an earlier checkout, follow each step below.
+across all identifiers. Environment variable names, config paths, Docker
+resources, and service units are a hard cutover — there are no long-lived
+`LOCALFLOW_*` aliases.
+
+Native gateway startups do perform a **one-time bootstrap migration** when they
+find an old Local Flow token (or config file) and no vocaphone token yet: the
+token is copied to `~/.config/vocaphone/token` so paired phones keep working.
+If Local Flow data exists but no token can be found, startup fails instead of
+minting a new secret. Still follow the steps below for env vars, data dirs,
+Docker volumes, and client reinstalls.
 
 ### Environment variables
 
-Rename every `LOCALFLOW_*` variable to `VOCAPHONE_*`:
+Rename every `LOCALFLOW_*` variable to `VOCAPHONE_*`. The common set:
 
 ```sh
-# Before (obsolete)                # After (current)
-LOCALFLOW_TOKEN=…                   VOCAPHONE_TOKEN=…
-LOCALFLOW_BIND_HOST=127.0.0.1       VOCAPHONE_BIND_HOST=127.0.0.1
-LOCALFLOW_PUBLISH_HOST=127.0.0.1    VOCAPHONE_PUBLISH_HOST=127.0.0.1
-LOCALFLOW_PUBLISH_PORT=8765         VOCAPHONE_PUBLISH_PORT=8765
-LOCALFLOW_NETWORK_MODE=host         VOCAPHONE_NETWORK_MODE=host
-LOCALFLOW_IMAGE=…                   VOCAPHONE_IMAGE=…
-LOCALFLOW_ENGINE=…                  VOCAPHONE_ENGINE=…
-LOCALFLOW_WHISPER_BINARY=…          VOCAPHONE_WHISPER_BINARY=…
-LOCALFLOW_WHISPER_MODEL=…           VOCAPHONE_WHISPER_MODEL=…
+# Before (obsolete)                         # After (current)
+LOCALFLOW_TOKEN=…                            VOCAPHONE_TOKEN=…
+LOCALFLOW_TOKEN_FILE=…                       VOCAPHONE_TOKEN_FILE=…
+LOCALFLOW_BIND_HOST=127.0.0.1                VOCAPHONE_BIND_HOST=127.0.0.1
+LOCALFLOW_PORT=8765                          VOCAPHONE_PORT=8765
+LOCALFLOW_PUBLISH_HOST=127.0.0.1             VOCAPHONE_PUBLISH_HOST=127.0.0.1
+LOCALFLOW_PUBLISH_PORT=8765                  VOCAPHONE_PUBLISH_PORT=8765
+LOCALFLOW_NETWORK_MODE=host                  VOCAPHONE_NETWORK_MODE=host
+LOCALFLOW_IMAGE=…                            VOCAPHONE_IMAGE=…
+LOCALFLOW_DATA_DIR=…                         VOCAPHONE_DATA_DIR=…
+LOCALFLOW_CONFIG_FILE=…                      VOCAPHONE_CONFIG_FILE=…
+LOCALFLOW_MODELS_DIR=…                       VOCAPHONE_MODELS_DIR=…
+LOCALFLOW_PUBLIC_URL=…                       VOCAPHONE_PUBLIC_URL=…
+LOCALFLOW_PAIRING_URL=…                      VOCAPHONE_PAIRING_URL=…
+LOCALFLOW_ENGINE=…                           VOCAPHONE_ENGINE=…
+LOCALFLOW_WHISPER_BINARY=…                   VOCAPHONE_WHISPER_BINARY=…
+LOCALFLOW_WHISPER_MODEL=…                    VOCAPHONE_WHISPER_MODEL=…
+LOCALFLOW_HANDY_BINARY=…                     VOCAPHONE_HANDY_BINARY=…
+LOCALFLOW_HANDY_MODEL=…                      VOCAPHONE_HANDY_MODEL=…
+LOCALFLOW_HANDY_FALLBACK_MODEL=…             VOCAPHONE_HANDY_FALLBACK_MODEL=…
+LOCALFLOW_VOCAMAC_APP=…                      VOCAPHONE_VOCAMAC_APP=…
+LOCALFLOW_VOCAMAC_MODEL=…                    VOCAPHONE_VOCAMAC_MODEL=…
+LOCALFLOW_WHISPERKIT_BINARY=…                VOCAPHONE_WHISPERKIT_BINARY=…
+LOCALFLOW_RETENTION_HOURS=24                 VOCAPHONE_RETENTION_HOURS=24
+LOCALFLOW_DELETE_SUCCESSFUL_AUDIO=true       VOCAPHONE_DELETE_SUCCESSFUL_AUDIO=true
+LOCALFLOW_DEBUG=false                        VOCAPHONE_DEBUG=false
 ```
 
 Security defaults (loopback binding, mode-600 token files, per-device bearer
@@ -336,10 +360,12 @@ Move existing data into the new locations or let the first run re-create them:
 | `~/Library/Logs/LocalFlow/` | `~/Library/Logs/Vocaphone/` |
 
 The token file and config are portable; copy them into the new location under
-the same permissions. Models can be moved or re-downloaded — the WebUI catalog
-keeps the same model URLs. If you move an existing sherpa-onnx or Moonshine
-model, rename its `.localflow-model.json` marker to `.vocaphone-model.json`;
-otherwise the gateway will treat that model as not installed.
+the same permissions (or let `vocaphone-server` / `scripts/setup-token.sh`
+perform the one-time token and config copy described above). Models can be
+moved or re-downloaded — the WebUI catalog keeps the same model URLs. If you
+move an existing sherpa-onnx or Moonshine model, rename its
+`.localflow-model.json` marker to `.vocaphone-model.json`; otherwise the
+gateway will treat that model as not installed.
 
 ### Docker volume
 
@@ -355,24 +381,28 @@ docker run --rm \
   -v localflow_localflow-data:/from:ro \
   -v vocaphone_vocaphone-data:/to \
   alpine sh -c 'cp -a /from/. /to/'
+# Rename model markers inside the copied volume when you keep existing models:
+docker run --rm -v vocaphone_vocaphone-data:/data alpine \
+  sh -c 'find /data -name .localflow-model.json -exec sh -c \
+  "mv \"\$1\" \"\${1%.localflow-model.json}.vocaphone-model.json\"" _ {} \;'
 # or omit the copy and let it download fresh:
 docker compose up --detach --build
 ```
 
 ### LaunchAgent / systemd units
 
-Stop and unload the old unit, then install the renamed one:
+The install helpers remove the obsolete Local Flow unit and install the renamed
+one. You can also do it manually:
 
 **macOS:**
 ```sh
-launchctl bootout "gui/$(id -u)/com.example.localflow.gateway"
+# install-launch-agent.sh boots out com.example.localflow.gateway automatically
 cd server && ./scripts/install-launch-agent.sh
 ```
 
 **Linux:**
 ```sh
-systemctl --user stop com.example.localflow.gateway.service
-systemctl --user disable com.example.localflow.gateway.service
+# install-systemd-user.sh disables com.example.localflow.gateway.service automatically
 cd server && ./scripts/install-systemd-user.sh
 ```
 
@@ -388,10 +418,11 @@ existing iOS and Android installations are not upgraded in place:
 - **iOS Apple Developer registration**: Register the new bundle identifiers and
   App Group under your existing team in the Apple Developer portal. See
   [decisions.md](decisions.md) for the final identifiers.
-- **Android**: Uninstall the old APK. Build the renamed
-  `com.vocahq.vocaphone` project and install the new APK. The Android Keystore
-  token ciphertext is not portable between application IDs — re-enter the token
-  and re-pair.
+- **Android**: Uninstall the old APK (`io.github.mrsunglasses.localflow`) before
+  installing the new one. `adb install -r` will **not** replace it — the
+  application ID changed to `com.vocahq.vocaphone`, so a side-by-side install
+  leaves both apps on the device. The Android Keystore token ciphertext is not
+  portable between application IDs — re-enter the token and re-pair.
 
 ### CLI entry points
 

--- a/ios/VocaPhoneApp/App/PairingScannerView.swift
+++ b/ios/VocaPhoneApp/App/PairingScannerView.swift
@@ -18,7 +18,7 @@ struct PairingScannerView: UIViewControllerRepresentable {
 @MainActor
 final class PairingScannerViewController: UIViewController, @preconcurrency AVCaptureMetadataOutputObjectsDelegate {
     private let captureSession = AVCaptureSession()
-    private let sessionQueue = DispatchQueue(label: "io.github.mrsunglasses.vocaphone.pairing-camera")
+    private let sessionQueue = DispatchQueue(label: "com.vocahq.vocaphone.pairing-camera")
     private let paired: (PairingPayload.Value) -> Void
     private let unavailable: (String) -> Void
     private var hasPaired = false

--- a/server/README.md
+++ b/server/README.md
@@ -7,7 +7,9 @@ management, engine selection, microphone testing, and operational status.
 
 > CLI entry points, env vars, and config paths previously used the Local Flow
 > working name (`localflow-server`, `LOCALFLOW_*`, `~/.config/localflow/`) and
-> were renamed to vocaphone in v0.3.0.
+> were renamed to vocaphone in v0.3.0. Native startups migrate a missing
+> bootstrap token from the old path once; see the
+> [migration guide](../docs/deployment.md#migrating-from-the-local-flow-working-name-v030).
 
 ## Deployment summary
 

--- a/server/app/cli.py
+++ b/server/app/cli.py
@@ -18,14 +18,15 @@ from app.storage import SessionRepository
 def serve() -> None:
     settings = Settings.from_env()
     host = settings.bind_host
-    token_source = "(from VOCAPHONE_TOKEN)" if _token_from_env() else "~/.config/vocaphone/token"
+    token_path = settings.token_file_display
+    token_source = "(from VOCAPHONE_TOKEN)" if _token_from_env() else token_path
     print(f"vocaphone gateway listening on {format_host_port(host, settings.port)}")
     print(f"WebUI (this host): {local_webui_url(host, settings.port)}")
     if host in WILDCARD_BIND_HOSTS:
         print("Network access: use this host's LAN or Tailscale IP with the same port")
     print(f"Token: {token_source}")
     if not _token_from_env():
-        print("  (cat ~/.config/vocaphone/token — enter that value in the phone app)")
+        print(f"  (cat {token_path} — enter that value in the phone app)")
     uvicorn.run(
         create_app(settings),
         host=host,

--- a/server/app/cli.py
+++ b/server/app/cli.py
@@ -37,7 +37,7 @@ def serve() -> None:
 def _token_from_env() -> bool:
     import os
 
-    return bool(os.environ.get("VOCAPHONE_TOKEN"))
+    return bool(os.environ.get("VOCAPHONE_TOKEN", "").strip())
 
 
 def status() -> None:

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -2,11 +2,20 @@ from __future__ import annotations
 
 import os
 import secrets
+import shutil
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 DEFAULT_HANDY_FALLBACK_MODEL = "handy-computer/whisper-base-gguf/whisper-base-Q8_0.gguf"
 WILDCARD_BIND_HOSTS = frozenset({"0.0.0.0", "::"})
+LEGACY_TOKEN_FILE = Path("~/.config/localflow/token")
+LEGACY_CONFIG_FILE = Path("~/.config/localflow/config.json")
+LEGACY_DATA_DIR = Path("~/.local/share/localflow")
+MIGRATION_DOCS = (
+    "https://github.com/VocaHQ/vocaphone/blob/main/docs/deployment.md"
+    "#migrating-from-the-local-flow-working-name-v030"
+)
 
 
 def format_host_port(host: str, port: int) -> str:
@@ -53,17 +62,18 @@ class Settings:
 
     @classmethod
     def from_env(cls) -> Settings:
+        _warn_ignored_legacy_env()
         token_file = Path(
             os.environ.get(
                 "VOCAPHONE_TOKEN_FILE",
                 "~/.config/vocaphone/token",
             )
         ).expanduser()
-        token = os.environ.get("VOCAPHONE_TOKEN", "")
+        token = os.environ.get("VOCAPHONE_TOKEN", "").strip()
         if not token and token_file.is_file():
             token = token_file.read_text(encoding="utf-8").strip()
         if not token:
-            token = _generate_token(token_file)
+            token = _resolve_or_migrate_token(token_file)
         if len(token) < 32:
             raise RuntimeError(
                 "Set VOCAPHONE_TOKEN to at least 32 characters or create "
@@ -72,6 +82,16 @@ class Settings:
         data_dir = Path(
             os.environ.get("VOCAPHONE_DATA_DIR", "~/.local/share/vocaphone")
         ).expanduser()
+        if "VOCAPHONE_DATA_DIR" not in os.environ:
+            _warn_unmigrated_legacy_data(data_dir)
+        config_path = Path(
+            os.environ.get(
+                "VOCAPHONE_CONFIG_FILE",
+                "~/.config/vocaphone/config.json",
+            )
+        ).expanduser()
+        if "VOCAPHONE_CONFIG_FILE" not in os.environ:
+            _migrate_legacy_config_file(config_path)
         return cls(
             token=token,
             data_dir=data_dir,
@@ -105,12 +125,7 @@ class Settings:
             models_dir=Path(
                 os.environ.get("VOCAPHONE_MODELS_DIR", str(data_dir / "models"))
             ).expanduser(),
-            config_path=Path(
-                os.environ.get(
-                    "VOCAPHONE_CONFIG_FILE",
-                    "~/.config/vocaphone/config.json",
-                )
-            ).expanduser(),
+            config_path=config_path,
             bind_host=os.environ.get("VOCAPHONE_BIND_HOST", "0.0.0.0"),
             port=int(os.environ.get("VOCAPHONE_PORT", "8765")),
             retention_hours=int(os.environ.get("VOCAPHONE_RETENTION_HOURS", "24")),
@@ -122,15 +137,132 @@ class Settings:
         )
 
 
+def _legacy_env_names() -> list[str]:
+    return sorted(name for name in os.environ if name.startswith("LOCALFLOW_"))
+
+
+def _warn_ignored_legacy_env() -> None:
+    leftover = _legacy_env_names()
+    if not leftover:
+        return
+    print(
+        "vocaphone: LOCALFLOW_* environment variables are obsolete "
+        f"({', '.join(leftover)}). Rename them to VOCAPHONE_*. "
+        "LOCALFLOW_TOKEN / LOCALFLOW_TOKEN_FILE are read only for a "
+        f"one-time bootstrap migration. See {MIGRATION_DOCS}",
+        file=sys.stderr,
+    )
+
+
+def _legacy_token_candidates() -> list[tuple[str, str]]:
+    """Return (source label, token) pairs from the pre-rename Local Flow layout."""
+    candidates: list[tuple[str, str]] = []
+    env_token = os.environ.get("LOCALFLOW_TOKEN", "").strip()
+    if env_token:
+        candidates.append(("LOCALFLOW_TOKEN", env_token))
+    legacy_file = Path(
+        os.environ.get("LOCALFLOW_TOKEN_FILE", str(LEGACY_TOKEN_FILE))
+    ).expanduser()
+    if legacy_file.is_file():
+        file_token = legacy_file.read_text(encoding="utf-8").strip()
+        if file_token:
+            candidates.append((str(legacy_file), file_token))
+    return candidates
+
+
+def _write_token_file(token_file: Path, token: str) -> None:
+    token_file.parent.mkdir(parents=True, exist_ok=True)
+    token_file.parent.chmod(0o700)
+    descriptor = os.open(token_file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        handle.write(token + "\n")
+
+
+def _resolve_or_migrate_token(token_file: Path) -> str:
+    """Prefer a one-time Local Flow token migration over minting a new secret."""
+    legacy = _legacy_token_candidates()
+    if legacy:
+        source, token = legacy[0]
+        try:
+            _write_token_file(token_file, token)
+        except FileExistsError:
+            # Another process created the destination between our checks.
+            existing = token_file.read_text(encoding="utf-8").strip()
+            if existing:
+                return existing
+            raise
+        except OSError as exc:
+            raise RuntimeError(
+                "Found a Local Flow bootstrap token at "
+                f"{source} but could not write {token_file}: {exc}. "
+                f"Copy it manually, then restart. See {MIGRATION_DOCS}"
+            ) from exc
+        print(
+            "vocaphone: migrated Local Flow bootstrap token from "
+            f"{source} to {token_file}. Paired phones keep working. "
+            f"See {MIGRATION_DOCS}",
+            file=sys.stderr,
+        )
+        return token
+
+    legacy_data = LEGACY_DATA_DIR.expanduser()
+    if legacy_data.is_dir() and any(legacy_data.iterdir()):
+        raise RuntimeError(
+            "Found Local Flow data at "
+            f"{legacy_data} but no vocaphone bootstrap token. "
+            "Copy ~/.config/localflow/token to ~/.config/vocaphone/token "
+            f"(or set VOCAPHONE_TOKEN) before starting the gateway so paired "
+            f"phones are not locked out. See {MIGRATION_DOCS}"
+        )
+    return _generate_token(token_file)
+
+
+def _migrate_legacy_config_file(config_path: Path) -> None:
+    if config_path.is_file():
+        return
+    legacy = LEGACY_CONFIG_FILE.expanduser()
+    if not legacy.is_file():
+        return
+    try:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.parent.chmod(0o700)
+        shutil.copy2(legacy, config_path)
+        config_path.chmod(0o600)
+    except OSError as exc:
+        print(
+            f"vocaphone: could not migrate {legacy} to {config_path}: {exc}. "
+            f"Copy it manually if you need the previous WebUI settings. "
+            f"See {MIGRATION_DOCS}",
+            file=sys.stderr,
+        )
+        return
+    print(
+        f"vocaphone: migrated Local Flow config from {legacy} to {config_path}. "
+        f"See {MIGRATION_DOCS}",
+        file=sys.stderr,
+    )
+
+
+def _warn_unmigrated_legacy_data(data_dir: Path) -> None:
+    if data_dir.exists():
+        return
+    legacy = LEGACY_DATA_DIR.expanduser()
+    if not legacy.is_dir() or not any(legacy.iterdir()):
+        return
+    print(
+        f"vocaphone: Local Flow data still exists at {legacy}. "
+        f"Move or copy it to {data_dir} (and rename any "
+        ".localflow-model.json markers to .vocaphone-model.json) to keep "
+        f"downloaded models and session history. See {MIGRATION_DOCS}",
+        file=sys.stderr,
+    )
+
+
 def _generate_token(token_file: Path) -> str:
     """First-run friendly default: create a private token automatically."""
     token = secrets.token_urlsafe(48)
     try:
-        token_file.parent.mkdir(parents=True, exist_ok=True)
-        token_file.parent.chmod(0o700)
-        descriptor = os.open(token_file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
-            handle.write(token + "\n")
+        _write_token_file(token_file, token)
     except OSError:
         return token
     return token

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -160,9 +160,7 @@ def _legacy_token_candidates() -> list[tuple[str, str]]:
     env_token = os.environ.get("LOCALFLOW_TOKEN", "").strip()
     if env_token:
         candidates.append(("LOCALFLOW_TOKEN", env_token))
-    legacy_file = Path(
-        os.environ.get("LOCALFLOW_TOKEN_FILE", str(LEGACY_TOKEN_FILE))
-    ).expanduser()
+    legacy_file = Path(os.environ.get("LOCALFLOW_TOKEN_FILE", str(LEGACY_TOKEN_FILE))).expanduser()
     if legacy_file.is_file():
         file_token = legacy_file.read_text(encoding="utf-8").strip()
         if file_token:

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -9,9 +9,6 @@ from pathlib import Path
 
 DEFAULT_HANDY_FALLBACK_MODEL = "handy-computer/whisper-base-gguf/whisper-base-Q8_0.gguf"
 WILDCARD_BIND_HOSTS = frozenset({"0.0.0.0", "::"})
-LEGACY_TOKEN_FILE = Path("~/.config/localflow/token")
-LEGACY_CONFIG_FILE = Path("~/.config/localflow/config.json")
-LEGACY_DATA_DIR = Path("~/.local/share/localflow")
 MIGRATION_DOCS = (
     "https://github.com/VocaHQ/vocaphone/blob/main/docs/deployment.md"
     "#migrating-from-the-local-flow-working-name-v030"
@@ -31,6 +28,35 @@ def local_webui_url(host: str, port: int) -> str:
     elif host == "::":
         host = "::1"
     return f"http://{format_host_port(host, port)}/"
+
+
+def _xdg_config_home() -> Path:
+    return Path(os.environ.get("XDG_CONFIG_HOME", "~/.config")).expanduser()
+
+
+def _xdg_data_home() -> Path:
+    return Path(os.environ.get("XDG_DATA_HOME", "~/.local/share")).expanduser()
+
+
+def _legacy_token_file() -> Path:
+    return _xdg_config_home() / "localflow" / "token"
+
+
+def _legacy_config_file() -> Path:
+    return _xdg_config_home() / "localflow" / "config.json"
+
+
+def _legacy_data_dir() -> Path:
+    return _xdg_data_home() / "localflow"
+
+
+def _display_path(path: Path | str) -> str:
+    """Render paths with `~` instead of an absolute home prefix for operators."""
+    text = str(path)
+    home = str(Path.home())
+    if home and (text == home or text.startswith(home + os.sep)):
+        return "~" + text[len(home) :]
+    return text
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,7 +92,7 @@ class Settings:
         token_file = Path(
             os.environ.get(
                 "VOCAPHONE_TOKEN_FILE",
-                "~/.config/vocaphone/token",
+                str(_xdg_config_home() / "vocaphone" / "token"),
             )
         ).expanduser()
         token = os.environ.get("VOCAPHONE_TOKEN", "").strip()
@@ -80,14 +106,14 @@ class Settings:
                 "~/.config/vocaphone/token with mode 600."
             )
         data_dir = Path(
-            os.environ.get("VOCAPHONE_DATA_DIR", "~/.local/share/vocaphone")
+            os.environ.get("VOCAPHONE_DATA_DIR", str(_xdg_data_home() / "vocaphone"))
         ).expanduser()
         if "VOCAPHONE_DATA_DIR" not in os.environ:
             _warn_unmigrated_legacy_data(data_dir)
         config_path = Path(
             os.environ.get(
                 "VOCAPHONE_CONFIG_FILE",
-                "~/.config/vocaphone/config.json",
+                str(_xdg_config_home() / "vocaphone" / "config.json"),
             )
         ).expanduser()
         if "VOCAPHONE_CONFIG_FILE" not in os.environ:
@@ -160,11 +186,13 @@ def _legacy_token_candidates() -> list[tuple[str, str]]:
     env_token = os.environ.get("LOCALFLOW_TOKEN", "").strip()
     if env_token:
         candidates.append(("LOCALFLOW_TOKEN", env_token))
-    legacy_file = Path(os.environ.get("LOCALFLOW_TOKEN_FILE", str(LEGACY_TOKEN_FILE))).expanduser()
+    legacy_file = Path(
+        os.environ.get("LOCALFLOW_TOKEN_FILE", str(_legacy_token_file()))
+    ).expanduser()
     if legacy_file.is_file():
         file_token = legacy_file.read_text(encoding="utf-8").strip()
         if file_token:
-            candidates.append((str(legacy_file), file_token))
+            candidates.append((_display_path(legacy_file), file_token))
     return candidates
 
 
@@ -178,8 +206,8 @@ def _write_token_file(token_file: Path, token: str) -> None:
 
 def _token_conflict_error(token_file: Path, source: str) -> RuntimeError:
     return RuntimeError(
-        f"{token_file} already contains a different bootstrap token than the "
-        f"Local Flow source ({source}). Remove the conflicting file or unset "
+        f"{_display_path(token_file)} already contains a different bootstrap token "
+        f"than the Local Flow source ({source}). Remove the conflicting file or unset "
         "LOCALFLOW_TOKEN / remove ~/.config/localflow/token, then retry so "
         f"paired phones keep the secret they already hold. See {MIGRATION_DOCS}"
     )
@@ -222,22 +250,22 @@ def _resolve_or_migrate_token(token_file: Path) -> str:
         except OSError as exc:
             raise RuntimeError(
                 "Found a Local Flow bootstrap token at "
-                f"{source} but could not write {token_file}: {exc}. "
+                f"{source} but could not write {_display_path(token_file)}: {exc}. "
                 f"Copy it manually, then restart. See {MIGRATION_DOCS}"
             ) from exc
         print(
             "vocaphone: migrated Local Flow bootstrap token from "
-            f"{source} to {token_file}. Paired phones keep working. "
+            f"{source} to {_display_path(token_file)}. Paired phones keep working. "
             f"See {MIGRATION_DOCS}",
             file=sys.stderr,
         )
         return token
 
-    legacy_data = LEGACY_DATA_DIR.expanduser()
+    legacy_data = _legacy_data_dir()
     if legacy_data.is_dir() and any(legacy_data.iterdir()):
         raise RuntimeError(
             "Found Local Flow data at "
-            f"{legacy_data} but no vocaphone bootstrap token. "
+            f"{_display_path(legacy_data)} but no vocaphone bootstrap token. "
             "Copy ~/.config/localflow/token to ~/.config/vocaphone/token "
             f"(or set VOCAPHONE_TOKEN) before starting the gateway so paired "
             f"phones are not locked out. See {MIGRATION_DOCS}"
@@ -246,10 +274,10 @@ def _resolve_or_migrate_token(token_file: Path) -> str:
 
 
 def _migrate_legacy_config_file(config_path: Path) -> None:
-    if config_path.is_file():
+    if config_path.is_file() and config_path.read_text(encoding="utf-8").strip():
         return
-    legacy = LEGACY_CONFIG_FILE.expanduser()
-    if not legacy.is_file():
+    legacy = _legacy_config_file()
+    if not legacy.is_file() or not legacy.read_text(encoding="utf-8").strip():
         return
     try:
         config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -258,14 +286,16 @@ def _migrate_legacy_config_file(config_path: Path) -> None:
         config_path.chmod(0o600)
     except OSError as exc:
         print(
-            f"vocaphone: could not migrate {legacy} to {config_path}: {exc}. "
+            "vocaphone: could not migrate "
+            f"{_display_path(legacy)} to {_display_path(config_path)}: {exc}. "
             f"Copy it manually if you need the previous WebUI settings. "
             f"See {MIGRATION_DOCS}",
             file=sys.stderr,
         )
         return
     print(
-        f"vocaphone: migrated Local Flow config from {legacy} to {config_path}. "
+        "vocaphone: migrated Local Flow config from "
+        f"{_display_path(legacy)} to {_display_path(config_path)}. "
         f"See {MIGRATION_DOCS}",
         file=sys.stderr,
     )
@@ -274,12 +304,13 @@ def _migrate_legacy_config_file(config_path: Path) -> None:
 def _warn_unmigrated_legacy_data(data_dir: Path) -> None:
     if data_dir.exists():
         return
-    legacy = LEGACY_DATA_DIR.expanduser()
+    legacy = _legacy_data_dir()
     if not legacy.is_dir() or not any(legacy.iterdir()):
         return
     print(
-        f"vocaphone: Local Flow data still exists at {legacy}. "
-        f"Move or copy it to {data_dir} (and rename any "
+        "vocaphone: Local Flow data still exists at "
+        f"{_display_path(legacy)}. "
+        f"Move or copy it to {_display_path(data_dir)} (and rename any "
         ".localflow-model.json markers to .vocaphone-model.json) to keep "
         f"downloaded models and session history. See {MIGRATION_DOCS}",
         file=sys.stderr,

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -176,19 +176,49 @@ def _write_token_file(token_file: Path, token: str) -> None:
         handle.write(token + "\n")
 
 
+def _token_conflict_error(token_file: Path, source: str) -> RuntimeError:
+    return RuntimeError(
+        f"{token_file} already contains a different bootstrap token than the "
+        f"Local Flow source ({source}). Remove the conflicting file or unset "
+        "LOCALFLOW_TOKEN / remove ~/.config/localflow/token, then retry so "
+        f"paired phones keep the secret they already hold. See {MIGRATION_DOCS}"
+    )
+
+
+def _persist_migrated_token(token_file: Path, token: str, source: str) -> None:
+    """Write a migrated token, replacing an empty destination if needed."""
+    token_file.parent.mkdir(parents=True, exist_ok=True)
+    token_file.parent.chmod(0o700)
+    if token_file.is_file():
+        existing = token_file.read_text(encoding="utf-8").strip()
+        if existing == token:
+            return
+        if existing:
+            raise _token_conflict_error(token_file, source)
+        token_file.write_text(token + "\n", encoding="utf-8")
+        token_file.chmod(0o600)
+        return
+    try:
+        _write_token_file(token_file, token)
+    except FileExistsError:
+        # Another process created the destination between our checks.
+        existing = token_file.read_text(encoding="utf-8").strip()
+        if existing == token:
+            return
+        if not existing:
+            token_file.write_text(token + "\n", encoding="utf-8")
+            token_file.chmod(0o600)
+            return
+        raise _token_conflict_error(token_file, source) from None
+
+
 def _resolve_or_migrate_token(token_file: Path) -> str:
     """Prefer a one-time Local Flow token migration over minting a new secret."""
     legacy = _legacy_token_candidates()
     if legacy:
         source, token = legacy[0]
         try:
-            _write_token_file(token_file, token)
-        except FileExistsError:
-            # Another process created the destination between our checks.
-            existing = token_file.read_text(encoding="utf-8").strip()
-            if existing:
-                return existing
-            raise
+            _persist_migrated_token(token_file, token, source)
         except OSError as exc:
             raise RuntimeError(
                 "Found a Local Flow bootstrap token at "

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -38,6 +38,22 @@ def _xdg_data_home() -> Path:
     return Path(os.environ.get("XDG_DATA_HOME", "~/.local/share")).expanduser()
 
 
+def _env_path(name: str, default: Path) -> Path:
+    """Resolve a path env var, treating missing/blank values as the default."""
+    value = os.environ.get(name, "").strip()
+    if not value:
+        return default
+    return Path(value).expanduser()
+
+
+def _default_token_file() -> Path:
+    return _xdg_config_home() / "vocaphone" / "token"
+
+
+def _default_config_file() -> Path:
+    return _xdg_config_home() / "vocaphone" / "config.json"
+
+
 def _legacy_token_file() -> Path:
     return _xdg_config_home() / "localflow" / "token"
 
@@ -74,6 +90,7 @@ class Settings:
     whisperkit_binary: str = "whisperkit-cli"
     models_dir: Path | None = None
     config_path: Path = Path("~/.config/vocaphone/config.json")
+    token_file: Path = Path("~/.config/vocaphone/token")
     bind_host: str = "0.0.0.0"
     port: int = 8765
     maximum_upload_bytes: int = 25 * 1024 * 1024
@@ -86,15 +103,14 @@ class Settings:
     def resolved_models_dir(self) -> Path:
         return self.models_dir if self.models_dir is not None else self.data_dir / "models"
 
+    @property
+    def token_file_display(self) -> str:
+        return _display_path(self.token_file)
+
     @classmethod
     def from_env(cls) -> Settings:
         _warn_ignored_legacy_env()
-        token_file = Path(
-            os.environ.get(
-                "VOCAPHONE_TOKEN_FILE",
-                str(_xdg_config_home() / "vocaphone" / "token"),
-            )
-        ).expanduser()
+        token_file = _env_path("VOCAPHONE_TOKEN_FILE", _default_token_file())
         token = os.environ.get("VOCAPHONE_TOKEN", "").strip()
         if not token and token_file.is_file():
             token = token_file.read_text(encoding="utf-8").strip()
@@ -103,20 +119,19 @@ class Settings:
         if len(token) < 32:
             raise RuntimeError(
                 "Set VOCAPHONE_TOKEN to at least 32 characters or create "
-                "~/.config/vocaphone/token with mode 600."
+                f"{_display_path(token_file)} with mode 600."
             )
-        data_dir = Path(
-            os.environ.get("VOCAPHONE_DATA_DIR", str(_xdg_data_home() / "vocaphone"))
-        ).expanduser()
-        if "VOCAPHONE_DATA_DIR" not in os.environ:
+        data_dir = _env_path("VOCAPHONE_DATA_DIR", _xdg_data_home() / "vocaphone")
+        if (
+            "VOCAPHONE_DATA_DIR" not in os.environ
+            or not os.environ.get("VOCAPHONE_DATA_DIR", "").strip()
+        ):
             _warn_unmigrated_legacy_data(data_dir)
-        config_path = Path(
-            os.environ.get(
-                "VOCAPHONE_CONFIG_FILE",
-                str(_xdg_config_home() / "vocaphone" / "config.json"),
-            )
-        ).expanduser()
-        if "VOCAPHONE_CONFIG_FILE" not in os.environ:
+        config_path = _env_path("VOCAPHONE_CONFIG_FILE", _default_config_file())
+        if (
+            "VOCAPHONE_CONFIG_FILE" not in os.environ
+            or not os.environ.get("VOCAPHONE_CONFIG_FILE", "").strip()
+        ):
             _migrate_legacy_config_file(config_path)
         return cls(
             token=token,
@@ -152,6 +167,7 @@ class Settings:
                 os.environ.get("VOCAPHONE_MODELS_DIR", str(data_dir / "models"))
             ).expanduser(),
             config_path=config_path,
+            token_file=token_file,
             bind_host=os.environ.get("VOCAPHONE_BIND_HOST", "0.0.0.0"),
             port=int(os.environ.get("VOCAPHONE_PORT", "8765")),
             retention_hours=int(os.environ.get("VOCAPHONE_RETENTION_HOURS", "24")),
@@ -186,9 +202,7 @@ def _legacy_token_candidates() -> list[tuple[str, str]]:
     env_token = os.environ.get("LOCALFLOW_TOKEN", "").strip()
     if env_token:
         candidates.append(("LOCALFLOW_TOKEN", env_token))
-    legacy_file = Path(
-        os.environ.get("LOCALFLOW_TOKEN_FILE", str(_legacy_token_file()))
-    ).expanduser()
+    legacy_file = _env_path("LOCALFLOW_TOKEN_FILE", _legacy_token_file())
     if legacy_file.is_file():
         file_token = legacy_file.read_text(encoding="utf-8").strip()
         if file_token:
@@ -208,7 +222,7 @@ def _token_conflict_error(token_file: Path, source: str) -> RuntimeError:
     return RuntimeError(
         f"{_display_path(token_file)} already contains a different bootstrap token "
         f"than the Local Flow source ({source}). Remove the conflicting file or unset "
-        "LOCALFLOW_TOKEN / remove ~/.config/localflow/token, then retry so "
+        f"LOCALFLOW_TOKEN / remove {_display_path(_legacy_token_file())}, then retry so "
         f"paired phones keep the secret they already hold. See {MIGRATION_DOCS}"
     )
 
@@ -266,7 +280,7 @@ def _resolve_or_migrate_token(token_file: Path) -> str:
         raise RuntimeError(
             "Found Local Flow data at "
             f"{_display_path(legacy_data)} but no vocaphone bootstrap token. "
-            "Copy ~/.config/localflow/token to ~/.config/vocaphone/token "
+            f"Copy {_display_path(_legacy_token_file())} to {_display_path(token_file)} "
             f"(or set VOCAPHONE_TOKEN) before starting the gateway so paired "
             f"phones are not locked out. See {MIGRATION_DOCS}"
         )

--- a/server/scripts/install-launch-agent.sh
+++ b/server/scripts/install-launch-agent.sh
@@ -27,6 +27,17 @@ sed \
 mv "$temporary" "$destination"
 trap - EXIT
 
+# Drop the pre-rename Local Flow LaunchAgent so it cannot keep crash-looping
+# after localflow-server disappears from the venv.
+legacy_label="com.example.localflow.gateway"
+legacy_service="$domain/$legacy_label"
+legacy_plist="$HOME/Library/LaunchAgents/${legacy_label}.plist"
+if launchctl print "$legacy_service" >/dev/null 2>&1 || [ -f "$legacy_plist" ]; then
+  launchctl bootout "$legacy_service" 2>/dev/null || true
+  rm -f "$legacy_plist"
+  printf 'Removed obsolete LaunchAgent %s\n' "$legacy_label"
+fi
+
 launchctl bootout "$service" 2>/dev/null || true
 remaining=50
 while launchctl print "$service" >/dev/null 2>&1; do

--- a/server/scripts/install-systemd-user.sh
+++ b/server/scripts/install-systemd-user.sh
@@ -30,6 +30,16 @@ sed -e "s/__REPOSITORY__/$escaped_repository/g" "$template" > "$temporary"
 mv "$temporary" "$destination"
 trap - EXIT
 
+# Drop the pre-rename Local Flow unit so it cannot keep restarting a missing
+# localflow-server binary after the vocaphone rename.
+legacy_unit="com.example.localflow.gateway.service"
+legacy_destination="$unit_dir/$legacy_unit"
+if systemctl --user cat "$legacy_unit" >/dev/null 2>&1 || [ -f "$legacy_destination" ]; then
+  systemctl --user disable --now "$legacy_unit" 2>/dev/null || true
+  rm -f "$legacy_destination"
+  printf 'Removed obsolete systemd unit %s\n' "$legacy_unit"
+fi
+
 systemctl --user daemon-reload
 systemctl --user enable --now "$unit_name"
 

--- a/server/scripts/setup-token.sh
+++ b/server/scripts/setup-token.sh
@@ -4,17 +4,30 @@ set -eu
 config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/vocaphone"
 token_file="$config_dir/token"
 legacy_token="${XDG_CONFIG_HOME:-$HOME/.config}/localflow/token"
+legacy_data="${XDG_DATA_HOME:-$HOME/.local/share}/localflow"
 
 mkdir -p "$config_dir"
 chmod 700 "$config_dir"
-if [ ! -f "$token_file" ]; then
-  if [ -f "$legacy_token" ]; then
-    cp "$legacy_token" "$token_file"
-    printf 'Migrated Local Flow token from %s\n' "$legacy_token"
-  else
-    umask 077
-    openssl rand -base64 48 > "$token_file"
-  fi
+
+# Treat a missing or empty vocaphone token as unset so an empty placeholder
+# cannot block migration the way a real secret would.
+if [ -s "$token_file" ]; then
+  :
+elif [ -n "${LOCALFLOW_TOKEN:-}" ]; then
+  printf '%s\n' "$LOCALFLOW_TOKEN" > "$token_file"
+  printf 'Migrated Local Flow token from LOCALFLOW_TOKEN\n'
+elif [ -s "$legacy_token" ]; then
+  cp "$legacy_token" "$token_file"
+  printf 'Migrated Local Flow token from %s\n' "$legacy_token"
+elif [ -d "$legacy_data" ] && [ -n "$(ls -A "$legacy_data" 2>/dev/null || true)" ]; then
+  printf 'Found Local Flow data at %s but no bootstrap token.\n' "$legacy_data" >&2
+  printf 'Copy %s to %s (or set VOCAPHONE_TOKEN) before minting a new secret so paired phones are not locked out.\n' \
+    "$legacy_token" "$token_file" >&2
+  exit 1
+else
+  umask 077
+  openssl rand -base64 48 > "$token_file"
 fi
+
 chmod 600 "$token_file"
 printf 'Token is stored at %s\n' "$token_file"

--- a/server/scripts/setup-token.sh
+++ b/server/scripts/setup-token.sh
@@ -3,21 +3,36 @@ set -eu
 
 config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/vocaphone"
 token_file="$config_dir/token"
-legacy_token="${XDG_CONFIG_HOME:-$HOME/.config}/localflow/token"
+legacy_token="${LOCALFLOW_TOKEN_FILE:-${XDG_CONFIG_HOME:-$HOME/.config}/localflow/token}"
 legacy_data="${XDG_DATA_HOME:-$HOME/.local/share}/localflow"
+
+# Strip leading/trailing whitespace so " " is treated like an unset value,
+# matching Settings.from_env().
+trim() {
+  printf '%s' "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+
+read_trimmed_file() {
+  if [ -f "$1" ]; then
+    # Avoid swallowing trailing newlines incorrectly: read whole file then trim.
+    trim "$(cat "$1")"
+  fi
+}
 
 mkdir -p "$config_dir"
 chmod 700 "$config_dir"
 
-# Treat a missing or empty vocaphone token as unset so an empty placeholder
-# cannot block migration the way a real secret would.
-if [ -s "$token_file" ]; then
+existing="$(read_trimmed_file "$token_file")"
+legacy_env="$(trim "${LOCALFLOW_TOKEN:-}")"
+legacy_file_token="$(read_trimmed_file "$legacy_token")"
+
+if [ -n "$existing" ]; then
   :
-elif [ -n "${LOCALFLOW_TOKEN:-}" ]; then
-  printf '%s\n' "$LOCALFLOW_TOKEN" > "$token_file"
+elif [ -n "$legacy_env" ]; then
+  printf '%s\n' "$legacy_env" > "$token_file"
   printf 'Migrated Local Flow token from LOCALFLOW_TOKEN\n'
-elif [ -s "$legacy_token" ]; then
-  cp "$legacy_token" "$token_file"
+elif [ -n "$legacy_file_token" ]; then
+  printf '%s\n' "$legacy_file_token" > "$token_file"
   printf 'Migrated Local Flow token from %s\n' "$legacy_token"
 elif [ -d "$legacy_data" ] && [ -n "$(ls -A "$legacy_data" 2>/dev/null || true)" ]; then
   printf 'Found Local Flow data at %s but no bootstrap token.\n' "$legacy_data" >&2

--- a/server/scripts/setup-token.sh
+++ b/server/scripts/setup-token.sh
@@ -3,12 +3,18 @@ set -eu
 
 config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/vocaphone"
 token_file="$config_dir/token"
+legacy_token="${XDG_CONFIG_HOME:-$HOME/.config}/localflow/token"
 
 mkdir -p "$config_dir"
 chmod 700 "$config_dir"
 if [ ! -f "$token_file" ]; then
-  umask 077
-  openssl rand -base64 48 > "$token_file"
+  if [ -f "$legacy_token" ]; then
+    cp "$legacy_token" "$token_file"
+    printf 'Migrated Local Flow token from %s\n' "$legacy_token"
+  else
+    umask 077
+    openssl rand -base64 48 > "$token_file"
+  fi
 fi
 chmod 600 "$token_file"
 printf 'Token is stored at %s\n' "$token_file"

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -240,3 +240,37 @@ def test_cli_token_from_env_strips_whitespace(monkeypatch: MonkeyPatch) -> None:
     assert _token_from_env() is False
     monkeypatch.setenv("VOCAPHONE_TOKEN", "real-token-with-at-least-thirty-two-chars")
     assert _token_from_env() is True
+
+
+def test_empty_localflow_token_file_env_falls_back_to_xdg(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("LOCALFLOW_TOKEN_FILE", "")
+    legacy_dir = home / ".config" / "localflow"
+    legacy_dir.mkdir(parents=True)
+    (legacy_dir / "token").write_text(
+        "legacy-token-with-at-least-thirty-two-chars\n", encoding="utf-8"
+    )
+
+    settings = Settings.from_env()
+
+    assert settings.token == "legacy-token-with-at-least-thirty-two-chars"
+
+
+def test_refuse_message_uses_resolved_token_paths(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    from app.config import _display_path
+
+    home = _isolate_home(monkeypatch, tmp_path)
+    custom_token = home / "custom" / "gateway.token"
+    monkeypatch.setenv("VOCAPHONE_TOKEN_FILE", str(custom_token))
+    legacy_data = home / ".local" / "share" / "localflow"
+    legacy_data.mkdir(parents=True)
+    (legacy_data / "sessions.sqlite3").write_text("x", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="no vocaphone bootstrap token") as raised:
+        Settings.from_env()
+    message = str(raised.value)
+    assert _display_path(custom_token) in message
+    assert "~/.config/localflow/token" in message
+    assert str(home) not in message

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from pytest import MonkeyPatch, CaptureFixture
+from pytest import CaptureFixture, MonkeyPatch
 
 from app.config import Settings, format_host_port, local_webui_url
 
@@ -110,9 +110,7 @@ def test_refuses_to_mint_when_legacy_data_exists_without_token(
         Settings.from_env()
 
 
-def test_fresh_install_still_mints_a_token(
-    tmp_path: Path, monkeypatch: MonkeyPatch
-) -> None:
+def test_fresh_install_still_mints_a_token(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     home = _isolate_home(monkeypatch, tmp_path)
 
     settings = Settings.from_env()

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -95,7 +95,8 @@ def test_warns_about_unmigrated_legacy_data_dir(
 
     err = capsys.readouterr().err
     assert "Local Flow data still exists" in err
-    assert str(legacy_data) in err
+    assert "~/.local/share/localflow" in err
+    assert str(home) not in err
 
 
 def test_refuses_to_mint_when_legacy_data_exists_without_token(
@@ -106,8 +107,10 @@ def test_refuses_to_mint_when_legacy_data_exists_without_token(
     legacy_data.mkdir(parents=True)
     (legacy_data / "sessions.sqlite3").write_text("x", encoding="utf-8")
 
-    with pytest.raises(RuntimeError, match="no vocaphone bootstrap token"):
+    with pytest.raises(RuntimeError, match="no vocaphone bootstrap token") as raised:
         Settings.from_env()
+    assert "~/.local/share/localflow" in str(raised.value)
+    assert str(home) not in str(raised.value)
 
 
 def test_fresh_install_still_mints_a_token(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
@@ -171,3 +174,69 @@ def test_migrate_accepts_matching_destination_token(
 
     _persist_migrated_token(destination, token, "LOCALFLOW_TOKEN")
     assert destination.read_text(encoding="utf-8").strip() == token
+
+
+def test_migrates_legacy_config_over_empty_destination(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("VOCAPHONE_TOKEN", "test-" + ("x" * 48))
+    legacy_config = home / ".config" / "localflow" / "config.json"
+    legacy_config.parent.mkdir(parents=True)
+    legacy_config.write_text('{"engine":"sherpa-onnx"}', encoding="utf-8")
+    destination = home / ".config" / "vocaphone" / "config.json"
+    destination.parent.mkdir(parents=True)
+    destination.write_text("\n", encoding="utf-8")
+
+    settings = Settings.from_env()
+
+    assert settings.config_path.read_text(encoding="utf-8") == '{"engine":"sherpa-onnx"}'
+    assert "migrated Local Flow config" in capsys.readouterr().err
+
+
+def test_honours_xdg_dirs_for_legacy_layout(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    _isolate_home(monkeypatch, tmp_path)
+    config_home = tmp_path / "xdg-config"
+    data_home = tmp_path / "xdg-data"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(data_home))
+    legacy_token = config_home / "localflow" / "token"
+    legacy_token.parent.mkdir(parents=True)
+    legacy_token.write_text("xdg-legacy-token-with-at-least-thirty-two\n", encoding="utf-8")
+    (data_home / "localflow" / "models").mkdir(parents=True)
+    (data_home / "localflow" / "models" / "keep.txt").write_text("x", encoding="utf-8")
+
+    settings = Settings.from_env()
+
+    assert settings.token == "xdg-legacy-token-with-at-least-thirty-two"
+    assert (config_home / "vocaphone" / "token").is_file()
+    err = capsys.readouterr().err
+    assert "migrated Local Flow bootstrap token" in err
+    assert "Local Flow data still exists" in err
+
+
+def test_whitespace_only_vocaphone_token_env_is_ignored(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("VOCAPHONE_TOKEN", "   \n\t  ")
+    legacy_dir = home / ".config" / "localflow"
+    legacy_dir.mkdir(parents=True)
+    (legacy_dir / "token").write_text(
+        "legacy-token-with-at-least-thirty-two-chars\n", encoding="utf-8"
+    )
+
+    settings = Settings.from_env()
+
+    assert settings.token == "legacy-token-with-at-least-thirty-two-chars"
+
+
+def test_cli_token_from_env_strips_whitespace(monkeypatch: MonkeyPatch) -> None:
+    from app.cli import _token_from_env
+
+    monkeypatch.setenv("VOCAPHONE_TOKEN", "   ")
+    assert _token_from_env() is False
+    monkeypatch.setenv("VOCAPHONE_TOKEN", "real-token-with-at-least-thirty-two-chars")
+    assert _token_from_env() is True

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -118,3 +118,56 @@ def test_fresh_install_still_mints_a_token(tmp_path: Path, monkeypatch: MonkeyPa
     token_file = home / ".config" / "vocaphone" / "token"
     assert len(settings.token) >= 32
     assert token_file.read_text(encoding="utf-8").strip() == settings.token
+
+
+def test_replaces_empty_destination_token_with_legacy(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    home = _isolate_home(monkeypatch, tmp_path)
+    legacy_dir = home / ".config" / "localflow"
+    legacy_dir.mkdir(parents=True)
+    (legacy_dir / "token").write_text(
+        "legacy-token-with-at-least-thirty-two-chars\n", encoding="utf-8"
+    )
+    destination = home / ".config" / "vocaphone" / "token"
+    destination.parent.mkdir(parents=True)
+    destination.write_text("\n", encoding="utf-8")
+
+    settings = Settings.from_env()
+
+    assert settings.token == "legacy-token-with-at-least-thirty-two-chars"
+    assert destination.read_text(encoding="utf-8").strip() == settings.token
+    assert "migrated Local Flow bootstrap token" in capsys.readouterr().err
+
+
+def test_migrate_rejects_conflicting_nonempty_destination(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    from app.config import _persist_migrated_token
+
+    home = _isolate_home(monkeypatch, tmp_path)
+    destination = home / ".config" / "vocaphone" / "token"
+    destination.parent.mkdir(parents=True)
+    destination.write_text("other-token-with-at-least-thirty-two-chars\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="different bootstrap token"):
+        _persist_migrated_token(
+            destination,
+            "legacy-token-with-at-least-thirty-two-chars",
+            "LOCALFLOW_TOKEN",
+        )
+
+
+def test_migrate_accepts_matching_destination_token(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    from app.config import _persist_migrated_token
+
+    home = _isolate_home(monkeypatch, tmp_path)
+    destination = home / ".config" / "vocaphone" / "token"
+    destination.parent.mkdir(parents=True)
+    token = "legacy-token-with-at-least-thirty-two-chars"
+    destination.write_text(token + "\n", encoding="utf-8")
+
+    _persist_migrated_token(destination, token, "LOCALFLOW_TOKEN")
+    assert destination.read_text(encoding="utf-8").strip() == token

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -1,8 +1,23 @@
 from __future__ import annotations
 
-from pytest import MonkeyPatch
+from pathlib import Path
+
+import pytest
+from pytest import MonkeyPatch, CaptureFixture
 
 from app.config import Settings, format_host_port, local_webui_url
+
+
+def _isolate_home(monkeypatch: MonkeyPatch, tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    for name in list(__import__("os").environ):
+        if name.startswith("LOCALFLOW_") or name.startswith("VOCAPHONE_"):
+            monkeypatch.delenv(name, raising=False)
+    return home
 
 
 def test_environment_defaults_to_all_interface_listener(monkeypatch: MonkeyPatch) -> None:
@@ -19,3 +34,89 @@ def test_environment_defaults_to_all_interface_listener(monkeypatch: MonkeyPatch
 def test_ipv6_listener_and_local_url_are_bracketed() -> None:
     assert format_host_port("::", 8765) == "[::]:8765"
     assert local_webui_url("::", 8765) == "http://[::1]:8765/"
+
+
+def test_migrates_legacy_token_file_instead_of_minting(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    home = _isolate_home(monkeypatch, tmp_path)
+    legacy_dir = home / ".config" / "localflow"
+    legacy_dir.mkdir(parents=True)
+    legacy_token = legacy_dir / "token"
+    legacy_token.write_text("legacy-token-with-at-least-thirty-two-chars\n", encoding="utf-8")
+
+    settings = Settings.from_env()
+
+    migrated = home / ".config" / "vocaphone" / "token"
+    assert settings.token == "legacy-token-with-at-least-thirty-two-chars"
+    assert migrated.read_text(encoding="utf-8").strip() == settings.token
+    assert "migrated Local Flow bootstrap token" in capsys.readouterr().err
+
+
+def test_migrates_legacy_token_env_instead_of_minting(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("LOCALFLOW_TOKEN", "env-legacy-token-with-at-least-thirty-two")
+
+    settings = Settings.from_env()
+
+    assert settings.token == "env-legacy-token-with-at-least-thirty-two"
+    err = capsys.readouterr().err
+    assert "LOCALFLOW_* environment variables are obsolete" in err
+    assert "migrated Local Flow bootstrap token" in err
+
+
+def test_migrates_legacy_config_file(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("VOCAPHONE_TOKEN", "test-" + ("x" * 48))
+    legacy_config = home / ".config" / "localflow" / "config.json"
+    legacy_config.parent.mkdir(parents=True)
+    legacy_config.write_text('{"engine":"sherpa-onnx"}', encoding="utf-8")
+
+    settings = Settings.from_env()
+
+    assert settings.config_path.read_text(encoding="utf-8") == '{"engine":"sherpa-onnx"}'
+    assert "migrated Local Flow config" in capsys.readouterr().err
+
+
+def test_warns_about_unmigrated_legacy_data_dir(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("VOCAPHONE_TOKEN", "test-" + ("x" * 48))
+    legacy_data = home / ".local" / "share" / "localflow"
+    (legacy_data / "models").mkdir(parents=True)
+    (legacy_data / "models" / "marker.txt").write_text("keep", encoding="utf-8")
+
+    Settings.from_env()
+
+    err = capsys.readouterr().err
+    assert "Local Flow data still exists" in err
+    assert str(legacy_data) in err
+
+
+def test_refuses_to_mint_when_legacy_data_exists_without_token(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    home = _isolate_home(monkeypatch, tmp_path)
+    legacy_data = home / ".local" / "share" / "localflow"
+    legacy_data.mkdir(parents=True)
+    (legacy_data / "sessions.sqlite3").write_text("x", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="no vocaphone bootstrap token"):
+        Settings.from_env()
+
+
+def test_fresh_install_still_mints_a_token(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    home = _isolate_home(monkeypatch, tmp_path)
+
+    settings = Settings.from_env()
+
+    token_file = home / ".config" / "vocaphone" / "token"
+    assert len(settings.token) >= 32
+    assert token_file.read_text(encoding="utf-8").strip() == settings.token


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #36. Hard-cutover renames could leave operators with a healthy-looking gateway that had minted a **new** bootstrap token, while paired phones still held the old one.

- One-time migrate `LOCALFLOW_TOKEN` / `LOCALFLOW_TOKEN_FILE` / legacy XDG token (and config) into vocaphone paths
- Refuse to mint when Local Flow data exists but no token can be found (`Settings.from_env` + `setup-token.sh`)
- Honor `XDG_*` dirs; treat blank path env vars as unset
- Operator messages/CLI banner use resolved token paths (with `~` redaction)
- Install helpers remove obsolete Local Flow units; docs + iOS label cleanup

## Validation

- `uv run ruff` / `mypy` / full `pytest`
- setup-token + migration edge-case coverage (whitespace, empty env, XDG, path messages)

## Status

All Bugbot review threads resolved.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db668d5c-a62b-4db2-a4d6-b27c72b991ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db668d5c-a62b-4db2-a4d6-b27c72b991ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

