### PR TITLE
feat(iOS): harden Quick Dictation reliability

### DIFF
--- a/docs/device-setup.md
+++ b/docs/device-setup.md
@@ -76,3 +76,32 @@ Verify that:
 Also test Messages, Mail, Safari, WhatsApp, Slack, and ChatGPT where installed.
 Secure fields and apps that disable third-party keyboards are expected platform
 limitations and must fail without presenting a gateway error.
+
+## Quick Dictation reliability gate
+
+Run these checks on a physical iPhone after changing audio or App Group code:
+
+- Start and finish from the keyboard several times. Recording and transcript
+  states should update immediately; the slower polling path is only a fallback.
+- Expand the standby Dynamic Island and tap **Turn off Quick Dictation**. The
+  Live Activity and orange microphone indicator must disappear without opening
+  vocaphone, and the next keyboard dictation must open the app.
+- Force-quit vocaphone while Quick Dictation is ready, wait at least 7 seconds,
+  and tap Dictate. The keyboard must treat the heartbeat as stale and open the
+  app instead of claiming that standby is ready.
+- During standby and during an active recording, test a phone call or Siri, an
+  AirPods disconnect, and reconnecting an input. Readiness and the Live Activity
+  must clear whenever input is unavailable. An interrupted recording should
+  finish and preserve the audio captured before the interruption.
+- Hold the spacebar until **Cursor control** is announced, then drag left and
+  right. The insertion point should move without inserting a space. A normal
+  spacebar tap must still insert exactly one space.
+- With recording sounds disabled, confirm there are no cues. Enable them in
+  vocaphone Settings and confirm the short start/stop cues play but are absent
+  from the resulting transcript.
+- Disable Full Access and reopen the keyboard. The inline warning and locked
+  dictation action must appear; re-enable Full Access before continuing.
+- Export diagnostics from vocaphone Settings. Confirm the file contains only
+  timestamps, build information, process source, finite state/lifecycle events,
+  and errors—never dictated or typed text, audio, gateway addresses, tokens, or
+  microphone names. Clear diagnostics and confirm a new export has no old rows.

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -12,10 +12,15 @@
 		07D7CA474CBB8812C0E83D1C /* VocaPhoneActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8988211922DAD4FC77AF89EB /* VocaPhoneActivityAttributes.swift */; };
 		0B939DE9494D3B8F14F18142 /* ModelLanguageSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */; };
 		0D07EBF90CE481AE0C1976CF /* SetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346B6558EE5557A35C916067 /* SetupView.swift */; };
+		108C096B9C0FB4861FC26437 /* StopQuickDictationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332854D2644CFCE5843E3F31 /* StopQuickDictationIntent.swift */; };
+		12A7F7D550BED2750227A111 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA135DE504590121F6D8843 /* DiagnosticLog.swift */; };
 		15CB6862BDAB7694EE44D7F8 /* DictationBarStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7842B22D05FB171B261101A /* DictationBarStyle.swift */; };
+		15E349A8DDDFD47EFA7EE2FA /* ReliabilityFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5877B4AB653982A0433A37 /* ReliabilityFeatureTests.swift */; };
+		16A937522A6A8C972B1107A2 /* DarwinNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3498C523755A678225152570 /* DarwinNotifications.swift */; };
 		1B72FBEA5D41DB51B82A1305 /* SetupStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA031D86C1DE3C2F8B047308 /* SetupStatusTests.swift */; };
 		1BB4BED912ADFA11ED122052 /* DictationPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCCE5FE1A8242B96B8CA9FD /* DictationPresentation.swift */; };
 		1D96E4B5456A18FA04F5F15D /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */; };
+		1EE70552DF2972DCE328ED01 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA135DE504590121F6D8843 /* DiagnosticLog.swift */; };
 		28C271BC0195C62E93292A9C /* SessionRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B854354D06D0111DEB123E7A /* SessionRecordTests.swift */; };
 		2C362C9B71AA6A93A6D7E4DB /* SessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */; };
 		2D1CF0D6875DFD7D9BFD10FF /* DictationBarStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7842B22D05FB171B261101A /* DictationBarStyle.swift */; };
@@ -53,11 +58,13 @@
 		6565BFD7DC56DDCECDBC0D7C /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */; };
 		68E7553DB227208E27DF3A8F /* KeyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5118F8CFAAE127CD5FF92076 /* KeyView.swift */; };
 		6BDE1B7BE51A2350AFE05074 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0AC0739F69438AEC347C44A4 /* Assets.xcassets */; };
+		6C48D9ED8AF4FE61AB76AE49 /* StopQuickDictationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332854D2644CFCE5843E3F31 /* StopQuickDictationIntent.swift */; };
 		76E660378F845C250AEA0673 /* AudioCapturePipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15DE10A5F8F90C87D4BA48A /* AudioCapturePipeline.swift */; };
 		7E3D8E857A83184E74B15433 /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */; };
 		8468AAFD83E231AD9BB99792 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCC7453FC149EBB02E3FB58 /* KeychainStore.swift */; };
 		84EB79403F7CED013A82334F /* PairingScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B3F1DBA8332A13B095E4BA /* PairingScannerView.swift */; };
 		84F2FD89DD3C1EB490E86A73 /* FinishRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B19321866AE8083C78C2B7F /* FinishRecordingIntent.swift */; };
+		867671B90E038F77BE36A4E6 /* DarwinNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3498C523755A678225152570 /* DarwinNotifications.swift */; };
 		89E3D47D85EBD6AD5A093813 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */; };
 		8DD5E5E2B734765883552523 /* DictationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3489C985467C23EB6A90AD /* DictationBarView.swift */; };
 		90F0433AE6FE139E90D62F9A /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */; };
@@ -65,20 +72,25 @@
 		94B667AC0FFB905D57BE2CA3 /* VocaPhoneLiveActivity.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = CF080065DC31C6DA8E693163 /* VocaPhoneLiveActivity.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		966E2D9A6D13630E7A2122A6 /* KeyLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87128326897BFA30E7B2038 /* KeyLayout.swift */; };
 		97EE4663316E8CF2EAE9761A /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */; };
+		9C6AF2EE68EB7AA4D4CF0F61 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA135DE504590121F6D8843 /* DiagnosticLog.swift */; };
 		A2112E100F4277466EA8DD4F /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */; };
 		A568F548D639C064CDA86F0D /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */; };
+		A59723F937FABF80B8158883 /* RecordingSoundFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0187C986535C090BEE7EFD8 /* RecordingSoundFeedback.swift */; };
 		A794CD8D0B445E5118500EC3 /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
 		A79BA8A795F60838D96EDFAA /* VocaPhoneLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D3E1455AD292ED6DA1DFAC /* VocaPhoneLiveActivity.swift */; };
+		AA2103E195D36B18D25CBF86 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA135DE504590121F6D8843 /* DiagnosticLog.swift */; };
 		ACDADCAF73BF41FE2355ED15 /* VocaPhoneKeyboard.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B7028AF4B134C7EDD726891E /* VocaPhoneKeyboard.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B0DF0FF5821BD7E8C839065C /* GatewayClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4211FAA8E574AEF57D788FA /* GatewayClient.swift */; };
 		B2406DA05AE90DDB7EED6246 /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
 		B463A007E4ABBFF427073748 /* SessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */; };
 		B4EE97A67B156A6D5BA0D258 /* QuickDictationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB84927D76F9C32C4BE1547 /* QuickDictationAvailability.swift */; };
+		B61F7C13B4B93422C9BA3680 /* DarwinNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3498C523755A678225152570 /* DarwinNotifications.swift */; };
 		B803C86D8A77C8A2D758DA0A /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C9B64B52A8D28D252CC3A5 /* AudioRecorder.swift */; };
 		BA7DED07F63C388ADD4EC07A /* KeyboardURLLauncher.m in Sources */ = {isa = PBXBuildFile; fileRef = 88548183D3F0AD213E2268E1 /* KeyboardURLLauncher.m */; };
 		BBEEC542D1574BF6C8DF319B /* BrandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9711C18238B39EA2E842C0F /* BrandPalette.swift */; };
 		BC36D829FEE2BEC0A6BC30C2 /* KeyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5118F8CFAAE127CD5FF92076 /* KeyView.swift */; };
 		BCB8CA3BAACE6280D9ED4B22 /* QuickDictationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB84927D76F9C32C4BE1547 /* QuickDictationAvailability.swift */; };
+		BF1BF9FEBFC0373AE2C4187D /* DarwinNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3498C523755A678225152570 /* DarwinNotifications.swift */; };
 		BF22B8C9A4943F8B06F74216 /* DictationBarComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FD84E65614D9F94D8EF0AC /* DictationBarComponents.swift */; };
 		C4D64FB835EAB5A67E6CE009 /* AudioCapturePipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15DE10A5F8F90C87D4BA48A /* AudioCapturePipeline.swift */; };
 		C80FCACABE7FF798EFD1EB61 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894063AE1B3DDA92C529268D /* AppConfiguration.swift */; };
@@ -143,8 +155,10 @@
 		2678D836274997421A54E901 /* AudioCaptureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCaptureTests.swift; sourceTree = "<group>"; };
 		28ECEDA044D2B1021710F205 /* TranscriptHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptHistoryView.swift; sourceTree = "<group>"; };
 		32BFD71F9D14772A0C7330CD /* DictationBarLabelColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarLabelColorTests.swift; sourceTree = "<group>"; };
+		332854D2644CFCE5843E3F31 /* StopQuickDictationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopQuickDictationIntent.swift; sourceTree = "<group>"; };
 		342F2B3B437269514C969C77 /* SetupStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupStatus.swift; sourceTree = "<group>"; };
 		346B6558EE5557A35C916067 /* SetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupView.swift; sourceTree = "<group>"; };
+		3498C523755A678225152570 /* DarwinNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarwinNotifications.swift; sourceTree = "<group>"; };
 		36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRecord.swift; sourceTree = "<group>"; };
 		36B96ADF2831E766F13F9565 /* VocaPhoneKeyboard-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "VocaPhoneKeyboard-Bridging-Header.h"; sourceTree = "<group>"; };
 		3785791C0D9A5ABA2506F1B7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -156,12 +170,14 @@
 		52F3A6E7B826D1389D462944 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		56047A6705008B5F17F003CE /* DictationPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationPresentationTests.swift; sourceTree = "<group>"; };
 		5B19321866AE8083C78C2B7F /* FinishRecordingIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishRecordingIntent.swift; sourceTree = "<group>"; };
+		5FA135DE504590121F6D8843 /* DiagnosticLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticLog.swift; sourceTree = "<group>"; };
 		5FC91810C8F97443ECEF7FD1 /* VocaPhoneApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = VocaPhoneApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6CF871FC84B4C6B2627A43C2 /* RecordingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingCoordinator.swift; sourceTree = "<group>"; };
 		70B3F1DBA8332A13B095E4BA /* PairingScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScannerView.swift; sourceTree = "<group>"; };
 		75FD84E65614D9F94D8EF0AC /* DictationBarComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarComponents.swift; sourceTree = "<group>"; };
 		786DEF44BDB4C70935762971 /* VocaPhoneLiveActivity.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VocaPhoneLiveActivity.entitlements; sourceTree = "<group>"; };
 		7948F8C6C72A8D7A16C18562 /* SharedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStore.swift; sourceTree = "<group>"; };
+		7B5877B4AB653982A0433A37 /* ReliabilityFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReliabilityFeatureTests.swift; sourceTree = "<group>"; };
 		7E9E5CE913B4FA5EF8EECD4E /* PairingPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingPayloadTests.swift; sourceTree = "<group>"; };
 		87F5D76EB1E944F3A323006D /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		88548183D3F0AD213E2268E1 /* KeyboardURLLauncher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KeyboardURLLauncher.m; sourceTree = "<group>"; };
@@ -194,6 +210,7 @@
 		CF080065DC31C6DA8E693163 /* VocaPhoneLiveActivity.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = VocaPhoneLiveActivity.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelLanguageSupport.swift; sourceTree = "<group>"; };
 		DBFB4BB0345784837C629340 /* PairingPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingPayload.swift; sourceTree = "<group>"; };
+		E0187C986535C090BEE7EFD8 /* RecordingSoundFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSoundFeedback.swift; sourceTree = "<group>"; };
 		EA031D86C1DE3C2F8B047308 /* SetupStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupStatusTests.swift; sourceTree = "<group>"; };
 		EE41EF03C8A4F930315EFE77 /* ModelLanguageSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelLanguageSupportTests.swift; sourceTree = "<group>"; };
 		FA83B914C241E5F8BF8F32AC /* DictationBarLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarLayoutTests.swift; sourceTree = "<group>"; };
@@ -240,6 +257,7 @@
 			children = (
 				B15DE10A5F8F90C87D4BA48A /* AudioCapturePipeline.swift */,
 				37C9B64B52A8D28D252CC3A5 /* AudioRecorder.swift */,
