### PR TITLE
Improve iOS and Android transcription latency

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/audio/AudioCapture.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/audio/AudioCapture.kt
@@ -115,13 +115,25 @@ class AudioCapture(
         }
     }
 
+    @Synchronized
     fun stop() {
         running.set(false)
-        thread?.let { runCatching { it.join(500) } }
+        val recorder = record
+        // AudioRecord.read is blocking. Stop the recorder first so the read loop
+        // wakes immediately; joining before stop made Finish wait up to 500 ms.
+        recorder?.let {
+            runCatching {
+                if (it.state == AudioRecord.STATE_INITIALIZED &&
+                    it.recordingState == AudioRecord.RECORDSTATE_RECORDING
+                ) {
+                    it.stop()
+                }
+            }
+        }
+        thread?.takeIf { it !== Thread.currentThread() }?.let { runCatching { it.join(500) } }
         thread = null
-        record?.let { recorder ->
-            runCatching { if (recorder.state == AudioRecord.STATE_INITIALIZED) recorder.stop() }
-            runCatching { recorder.release() }
+        recorder?.let {
+            runCatching { it.release() }
         }
         record = null
         releaseCommunicationDevice()

--- a/android/app/src/main/java/com/vocahq/vocaphone/data/DiagnosticLog.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/data/DiagnosticLog.kt
@@ -15,6 +15,7 @@ class DiagnosticLog(
     private val buildVersion: String = "unknown",
     private val nowMillis: () -> Long = System::currentTimeMillis,
 ) {
+    private var lineCount: Int? = null
 
     constructor(context: Context) : this(
         file = File(context.filesDir, "diagnostics/events.log"),
@@ -36,6 +37,12 @@ class DiagnosticLog(
         append(event = "action", value = action, source = source)
     }
 
+    /** Millisecond timestamps around the content-free dictation pipeline. */
+    @Synchronized
+    fun recordTiming(stage: String, source: String?) {
+        append(event = "timing", value = stage, source = source)
+    }
+
     @Synchronized
     fun read(): String = runCatching { file.takeIf(File::isFile)?.readText().orEmpty() }
         .getOrDefault("")
@@ -43,6 +50,7 @@ class DiagnosticLog(
     @Synchronized
     fun clear() {
         file.delete()
+        lineCount = 0
     }
 
     /** Keep values single-line and bounded even if a future call site is wrong. */
@@ -60,16 +68,26 @@ class DiagnosticLog(
             "source=${knownSource(source)}",
         ).joinToString(" ") + "\n"
 
-        val existing = runCatching { file.takeIf(File::isFile)?.readLines().orEmpty() }
-            .getOrDefault(emptyList())
-        val lines = (existing + line.trimEnd()).takeLast(MAX_EVENTS).toMutableList()
+        runCatching {
+            file.parentFile?.mkdirs()
+            val existingCount = lineCount ?: file.takeIf(File::isFile)
+                ?.useLines { lines -> lines.count { it.isNotBlank() } }
+                .orZero()
+            file.appendText(line)
+            lineCount = existingCount + 1
+            if (lineCount.orZero() > MAX_EVENTS || file.length() > MAX_BYTES) {
+                trim()
+            }
+        }
+    }
+
+    private fun trim() {
+        val lines = file.readLines().takeLast(MAX_EVENTS).toMutableList()
         while (lines.joinToString("\n").toByteArray(Charsets.UTF_8).size > MAX_BYTES && lines.isNotEmpty()) {
             lines.removeAt(0)
         }
-        runCatching {
-            file.parentFile?.mkdirs()
-            file.writeText(lines.joinToString("\n") + if (lines.isNotEmpty()) "\n" else "")
-        }
+        file.writeText(lines.joinToString("\n") + if (lines.isNotEmpty()) "\n" else "")
+        lineCount = lines.size
     }
 
     private fun knownEvent(value: String): String = value.takeIf { it in EVENTS } ?: "unknown"
@@ -78,6 +96,7 @@ class DiagnosticLog(
         "state" -> value.takeIf { it in STATES } ?: "unknown"
         "error" -> value.takeIf { it in ERROR_CATEGORIES } ?: "unknown"
         "action" -> value.takeIf { it in ACTIONS } ?: "unknown"
+        "timing" -> value.takeIf { it in TIMING_STAGES } ?: "unknown"
         else -> "unknown"
     }
 
@@ -88,7 +107,7 @@ class DiagnosticLog(
         const val MAX_EVENTS = 200
         const val MAX_BYTES = 48 * 1024
         const val MAX_VALUE_LENGTH = 64
-        val EVENTS = setOf("state", "error", "action")
+        val EVENTS = setOf("state", "error", "action", "timing")
         val SOURCES = setOf("IME", "COMPANION_APP", "none")
         val ERROR_CATEGORIES = setOf("audio", "gateway", "insertion", "settings", "setup", "unknown")
         val ACTIONS = setOf(
@@ -104,6 +123,19 @@ class DiagnosticLog(
             "keyboard_destroyed",
             "unknown",
         )
+        val TIMING_STAGES = setOf(
+            "finish_requested",
+            "capture_stopped",
+            "stream_handshake_started",
+            "stream_ready",
+            "batch_fallback",
+            "upload_started",
+            "upload_completed",
+            "transcription_started",
+            "transcript_ready",
+            "insertion_started",
+            "insertion_completed",
+        )
         val STATES = setOf(
             "IDLE",
             "LISTENING",
@@ -118,6 +150,8 @@ class DiagnosticLog(
         )
     }
 }
+
+private fun Int?.orZero(): Int = this ?: 0
 
 private fun packageVersion(context: Context): String = runCatching {
     context.packageManager.getPackageInfo(context.packageName, 0).versionName

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -19,17 +19,23 @@ import com.vocahq.vocaphone.data.HistoryRepository
 import com.vocahq.vocaphone.data.DiagnosticLog
 import com.vocahq.vocaphone.gateway.GatewayClient
 import com.vocahq.vocaphone.gateway.GatewayException
+import com.vocahq.vocaphone.gateway.GatewayAudioStream
+import com.vocahq.vocaphone.gateway.GatewayStreamingPolicy
 import com.vocahq.vocaphone.gateway.StreamingUnavailableException
 import com.vocahq.vocaphone.settings.VocaPhoneSettings
 import com.vocahq.vocaphone.settings.SettingsRepository
 import java.io.File
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -38,8 +44,10 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 
 /** Where a dictation was started from, which decides where its transcript goes. */
 enum class DictationSource {
@@ -76,7 +84,7 @@ class DictationController(
     private var activeSource: DictationSource? = null
 
     @Volatile
-    private var finishRequested = false
+    private var finishSignal = CompletableDeferred<Unit>()
 
     @Volatile
     private var cancelRequested = false
@@ -100,7 +108,7 @@ class DictationController(
         if (pipeline?.isActive == true) return
         activeSource = source
         diagnostics.recordAction("start", source.name)
-        finishRequested = false
+        finishSignal = CompletableDeferred()
         cancelRequested = false
         pipeline = scope.launch {
             val configuration = settings.current()
@@ -127,13 +135,14 @@ class DictationController(
     }
 
     fun finish() {
-        finishRequested = true
+        finishSignal.complete(Unit)
+        diagnostics.recordTiming("finish_requested", activeSource?.name)
     }
 
     fun cancel() {
         diagnostics.recordAction("cancel", activeSource?.name)
         cancelRequested = true
-        finishRequested = true
+        finishSignal.complete(Unit)
         capture?.stop()
         if (_state.value.phase != DictationPhase.LISTENING) {
             pipeline?.cancel()
@@ -205,56 +214,63 @@ class DictationController(
         audioDirectory.mkdirs()
         val wavFile = File(audioDirectory, "$sessionId.wav")
         val client = GatewayClient(configuration.gatewayUrl, token)
-
-        _state.value = DictationState(
-            sessionId = sessionId,
-            phase = DictationPhase.LISTENING,
-            language = configuration.effectiveLanguage,
-            style = configuration.style,
-            startedAtElapsedMillis = SystemClock.elapsedRealtime(),
+        val sessionFinishSignal = finishSignal
+        val frames = Channel<ShortArray>(capacity = FILE_FRAME_BUFFER_CAPACITY)
+        val shouldAttemptStreaming = GatewayStreamingPolicy.shouldAttemptStreaming(
+            supported = configuration.lastStreamingSupported,
+            checkedAtMillis = configuration.lastEngineCheckedAtMillis,
         )
-
-        // Streaming is preferred but never required: a gateway whose engine has no
-        // streaming support answers the handshake and we fall back to batch.
-        val stream = try {
-            client.openStream(
-                sessionId = sessionId,
-                language = configuration.effectiveLanguage.wireValue,
-                style = configuration.style.wireValue,
-                sampleRate = CaptureFormat.SAMPLE_RATE,
-            ).also { it.connect() }
-        } catch (_: StreamingUnavailableException) {
+        val streamFrames = if (shouldAttemptStreaming) {
+            Channel<ShortArray>(capacity = STREAM_FRAME_BUFFER_CAPACITY)
+        } else {
             null
-        } catch (error: GatewayException) {
-            fail(sessionId, error, wavFile = null, configuration = configuration)
-            return
         }
-        _state.update { it.copy(streaming = stream != null) }
-
-        val frames = Channel<ShortArray>(capacity = 64, onBufferOverflow = BufferOverflow.DROP_OLDEST)
         val writer = WavWriter(wavFile)
-        var captureError: Throwable? = null
+        val captureError = AtomicReference<Throwable?>()
+        val streamReference = AtomicReference<GatewayAudioStream?>()
+        val streamAcceptingFrames = AtomicBoolean(streamFrames != null)
+        val droppedStreamFrames = AtomicInteger()
+        val batchFallbackRecorded = AtomicBoolean()
+        fun recordBatchFallback() {
+            if (batchFallbackRecorded.compareAndSet(false, true)) {
+                diagnostics.recordTiming("batch_fallback", source.name)
+            }
+        }
 
         val recorder = AudioCapture(
             context = context,
             preference = configuration.microphone,
-            onFrame = { samples, count -> frames.trySend(samples.copyOf(count)) },
+            onFrame = { samples, count ->
+                val frame = samples.copyOf(count)
+                if (frames.trySend(frame).isFailure) {
+                    captureError.compareAndSet(
+                        null,
+                        IllegalStateException("Audio processing could not keep up."),
+                    )
+                    sessionFinishSignal.complete(Unit)
+                }
+                if (streamAcceptingFrames.get() && streamFrames?.trySend(frame)?.isFailure == true) {
+                    droppedStreamFrames.incrementAndGet()
+                    streamAcceptingFrames.set(false)
+                    streamFrames.cancel()
+                }
+            },
             onError = { error ->
-                captureError = error
-                finishRequested = true
+                captureError.compareAndSet(null, error)
+                sessionFinishSignal.complete(Unit)
             },
         )
         capture = recorder
         if (!recorder.start()) {
             frames.close()
+            streamFrames?.close()
             writer.close()
             wavFile.delete()
-            stream?.cancel()
             fail(
                 sessionId,
                 GatewayException(
                     "microphone_unavailable",
-                    captureError?.message ?: "The microphone is not available right now.",
+                    captureError.get()?.message ?: "The microphone is not available right now.",
                     recoverable = true,
                 ),
                 wavFile = null,
@@ -263,17 +279,20 @@ class DictationController(
             return
         }
 
+        val captureStartedAt = SystemClock.elapsedRealtime()
+        _state.value = DictationState(
+            sessionId = sessionId,
+            phase = DictationPhase.LISTENING,
+            language = configuration.effectiveLanguage,
+            style = configuration.style,
+            startedAtElapsedMillis = captureStartedAt,
+        )
+
         // Frames are drained off the capture thread: file writes and socket sends
         // must never stall the AudioRecord read loop.
         val drain = scope.launch(Dispatchers.IO) {
-            var scratch = ByteArray(0)
             for (frame in frames) {
                 writer.write(frame, frame.size)
-                if (stream != null) {
-                    if (scratch.size < frame.size * 4) scratch = ByteArray(frame.size * 4)
-                    PcmConversion.pcm16ToFloat32LittleEndian(frame, frame.size, scratch)
-                    stream.sendFrames(scratch, frame.size * 4)
-                }
                 val level = PcmConversion.level(frame, frame.size)
                 _state.update { current ->
                     if (current.phase != DictationPhase.LISTENING) {
@@ -282,7 +301,8 @@ class DictationController(
                         current.copy(
                             level = level,
                             recordedMillis = writer.durationMillis,
-                            partialTranscript = stream?.latestPartial() ?: current.partialTranscript,
+                            partialTranscript = streamReference.get()?.latestPartial()
+                                ?: current.partialTranscript,
                             inputRouteLabel = recorder.currentRouteLabel() ?: current.inputRouteLabel,
                         )
                     }
@@ -290,12 +310,73 @@ class DictationController(
             }
         }
 
-        awaitFinish()
+        val streamPump = streamFrames?.let { channel ->
+            scope.launch(Dispatchers.IO) {
+                val candidate = client.openStream(
+                    sessionId = sessionId,
+                    language = configuration.effectiveLanguage.wireValue,
+                    style = configuration.style.wireValue,
+                    sampleRate = CaptureFormat.SAMPLE_RATE,
+                )
+                var ready = false
+                try {
+                    diagnostics.recordTiming("stream_handshake_started", source.name)
+                    candidate.connect()
+                    if (!currentCoroutineContext().isActive) return@launch
+                    ready = true
+                    streamReference.set(candidate)
+                    diagnostics.recordTiming("stream_ready", source.name)
+                    _state.update { it.copy(streaming = true) }
+
+                    var scratch = ByteArray(0)
+                    for (frame in channel) {
+                        if (scratch.size < frame.size * 4) scratch = ByteArray(frame.size * 4)
+                        PcmConversion.pcm16ToFloat32LittleEndian(frame, frame.size, scratch)
+                        if (!candidate.sendFrames(scratch, frame.size * 4)) {
+                            droppedStreamFrames.incrementAndGet()
+                            streamAcceptingFrames.set(false)
+                            break
+                        }
+                    }
+                } catch (_: StreamingUnavailableException) {
+                    streamAcceptingFrames.set(false)
+                    channel.cancel()
+                    recordBatchFallback()
+                } catch (_: GatewayException) {
+                    // Streaming is an optimization. The complete WAV remains the
+                    // authoritative retry path for reachability and auth errors.
+                    streamAcceptingFrames.set(false)
+                    channel.cancel()
+                    recordBatchFallback()
+                } finally {
+                    if (!ready || !currentCoroutineContext().isActive) {
+                        candidate.cancel()
+                        streamReference.compareAndSet(candidate, null)
+                    }
+                }
+            }
+        }
+        if (streamFrames == null) recordBatchFallback()
+
+        awaitFinish(sessionFinishSignal)
         recorder.stop()
+        diagnostics.recordTiming("capture_stopped", source.name)
         capture = null
         frames.close()
+        streamAcceptingFrames.set(false)
+        streamFrames?.close()
         drain.join()
         writer.close()
+
+        var stream = streamReference.get()
+        if (stream == null) {
+            streamPump?.cancel()
+            streamPump?.join()
+            recordBatchFallback()
+        } else {
+            streamPump?.join()
+            stream = streamReference.get()
+        }
 
         if (cancelRequested) {
             stream?.cancel()
@@ -304,7 +385,7 @@ class DictationController(
             return
         }
 
-        captureError?.let { error ->
+        captureError.get()?.let { error ->
             diagnostics.recordError("audio", source.name)
             stream?.cancel()
             wavFile.delete()
@@ -335,11 +416,13 @@ class DictationController(
             return
         }
 
-        if (stream != null) {
+        if (stream != null && droppedStreamFrames.get() == 0) {
             _state.update { it.copy(phase = DictationPhase.TRANSCRIBING) }
             val transcript = try {
+                diagnostics.recordTiming("transcription_started", source.name)
                 stream.finish()
             } catch (_: StreamingUnavailableException) {
+                recordBatchFallback()
                 null
             } catch (error: GatewayException) {
                 if (!error.recoverable) {
@@ -347,6 +430,7 @@ class DictationController(
                     fail(sessionId, error, wavFile = null, configuration = configuration)
                     return
                 }
+                recordBatchFallback()
                 null
             }
             val cleaned = TranscriptSanitizer.clean(transcript)
@@ -362,6 +446,9 @@ class DictationController(
             }
             // The stream failed after audio was captured; the complete WAV on disk
             // is exactly what the batch endpoints need.
+        } else {
+            stream?.cancel()
+            recordBatchFallback()
         }
 
         deliverBatch(
@@ -379,17 +466,30 @@ class DictationController(
      * Recording follows the user across apps until they press Finish, warning a
      * minute before the cap and stopping at it rather than recording forever.
      */
-    private suspend fun awaitFinish() {
-        var warned = false
-        while (!finishRequested) {
-            val elapsed = SystemClock.elapsedRealtime() - _state.value.startedAtElapsedMillis
-            if (!warned && elapsed >= DictationState.RECORDING_WARNING_MILLIS) {
-                warned = true
-                _state.update { it.copy(approachingLimit = true) }
-            }
-            if (elapsed >= DictationState.MAXIMUM_RECORDING_MILLIS) return
-            delay(100)
+    private suspend fun awaitFinish(signal: CompletableDeferred<Unit>) {
+        val startedAt = _state.value.startedAtElapsedMillis
+        if (awaitSignalUntil(
+                signal,
+                startedAt + DictationState.RECORDING_WARNING_MILLIS,
+            )
+        ) {
+            return
         }
+        _state.update { it.copy(approachingLimit = true) }
+        awaitSignalUntil(signal, startedAt + DictationState.MAXIMUM_RECORDING_MILLIS)
+    }
+
+    private suspend fun awaitSignalUntil(
+        signal: CompletableDeferred<Unit>,
+        deadlineElapsedMillis: Long,
+    ): Boolean {
+        if (signal.isCompleted) return true
+        val remaining = deadlineElapsedMillis - SystemClock.elapsedRealtime()
+        if (remaining <= 0) return signal.isCompleted
+        return withTimeoutOrNull(remaining) {
+            signal.await()
+            true
+        } ?: false
     }
 
     private suspend fun deliverBatch(
@@ -404,8 +504,11 @@ class DictationController(
         try {
             _state.update { it.copy(phase = DictationPhase.UPLOADING) }
             client.createSession(sessionId, language, style)
+            diagnostics.recordTiming("upload_started", source.name)
             client.uploadAudio(sessionId, wavFile)
+            diagnostics.recordTiming("upload_completed", source.name)
             _state.update { it.copy(phase = DictationPhase.TRANSCRIBING) }
+            diagnostics.recordTiming("transcription_started", source.name)
             val session = client.finish(sessionId)
             // Marker-only output means the model heard nothing worth writing.
             val transcript = TranscriptSanitizer.clean(session.transcript)
@@ -429,6 +532,7 @@ class DictationController(
         configuration: VocaPhoneSettings,
         source: DictationSource,
     ) {
+        diagnostics.recordTiming("transcript_ready", source.name)
         val target = when (source) {
             DictationSource.IME -> imeInserter
             DictationSource.COMPANION_APP -> null
@@ -454,6 +558,7 @@ class DictationController(
         }
 
         _state.update { it.copy(phase = DictationPhase.INSERTING, transcript = transcript) }
+        diagnostics.recordTiming("insertion_started", source.name)
         // The IME connection is reacquired here rather than at Start, so the
         // transcript is committed to the editor still owned by the keyboard.
         val report = target.insert(transcript)
@@ -469,6 +574,9 @@ class DictationController(
             if (report.outcome == InsertionOutcome.INSERTED) "inserted" else "insertion_failed",
             source.name,
         )
+        if (report.outcome == InsertionOutcome.INSERTED) {
+            diagnostics.recordTiming("insertion_completed", source.name)
+        }
         _state.value = _state.value.copy(
             phase = if (report.outcome == InsertionOutcome.INSERTED) {
                 DictationPhase.INSERTED
@@ -537,5 +645,11 @@ class DictationController(
 
         /** How long the "Inserted" confirmation stays before the keyboard goes idle. */
         const val INSERTED_LINGER_MILLIS = 2_000L
+
+        /** File writing should stay far ahead of this six-second safety buffer. */
+        const val FILE_FRAME_BUFFER_CAPACITY = 64
+
+        /** Covers the eight-second socket timeout without unbounded PCM growth. */
+        const val STREAM_FRAME_BUFFER_CAPACITY = 96
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/gateway/GatewayStreamingPolicy.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/gateway/GatewayStreamingPolicy.kt
@@ -1,0 +1,20 @@
+package com.vocahq.vocaphone.gateway
+
+/**
+ * Avoids an unnecessary WebSocket handshake when a recent health check says
+ * the selected model is batch-only. Unknown or stale data still negotiates so
+ * a model changed from the gateway dashboard becomes usable automatically.
+ */
+object GatewayStreamingPolicy {
+    const val CAPABILITY_FRESHNESS_MILLIS = 5 * 60 * 1000L
+
+    fun shouldAttemptStreaming(
+        supported: Boolean,
+        checkedAtMillis: Long?,
+        nowMillis: Long = System.currentTimeMillis(),
+    ): Boolean {
+        val age = checkedAtMillis?.let(nowMillis::minus) ?: return true
+        if (age < 0 || age > CAPABILITY_FRESHNESS_MILLIS) return true
+        return supported
+    }
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -50,6 +51,7 @@ data class VocaPhoneSettings(
     val lastEngine: String = "",
     val lastEngineReady: Boolean = false,
     val lastStreamingSupported: Boolean = false,
+    val lastEngineCheckedAtMillis: Long? = null,
     /**
      * Languages the gateway's loaded model covers, empty when it made no claim.
      * Drives which options the language picker offers rather than what it hides.
@@ -94,11 +96,17 @@ class SettingsRepository(private val context: Context) {
             preferences[Keys.GATEWAY_URL] = url
             preferences[Keys.TOKEN_CIPHERTEXT] = sealed.ciphertext
             preferences[Keys.TOKEN_NONCE] = sealed.nonce
+            preferences.clearEngineStatus()
         }
     }
 
     /** Corrects the address while leaving the sealed token exactly as it is. */
-    suspend fun setGatewayUrl(url: String) = put(Keys.GATEWAY_URL, url)
+    suspend fun setGatewayUrl(url: String) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.GATEWAY_URL] = url
+            preferences.clearEngineStatus()
+        }
+    }
 
     suspend fun clearGateway() {
         context.dataStore.edit { preferences ->
@@ -108,6 +116,7 @@ class SettingsRepository(private val context: Context) {
             preferences.remove(Keys.LAST_ENGINE)
             preferences.remove(Keys.LAST_ENGINE_READY)
             preferences.remove(Keys.LAST_STREAMING)
+            preferences.remove(Keys.LAST_ENGINE_CHECKED_AT)
             preferences.remove(Keys.MODEL_LANGUAGES)
             preferences.remove(Keys.MODEL_DETECTS_LANGUAGE)
         }
@@ -129,6 +138,7 @@ class SettingsRepository(private val context: Context) {
         engine: String,
         ready: Boolean,
         streamingSupported: Boolean,
+        checkedAtMillis: Long = System.currentTimeMillis(),
         modelLanguages: Set<String> = emptySet(),
         modelDetectsLanguage: Boolean = false,
     ) {
@@ -136,6 +146,7 @@ class SettingsRepository(private val context: Context) {
             preferences[Keys.LAST_ENGINE] = engine
             preferences[Keys.LAST_ENGINE_READY] = ready
             preferences[Keys.LAST_STREAMING] = streamingSupported
+            preferences[Keys.LAST_ENGINE_CHECKED_AT] = checkedAtMillis
             preferences[Keys.MODEL_LANGUAGES] = modelLanguages
             preferences[Keys.MODEL_DETECTS_LANGUAGE] = modelDetectsLanguage
         }
@@ -156,6 +167,7 @@ class SettingsRepository(private val context: Context) {
         lastEngine = this[Keys.LAST_ENGINE].orEmpty(),
         lastEngineReady = this[Keys.LAST_ENGINE_READY] ?: false,
         lastStreamingSupported = this[Keys.LAST_STREAMING] ?: false,
+        lastEngineCheckedAtMillis = this[Keys.LAST_ENGINE_CHECKED_AT],
         modelLanguages = this[Keys.MODEL_LANGUAGES].orEmpty(),
         modelDetectsLanguage = this[Keys.MODEL_DETECTS_LANGUAGE] ?: false,
     )
@@ -172,7 +184,17 @@ class SettingsRepository(private val context: Context) {
         val LAST_ENGINE = stringPreferencesKey("last_engine")
         val LAST_ENGINE_READY = booleanPreferencesKey("last_engine_ready")
         val LAST_STREAMING = booleanPreferencesKey("last_streaming_supported")
+        val LAST_ENGINE_CHECKED_AT = longPreferencesKey("last_engine_checked_at")
         val MODEL_LANGUAGES = stringSetPreferencesKey("model_languages")
         val MODEL_DETECTS_LANGUAGE = booleanPreferencesKey("model_detects_language")
+    }
+
+    private fun androidx.datastore.preferences.core.MutablePreferences.clearEngineStatus() {
+        remove(Keys.LAST_ENGINE)
+        remove(Keys.LAST_ENGINE_READY)
+        remove(Keys.LAST_STREAMING)
+        remove(Keys.LAST_ENGINE_CHECKED_AT)
+        remove(Keys.MODEL_LANGUAGES)
+        remove(Keys.MODEL_DETECTS_LANGUAGE)
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/data/DiagnosticLogTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/data/DiagnosticLogTest.kt
@@ -18,6 +18,7 @@ class DiagnosticLogTest {
             )
 
             log.recordState("LISTENING", "IME")
+            log.recordTiming("finish_requested", "IME")
             log.recordError("settings", "IME")
             log.recordError("https://token@homelab.example:8765", "IME")
             log.recordAction("transcript=never persist this", "IME")
@@ -25,12 +26,31 @@ class DiagnosticLogTest {
             val output = log.read()
             assertTrue(output.contains("ts=1234"))
             assertTrue(output.contains("event=state value=LISTENING source=IME"))
+            assertTrue(output.contains("event=timing value=finish_requested source=IME"))
             assertTrue(output.contains("event=error value=settings source=IME"))
             assertTrue(output.contains("event=error value=unknown source=IME"))
             assertTrue(output.contains("event=action value=unknown source=IME"))
             assertFalse(output.contains("homelab"))
             assertFalse(output.contains("transcript"))
             assertFalse(output.contains("token"))
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `timing stages reject arbitrary values`() {
+        val directory = Files.createTempDirectory("vocaphone-diagnostics").toFile()
+        try {
+            val log = DiagnosticLog(directory.resolve("events.log"), nowMillis = { 4321L })
+            log.recordTiming("transcript_ready", "COMPANION_APP")
+            log.recordTiming("transcript=private", "COMPANION_APP")
+
+            val output = log.read()
+            assertTrue(output.contains("ts=4321"))
+            assertTrue(output.contains("event=timing value=transcript_ready"))
+            assertTrue(output.contains("event=timing value=unknown"))
+            assertFalse(output.contains("private"))
         } finally {
             directory.deleteRecursively()
         }

--- a/android/app/src/test/java/com/vocahq/vocaphone/gateway/GatewayStreamingPolicyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/gateway/GatewayStreamingPolicyTest.kt
@@ -1,0 +1,43 @@
+package com.vocahq.vocaphone.gateway
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GatewayStreamingPolicyTest {
+    @Test
+    fun `fresh batch capability skips streaming negotiation`() {
+        assertFalse(
+            GatewayStreamingPolicy.shouldAttemptStreaming(
+                supported = false,
+                checkedAtMillis = 10_000L,
+                nowMillis = 20_000L,
+            )
+        )
+    }
+
+    @Test
+    fun `unknown or stale capability negotiates again`() {
+        assertTrue(
+            GatewayStreamingPolicy.shouldAttemptStreaming(
+                supported = false,
+                checkedAtMillis = null,
+                nowMillis = 20_000L,
+            )
+        )
+        assertTrue(
+            GatewayStreamingPolicy.shouldAttemptStreaming(
+                supported = false,
+                checkedAtMillis = 10_000L,
+                nowMillis = 10_000L + GatewayStreamingPolicy.CAPABILITY_FRESHNESS_MILLIS + 1,
+            )
+        )
+        assertTrue(
+            GatewayStreamingPolicy.shouldAttemptStreaming(
+                supported = true,
+                checkedAtMillis = 10_000L,
+                nowMillis = 20_000L,
+            )
+        )
+    }
+}

--- a/ios/VocaPhoneActivityShared/FinishRecordingIntent.swift
+++ b/ios/VocaPhoneActivityShared/FinishRecordingIntent.swift
@@ -22,6 +22,7 @@ struct FinishRecordingIntent: LiveActivityIntent {
               record.state == .recording
         else { return .result() }
 
+        DiagnosticLog.record(.finishRequested, source: .liveActivity)
         try record.transition(to: .finalizing)
         try SharedStore.shared.save(record)
         return .result()

--- a/ios/VocaPhoneApp/Networking/GatewayClient.swift
+++ b/ios/VocaPhoneApp/Networking/GatewayClient.swift
@@ -26,6 +26,10 @@ enum GatewayStatusPreferences {
     static let healthMessageKey = "gatewayHealthMessage"
     static let engineKey = "gatewayEngine"
     static let engineReadyKey = "gatewayEngineReady"
+    static let streamingSupportedKey = "gatewayStreamingSupported"
+    static let streamingSupportKnownKey = "gatewayStreamingSupportKnown"
+    static let streamingSupportCheckedAtKey = "gatewayStreamingSupportCheckedAt"
+    static let streamingSupportBaseURLKey = "gatewayStreamingSupportBaseURL"
 
     /// Both the setup checklist and the settings screen read this state, so the
     /// writes live in one place rather than being duplicated per view.
@@ -45,6 +49,33 @@ enum GatewayStatusPreferences {
     static func storeLanguageSupport(_ health: GatewayHealth?) {
         KeyboardPreferences.modelLanguages = Set(health?.languages ?? [])
         KeyboardPreferences.modelDetectsLanguage = health?.detectsLanguageAutomatically ?? false
+    }
+
+    static func storeStreamingSupport(_ supported: Bool?, for baseURL: URL?) {
+        let defaults = UserDefaults.standard
+        guard let supported, let baseURL else {
+            defaults.removeObject(forKey: streamingSupportedKey)
+            defaults.set(false, forKey: streamingSupportKnownKey)
+            defaults.removeObject(forKey: streamingSupportCheckedAtKey)
+            defaults.removeObject(forKey: streamingSupportBaseURLKey)
+            return
+        }
+        defaults.set(supported, forKey: streamingSupportedKey)
+        defaults.set(true, forKey: streamingSupportKnownKey)
+        defaults.set(Date(), forKey: streamingSupportCheckedAtKey)
+        defaults.set(baseURL.absoluteString, forKey: streamingSupportBaseURLKey)
+    }
+
+    static func shouldAttemptStreaming(for baseURL: URL, now: Date = Date()) -> Bool {
+        let defaults = UserDefaults.standard
+        let supported = defaults.bool(forKey: streamingSupportedKey)
+        return GatewayStreamingPolicy.shouldAttemptStreaming(
+            supported: defaults.bool(forKey: streamingSupportKnownKey) ? supported : nil,
+            checkedAt: defaults.object(forKey: streamingSupportCheckedAtKey) as? Date,
+            cachedBaseURL: defaults.string(forKey: streamingSupportBaseURLKey),
+            currentBaseURL: baseURL,
+            now: now
+        )
     }
 }
 

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -225,6 +225,7 @@ final class RecordingCoordinator {
                 ready: false
             )
             GatewayStatusPreferences.storeLanguageSupport(nil)
+            GatewayStatusPreferences.storeStreamingSupport(nil, for: nil)
             return
         }
         let client = GatewayClient(baseURL: baseURL, token: token)
@@ -240,6 +241,10 @@ final class RecordingCoordinator {
                 ready: health.engineReady
             )
             GatewayStatusPreferences.storeLanguageSupport(health)
+            GatewayStatusPreferences.storeStreamingSupport(
+                health.streamingSupported,
+                for: baseURL
+            )
         } catch let GatewayError.api(status, _) where status == 401 {
             GatewayStatusPreferences.store(
                 message: "Gateway reachable, but the pairing token was rejected.",
@@ -247,6 +252,7 @@ final class RecordingCoordinator {
                 ready: false
             )
             GatewayStatusPreferences.storeLanguageSupport(nil)
+            GatewayStatusPreferences.storeStreamingSupport(nil, for: nil)
         } catch {
             GatewayStatusPreferences.store(
                 message: "Gateway test failed: \(error.localizedDescription)",
@@ -254,6 +260,7 @@ final class RecordingCoordinator {
                 ready: false
             )
             GatewayStatusPreferences.storeLanguageSupport(nil)
+            GatewayStatusPreferences.storeStreamingSupport(nil, for: nil)
         }
     }
 
@@ -298,6 +305,7 @@ final class RecordingCoordinator {
 
     func requestFinish() {
         guard var record = activeRecord, record.state == .recording else { return }
+        DiagnosticLog.record(.finishRequested)
         do {
             try record.transition(to: .finalizing)
             try store.save(record)
@@ -429,14 +437,18 @@ final class RecordingCoordinator {
             record = latestRecord
             let audioURL = try recorder.start(sessionID: record.sessionID, directory: directory)
             if let client = gatewayClient, let chunks = recorder.pcmChunks {
-                await streamingBridge.start(
-                    client: client,
-                    sessionID: record.sessionID,
-                    language: record.language,
-                    style: record.style,
-                    sampleRate: Int(recorder.transcriptionSampleRate),
-                    chunks: chunks
-                )
+                if GatewayStatusPreferences.shouldAttemptStreaming(for: client.baseURL) {
+                    await streamingBridge.start(
+                        client: client,
+                        sessionID: record.sessionID,
+                        language: record.language,
+                        style: record.style,
+                        sampleRate: Int(recorder.transcriptionSampleRate),
+                        chunks: chunks
+                    )
+                } else {
+                    await streamingBridge.skipUnsupportedModel()
+                }
             }
             if record.state == .launchingApp {
                 try record.transition(to: .recording)
@@ -509,8 +521,11 @@ final class RecordingCoordinator {
         pollingTask?.cancel()
         pollingTask = Task { [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(for: .milliseconds(1_500))
                 guard let self else { return }
+                guard let interval = SessionPollingPolicy.interval(for: self.activeRecord?.state)
+                else { return }
+                try? await Task.sleep(for: .milliseconds(Int(interval * 1_000)))
+                guard !Task.isCancelled else { return }
                 await self.handleSharedStateSignal()
             }
         }
@@ -526,8 +541,10 @@ final class RecordingCoordinator {
         let output = recorder.stopSession(
             keepAudioSessionActive: true
         ) ?? resolvedAudioURL(for: record)
+        DiagnosticLog.record(.captureStopped)
         if wasRecording {
-            await soundFeedback.play(.stop)
+            // Feedback is optional and should never sit in front of gateway work.
+            Task { await soundFeedback.play(.stop) }
         }
         meterLevel = 0
         if shouldRemainReady {
@@ -572,6 +589,7 @@ final class RecordingCoordinator {
                 try record.transition(to: .readyToInsert)
                 try store.save(record)
                 activeRecord = record
+                DiagnosticLog.record(.transcriptReady)
                 UserDefaults.standard.set(
                     "Gateway and streaming model are ready.",
                     forKey: GatewayStatusPreferences.healthMessageKey
@@ -591,13 +609,16 @@ final class RecordingCoordinator {
                 style: record.style
             )
             record.serverJobID = created.jobID
+            DiagnosticLog.record(.uploadStarted)
             _ = try await client.uploadAudio(sessionID: record.sessionID, fileURL: output)
+            DiagnosticLog.record(.uploadCompleted)
             try record.transition(to: .transcribing)
             try store.save(record)
             activeRecord = record
             message = "Transcribing on your gateway…"
             liveActivity.update(status: "Transcribing", canFinish: false)
 
+            DiagnosticLog.record(.transcriptionStarted)
             let finished = try await client.finish(sessionID: record.sessionID)
             guard let transcript = finished.transcript, !transcript.isEmpty else {
                 throw GatewayError.api(status: 500, code: finished.errorCode ?? "empty_transcript")
@@ -607,6 +628,7 @@ final class RecordingCoordinator {
             try record.transition(to: .readyToInsert)
             try store.save(record)
             activeRecord = record
+            DiagnosticLog.record(.transcriptReady)
             UserDefaults.standard.set(
                 "Gateway and model are ready.",
                 forKey: GatewayStatusPreferences.healthMessageKey
@@ -838,9 +860,9 @@ final class RecordingCoordinator {
         )
     }
 
-    /// Fast path for keyboard and Live Activity writes. The 1.5-second polling
-    /// loop remains as recovery if iOS drops a Darwin notification or recreates
-    /// one process between the durable write and its signal.
+    /// Fast path for keyboard and Live Activity writes. Adaptive polling remains
+    /// as recovery if iOS drops a Darwin notification or recreates one process
+    /// between the durable write and its signal.
     private func handleSharedStateSignal() async {
         guard let current = activeRecord, !current.state.isTerminal else {
             await startPendingQuickDictationIfNeeded()
@@ -999,6 +1021,8 @@ private actor StreamingAudioBridge {
     private var stream: GatewayAudioStream?
     private var pump: Task<Void, Never>?
     private var failed = false
+    private var ready = false
+    private var fallbackRecorded = false
 
     func start(
         client: GatewayClient,
@@ -1007,40 +1031,74 @@ private actor StreamingAudioBridge {
         style: String,
         sampleRate: Int,
         chunks: AsyncStream<Data>
-    ) async {
+    ) {
         cancel()
-        guard let opened = try? await client.startAudioStream(
-            sessionID: sessionID,
-            language: language,
-            style: style,
-            sampleRate: sampleRate
-        ) else { return }
-
-        stream = opened
         failed = false
+        DiagnosticLog.record(.streamHandshakeStarted)
         pump = Task { [weak self] in
+            let opened: GatewayAudioStream
+            do {
+                opened = try await client.startAudioStream(
+                    sessionID: sessionID,
+                    language: language,
+                    style: style,
+                    sampleRate: sampleRate
+                )
+            } catch {
+                guard !Task.isCancelled else { return }
+                await self?.recordFallbackIfNeeded()
+                return
+            }
+            guard !Task.isCancelled else {
+                opened.cancel()
+                return
+            }
+            await self?.attach(opened)
+            DiagnosticLog.record(.streamReady)
             for await chunk in chunks {
+                guard !Task.isCancelled else { break }
                 await self?.deliver(chunk)
             }
         }
     }
 
+    func skipUnsupportedModel() {
+        cancel()
+        recordFallbackIfNeeded()
+    }
+
     /// Returns a transcript only when the whole recording reached the gateway.
     /// Any loss makes the stream untrustworthy, so the caller uploads instead.
     func finish(droppedChunks: Int) async -> String? {
+        guard droppedChunks == 0 else {
+            cancelPendingNegotiation()
+            recordFallbackIfNeeded()
+            return nil
+        }
+        guard ready else {
+            cancelPendingNegotiation()
+            recordFallbackIfNeeded()
+            return nil
+        }
         // The recorder finished the chunk stream before calling this, so the
         // pump terminates once it has drained what is still buffered.
         await pump?.value
         pump = nil
-        guard droppedChunks == 0, !failed, let stream else {
-            cancel()
+        guard !failed, let stream else {
+            stream?.cancel()
+            self.stream = nil
+            ready = false
+            recordFallbackIfNeeded()
             return nil
         }
         self.stream = nil
+        ready = false
         do {
+            DiagnosticLog.record(.transcriptionStarted)
             return try await stream.finish()
         } catch {
             stream.cancel()
+            recordFallbackIfNeeded()
             return nil
         }
     }
@@ -1051,6 +1109,28 @@ private actor StreamingAudioBridge {
         stream?.cancel()
         stream = nil
         failed = false
+        ready = false
+        fallbackRecorded = false
+    }
+
+    private func cancelPendingNegotiation() {
+        pump?.cancel()
+        pump = nil
+        stream?.cancel()
+        stream = nil
+        failed = false
+        ready = false
+    }
+
+    private func attach(_ opened: GatewayAudioStream) {
+        stream = opened
+        ready = true
+    }
+
+    private func recordFallbackIfNeeded() {
+        guard !fallbackRecorded else { return }
+        fallbackRecorded = true
+        DiagnosticLog.record(.batchFallback)
     }
 
     private func deliver(_ chunk: Data) async {

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -163,6 +163,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
               var record = try? store.load(id),
               record.state == .recording
         else { return }
+        DiagnosticLog.record(.finishRequested)
         transition(&record, to: .finalizing)
     }
 
@@ -398,6 +399,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             after: textDocumentProxy.documentContextAfterInput
         )
         do {
+            DiagnosticLog.record(.insertionStarted)
             try record.transition(to: .inserting)
             try store.save(record)
             textDocumentProxy.insertText(prepared)
@@ -406,6 +408,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             try store.save(record)
             try record.transition(to: .completed)
             try store.save(record)
+            DiagnosticLog.record(.insertionCompleted)
             activeSessionID = nil
             sessionTargetDocumentID = nil
             render(record)
@@ -506,7 +509,12 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             pollingInterval = nil
             return
         }
-        let desiredInterval: TimeInterval = record?.state == .recording ? 0.25 : 1.5
+        guard let desiredInterval = SessionPollingPolicy.interval(for: record?.state) else {
+            pollingTimer?.invalidate()
+            pollingTimer = nil
+            pollingInterval = nil
+            return
+        }
         if pollingInterval != desiredInterval {
             pollingTimer?.invalidate()
             pollingTimer = nil

--- a/ios/VocaPhoneShared/DiagnosticLog.swift
+++ b/ios/VocaPhoneShared/DiagnosticLog.swift
@@ -32,6 +32,17 @@ enum DiagnosticEvent: String, Codable, Sendable {
     case audioInputUnavailable
     case liveActivityStarted
     case liveActivityEnded
+    case finishRequested
+    case captureStopped
+    case streamHandshakeStarted
+    case streamReady
+    case batchFallback
+    case uploadStarted
+    case uploadCompleted
+    case transcriptionStarted
+    case transcriptReady
+    case insertionStarted
+    case insertionCompleted
     case operationFailed
 }
 
@@ -111,6 +122,10 @@ struct DiagnosticEntry: Codable, Equatable, Sendable {
 
     let schemaVersion: Int
     let timestamp: Date
+    /// Monotonic across processes for one device boot, with enough resolution
+    /// to distinguish notification, capture, upload and insertion delays.
+    /// Optional so diagnostics written by earlier builds still decode.
+    let uptimeMilliseconds: UInt64?
     let source: DiagnosticSource
     let event: DiagnosticEvent
     let metadata: DiagnosticMetadata
@@ -119,12 +134,16 @@ struct DiagnosticEntry: Codable, Equatable, Sendable {
 
     init(
         timestamp: Date = Date(),
+        uptimeMilliseconds: UInt64? = nil,
         source: DiagnosticSource,
         event: DiagnosticEvent,
         metadata: DiagnosticMetadata = .empty
     ) {
         schemaVersion = Self.schemaVersion
         self.timestamp = timestamp
+        self.uptimeMilliseconds = uptimeMilliseconds ?? UInt64(
+            (ProcessInfo.processInfo.systemUptime * 1_000).rounded()
+        )
         self.source = source
         self.event = event
         self.metadata = metadata

--- a/ios/VocaPhoneShared/SessionRecord.swift
+++ b/ios/VocaPhoneShared/SessionRecord.swift
@@ -168,3 +168,45 @@ struct SessionRecord: Codable, Equatable, Identifiable, Sendable {
 enum SessionTransitionError: Error, Equatable {
     case invalid(from: SessionState, to: SessionState)
 }
+
+/// Polling is only a recovery path for a dropped Darwin notification. Keep it
+/// responsive while the user is waiting for Finish or insertion, then relax it
+/// for states that require an explicit user action rather than background work.
+enum SessionPollingPolicy {
+    static let responsiveInterval: TimeInterval = 0.25
+    static let relaxedInterval: TimeInterval = 1.5
+
+    static func interval(for state: SessionState?) -> TimeInterval? {
+        guard let state, !state.isTerminal else { return nil }
+        switch state {
+        case .recording, .finalizing, .uploading, .transcribing:
+            return responsiveInterval
+        default:
+            return relaxedInterval
+        }
+    }
+}
+
+/// A recent health response is authoritative enough to avoid opening a socket
+/// that the selected model explicitly cannot use. Unknown or stale capability
+/// data still negotiates normally, so changing models in the gateway recovers
+/// without requiring the app to be re-paired.
+enum GatewayStreamingPolicy {
+    static let capabilityFreshnessInterval: TimeInterval = 5 * 60
+
+    static func shouldAttemptStreaming(
+        supported: Bool?,
+        checkedAt: Date?,
+        cachedBaseURL: String?,
+        currentBaseURL: URL,
+        now: Date = Date()
+    ) -> Bool {
+        guard let supported,
+              let checkedAt,
+              cachedBaseURL == currentBaseURL.absoluteString,
+              now.timeIntervalSince(checkedAt) >= 0,
+              now.timeIntervalSince(checkedAt) <= capabilityFreshnessInterval
+        else { return true }
+        return supported
+    }
+}

--- a/ios/VocaPhoneTests/ReliabilityFeatureTests.swift
+++ b/ios/VocaPhoneTests/ReliabilityFeatureTests.swift
@@ -2,6 +2,54 @@ import Foundation
 import Testing
 
 struct ReliabilityFeatureTests {
+    @Test func latencySensitiveSessionStatesUseResponsiveFallbackPolling() {
+        for state in [
+            SessionState.recording,
+            .finalizing,
+            .uploading,
+            .transcribing,
+        ] {
+            #expect(
+                SessionPollingPolicy.interval(for: state)
+                    == SessionPollingPolicy.responsiveInterval
+            )
+        }
+        #expect(
+            SessionPollingPolicy.interval(for: .readyToInsert)
+                == SessionPollingPolicy.relaxedInterval
+        )
+        #expect(SessionPollingPolicy.interval(for: .completed) == nil)
+    }
+
+    @Test func freshBatchCapabilitySkipsOnlyTheMatchingGateway() throws {
+        let gateway = try #require(URL(string: "http://gateway.local:8765"))
+        let checkedAt = Date(timeIntervalSince1970: 10_000)
+
+        #expect(!GatewayStreamingPolicy.shouldAttemptStreaming(
+            supported: false,
+            checkedAt: checkedAt,
+            cachedBaseURL: gateway.absoluteString,
+            currentBaseURL: gateway,
+            now: checkedAt.addingTimeInterval(30)
+        ))
+        #expect(GatewayStreamingPolicy.shouldAttemptStreaming(
+            supported: false,
+            checkedAt: checkedAt,
+            cachedBaseURL: "http://another-gateway.local:8765",
+            currentBaseURL: gateway,
+            now: checkedAt.addingTimeInterval(30)
+        ))
+        #expect(GatewayStreamingPolicy.shouldAttemptStreaming(
+            supported: false,
+            checkedAt: checkedAt,
+            cachedBaseURL: gateway.absoluteString,
+            currentBaseURL: gateway,
+            now: checkedAt.addingTimeInterval(
+                GatewayStreamingPolicy.capabilityFreshnessInterval + 1
+            )
+        ))
+    }
+
     @Test func multipleDarwinObserversReceiveTheSameSignal() {
         let semaphore = DispatchSemaphore(value: 0)
         let callbackQueue = DispatchQueue(
@@ -101,16 +149,18 @@ struct ReliabilityFeatureTests {
         DiagnosticLog.append(
             DiagnosticEntry(
                 timestamp: Date(timeIntervalSince1970: 10_000),
+                uptimeMilliseconds: 42_123,
                 source: .keyboard,
-                event: .sessionStateChanged,
+                event: .finishRequested,
                 metadata: .state(.recording)
             ),
             to: file
         )
 
         let contents = String(decoding: try Data(contentsOf: file), as: UTF8.self)
-        #expect(contents.contains("sessionStateChanged"))
+        #expect(contents.contains("finishRequested"))
         #expect(contents.contains("recording"))
+        #expect(contents.contains("42123"))
         #expect(!contents.localizedCaseInsensitiveContains("transcript"))
         #expect(!contents.localizedCaseInsensitiveContains("audioPath"))
         #expect(!contents.localizedCaseInsensitiveContains("token"))


### PR DESCRIPTION
## Summary

- start capture before streaming negotiation and skip unnecessary handshakes for recently confirmed batch-only models
- make Finish, capture shutdown, session polling, and batch fallback responsive on iOS and Android
- keep file persistence independent from streaming with bounded buffers and an intact WAV fallback
- add privacy-safe stage timing diagnostics for capture, upload, transcription, and insertion
- add focused streaming-capability and latency polling coverage

## Validation

- `./gradlew lintDebug testDebugUnitTest assembleDebug`
- full iOS test suite: 104 tests across 13 suites
- targeted iOS reliability suite: 11 tests
- unsigned generic iPhone-device build
- `git diff --check`

## Performance boundary

A batch-only speech-to-text model still begins inference after Finish. This PR removes avoidable client-side waiting but does not change the selected gateway model or silently substitute a streaming model.