### PR TITLE
feat(android): add IME feasibility spike

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -80,6 +80,20 @@ silent failure.
    **Test connection**, which reports reachability, token validity, the active
    engine, whether it is ready, and whether it supports streaming.
 
+## Experimental keyboard spike
+
+The Android build also contains an experimental VocaPhone keyboard. It is a
+feasibility path for the next permission-minimal release: the microphone lives
+inside the keyboard and the transcript is written through Android's
+`InputConnection`, without reading the field or using an overlay.
+
+The current beta keeps the existing bubble/accessibility path as the default, so
+this keyboard is not yet part of the required setup. To try it, open the
+**Try the VocaPhone keyboard** card in setup or Settings, enable the keyboard in
+Android's keyboard settings, then choose VocaPhone from the keyboard picker.
+The gateway, audio capture, streaming fallback and history are shared with the
+existing dictation pipeline.
+
 ## How accessibility access is used
 
 vocaphone is not an accessibility tool, so it states plainly what it does with

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -78,6 +78,20 @@
             android:exported="false"
             android:foregroundServiceType="microphone" />
 
+        <!-- Experimental IME spike. The service writes through InputConnection. -->
+        <service
+            android:name=".ime.VocaPhoneInputMethodService"
+            android:exported="true"
+            android:label="@string/ime_name"
+            android:permission="android.permission.BIND_INPUT_METHOD">
+            <intent-filter>
+                <action android:name="android.view.InputMethod" />
+            </intent-filter>
+            <meta-data
+                android:name="android.view.im"
+                android:resource="@xml/method" />
+        </service>
+
         <service
             android:name=".accessibility.VocaPhoneAccessibilityService"
             android:exported="true"

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/ImeInputPolicy.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/ImeInputPolicy.kt
@@ -1,0 +1,27 @@
+package com.vocahq.vocaphone.core
+
+import android.text.InputType
+
+/**
+ * The editor fields into which the experimental keyboard may offer dictation.
+ *
+ * The IME can see an EditorInfo without reading the field contents. Keeping this
+ * gate limited to ordinary text fields prevents the keyboard from presenting a
+ * microphone action in passwords, PINs, phone numbers or date fields.
+ */
+object ImeInputPolicy {
+
+    fun acceptsDictation(inputType: Int): Boolean {
+        if (inputType and InputType.TYPE_MASK_CLASS != InputType.TYPE_CLASS_TEXT) {
+            return false
+        }
+
+        return inputType and InputType.TYPE_MASK_VARIATION !in SENSITIVE_VARIATIONS
+    }
+
+    private val SENSITIVE_VARIATIONS = setOf(
+        InputType.TYPE_TEXT_VARIATION_PASSWORD,
+        InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD,
+        InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD,
+    )
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -44,6 +44,9 @@ enum class DictationSource {
 
     /** The companion app's scratchpad: the transcript stays in the app. */
     COMPANION_APP,
+
+    /** The experimental system keyboard: commit into its current InputConnection. */
+    IME,
 }
 
 /**
@@ -63,6 +66,10 @@ class DictationController(
     /** Set by the accessibility service while it is connected. */
     @Volatile
     var inserter: TranscriptInserter? = null
+
+    /** Set by the experimental IME while the keyboard service is connected. */
+    @Volatile
+    var imeInserter: TranscriptInserter? = null
 
     private var pipeline: Job? = null
     private var capture: AudioCapture? = null
@@ -399,10 +406,12 @@ class DictationController(
         configuration: VocaPhoneSettings,
         source: DictationSource,
     ) {
-        val target = inserter
-        val shouldInsert = source == DictationSource.BUBBLE &&
-            configuration.automaticInsertion &&
-            target != null
+        val target = when (source) {
+            DictationSource.BUBBLE -> inserter.takeIf { configuration.automaticInsertion }
+            DictationSource.IME -> imeInserter
+            DictationSource.COMPANION_APP -> null
+        }
+        val shouldInsert = target != null
 
         if (!shouldInsert) {
             _state.value = _state.value.copy(
@@ -445,7 +454,7 @@ class DictationController(
         )
         if (report.outcome == InsertionOutcome.INSERTED) {
             // "Inserted" is a confirmation, not a state the user acts on: after a
-            // moment the bubble returns to its idle mic on its own.
+            // moment the bubble or keyboard returns to its idle mic on its own.
             scope.launch {
                 delay(INSERTED_LINGER_MILLIS)
                 _state.update { current ->

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -1,0 +1,159 @@
+package com.vocahq.vocaphone.ime
+
+import android.inputmethodservice.InputMethodService
+import android.view.View
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import android.widget.Button
+import android.widget.TextView
+import com.vocahq.vocaphone.R
+import com.vocahq.vocaphone.VocaPhoneApplication
+import com.vocahq.vocaphone.core.DictationPhase
+import com.vocahq.vocaphone.core.DictationState
+import com.vocahq.vocaphone.core.ImeInputPolicy
+import com.vocahq.vocaphone.core.TranscriptSanitizer
+import com.vocahq.vocaphone.dictation.AppliedInsertion
+import com.vocahq.vocaphone.dictation.DictationService
+import com.vocahq.vocaphone.dictation.DictationSource
+import com.vocahq.vocaphone.dictation.InsertionOutcome
+import com.vocahq.vocaphone.dictation.InsertionReport
+import com.vocahq.vocaphone.dictation.TranscriptInserter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Feasibility-spike keyboard for system-wide dictation.
+ *
+ * This service deliberately stays small. It proves the important platform path:
+ * the keyboard owns the focused InputConnection, while the existing dictation
+ * controller continues to own capture, gateway delivery and retryable history.
+ */
+class VocaPhoneInputMethodService : InputMethodService(), TranscriptInserter {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val container by lazy { VocaPhoneApplication.container(this) }
+
+    private var inputView: View? = null
+    private var statusView: TextView? = null
+    private var dictateButton: Button? = null
+    private var lastState = DictationState()
+    private var currentInputType: Int = 0
+
+    override fun onCreate() {
+        super.onCreate()
+        container.dictation.imeInserter = this
+        scope.launch {
+            container.dictation.state.collect { state ->
+                lastState = state
+                render(state)
+            }
+        }
+    }
+
+    override fun onCreateInputView(): View = layoutInflater
+        .inflate(R.layout.input_method_view, null)
+        .also { view ->
+            inputView = view
+            statusView = view.findViewById(R.id.ime_status)
+            dictateButton = view.findViewById<Button>(R.id.ime_dictate).also { button ->
+                button.setOnClickListener { toggleDictation() }
+            }
+            view.findViewById<Button>(R.id.ime_switch).setOnClickListener {
+                getSystemService(InputMethodManager::class.java)?.showInputMethodPicker()
+            }
+            render(lastState)
+        }
+
+    override fun onStartInput(attribute: EditorInfo?, restarting: Boolean) {
+        super.onStartInput(attribute, restarting)
+        currentInputType = attribute?.inputType ?: 0
+        render(lastState)
+    }
+
+    override fun onFinishInput() {
+        // The InputConnection belongs to the editor that just lost focus. Do not
+        // leave its input type eligible while Android is transitioning elsewhere.
+        currentInputType = 0
+        render(lastState)
+        super.onFinishInput()
+    }
+
+    override fun onDestroy() {
+        if (container.dictation.imeInserter === this) {
+            container.dictation.imeInserter = null
+        }
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    override suspend fun insert(transcript: String): InsertionReport =
+        withContext(Dispatchers.Main.immediate) {
+            if (!ImeInputPolicy.acceptsDictation(currentInputType)) {
+                return@withContext InsertionReport(InsertionOutcome.NO_TARGET)
+            }
+
+            val connection = currentInputConnection
+                ?: return@withContext InsertionReport(InsertionOutcome.NO_TARGET)
+            val cleaned = TranscriptSanitizer.clean(transcript)
+            if (cleaned.isEmpty()) {
+                return@withContext InsertionReport(InsertionOutcome.NO_TARGET)
+            }
+
+            val committed = runCatching { connection.commitText(cleaned, 1) }
+                .getOrDefault(false)
+            if (!committed) {
+                InsertionReport(InsertionOutcome.UNSUPPORTED_EDITOR)
+            } else {
+                // InputConnection does not expose a portable undo range. The
+                // keyboard's first spike proves insertion only; undo remains owned
+                // by the existing accessibility destination until the IME contract
+                // grows a cursor-aware undo implementation.
+                InsertionReport(InsertionOutcome.INSERTED)
+            }
+        }
+
+    override suspend fun undo(insertion: AppliedInsertion): Boolean = false
+
+    override fun currentTargetPackage(): String? =
+        currentInputEditorInfo?.packageName
+
+    private fun toggleDictation() {
+        when {
+            !ImeInputPolicy.acceptsDictation(currentInputType) -> render(lastState)
+            lastState.phase == DictationPhase.LISTENING ->
+                DictationService.send(this, DictationService.ACTION_FINISH)
+            lastState.phase.isBusy ->
+                DictationService.send(this, DictationService.ACTION_CANCEL)
+            else -> DictationService.start(this, DictationSource.IME)
+        }
+    }
+
+    private fun render(state: DictationState) {
+        if (inputView == null) return
+
+        val accepted = ImeInputPolicy.acceptsDictation(currentInputType)
+        statusView?.text = when {
+            !accepted -> "Dictation is unavailable in password or non-text fields."
+            state.phase == DictationPhase.PERMISSION_REPAIR -> "Open VocaPhone to finish setup."
+            else -> state.statusText
+        }
+        dictateButton?.apply {
+            isEnabled = accepted && state.phase !in setOf(
+                DictationPhase.FINALIZING,
+                DictationPhase.UPLOADING,
+                DictationPhase.TRANSCRIBING,
+            )
+            text = when {
+                state.phase == DictationPhase.LISTENING -> getString(R.string.ime_finish)
+                state.phase.isBusy -> getString(R.string.ime_cancel)
+                else -> getString(R.string.ime_dictate)
+            }
+            contentDescription = text
+        }
+    }
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/AppInfo.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/AppInfo.kt
@@ -71,6 +71,12 @@ fun diagnosticsReport(
             "missing ${setup.remainingSteps.joinToString { it.label }}"
         }
     )
+    appendLine()
+    appendLine("Keyboard: " + when {
+        setup.ime.selected -> "enabled and selected"
+        setup.ime.enabled -> "enabled, not selected"
+        else -> "not enabled"
+    })
 }
 
 /** Enough to debug a transport problem, without naming the host. */

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/ImeSetup.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/ImeSetup.kt
@@ -1,0 +1,50 @@
+package com.vocahq.vocaphone.ui
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import android.view.inputmethod.InputMethodManager
+import com.vocahq.vocaphone.ime.VocaPhoneInputMethodService
+
+data class ImeSetupStatus(
+    val enabled: Boolean = false,
+    val selected: Boolean = false,
+)
+
+/** System handoff helpers for the keyboard experiment. */
+object ImeSetup {
+
+    fun read(context: Context): ImeSetupStatus {
+        val component = ComponentName(context, VocaPhoneInputMethodService::class.java)
+        // Android 14+ blocks ordinary target-SDK 34+ apps from reading the raw
+        // ENABLED_INPUT_METHODS secure setting. InputMethodManager is the public
+        // API for the same information and works for targetSdk 36.
+        val manager = context.getSystemService(InputMethodManager::class.java)
+
+        return ImeSetupStatus(
+            enabled = manager?.enabledInputMethodList.orEmpty().any { info ->
+                info.packageName == component.packageName && info.serviceName == component.className
+            },
+            selected = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                manager?.currentInputMethodInfo?.let { info ->
+                    info.packageName == component.packageName && info.serviceName == component.className
+                } == true
+            } else {
+                Settings.Secure.getString(
+                    context.contentResolver,
+                    Settings.Secure.DEFAULT_INPUT_METHOD,
+                ) == component.flattenToString()
+            },
+        )
+    }
+
+    fun openSettings(context: Context) {
+        context.startActivity(Intent(Settings.ACTION_INPUT_METHOD_SETTINGS))
+    }
+
+    fun showPicker(context: Context) {
+        context.getSystemService(InputMethodManager::class.java)?.showInputMethodPicker()
+    }
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -95,6 +95,8 @@ fun SettingsScreen(
             )
         }
 
+        ImeSetupCard(setup.ime)
+
         // One row rather than 27 wrapping chips, which pushed every setting below
         // this one off the screen. The full list, with search, lives in a sheet.
         var pickingLanguage by remember { mutableStateOf(false) }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
@@ -60,6 +60,8 @@ fun SetupScreen(
 
         SetupProgress(status)
 
+        ImeSetupCard(status.ime)
+
         AccessibilityDisclosure(
             accepted = status.disclosureAccepted,
             onAccept = onAcceptDisclosure,
@@ -140,6 +142,45 @@ fun SetupScreen(
                 "Still to do: " + status.remainingSteps.joinToString { it.label },
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/**
+ * Discoverable handoff for the first IME build. This is informational during the
+ * migration: the existing bubble checklist remains the release path for now.
+ */
+@Composable
+internal fun ImeSetupCard(status: ImeSetupStatus, modifier: Modifier = Modifier) {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    Notice(modifier = modifier) {
+        Text("Try the VocaPhone keyboard", style = MaterialTheme.typography.titleSmall)
+        Text(
+            "This experimental path puts the microphone inside VocaPhone's keyboard " +
+                "and inserts through Android's text connection. It does not read the " +
+                "contents of the field.",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Text(
+            when {
+                status.selected -> "VocaPhone is the selected keyboard."
+                status.enabled -> "VocaPhone is enabled. Open the picker to select it."
+                else -> "VocaPhone is not enabled as a keyboard yet."
+            },
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        SecondaryButton(
+            text = if (status.enabled) "Keyboard settings" else "Enable keyboard",
+            onClick = { ImeSetup.openSettings(context) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        if (status.enabled && !status.selected) {
+            SecondaryButton(
+                text = "Choose VocaPhone keyboard",
+                onClick = { ImeSetup.showPicker(context) },
+                modifier = Modifier.fillMaxWidth(),
             )
         }
     }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupStatus.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupStatus.kt
@@ -34,6 +34,8 @@ data class SetupStatus(
     val batteryUnrestricted: Boolean = false,
     val gatewayConfigured: Boolean = false,
     val disclosureAccepted: Boolean = false,
+    /** Status of the optional IME feasibility spike; it is not yet required. */
+    val ime: ImeSetupStatus = ImeSetupStatus(),
     /** The accessibility switch is probably greyed out; see [RestrictedSettingsPolicy]. */
     val restrictedSettingsGuidance: Boolean = false,
 ) {
@@ -68,6 +70,7 @@ data class SetupStatus(
                 batteryUnrestricted = context.isBatteryUnrestricted(),
                 gatewayConfigured = gatewayConfigured,
                 disclosureAccepted = disclosureAccepted,
+                ime = ImeSetup.read(context),
                 restrictedSettingsGuidance = RestrictedSettingsPolicy.guidanceNeeded(
                     sdkInt = Build.VERSION.SDK_INT,
                     installerPackage = context.installerPackage(),

--- a/android/app/src/main/res/layout/input_method_view.xml
+++ b/android/app/src/main/res/layout/input_method_view.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/keyboard_surface"
+    android:gravity="center_vertical"
+    android:minHeight="96dp"
+    android:orientation="vertical"
+    android:paddingStart="16dp"
+    android:paddingTop="8dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="8dp">
+
+    <TextView
+        android:id="@+id/ime_status"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:text="Tap to dictate"
+        android:textColor="@color/keyboard_on_surface"
+        android:textSize="14sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/ime_dictate"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Dictate" />
+
+        <Button
+            android:id="@+id/ime_switch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="Switch keyboard" />
+    </LinearLayout>
+</LinearLayout>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -10,6 +10,9 @@
 -->
 <resources>
 
+    <color name="keyboard_surface">#212121</color>
+    <color name="keyboard_on_surface">#FFFFFFFF</color>
+
     <!-- Mirrors of VocaPhoneDarkColors in ui/theme/Theme.kt. -->
     <color name="on_surface_dark">#FFE3E4E1</color>
     <color name="brand_dark">#FF77D0B2</color>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,11 @@
 <resources>
     <string name="app_name">vocaphone</string>
 
+    <string name="ime_name">VocaPhone keyboard</string>
+    <string name="ime_dictate">Dictate</string>
+    <string name="ime_finish">Finish</string>
+    <string name="ime_cancel">Cancel</string>
+
     <string name="bubble_dictate">Dictate</string>
     <string name="bubble_finish">Finish dictation</string>
     <string name="bubble_cancel">Cancel dictation</string>

--- a/android/app/src/main/res/xml/method.xml
+++ b/android/app/src/main/res/xml/method.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<input-method xmlns:android="http://schemas.android.com/apk/res/android"
+    android:supportsSwitchingToNextInputMethod="true" />

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/ImeInputPolicyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/ImeInputPolicyTest.kt
@@ -1,0 +1,45 @@
+package com.vocahq.vocaphone.core
+
+import android.text.InputType
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImeInputPolicyTest {
+
+    @Test
+    fun `ordinary text fields offer dictation`() {
+        assertTrue(ImeInputPolicy.acceptsDictation(InputType.TYPE_CLASS_TEXT))
+        assertTrue(
+            ImeInputPolicy.acceptsDictation(
+                InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS,
+            ),
+        )
+    }
+
+    @Test
+    fun `password fields never offer dictation`() {
+        assertFalse(
+            ImeInputPolicy.acceptsDictation(
+                InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD,
+            ),
+        )
+        assertFalse(
+            ImeInputPolicy.acceptsDictation(
+                InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD,
+            ),
+        )
+        assertFalse(
+            ImeInputPolicy.acceptsDictation(
+                InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD,
+            ),
+        )
+    }
+
+    @Test
+    fun `non-text fields do not offer dictation`() {
+        assertFalse(ImeInputPolicy.acceptsDictation(InputType.TYPE_CLASS_NUMBER))
+        assertFalse(ImeInputPolicy.acceptsDictation(InputType.TYPE_CLASS_PHONE))
+        assertFalse(ImeInputPolicy.acceptsDictation(InputType.TYPE_CLASS_DATETIME))
+    }
+}


### PR DESCRIPTION
## Summary
- add a real VocaPhone InputMethodService backed by the existing dictation pipeline
- insert transcripts through InputConnection without reading the target field
- block dictation controls in password and non-text fields
- add keyboard enable/select handoff in setup and Settings
- keep the existing bubble and accessibility flow unchanged for this feasibility PR

## Verification
- ./gradlew assembleDebug testDebugUnitTest lintDebug
- ./gradlew assembleRelease
- signed release APK verified with apksigner
- merged manifest verified with aapt: BIND_INPUT_METHOD, android.view.InputMethod, and android.view.im metadata
- physical POCO F1 check: VocaPhone appeared in the IME list and rendered its keyboard view inside Chrome
- restored the device default keyboard to Dictus after testing

## Boundary
This PR proves the IME lifecycle and insertion surface. Gateway-backed live transcription into a real editor remains the next physical-device acceptance test because the device gateway is not configured.