### PR TITLE
feat: link web dashboard from phone settings

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -82,6 +82,17 @@ fun SettingsScreen(
                 style = MaterialTheme.typography.bodyMedium,
             )
             SecondaryButton("Gateway settings", onClick = onOpenGateway)
+            SecondaryButton(
+                text = "Open web dashboard",
+                onClick = { context.openUrl(settings.gatewayUrl) },
+                enabled = settings.gatewayUrl.isNotEmpty(),
+            )
+            Text(
+                "For more customization, including choosing the speech-to-text model, " +
+                    "open your gateway's web dashboard.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
 
         // One row rather than 27 wrapping chips, which pushed every setting below

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -50,7 +50,7 @@ struct SettingsView: View {
     }
 
     private var setupSection: some View {
-        Section("Setup") {
+        Section {
             NavigationLink {
                 GatewaySetupView()
             } label: {
@@ -80,6 +80,18 @@ struct SettingsView: View {
                 Label("Guided setup", systemImage: "checklist")
             }
 
+            if let dashboardURL = validatedGatewayURL {
+                Link(destination: dashboardURL) {
+                    Label("Open web dashboard", systemImage: "arrow.up.right.square")
+                }
+            } else {
+                Button {} label: {
+                    Label("Open web dashboard", systemImage: "arrow.up.right.square")
+                }
+                    .disabled(true)
+                    .accessibilityHint("Configure a transcription gateway first")
+            }
+
             if !gatewayEngine.isEmpty {
                 LabeledContent("Model") {
                     Text(gatewayEngine)
@@ -87,6 +99,13 @@ struct SettingsView: View {
                         .textSelection(.enabled)
                 }
             }
+        } header: {
+            Text("Setup")
+        } footer: {
+            Text(
+                "For more customization, including choosing the speech-to-text model, "
+                    + "open your gateway's web dashboard."
+            )
         }
     }
 
@@ -232,6 +251,10 @@ struct SettingsView: View {
 
     private var selectedMicrophonePreference: MicrophonePreference {
         MicrophonePreference(rawValue: microphonePreferenceRawValue) ?? .automatic
+    }
+
+    private var validatedGatewayURL: URL? {
+        GatewayEndpoint.validatedURL(from: gatewayURL)
     }
 }
 


### PR DESCRIPTION
## Summary

- add an Open web dashboard action to Android and iOS Settings using the configured gateway URL
- disable the action until a gateway is configured and keep bearer tokens out of browser links
- explain that advanced customization, including choosing the speech-to-text model, is available in the gateway dashboard
- expose the unavailable iOS action with disabled control semantics for accessibility

## Verification

- `cd ios && just test` (93 tests passed)
- `cd android && ./gradlew assembleDebug testDebugUnitTest lintDebug`
- `git diff --check`

Self-review completed before staging.