### PR TITLE
feat: print a terminal pairing QR from just token

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,11 +201,14 @@ WebUI (this host): http://127.0.0.1:8765/
 Network access: use this host's LAN or Tailscale IP with the same port
 Token: ~/.config/vocaphone/token
   (cat ~/.config/vocaphone/token — enter that value in the phone app)
+  or: just token  (prints a terminal QR for headless phone pairing)
 ```
 
 Open the WebUI, enter the token from `~/.config/vocaphone/token`, download a
 recommended model (SenseVoice Small INT8 or Parakeet TDT INT8 on CPU), select it,
-and confirm Overview shows **Ready for dictation**.
+and confirm Overview shows **Ready for dictation**. For headless phone pairing
+without the WebUI, run `just token` (or `just server token` from the repo root)
+on a TTY to print a scannable pairing QR.
 
 To keep the gateway running after the terminal closes (systemd user unit):
 
@@ -279,7 +282,13 @@ tailscale serve status
 
 ### Pair the phone with a QR code (iPhone or Android)
 
-Once the WebUI is open and authenticated on the gateway host:
+**Without the WebUI (headless):** on the gateway host, run `just token` (or
+`just server token` from the repo root). On a TTY it prints an ASCII QR that
+encodes the same pairing payload as the WebUI. Point the phone's camera at the
+terminal, or use `just token --plain` / `cat ~/.config/vocaphone/token` when you
+only need the secret.
+
+**From the WebUI:** once authenticated on the gateway host:
 
 1. Stay on **Overview** — the **Pair phone app** card shows a QR for a
    phone-reachable address (LAN IP preferred, or `VOCAPHONE_PUBLIC_URL` if set).
@@ -297,8 +306,9 @@ Once the WebUI is open and authenticated on the gateway host:
 You can still paste manually:
 
 1. **Gateway address** — the LAN, Tailscale, or HTTPS URL above.
-2. **Bearer token** — `cat ~/.config/vocaphone/token` for native installs, or the
-   `VOCAPHONE_TOKEN` value from `server/.env` for Docker.
+2. **Bearer token** — `just token --plain` or `cat ~/.config/vocaphone/token`
+   for native installs, or the `VOCAPHONE_TOKEN` value from `server/.env` for
+   Docker.
 
 Then use **Save and test** / **Test connection**. Tailscale is recommended for a
 private personal deployment, but it is not mandatory. Follow

--- a/server/README.md
+++ b/server/README.md
@@ -85,10 +85,10 @@ uv run vocaphone-server
 
 Do not pass `--extra apple` on Linux. The first run creates
 `~/.config/vocaphone/token` with mode `600`. The banner prints the WebUI URL and
-token path; show the secret with `cat ~/.config/vocaphone/token`. Open
-`http://127.0.0.1:8765/`, enter the token, download a recommended model
-(SenseVoice Small INT8 or Parakeet TDT INT8 on CPU), select it, and confirm
-**Ready for dictation**.
+token path; show the secret (and a terminal pairing QR) with `just token` or
+`uv run vocaphone-token`. Open `http://127.0.0.1:8765/`, enter the token,
+download a recommended model (SenseVoice Small INT8 or Parakeet TDT INT8 on
+CPU), select it, and confirm **Ready for dictation**.
 
 To keep the gateway running after the terminal closes:
 
@@ -125,7 +125,10 @@ The code encodes a versioned JSON payload:
 
 Discovery prefers private Wi‑Fi addresses (for example `192.168.x.x`). Override
 with `VOCAPHONE_PUBLIC_URL` or `VOCAPHONE_PAIRING_URL` when automatic selection
-is wrong. The QR is only available through the authenticated WebUI/API.
+is wrong. The same payload is available without the WebUI: on a TTY,
+`just token` (or `uv run vocaphone-token`) prints an ASCII QR for headless
+setup; use `just token --plain` when you only want the secret (pipes always get
+plain output).
 
 The same card can create a named per-device token and immediately show its own
 QR instead of the shared bootstrap token, and a **Token to encode** dropdown

