### PR TITLE
feat(android): harden IME dictation lifecycle

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/audio/AudioCapture.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/audio/AudioCapture.kt
@@ -2,7 +2,9 @@ package com.vocahq.vocaphone.audio
 
 import android.Manifest
 import android.content.Context
+import android.media.AudioAttributes
 import android.media.AudioFormat
+import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.MediaRecorder
@@ -41,11 +43,20 @@ class AudioCapture(
     @Volatile
     private var heldCommunicationDevice = false
 
+    @Volatile
+    private var audioFocusRequest: AudioFocusRequest? = null
+
     private val audioManager: AudioManager? get() = context.getSystemService(AudioManager::class.java)
 
     @RequiresPermission(Manifest.permission.RECORD_AUDIO)
     fun start(): Boolean {
         if (!running.compareAndSet(false, true)) return true
+
+        if (!requestAudioFocus()) {
+            running.set(false)
+            onError(IllegalStateException("Another app is using the microphone."))
+            return false
+        }
 
         val minimum = AudioRecord.getMinBufferSize(
             CaptureFormat.SAMPLE_RATE,
@@ -54,6 +65,7 @@ class AudioCapture(
         )
         if (minimum <= 0) {
             running.set(false)
+            abandonAudioFocus()
             onError(IllegalStateException("This device cannot record 16 kHz mono audio."))
             return false
         }
@@ -71,6 +83,7 @@ class AudioCapture(
             )
         } catch (error: Throwable) {
             running.set(false)
+            abandonAudioFocus()
             onError(error)
             return false
         }
@@ -78,6 +91,7 @@ class AudioCapture(
         if (recorder.state != AudioRecord.STATE_INITIALIZED) {
             recorder.release()
             running.set(false)
+            abandonAudioFocus()
             onError(IllegalStateException("The microphone is not available right now."))
             return false
         }
@@ -102,7 +116,7 @@ class AudioCapture(
     }
 
     fun stop() {
-        if (!running.compareAndSet(true, false)) return
+        running.set(false)
         thread?.let { runCatching { it.join(500) } }
         thread = null
         record?.let { recorder ->
@@ -111,6 +125,43 @@ class AudioCapture(
         }
         record = null
         releaseCommunicationDevice()
+        abandonAudioFocus()
+    }
+
+    /**
+     * Capturing speech owns transient audio focus. A call, Siri or another
+     * exclusive microphone user therefore turns this dictation into an explicit
+     * interruption instead of leaving a foreground service that appears alive.
+     */
+    private fun requestAudioFocus(): Boolean {
+        val manager = audioManager ?: return true
+        val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build(),
+            )
+            .setOnAudioFocusChangeListener { change ->
+                if (change == AudioManager.AUDIOFOCUS_LOSS ||
+                    change == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT ||
+                    change == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK
+                ) {
+                    if (running.get()) {
+                        onError(IllegalStateException("Microphone access was interrupted."))
+                        running.set(false)
+                    }
+                }
+            }
+            .build()
+        audioFocusRequest = request
+        return manager.requestAudioFocus(request) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+    }
+
+    private fun abandonAudioFocus() {
+        val request = audioFocusRequest ?: return
+        audioFocusRequest = null
+        runCatching { audioManager?.abandonAudioFocusRequest(request) }
     }
 
     /**

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -298,6 +298,22 @@ class DictationController(
             return
         }
 
+        captureError?.let { error ->
+            stream?.cancel()
+            wavFile.delete()
+            fail(
+                sessionId,
+                GatewayException(
+                    "audio_interrupted",
+                    error.message ?: "Microphone access was interrupted. Try again.",
+                    recoverable = false,
+                ),
+                wavFile = null,
+                configuration = configuration,
+            )
+            return
+        }
+
         _state.update { it.copy(phase = DictationPhase.FINALIZING, level = 0f) }
 
         if (writer.durationMillis < MINIMUM_RECORDING_MILLIS) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.Button
+import android.widget.ProgressBar
 import android.widget.TextView
 import com.vocahq.vocaphone.R
 import com.vocahq.vocaphone.VocaPhoneApplication
@@ -40,9 +41,13 @@ class VocaPhoneInputMethodService : InputMethodService(), TranscriptInserter {
 
     private var inputView: View? = null
     private var statusView: TextView? = null
+    private var partialView: TextView? = null
+    private var elapsedView: TextView? = null
+    private var progressView: ProgressBar? = null
     private var dictateButton: Button? = null
     private var lastState = DictationState()
     private var currentInputType: Int = 0
+    private var startedImeDictation = false
 
     override fun onCreate() {
         super.onCreate()
@@ -50,6 +55,7 @@ class VocaPhoneInputMethodService : InputMethodService(), TranscriptInserter {
         scope.launch {
             container.dictation.state.collect { state ->
                 lastState = state
+                if (!state.phase.isBusy) startedImeDictation = false
                 render(state)
             }
         }
@@ -60,6 +66,9 @@ class VocaPhoneInputMethodService : InputMethodService(), TranscriptInserter {
         .also { view ->
             inputView = view
             statusView = view.findViewById(R.id.ime_status)
+            partialView = view.findViewById(R.id.ime_partial)
+            elapsedView = view.findViewById(R.id.ime_elapsed)
+            progressView = view.findViewById(R.id.ime_progress)
             dictateButton = view.findViewById<Button>(R.id.ime_dictate).also { button ->
                 button.setOnClickListener { toggleDictation() }
             }
@@ -84,6 +93,11 @@ class VocaPhoneInputMethodService : InputMethodService(), TranscriptInserter {
     }
 
     override fun onDestroy() {
+        if (startedImeDictation && lastState.phase.isBusy) {
+            // Switching away from VocaPhone must not leave its microphone session
+            // alive after the keyboard that owns it has gone away.
+            container.dictation.cancel()
+        }
         if (container.dictation.imeInserter === this) {
             container.dictation.imeInserter = null
         }
@@ -129,7 +143,18 @@ class VocaPhoneInputMethodService : InputMethodService(), TranscriptInserter {
                 DictationService.send(this, DictationService.ACTION_FINISH)
             lastState.phase.isBusy ->
                 DictationService.send(this, DictationService.ACTION_CANCEL)
-            else -> DictationService.start(this, DictationSource.IME)
+            lastState.phase == DictationPhase.PERMISSION_REPAIR -> openCompanion()
+            lastState.phase == DictationPhase.FAILED -> openCompanion()
+            else -> {
+                startedImeDictation = true
+                DictationService.start(this, DictationSource.IME)
+            }
+        }
+    }
+
+    private fun openCompanion() {
+        packageManager.getLaunchIntentForPackage(packageName)?.let { intent ->
+            startActivity(intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK))
         }
     }
 
@@ -142,15 +167,31 @@ class VocaPhoneInputMethodService : InputMethodService(), TranscriptInserter {
             state.phase == DictationPhase.PERMISSION_REPAIR -> "Open VocaPhone to finish setup."
             else -> state.statusText
         }
+        val recording = state.isRecording
+        partialView?.apply {
+            text = state.partialTranscript
+            visibility = if (recording && state.partialTranscript.isNotEmpty()) View.VISIBLE else View.GONE
+        }
+        elapsedView?.apply {
+            text = if (recording) "${state.recordedMillis / 1000}s" else ""
+            visibility = if (recording) View.VISIBLE else View.GONE
+        }
+        progressView?.apply {
+            progress = (state.level.coerceIn(0f, 1f) * 100).toInt()
+            visibility = if (recording) View.VISIBLE else View.GONE
+        }
         dictateButton?.apply {
             isEnabled = accepted && state.phase !in setOf(
                 DictationPhase.FINALIZING,
                 DictationPhase.UPLOADING,
                 DictationPhase.TRANSCRIBING,
+                DictationPhase.INSERTING,
             )
             text = when {
                 state.phase == DictationPhase.LISTENING -> getString(R.string.ime_finish)
                 state.phase.isBusy -> getString(R.string.ime_cancel)
+                state.phase == DictationPhase.PERMISSION_REPAIR || state.phase == DictationPhase.FAILED ->
+                    getString(R.string.ime_open_app)
                 else -> getString(R.string.ime_dictate)
             }
             contentDescription = text

--- a/android/app/src/main/res/layout/input_method_view.xml
+++ b/android/app/src/main/res/layout/input_method_view.xml
@@ -21,6 +21,36 @@
         android:textColor="@color/keyboard_on_surface"
         android:textSize="14sp" />
 
+    <ProgressBar
+        android:id="@+id/ime_progress"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="4dp"
+        android:layout_marginTop="6dp"
+        android:max="100"
+        android:progress="0"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/ime_partial"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:ellipsize="end"
+        android:maxLines="2"
+        android:textColor="@color/keyboard_on_surface"
+        android:textSize="13sp"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/ime_elapsed"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textColor="@color/keyboard_on_surface"
+        android:textSize="12sp"
+        android:visibility="gone" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="ime_dictate">Dictate</string>
     <string name="ime_finish">Finish</string>
     <string name="ime_cancel">Cancel</string>
+    <string name="ime_open_app">Open VocaPhone</string>
 
     <string name="bubble_dictate">Dictate</string>
     <string name="bubble_finish">Finish dictation</string>


### PR DESCRIPTION
## Summary
- acquire and release transient audio focus for microphone capture
- turn calls, Siri, route interruptions and dead audio reads into an explicit cancelled failure
- ensure user cancellation wins over a simultaneous capture error
- cancel an active IME-owned session when the keyboard service is destroyed
- expose streaming partial text, level and elapsed time in the keyboard
- make permission and failed states open the companion app for repair

## Verification
- ./gradlew assembleDebug testDebugUnitTest lintDebug
- ./gradlew assembleRelease
- signed release build completed with R8/minification
- PR 1 physical device validation remains available on the POCO F1

## Base
This is intentionally stacked on PR #52.