+				E0187C986535C090BEE7EFD8 /* RecordingSoundFeedback.swift */,
 			);
 			path = Audio;
 			sourceTree = "<group>";
@@ -249,6 +267,8 @@
 			children = (
 				894063AE1B3DDA92C529268D /* AppConfiguration.swift */,
 				A9711C18238B39EA2E842C0F /* BrandPalette.swift */,
+				3498C523755A678225152570 /* DarwinNotifications.swift */,
+				5FA135DE504590121F6D8843 /* DiagnosticLog.swift */,
 				9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */,
 				9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */,
 				A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */,
@@ -326,6 +346,7 @@
 				C45D98EAFE18C689DC7551E9 /* LanguageMenuTests.swift */,
 				EE41EF03C8A4F930315EFE77 /* ModelLanguageSupportTests.swift */,
 				7E9E5CE913B4FA5EF8EECD4E /* PairingPayloadTests.swift */,
+				7B5877B4AB653982A0433A37 /* ReliabilityFeatureTests.swift */,
 				B854354D06D0111DEB123E7A /* SessionRecordTests.swift */,
 				EA031D86C1DE3C2F8B047308 /* SetupStatusTests.swift */,
 			);
@@ -351,6 +372,7 @@
 			isa = PBXGroup;
 			children = (
 				5B19321866AE8083C78C2B7F /* FinishRecordingIntent.swift */,
+				332854D2644CFCE5843E3F31 /* StopQuickDictationIntent.swift */,
 				8988211922DAD4FC77AF89EB /* VocaPhoneActivityAttributes.swift */,
 			);
 			path = VocaPhoneActivityShared;
@@ -507,6 +529,8 @@
 			files = (
 				CE9227DEA1DE35F0F9987562 /* AppConfiguration.swift in Sources */,
 				0580A3BE7DFF0FB43B4A41BD /* BrandPalette.swift in Sources */,
+				B61F7C13B4B93422C9BA3680 /* DarwinNotifications.swift in Sources */,
+				AA2103E195D36B18D25CBF86 /* DiagnosticLog.swift in Sources */,
 				BF22B8C9A4943F8B06F74216 /* DictationBarComponents.swift in Sources */,
 				2D1CF0D6875DFD7D9BFD10FF /* DictationBarStyle.swift in Sources */,
 				F1CDF580A8C552E1A03524A1 /* DictationBarView.swift in Sources */,
@@ -537,6 +561,8 @@
 				B803C86D8A77C8A2D758DA0A /* AudioRecorder.swift in Sources */,
 				590AE5D90BD9113ABA4EEF3F /* BrandPalette.swift in Sources */,
 				D4CA018F48AA244D322B9156 /* ContentView.swift in Sources */,
+				BF1BF9FEBFC0373AE2C4187D /* DarwinNotifications.swift in Sources */,
+				1EE70552DF2972DCE328ED01 /* DiagnosticLog.swift in Sources */,
 				84F2FD89DD3C1EB490E86A73 /* FinishRecordingIntent.swift in Sources */,
 				B0DF0FF5821BD7E8C839065C /* GatewayClient.swift in Sources */,
 				062CD049AAD6768AE5AB3766 /* GatewayEndpoint.swift in Sources */,
@@ -550,11 +576,13 @@
 				84EB79403F7CED013A82334F /* PairingScannerView.swift in Sources */,
 				B4EE97A67B156A6D5BA0D258 /* QuickDictationAvailability.swift in Sources */,
 				5D5A394AA7E8170CFE4E128B /* RecordingCoordinator.swift in Sources */,
+				A59723F937FABF80B8158883 /* RecordingSoundFeedback.swift in Sources */,
 				B463A007E4ABBFF427073748 /* SessionRecord.swift in Sources */,
 				387B6B6A0B0AE57B6324B55F /* SettingsView.swift in Sources */,
 				366E7DFAD5B2666FC1FF9FB3 /* SetupStatus.swift in Sources */,
 				0D07EBF90CE481AE0C1976CF /* SetupView.swift in Sources */,
 				D9811B8978380027BF95D0D5 /* SharedStore.swift in Sources */,
+				108C096B9C0FB4861FC26437 /* StopQuickDictationIntent.swift in Sources */,
 				89E3D47D85EBD6AD5A093813 /* TextInsertion.swift in Sources */,
 				D1CD3C13398FA4514EF57CA7 /* TranscriptHistoryView.swift in Sources */,
 				E2C8F215E536CABB80623B3A /* VocaPhoneActivityAttributes.swift in Sources */,
@@ -568,6 +596,8 @@
 			files = (
 				314748D93E078B40FEEEBEBE /* AppConfiguration.swift in Sources */,
 				5FB6858C38350EC77F45EB62 /* BrandPalette.swift in Sources */,
+				867671B90E038F77BE36A4E6 /* DarwinNotifications.swift in Sources */,
+				12A7F7D550BED2750227A111 /* DiagnosticLog.swift in Sources */,
 				3655C2E063B7C9B8F286057B /* FinishRecordingIntent.swift in Sources */,
 				1D96E4B5456A18FA04F5F15D /* GatewayEndpoint.swift in Sources */,
 				5769EF4A106AFBD7B375DC5D /* KeyboardPreferences.swift in Sources */,
@@ -577,6 +607,7 @@
 				58CDCA65875E94B8F7BE0101 /* QuickDictationAvailability.swift in Sources */,
 				3F3E17AFAAE8EB6B79A872BE /* SessionRecord.swift in Sources */,
 				B2406DA05AE90DDB7EED6246 /* SharedStore.swift in Sources */,
+				6C48D9ED8AF4FE61AB76AE49 /* StopQuickDictationIntent.swift in Sources */,
 				D4FEC9D26550CB1696FDF424 /* TextInsertion.swift in Sources */,
 				07D7CA474CBB8812C0E83D1C /* VocaPhoneActivityAttributes.swift in Sources */,
 				A79BA8A795F60838D96EDFAA /* VocaPhoneLiveActivity.swift in Sources */,
@@ -591,6 +622,8 @@
 				76E660378F845C250AEA0673 /* AudioCapturePipeline.swift in Sources */,
 				F6901AAB3D79295B2F40E436 /* AudioCaptureTests.swift in Sources */,
 				BBEEC542D1574BF6C8DF319B /* BrandPalette.swift in Sources */,
+				16A937522A6A8C972B1107A2 /* DarwinNotifications.swift in Sources */,
+				9C6AF2EE68EB7AA4D4CF0F61 /* DiagnosticLog.swift in Sources */,
 				91C1D5BB9A998A47DFF79A52 /* DictationBarComponents.swift in Sources */,
 				F97104FEC3A627ACF8F869AD /* DictationBarLabelColorTests.swift in Sources */,
 				3226364FB9F43F49B12FE2A6 /* DictationBarLayoutTests.swift in Sources */,
@@ -611,6 +644,7 @@
 				2E93E016656B5EA74568DD4F /* PairingPayload.swift in Sources */,
 				DCF552B58B7A7A12C517C17B /* PairingPayloadTests.swift in Sources */,
 				BCB8CA3BAACE6280D9ED4B22 /* QuickDictationAvailability.swift in Sources */,
+				15E349A8DDDFD47EFA7EE2FA /* ReliabilityFeatureTests.swift in Sources */,
 				2C362C9B71AA6A93A6D7E4DB /* SessionRecord.swift in Sources */,
 				28C271BC0195C62E93292A9C /* SessionRecordTests.swift in Sources */,
 				3219DC5DD26E1998A7A0CD5C /* SetupStatus.swift in Sources */,

--- a/ios/VocaPhoneActivityShared/StopQuickDictationIntent.swift
+++ b/ios/VocaPhoneActivityShared/StopQuickDictationIntent.swift
@@ -1,0 +1,33 @@
+import ActivityKit
+import AppIntents
+import Foundation
+
+/// Runs from the Live Activity without opening VocaPhone. The App Group write
+/// makes the command durable, while the Darwin ping tells the still-running
+/// containing app to release its audio engine immediately.
+struct StopQuickDictationIntent: LiveActivityIntent {
+    static let title: LocalizedStringResource = "Turn off Quick Dictation"
+    static let description = IntentDescription(
+        "Stops VocaPhone standby and releases the microphone."
+    )
+
+    func perform() async throws -> some IntentResult {
+        KeyboardPreferences.quickDictationEnabled = false
+        try? SharedStore.shared.clearQuickDictationAvailability()
+        DiagnosticLog.record(.stopQuickDictationRequested)
+        VocaPhoneDarwinCenter.post(.stopQuickDictationRequested)
+
+        let content = ActivityContent(
+            state: VocaPhoneActivityAttributes.ContentState(
+                status: "Quick Dictation off",
+                canFinish: false,
+                phase: .finished
+            ),
+            staleDate: nil
+        )
+        for activity in Activity<VocaPhoneActivityAttributes>.activities {
+            await activity.end(content, dismissalPolicy: .immediate)
+        }
+        return .result()
+    }
+}

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -29,6 +29,13 @@ struct SettingsView: View {
         KeyboardPreferences.microphonePreferenceKey,
         store: KeyboardPreferences.defaults
     ) private var microphonePreferenceRawValue = MicrophonePreference.automatic.rawValue
+    @AppStorage(
+        KeyboardPreferences.recordingSoundsKey,
+        store: KeyboardPreferences.defaults
+    ) private var recordingSoundsEnabled = false
+    @State private var diagnosticExportURL: URL?
+    @State private var isSharingDiagnostics = false
+    @State private var diagnosticsStatus: String?
 
     /// Every explanation on this screen is a `Section` footer, not a row.
     /// Explanatory paragraphs used to sit in rows of their own, so each one drew
@@ -42,11 +49,18 @@ struct SettingsView: View {
             transcriptionLanguageSection
             writingStyleSection
             microphoneSection
+            recordingFeedbackSection
             permissionsSection
+            diagnosticsSection
             privacySection
         }
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $isSharingDiagnostics, onDismiss: removeDiagnosticExport) {
+            if let diagnosticExportURL {
+                DiagnosticShareSheet(activityItems: [diagnosticExportURL])
+            }
+        }
     }
 
     private var setupSection: some View {
@@ -210,6 +224,19 @@ struct SettingsView: View {
         }
     }
 
