### PR TITLE
feat: follow VocaMac and Handy model selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ limits, Android accessibility consent, and what the bubble will never touch
   silence detection, retention cleanup, and stable error responses
 - VocaMac, Handy, WhisperKit, Apple-native MLX Audio, persistent `sherpa-onnx`
   and `faster-whisper`, multilingual Moonshine, and `whisper.cpp` adapters.
-  The VocaMac and Handy desktop apps are optional, Mac-only, and reuse the
-  models they already downloaded
+  The optional Mac-only VocaMac and Handy adapters follow the model currently
+  selected in each desktop app; current VocaMac builds expose WhisperKit,
+  Parakeet, Apple Speech, and specialized ONNX selections headlessly
 - A 58-model catalog spanning Whisper, Parakeet, SenseVoice, Moonshine, GigaAM,
   Canary, Qwen3-ASR, Granite Speech, and Dolphin (40 Eastern
   languages, including Hindi, Bengali, Tamil and Urdu), filterable by the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,12 +65,14 @@ engines that can identify model files also expose best-effort warmup.
 `HandyEngine` can reuse Handy's selected downloaded model, `WhisperKitEngine`
 runs Core ML folders through one managed loopback-only WhisperKit service on
 Apple silicon, and `WhisperCppEngine` is the portable CLI fallback.
-`VocaMacEngine` covers the other optional desktop app: VocaMac exposes no
-headless transcription command, so instead of driving the app it reads the model
-chosen in VocaMac's preferences, rejects incomplete downloads the way VocaMac's
-own asset check does, and hands the Core ML folder and VocaMac's tokenizers to
-`WhisperKitEngine`. Both desktop apps are optional and Mac-only — Handy needs
-macOS, VocaMac needs Apple silicon — so `app/system.py` holds one table of
+`VocaMacEngine` covers the other optional desktop app. Current VocaMac builds
+expose a one-shot headless interface backed by their internal multi-engine
+router, so the gateway follows the app's selected WhisperKit, FluidAudio
+Parakeet, Apple Speech, or sherpa-onnx model without opening or disturbing its
+GUI. A side-effect-free executable capability check keeps older builds on the
+original complete-WhisperKit-folder compatibility path rather than launching an
+old GUI with an unknown flag. Both desktop apps are optional and Mac-only —
+Handy needs macOS, VocaMac needs Apple silicon — so `app/system.py` holds one table of
 per-engine host requirements that drives the WebUI picker contents, the label
 shown beside each engine, and the `422` rejection when a host cannot run the
 selected engine. The service

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -67,20 +67,21 @@ cd server
 uv run vocaphone-status
 ```
 
-For a native VocaMac setup, check that the app is installed, that
-`whisperkit-cli` is on `PATH`, and that the model VocaMac selected finished
-downloading. An interrupted download leaves the variant folder in place with
-empty Core ML components, and the gateway skips it:
+For a native VocaMac setup, check that the app is installed and its selected
+model is reported as downloaded and supported:
 
 ```sh
-test -d /Applications/VocaMac.app
-command -v whisperkit-cli
+test -x /Applications/VocaMac.app/Contents/MacOS/VocaMac
 defaults read com.vocamac.app vocamac.selectedModelSize
