### PR TITLE
build: add justfiles for the three apps and optional direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,37 @@
+# direnv (https://direnv.net) — optional per-developer shell setup.
+#
+# Run `direnv allow` once after cloning. Everything in the repository works
+# without direnv; this only saves typing.
+#
+# Deliberately NOT loading server/.env. That file holds the Compose bearer
+# token, and app/config.py reads VOCAPHONE_TOKEN straight from the environment,
+# so exporting it here would make a natively run gateway (`just run`) serve the
+# container's token instead of ~/.config/vocaphone/token — silently, because
+# both are valid. Compose reads that file by itself, and server/justfile sets
+# `dotenv-load := false` for the same reason.
+
+# The gateway virtualenv, so python, pytest and ruff work without `uv run`.
+# This is repository-wide rather than scoped to server/, which keeps direnv to
+# one file and one `direnv allow`; the gateway is the only Python project here.
+if [ -d server/.venv/bin ]; then
+  PATH_add server/.venv/bin
+fi
+
+# Gradle finds the SDK through android/local.properties, but adb, sdkmanager
+# and Android Studio's command line tools go looking for ANDROID_HOME.
+if [ -z "${ANDROID_HOME:-}" ]; then
+  for candidate in "${HOME}/Library/Android/sdk" "${HOME}/Android/Sdk"; do
+    if [ -d "${candidate}" ]; then
+      export ANDROID_HOME="${candidate}"
+      break
+    fi
+  done
+fi
+if [ -n "${ANDROID_HOME:-}" ] && [ -d "${ANDROID_HOME}/platform-tools" ]; then
+  PATH_add "${ANDROID_HOME}/platform-tools"
+fi
+
+# Personal, machine-specific settings: VOCAPHONE_SIM for the iOS simulator to
+# use, ANDROID_SERIAL to pick between attached devices, and anything else you
+# would rather not type. Gitignored, so it never reaches a pull request.
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,14 @@ server/*.sqlite3
 *.p12
 *.mobileprovision
 
+# direnv: the repository-root .envrc is checked in and contains no secrets.
+# Every other .envrc is personal — server/.envrc in particular is easy to
+# create by copying server/.env, which carries a live bearer token.
+.direnv/
+.envrc
+.envrc.local
+!/.envrc
+
 # Android (see also android/.gitignore)
 .gradle/
 android/local.properties

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,12 +21,27 @@ are available.
 
 ## Development setup
 
-- Install Xcode, XcodeGen, `uv`, and FFmpeg.
+- Install [`just`](https://just.systems), Xcode, XcodeGen, `uv`, and FFmpeg.
 - For Android work, install a recent Android Studio / SDK and JDK 17+.
-- Run `xcodegen generate --spec project.yml` from `ios/` after changing
-  `ios/project.yml`.
+- Run `just ios gen` after changing `ios/project.yml`, and commit the
+  regenerated project. The other iOS recipes regenerate it for you; this one
+  matters because CI fails when the checked-in project is stale.
 - Never commit microphone recordings, bearer tokens, signing material, tailnet
   hostnames, local database files, or Apple provisioning profiles.
+
+Each application owns a justfile, and the repository root aggregates them, so
+recipes work from either place:
+
+```sh
+just --list              # cross-cutting recipes and the three modules
+just --list server       # one application's recipes
+cd server && just test   # same as `just server test` from the root
+just doctor              # what each application's toolchain is missing
+```
+
+`just doctor` is the fastest way to find out what a fresh machine still needs;
+it reports all three toolchains and never fails, because nobody has all of them
+installed at once.
 
 ### direnv (optional)
 
@@ -55,49 +70,44 @@ it, secret and all.
 
 ## Required checks
 
-Run the gateway checks:
+Each application has one recipe that runs everything its workflow gates on.
+Run the one for what you changed:
 
 ```sh
-cd server
-uv sync --all-groups --extra engines
-uv run ruff check .
-uv run ruff format --check .
-uv run mypy app
-uv run pytest
+just server install   # once, and after dependency changes
+just server test      # lint, types, dependency audit, unit tests, Compose
+just ios ci           # regenerates the project, builds, runs the unit tests
+just android ci       # assembles, unit tests, lint, Room schema freshness
 ```
 
-For container changes, also run:
+`just ci` from the repository root runs all three and skips any whose toolchain
+is absent, which is what a contributor with only one platform installed wants.
+
+These recipes carry the same flags as the workflows in `.github/workflows/`, so
+a green run locally means a green run there. `just server test` goes further
+than its workflow does, adding a lockfile check and a dependency audit. Read
+the justfile when you need the underlying command; it is deliberately the only
+place they are written down.
+
+For container changes, also build the image:
 
 ```sh
-cd server
-VOCAPHONE_TOKEN=test-token-with-at-least-thirty-two-characters docker compose config
-docker build --tag vocaphone-gateway:test .
+just server image
 ```
 
 When changing documentation, check local links and commands against the current
 repository layout, then run `git diff --check`. Do not publish machine-specific
 paths, real tailnet hostnames, tokens, recordings, or transcript samples.
 
-Then build and test the iOS project on an installed simulator:
-
-```sh
-cd ios
-xcodegen generate --spec project.yml
-xcodebuild \
-  -project VocaPhone.xcodeproj \
-  -scheme VocaPhone \
-  -sdk iphonesimulator \
-  -destination 'platform=iOS Simulator,name=iPhone 17' \
-  CODE_SIGNING_ALLOWED=NO \
-  test
-```
-
 Keyboard, microphone, background-audio, and insertion changes must also be
-verified on a physical iPhone. Describe the tested app, iOS version, and exact
+verified on a physical iPhone — `just ios device` builds and installs onto a
+connected phone, and [docs/device-setup.md](docs/device-setup.md) has the
+acceptance sequence. Describe the tested app, iOS version, and exact
 interaction sequence in the pull request.
 
-For Android changes, run the project unit tests from `android/` and note whether
-the floating bubble was exercised on a physical device.
+For Android changes, note whether the floating bubble was exercised on a
+physical device; `just android run` installs and launches on one, and
+`just android permissions` grants what the bubble needs.
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,31 @@ are available.
 - Never commit microphone recordings, bearer tokens, signing material, tailnet
   hostnames, local database files, or Apple provisioning profiles.
 
+### direnv (optional)
+
+[direnv](https://direnv.net) is set up but not required; every command in this
+repository works without it. With direnv installed, run `direnv allow` once
+after cloning. The checked-in `.envrc` then puts the gateway virtualenv and the
+Android SDK's `platform-tools` on `PATH`, so `pytest`, `ruff` and `adb` work
+without `uv run` or a full path, and exports `ANDROID_HOME`.
+
+Machine-specific settings belong in `.envrc.local`, which is gitignored and
+sourced automatically:
+
+```sh
+export VOCAPHONE_SIM='iPhone 17 Pro'   # which simulator ios/justfile uses
+export ANDROID_SERIAL=emulator-5554    # which device android/justfile targets
+```
+
+`.envrc` deliberately does not load `server/.env`. That file holds the Compose
+bearer token, and the gateway reads `VOCAPHONE_TOKEN` straight from the
+environment, so exporting it would make a natively run gateway serve the
+container's token instead of the one in `~/.config/vocaphone/token` — silently,
+because both are valid. Compose reads that file by itself. For the same reason,
+only the repository-root `.envrc` is tracked; any nested one is gitignored,
+since the quickest way to make `server/.envrc` is to copy `server/.env` into
+it, secret and all.
+
 ## Required checks
 
 Run the gateway checks:

--- a/README.md
+++ b/README.md
@@ -351,6 +351,12 @@ accessibility disclosure, and the supported gateway address forms.
 
 ## Build and test
 
+Optional: with [direnv](https://direnv.net) installed, `direnv allow` once after
+cloning puts the gateway virtualenv and the Android SDK's `platform-tools` on
+`PATH` and exports `ANDROID_HOME`, so the `uv run` prefixes and the
+`ANDROID_HOME` export below become unnecessary. Everything works without it —
+see [CONTRIBUTING.md](CONTRIBUTING.md#direnv-optional).
+
 Gateway checks:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -351,50 +351,35 @@ accessibility disclosure, and the supported gateway address forms.
 
 ## Build and test
 
+Development uses [`just`](https://just.systems). Each application has a
+justfile, and the repository root aggregates them, so every recipe works from
+the root or from inside the application directory:
+
+```sh
+just ci               # all three applications, skipping absent toolchains
+just server test      # gateway: lint, types, dependency audit, tests, Compose
+just ios ci           # iOS: regenerate the project, build, run unit tests
+just android ci       # Android: assemble, unit tests, lint, Room schema
+just doctor           # what each toolchain is still missing
+```
+
+The recipes carry the same flags as the [CI workflows](.github/workflows/), so
+a green run locally means a green run there; the gateway's also audits
+dependencies, which CI leaves out. `just --list` shows the rest — running the
+apps (`just ios run`,
+`just android run`, `just server run`), streaming logs, installing onto a
+physical phone, and managing the container deployment.
+
 Optional: with [direnv](https://direnv.net) installed, `direnv allow` once after
 cloning puts the gateway virtualenv and the Android SDK's `platform-tools` on
-`PATH` and exports `ANDROID_HOME`, so the `uv run` prefixes and the
-`ANDROID_HOME` export below become unnecessary. Everything works without it —
-see [CONTRIBUTING.md](CONTRIBUTING.md#direnv-optional).
+`PATH` and exports `ANDROID_HOME`, so `pytest` and `adb` resolve without a
+prefix or a full path. Everything works without it — see
+[CONTRIBUTING.md](CONTRIBUTING.md#direnv-optional).
 
-Gateway checks:
-
-```sh
-cd server
-# On macOS add --extra apple for MLX / WhisperKit tooling in the dev environment.
-uv sync --all-groups --extra engines
-uv run ruff check .
-uv run ruff format --check .
-uv run mypy app
-uv run pytest
-VOCAPHONE_TOKEN=test-token-with-at-least-thirty-two-characters docker compose config --quiet
-```
-
-Android checks:
-
-```sh
-cd android
-export ANDROID_HOME="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
-./gradlew assembleDebug testDebugUnitTest lintDebug
-```
-
-iOS checks:
-
-```sh
-cd ios
-xcodegen generate --spec project.yml
-xcodebuild \
-  -project VocaPhone.xcodeproj \
-  -scheme VocaPhone \
-  -sdk iphonesimulator \
-  -destination 'platform=iOS Simulator,name=iPhone 17' \
-  CODE_SIGNING_ALLOWED=NO \
-  test
-```
-
-The generated Xcode project is checked in. Regenerate it after changing
-`ios/project.yml`. Keyboard, microphone, background audio, and insertion changes
-still require physical-device verification.
+The generated Xcode project is checked in. Run `just ios gen` after changing
+`ios/project.yml` and commit the result; CI fails when it is stale. Keyboard,
+microphone, background audio, and insertion changes still require
+physical-device verification.
 
 ## Project layout
 

--- a/android/justfile
+++ b/android/justfile
@@ -1,0 +1,235 @@
+# vocaphone (Android) — Gradle and adb, named.
+#
+# `just run` is the one to reach for: assemble the debug APK, install it on the
+# connected phone or running emulator, and launch it. `just ci` is what the
+# Quality (Android) workflow gates on.
+#
+# Every device recipe targets one device explicitly. With more than one
+# attached, name the one you want:
+#   ANDROID_SERIAL=emulator-5554 just run
+
+app_id := "com.vocahq.vocaphone"
+activity := app_id / ".ui.MainActivity"
+apk := "app/build/outputs/apk/debug/vocaphone-debug.apk"
+
+# List the available recipes.
+default:
+    @{{ just_executable() }} --list --unsorted
+
+# Assemble the debug APK.
+[group('build')]
+build:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export ANDROID_HOME="$({{ just_executable() }} _sdk)"
+    ./gradlew assembleDebug
+
+# Build, install and launch the app on a device or emulator.
+[group('run')]
+run: build
+    #!/usr/bin/env bash
+    set -euo pipefail
+    adb=("$({{ just_executable() }} _adb)" -s "$({{ just_executable() }} _serial)")
+    "${adb[@]}" install -r '{{ apk }}'
+    "${adb[@]}" shell am start -n '{{ activity }}'
+    echo "Launched {{ app_id }}. Console output: just logs"
+
+# Install the last built APK without rebuilding it.
+[group('run')]
+install:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    adb=("$({{ just_executable() }} _adb)" -s "$({{ just_executable() }} _serial)")
+    "${adb[@]}" install -r '{{ apk }}'
+
+# Force-stop the app on the device.
+[group('run')]
+stop:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    adb=("$({{ just_executable() }} _adb)" -s "$({{ just_executable() }} _serial)")
+    "${adb[@]}" shell am force-stop {{ app_id }}
+
+# Stream the running app's logcat output.
+[group('run')]
+logs:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    adb=("$({{ just_executable() }} _adb)" -s "$({{ just_executable() }} _serial)")
+    pid="$("${adb[@]}" shell pidof -s {{ app_id }} 2>/dev/null | tr -d '\r' || true)"
+    if [ -z "${pid}" ]; then
+        echo "{{ app_id }} is not running. Start it with: just run" >&2
+        exit 1
+    fi
+    "${adb[@]}" logcat --pid="${pid}"
+
+# Grant the runtime permissions the dictation bubble needs.
+[group('run')]
+permissions:
+    #!/usr/bin/env bash
+    # Saves re-doing the permission dance by hand after every fresh install.
+    # The accessibility service is not grantable this way and stays manual.
+    set -euo pipefail
+    adb=("$({{ just_executable() }} _adb)" -s "$({{ just_executable() }} _serial)")
+    for permission in RECORD_AUDIO POST_NOTIFICATIONS CAMERA; do
+        "${adb[@]}" shell pm grant {{ app_id }} "android.permission.${permission}" || true
+    done
+    # Overlay is an appop, not a runtime permission, so pm grant cannot set it.
+    "${adb[@]}" shell appops set {{ app_id }} SYSTEM_ALERT_WINDOW allow || true
+    echo "Enable the accessibility service by hand: Settings → Accessibility → vocaphone."
+
+# Run the unit tests; pass a filter, e.g. `just test '*DictationTest'`.
+[group('test')]
+test *filter:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export ANDROID_HOME="$({{ just_executable() }} _sdk)"
+    filters=()
+    for pattern in {{ filter }}; do filters+=(--tests "${pattern}"); done
+    # macOS ships bash 3.2, where an empty array under `set -u` is an error.
+    ./gradlew testDebugUnitTest ${filters[@]+"${filters[@]}"}
+
+# Run Android Lint over the debug variant.
+[group('test')]
+lint:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export ANDROID_HOME="$({{ just_executable() }} _sdk)"
+    ./gradlew lintDebug
+
+# Everything CI checks for Android: build, unit tests, lint, fresh Room schema.
+[group('test')]
+ci:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export ANDROID_HOME="$({{ just_executable() }} _sdk)"
+    ./gradlew assembleDebug testDebugUnitTest lintDebug
+    git diff --exit-code -- app/schemas \
+        || { echo "The checked-in Room schema is stale — commit app/schemas." >&2; exit 1; }
+
+# Deliberately not _adb: the point of this recipe is to work when nothing is
+# attached, which is exactly when _adb refuses. A comment inside a recipe body
+# would be echoed as a command, so it lives up here.
+#
+# List attached devices and emulators.
+[group('device')]
+devices:
+    @"$({{ just_executable() }} _sdk)/platform-tools/adb" devices -l
+
+# Delete Gradle build output.
+[group('build')]
+clean:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export ANDROID_HOME="$({{ just_executable() }} _sdk)"
+    ./gradlew clean
+
+# Check that the toolchain this justfile needs is actually installed.
+[group('build')]
+doctor:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    ok=0
+    version=$(java -version 2>&1 | sed -n '1s/.*version "\([0-9]*\).*/\1/p')
+    if [ -n "${version}" ] && [ "${version}" -ge 17 ]; then
+        echo "ok       JDK ${version}"
+    else
+        echo "MISSING  JDK 17 or newer — brew install --cask temurin"
+        ok=1
+    fi
+    if sdk=$({{ just_executable() }} _sdk 2>/dev/null); then
+        echo "ok       Android SDK at ${sdk}"
+        if [ -x "${sdk}/platform-tools/adb" ]; then
+            echo "ok       adb"
+            adb="${sdk}/platform-tools/adb"
+            ready=$("${adb}" devices | sed -n '2,$p' | grep -c 'device$' || true)
+            other=$("${adb}" devices | sed -n '2,$p' | grep -c . || true)
+            echo "note     ${ready} ready device(s), $((other - ready)) attached but not ready"
+        else
+            echo "MISSING  platform-tools — install them from Android Studio's SDK Manager"
+            ok=1
+        fi
+    else
+        echo "MISSING  Android SDK — install Android Studio, or set ANDROID_HOME"
+        ok=1
+    fi
+    if [ "${ok}" -ne 0 ]; then
+        echo
+        echo "Install what is marked MISSING above, then run just doctor again."
+    fi
+    exit "${ok}"
+
+# Resolve the Android SDK the same way Gradle does: local.properties wins over
+# the environment, because that is the file Android Studio writes.
+[private]
+_sdk:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -f local.properties ]; then
+        dir=$(sed -n 's/^sdk\.dir=//p' local.properties | head -1)
+        if [ -n "${dir}" ] && [ -d "${dir}" ]; then
+            echo "${dir}"
+            exit 0
+        fi
+    fi
+    for candidate in "${ANDROID_HOME:-}" "${ANDROID_SDK_ROOT:-}" \
+        "${HOME}/Library/Android/sdk" "${HOME}/Android/Sdk"; do
+        if [ -n "${candidate}" ] && [ -d "${candidate}" ]; then
+            echo "${candidate}"
+            exit 0
+        fi
+    done
+    echo "No Android SDK found. Install Android Studio, then either let it write" >&2
+    echo "android/local.properties or export ANDROID_HOME=<sdk path>." >&2
+    exit 1
+
+# Resolve adb out of the SDK, so a machine without it on PATH still works.
+[private]
+_adb:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    adb="$({{ just_executable() }} _sdk)/platform-tools/adb"
+    if [ ! -x "${adb}" ]; then
+        echo "adb is missing from the SDK. Install platform-tools from Android" >&2
+        echo "Studio's SDK Manager." >&2
+        exit 1
+    fi
+    echo "${adb}"
+
+# Pick the device to act on, and say so out loud when the choice is ambiguous.
+[private]
+_serial:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    adb="$({{ just_executable() }} _adb)"
+    # Only "device" is ready. An emulator that is still booting, or one left
+    # half-dead by a previous run, reports "offline" — and adb counts it when
+    # it decides there is "more than one device/emulator", which is why every
+    # recipe passes -s instead of letting adb choose.
+    ready=$({ "${adb}" devices | sed -n '2,$p' | grep 'device$' || true; } | cut -f1)
+    count=$(printf '%s' "${ready}" | grep -c . || true)
+    if [ -n "${ANDROID_SERIAL:-}" ]; then
+        if printf '%s\n' "${ready}" | grep -qx "${ANDROID_SERIAL}"; then
+            echo "${ANDROID_SERIAL}"
+            exit 0
+        fi
+        echo "ANDROID_SERIAL=${ANDROID_SERIAL} is not a ready device. Attached:" >&2
+        "${adb}" devices -l | sed -n '2,$p' >&2
+        exit 1
+    fi
+    if [ "${count}" -eq 1 ]; then
+        printf '%s\n' "${ready}"
+        exit 0
+    fi
+    if [ "${count}" -eq 0 ]; then
+        echo "No ready device. Start an emulator, or plug in a phone with USB" >&2
+        echo "debugging enabled, then check: just devices" >&2
+        if "${adb}" devices | sed -n '2,$p' | grep -q .; then
+            echo "Something is attached but not ready yet:" >&2
+            "${adb}" devices -l | sed -n '2,$p' >&2
+        fi
+        exit 1
+    fi
+    echo "More than one ready device. Name the one you want:" >&2
+    printf '%s\n' "${ready}" | sed 's/^/  ANDROID_SERIAL=/;s/$/ just run/' >&2
+    exit 1

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -142,6 +142,11 @@ printf 'VOCAPHONE_PUBLISH_PORT=8765\n' >> .env
 docker compose up --detach --build
 ```
 
+[`server/.env.example`](../server/.env.example) is the annotated template for
+the same file, covering the optional image tag, network mode and Swagger UI
+settings. Copy it and append a generated token rather than committing either
+file.
+
 `VOCAPHONE_PUBLISH_HOST=127.0.0.1` is the safe default for Tailscale Serve. Set
 it to `0.0.0.0` only when direct LAN access is intentional and protected by the
 host firewall. Never forward the port from the public internet.

--- a/ios/justfile
+++ b/ios/justfile
@@ -1,0 +1,265 @@
+# vocaphone (iOS) — the xcodebuild incantations, named.
+#
+# `just run` is the one to reach for: regenerate the project, build it, boot a
+# simulator, install the app, launch it. `just test` is what CI runs.
+#
+# Pick a different simulator for any recipe with either of:
+#   just sim="iPhone 17 Pro" run
+#   VOCAPHONE_SIM="iPhone 16" just run
+
+project := "VocaPhone.xcodeproj"
+scheme := "VocaPhone"
+app_id := "com.vocahq.vocaphone"
+sim := env("VOCAPHONE_SIM", "iPhone 17")
+
+# Derived data lives in the repo (build/ is gitignored) so that `just clean` is
+# one directory removal instead of a hunt through ~/Library/Developer.
+derived := justfile_directory() / "build/DerivedData"
+device_derived := justfile_directory() / "build/DerivedDataDevice"
+
+# Index-while-building only feeds Xcode's editor and there are no Swift
+# packages to resolve, so both are pure overhead from the command line.
+sim_flags := "-project " + project + " -scheme " + scheme + " -sdk iphonesimulator" \
+    + " -configuration Debug -derivedDataPath '" + derived + "'" \
+    + " -disableAutomaticPackageResolution" \
+    + " CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO"
+
+app := derived / "Build/Products/Debug-iphonesimulator/VocaPhoneApp.app"
+
+# List the available recipes.
+default:
+    @{{ just_executable() }} --list --unsorted
+
+# Regenerate VocaPhone.xcodeproj from project.yml.
+[group('build')]
+gen:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v xcodegen >/dev/null 2>&1; then
+        echo "xcodegen is missing. Install it with: brew install xcodegen" >&2
+        exit 1
+    fi
+    xcodegen generate --spec project.yml
+
+# Open the project in Xcode (regenerating it first).
+[group('build')]
+edit: gen
+    open {{ project }}
+
+# Build the app for the simulator.
+[group('build')]
+build: gen
+    #!/usr/bin/env bash
+    set -euo pipefail
+    udid="$({{ just_executable() }} _udid)"
+    # -quiet drops roughly 1500 lines of per-file compile commands and still
+    # prints warnings and errors.
+    xcodebuild {{ sim_flags }} -destination "platform=iOS Simulator,id=${udid}" -quiet build
+
+# Build, install and launch the app on a simulator.
+[group('run')]
+run: gen
+    #!/usr/bin/env bash
+    set -euo pipefail
+    udid="$({{ just_executable() }} _udid)"
+    # A cold simulator spends over a minute in data migration, and the build
+    # needs no device at all, so let that minute overlap compilation.
+    xcrun simctl bootstatus "${udid}" -b >/dev/null &
+    boot=$!
+    xcodebuild {{ sim_flags }} -destination "platform=iOS Simulator,id=${udid}" -quiet build
+    wait "${boot}"
+    open -a Simulator
+    xcrun simctl install "${udid}" "{{ app }}"
+    xcrun simctl launch "${udid}" {{ app_id }} >/dev/null
+    echo "Launched {{ app_id }} on {{ sim }}. Console output: just logs"
+
+# Stop the app on the simulator.
+[group('run')]
+stop:
+    @xcrun simctl terminate "$({{ just_executable() }} _udid)" {{ app_id }} 2>/dev/null || true
+
+# Stream the app's and the keyboard's console output from the simulator.
+[group('run')]
+logs:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    udid="$({{ just_executable() }} _udid)"
+    # simctl's own error for an unbooted device is four lines of CoreSimulator
+    # domain codes that never mention the actual problem.
+    if ! xcrun simctl list devices | grep -F "${udid}" | grep -q Booted; then
+        echo "{{ sim }} is not booted. Start the app first: just run" >&2
+        exit 1
+    fi
+    xcrun simctl spawn "${udid}" log stream --style compact --level debug \
+        --predicate 'processImagePath CONTAINS "VocaPhone"'
+
+# Open iOS Settings on the simulator, to add the keyboard under General → Keyboard.
+[group('run')]
+settings:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    udid="$({{ just_executable() }} _udid)"
+    # Unlike logs, this one is worth booting for: reaching Settings is the whole
+    # point, and bootstatus returns immediately when the device is already up.
+    xcrun simctl bootstatus "${udid}" -b >/dev/null
+    open -a Simulator
+    xcrun simctl launch "${udid}" com.apple.Preferences >/dev/null
+
+# Run the unit tests; pass identifiers to narrow, e.g. `just test VocaPhoneTests/KeyLayoutTests`.
+[group('test')]
+test *only: gen
+    #!/usr/bin/env bash
+    set -euo pipefail
+    udid="$({{ just_executable() }} _udid)"
+    filters=()
+    for id in {{ only }}; do filters+=("-only-testing:${id}"); done
+    xcrun simctl bootstatus "${udid}" -b >/dev/null &
+    boot=$!
+    xcodebuild {{ sim_flags }} -destination "platform=iOS Simulator,id=${udid}" \
+        -quiet build-for-testing
+    wait "${boot}"
+    # The test run keeps its full output: it is short and carries the failed
+    # expectation.
+    # macOS ships bash 3.2, where an empty array under `set -u` is an error.
+    xcodebuild {{ sim_flags }} -destination "platform=iOS Simulator,id=${udid}" \
+        ${filters[@]+"${filters[@]}"} test-without-building
+
+# Everything CI checks for iOS: a non-stale project, then a build and the tests.
+[group('test')]
+ci: gen
+    @git diff --exit-code -- {{ project }} || { echo "VocaPhone.xcodeproj is stale — commit the regenerated project." >&2; exit 1; }
+    @{{ just_executable() }} test
+
+# Build and install on a connected iPhone. Signing must already work in Xcode.
+[group('device')]
+device: gen
+    #!/usr/bin/env bash
+    set -euo pipefail
+    udid="${VOCAPHONE_DEVICE:-$({{ just_executable() }} _device_udid)}"
+    xcodebuild -project {{ project }} -scheme {{ scheme }} \
+        -destination "platform=iOS,id=${udid}" \
+        -configuration Debug \
+        -derivedDataPath '{{ device_derived }}' \
+        -disableAutomaticPackageResolution \
+        -allowProvisioningUpdates \
+        -quiet build
+    bundle="{{ device_derived }}/Build/Products/Debug-iphoneos/VocaPhoneApp.app"
+    xcrun devicectl device install app --device "${udid}" "${bundle}"
+    xcrun devicectl device process launch --device "${udid}" {{ app_id }}
+    echo "Keyboard, microphone, background audio and insertion changes still"
+    echo "need the manual pass in docs/device-setup.md."
+
+# List connected iPhones and their identifiers.
+[group('device')]
+devices:
+    xcrun devicectl list devices
+
+# Delete build output and derived data.
+[group('build')]
+clean:
+    rm -rf '{{ justfile_directory() }}/build'
+
+# Erase the simulator back to a clean install (drops the added keyboard).
+[group('run')]
+reset-sim:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    udid="$({{ just_executable() }} _udid)"
+    xcrun simctl shutdown "${udid}" 2>/dev/null || true
+    xcrun simctl erase "${udid}"
+
+# Check that the toolchain this justfile needs is actually installed.
+[group('build')]
+doctor:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    ok=0
+    if xcodebuild -version >/dev/null 2>&1; then
+        echo "ok       $(xcodebuild -version | tr '\n' ' ')"
+    else
+        echo "MISSING  Xcode command line tools — install Xcode, then: sudo xcode-select -s /Applications/Xcode.app"
+        ok=1
+    fi
+    if command -v xcodegen >/dev/null 2>&1; then
+        echo "ok       $(xcodegen --version 2>&1 | head -1)"
+    else
+        echo "MISSING  xcodegen — brew install xcodegen"
+        ok=1
+    fi
+    runtimes=$(xcrun simctl list runtimes available 2>/dev/null | grep -c 'iOS ' || true)
+    if [ "${runtimes}" -gt 0 ]; then
+        echo "ok       ${runtimes} iOS simulator runtime(s) installed"
+    else
+        echo "MISSING  no iOS simulator runtime — xcodebuild -downloadPlatform iOS"
+        ok=1
+    fi
+    if [ "${ok}" -ne 0 ]; then
+        echo
+        echo "Install what is marked MISSING above, then run just doctor again."
+    fi
+    exit "${ok}"
+
+# Resolve the simulator named by `sim`, creating it if this machine has none.
+[private]
+_udid:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # The trailing " (" keeps "iPhone 17" from matching "iPhone 17 Pro". The
+    # `|| true` is there because a grep that matches nothing is the normal case
+    # on a machine with no simulator yet, not a failure.
+    udid=$(
+        { xcrun simctl list devices available | grep -F '{{ sim }} (' || true; } \
+            | sed -n 's/.*(\([0-9A-F-]\{36\}\)).*/\1/p' \
+            | head -1
+    )
+    if [ -n "${udid}" ]; then
+        echo "${udid}"
+        exit 0
+    fi
+    device_type=$(
+        { xcrun simctl list devicetypes | grep -F '{{ sim }} (' || true; } \
+            | sed -n 's/.*(\(com\.apple\.CoreSimulator\.SimDeviceType\.[^)]*\)).*/\1/p' \
+            | head -1
+    )
+    runtime=$(
+        xcrun simctl list runtimes available \
+            | sed -n 's/.* - \(com\.apple\.CoreSimulator\.SimRuntime\.iOS[^ ]*\).*/\1/p' \
+            | tail -1
+    )
+    if [ -z "${device_type}" ]; then
+        echo "No simulator device type named '{{ sim }}'. Pick one from:" >&2
+        xcrun simctl list devicetypes | grep iPhone >&2
+        exit 1
+    fi
+    if [ -z "${runtime}" ]; then
+        echo "No iOS simulator runtime installed. Install one with:" >&2
+        echo "  xcodebuild -downloadPlatform iOS" >&2
+        exit 1
+    fi
+    echo "Creating simulator '{{ sim }}'" >&2
+    xcrun simctl create '{{ sim }}' "${device_type}" "${runtime}"
+
+# Resolve the single connected iPhone, or explain why it cannot.
+[private]
+_device_udid:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Each row of `devicectl list devices` carries exactly one UUID, the
+    # identifier that --device wants; the state column says whether it is
+    # plugged in right now.
+    udids=$(
+        { xcrun devicectl list devices 2>/dev/null | grep -i 'connected' || true; } \
+            | sed -n 's/.*[^0-9A-Fa-f-]\([0-9A-Fa-f]\{8\}-[0-9A-Fa-f]\{4\}-[0-9A-Fa-f]\{4\}-[0-9A-Fa-f]\{4\}-[0-9A-Fa-f]\{12\}\).*/\1/p'
+    )
+    count=$(printf '%s' "${udids}" | grep -c . || true)
+    if [ "${count}" -eq 1 ]; then
+        printf '%s\n' "${udids}"
+        exit 0
+    fi
+    if [ "${count}" -eq 0 ]; then
+        echo "No connected iPhone found. Unlock it, trust this Mac, then: just devices" >&2
+    else
+        echo "More than one device connected. Pick one from \`just devices\` and set:" >&2
+        echo "  VOCAPHONE_DEVICE=<identifier> just device" >&2
+    fi
+    exit 1

--- a/justfile
+++ b/justfile
@@ -1,0 +1,68 @@
+# vocaphone — one entry point for three applications.
+#
+# Each application owns its own justfile, because the three share no toolchain
+# at all. This file only aggregates them, so both of these work:
+#
+#   cd server && just run       # what you type while working on one app
+#   just server run             # the same recipe, from anywhere in the repo
+#   just --list server          # that app's recipes on their own
+#
+# Recipes here are the cross-cutting ones: they fan out over all three.
+
+mod android
+mod ios
+mod server
+
+# List the modules and the cross-cutting recipes.
+default:
+    @{{ just_executable() }} --list --unsorted
+
+# Run every application's checks, skipping any whose toolchain is absent.
+ci:
+    #!/usr/bin/env bash
+    # Nobody has all three toolchains installed at once — the iOS leg cannot run
+    # off macOS — so a missing one is reported and skipped rather than failed.
+    # Whatever can run, runs, and the exit code reflects only those legs.
+    set -uo pipefail
+    status=0
+    just_bin='{{ just_executable() }}'
+
+    echo "==> server"
+    if command -v uv >/dev/null 2>&1; then
+        # The gateway follows the django-modern-rest convention, where `test`
+        # is the run-everything recipe and `unit` is just pytest.
+        "${just_bin}" server::test || status=1
+    else
+        echo "skipped  uv is not installed"
+    fi
+
+    echo
+    echo "==> android"
+    if "${just_bin}" android::_sdk >/dev/null 2>&1; then
+        "${just_bin}" android::ci || status=1
+    else
+        echo "skipped  no Android SDK on this machine"
+    fi
+
+    echo
+    echo "==> ios"
+    if [ "$(uname -s)" = "Darwin" ] && command -v xcodegen >/dev/null 2>&1; then
+        "${just_bin}" ios::ci || status=1
+    else
+        echo "skipped  needs macOS with xcodegen installed"
+    fi
+
+    exit "${status}"
+
+# Report the toolchain state of all three applications.
+doctor:
+    #!/usr/bin/env bash
+    # Always exits 0: not having the Android SDK on a machine you only write
+    # Swift on is a fact, not a fault. Each application's own `just doctor` is
+    # the one that fails when something it needs is missing.
+    set -uo pipefail
+    for app in server android ios; do
+        echo "==> ${app}"
+        '{{ just_executable() }}' "${app}::doctor" || true
+        echo
+    done

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,21 +1,38 @@
-# Generate a private value with: openssl rand -hex 32
-VOCAPHONE_TOKEN=replace-me
+# Compose settings for the vocaphone gateway.
+#
+# Copy this file, then fill in a token:
+#
+#   umask 077
+#   cp .env.example .env
+#   printf 'VOCAPHONE_TOKEN=%s\n' "$(openssl rand -hex 32)" >> .env
+#
+# Only `docker compose` reads .env. A gateway started natively (`just run`)
+# takes its token from ~/.config/vocaphone/token instead, and direnv is set up
+# not to export anything from here. Never commit the populated .env.
 
-# Optional: serve the Swagger UI at /docs (and /openapi.json). Off by default
-# since the schema/UI is extra surface area; enable only for local development.
-# VOCAPHONE_DEBUG=true
+# Bearer token the phone apps present on every request. At least 32 characters.
+# Compose passes it to the container as a secret, not as an environment
+# variable. Generate one with: openssl rand -hex 32
+VOCAPHONE_TOKEN=
 
-# Keep the gateway private on the host and expose it with Tailscale Serve.
+# Host interface and port Docker publishes the gateway on.
+# 127.0.0.1 keeps it on loopback, which is what Tailscale Serve expects. Use
+# 0.0.0.0 only for a trusted LAN, with the host firewall up. Never forward this
+# port from the public internet.
 VOCAPHONE_PUBLISH_HOST=127.0.0.1
 VOCAPHONE_PUBLISH_PORT=8765
 
-# Optional: use a prebuilt multi-architecture image instead of the local tag.
-# VOCAPHONE_IMAGE=ghcr.io/your-user/vocaphone-gateway:latest
+# Uncomment on Linux Docker Engine to share the host's network namespace, so
+# the pairing QR can discover the machine's real LAN address instead of the
+# container's bridge IP. This ignores VOCAPHONE_PUBLISH_HOST and _PORT, so lock
+# the port down with the host firewall first. Docker Desktop does not support
+# it.
+#VOCAPHONE_NETWORK_MODE=host
 
-# Optional, Linux Docker Engine only: share the host's network namespace so the
-# gateway's LAN-address auto-discovery (and pairing QR) sees the host's real
-# 192.168.x.x interface instead of the container's private bridge address.
-# VOCAPHONE_PUBLISH_HOST/PORT are ignored in this mode; the container binds
-# directly per VOCAPHONE_BIND_HOST (0.0.0.0 by default) and VOCAPHONE_PORT
-# (8765 by default). Not supported by Docker Desktop on macOS/Windows.
-# VOCAPHONE_NETWORK_MODE=host
+# Use a prebuilt multi-architecture image instead of building the local tag.
+#VOCAPHONE_IMAGE=ghcr.io/your-user/vocaphone-gateway:latest
+
+# Serve the Swagger UI at /docs and the schema at /openapi.json. Off by
+# default: the schema and UI are extra surface area, so enable this only for
+# local development.
+#VOCAPHONE_DEBUG=true

--- a/server/justfile
+++ b/server/justfile
@@ -1,0 +1,158 @@
+set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
+# server/.env holds the Compose token. It belongs to the container, not to the
+# recipes, so it is never loaded into this file's environment.
+set dotenv-load := false
+
+# Do not update the env, when running
+export UV_NO_SYNC := '1'
+
+# List all available recipes
+_default:
+    @just --list --unsorted --list-submodules
+
+# Install dependencies
+[group('dev')]
+install:
+    uv sync --all-groups --all-extras
+
+# Format code with ruff
+[group('dev')]
+format:
+    uv run python -m ruff format
+    uv run python -m ruff check --fix
+
+# Run all linters
+[group('dev')]
+lint:
+    uv run python -m ruff check --exit-non-zero-on-fix
+    uv run python -m ruff format --check --diff
+
+# Run all checks
+[group('dev')]
+test: lint type-check package unit compose
+
+# Run all type checkers
+[group('type-check')]
+type-check:
+    uv run python -m mypy
+
+# Run unit tests
+[group('testing')]
+unit *args='':
+    uv run python -m pytest -n auto {{ args }}
+
+# Validate package dependencies and run security audit
+[group('testing')]
+package:
+    uv sync --all-groups --all-extras --locked --check
+    uv pip check
+    uv --preview-features audit audit
+
+# The token only has to satisfy the length rule; it serves nothing. It sits up
+# here because a comment inside a recipe body is echoed as a command.
+#
+# Validate the Compose deployment
+[group('testing')]
+compose:
+    VOCAPHONE_TOKEN=test-token-with-at-least-thirty-two-characters \
+      docker compose config --quiet
+
+# Start the gateway on http://127.0.0.1:8765/
+[group('run')]
+run:
+    uv run vocaphone-server
+
+# Start the gateway bound to loopback only, ignoring any LAN or tailnet address
+[group('run')]
+run-local:
+    VOCAPHONE_BIND_HOST=127.0.0.1 uv run vocaphone-server
+
+# Print the bearer token to enter in the phone app
+[group('run')]
+token:
+    #!/usr/bin/env bash
+    file="${VOCAPHONE_TOKEN_FILE:-${XDG_CONFIG_HOME:-${HOME}/.config}/vocaphone/token}"
+    if [ -n "${VOCAPHONE_TOKEN:-}" ]; then
+      echo "${VOCAPHONE_TOKEN}"
+      exit 0
+    fi
+    if [ ! -f "${file}" ]; then
+      echo "No token yet — the gateway writes one on first start: just run" >&2
+      exit 1
+    fi
+    cat "${file}"
+
+# Ask a running gateway for its health
+[group('run')]
+status:
+    uv run vocaphone-status
+
+# Ask a running gateway for its diagnostics report
+[group('run')]
+diag:
+    uv run vocaphone-diagnostics
+
+# Build and start the container deployment in the background
+[group('container')]
+up:
+    docker compose up --detach --build
+
+# Stop the container deployment; `just down -v` also drops models, config and DB
+[group('container')]
+down *args='':
+    docker compose down {{ args }}
+
+# Follow the container's logs
+[group('container')]
+container-logs:
+    docker compose logs --follow
+
+# Build the gateway image without starting anything
+[group('container')]
+image:
+    docker build --tag vocaphone-gateway:local .
+
+# Remove tool caches; the virtualenv stays, rebuilding it is a long download
+[group('build')]
+clean:
+    rm -rf .pytest_cache .ruff_cache .mypy_cache
+
+# Report what this justfile needs and cannot find
+[group('build')]
+doctor:
+    #!/usr/bin/env bash
+    ok=0
+    if command -v uv >/dev/null 2>&1; then
+      echo "ok       $(uv --version)"
+    else
+      echo "MISSING  uv — curl -LsSf https://astral.sh/uv/install.sh | sh"
+      ok=1
+    fi
+    # Every engine normalizes through FFmpeg, and tests/test_audio.py shells out
+    # to it against real audio, so this is required, not optional.
+    if command -v ffmpeg >/dev/null 2>&1; then
+      echo "ok       ffmpeg"
+    else
+      echo "MISSING  ffmpeg — brew install ffmpeg (or apt install ffmpeg)"
+      ok=1
+    fi
+    if command -v docker >/dev/null 2>&1; then
+      echo "ok       docker"
+    else
+      echo "MISSING  docker — needed by just compose and the container recipes"
+      ok=1
+    fi
+    if [ "$(uname -s)" = "Darwin" ]; then
+      for tool in whisperkit-cli whisper-cli; do
+        if command -v "${tool}" >/dev/null 2>&1; then
+          echo "ok       ${tool}"
+        else
+          echo "note     ${tool} absent — optional, the gateway runs its own models"
+        fi
+      done
+    fi
+    if [ "${ok}" -ne 0 ]; then
+      echo
+      echo "Install what is marked MISSING above, then run just doctor again."
+    fi
+    exit "${ok}"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -40,8 +40,12 @@ dev = [
   # over plain httpx; without it every run prints a deprecation warning.
   "httpx2>=2,<3",
   "mypy>=1.17,<2",
-  "pytest>=8.4,<9",
+  # 9.0.3 is the floor that clears CVE-2025-71176 (tmpdir handling), which
+  # `just package` audits for.
+  "pytest>=9.0.3,<10",
   "pytest-asyncio>=1.1,<2",
+  # `just unit` runs the suite across cores.
+  "pytest-xdist>=3.8,<4",
   "ruff>=0.12,<1",
 ]
 

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -269,6 +269,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/f2/d716426220b462bbb5bb354b9c6c8d9a41285f067203c860cc79f9f19917/ctranslate2-4.8.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:84723cae6f802551bbf2438e5e4810722631a2183b89a82c31df26566b54821d", size = 16860414, upload-time = "2026-07-03T12:39:55.54Z" },
     { url = "https://files.pythonhosted.org/packages/69/11/cdab0e7e2ad4e547f15ab227c09207569f1272abae05816900ecebb0797a/ctranslate2-4.8.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1910752ec541980644191fa3b407bc61dee00e88070b0aed29b4cef75010b3ea", size = 39465200, upload-time = "2026-07-03T12:39:59.017Z" },
     { url = "https://files.pythonhosted.org/packages/c0/03/126e963fc3237a416f3085b8a663ebd8ab449ed6c37195b4e0b49597ba0c/ctranslate2-4.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:dc9f1abef55579cc02cdc74b3a55df38491ec56d177d6e6039609d61d09ed30e", size = 19499597, upload-time = "2026-07-03T12:40:01.68Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -643,7 +652,7 @@ name = "mlx"
 version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
+    { name = "mlx-metal" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/a6/489176d8a2a06137a299910057cc44dc3fccfb73151f7562fea2b75894d9/mlx-0.32.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:ea5a594355c89c0095eaba413fd39d4caa8642fa13432dfb0c9354d141046467", size = 558889, upload-time = "2026-07-07T17:55:45.268Z" },
@@ -688,7 +697,7 @@ version = "0.31.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
-    { name = "mlx", marker = "sys_platform == 'darwin'" },
+    { name = "mlx" },
     { name = "numpy" },
     { name = "protobuf" },
     { name = "pyyaml" },
@@ -1035,7 +1044,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1044,9 +1053,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1060,6 +1069,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]
@@ -1467,7 +1489,7 @@ version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_version < '0'" },
     { name = "rich" },
     { name = "shellingham" },
 ]
@@ -1592,6 +1614,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -1616,8 +1639,9 @@ dev = [
     { name = "httpx", specifier = ">=0.28,<1" },
     { name = "httpx2", specifier = ">=2,<3" },
     { name = "mypy", specifier = ">=1.17,<2" },
-    { name = "pytest", specifier = ">=8.4,<9" },
+    { name = "pytest", specifier = ">=9.0.3,<10" },
     { name = "pytest-asyncio", specifier = ">=1.1,<2" },
+    { name = "pytest-xdist", specifier = ">=3.8,<4" },
     { name = "ruff", specifier = ">=0.12,<1" },
 ]
 


### PR DESCRIPTION
Ref #34 

## What changed
Adds a justfile per application plus a root aggregator, so the commands for building, running and checking each app live in one place instead of being copied out of prose. 

Adds optional direnv setup, and points README and CONTRIBUTING at the recipes.

## What we get
```sh
just ci              # all three applications, skipping absent toolchains
just server test     # gateway: lint, types, dependency audit, tests, compose
just server unit     # gateway: tests that allow you to specify a particular test
just ios ci          # iOS: regenerate the project, build, run unit tests
just android ci      # Android: assemble, unit tests, lint, Room schema
just doctor          # what each toolchain is still missing
```
`just ci` is smart and skips what it can’t do, meaning it’s the same command for Linux and Mac users.

Each app's recipes also work from inside its directory (`cd ios && just run`), because module recipes execute in their own directory. Beyond CI parity, the files carry the things that were previously tribal knowledge:

```sh
just ios device            # installs onto a connected iPhone via devicectl
just ios settings          # opens where the keyboard has to be added by hand
just android permissions   # grants what the dictation bubble needs
just server token          # prints the pairing token
```
## Dependency changes

server/pyproject.toml and uv.lock change for two reasons:

- **pytest** `>=8.4,<9` -> `>=9.0.3,<10`. just server test runs uv audit, which fails on CVE-2025-71176 (vulnerable tmpdir handling) below 9.0.3. I checked before bumping.

- **pytest-xdist** added. `just unit` runs `-n auto`: 4.2s -> 2.4s, all tests passing in parallel. `-n0` still available for a debugger.

`quality-server.yml` runs plain `uv run pytest`, so CI does not touch xdist.

## direnv (optional)
`.envrc` is checked in and contains no secrets. After `direnv allow` it puts the gateway virtualenv and the SDK's` platform-tools` on `PATH` and exports `ANDROID_HOME`. Everything works without it.

It deliberately does not load `server/.env`: the gateway reads `VOCAPHONE_TOKEN` from the environment, so exporting the Compose token would make a natively run gateway serve the container's token instead of `~/.config/vocaphone/token` — silently, since both are valid.

`.gitignore` now tracks only the root `.envrc` and ignores nested ones. The quickest way to produce `server/.envrc` is to copy `server/.env` into it, secret and all, and nothing previously caught that.















