### PR TITLE
fix(android): keep keyboard above gesture navigation

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/LifecycleInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/LifecycleInputMethodService.kt
@@ -1,12 +1,18 @@
 package com.vocahq.vocaphone.ime
 
+import android.content.res.Configuration
 import android.graphics.Color
 import android.inputmethodservice.InputMethodService
+import android.provider.Settings
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.graphics.drawable.toDrawable
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
@@ -28,6 +34,7 @@ abstract class LifecycleInputMethodService : InputMethodService(),
     private val lifecycleRegistry = LifecycleRegistry(this)
     private val store = ViewModelStore()
     private val savedStateController = SavedStateRegistryController.create(this)
+    private var inputComposeView: ComposeView? = null
 
     final override val lifecycle: Lifecycle get() = lifecycleRegistry
     final override val viewModelStore: ViewModelStore get() = store
@@ -45,29 +52,59 @@ abstract class LifecycleInputMethodService : InputMethodService(),
             lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
         }
 
+        val surfaceColor = keyboardSurfaceColor()
         val composeView = ComposeView(this).apply {
             setViewTreeLifecycleOwner(this@LifecycleInputMethodService)
             setViewTreeViewModelStoreOwner(this@LifecycleInputMethodService)
             setViewTreeSavedStateRegistryOwner(this@LifecycleInputMethodService)
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+            // Match keyboard chrome so nav-bar padding is not a transparent hole.
+            setBackgroundColor(surfaceColor)
+            // Pad before the first measure so the IME window height includes it.
+            setPadding(0, 0, 0, navigationBarBottomInsetPx(this))
             setContent { KeyboardContent() }
+            ViewCompat.setOnApplyWindowInsetsListener(this) { view, insets ->
+                val bottom = navigationBarBottomInsetPx(view, insets)
+                if (view.paddingBottom != bottom) {
+                    view.setPadding(0, 0, 0, bottom)
+                }
+                insets
+            }
         }
-        window?.window?.decorView?.apply {
-            setViewTreeLifecycleOwner(this@LifecycleInputMethodService)
-            setViewTreeViewModelStoreOwner(this@LifecycleInputMethodService)
-            setViewTreeSavedStateRegistryOwner(this@LifecycleInputMethodService)
+        inputComposeView = composeView
+
+        window?.window?.let { imeWindow ->
+            // Edge-to-edge so navigation-bar insets are dispatched to the input view.
+            WindowCompat.setDecorFitsSystemWindows(imeWindow, false)
+            imeWindow.setBackgroundDrawable(surfaceColor.toDrawable())
+            imeWindow.decorView.apply {
+                setViewTreeLifecycleOwner(this@LifecycleInputMethodService)
+                setViewTreeViewModelStoreOwner(this@LifecycleInputMethodService)
+                setViewTreeSavedStateRegistryOwner(this@LifecycleInputMethodService)
+            }
         }
-        window?.window?.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
         return composeView
     }
 
     @Composable
     protected abstract fun KeyboardContent()
 
-    override fun onStartInputView(info: android.view.inputmethod.EditorInfo?, restarting: Boolean) {
+    override fun onStartInputView(info: EditorInfo?, restarting: Boolean) {
         super.onStartInputView(info, restarting)
         if (lifecycleRegistry.currentState == Lifecycle.State.STARTED) {
             lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+        }
+        // Insets are often only available once the IME window is showing.
+        inputComposeView?.let { view ->
+            val bottom = navigationBarBottomInsetPx(view)
+            if (view.paddingBottom != bottom) {
+                view.setPadding(0, 0, 0, bottom)
+                // First layout may have used a 0 inset; force the soft-input
+                // window to remeasure now that padding is known.
+                view.requestLayout()
+                window?.window?.decorView?.requestLayout()
+            }
+            ViewCompat.requestApplyInsets(view)
         }
     }
 
@@ -87,7 +124,43 @@ abstract class LifecycleInputMethodService : InputMethodService(),
             lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
         }
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        inputComposeView = null
         store.clear()
         super.onDestroy()
+    }
+
+    private fun keyboardSurfaceColor(): Int {
+        val night = (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+            Configuration.UI_MODE_NIGHT_YES
+        // Keep in sync with Theme.kt surfaceContainerLowest.
+        return if (night) Color.rgb(0x10, 0x12, 0x10) else Color.WHITE
+    }
+
+    private fun navigationBarBottomInsetPx(
+        view: View,
+        insets: WindowInsetsCompat? = ViewCompat.getRootWindowInsets(view),
+    ): Int {
+        if (insets != null) {
+            val navigation = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
+            val gestures = insets.getInsets(WindowInsetsCompat.Type.systemGestures()).bottom
+            val tappable = insets.getInsets(WindowInsetsCompat.Type.tappableElement()).bottom
+            val resolved = maxOf(navigation, gestures, tappable)
+            if (resolved > 0) return resolved
+        }
+
+        // IME windows often report 0 insets even when gesture nav draws over the
+        // bottom row. Fall back to the framework nav-bar height for gesture mode.
+        val navigationMode = Settings.Secure.getInt(contentResolver, "navigation_mode", 0)
+        if (navigationMode != GESTURE_NAVIGATION_MODE) return 0
+
+        val resId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
+        val fromRes = if (resId > 0) resources.getDimensionPixelSize(resId) else 0
+        val fallback = (GESTURE_NAV_FALLBACK_DP * resources.displayMetrics.density).toInt()
+        return maxOf(fromRes, fallback)
+    }
+
+    private companion object {
+        const val GESTURE_NAVIGATION_MODE = 2
+        const val GESTURE_NAV_FALLBACK_DP = 48
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- On gesture navigation, the VocaPhone keyboard drew under the system gesture handle, so the bottom key row was hard to press.
- The IME ComposeView now gets navigation-bar insets as bottom padding before the first measure, and again when the input view starts. If the window still reports 0 insets in gesture mode, we fall back to the framework `navigation_bar_height` (at least 48dp).
- Three-button navigation is unchanged: when insets are already accounted for and navigation mode is not gesture, no extra padding is added.

## Verification

- [ ] `just ios ci` (not run; Android-only change)
- [x] `./gradlew assembleDebug -PskipNative testDebugUnitTest`
- [ ] Gateway changes: n/a
- [x] Emulator test with gesture navigation (Pixel API 33, software accel; nested KVM is broken in this cloud VM)

### Before (gesture nav overlaps bottom row)

![Before: bottom keys under gesture pill](https://cursor.com/artifacts/c/art-d1f86acd-15ac-47b5-8c40-48ff85aef4de)

### After (keys clear of the gesture pill)

![After: padding above gesture pill](https://cursor.com/artifacts/c/art-7ebdfdb1-d6e6-4a45-a93a-116959cf72c2)

### Also verified for 3-button navigation bar
<img width="1011" height="851" alt="image" src="https://github.com/user-attachments/assets/950a9dac-78be-4208-9094-aac84fa8867a" />


## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for data-flow, permission, retention, or network changes (n/a)