+    private var recordingFeedbackSection: some View {
+        Section {
+            Toggle("Play recording start and stop sounds", isOn: $recordingSoundsEnabled)
+        } header: {
+            Text("Recording feedback")
+        } footer: {
+            Text(
+                "Short, quiet tones play outside the captured audio, so they are not "
+                    + "included in the transcript. Haptic feedback remains available."
+            )
+        }
+    }
+
     private var permissionsSection: some View {
         Section {
             Button("Request microphone permission") {
@@ -227,6 +254,44 @@ struct SettingsView: View {
                     + "Full Access is used only for shared session state and communication "
                     + "with your configured gateway."
             )
+        }
+    }
+
+    private var diagnosticsSection: some View {
+        Section {
+            Button {
+                do {
+                    diagnosticExportURL = try DiagnosticLog.makeExportFile()
+                    diagnosticsStatus = nil
+                    isSharingDiagnostics = true
+                } catch {
+                    DiagnosticLog.record(
+                        .operationFailed,
+                        metadata: .error(.diagnosticExportFailed)
+                    )
+                    diagnosticsStatus = "The diagnostic export could not be prepared."
+                }
+            } label: {
+                Label("Export diagnostics", systemImage: "square.and.arrow.up")
+            }
+
+            Button(role: .destructive) {
+                DiagnosticLog.clear()
+                diagnosticsStatus = "Diagnostics cleared."
+            } label: {
+                Label("Clear diagnostics", systemImage: "trash")
+            }
+        } header: {
+            Text("Diagnostics")
+        } footer: {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(
+                    "The bounded export contains up to seven days of build information, app/keyboard "
+                        + "source, state transitions, and lifecycle errors only. It never "
+                        + "contains transcripts, typed text, audio, addresses, or credentials."
+                )
+                if let diagnosticsStatus { Text(diagnosticsStatus) }
+            }
         }
     }
 
@@ -256,6 +321,26 @@ struct SettingsView: View {
     private var validatedGatewayURL: URL? {
         GatewayEndpoint.validatedURL(from: gatewayURL)
     }
+
+    private func removeDiagnosticExport() {
+        if let diagnosticExportURL {
+            try? FileManager.default.removeItem(at: diagnosticExportURL)
+        }
+        diagnosticExportURL = nil
+    }
+}
+
+private struct DiagnosticShareSheet: UIViewControllerRepresentable {
+    let activityItems: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+
+    func updateUIViewController(
+        _ uiViewController: UIActivityViewController,
+        context: Context
+    ) {}
 }
 
 /// The full language list, reached from Settings. Search matters at 27 entries,

--- a/ios/VocaPhoneApp/Audio/AudioRecorder.swift
+++ b/ios/VocaPhoneApp/Audio/AudioRecorder.swift
@@ -2,6 +2,13 @@ import AVFAudio
 import Foundation
 import os
 
+enum AudioSessionLifecycleEvent: Equatable, Sendable {
+    case interruptionBegan
+    case interruptionEnded(shouldResume: Bool)
+    case mediaServicesReset
+    case inputUnavailable
+}
+
 @MainActor
 final class AudioRecorder: NSObject {
     private var engine: AVAudioEngine?
@@ -13,10 +20,11 @@ final class AudioRecorder: NSObject {
     private var outputURL: URL?
     private var meterTimer: Timer?
     private var limitTimer: Timer?
-    nonisolated(unsafe) private var routeChangeObserver: (any NSObjectProtocol)?
+    nonisolated(unsafe) private var lifecycleObservers: [any NSObjectProtocol] = []
     var onMeter: ((Float) -> Void)?
     var onMaximumDuration: (() -> Void)?
     var onInputRouteChanged: ((String?) -> Void)?
+    var onAudioSessionLifecycleEvent: ((AudioSessionLifecycleEvent) -> Void)?
     var microphonePreference: MicrophonePreference = .automatic
 
     /// Chunks of float32 PCM at the transcription sample rate, in order. Backed
@@ -28,20 +36,43 @@ final class AudioRecorder: NSObject {
 
     override init() {
         super.init()
-        routeChangeObserver = NotificationCenter.default.addObserver(
+        let center = NotificationCenter.default
+        let session = AVAudioSession.sharedInstance()
+        lifecycleObservers.append(center.addObserver(
             forName: AVAudioSession.routeChangeNotification,
-            object: AVAudioSession.sharedInstance(),
+            object: session,
+            queue: .main
+        ) { [weak self] notification in
+            let rawReason = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt
+            MainActor.assumeIsolated {
+                self?.handleRouteChange(rawReason: rawReason)
+            }
+        })
+        lifecycleObservers.append(center.addObserver(
+            forName: AVAudioSession.interruptionNotification,
+            object: session,
+            queue: .main
+        ) { [weak self] notification in
+            let rawType = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt
+            let rawOptions = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt
+            MainActor.assumeIsolated {
+                self?.handleInterruption(rawType: rawType, rawOptions: rawOptions)
+            }
+        })
+        lifecycleObservers.append(center.addObserver(
+            forName: AVAudioSession.mediaServicesWereResetNotification,
+            object: session,
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                self?.publishCurrentInput()
+                self?.onAudioSessionLifecycleEvent?(.mediaServicesReset)
             }
-        }
+        })
     }
 
     deinit {
-        if let routeChangeObserver {
-            NotificationCenter.default.removeObserver(routeChangeObserver)
+        for observer in lifecycleObservers {
+            NotificationCenter.default.removeObserver(observer)
         }
     }
 
@@ -64,6 +95,12 @@ final class AudioRecorder: NSObject {
         AVAudioApplication.requestRecordPermission { granted in
             Task { @MainActor in completion(granted) }
         }
+    }
+
+    /// Warms the same graph `start` will capture from. Recording feedback can
+    /// therefore play before the tap starts without paying a second setup cost.
+    func prepareForRecording() throws {
+        try ensureEngineRunning()
     }
 
     /// Starts writing from the already-running microphone engine. When Quick
@@ -297,6 +334,31 @@ final class AudioRecorder: NSObject {
 
     private func publishCurrentInput() {
         onInputRouteChanged?(currentInputName)
+    }
+
+    private func handleRouteChange(rawReason: UInt?) {
+        publishCurrentInput()
+        guard let rawReason,
+              AVAudioSession.RouteChangeReason(rawValue: rawReason) == .oldDeviceUnavailable,
+              AVAudioSession.sharedInstance().currentRoute.inputs.isEmpty
+        else { return }
+        onAudioSessionLifecycleEvent?(.inputUnavailable)
+    }
+
+    private func handleInterruption(rawType: UInt?, rawOptions: UInt?) {
+        guard let rawType,
+              let type = AVAudioSession.InterruptionType(rawValue: rawType)
+        else { return }
+        switch type {
+        case .began:
+            onAudioSessionLifecycleEvent?(.interruptionBegan)
+        case .ended:
+            let shouldResume = AVAudioSession.InterruptionOptions(rawValue: rawOptions ?? 0)
+                .contains(.shouldResume)
+            onAudioSessionLifecycleEvent?(.interruptionEnded(shouldResume: shouldResume))
+        @unknown default:
+            onAudioSessionLifecycleEvent?(.interruptionBegan)
+        }
     }
 }
 

--- a/ios/VocaPhoneApp/Audio/RecordingSoundFeedback.swift
+++ b/ios/VocaPhoneApp/Audio/RecordingSoundFeedback.swift
@@ -1,0 +1,78 @@
+import AVFAudio
+import Foundation
+
+enum RecordingSoundCue: Sendable {
+    case start
+    case stop
+
+    fileprivate var frequency: Double {
+        switch self {
+        case .start: 880
+        case .stop: 620
+        }
+    }
+}
+
+/// Plays a very short cue while the microphone graph is warm but before or
+/// after capture. Keeping the cue outside the capture window prevents the
+/// phone's own speaker from becoming the first or last sound in a transcript.
+@MainActor
+final class RecordingSoundFeedback {
+    private var player: AVAudioPlayer?
+
+    func play(_ cue: RecordingSoundCue) async {
+        guard KeyboardPreferences.recordingSoundsEnabled else { return }
+        do {
+            let player = try AVAudioPlayer(data: Self.waveData(frequency: cue.frequency))
+            self.player = player
+            player.volume = 0.28
+            player.prepareToPlay()
+            guard player.play() else { return }
+            try? await Task.sleep(for: .milliseconds(140))
+            if Task.isCancelled { player.stop() }
+            if self.player === player { self.player = nil }
+        } catch {
+            // Sound feedback is optional and must never block dictation.
+        }
+    }
+
+    private static func waveData(frequency: Double) -> Data {
+        let sampleRate: UInt32 = 44_100
+        let duration = 0.075
+        let sampleCount = Int(Double(sampleRate) * duration)
+        let bytesPerSample = 2
+        let dataSize = UInt32(sampleCount * bytesPerSample)
+        var data = Data()
+
+        data.append(contentsOf: "RIFF".utf8)
+        data.appendLittleEndian(UInt32(36) + dataSize)
+        data.append(contentsOf: "WAVEfmt ".utf8)
+        data.appendLittleEndian(UInt32(16))
+        data.appendLittleEndian(UInt16(1))
+        data.appendLittleEndian(UInt16(1))
+        data.appendLittleEndian(sampleRate)
+        data.appendLittleEndian(sampleRate * UInt32(bytesPerSample))
+        data.appendLittleEndian(UInt16(bytesPerSample))
+        data.appendLittleEndian(UInt16(16))
+        data.append(contentsOf: "data".utf8)
+        data.appendLittleEndian(dataSize)
+
+        let fadeSamples = max(1, Int(Double(sampleRate) * 0.008))
+        for index in 0..<sampleCount {
+            let fadeIn = min(1, Double(index) / Double(fadeSamples))
+            let fadeOut = min(1, Double(sampleCount - index - 1) / Double(fadeSamples))
+            let envelope = min(fadeIn, fadeOut)
+            let phase = 2 * Double.pi * frequency * Double(index) / Double(sampleRate)
+            let sample = Int16((sin(phase) * envelope * 0.28 * Double(Int16.max)).rounded())
+            data.appendLittleEndian(UInt16(bitPattern: sample))
+        }
+        return data
+    }
+}
+
+private extension Data {
+    mutating func appendLittleEndian<T: FixedWidthInteger>(_ value: T) {
+        var littleEndian = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndian) { append(contentsOf: $0) }
+    }
+}

--- a/ios/VocaPhoneApp/Sessions/LiveActivityManager.swift
+++ b/ios/VocaPhoneApp/Sessions/LiveActivityManager.swift
@@ -65,6 +65,10 @@ final class LiveActivityManager: @unchecked Sendable {
             ),
             staleDate: expiresAt
         )
+        DiagnosticLog.record(
+            .liveActivityStarted,
+            metadata: .phase(.standby)
+        )
     }
 
     /// Removes the standby Live Activity when Quick Dictation releases the
