### PR TITLE
build(android): merge beta.8 version bump

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -43,7 +43,7 @@ stays at 36, which is what Play requires from 31 August 2026.
 
 ## GitHub beta releases
 
-Pushing a tag such as `v0.1.0-beta.7` runs
+Pushing a tag such as `v0.1.0-beta.8` runs
 `.github/workflows/android-beta.yml`. Before tagging, bump `versionCode` and
 `versionName` in `app/build.gradle.kts`; the workflow refuses to publish when
 the tag and APK version do not match.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.vocahq.vocaphone"
         minSdk = 33
         targetSdk = 36
-        versionCode = 7
-        versionName = "0.1.0-beta.7"
+        versionCode = 8
+        versionName = "0.1.0-beta.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
## Summary
- Bump Android version code from 7 to 8.
- Set the Android version name to `0.1.0-beta.8`.
- Update the Android beta release documentation.

The `v0.1.0-beta.8` prerelease and signed APK have already been published from this commit.

## Validation
- `./gradlew assembleRelease testDebugUnitTest lintRelease`
- APK package/version verified with `aapt`.
- APK signature verified with `apksigner` against the pinned release certificate.