--- a/server/app/cli.py
+++ b/server/app/cli.py
@@ -6,19 +6,27 @@ import json
 import os
 import sys
 import urllib.request
-from pathlib import Path
 
 import uvicorn
 
 from app.audio import FFmpegNormalizer
-from app.config import WILDCARD_BIND_HOSTS, Settings, format_host_port, local_webui_url
+from app.config import (
+    WILDCARD_BIND_HOSTS,
+    Settings,
+    _default_config_file,
+    _default_token_file,
+    _env_path,
+    format_host_port,
+    local_webui_url,
+)
 from app.engines import StaticEngineProvider
 from app.main import create_app, select_engine
 from app.pairing import (
+    default_pairing_url,
     encode_pairing_payload,
-    primary_gateway_base_url,
     qr_ascii_for_payload,
 )
+from app.runtime_config import RuntimeConfig
 from app.service import TranscriptionService
 from app.storage import SessionRepository
 
@@ -48,19 +56,17 @@ def _token_from_env() -> bool:
     return bool(os.environ.get("VOCAPHONE_TOKEN", "").strip())
 
 
-def _default_token_file() -> Path:
-    config_home = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
-    return config_home / "vocaphone" / "token"
-
-
 def _load_existing_bootstrap_token() -> str:
-    """Return the bootstrap token without minting a new secret."""
+    """Return the bootstrap token without minting a new secret.
+
+    Path resolution matches :meth:`Settings.from_env` (blank
+    ``VOCAPHONE_TOKEN_FILE`` falls back to the default; ``~`` and
+    ``XDG_CONFIG_HOME`` are expanded the same way).
+    """
     token = os.environ.get("VOCAPHONE_TOKEN", "").strip()
     if token:
         return token