@@ -84,6 +88,10 @@ final class LiveActivityManager: @unchecked Sendable {
                 phase: .finished
             ),
             dismissalPolicy: .immediate
+        )
+        DiagnosticLog.record(
+            .liveActivityEnded,
+            metadata: .reason(.quickDictationOff)
         )
     }
 
@@ -105,6 +113,10 @@ final class LiveActivityManager: @unchecked Sendable {
                 startedAt: recordingStartedAt
             ),
             staleDate: nil
+        )
+        DiagnosticLog.record(
+            .liveActivityStarted,
+            metadata: .phase(.recording)
         )
     }
 
@@ -138,6 +150,10 @@ final class LiveActivityManager: @unchecked Sendable {
         activeSessionID = nil
         recordingStartedAt = nil
         beginTransition()
+        DiagnosticLog.record(
+            .liveActivityEnded,
+            metadata: .reason(.sessionFinished)
+        )
 
         guard standbyRequested, let standbyExpiresAt, standbyExpiresAt > Date() else {
             endAll(
@@ -283,6 +299,10 @@ final class LiveActivityManager: @unchecked Sendable {
         guard !activities.isEmpty else { return }
 
         logger.info("Ending \(activities.count) Live Activities before \(reason, privacy: .public)")
+        DiagnosticLog.record(
+            .liveActivityEnded,
+            metadata: .reason(.processExit)
+        )
         let content = ActivityContent(
             state: VocaPhoneActivityAttributes.ContentState(
                 status: "VocaPhone closed",

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -21,13 +21,18 @@ final class RecordingCoordinator {
     private let store = SharedStore.shared
     private var pollingTask: Task<Void, Never>?
     private var pipelineTask: Task<Void, Never>?
+    private var pipelineSessionID: UUID?
     private var cancellationMonitorTask: Task<Void, Never>?
     private var quickDictationWatcherTask: Task<Void, Never>?
     private var startingSessionID: UUID?
     private var gatewayClient: GatewayClient?
     private var lastMicrophoneName: String?
+    private var audioSessionAvailable = true
+    private var audioLifecycleGeneration = 0
+    private var darwinObservations: [VocaPhoneDarwinObservation] = []
     private let liveActivity = LiveActivityManager.shared
     private let streamingBridge = StreamingAudioBridge()
+    private let soundFeedback = RecordingSoundFeedback()
 
     var stateLabel: String { (activeRecord?.state ?? .idle).displayName }
     var isRecording: Bool { activeRecord?.state == .recording && recorder.isRecording }
@@ -113,10 +118,16 @@ final class RecordingCoordinator {
             self.currentMicrophoneName = inputName
             if let inputName {
                 self.lastMicrophoneName = inputName
+                self.audioSessionAvailable = true
             }
         }
+        recorder.onAudioSessionLifecycleEvent = { [weak self] event in
+            self?.handleAudioSessionLifecycleEvent(event)
+        }
+        installDarwinObservers()
         loadGatewaySettings()
         refreshSetupStatus()
+        DiagnosticLog.record(.appStarted)
     }
 
     func handleDeepLink(_ url: URL) {
@@ -164,6 +175,7 @@ final class RecordingCoordinator {
                 + "recording=\(recorder.isRecording)"
         )
         guard KeyboardPreferences.quickDictationEnabled,
+              audioSessionAvailable,
               recorder.recordPermission == .granted,
               !recorder.isRecording,
               startingSessionID == nil
@@ -188,6 +200,10 @@ final class RecordingCoordinator {
         KeyboardPreferences.quickDictationEnabled = false
         clearQuickDictationReadiness(deactivateAudioSession: true)
         message = "Quick Dictation is off. The keyboard will open vocaphone next time."
+        DiagnosticLog.record(
+            .quickDictationStopped,
+            metadata: .reason(.userRequested)
+        )
     }
 
     func updateGateway(baseURL: URL, token: String) {
@@ -295,6 +311,8 @@ final class RecordingCoordinator {
 
     func cancel() {
         pipelineTask?.cancel()
+        pipelineTask = nil
+        pipelineSessionID = nil
         cancellationMonitorTask?.cancel()
         Task { await streamingBridge.cancel() }
         guard var record = activeRecord else { return }
@@ -396,6 +414,19 @@ final class RecordingCoordinator {
             }
 
             let directory = try localAudioDirectory()
+            try recorder.prepareForRecording()
+            await soundFeedback.play(.start)
+            guard let latestRecord = try store.load(id),
+                  [.launchingApp, .awaitingReturn].contains(latestRecord.state)
+            else {
+                if KeyboardPreferences.quickDictationEnabled, audioSessionAvailable {
+                    armQuickDictation()
+                } else {
+                    recorder.stopStandby(deactivateAudioSession: true)
+                }
+                return
+            }
+            record = latestRecord
             let audioURL = try recorder.start(sessionID: record.sessionID, directory: directory)
             if let client = gatewayClient, let chunks = recorder.pcmChunks {
                 await streamingBridge.start(
@@ -428,6 +459,24 @@ final class RecordingCoordinator {
             }
             beginPolling()
         } catch {
+            recorder.cancelSession(keepAudioSessionActive: false)
+            clearQuickDictationReadiness(deactivateAudioSession: true)
+            if var failedRecord = try? store.load(id),
+               [.launchingApp, .awaitingReturn].contains(failedRecord.state)
+            {
+                try? failedRecord.transition(to: .canceled)
+                failedRecord.error = SessionFailure(
+                    code: "recording_start_failed",
+                    message: "The microphone could not start. Try dictating again.",
+                    recoverable: false
+                )
+                try? store.save(failedRecord)
+                activeRecord = failedRecord
+            }
+            DiagnosticLog.record(
+                .operationFailed,
+                metadata: .error(.recordingStartFailed)
+            )
             message = "Recording could not start: \(error.localizedDescription)"
         }
     }
@@ -445,9 +494,14 @@ final class RecordingCoordinator {
     }
 
     private func startPipeline(_ record: SessionRecord) {
+        guard pipelineSessionID != record.sessionID else { return }
         pipelineTask?.cancel()
+        pipelineSessionID = record.sessionID
         pipelineTask = Task { [weak self] in
             await self?.finalizeAndTranscribe(record)
+            guard let self, self.pipelineSessionID == record.sessionID else { return }
+            self.pipelineSessionID = nil
+            self.pipelineTask = nil
         }
     }
 
@@ -455,38 +509,9 @@ final class RecordingCoordinator {
         pollingTask?.cancel()
         pollingTask = Task { [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(for: .milliseconds(250))
-                guard let self, let current = self.activeRecord,
-                      let shared = try? self.store.load(current.sessionID)
-                else { continue }
-                // Four times a second the record is usually identical. Assigning
-                // it anyway would invalidate observers for no reason.
-                if shared != current {
-                    self.activeRecord = shared
-                }
-                switch shared.state {
-                case .finalizing:
-                    self.liveActivity.update(status: "Finishing", canFinish: false)
-                    self.startPipeline(shared)
-                    return
-                case .uploading where !self.recorder.isRecording:
-                    self.startPipeline(shared)
-                    return
-                case .canceled:
-                    let shouldRemainReady = self.shouldKeepQuickDictationReady(after: shared)
-                    self.recorder.cancelSession(keepAudioSessionActive: shouldRemainReady)
-                    if shouldRemainReady {
-                        self.armQuickDictation()
-                        self.message = "Recording canceled. Quick Dictation is still ready."
-                    } else {
-                        self.clearQuickDictationReadiness(deactivateAudioSession: true)
-                        self.message = "Recording canceled."
-                    }
-                    self.liveActivity.end(status: "Canceled", dismissAfter: 0)
-                    return
-                default:
-                    continue
-                }
+                try? await Task.sleep(for: .milliseconds(1_500))
+                guard let self else { return }
+                await self.handleSharedStateSignal()
             }
         }
     }
@@ -497,9 +522,13 @@ final class RecordingCoordinator {
         defer { cancellationMonitorTask?.cancel() }
         var record = incoming
         let shouldRemainReady = shouldKeepQuickDictationReady(after: record)
+        let wasRecording = recorder.isRecording
         let output = recorder.stopSession(
-            keepAudioSessionActive: shouldRemainReady
+            keepAudioSessionActive: true
         ) ?? resolvedAudioURL(for: record)
+        if wasRecording {
+            await soundFeedback.play(.stop)
+        }
         meterLevel = 0
         if shouldRemainReady {
             armQuickDictation()
@@ -625,7 +654,7 @@ final class RecordingCoordinator {
         cancellationMonitorTask?.cancel()
         cancellationMonitorTask = Task { [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(for: .milliseconds(150))
+                try? await Task.sleep(for: .milliseconds(750))
                 guard let self,
                       let record = try? self.store.load(sessionID)
                 else { continue }
@@ -644,6 +673,10 @@ final class RecordingCoordinator {
         message failureMessage: String,
         recoverable: Bool = true
     ) async {
+        DiagnosticLog.record(
+            .operationFailed,
+            metadata: .error(diagnosticErrorCode(for: code, state: state))
+        )
         do {
             try record.transition(to: state)
             record.error = SessionFailure(code: code, message: failureMessage, recoverable: recoverable)
@@ -682,11 +715,13 @@ final class RecordingCoordinator {
 
     private func shouldKeepQuickDictationReady(after record: SessionRecord) -> Bool {
         KeyboardPreferences.quickDictationEnabled
+            && audioSessionAvailable
             && record.sourceDocumentID != "in-app-test"
     }
 
     private func armQuickDictation() {
         guard KeyboardPreferences.quickDictationEnabled,
+              audioSessionAvailable,
               !recorder.isRecording
         else { return }
 
@@ -704,8 +739,13 @@ final class RecordingCoordinator {
             quickDictationExpiresAt = availability.expiresAt
             beginQuickDictationWatcher(availability)
             liveActivity.startStandby(expiresAt: availability.expiresAt)
+            DiagnosticLog.record(.quickDictationArmed)
             debugQuickDictation("armed until \(availability.expiresAt)")
         } catch {
+            DiagnosticLog.record(
+                .operationFailed,
+                metadata: .error(.quickDictationArmFailed)
+            )
             debugQuickDictation("arming failed: \(error.localizedDescription)")
             clearQuickDictationReadiness(deactivateAudioSession: true)
             message = "Quick Dictation could not stay ready: \(error.localizedDescription)"
@@ -715,21 +755,30 @@ final class RecordingCoordinator {
     private func beginQuickDictationWatcher(_ availability: QuickDictationAvailability) {
         quickDictationWatcherTask?.cancel()
         quickDictationWatcherTask = Task { [weak self] in
+            var refreshedAvailability = availability
             while !Task.isCancelled {
-                try? await Task.sleep(for: .milliseconds(200))
+                try? await Task.sleep(for: .seconds(2))
                 guard let self else { return }
-                guard availability.isReady(), self.recorder.isStandbyActive else {
+                guard refreshedAvailability.expiresAt > Date(),
+                      self.recorder.isStandbyActive,
+                      self.audioSessionAvailable
+                else {
                     self.clearQuickDictationReadiness(deactivateAudioSession: true)
                     return
                 }
-                guard let pending = try? self.store.recent(limit: 8).first(where: {
-                    [.launchingApp, .awaitingReturn].contains($0.state)
-                        && $0.createdAt >= availability.activatedAt
-                        && $0.createdAt < availability.expiresAt
-                }) else { continue }
-
-                await self.startSession(id: pending.sessionID)
-                return
+                refreshedAvailability = refreshedAvailability.refreshingHeartbeat()
+                do {
+                    try self.store.saveQuickDictationAvailability(
+                        refreshedAvailability,
+                        notifyObservers: false
+                    )
+                } catch {
+                    self.clearQuickDictationReadiness(deactivateAudioSession: true)
+                    return
+                }
+                await self.startPendingQuickDictationIfNeeded(
+                    availability: refreshedAvailability
+                )
             }
         }
     }
@@ -764,6 +813,138 @@ final class RecordingCoordinator {
         return directory.appendingPathComponent(reference)
     }
 
+    private func installDarwinObservers() {
+        darwinObservations.append(
+            VocaPhoneDarwinCenter.observe(.sessionChanged) { [weak self] in
+                Task { @MainActor [weak self] in
+                    await self?.handleSharedStateSignal()
+                }
+            }
+        )
+        darwinObservations.append(
+            VocaPhoneDarwinCenter.observe(.keyboardStatusChanged) { [weak self] in
+                Task { @MainActor [weak self] in
+                    self?.refreshSetupStatus()
+                }
+            }
+        )
+        darwinObservations.append(
+            VocaPhoneDarwinCenter.observe(.stopQuickDictationRequested) { [weak self] in
+                Task { @MainActor [weak self] in
+                    DiagnosticLog.record(.stopQuickDictationRequested)
+                    self?.stopQuickDictation()
+                }
+            }
+        )
+    }
+
+    /// Fast path for keyboard and Live Activity writes. The 1.5-second polling
+    /// loop remains as recovery if iOS drops a Darwin notification or recreates
+    /// one process between the durable write and its signal.
+    private func handleSharedStateSignal() async {
+        guard let current = activeRecord, !current.state.isTerminal else {
+            await startPendingQuickDictationIfNeeded()
+            return
+        }
+        guard let shared = try? store.load(current.sessionID) else { return }
+        if shared != current { activeRecord = shared }
+
+        switch shared.state {
+        case .finalizing:
+            liveActivity.update(status: "Finishing", canFinish: false)
+            startPipeline(shared)
+        case .uploading where !recorder.isRecording && pipelineSessionID == nil:
+            startPipeline(shared)
+        case .canceled:
+            pipelineTask?.cancel()
+            pipelineTask = nil
+            pipelineSessionID = nil
+            await streamingBridge.cancel()
+            let shouldRemainReady = shouldKeepQuickDictationReady(after: shared)
+            recorder.cancelSession(keepAudioSessionActive: shouldRemainReady)
+            if shouldRemainReady {
+                armQuickDictation()
+                message = "Recording canceled. Quick Dictation is still ready."
+            } else {
+                clearQuickDictationReadiness(deactivateAudioSession: true)
+                message = "Recording canceled."
+            }
+            liveActivity.end(status: "Canceled", dismissAfter: 0)
+            await startPendingQuickDictationIfNeeded()
+        default:
+            if shared.state.isTerminal {
+                await startPendingQuickDictationIfNeeded()
+            }
+        }
+    }
+
+    private func startPendingQuickDictationIfNeeded(
+        availability suppliedAvailability: QuickDictationAvailability? = nil
+    ) async {
+        guard recorder.isStandbyActive, audioSessionAvailable else { return }
+        let availability = suppliedAvailability
+            ?? (try? store.loadQuickDictationAvailability())
+        guard let availability, availability.isReady() else { return }
+        guard let pending = try? store.recent(limit: 8).first(where: {
+            [.launchingApp, .awaitingReturn].contains($0.state)
+                && availability.acceptsRequest(createdAt: $0.createdAt)
+        }) else { return }
+        await startSession(id: pending.sessionID)
+    }
+
+    private func handleAudioSessionLifecycleEvent(_ event: AudioSessionLifecycleEvent) {
+        switch event {
+        case .interruptionBegan:
+            DiagnosticLog.record(.audioInterruptionBegan)
+            handleAudioLoss(reason: "Audio was interrupted. Finishing what was captured.")
+        case let .interruptionEnded(shouldResume):
+            audioLifecycleGeneration &+= 1
+            audioSessionAvailable = true
+            DiagnosticLog.record(
+                .audioInterruptionEnded,
+                metadata: .reason(shouldResume ? .resumeAllowed : .resumeNotAllowed)
+            )
+            if shouldResume,
+               KeyboardPreferences.containingAppIsForeground,
+               KeyboardPreferences.quickDictationEnabled
+            {
+                prepareQuickDictationIfEnabled()
+            }
+        case .mediaServicesReset:
+            DiagnosticLog.record(.audioMediaServicesReset)
+            handleAudioLoss(reason: "iPhone audio restarted. Finishing what was captured.")
+            let recoveryGeneration = audioLifecycleGeneration
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .seconds(1))
+                guard let self,
+                      self.audioLifecycleGeneration == recoveryGeneration
+                else { return }
+                self.audioSessionAvailable = true
+                if KeyboardPreferences.containingAppIsForeground,
+                   KeyboardPreferences.quickDictationEnabled
+                {
+                    self.prepareQuickDictationIfEnabled()
+                }
+            }
+        case .inputUnavailable:
+            DiagnosticLog.record(.audioInputUnavailable)
+            handleAudioLoss(reason: "The microphone input became unavailable.")
+        }
+    }
+
+    private func handleAudioLoss(reason: String) {
+        audioLifecycleGeneration &+= 1
+        audioSessionAvailable = false
+        if activeRecord?.state == .recording, recorder.isRecording {
+            message = reason
+            liveActivity.end(status: "Audio interrupted", dismissAfter: 0)
+            requestFinish()
+        } else {
+            clearQuickDictationReadiness(deactivateAudioSession: true)
+            message = reason
+        }
+    }
+
     private func loadGatewaySettings() {
         guard let value = UserDefaults.standard.string(forKey: "gatewayURL"),
               let baseURL = GatewayEndpoint.validatedURL(from: value),
@@ -782,6 +963,21 @@ final class RecordingCoordinator {
         }
         if error is URLError { return "server_unavailable" }
         return "transcription_failed"
+    }
+
+    private func diagnosticErrorCode(
+        for code: String,
+        state: SessionState
+    ) -> DiagnosticErrorCode {
+        switch code {
+        case "audio_missing": .audioMissing
+        case "gateway_not_configured": .gatewayNotConfigured
+        case "microphone_permission_denied": .microphonePermissionDenied
+        case "language_unsupported": .languageUnsupported
+        case "server_unavailable": .serverUnavailable
+        default:
+            state == .uploadFailedRecoverable ? .uploadFailed : .transcriptionFailed
+        }
     }
 
     private func debugQuickDictation(_ value: String) {

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -6,8 +6,17 @@ enum KeyboardOutput {
     case newline
     case deleteBackward
     case deleteWord
+    case moveCursor(Int)
     /// Carries the globe key itself so the keyboard picker can anchor to it.
     case nextInputMode(UIView, UIEvent?)
+}
+
+enum CursorTrackpad {
+    static let pointsPerCharacter: CGFloat = 10
+
+    static func step(forHorizontalTranslation translation: CGFloat) -> Int {
+        Int(translation / pointsPerCharacter)
+    }
 }
 
 @MainActor
@@ -67,18 +76,23 @@ final class KeyGridView: UIView {
     private var previewPool: [KeyPreviewView] = []
     private var tracked: [TrackedTouch] = []
     private var deleteTimer: Timer?
+    private var spaceTrackpadTimer: Timer?
     private var deleteRepeatCount = 0
     private var lastShiftTapAt: Date?
 
-    private final class TrackedTouch {
+    private final class TrackedTouch: @unchecked Sendable {
         let touch: UITouch
         var key: KeyView
         let allowsSlide: Bool
         var preview: KeyPreviewView?
+        let initialPoint: CGPoint
+        var lastCursorStep = 0
+        var isCursorTracking = false
 
-        init(touch: UITouch, key: KeyView) {
+        init(touch: UITouch, key: KeyView, initialPoint: CGPoint) {
             self.touch = touch
             self.key = key
+            self.initialPoint = initialPoint
             allowsSlide = key.spec.cap.isCharacter
         }
     }
@@ -259,6 +273,8 @@ final class KeyGridView: UIView {
     }
 
     private func releaseTouches() {
+        spaceTrackpadTimer?.invalidate()
+        spaceTrackpadTimer = nil
         for item in tracked {
             item.key.isHighlighted = false
             recycle(item.preview)
@@ -282,13 +298,15 @@ final class KeyGridView: UIView {
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         for touch in touches {
-            guard let key = key(at: touch.location(in: self), characterOnly: false)
+            let point = touch.location(in: self)
+            guard let key = key(at: point, characterOnly: false)
             else { continue }
-            let item = TrackedTouch(touch: touch, key: key)
+            let item = TrackedTouch(touch: touch, key: key, initialPoint: point)
             tracked.append(item)
             key.isHighlighted = true
             UIDevice.current.playInputClick()
             showPreview(for: item)
+            if key.spec.cap == .space { scheduleSpaceTrackpad(for: item) }
             if key.spec.cap.actsOnTouchDown {
                 performTouchDownAction(for: key, event: event)
             }
@@ -299,6 +317,11 @@ final class KeyGridView: UIView {
         for touch in touches {
             guard let item = tracked.first(where: { $0.touch === touch }) else { continue }
             let point = touch.location(in: self)
+
+            if item.key.spec.cap == .space {
+                handleSpaceMovement(item, point: point)
+                continue
+            }
 
             guard item.allowsSlide else {
                 // Function keys stay bound to their own touch but disengage when
@@ -333,7 +356,11 @@ final class KeyGridView: UIView {
         for touch in touches {
             guard let index = tracked.firstIndex(where: { $0.touch === touch }) else { continue }
             let item = tracked.remove(at: index)
-            let shouldCommit = commit && item.key.isHighlighted
+            if item.key.spec.cap == .space {
+                spaceTrackpadTimer?.invalidate()
+                spaceTrackpadTimer = nil
+            }
+            let shouldCommit = commit && item.key.isHighlighted && !item.isCursorTracking
             item.key.isHighlighted = false
             recycle(item.preview)
             item.preview = nil
@@ -372,6 +399,46 @@ final class KeyGridView: UIView {
         default:
             break
         }
+    }
+
+    private func scheduleSpaceTrackpad(for item: TrackedTouch) {
+        guard !UIAccessibility.isVoiceOverRunning else { return }
+        spaceTrackpadTimer?.invalidate()
+        spaceTrackpadTimer = Timer.scheduledTimer(withTimeInterval: 0.32, repeats: false) {
+            [weak self, weak item] _ in
+            MainActor.assumeIsolated {
+                guard let self,
+                      let item,
+                      self.tracked.contains(where: { $0 === item }),
+                      item.key.isHighlighted
+                else { return }
+                item.isCursorTracking = true
+                item.lastCursorStep = 0
+                UISelectionFeedbackGenerator().selectionChanged()
+                UIAccessibility.post(notification: .announcement, argument: "Cursor control")
+            }
+        }
+    }
+
+    private func handleSpaceMovement(_ item: TrackedTouch, point: CGPoint) {
+        guard item.isCursorTracking else {
+            let distance = hypot(point.x - item.initialPoint.x, point.y - item.initialPoint.y)
+            if distance > 14 {
+                spaceTrackpadTimer?.invalidate()
+                spaceTrackpadTimer = nil
+            }
+            item.key.isHighlighted = item.key.hitRect.contains(point)
+            return
+        }
+
+        item.key.isHighlighted = true
+        let step = CursorTrackpad.step(
+            forHorizontalTranslation: point.x - item.initialPoint.x
+        )
+        let delta = step - item.lastCursorStep
+        guard delta != 0 else { return }
+        item.lastCursorStep = step
+        delegate?.keyGrid(self, didProduce: .moveCursor(delta))
     }
 
     private func toggleShift() {

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -4,6 +4,8 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     private let store = SharedStore.shared
     private var activeSessionID: UUID?
     private var pollingTimer: Timer?
+    private var pollingInterval: TimeInterval?
+    private var darwinObservations: [VocaPhoneDarwinObservation] = []
     private var appLaunchFallbackTask: Task<Void, Never>?
     private var lastInsertedText: String?
     private var isPerformingInsertion = false
@@ -76,6 +78,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // A recreated extension instance can inherit a session the previous one
         // started, so scan once on appear and let `render` decide about polling.
         applyDocumentTraits()
+        installDarwinObservers()
         publishKeyboardStatus()
         refresh()
     }
@@ -92,6 +95,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         super.viewWillDisappear(animated)
         pollingTimer?.invalidate()
         pollingTimer = nil
+        pollingInterval = nil
+        darwinObservations.forEach { $0.invalidate() }
+        darwinObservations.removeAll()
         appLaunchFallbackTask?.cancel()
     }
 
@@ -111,6 +117,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         lastPublishedAt = now
         try? store.saveKeyboardStatus(
             KeyboardStatus(lastSeenAt: now, hasFullAccess: hasFullAccess)
+        )
+        DiagnosticLog.record(
+            .keyboardShown,
+            metadata: .fullAccess(hasFullAccess)
         )
     }
 
@@ -235,6 +245,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         case .deleteWord:
             deleteWordBackward()
             releaseUndoIfDetached()
+        case let .moveCursor(offset):
+            textDocumentProxy.adjustTextPosition(byCharacterOffset: offset)
+            lastSpaceInsertedAt = nil
+            releaseUndoIfDetached()
         case let .nextInputMode(anchor, event):
             // `handleInputModeList` also drives the long-press keyboard picker,
             // which `advanceToNextInputMode` alone cannot offer.
@@ -338,12 +352,14 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             activeSessionID = record.sessionID
             sessionTargetDocumentID = record.sourceDocumentID
             render(record)
-            if let availability = try? store.loadQuickDictationAvailability(),
-               availability.isReady()
-            {
+            let availability = try? store.loadQuickDictationAvailability()
+            if availability?.isReady() == true {
                 dictationBar.flash("Starting with Quick Dictation…")
                 scheduleContainingAppFallback(for: record)
             } else {
+                if availability != nil {
+                    DiagnosticLog.record(.quickDictationStale)
+                }
                 openContainingApp(for: record)
             }
         } catch {
@@ -464,6 +480,20 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         }
     }
 
+    private func installDarwinObservers() {
+        guard darwinObservations.isEmpty else { return }
+        darwinObservations.append(
+            VocaPhoneDarwinCenter.observe(.sessionChanged) { [weak self] in
+                Task { @MainActor [weak self] in self?.refresh() }
+            }
+        )
+        darwinObservations.append(
+            VocaPhoneDarwinCenter.observe(.quickDictationChanged) { [weak self] in
+                Task { @MainActor [weak self] in self?.refresh() }
+            }
+        )
+    }
+
     /// The keyboard is the only writer that opens a session, so an idle keyboard
     /// has nothing to wait for. Polling runs only while a session is in flight,
     /// which keeps ordinary typing free of a four-times-a-second directory scan
@@ -473,16 +503,23 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         guard needsUpdates else {
             pollingTimer?.invalidate()
             pollingTimer = nil
+            pollingInterval = nil
             return
         }
+        let desiredInterval: TimeInterval = record?.state == .recording ? 0.25 : 1.5
+        if pollingInterval != desiredInterval {
+            pollingTimer?.invalidate()
+            pollingTimer = nil
+        }
         guard pollingTimer == nil else { return }
-        let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
+        let timer = Timer(timeInterval: desiredInterval, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated { self?.refresh() }
         }
         // Common mode keeps session updates flowing while a touch is being
         // tracked on the key grid.
         RunLoop.main.add(timer, forMode: .common)
         pollingTimer = timer
+        pollingInterval = desiredInterval
     }
 
     private func refresh() {

--- a/ios/VocaPhoneLiveActivity/VocaPhoneLiveActivity.swift
+++ b/ios/VocaPhoneLiveActivity/VocaPhoneLiveActivity.swift
@@ -35,6 +35,12 @@ struct VocaPhoneRecordingActivity: Widget {
                     }
                     .buttonStyle(.borderedProminent)
                     .tint(.red)
+                } else if context.state.effectivePhase == .standby {
+                    Button(intent: StopQuickDictationIntent()) {
+                        Label("Turn off", systemImage: "mic.slash.fill")
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.brand)
                 }
             }
             .padding()
@@ -65,6 +71,13 @@ struct VocaPhoneRecordingActivity: Widget {
                         }
                         .buttonStyle(.borderedProminent)
                         .tint(.red)
+                    } else if context.state.effectivePhase == .standby {
+                        Button(intent: StopQuickDictationIntent()) {
+                            Label("Turn off Quick Dictation", systemImage: "mic.slash.fill")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(.brand)
                     }
                 }
             } compactLeading: {

--- a/ios/VocaPhoneShared/DarwinNotifications.swift
+++ b/ios/VocaPhoneShared/DarwinNotifications.swift
@@ -1,0 +1,141 @@
+import CoreFoundation
+import Foundation
+
+/// Cross-process wake-up signals shared by the containing app, keyboard, and
+/// Live Activity extension. Darwin notifications intentionally carry no data;
+/// every receiver rereads the durable App Group record after the ping.
+enum VocaPhoneDarwinNotification: String, Sendable {
+    case sessionChanged = "com.vocahq.vocaphone.session-changed"
+    case keyboardStatusChanged = "com.vocahq.vocaphone.keyboard-status-changed"
+    case quickDictationChanged = "com.vocahq.vocaphone.quick-dictation-changed"
+    case stopQuickDictationRequested = "com.vocahq.vocaphone.stop-quick-dictation"
+
+    fileprivate var name: CFNotificationName {
+        CFNotificationName(rawValue as CFString)
+    }
+}
+
+/// Owns one Darwin observer. Keeping observations token-based allows multiple
+/// listeners for the same notification without one process-global callback
+/// silently replacing another.
+final class VocaPhoneDarwinObservation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var context: UnsafeMutableRawPointer?
+    private let name: CFNotificationName
+
+    fileprivate init(
+        notification: VocaPhoneDarwinNotification,
+        queue: DispatchQueue,
+        handler: @escaping @Sendable () -> Void
+    ) {
+        name = notification.name
+        let context = DarwinCallbackRegistry.shared.insert(
+            queue: queue,
+            handler: handler
+        )
+        self.context = context
+        CFNotificationCenterAddObserver(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            context,
+            vocaPhoneDarwinCallback,
+            notification.name.rawValue,
+            nil,
+            .deliverImmediately
+        )
+    }
+
+    func invalidate() {
+        lock.lock()
+        guard let context else {
+            lock.unlock()
+            return
+        }
+        self.context = nil
+        lock.unlock()
+
+        CFNotificationCenterRemoveObserver(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            context,
+            name,
+            nil
+        )
+        DarwinCallbackRegistry.shared.remove(context: context)
+    }
+
+    deinit {
+        invalidate()
+    }
+}
+
+enum VocaPhoneDarwinCenter {
+    static func post(_ notification: VocaPhoneDarwinNotification) {
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            notification.name,
+            nil,
+            nil,
+            true
+        )
+    }
+
+    @discardableResult
+    static func observe(
+        _ notification: VocaPhoneDarwinNotification,
+        queue: DispatchQueue = .main,
+        handler: @escaping @Sendable () -> Void
+    ) -> VocaPhoneDarwinObservation {
+        VocaPhoneDarwinObservation(
+            notification: notification,
+            queue: queue,
+            handler: handler
+        )
+    }
+}
+
+private let vocaPhoneDarwinCallback: CFNotificationCallback = { _, observer, _, _, _ in
+    guard let observer else { return }
+    DarwinCallbackRegistry.shared.deliver(context: observer)
+}
+
+private final class DarwinCallbackRegistry: @unchecked Sendable {
+    struct Entry: @unchecked Sendable {
+        let queue: DispatchQueue
+        let handler: @Sendable () -> Void
+    }
+
+    static let shared = DarwinCallbackRegistry()
+
+    private let lock = NSLock()
+    private var entries: [UInt: Entry] = [:]
+    private var nextIdentifier: UInt = 1
+
+    @discardableResult
+    func insert(
+        queue: DispatchQueue,
+        handler: @escaping @Sendable () -> Void
+    ) -> UnsafeMutableRawPointer {
+        lock.lock()
+        let identifier = nextIdentifier
+        // Opaque observer values are never dereferenced. Monotonic identifiers
+        // avoid an old in-flight callback ever matching a newer observation.
+        nextIdentifier &+= 1
+        if nextIdentifier == 0 { nextIdentifier = 1 }
+        entries[identifier] = Entry(queue: queue, handler: handler)
+        lock.unlock()
+        return UnsafeMutableRawPointer(bitPattern: identifier)!
+    }
+
+    func remove(context: UnsafeMutableRawPointer) {
+        lock.lock()
+        entries.removeValue(forKey: UInt(bitPattern: context))
+        lock.unlock()
+    }
+
+    func deliver(context: UnsafeMutableRawPointer) {
+        lock.lock()
+        let entry = entries[UInt(bitPattern: context)]
+        lock.unlock()
+        guard let entry else { return }
+        entry.queue.async(execute: entry.handler)
+    }
+}

--- a/ios/VocaPhoneShared/DiagnosticLog.swift
+++ b/ios/VocaPhoneShared/DiagnosticLog.swift
@@ -1,0 +1,289 @@
+import Foundation
+
+enum DiagnosticSource: String, Codable, Sendable {
+    case app
+    case keyboard
+    case liveActivity
+    case tests
+
+    static var current: DiagnosticSource {
+        let identifier = Bundle.main.bundleIdentifier ?? ""
+        if identifier.hasSuffix(".keyboard") { return .keyboard }
+        if identifier.hasSuffix(".liveactivity") { return .liveActivity }
+        if identifier.contains("Tests") || identifier.contains("tests") { return .tests }
+        return .app
+    }
+}
+
+/// Deliberately finite and content-free. There is no API here that accepts a
+/// transcript, typed text, audio path, URL, token, microphone name, or arbitrary
+/// metadata, so private user content cannot accidentally enter an export.
+enum DiagnosticEvent: String, Codable, Sendable {
+    case appStarted
+    case keyboardShown
+    case sessionStateChanged
+    case quickDictationArmed
+    case quickDictationStopped
+    case quickDictationStale
+    case stopQuickDictationRequested
+    case audioInterruptionBegan
+    case audioInterruptionEnded
+    case audioMediaServicesReset
+    case audioInputUnavailable
+    case liveActivityStarted
+    case liveActivityEnded
+    case operationFailed
+}
+
+enum DiagnosticReason: String, Codable, Sendable {
+    case userRequested
+    case quickDictationOff
+    case sessionFinished
+    case processExit
+    case resumeAllowed
+    case resumeNotAllowed
+}
+
+enum DiagnosticPhase: String, Codable, Sendable {
+    case standby
+    case recording
+}
+
+enum DiagnosticErrorCode: String, Codable, Sendable {
+    case audioMissing
+    case diagnosticExportFailed
+    case gatewayNotConfigured
+    case languageUnsupported
+    case microphonePermissionDenied
+    case quickDictationArmFailed
+    case recordingStartFailed
+    case serverUnavailable
+    case transcriptionFailed
+    case uploadFailed
+}
+
+struct DiagnosticMetadata: Codable, Equatable, Sendable {
+    let state: SessionState?
+    let reason: DiagnosticReason?
+    let phase: DiagnosticPhase?
+    let errorCode: DiagnosticErrorCode?
+    let hasFullAccess: Bool?
+
+    static let empty = DiagnosticMetadata()
+
+    private init(
+        state: SessionState? = nil,
+        reason: DiagnosticReason? = nil,
+        phase: DiagnosticPhase? = nil,
+        errorCode: DiagnosticErrorCode? = nil,
+        hasFullAccess: Bool? = nil
+    ) {
+        self.state = state
+        self.reason = reason
+        self.phase = phase
+        self.errorCode = errorCode
+        self.hasFullAccess = hasFullAccess
+    }
+
+    static func state(_ state: SessionState) -> DiagnosticMetadata {
+        DiagnosticMetadata(state: state)
+    }
+
+    static func reason(_ reason: DiagnosticReason) -> DiagnosticMetadata {
+        DiagnosticMetadata(reason: reason)
+    }
+
+    static func phase(_ phase: DiagnosticPhase) -> DiagnosticMetadata {
+        DiagnosticMetadata(phase: phase)
+    }
+
+    static func error(_ errorCode: DiagnosticErrorCode) -> DiagnosticMetadata {
+        DiagnosticMetadata(errorCode: errorCode)
+    }
+
+    static func fullAccess(_ hasFullAccess: Bool) -> DiagnosticMetadata {
+        DiagnosticMetadata(hasFullAccess: hasFullAccess)
+    }
+}
+
+struct DiagnosticEntry: Codable, Equatable, Sendable {
+    static let schemaVersion = 1
+
+    let schemaVersion: Int
+    let timestamp: Date
+    let source: DiagnosticSource
+    let event: DiagnosticEvent
+    let metadata: DiagnosticMetadata
+    let appVersion: String
+    let buildNumber: String
+
+    init(
+        timestamp: Date = Date(),
+        source: DiagnosticSource,
+        event: DiagnosticEvent,
+        metadata: DiagnosticMetadata = .empty
+    ) {
+        schemaVersion = Self.schemaVersion
+        self.timestamp = timestamp
+        self.source = source
+        self.event = event
+        self.metadata = metadata
+        appVersion = Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleShortVersionString"
+        ) as? String ?? "unknown"
+        buildNumber = Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleVersion"
+        ) as? String ?? "unknown"
+    }
+}
+
+enum DiagnosticLog {
+    static let maximumFileSize = 200_000
+    static let retentionInterval: TimeInterval = 7 * 24 * 60 * 60
+
+    private static let fileName = "vocaphone-diagnostics.ndjson"
+    private static let lock = NSLock()
+    private static let writeQueue = DispatchQueue(
+        label: "com.vocahq.vocaphone.diagnostics",
+        qos: .utility
+    )
+
+    static func record(
+        _ event: DiagnosticEvent,
+        source: DiagnosticSource = .current,
+        metadata: DiagnosticMetadata = .empty
+    ) {
+        guard let fileURL else { return }
+        let entry = DiagnosticEntry(source: source, event: event, metadata: metadata)
+        writeQueue.async {
+            append(entry, to: fileURL)
+        }
+    }
+
+    static func read() -> String {
+        guard let fileURL else { return "" }
+        return writeQueue.sync { coordinatedRead(from: fileURL) }
+    }
+
+    static func clear() {
+        guard let fileURL else { return }
+        writeQueue.sync { coordinatedWrite(Data(), to: fileURL) }
+    }
+
+    static func makeExportFile(now: Date = Date()) throws -> URL {
+        let entries = retainedEntries(from: read(), now: now)
+        let version = Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleShortVersionString"
+        ) as? String ?? "unknown"
+        let build = Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleVersion"
+        ) as? String ?? "unknown"
+        let header = """
+        VocaPhone diagnostics
+        App: \(version) (\(build))
+        OS: \(ProcessInfo.processInfo.operatingSystemVersionString)
+        Privacy: state and lifecycle metadata only; no transcript, typed text, audio, or credentials.
+        ---
+
+        """
+        let body = entries.joined(separator: "\n")
+        let exportURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocaphone-diagnostics-\(Int(now.timeIntervalSince1970)).txt")
+        try Data((header + body + (body.isEmpty ? "" : "\n")).utf8)
+            .write(to: exportURL, options: .atomic)
+        return exportURL
+    }
+
+    /// Internal entry point used by tests with an isolated temporary file.
+    static func append(_ entry: DiagnosticEntry, to fileURL: URL) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        guard var line = try? encoder.encode(entry) else { return }
+        line.append(0x0A)
+
+        lock.lock()
+        defer { lock.unlock() }
+        let parent = fileURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        let coordinator = NSFileCoordinator()
+        var coordinationError: NSError?
+        coordinator.coordinate(
+            writingItemAt: fileURL,
+            options: .forMerging,
+            error: &coordinationError
+        ) { coordinatedURL in
+            if !FileManager.default.fileExists(atPath: coordinatedURL.path) {
+                FileManager.default.createFile(atPath: coordinatedURL.path, contents: nil)
+            }
+            guard let handle = try? FileHandle(forWritingTo: coordinatedURL) else { return }
+            do {
+                try handle.seekToEnd()
+                try handle.write(contentsOf: line)
+                try handle.close()
+            } catch {
+                try? handle.close()
+                return
+            }
+            trimIfNeeded(coordinatedURL)
+        }
+    }
+
+    static func retainedEntries(from contents: String, now: Date) -> [String] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return contents.split(separator: "\n").compactMap { line in
+            guard let entry = try? decoder.decode(DiagnosticEntry.self, from: Data(line.utf8)),
+                  now.timeIntervalSince(entry.timestamp) <= retentionInterval
+            else { return nil }
+            return String(line)
+        }
+    }
+
+    private static var fileURL: URL? {
+        FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: AppConfiguration.appGroupIdentifier
+        )?.appendingPathComponent(fileName)
+    }
+
+    private static func coordinatedRead(from fileURL: URL) -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        var result = ""
+        let coordinator = NSFileCoordinator()
+        var coordinationError: NSError?
+        coordinator.coordinate(readingItemAt: fileURL, options: [], error: &coordinationError) {
+            coordinatedURL in
+            result = (try? String(contentsOf: coordinatedURL, encoding: .utf8)) ?? ""
+        }
+        return result
+    }
+
+    private static func coordinatedWrite(_ data: Data, to fileURL: URL) {
+        lock.lock()
+        defer { lock.unlock() }
+        let coordinator = NSFileCoordinator()
+        var coordinationError: NSError?
+        coordinator.coordinate(
+            writingItemAt: fileURL,
+            options: .forReplacing,
+            error: &coordinationError
+        ) { coordinatedURL in
+            try? data.write(to: coordinatedURL, options: .atomic)
+        }
+    }
+
+    private static func trimIfNeeded(_ fileURL: URL) {
+        guard let data = try? Data(contentsOf: fileURL),
+              data.count > maximumFileSize
+        else { return }
+
+        let suffix = data.suffix(maximumFileSize)
+        guard let newline = suffix.firstIndex(of: 0x0A) else {
+            try? Data(suffix).write(to: fileURL, options: .atomic)
+            return
+        }
+        let start = suffix.index(after: newline)
+        try? Data(suffix[start...]).write(to: fileURL, options: .atomic)
+    }
+}

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -202,6 +202,7 @@ enum KeyboardPreferences {
     static let writingStyleKey = "writingStyle"
     static let transcriptionLanguageKey = "transcriptionLanguage"
     static let microphonePreferenceKey = "microphonePreference"
+    static let recordingSoundsKey = "recordingSoundsEnabled"
     static let containingAppForegroundKey = "containingAppForeground"
     static let setupCompletedKey = "setupCompleted"
     static let firstDictationKey = "hasCompletedFirstDictation"
@@ -233,6 +234,11 @@ enum KeyboardPreferences {
         set {
             defaults?.set(newValue, forKey: quickDictationKey)
         }
+    }
+
+    static var recordingSoundsEnabled: Bool {
+        get { defaults?.bool(forKey: recordingSoundsKey) ?? false }
+        set { defaults?.set(newValue, forKey: recordingSoundsKey) }
     }
 
     static var writingStyle: WritingStyle {

--- a/ios/VocaPhoneShared/QuickDictationAvailability.swift
+++ b/ios/VocaPhoneShared/QuickDictationAvailability.swift
@@ -2,19 +2,46 @@ import Foundation
 
 struct QuickDictationAvailability: Codable, Equatable, Sendable {
     static let schemaVersion = 1
+    static let heartbeatMaximumAge: TimeInterval = 6
 
     let schemaVersion: Int
     let activatedAt: Date
     let expiresAt: Date
+    let heartbeatAt: Date?
 
-    init(activatedAt: Date = Date(), expiresAt: Date) {
+    init(
+        activatedAt: Date = Date(),
+        expiresAt: Date,
+        heartbeatAt: Date? = nil
+    ) {
         schemaVersion = Self.schemaVersion
         self.activatedAt = Self.normalizedTimestamp(activatedAt)
         self.expiresAt = Self.normalizedTimestamp(expiresAt)
+        self.heartbeatAt = Self.normalizedTimestamp(heartbeatAt ?? activatedAt)
     }
 
     func isReady(at date: Date = Date()) -> Bool {
-        schemaVersion == Self.schemaVersion && expiresAt > date
+        guard schemaVersion == Self.schemaVersion,
+              expiresAt > date,
+              let heartbeatAt
+        else { return false }
+        let heartbeatAge = date.timeIntervalSince(heartbeatAt)
+        return heartbeatAge >= -1 && heartbeatAge <= Self.heartbeatMaximumAge
+    }
+
+    func refreshingHeartbeat(at date: Date = Date()) -> QuickDictationAvailability {
+        QuickDictationAvailability(
+            activatedAt: activatedAt,
+            expiresAt: expiresAt,
+            heartbeatAt: date
+        )
+    }
+
+    /// A keyboard request and a standby re-arm can cross in separate processes.
+    /// The tiny grace window accepts that in-flight request without adopting an
+    /// older abandoned session from before Quick Dictation was available.
+    func acceptsRequest(createdAt: Date, grace: TimeInterval = 2) -> Bool {
+        createdAt >= activatedAt.addingTimeInterval(-grace) && createdAt < expiresAt
     }
 
     private static func normalizedTimestamp(_ date: Date) -> Date {

--- a/ios/VocaPhoneShared/SharedStore.swift
+++ b/ios/VocaPhoneShared/SharedStore.swift
@@ -31,6 +31,13 @@ final class SharedStore: @unchecked Sendable {
         if record.state != .recording {
             try? fileManager.removeItem(at: meterURL(for: record.sessionID, directory: directory))
         }
+        notify(.sessionChanged)
+        if rootOverride == nil {
+            DiagnosticLog.record(
+                .sessionStateChanged,
+                metadata: .state(record.state)
+            )
+        }
     }
 
     /// Written several times a second while recording. An atomic write means a
@@ -170,11 +177,15 @@ final class SharedStore: @unchecked Sendable {
             .contentModificationDate ?? .distantPast
     }
 
-    func saveQuickDictationAvailability(_ availability: QuickDictationAvailability) throws {
+    func saveQuickDictationAvailability(
+        _ availability: QuickDictationAvailability,
+        notifyObservers: Bool = true
+    ) throws {
         let root = try rootDirectory()
         try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
         let data = try encoder.encode(availability)
         try data.write(to: quickDictationURL(root: root), options: .atomic)
+        if notifyObservers { notify(.quickDictationChanged) }
     }
 
     func loadQuickDictationAvailability() throws -> QuickDictationAvailability? {
@@ -194,6 +205,7 @@ final class SharedStore: @unchecked Sendable {
         let fileURL = quickDictationURL(root: try rootDirectory())
         guard fileManager.fileExists(atPath: fileURL.path) else { return }
         try fileManager.removeItem(at: fileURL)
+        notify(.quickDictationChanged)
     }
 
     func saveKeyboardStatus(_ status: KeyboardStatus) throws {
@@ -201,6 +213,7 @@ final class SharedStore: @unchecked Sendable {
         try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
         let data = try encoder.encode(status)
         try data.write(to: keyboardStatusURL(root: root), options: .atomic)
+        notify(.keyboardStatusChanged)
     }
 
     func loadKeyboardStatus() throws -> KeyboardStatus? {
@@ -255,5 +268,10 @@ final class SharedStore: @unchecked Sendable {
               let level = try? decoder.decode(Float.self, from: data)
         else { return }
         record.meterLevel = min(max(level, 0), 1)
+    }
+
+    private func notify(_ notification: VocaPhoneDarwinNotification) {
+        guard rootOverride == nil else { return }
+        VocaPhoneDarwinCenter.post(notification)
     }
 }

--- a/ios/VocaPhoneTests/ReliabilityFeatureTests.swift
+++ b/ios/VocaPhoneTests/ReliabilityFeatureTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import Testing
+
+struct ReliabilityFeatureTests {
+    @Test func multipleDarwinObserversReceiveTheSameSignal() {
+        let semaphore = DispatchSemaphore(value: 0)
+        let callbackQueue = DispatchQueue(
+            label: "com.vocahq.vocaphone.tests.darwin",
+            attributes: .concurrent
+        )
+        let first = VocaPhoneDarwinCenter.observe(
+            .quickDictationChanged,
+            queue: callbackQueue
+        ) {
+            semaphore.signal()
+        }
+        let second = VocaPhoneDarwinCenter.observe(
+            .quickDictationChanged,
+            queue: callbackQueue
+        ) {
+            semaphore.signal()
+        }
+        defer {
+            first.invalidate()
+            second.invalidate()
+        }
+
+        VocaPhoneDarwinCenter.post(.quickDictationChanged)
+        #expect(semaphore.wait(timeout: .now() + 1) == .success)
+        #expect(semaphore.wait(timeout: .now() + 1) == .success)
+    }
+
+    @Test func quickDictationRequiresAFreshHeartbeat() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let availability = QuickDictationAvailability(
+            activatedAt: now,
+            expiresAt: now.addingTimeInterval(600),
+            heartbeatAt: now
+        )
+
+        #expect(availability.isReady(at: now.addingTimeInterval(5)))
+        #expect(!availability.isReady(at: now.addingTimeInterval(7)))
+    }
+
+    @Test func refreshingHeartbeatPreservesTheStandbyWindow() {
+        let started = Date(timeIntervalSince1970: 10_000)
+        let expires = started.addingTimeInterval(600)
+        let refreshedAt = started.addingTimeInterval(4)
+        let availability = QuickDictationAvailability(
+            activatedAt: started,
+            expiresAt: expires
+        ).refreshingHeartbeat(at: refreshedAt)
+
+        #expect(availability.activatedAt == started)
+        #expect(availability.expiresAt == expires)
+        #expect(availability.heartbeatAt == refreshedAt)
+        #expect(availability.isReady(at: refreshedAt))
+    }
+
+    @Test func standbyAcceptsARequestThatRacedWithRearming() {
+        let started = Date(timeIntervalSince1970: 10_000)
+        let availability = QuickDictationAvailability(
+            activatedAt: started,
+            expiresAt: started.addingTimeInterval(600)
+        )
+
+        #expect(availability.acceptsRequest(createdAt: started.addingTimeInterval(-1)))
+        #expect(!availability.acceptsRequest(createdAt: started.addingTimeInterval(-3)))
+        #expect(!availability.acceptsRequest(createdAt: availability.expiresAt))
+    }
+
+    @Test func oldAvailabilityFilesWithoutAHeartbeatAreStale() throws {
+        let json = """
+        {"activatedAt":"2026-01-01T00:00:00Z","expiresAt":"2027-01-01T00:00:00Z",\
+        "schemaVersion":1}
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let availability = try decoder.decode(
+            QuickDictationAvailability.self,
+            from: Data(json.utf8)
+        )
+
+        #expect(availability.heartbeatAt == nil)
+        #expect(!availability.isReady(at: Date(timeIntervalSince1970: 1_800_000_000)))
+    }
+
+    @Test func cursorTrackpadEmitsOnlyWholeCharacterSteps() {
+        #expect(CursorTrackpad.step(forHorizontalTranslation: 9.9) == 0)
+        #expect(CursorTrackpad.step(forHorizontalTranslation: 10) == 1)
+        #expect(CursorTrackpad.step(forHorizontalTranslation: 27) == 2)
+        #expect(CursorTrackpad.step(forHorizontalTranslation: -9.9) == 0)
+        #expect(CursorTrackpad.step(forHorizontalTranslation: -10) == -1)
+    }
+
+    @Test func diagnosticsHaveNoPrivateContentFields() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("diagnostics.ndjson")
+        DiagnosticLog.append(
+            DiagnosticEntry(
+                timestamp: Date(timeIntervalSince1970: 10_000),
+                source: .keyboard,
+                event: .sessionStateChanged,
+                metadata: .state(.recording)
+            ),
+            to: file
+        )
+
+        let contents = String(decoding: try Data(contentsOf: file), as: UTF8.self)
+        #expect(contents.contains("sessionStateChanged"))
+        #expect(contents.contains("recording"))
+        #expect(!contents.localizedCaseInsensitiveContains("transcript"))
+        #expect(!contents.localizedCaseInsensitiveContains("audioPath"))
+        #expect(!contents.localizedCaseInsensitiveContains("token"))
+        #expect(!contents.localizedCaseInsensitiveContains("gatewayURL"))
+    }
+
+    @Test func diagnosticExportDropsEntriesOlderThanSevenDays() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let old = DiagnosticEntry(
+            timestamp: now.addingTimeInterval(-8 * 24 * 60 * 60),
+            source: .app,
+            event: .appStarted
+        )
+        let recent = DiagnosticEntry(
+            timestamp: now.addingTimeInterval(-60),
+            source: .app,
+            event: .quickDictationArmed
+        )
+        let contents = try [old, recent]
+            .map { String(decoding: try encoder.encode($0), as: UTF8.self) }
+            .joined(separator: "\n")
+
+        let retained = DiagnosticLog.retainedEntries(from: contents, now: now)
+        #expect(retained.count == 1)
+        #expect(retained[0].contains("quickDictationArmed"))
+    }
+
+    @Test func diagnosticFileIsBounded() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let file = directory.appendingPathComponent("diagnostics.ndjson")
+        try Data(repeating: 0x78, count: DiagnosticLog.maximumFileSize + 1_000)
+            .write(to: file)
+
+        DiagnosticLog.append(
+            DiagnosticEntry(source: .tests, event: .appStarted),
+            to: file
+        )
+
+        let size = try #require(file.resourceValues(forKeys: [.fileSizeKey]).fileSize)
+        #expect(size <= DiagnosticLog.maximumFileSize)
+    }
+}

--- a/ios/VocaPhoneTests/SessionRecordTests.swift
+++ b/ios/VocaPhoneTests/SessionRecordTests.swift
@@ -188,6 +188,7 @@ struct SessionRecordTests {
     @Test func quickDictationAvailabilityExpires() {
         let now = Date(timeIntervalSince1970: 1_000)
         let availability = QuickDictationAvailability(
+            activatedAt: now,
             expiresAt: now.addingTimeInterval(600)
         )
         #expect(availability.isReady(at: now))


### PR DESCRIPTION
## Summary

- Replace frequent app/keyboard polling with Darwin notification signals backed by durable App Group state and a slower fallback.
- Add Quick Dictation heartbeats, interruption and route-loss recovery, and a Dynamic Island action that stops the real standby audio engine.
- Add bounded privacy-safe diagnostics, optional recording cues, spacebar cursor control, and physical-device acceptance coverage.
- Harden reviewed race and failure paths so stale callbacks cannot target new observers, stale audio recovery cannot re-arm after newer loss, and recording-start failures cannot strand the keyboard.

## Verification

- [x] `just ios::ci` — generated-project check passed; 102 tests passed across 13 suites
- [ ] `just android::ci` — not run; iOS-only change
- [x] Gateway changes: not applicable
- [ ] Physical-device test — signed iPhone build and installation passed; launch was denied because the device was locked, and the documented call/Siri/AirPods and keyboard interaction pass remains

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for diagnostic retention/privacy, audio lifecycle, and physical-device acceptance

## Review notes

- Diagnostics accept only finite event, state, reason, and error enums. They cannot accept transcript text, typed text, audio paths, gateway URLs, credentials, or microphone names.
- Existing unrelated untracked `.omo` and Plan files are intentionally excluded.