-du -sh ~/Library/Application\ Support/VocaMac/models/models/argmaxinc/whisperkit-coreml/*
+/Applications/VocaMac.app/Contents/MacOS/VocaMac --list-models --json
 ```
 
-A folder of a few kilobytes is an incomplete download — re-download that model
-in VocaMac's Models tab.
+The selected entry must have `"selected":true`, `"downloaded":true`, and
+`"supported":true`. Current builds can run WhisperKit, Parakeet, Apple Speech,
+and specialized ONNX selections through the headless interface. An older build
+without `--list-models` can use only complete VocaMac WhisperKit downloads and
+also requires `whisperkit-cli` on `PATH`; update VocaMac to follow other model
+families.
 
 With `VOCAPHONE_ENGINE=whisper.cpp`, also check
 `$VOCAPHONE_WHISPER_BINARY` and `$VOCAPHONE_WHISPER_MODEL`.

--- a/ios/VocaPhoneApp/Networking/GatewayClient.swift
+++ b/ios/VocaPhoneApp/Networking/GatewayClient.swift
@@ -119,7 +119,9 @@ struct GatewayClient: Sendable {
     func finish(sessionID: UUID) async throws -> GatewaySession {
         var request = URLRequest(url: endpoint("v1/sessions/\(sessionID.uuidString.lowercased())/finish"))
         request.httpMethod = "POST"
-        request.timeoutInterval = 90
+        // One-shot local engines can spend several minutes loading or compiling
+        // a newly selected model before their first transcription completes.
+        request.timeoutInterval = 540
         return try await perform(request, as: GatewaySession.self)
     }
 

--- a/server/README.md
+++ b/server/README.md
@@ -28,18 +28,19 @@ Requires [Homebrew](https://brew.sh/), Python 3.12+, and
 [uv](https://docs.astral.sh/uv/). Install the host dependencies first:
 
 - `ffmpeg` — audio normalization (required by every engine)
-- `whisperkit-cli` — WhisperKit/Core ML engine on Apple silicon, and the engine
-  behind the VocaMac adapter
+- `whisperkit-cli` — standalone WhisperKit/Core ML engine on Apple silicon and
+  the compatibility path for older VocaMac builds
 - `whisper-cpp` — provides `whisper-cli` for GGML `whisper.cpp` models,
   including the Handy model family, which runs without the Handy app
 
 The [VocaMac](https://github.com/VocaHQ/vocamac) and
 [Handy](https://handy.computer) desktop apps are **optional and Mac-only**:
 VocaMac needs an Apple silicon Mac, Handy needs macOS. Install neither and the
-gateway downloads and runs its own models; install either and the gateway can
-reuse the models that app already downloaded instead of asking for a second
-copy. On Linux and in containers both engines are hidden from the WebUI picker,
-and selecting one through the API is rejected with `422 invalid_engine`.
+gateway downloads and runs its own models. Current VocaMac builds expose their
+selected WhisperKit, Parakeet, Apple Speech, or sherpa-onnx model through a
+headless command; Handy similarly exposes its selected downloaded model. On
+Linux and in containers both engines are hidden from the WebUI picker, and
+selecting one through the API is rejected with `422 invalid_engine`.
 
 ```sh
 brew install ffmpeg whisperkit-cli whisper-cpp
@@ -251,8 +252,8 @@ redistributing weights.
 
 The `auto` engine preference uses the first runnable option in this order:
 
-1. VocaMac when the app is installed and one of its downloaded Core ML models
-   is complete
+1. VocaMac when the app is installed and its selected model is supported and
+   downloaded
 2. Handy when its macOS application binary is present
 3. a downloaded WhisperKit model kept resident in a managed loopback service
 4. a downloaded MLX Audio model on Apple silicon
@@ -317,11 +318,17 @@ starts it on a random `127.0.0.1` port during warmup and reuses the loaded
 Core ML model. If an older CLI does not support `serve`, transcription falls
 back to the compatible one-shot command rather than becoming unavailable.
 
-VocaMac has no headless transcription command, so its adapter reuses the app's
-Core ML model library and tokenizers through `whisperkit-cli` rather than the
-app itself: it reads the model chosen in VocaMac's Models tab, verifies the
-downloaded files are complete, and skips partial downloads in favour of another
-complete model. VocaMac does not need to be running.
+Current VocaMac builds expose one-shot file transcription through the app binary.
+The adapter asks that interface which model is selected and then invokes the same
+internal router VocaMac uses for WhisperKit, FluidAudio Parakeet, Apple Speech,
+and specialized sherpa-onnx models. Changing the selection in VocaMac affects the
+next phone transcription without restarting the gateway, and the command does
+not open, close, or disturb the VocaMac GUI.
+
+Older VocaMac builds without the headless interface retain the compatibility
+path: the adapter can reuse complete WhisperKit Core ML folders and tokenizers
+through `whisperkit-cli`. That legacy path cannot run VocaMac's other embedded
+engines. VocaMac does not need to be running in either mode.
 
 To force VocaMac from the environment:
 
@@ -331,10 +338,11 @@ export VOCAPHONE_VOCAMAC_MODEL='small'   # optional; otherwise VocaMac's own cho
 uv run vocaphone-server
 ```
 
-`VOCAPHONE_VOCAMAC_MODEL` accepts either a VocaMac model size (`small`,
-`large-v3-v20240930_turbo_632MB`) or a WhisperKit folder name
-(`openai_whisper-small`). A configured model is never substituted: if it is not
-downloaded, the engine reports unavailable rather than quietly using another.
+`VOCAPHONE_VOCAMAC_MODEL` accepts any VocaMac model ID, including `small`,
+`parakeet-tdt-0.6b-v2`, `apple-speech`, or `canary-180m-flash`. WhisperKit folder
+names such as `openai_whisper-small` remain accepted for compatibility. A
+configured model is never substituted: if it is not downloaded or supported,
+the engine reports unavailable rather than quietly using another.
 
 To force Handy from the environment:
 
@@ -368,7 +376,7 @@ uv run vocaphone-server
 | `VOCAPHONE_ENGINE` | `auto` | `auto` | `auto`, `vocamac`, `handy`, `mlx-audio`, `whisperkit`, `sherpa-onnx`, `faster-whisper`, `moonshine`, or `whisper.cpp` |
 | `VOCAPHONE_WHISPER_BINARY` | `/opt/homebrew/bin/whisper-cli` | `/usr/local/bin/whisper-cli` | `whisper.cpp` executable |
 | `VOCAPHONE_WHISPER_MODEL` | base model path | base model path | Fallback `whisper.cpp` model |
-| `VOCAPHONE_WHISPERKIT_BINARY` | `whisperkit-cli` | unavailable | WhisperKit executable |
+| `VOCAPHONE_WHISPERKIT_BINARY` | `whisperkit-cli` | unavailable | Standalone WhisperKit executable and legacy VocaMac fallback |
 | `VOCAPHONE_VOCAMAC_APP` | `/Applications/VocaMac.app` | unavailable | Optional VocaMac app bundle |
 | `VOCAPHONE_VOCAMAC_MODEL` | unset | unset | Pin a VocaMac model instead of following the app's choice |
 | `VOCAPHONE_RETENTION_HOURS` | `24` | `24` | Failed-session retry retention |
@@ -430,9 +438,10 @@ Funnel. See [deployment.md](../docs/deployment.md) for LAN/VPS alternatives and
 Engine probes are cached for five seconds. sherpa-onnx, MLX Audio,
 `faster-whisper`, and Moonshine load their selected model once and keep it
 resident. WhisperKit warmup starts its managed loopback service and keeps the
-Core ML model resident there, and the VocaMac adapter inherits that behavior for
-VocaMac's own models. Handy and `whisper.cpp` retain the filesystem-prefetch
-warmup behavior.
+Core ML model resident there. Current VocaMac headless transcription is one-shot,
+so its first-load cost is included in each request; older WhisperKit-only VocaMac
+builds retain the persistent compatibility path. Handy and `whisper.cpp` retain
+the filesystem-prefetch warmup behavior.
 
 ## Docker performance profiles
 

--- a/server/app/fragments/engine.py
+++ b/server/app/fragments/engine.py
@@ -20,8 +20,8 @@ ENGINE_LABELS = {
 ENGINE_HINTS = {
     "auto": "Uses the fastest compatible installed local engine for this machine.",
     "vocamac": (
-        "Optional Apple silicon Mac app. Reuses VocaMac's downloaded Core ML "
-        "models through whisperkit-cli. No download needed."
+        "Optional Apple silicon Mac app. Follows VocaMac's selected downloaded "
+        "model through its headless interface. No second download needed."
     ),
     "handy": (
         "Optional macOS app. Reuses the Handy app and its downloaded models. No download needed."

--- a/server/app/models/handy.py
+++ b/server/app/models/handy.py
@@ -29,13 +29,17 @@ class HandyEngine:
             or Path("~/Library/Application Support/com.pais.handy/settings_store.json").expanduser()
         )
         self.huggingface_cache = huggingface_cache or Path("~/.cache/huggingface/hub").expanduser()
-        self.model = model or self._read_selected_model()
+        # An explicit model pins the adapter. Without one, follow Handy's
+        # persisted selection so changing models in the app takes effect without
+        # rebuilding or restarting the vocaphone gateway.
+        self.model = model
         self.fallback_model = fallback_model
 
     async def health(self) -> EngineHealth:
+        app_selected_model = self._selected_model()
         available_models = self._downloaded_models()
         selected_model = (
-            available_models[0] if available_models else self.model or "no-model-selected"
+            available_models[0] if available_models else app_selected_model or "no-model-selected"
         )
         ready = self.binary.is_file() and os.access(self.binary, os.X_OK) and bool(available_models)
         return EngineHealth(
@@ -101,10 +105,14 @@ class HandyEngine:
 
     def _downloaded_models(self) -> list[str]:
         models: list[str] = []
-        for model in (self.model, self.fallback_model):
+        selected_model = self._selected_model()
+        for model in (selected_model, self.fallback_model):
             if model and model not in models and self._model_is_downloaded(model):
                 models.append(model)
         return models
+
+    def _selected_model(self) -> str | None:
+        return self.model or self._read_selected_model()
 
     def _read_selected_model(self) -> str | None:
         try:

--- a/server/app/models/vocamac.py
+++ b/server/app/models/vocamac.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import asyncio
+import json
+import os
 import plistlib
 import shutil
+import subprocess
+import time
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from app.errors import EngineUnavailableError, TranscriptionProcessError
 from app.models.base import EngineHealth, EngineTranscription, TranscriptionOptions
@@ -38,15 +45,25 @@ REQUIRED_COMPONENTS = (
     "TextDecoder.mlmodelc",
 )
 _MODEL_DEFINITIONS = ("model.mil", "model.mlmodel", "coremldata.bin")
+_VOCAMAC_EXECUTABLE = Path("Contents/MacOS/VocaMac")
+_HEADLESS_MARKER = b"--transcribe-file"
+_HEADLESS_TIMEOUT_SECONDS = 300
+
+
+@dataclass(frozen=True, slots=True)
+class _HeadlessModel:
+    id: str
+    downloaded: bool
+    supported: bool
 
 
 class VocaMacEngine:
-    """Adapter that runs VocaMac's downloaded Core ML models through WhisperKit.
+    """Adapter for VocaMac's selected local transcription model.
 
-    VocaMac has no headless transcription command, so unlike `HandyEngine` this
-    adapter cannot delegate to the app itself. What it reuses is the app's model
-    library: plain WhisperKit Core ML folders that `WhisperKitEngine` already
-    knows how to serve, plus the tokenizers VocaMac downloaded alongside them.
+    Current VocaMac builds expose a headless file-transcription command backed
+    by the same multi-engine router as the app. Older builds are kept working by
+    the original WhisperKit-folder adapter, without ever probing an old app with
+    command-line arguments that would launch its GUI.
     """
 
     def __init__(
@@ -66,9 +83,14 @@ class VocaMacEngine:
         self.preferences_file = preferences_file or DEFAULT_PREFERENCES_FILE.expanduser()
         self._delegate: WhisperKitEngine | None = None
         self._delegate_path: Path | None = None
+        self._headless_signature: tuple[int, int] | None = None
+        self._headless_capable = False
 
     def is_available(self) -> bool:
         """Cheap synchronous check used while resolving the `auto` engine."""
+        if self._headless_supported():
+            model = self._headless_model()
+            return model is not None and model.downloaded and model.supported
         return (
             self.app_path.exists()
             and self._resolved_binary() is not None
@@ -76,9 +98,20 @@ class VocaMacEngine:
         )
 
     async def health(self) -> EngineHealth:
+        if self._headless_supported():
+            model = await asyncio.to_thread(self._headless_model)
+            wanted = model.id if model is not None else self._wanted_model_name()
+            return EngineHealth(
+                ready=model is not None and model.downloaded and model.supported,
+                name=f"vocamac:{wanted}",
+            )
+        return await self._legacy_health()
+
+    async def _legacy_health(self) -> EngineHealth:
         models = self._usable_models()
         if not models:
-            wanted = self._selected_variant()
+            selected, variant = self._selection()
+            wanted = variant or selected
             return EngineHealth(ready=False, name=f"vocamac:{wanted or 'no-model-selected'}")
         delegate = await self._delegate_for(models[0]).health()
         return EngineHealth(
@@ -87,6 +120,11 @@ class VocaMacEngine:
         )
 
     async def warmup(self) -> int:
+        # The VocaMac CLI is deliberately one-shot. A future persistent CLI
+        # mode can expose real warmup; reporting zero avoids loading a model
+        # merely for a readiness probe and then immediately exiting.
+        if self._headless_supported():
+            return 0
         models = self._usable_models()
         if not models or not (await self.health()).ready:
             return 0
@@ -95,8 +133,85 @@ class VocaMacEngine:
     async def transcribe(
         self, audio_path: Path, options: TranscriptionOptions
     ) -> EngineTranscription:
+        if self._headless_supported():
+            return await self._transcribe_headless(audio_path, options)
+        return await self._transcribe_legacy(audio_path, options)
+
+    async def _transcribe_headless(
+        self, audio_path: Path, options: TranscriptionOptions
+    ) -> EngineTranscription:
+        executable = self._app_executable()
+        if executable is None:
+            raise EngineUnavailableError("VocaMac's headless executable is unavailable.")
+
+        arguments = [
+            str(executable),
+            "--transcribe-file",
+            str(audio_path),
+            "--json",
+        ]
+        configured_model = self._configured_model_id()
+        if configured_model:
+            arguments.extend(["--model", configured_model])
+        # Pass `auto` explicitly too. Omitting the argument asks the VocaMac CLI
+        # to inherit its GUI preference, which may differ from this session.
+        arguments.extend(["--language", options.language])
+
+        started = time.monotonic()
+        process = await asyncio.create_subprocess_exec(
+            *arguments,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=_headless_environment(),
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(), timeout=_HEADLESS_TIMEOUT_SECONDS
+            )
+        except TimeoutError as error:
+            process.kill()
+            await process.wait()
+            raise TranscriptionProcessError("VocaMac transcription timed out.") from error
+
+        if process.returncode != 0:
+            _raise_headless_failure(stderr)
+
+        try:
+            payload: dict[str, Any] = json.loads(stdout)
+            transcript = payload["text"]
+        except (json.JSONDecodeError, KeyError, TypeError) as error:
+            raise TranscriptionProcessError(
+                "VocaMac returned an invalid transcription response."
+            ) from error
+        if not isinstance(transcript, str) or not transcript.strip():
+            raise TranscriptionProcessError("VocaMac returned an empty transcript.")
+
+        total_ms = _elapsed_ms(started)
+        duration = payload.get("duration_seconds")
+        inference_ms = (
+            max(0, round(duration * 1000))
+            if isinstance(duration, (int, float)) and not isinstance(duration, bool)
+            else 0
+        )
+        return EngineTranscription(
+            text=transcript.strip(),
+            model_load_ms=max(0, total_ms - inference_ms),
+            inference_ms=inference_ms,
+        )
+
+    async def _transcribe_legacy(
+        self, audio_path: Path, options: TranscriptionOptions
+    ) -> EngineTranscription:
         models = self._usable_models()
         if not models or not (await self.health()).ready:
+            selected, variant = self._selection()
+            if selected is not None and variant is None:
+                raise EngineUnavailableError(
+                    f"VocaMac selected '{selected}', which is not a WhisperKit model. "
+                    "VocaMac does not expose its other engines for headless transcription; "
+                    "select a Whisper model in VocaMac or select the matching native engine "
+                    "and model in the vocaphone gateway."
+                )
             raise EngineUnavailableError(
                 "VocaMac, one of its downloaded models, or the WhisperKit CLI is "
                 "unavailable. Install VocaMac, download a model in its Models tab, "
@@ -111,6 +226,80 @@ class VocaMacEngine:
         if last_error is not None:
             raise last_error
         raise EngineUnavailableError("No usable VocaMac transcription model is available.")
+
+    def _headless_model(self) -> _HeadlessModel | None:
+        executable = self._app_executable()
+        if executable is None:
+            return None
+        try:
+            process = subprocess.run(
+                [str(executable), "--list-models", "--json"],
+                capture_output=True,
+                check=False,
+                timeout=5,
+                env=_headless_environment(),
+            )
+            if process.returncode != 0:
+                return None
+            payload: dict[str, Any] = json.loads(process.stdout)
+            entries = payload["models"]
+        except (OSError, subprocess.SubprocessError, json.JSONDecodeError, KeyError, TypeError):
+            return None
+        if not isinstance(entries, list):
+            return None
+
+        configured = self._configured_model_id()
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            model_id = entry.get("id")
+            matches = model_id == configured if configured else entry.get("selected") is True
+            if matches and isinstance(model_id, str):
+                return _HeadlessModel(
+                    id=model_id,
+                    downloaded=entry.get("downloaded") is True,
+                    supported=entry.get("supported") is True,
+                )
+        return None
+
+    def _configured_model_id(self) -> str | None:
+        if not self.model:
+            return None
+        for model_id, folder_name in MODEL_VARIANTS.items():
+            if self.model in {model_id, folder_name}:
+                return model_id
+        return self.model
+
+    def _wanted_model_name(self) -> str:
+        configured = self._configured_model_id()
+        if configured:
+            return configured
+        selected, variant = self._selection()
+        return selected or variant or "no-model-selected"
+
+    def _app_executable(self) -> Path | None:
+        executable = self.app_path / _VOCAMAC_EXECUTABLE
+        if executable.is_file() and os.access(executable, os.X_OK):
+            return executable
+        return None
+
+    def _headless_supported(self) -> bool:
+        executable = self._app_executable()
+        if executable is None:
+            self._headless_signature = None
+            self._headless_capable = False
+            return False
+        try:
+            metadata = executable.stat()
+        except OSError:
+            self._headless_signature = None
+            self._headless_capable = False
+            return False
+        signature = (metadata.st_size, metadata.st_mtime_ns)
+        if signature != self._headless_signature:
+            self._headless_capable = _file_contains(executable, _HEADLESS_MARKER)
+            self._headless_signature = signature
+        return self._headless_capable
 
     def close(self) -> None:
         delegate = self._delegate
@@ -134,8 +323,15 @@ class VocaMacEngine:
 
     def _usable_models(self) -> list[Path]:
         """VocaMac's selected model first, then its other complete downloads."""
-        selected = self._selected_variant()
-        preferred = self.models_dir / selected if selected else None
+        selected, variant = self._selection()
+        # Current VocaMac releases persist one preference across WhisperKit,
+        # FluidAudio Parakeet, Apple Speech, and sherpa-onnx models. Only the
+        # Whisper entries live in this directory or can be served by
+        # whisperkit-cli. Treating a non-Whisper selection as "no selection"
+        # silently ran another downloaded Whisper model instead.
+        if selected is not None and variant is None:
+            return []
+        preferred = self.models_dir / variant if variant else None
         if preferred is not None and not _model_is_usable(preferred):
             preferred = None
         if self.model:
@@ -151,16 +347,25 @@ class VocaMacEngine:
             models.insert(0, preferred)
         return models
 
-    def _selected_variant(self) -> str | None:
+    def _selection(self) -> tuple[str | None, str | None]:
+        """Return the persisted selection and its WhisperKit folder, if any.
+
+        An explicit environment override may already be a WhisperKit folder
+        name. A VocaMac preference cannot: its value is a ModelSize raw value,
+        so an unknown value belongs to another/new engine and must not fall
+        through to a downloaded Whisper model.
+        """
         if self.model:
-            return MODEL_VARIANTS.get(self.model, self.model)
+            return self.model, MODEL_VARIANTS.get(self.model, self.model)
         try:
             with self.preferences_file.open("rb") as handle:
                 payload = plistlib.load(handle)
             selected = payload[SELECTED_MODEL_KEY]
         except (OSError, plistlib.InvalidFileException, KeyError, TypeError):
-            return None
-        return MODEL_VARIANTS.get(selected) if isinstance(selected, str) else None
+            return None, None
+        if not isinstance(selected, str):
+            return None, None
+        return selected, MODEL_VARIANTS.get(selected)
 
     def _downloaded_directories(self) -> list[Path]:
         try:
@@ -202,3 +407,56 @@ def _model_weight_bytes(directory: Path) -> int:
         except OSError:
             return 0
     return total
+
+
+def _file_contains(path: Path, marker: bytes) -> bool:
+    """Side-effect-free capability probe for old VocaMac app binaries.
+
+    Passing an unknown flag to an old VocaMac build launches its GUI and can
+    trigger its single-instance cleanup, so capability detection must inspect
+    the executable rather than execute it.
+    """
+    overlap = b""
+    try:
+        with path.open("rb") as handle:
+            while chunk := handle.read(64 * 1024):
+                combined = overlap + chunk
+                if marker in combined:
+                    return True
+                overlap = combined[-max(0, len(marker) - 1) :]
+    except OSError:
+        return False
+    return False
+
+
+def _headless_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    # Development-signed VocaMac builds may contain LLVM coverage hooks. Never
+    # let a gateway request drop default.profraw into its working directory.
+    environment["LLVM_PROFILE_FILE"] = os.devnull
+    return environment
+
+
+def _raise_headless_failure(stderr: bytes) -> None:
+    detail = stderr.decode("utf-8", errors="replace").strip()
+    code = ""
+    message = "VocaMac transcription failed."
+    try:
+        payload: dict[str, Any] = json.loads(detail)
+        raw_code = payload.get("error")
+        raw_message = payload.get("message")
+        if isinstance(raw_code, str):
+            code = raw_code
+        if isinstance(raw_message, str) and raw_message:
+            message = raw_message
+    except (json.JSONDecodeError, TypeError):
+        if detail:
+            message = detail.splitlines()[-1][:300]
+
+    if code in {"model_not_found", "model_not_downloaded", "model_unsupported"}:
+        raise EngineUnavailableError(message)
+    raise TranscriptionProcessError(message)
+
+
+def _elapsed_ms(started: float) -> int:
+    return max(0, round((time.monotonic() - started) * 1000))

--- a/server/tests/test_handy.py
+++ b/server/tests/test_handy.py
@@ -1,9 +1,25 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from app.models.base import TranscriptionOptions
 from app.models.handy import HandyEngine
+
+
+def _write_selected_model(settings_file: Path, model: str) -> None:
+    settings_file.write_text(
+        json.dumps({"settings": {"selected_model": model}}),
+        encoding="utf-8",
+    )
+
+
+def _write_downloaded_model(cache: Path, model: str) -> Path:
+    owner, repository, filename = model.split("/")
+    model_path = cache / f"models--{owner}--{repository}" / "snapshots" / "revision" / filename
+    model_path.parent.mkdir(parents=True, exist_ok=True)
+    model_path.write_bytes(b"model")
+    return model_path
 
 
 async def test_handy_adapter_uses_downloaded_model_and_parses_json(
@@ -50,6 +66,25 @@ async def test_handy_health_is_false_when_model_is_not_downloaded(
     assert (await engine.health()).ready is False
 
 
+async def test_handy_reports_an_unavailable_model_selected_in_the_app(tmp_path: Path) -> None:
+    selected = "owner/repository/missing.gguf"
+    settings_file = tmp_path / "settings_store.json"
+    _write_selected_model(settings_file, selected)
+    binary = tmp_path / "handy"
+    binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    binary.chmod(0o700)
+
+    engine = HandyEngine(
+        binary,
+        settings_file=settings_file,
+        huggingface_cache=tmp_path / "cache",
+    )
+
+    health = await engine.health()
+    assert health.ready is False
+    assert health.name == f"handy:{selected}"
+
+
 async def test_handy_retries_empty_primary_result_with_downloaded_fallback(
     tmp_path: Path,
 ) -> None:
@@ -93,3 +128,61 @@ async def test_handy_retries_empty_primary_result_with_downloaded_fallback(
     )
 
     assert transcript == "fallback result"
+
+
+async def test_handy_follows_the_model_selected_in_the_app_without_restart(
+    tmp_path: Path,
+) -> None:
+    first = "owner/first/first.gguf"
+    second = "owner/second/second.gguf"
+    settings_file = tmp_path / "settings_store.json"
+    binary = tmp_path / "handy"
+    binary.write_text(
+        '#!/bin/sh\nprintf \'%s\\n\' "$*" > "$0.args"\nprintf \'%s\\n\' \'{"text":"result"}\'\n',
+        encoding="utf-8",
+    )
+    binary.chmod(0o700)
+    for model in (first, second):
+        _write_downloaded_model(tmp_path / "cache", model)
+    _write_selected_model(settings_file, first)
+    engine = HandyEngine(
+        binary,
+        settings_file=settings_file,
+        huggingface_cache=tmp_path / "cache",
+    )
+
+    assert (await engine.health()).name == f"handy:{first}"
+
+    _write_selected_model(settings_file, second)
+    audio = tmp_path / "audio.wav"
+    audio.write_bytes(b"audio")
+    assert (await engine.health()).name == f"handy:{second}"
+    assert (
+        await engine.transcribe(audio, TranscriptionOptions(language="auto", style="raw"))
+        == "result"
+    )
+    arguments = (tmp_path / "handy.args").read_text(encoding="utf-8")
+    assert f"--model {second}" in arguments
+
+
+async def test_handy_explicit_model_override_does_not_follow_the_app(
+    tmp_path: Path,
+) -> None:
+    configured = "owner/configured/configured.gguf"
+    selected = "owner/selected/selected.gguf"
+    settings_file = tmp_path / "settings_store.json"
+    binary = tmp_path / "handy"
+    binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    binary.chmod(0o700)
+    for model in (configured, selected):
+        _write_downloaded_model(tmp_path / "cache", model)
+    _write_selected_model(settings_file, selected)
+
+    engine = HandyEngine(
+        binary,
+        configured,
+        settings_file=settings_file,
+        huggingface_cache=tmp_path / "cache",
+    )
+
+    assert (await engine.health()).name == f"handy:{configured}"

--- a/server/tests/test_vocamac.py
+++ b/server/tests/test_vocamac.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import json
 import plistlib
 from pathlib import Path
 
+import pytest
+
+from app.errors import EngineUnavailableError
 from app.models.base import EngineTranscription, TranscriptionOptions
 from app.models.vocamac import REQUIRED_COMPONENTS, VocaMacEngine
 
@@ -61,6 +65,156 @@ def _build_engine(tmp_path: Path, *, model: str | None = None) -> tuple[VocaMacE
     return engine, models_dir
 
 
+def _build_headless_engine(
+    tmp_path: Path,
+    models: list[dict[str, object]],
+    *,
+    model: str | None = None,
+    transcription: dict[str, object] | None = None,
+    failure: dict[str, str] | None = None,
+) -> tuple[VocaMacEngine, Path]:
+    app_path = tmp_path / "VocaMac.app"
+    executable = app_path / "Contents" / "MacOS" / "VocaMac"
+    executable.parent.mkdir(parents=True)
+    model_payload = json.dumps({"models": models}, separators=(",", ":"))
+    transcription_payload = json.dumps(
+        transcription
+        or {
+            "text": "private local result",
+            "model": "parakeet-tdt-0.6b-v2",
+            "engine": "parakeet",
+            "detected_language": "en",
+            "duration_seconds": 0.125,
+            "audio_length_seconds": 1.0,
+        },
+        separators=(",", ":"),
+    )
+    failure_payload = json.dumps(failure, separators=(",", ":")) if failure else ""
+    executable.write_text(
+        "#!/bin/sh\n"
+        "# --transcribe-file capability marker\n"
+        'printf \'%s\\n\' "$@" > "$0.args"\n'
+        'case "$1" in\n'
+        f"  --list-models) printf '%s\\n' '{model_payload}' ;;\n"
+        + (
+            f"  --transcribe-file) printf '%s\\n' '{failure_payload}' >&2; exit 4 ;;\n"
+            if failure
+            else f"  --transcribe-file) printf '%s\\n' '{transcription_payload}' ;;\n"
+        )
+        + "  *) exit 2 ;;\n"
+        "esac\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o700)
+    engine = VocaMacEngine(
+        str(tmp_path / "missing-whisperkit-cli"),
+        model,
+        app_path=app_path,
+        support_dir=tmp_path / "support",
+        preferences_file=tmp_path / "com.vocamac.app.plist",
+    )
+    return engine, executable
+
+
+def _headless_model(
+    model_id: str,
+    *,
+    selected: bool,
+    downloaded: bool = True,
+    supported: bool = True,
+) -> dict[str, object]:
+    return {
+        "id": model_id,
+        "name": model_id,
+        "engine": "parakeet" if model_id.startswith("parakeet") else "whisperkit",
+        "selected": selected,
+        "downloaded": downloaded,
+        "supported": supported,
+        "system_managed": False,
+    }
+
+
+async def test_vocamac_headless_cli_uses_the_apps_selected_parakeet_model(
+    tmp_path: Path,
+) -> None:
+    engine, executable = _build_headless_engine(
+        tmp_path,
+        [
+            _headless_model("small", selected=False),
+            _headless_model("parakeet-tdt-0.6b-v2", selected=True),
+        ],
+    )
+    audio = tmp_path / "audio.wav"
+    audio.write_bytes(b"audio")
+
+    assert engine.is_available() is True
+    assert (await engine.health()).name == "vocamac:parakeet-tdt-0.6b-v2"
+    result = await engine.transcribe(audio, TranscriptionOptions("en", "raw"))
+
+    assert result.text == "private local result"
+    assert result.inference_ms == 125
+    arguments = Path(f"{executable}.args").read_text(encoding="utf-8").splitlines()
+    assert arguments[:3] == ["--transcribe-file", str(audio), "--json"]
+    assert arguments[arguments.index("--language") + 1] == "en"
+    assert "--model" not in arguments
+
+
+async def test_vocamac_headless_cli_honours_an_explicit_model_override(
+    tmp_path: Path,
+) -> None:
+    engine, executable = _build_headless_engine(
+        tmp_path,
+        [
+            _headless_model("small", selected=False),
+            _headless_model("parakeet-tdt-0.6b-v2", selected=True),
+        ],
+        model="openai_whisper-small",
+    )
+    audio = tmp_path / "audio.wav"
+    audio.write_bytes(b"audio")
+
+    assert engine.is_available() is True
+    assert (await engine.health()).name == "vocamac:small"
+    await engine.transcribe(audio, TranscriptionOptions("auto", "raw"))
+
+    arguments = Path(f"{executable}.args").read_text(encoding="utf-8").splitlines()
+    assert arguments[arguments.index("--model") + 1] == "small"
+    assert arguments[arguments.index("--language") + 1] == "auto"
+
+
+async def test_vocamac_headless_cli_reports_an_unavailable_selected_model(
+    tmp_path: Path,
+) -> None:
+    engine, _ = _build_headless_engine(
+        tmp_path,
+        [_headless_model("parakeet-tdt-0.6b-v2", selected=True, downloaded=False)],
+    )
+
+    health = await engine.health()
+
+    assert engine.is_available() is False
+    assert health.ready is False
+    assert health.name == "vocamac:parakeet-tdt-0.6b-v2"
+
+
+async def test_vocamac_headless_cli_surfaces_model_failures_as_unavailable(
+    tmp_path: Path,
+) -> None:
+    engine, _ = _build_headless_engine(
+        tmp_path,
+        [_headless_model("parakeet-tdt-0.6b-v2", selected=True)],
+        failure={
+            "error": "model_not_downloaded",
+            "message": "Model is not downloaded: parakeet-tdt-0.6b-v2",
+        },
+    )
+    audio = tmp_path / "audio.wav"
+    audio.write_bytes(b"audio")
+
+    with pytest.raises(EngineUnavailableError, match="Model is not downloaded"):
+        await engine.transcribe(audio, TranscriptionOptions("auto", "raw"))
+
+
 async def test_vocamac_runs_the_model_selected_in_the_app(tmp_path: Path) -> None:
     engine, models_dir = _build_engine(tmp_path)
     _write_model(models_dir, "openai_whisper-tiny", weight_bytes=512)
@@ -94,6 +248,39 @@ async def test_vocamac_skips_an_interrupted_download(tmp_path: Path) -> None:
 
     assert health.ready is True
     assert health.name == "vocamac:openai_whisper-small"
+
+
+async def test_vocamac_does_not_replace_a_selected_parakeet_model_with_whisper(
+    tmp_path: Path,
+) -> None:
+    engine, models_dir = _build_engine(tmp_path)
+    _write_model(models_dir, "openai_whisper-small")
+    _write_preferences(tmp_path, "parakeet-tdt-0.6b-v2")
+
+    health = await engine.health()
+
+    assert engine.is_available() is False
+    assert health.ready is False
+    assert health.name == "vocamac:parakeet-tdt-0.6b-v2"
+
+    audio = tmp_path / "audio.wav"
+    audio.write_bytes(b"audio")
+    with pytest.raises(EngineUnavailableError, match="not a WhisperKit model"):
+        await engine.transcribe(audio, TranscriptionOptions("auto", "raw"))
+
+
+async def test_vocamac_does_not_replace_an_unknown_future_model_with_whisper(
+    tmp_path: Path,
+) -> None:
+    engine, models_dir = _build_engine(tmp_path)
+    _write_model(models_dir, "openai_whisper-small")
+    _write_preferences(tmp_path, "future-vocamac-engine-model")
+
+    health = await engine.health()
+
+    assert engine.is_available() is False
+    assert health.ready is False
+    assert health.name == "vocamac:future-vocamac-engine-model"
 
 
 async def test_vocamac_prefers_the_largest_model_without_a_selection(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Follow Handy's persisted model selection dynamically so app changes take effect without restarting the gateway, while preserving explicit model pins and the configured fallback.
- Use VocaMac's headless CLI to run its currently selected downloaded and supported WhisperKit, Parakeet, Apple Speech, or sherpa-onnx model.
- Preserve a side-effect-free legacy path for older VocaMac builds that can only reuse complete WhisperKit downloads.
- Pass each VocaPhone session's language explicitly, extend the iOS finish timeout for one-shot model loading, and update user-facing documentation.
- Add regression coverage for dynamic selection, explicit overrides, unavailable models, legacy compatibility, and CLI error handling.

## Verification

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy app`
- [x] `uv run pytest`
- [ ] Compose validation/container build, if deployment files changed — not applicable; no deployment files changed
- [ ] iOS simulator build/tests — intentionally not run per request; the iOS change only increases the finish request timeout
- [ ] Physical-device test, if keyboard, microphone, background audio, or insertion changed — not applicable; those paths did not change
- [x] Live installed VocaMac smoke test using the selected `parakeet-tdt-0.6b-v2` model and an explicit `auto` language request

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for the desktop-app model-selection data flow