-    token_file = Path(
-        os.environ.get("VOCAPHONE_TOKEN_FILE", str(_default_token_file()))
-    ).expanduser()
+    token_file = _env_path("VOCAPHONE_TOKEN_FILE", _default_token_file())
     if not token_file.is_file():
         print(
             "No token yet — the gateway writes one on first start: just run",
@@ -72,6 +78,11 @@ def _load_existing_bootstrap_token() -> str:
         print(f"Token file is empty: {token_file}", file=sys.stderr)
         raise SystemExit(1)
     return token
+
+
+def _saved_pairing_url() -> str | None:
+    config_path = _env_path("VOCAPHONE_CONFIG_FILE", _default_config_file())
+    return RuntimeConfig.load(config_path).pairing_url
 
 
 def token() -> None:
@@ -98,13 +109,13 @@ def token() -> None:
         return
 
     port = int(os.environ.get("VOCAPHONE_PORT", "8765"))
-    gateway_url = primary_gateway_base_url(port)
+    gateway_url = default_pairing_url(port, saved_pairing_url=_saved_pairing_url())
     print(f"Token: {secret}")
     if gateway_url is None:
         print(
             "No phone-reachable gateway address found. Set VOCAPHONE_PUBLIC_URL "
-            f"or VOCAPHONE_PAIRING_URL (for example http://192.168.1.20:{port}) "
-            "to encode a pairing QR.",
+            f"or VOCAPHONE_PAIRING_URL (for example http://192.168.1.20:{port}), "
+            "or pick an address in the WebUI pairing card.",
             file=sys.stderr,
         )
         return
@@ -115,7 +126,10 @@ def token() -> None:
     print()
     print(qr_ascii_for_payload(payload), end="")
     print()
-    print("Override the encoded address with VOCAPHONE_PUBLIC_URL or VOCAPHONE_PAIRING_URL.")
+    print(
+        "Override the encoded address with VOCAPHONE_PUBLIC_URL, VOCAPHONE_PAIRING_URL, "
+        "or the WebUI pairing card."
+    )
 
 
 def status() -> None:

--- a/server/app/cli.py
+++ b/server/app/cli.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import argparse
 import asyncio
 import json
+import os
 import sys
 import urllib.request
+from pathlib import Path
 
 import uvicorn
 
@@ -11,6 +14,11 @@ from app.audio import FFmpegNormalizer
 from app.config import WILDCARD_BIND_HOSTS, Settings, format_host_port, local_webui_url
 from app.engines import StaticEngineProvider
 from app.main import create_app, select_engine
+from app.pairing import (
+    encode_pairing_payload,
+    primary_gateway_base_url,
+    qr_ascii_for_payload,
+)
 from app.service import TranscriptionService
 from app.storage import SessionRepository
 
@@ -27,6 +35,7 @@ def serve() -> None:
     print(f"Token: {token_source}")
     if not _token_from_env():
         print(f"  (cat {token_path} — enter that value in the phone app)")
+        print("  or: just token  (prints a terminal QR for headless phone pairing)")
     uvicorn.run(
         create_app(settings),
         host=host,
@@ -36,9 +45,77 @@ def serve() -> None:
 
 
 def _token_from_env() -> bool:
-    import os
-
     return bool(os.environ.get("VOCAPHONE_TOKEN", "").strip())
+
+
+def _default_token_file() -> Path:
+    config_home = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    return config_home / "vocaphone" / "token"
+
+
+def _load_existing_bootstrap_token() -> str:
+    """Return the bootstrap token without minting a new secret."""
+    token = os.environ.get("VOCAPHONE_TOKEN", "").strip()
+    if token:
+        return token
+    token_file = Path(
+        os.environ.get("VOCAPHONE_TOKEN_FILE", str(_default_token_file()))
+    ).expanduser()
+    if not token_file.is_file():
+        print(
+            "No token yet — the gateway writes one on first start: just run",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    token = token_file.read_text(encoding="utf-8").strip()
+    if not token:
+        print(f"Token file is empty: {token_file}", file=sys.stderr)
+        raise SystemExit(1)
+    return token
+
+
+def token() -> None:
+    """Print the bootstrap token, and a terminal pairing QR when useful.
+
+    Interactive terminals get the phone-scannable pairing QR (same JSON the
+    WebUI encodes). Piped / ``--plain`` output stays a single line so scripts
+    can still do ``TOKEN=$(just token --plain)``.
+    """
+    parser = argparse.ArgumentParser(
+        prog="vocaphone-token",
+        description="Show the bootstrap bearer token and an optional terminal pairing QR.",
+    )
+    parser.add_argument(
+        "--plain",
+        action="store_true",
+        help="Print only the token (always used when stdout is not a TTY).",
+    )
+    args = parser.parse_args()
+    secret = _load_existing_bootstrap_token()
+    plain = args.plain or not sys.stdout.isatty()
+    if plain:
+        print(secret)
+        return
+
+    port = int(os.environ.get("VOCAPHONE_PORT", "8765"))
+    gateway_url = primary_gateway_base_url(port)
+    print(f"Token: {secret}")
+    if gateway_url is None:
+        print(
+            "No phone-reachable gateway address found. Set VOCAPHONE_PUBLIC_URL "
+            f"or VOCAPHONE_PAIRING_URL (for example http://192.168.1.20:{port}) "
+            "to encode a pairing QR.",
+            file=sys.stderr,
+        )
+        return
+
+    payload = encode_pairing_payload(gateway_url, secret)
+    print(f"Gateway: {gateway_url}")
+    print("Scan with the phone app (Settings → Scan pairing QR / Gateway → Scan QR):")
+    print()
+    print(qr_ascii_for_payload(payload), end="")
+    print()
+    print("Override the encoded address with VOCAPHONE_PUBLIC_URL or VOCAPHONE_PAIRING_URL.")
 
 
 def status() -> None:

--- a/server/app/pairing.py
+++ b/server/app/pairing.py
@@ -255,3 +255,21 @@ def qr_svg_for_payload(payload: str, *, box_size: int = 6, border: int = 2) -> s
     image = qr.make_image()
     svg = image.to_string(encoding="unicode")
     return str(svg)
+
+
+def qr_ascii_for_payload(payload: str, *, border: int = 1, invert: bool = True) -> str:
+    """Return a terminal-scannable ASCII QR for *payload* (no Pillow)."""
+    import io
+
+    import qrcode
+
+    qr = qrcode.QRCode(
+        version=None,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        border=border,
+    )
+    qr.add_data(payload)
+    qr.make(fit=True)
+    buffer = io.StringIO()
+    qr.print_ascii(out=buffer, invert=invert)
+    return buffer.getvalue()

--- a/server/app/pairing.py
+++ b/server/app/pairing.py
@@ -163,6 +163,23 @@ def primary_gateway_base_url(port: int) -> str | None:
     return urls[0] if urls else None
 
 
+def default_pairing_url(port: int, *, saved_pairing_url: str | None = None) -> str | None:
+    """URL a pairing QR should encode by default (WebUI and CLI).
+
+    Prefer a non-stale saved WebUI choice, then env overrides / discovery via
+    :func:`primary_gateway_base_url`. Ambient LAN or Tailscale IPs that no
+    longer appear in discovery are treated as stale — the same rule the
+    Overview card applies with :func:`forget_stale_lan_addresses` — without
+    writing config.
+    """
+    if saved_pairing_url:
+        if not is_ambient_lan_address(saved_pairing_url):
+            return saved_pairing_url
+        if saved_pairing_url in discover_gateway_base_urls(port):
+            return saved_pairing_url
+    return primary_gateway_base_url(port)
+
+
 def _local_ipv4_addresses() -> list[str]:
     found: set[str] = set()
     try:

--- a/server/justfile
+++ b/server/justfile
@@ -67,20 +67,10 @@ run:
 run-local:
     VOCAPHONE_BIND_HOST=127.0.0.1 uv run vocaphone-server
 
-# Print the bearer token to enter in the phone app
+# Print the bearer token; on a TTY also show a phone-scannable pairing QR
 [group('run')]
-token:
-    #!/usr/bin/env bash
-    file="${VOCAPHONE_TOKEN_FILE:-${XDG_CONFIG_HOME:-${HOME}/.config}/vocaphone/token}"
-    if [ -n "${VOCAPHONE_TOKEN:-}" ]; then
-      echo "${VOCAPHONE_TOKEN}"
-      exit 0
-    fi
-    if [ ! -f "${file}" ]; then
-      echo "No token yet — the gateway writes one on first start: just run" >&2
-      exit 1
-    fi
-    cat "${file}"
+token *args='':
+    uv run vocaphone-token {{ args }}
 
 # Ask a running gateway for its health
 [group('run')]

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -32,6 +32,7 @@ vocaphone-server = "app.cli:serve"
 vocaphone-status = "app.cli:status"
 vocaphone-diagnostics = "app.cli:diagnostics"
 vocaphone-cleanup = "app.cli:cleanup"
+vocaphone-token = "app.cli:token"
 
 [dependency-groups]
 dev = [

--- a/server/tests/test_cli_token.py
+++ b/server/tests/test_cli_token.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -20,14 +21,18 @@ def _isolate_home(monkeypatch: MonkeyPatch, tmp_path: Path) -> Path:
     return home
 
 
+def _write_token(home: Path, secret: str = "test-token-with-at-least-thirty-two-characters") -> str:
+    token_file = home / ".config" / "vocaphone" / "token"
+    token_file.parent.mkdir(parents=True)
+    token_file.write_text(secret + "\n", encoding="utf-8")
+    return secret
+
+
 def test_token_plain_prints_only_the_secret(
     tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
 ) -> None:
     home = _isolate_home(monkeypatch, tmp_path)
-    token_file = home / ".config" / "vocaphone" / "token"
-    token_file.parent.mkdir(parents=True)
-    secret = "test-token-with-at-least-thirty-two-characters"
-    token_file.write_text(secret + "\n", encoding="utf-8")
+    secret = _write_token(home)
     monkeypatch.setattr("sys.argv", ["vocaphone-token", "--plain"])
 
     cli.token()
@@ -41,6 +46,20 @@ def test_token_reads_env_override(
     _isolate_home(monkeypatch, tmp_path)
     secret = "env-token-with-at-least-thirty-two-chars-ok"
     monkeypatch.setenv("VOCAPHONE_TOKEN", secret)
+    monkeypatch.setattr("sys.argv", ["vocaphone-token", "--plain"])
+
+    cli.token()
+
+    assert capsys.readouterr().out == secret + "\n"
+
+
+def test_token_blank_token_file_env_falls_back_to_default(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    home = _isolate_home(monkeypatch, tmp_path)
+    secret = _write_token(home)
+    # Same rule as Settings.from_env / the old just recipe: blank means unset.
+    monkeypatch.setenv("VOCAPHONE_TOKEN_FILE", "   ")
     monkeypatch.setattr("sys.argv", ["vocaphone-token", "--plain"])
 
     cli.token()
@@ -65,10 +84,7 @@ def test_token_tty_prints_pairing_qr(
     tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
 ) -> None:
     home = _isolate_home(monkeypatch, tmp_path)
-    token_file = home / ".config" / "vocaphone" / "token"
-    token_file.parent.mkdir(parents=True)
-    secret = "test-token-with-at-least-thirty-two-characters"
-    token_file.write_text(secret + "\n", encoding="utf-8")
+    secret = _write_token(home)
     monkeypatch.setenv("VOCAPHONE_PUBLIC_URL", "http://192.168.1.20:8765")
     monkeypatch.setattr("sys.argv", ["vocaphone-token"])
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
@@ -82,17 +98,38 @@ def test_token_tty_prints_pairing_qr(
     assert any(ch in out for ch in ("█", "▀", "▄", "#", "*"))
 
 
+def test_token_tty_prefers_saved_webui_pairing_url(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    home = _isolate_home(monkeypatch, tmp_path)
+    secret = _write_token(home)
+    config_path = home / ".config" / "vocaphone" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps({"pairing_url": "https://dictation.example.com"}),
+        encoding="utf-8",
+    )
+    # Env discovery would prefer LAN; saved WebUI choice must win (Overview card).
+    monkeypatch.setenv("VOCAPHONE_PUBLIC_URL", "http://192.168.1.20:8765")
+    monkeypatch.setattr("sys.argv", ["vocaphone-token"])
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+    cli.token()
+
+    out = capsys.readouterr().out
+    assert secret in out
+    assert "https://dictation.example.com" in out
+    assert "192.168.1.20" not in out
+
+
 def test_token_tty_without_gateway_warns(
     tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
 ) -> None:
     home = _isolate_home(monkeypatch, tmp_path)
-    token_file = home / ".config" / "vocaphone" / "token"
-    token_file.parent.mkdir(parents=True)
-    secret = "test-token-with-at-least-thirty-two-characters"
-    token_file.write_text(secret + "\n", encoding="utf-8")
+    secret = _write_token(home)
     monkeypatch.setattr("sys.argv", ["vocaphone-token"])
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
-    monkeypatch.setattr("app.cli.primary_gateway_base_url", lambda _port: None)
+    monkeypatch.setattr("app.cli.default_pairing_url", lambda _port, **_kwargs: None)
 
     cli.token()
 

--- a/server/tests/test_cli_token.py
+++ b/server/tests/test_cli_token.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pytest import CaptureFixture, MonkeyPatch
+
+from app import cli
+
+
+def _isolate_home(monkeypatch: MonkeyPatch, tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    for name in list(__import__("os").environ):
+        if name.startswith("LOCALFLOW_") or name.startswith("VOCAPHONE_"):
+            monkeypatch.delenv(name, raising=False)
+    return home
+
+
+def test_token_plain_prints_only_the_secret(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    home = _isolate_home(monkeypatch, tmp_path)
+    token_file = home / ".config" / "vocaphone" / "token"
+    token_file.parent.mkdir(parents=True)
+    secret = "test-token-with-at-least-thirty-two-characters"
+    token_file.write_text(secret + "\n", encoding="utf-8")
+    monkeypatch.setattr("sys.argv", ["vocaphone-token", "--plain"])
+
+    cli.token()
+
+    assert capsys.readouterr().out == secret + "\n"
+
+
+def test_token_reads_env_override(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    _isolate_home(monkeypatch, tmp_path)
+    secret = "env-token-with-at-least-thirty-two-chars-ok"
+    monkeypatch.setenv("VOCAPHONE_TOKEN", secret)
+    monkeypatch.setattr("sys.argv", ["vocaphone-token", "--plain"])
+
+    cli.token()
+
+    assert capsys.readouterr().out == secret + "\n"
+
+
+def test_token_missing_file_exits(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.setattr("sys.argv", ["vocaphone-token", "--plain"])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.token()
+
+    assert exc.value.code == 1
+    assert "No token yet" in capsys.readouterr().err
+
+
+def test_token_tty_prints_pairing_qr(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    home = _isolate_home(monkeypatch, tmp_path)
+    token_file = home / ".config" / "vocaphone" / "token"
+    token_file.parent.mkdir(parents=True)
+    secret = "test-token-with-at-least-thirty-two-characters"
+    token_file.write_text(secret + "\n", encoding="utf-8")
+    monkeypatch.setenv("VOCAPHONE_PUBLIC_URL", "http://192.168.1.20:8765")
+    monkeypatch.setattr("sys.argv", ["vocaphone-token"])
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+    cli.token()
+
+    out = capsys.readouterr().out
+    assert secret in out
+    assert "http://192.168.1.20:8765" in out
+    assert "Scan with the phone app" in out
+    assert any(ch in out for ch in ("█", "▀", "▄", "#", "*"))
+
+
+def test_token_tty_without_gateway_warns(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    home = _isolate_home(monkeypatch, tmp_path)
+    token_file = home / ".config" / "vocaphone" / "token"
+    token_file.parent.mkdir(parents=True)
+    secret = "test-token-with-at-least-thirty-two-characters"
+    token_file.write_text(secret + "\n", encoding="utf-8")
+    monkeypatch.setattr("sys.argv", ["vocaphone-token"])
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("app.cli.primary_gateway_base_url", lambda _port: None)
+
+    cli.token()
+
+    captured = capsys.readouterr()
+    assert secret in captured.out
+    assert "No phone-reachable gateway address" in captured.err

--- a/server/tests/test_pairing.py
+++ b/server/tests/test_pairing.py
@@ -11,6 +11,7 @@ from app.pairing import (
     is_ambient_lan_address,
     normalize_gateway_input,
     primary_gateway_base_url,
+    qr_ascii_for_payload,
     qr_svg_for_payload,
 )
 
@@ -80,6 +81,19 @@ def test_qr_svg_contains_path_and_is_svg() -> None:
     assert svg.lstrip().startswith("<?xml") or "<svg" in svg
     assert "path" in svg.lower() or "rect" in svg.lower()
     assert len(svg) > 200
+
+
+def test_qr_ascii_is_multiline_and_dense() -> None:
+    payload = encode_pairing_payload(
+        "http://192.168.1.75:8765",
+        "test-token-with-at-least-thirty-two-characters",
+    )
+    ascii_qr = qr_ascii_for_payload(payload)
+    lines = [line for line in ascii_qr.splitlines() if line.strip()]
+    assert len(lines) >= 10
+    assert len(ascii_qr) > 200
+    # Half-block / full-block glyphs from qrcode.print_ascii(invert=True).
+    assert any(ch in ascii_qr for ch in ("█", "▀", "▄", "#", "*"))
 
 
 def test_primary_gateway_base_url_prefers_override(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/server/tests/test_pairing.py
+++ b/server/tests/test_pairing.py
@@ -7,6 +7,7 @@ import pytest
 from app.pairing import (
     PAIRING_VERSION,
     decode_pairing_payload,
+    default_pairing_url,
     encode_pairing_payload,
     is_ambient_lan_address,
     normalize_gateway_input,
@@ -99,6 +100,37 @@ def test_qr_ascii_is_multiline_and_dense() -> None:
 def test_primary_gateway_base_url_prefers_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VOCAPHONE_PUBLIC_URL", "http://homelab.example:8765")
     assert primary_gateway_base_url(8765) == "http://homelab.example:8765"
+
+
+def test_default_pairing_url_prefers_saved_non_ambient_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VOCAPHONE_PUBLIC_URL", "http://192.168.1.20:8765")
+    assert (
+        default_pairing_url(8765, saved_pairing_url="https://dictation.example.com")
+        == "https://dictation.example.com"
+    )
+
+
+def test_default_pairing_url_drops_stale_ambient_lan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VOCAPHONE_PUBLIC_URL", "http://192.168.9.9:8765")
+    # 10.0.0.1 is ambient LAN and not in discovered set (override is the only hit).
+    assert (
+        default_pairing_url(8765, saved_pairing_url="http://10.0.0.1:8765")
+        == "http://192.168.9.9:8765"
+    )
+
+
+def test_default_pairing_url_keeps_live_ambient_lan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VOCAPHONE_PUBLIC_URL", "http://192.168.1.20:8765")
+    assert (
+        default_pairing_url(8765, saved_pairing_url="http://192.168.1.20:8765")
+        == "http://192.168.1.20:8765"
+    )
 
 
 def test_normalize_gateway_input_adds_scheme_and_default_port() -> None:


### PR DESCRIPTION
## Summary

Headless gateway hosts can pair a phone without opening the WebUI.

<img width="1213" height="943" alt="image" src="https://github.com/user-attachments/assets/adfdb7e8-5813-40cc-add2-a0a3b6d14a9e" />


`just token` (and `uv run vocaphone-token`) still prints the bootstrap bearer token. On a TTY it also prints an ASCII QR of the same `{"v":1,"url","token"}` payload the WebUI pairing card encodes, using LAN/Tailscale discovery (or `VOCAPHONE_PUBLIC_URL` / `VOCAPHONE_PAIRING_URL`).

Piped output and `just token --plain` stay a single-line secret so existing scripts keep working.

## Test plan

- [x] `pytest tests/test_cli_token.py tests/test_pairing.py`
- [x] Manual: piped / `--plain` prints only the token
- [x] Manual: forced TTY path prints token, gateway URL, and scannable ASCII QR
- [x] ruff + mypy on changed modules
- [ ] On a real host with a running gateway: `just token`, scan from iOS/Android QR pairing


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operator-facing CLI and docs only; token loading matches existing gateway rules and does not change auth or server APIs.
> 
> **Overview**
> **Headless phone pairing** is supported: `just token` and `uv run vocaphone-token` still expose the bootstrap bearer token, and on an **interactive TTY** they also print an **ASCII QR** encoding the same `{"v":1,"url","token"}` payload as the WebUI pairing card. **`--plain`** or **non-TTY stdout** keeps a **single-line secret** so scripts like `TOKEN=$(just token --plain)` stay unchanged.
> 
> The CLI resolves the encoded gateway URL via new **`default_pairing_url`** (saved WebUI `pairing_url`, env overrides, discovery, stale ambient LAN rules) and **`qr_ascii_for_payload`** in `pairing.py`. The server startup banner and READMEs document the headless flow; `just token` delegates to Python instead of shell `cat`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9e9be57060412e91a2a1ff6c46daed261bc079a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->