### PR TITLE
fix(mobile): survive another app holding the microphone

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/audio/AudioCapture.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/audio/AudioCapture.kt
@@ -7,11 +7,44 @@ import android.media.AudioFormat
 import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.media.AudioRecord
+import android.media.AudioRecordingConfiguration
 import android.media.MediaRecorder
 import android.os.Process
 import androidx.annotation.RequiresPermission
 import com.vocahq.vocaphone.core.MicrophonePreference
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.delay
+
+/**
+ * Why a capture ended without the user asking it to. Android surfaces all of
+ * these as an ordinary failure, but each one means another app took the input
+ * rather than that recording is broken — so whatever was captured first is
+ * still the user's words.
+ */
+enum class MicrophoneInterruption {
+    /** A call, an assistant, or another exclusive user took audio focus. */
+    FOCUS_LOST,
+
+    /** Android is feeding this capture zeros because another app holds the input. */
+    SILENCED,
+
+    /** The capture session was torn down underneath the read loop. */
+    CAPTURE_LOST,
+}
+
+/**
+ * A microphone another app is holding, as opposed to one that does not work.
+ * The distinction is what lets an interrupted dictation keep its audio instead
+ * of discarding a sentence the user already finished saying.
+ */
+class MicrophoneInterruptedException(
+    val interruption: MicrophoneInterruption,
+    message: String,
+) : IllegalStateException(message)
 
 /**
  * Microphone capture on its own high-priority thread. The read loop only copies
@@ -46,17 +79,25 @@ class AudioCapture(
     @Volatile
     private var audioFocusRequest: AudioFocusRequest? = null
 
+    /**
+     * The first reason capture ended. Focus loss, silencing and a dead recorder
+     * arrive together when another app takes the microphone, and only the one
+     * that arrived first explains anything.
+     */
+    private val reported = AtomicReference<Throwable?>(null)
+
+    @Volatile
+    private var watchdog: ScheduledExecutorService? = null
+
+    @Volatile
+    private var silenceCallback: AudioManager.AudioRecordingCallback? = null
+
     private val audioManager: AudioManager? get() = context.getSystemService(AudioManager::class.java)
 
     @RequiresPermission(Manifest.permission.RECORD_AUDIO)
-    fun start(): Boolean {
+    suspend fun start(): Boolean {
         if (!running.compareAndSet(false, true)) return true
-
-        if (!requestAudioFocus()) {
-            running.set(false)
-            onError(IllegalStateException("Another app is using the microphone."))
-            return false
-        }
+        reported.set(null)
 
         val minimum = AudioRecord.getMinBufferSize(
             CaptureFormat.SAMPLE_RATE,
@@ -65,7 +106,6 @@ class AudioCapture(
         )
         if (minimum <= 0) {
             running.set(false)
-            abandonAudioFocus()
             onError(IllegalStateException("This device cannot record 16 kHz mono audio."))
             return false
         }
@@ -73,52 +113,35 @@ class AudioCapture(
         // overrun the buffer and drop the middle of a sentence.
         val bufferBytes = maxOf(minimum * 4, frameSamples * CaptureFormat.BYTES_PER_SAMPLE * 8)
 
-        val recorder = try {
-            AudioRecord(
-                MediaRecorder.AudioSource.VOICE_RECOGNITION,
-                CaptureFormat.SAMPLE_RATE,
-                AudioFormat.CHANNEL_IN_MONO,
-                AudioFormat.ENCODING_PCM_16BIT,
-                bufferBytes,
-            )
-        } catch (error: Throwable) {
-            running.set(false)
-            abandonAudioFocus()
-            onError(error)
-            return false
+        // Focus is how a call announces itself mid-dictation, not permission to
+        // record. Refusing to start without it would fail dictations that would
+        // have worked, so a refusal is noted and capture is attempted anyway.
+        requestAudioFocus()
+
+        // Another app letting go of the microphone — a call ending, a screen
+        // recorder handing it back — is not instantaneous, and Android reports
+        // that gap as an ordinary failure. Retrying across it turns a lost
+        // dictation into a slightly delayed one.
+        repeat(START_ATTEMPTS) { attempt ->
+            if (attempt > 0) delay(START_RETRY_MILLIS)
+            // `stop` during the wait means the dictation is already over; a
+            // later attempt would open a recorder nothing would ever close.
+            if (!running.get()) return false
+            if (openRecorder(bufferBytes)) return true
         }
 
-        if (recorder.state != AudioRecord.STATE_INITIALIZED) {
-            recorder.release()
-            running.set(false)
-            abandonAudioFocus()
-            onError(IllegalStateException("The microphone is not available right now."))
-            return false
-        }
-
-        record = recorder
-        return try {
-            applyPreference(recorder)
-            recorder.startRecording()
-            if (recorder.recordingState != AudioRecord.RECORDSTATE_RECORDING) {
-                throw IllegalStateException("Another app is using the microphone.")
-            }
-            thread = Thread({ readLoop(recorder) }, "vocaphone-capture").apply {
-                priority = Thread.MAX_PRIORITY
-                start()
-            }
-            true
-        } catch (error: Throwable) {
-            stop()
-            onError(error)
-            false
-        }
+        running.set(false)
+        releaseCommunicationDevice()
+        abandonAudioFocus()
+        onError(unavailableMicrophone())
+        return false
     }
 
     @Synchronized
     fun stop() {
         running.set(false)
         val recorder = record
+        stopSilenceWatch(recorder)
         // AudioRecord.read is blocking. Stop the recorder first so the read loop
         // wakes immediately; joining before stop made Finish wait up to 500 ms.
         recorder?.let {
@@ -141,12 +164,77 @@ class AudioCapture(
     }
 
     /**
-     * Capturing speech owns transient audio focus. A call, Siri or another
-     * exclusive microphone user therefore turns this dictation into an explicit
-     * interruption instead of leaving a foreground service that appears alive.
+     * One attempt at owning the input. Returns false — having cleaned up after
+     * itself — when the microphone was not available this time round.
      */
-    private fun requestAudioFocus(): Boolean {
-        val manager = audioManager ?: return true
+    @Synchronized
+    @RequiresPermission(Manifest.permission.RECORD_AUDIO)
+    private fun openRecorder(bufferBytes: Int): Boolean {
+        val recorder = try {
+            AudioRecord(
+                MediaRecorder.AudioSource.VOICE_RECOGNITION,
+                CaptureFormat.SAMPLE_RATE,
+                AudioFormat.CHANNEL_IN_MONO,
+                AudioFormat.ENCODING_PCM_16BIT,
+                bufferBytes,
+            )
+        } catch (_: Throwable) {
+            return false
+        }
+        if (recorder.state != AudioRecord.STATE_INITIALIZED) {
+            runCatching { recorder.release() }
+            return false
+        }
+
+        return try {
+            applyPreference(recorder)
+            recorder.startRecording()
+            if (recorder.recordingState != AudioRecord.RECORDSTATE_RECORDING) {
+                throw IllegalStateException("The microphone did not start.")
+            }
+            record = recorder
+            watchForSilencing(recorder)
+            thread = Thread({ readLoop(recorder) }, "vocaphone-capture").apply {
+                priority = Thread.MAX_PRIORITY
+                start()
+            }
+            true
+        } catch (_: Throwable) {
+            record = null
+            stopSilenceWatch(recorder)
+            runCatching { recorder.stop() }
+            runCatching { recorder.release() }
+            releaseCommunicationDevice()
+            false
+        }
+    }
+
+    /**
+     * "Could not start" means different things to the user depending on who else
+     * is holding the input, so the cause is read once here rather than guessed
+     * at by every surface that shows the message.
+     */
+    private fun unavailableMicrophone(): MicrophoneInterruptedException {
+        val mode = runCatching { audioManager?.mode }.getOrNull()
+        val inCall = mode == AudioManager.MODE_IN_CALL || mode == AudioManager.MODE_IN_COMMUNICATION
+        return MicrophoneInterruptedException(
+            MicrophoneInterruption.SILENCED,
+            if (inCall) {
+                "The microphone is busy with a call. Try again once the call ends."
+            } else {
+                "Another app is using the microphone. Stop that recording and try again."
+            },
+        )
+    }
+
+    /**
+     * Capturing speech asks for transient exclusive focus, which is how a call
+     * or a voice assistant announces itself mid-dictation. Whether the request
+     * is granted is deliberately not acted on: focus is advisory, and the
+     * microphone is frequently usable without it.
+     */
+    private fun requestAudioFocus() {
+        val manager = audioManager ?: return
         val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
             .setAudioAttributes(
                 AudioAttributes.Builder()
@@ -155,25 +243,94 @@ class AudioCapture(
                     .build(),
             )
             .setOnAudioFocusChangeListener { change ->
-                if (change == AudioManager.AUDIOFOCUS_LOSS ||
-                    change == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT ||
-                    change == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK
-                ) {
-                    if (running.get()) {
-                        onError(IllegalStateException("Microphone access was interrupted."))
-                        running.set(false)
-                    }
+                when (change) {
+                    // The user's attention has moved to a call or an assistant,
+                    // so capture ends here and says why it did.
+                    AudioManager.AUDIOFOCUS_LOSS,
+                    AudioManager.AUDIOFOCUS_LOSS_TRANSIENT,
+                    -> interrupt(
+                        MicrophoneInterruption.FOCUS_LOST,
+                        "Something else needed the microphone. Try dictating again.",
+                    )
+                    // Ducking asks a player to turn itself down. A recording has
+                    // no volume to turn down, so a notification chime or a
+                    // navigation prompt must not end a dictation.
+                    else -> Unit
                 }
             }
             .build()
         audioFocusRequest = request
-        return manager.requestAudioFocus(request) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        manager.requestAudioFocus(request)
     }
 
     private fun abandonAudioFocus() {
         val request = audioFocusRequest ?: return
         audioFocusRequest = null
         runCatching { audioManager?.abandonAudioFocusRequest(request) }
+    }
+
+    /**
+     * Android 10 and later let two apps hold the microphone at once and simply
+     * feed the loser digital silence, reporting no error anywhere. Without this
+     * the dictation looks healthy for its whole length and then produces an
+     * empty transcript, so the silencing is turned into the interruption it is.
+     */
+    private fun watchForSilencing(recorder: AudioRecord) {
+        val executor = Executors.newSingleThreadScheduledExecutor { runnable ->
+            Thread(runnable, "vocaphone-capture-watch")
+        }
+        val callback = object : AudioManager.AudioRecordingCallback() {
+            override fun onRecordingConfigChanged(configs: List<AudioRecordingConfiguration>) {
+                if (!running.get() || configs.none { it.isClientSilenced }) return
+                // A route change can silence a capture for a few frames on its
+                // way somewhere else. Only silence that is still there a moment
+                // later is another app holding the input.
+                runCatching {
+                    executor.schedule(
+                        ::confirmSilenced,
+                        SILENCE_CONFIRMATION_MILLIS,
+                        TimeUnit.MILLISECONDS,
+                    )
+                }
+            }
+        }
+        watchdog = executor
+        silenceCallback = callback
+        runCatching { recorder.registerAudioRecordingCallback(executor, callback) }
+    }
+
+    private fun confirmSilenced() {
+        if (!running.get()) return
+        val silenced = runCatching {
+            record?.activeRecordingConfiguration?.isClientSilenced
+        }.getOrNull() ?: return
+        if (!silenced) return
+        interrupt(
+            MicrophoneInterruption.SILENCED,
+            "Another app took the microphone. Try again once it has finished.",
+        )
+    }
+
+    private fun stopSilenceWatch(recorder: AudioRecord?) {
+        silenceCallback?.let { callback ->
+            silenceCallback = null
+            runCatching { recorder?.unregisterAudioRecordingCallback(callback) }
+        }
+        watchdog?.let { executor ->
+            watchdog = null
+            runCatching { executor.shutdownNow() }
+        }
+    }
+
+    /**
+     * Ends capture for a reason that is not the user's doing. Only the first
+     * reason is reported: everything after it is a consequence of it.
+     */
+    private fun interrupt(reason: MicrophoneInterruption, message: String) {
+        val error = MicrophoneInterruptedException(reason, message)
+        if (!reported.compareAndSet(null, error)) return
+        running.set(false)
+        onError(error)
     }
 
     /**
@@ -225,13 +382,39 @@ class AudioCapture(
             }
             when (count) {
                 0 -> continue
+                // A dead object is the microphone being reclaimed, which is an
+                // interruption rather than a fault in this recording.
+                AudioRecord.ERROR_DEAD_OBJECT -> {
+                    interrupt(
+                        MicrophoneInterruption.CAPTURE_LOST,
+                        "Another app took the microphone. Try again once it has finished.",
+                    )
+                    return
+                }
+
                 AudioRecord.ERROR_INVALID_OPERATION, AudioRecord.ERROR_BAD_VALUE,
-                AudioRecord.ERROR_DEAD_OBJECT, AudioRecord.ERROR,
+                AudioRecord.ERROR,
                 -> {
-                    if (running.get()) onError(IllegalStateException("Microphone capture stopped."))
+                    if (running.get()) {
+                        interrupt(
+                            MicrophoneInterruption.CAPTURE_LOST,
+                            "Microphone capture stopped unexpectedly. Try dictating again.",
+                        )
+                    }
                     return
                 }
             }
         }
+    }
+
+    private companion object {
+        /** Attempts at a microphone another app is in the middle of releasing. */
+        const val START_ATTEMPTS = 3
+
+        /** Long enough for a call teardown or a recorder handoff to complete. */
+        const val START_RETRY_MILLIS = 150L
+
+        /** Silence still present after this is another app, not a route change. */
+        const val SILENCE_CONFIRMATION_MILLIS = 400L
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/audio/AudioFormatting.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/audio/AudioFormatting.kt
@@ -32,6 +32,16 @@ object PcmConversion {
         return into
     }
 
+    /** The loudest absolute sample in a frame, 0…32768. */
+    fun peak(samples: ShortArray, count: Int = samples.size): Int {
+        var peak = 0
+        for (index in 0 until count) {
+            val magnitude = kotlin.math.abs(samples[index].toInt())
+            if (magnitude > peak) peak = magnitude
+        }
+        return peak
+    }
+
     /** Root-mean-square amplitude in 0…1, for the recording meter only. */
     fun level(samples: ShortArray, count: Int = samples.size): Float {
         if (count <= 0) return 0f
@@ -42,6 +52,20 @@ object PcmConversion {
         }
         return kotlin.math.sqrt(sum / count).toFloat().coerceIn(0f, 1f)
     }
+}
+
+/**
+ * Android hands an app whose microphone another app has taken a stream of exact
+ * zeros and reports nothing at all — no error, no callback on some devices. A
+ * working microphone always has a noise floor, so a whole recording this quiet
+ * is that silencing rather than a quiet room, and saying so beats reporting an
+ * empty transcript the user cannot act on.
+ */
+object SilentCapture {
+    /** Two least-significant bits: below any noise floor, above a dithered zero. */
+    const val PEAK_THRESHOLD = 2
+
+    fun heardSomething(peak: Int): Boolean = peak > PEAK_THRESHOLD
 }
 
 /**

--- a/android/app/src/main/java/com/vocahq/vocaphone/data/DiagnosticLog.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/data/DiagnosticLog.kt
@@ -109,7 +109,20 @@ class DiagnosticLog(
         const val MAX_VALUE_LENGTH = 64
         val EVENTS = setOf("state", "error", "action", "timing")
         val SOURCES = setOf("IME", "COMPANION_APP", "none")
-        val ERROR_CATEGORIES = setOf("audio", "gateway", "insertion", "settings", "setup", "unknown")
+        // Microphone failures are split by cause: after the fact, the call or
+        // the screen recording that took the input is long gone, and "audio" on
+        // its own cannot tell those apart from a broken recorder.
+        val ERROR_CATEGORIES = setOf(
+            "audio",
+            "audio_focus_lost",
+            "audio_silenced",
+            "audio_capture_lost",
+            "gateway",
+            "insertion",
+            "settings",
+            "setup",
+            "unknown",
+        )
         val ACTIONS = setOf(
             "start",
             "cancel",

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -8,7 +8,10 @@ import android.os.SystemClock
 import androidx.core.content.ContextCompat
 import com.vocahq.vocaphone.audio.AudioCapture
 import com.vocahq.vocaphone.audio.CaptureFormat
+import com.vocahq.vocaphone.audio.MicrophoneInterruptedException
+import com.vocahq.vocaphone.audio.MicrophoneInterruption
 import com.vocahq.vocaphone.audio.PcmConversion
+import com.vocahq.vocaphone.audio.SilentCapture
 import com.vocahq.vocaphone.audio.WavWriter
 import com.vocahq.vocaphone.core.DictationFailure
 import com.vocahq.vocaphone.core.DictationPhase
@@ -299,12 +302,14 @@ class DictationController(
             streamFrames?.close()
             writer.close()
             wavFile.delete()
+            // Nothing was captured, so there is nothing for Retry to re-send.
+            // The user's next step is to start again, not to resend silence.
             fail(
                 sessionId,
                 GatewayException(
                     "microphone_unavailable",
                     captureError.get()?.message ?: "The microphone is not available right now.",
-                    recoverable = true,
+                    recoverable = false,
                 ),
                 wavFile = null,
                 configuration = configuration,
@@ -323,9 +328,17 @@ class DictationController(
 
         // Frames are drained off the capture thread: file writes and socket sends
         // must never stall the AudioRecord read loop.
+        val heardSomething = AtomicBoolean(false)
         val drain = scope.launch(Dispatchers.IO) {
             for (frame in frames) {
                 writer.write(frame, frame.size)
+                // Only until the first real sample arrives: past that the
+                // recording is known to contain audio and the scan is waste.
+                if (!heardSomething.get() &&
+                    SilentCapture.heardSomething(PcmConversion.peak(frame, frame.size))
+                ) {
+                    heardSomething.set(true)
+                }
                 incrementalReference.get()?.let { session ->
                     if (!session.offer(frame) && incrementalReference.compareAndSet(session, null)) {
                         incrementalFallback.set(true)
@@ -426,21 +439,30 @@ class DictationController(
         }
 
         captureError.get()?.let { error ->
-            incrementalReference.getAndSet(null)?.cancel()
-            diagnostics.recordError("audio", source.name)
-            stream?.cancel()
-            wavFile.delete()
-            fail(
-                sessionId,
-                GatewayException(
-                    "audio_interrupted",
-                    error.message ?: "Microphone access was interrupted. Try again.",
-                    recoverable = false,
-                ),
-                wavFile = null,
-                configuration = configuration,
-            )
-            return
+            diagnostics.recordError(audioErrorCategory(error), source.name)
+            // Another app taking the microphone does not invalidate the audio
+            // recorded before it did. A sentence the user already finished
+            // saying is transcribed rather than thrown away; only a capture
+            // that produced nothing usable is reported as a failure.
+            val salvageable = error is MicrophoneInterruptedException &&
+                heardSomething.get() &&
+                writer.durationMillis >= MINIMUM_RECORDING_MILLIS
+            if (!salvageable) {
+                incrementalReference.getAndSet(null)?.cancel()
+                stream?.cancel()
+                wavFile.delete()
+                fail(
+                    sessionId,
+                    GatewayException(
+                        "audio_interrupted",
+                        error.message ?: "Microphone access was interrupted. Try again.",
+                        recoverable = false,
+                    ),
+                    wavFile = null,
+                    configuration = configuration,
+                )
+                return
+            }
         }
 
         _state.update { it.copy(phase = DictationPhase.FINALIZING, level = 0f) }
@@ -452,6 +474,27 @@ class DictationController(
             fail(
                 sessionId,
                 GatewayException("audio_empty", "That was too short to transcribe.", recoverable = false),
+                wavFile = null,
+                configuration = configuration,
+            )
+            return
+        }
+
+        // A recording of exact digital zeros is what Android gives an app whose
+        // microphone another app holds. Transcribing it would spend the wait to
+        // report an empty transcript, which says nothing the user can act on.
+        if (!heardSomething.get()) {
+            incrementalReference.getAndSet(null)?.cancel()
+            stream?.cancel()
+            wavFile.delete()
+            fail(
+                sessionId,
+                GatewayException(
+                    "microphone_silenced",
+                    "Another app was using the microphone, so VocaPhone recorded silence. " +
+                        "Stop that recording and try again.",
+                    recoverable = false,
+                ),
                 wavFile = null,
                 configuration = configuration,
             )
@@ -765,12 +808,29 @@ class DictationController(
     }
 
     private fun errorCategory(error: GatewayException): String = when {
+        error.code == "microphone_silenced" -> "audio_silenced"
         error.code.startsWith("audio") -> "audio"
         error.code.startsWith("microphone") -> "audio"
         error.code.startsWith("insert") -> "insertion"
         error.code == "permission_repair" -> "setup"
         else -> "gateway"
     }
+
+    /**
+     * Which microphone failure this was. The on-device log is the only record
+     * that survives the call or the screen recording that caused it, so the
+     * cause is kept rather than flattened into a single "audio" category.
+     */
+    private fun audioErrorCategory(error: Throwable): String =
+        if (error !is MicrophoneInterruptedException) {
+            "audio"
+        } else {
+            when (error.interruption) {
+                MicrophoneInterruption.FOCUS_LOST -> "audio_focus_lost"
+                MicrophoneInterruption.SILENCED -> "audio_silenced"
+                MicrophoneInterruption.CAPTURE_LOST -> "audio_capture_lost"
+            }
+        }
 
     private companion object {
         /** Below this, there is nothing a model could usefully transcribe. */

--- a/android/app/src/test/java/com/vocahq/vocaphone/audio/AudioFormattingTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/audio/AudioFormattingTest.kt
@@ -43,6 +43,37 @@ class PcmConversionTest {
         assertEquals(0f, PcmConversion.level(ShortArray(0)), 0f)
         assertEquals(1f, PcmConversion.level(ShortArray(160) { Short.MIN_VALUE }), 1e-6f)
     }
+
+    @Test
+    fun `peak reports the loudest sample regardless of its sign`() {
+        assertEquals(0, PcmConversion.peak(ShortArray(160)))
+        assertEquals(0, PcmConversion.peak(ShortArray(0)))
+        assertEquals(900, PcmConversion.peak(shortArrayOf(12, -900, 40)))
+        assertEquals(32_768, PcmConversion.peak(shortArrayOf(0, Short.MIN_VALUE)))
+    }
+
+    @Test
+    fun `peak reads only the requested sample count`() {
+        val samples = shortArrayOf(5, 7, 30_000, 30_000)
+        assertEquals(7, PcmConversion.peak(samples, count = 2))
+    }
+}
+
+class SilentCaptureTest {
+
+    /**
+     * A microphone Android has taken away delivers exact zeros. A microphone
+     * that is merely in a quiet room does not: its noise floor sits far above
+     * the two least-significant bits this allows for.
+     */
+    @Test
+    fun `a silenced capture is told apart from a quiet room`() {
+        assertTrue(!SilentCapture.heardSomething(PcmConversion.peak(ShortArray(160))))
+        assertTrue(!SilentCapture.heardSomething(SilentCapture.PEAK_THRESHOLD))
+        assertTrue(SilentCapture.heardSomething(SilentCapture.PEAK_THRESHOLD + 1))
+        // A whisper two hundred times quieter than full scale still counts.
+        assertTrue(SilentCapture.heardSomething(PcmConversion.peak(shortArrayOf(0, -160, 0))))
+    }
 }
 
 class WavWriterTest {

--- a/android/app/src/test/java/com/vocahq/vocaphone/data/DiagnosticLogTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/data/DiagnosticLogTest.kt
@@ -38,6 +38,30 @@ class DiagnosticLogTest {
         }
     }
 
+    /**
+     * A microphone failure is only diagnosable after the fact if the log says
+     * which one it was: the call or the screen recording that took the input is
+     * gone by the time anyone reads this.
+     */
+    @Test
+    fun `microphone failures are logged by cause rather than as one category`() {
+        val directory = Files.createTempDirectory("vocaphone-diagnostics").toFile()
+        try {
+            val log = DiagnosticLog(directory.resolve("events.log"), nowMillis = { 99L })
+
+            log.recordError("audio_focus_lost", "IME")
+            log.recordError("audio_silenced", "COMPANION_APP")
+            log.recordError("audio_capture_lost", "IME")
+
+            val output = log.read()
+            assertTrue(output.contains("event=error value=audio_focus_lost source=IME"))
+            assertTrue(output.contains("event=error value=audio_silenced source=COMPANION_APP"))
+            assertTrue(output.contains("event=error value=audio_capture_lost source=IME"))
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
     @Test
     fun `timing stages reject arbitrary values`() {
         val directory = Files.createTempDirectory("vocaphone-diagnostics").toFile()

--- a/ios/VocaPhoneApp/Audio/AudioCapturePipeline.swift
+++ b/ios/VocaPhoneApp/Audio/AudioCapturePipeline.swift
@@ -11,6 +11,11 @@ enum CaptureFormat {
     /// Roughly 100 ms of audio per chunk. Small enough to keep streaming
     /// latency low, large enough to avoid a WebSocket frame every drain tick.
     static let chunkSampleCount = 1_600
+    /// A recording whose loudest sample never reached this is digital silence,
+    /// which is what a microphone another app has taken delivers. A working
+    /// microphone in a quiet room still has a noise floor far above two
+    /// sixteen-bit least-significant bits.
+    static let silenceThreshold: Float = 2 / 32_768
 }
 
 /// Single-producer, single-consumer float ring buffer with preallocated
@@ -99,6 +104,7 @@ final class AudioCapturePipeline: @unchecked Sendable {
     private var file: AVAudioFile?
     private var carry: [Float] = []
     private let meter = OSAllocatedUnfairLock(initialState: Float(0))
+    private let peak = OSAllocatedUnfairLock(initialState: Float(0))
     private let dropped = OSAllocatedUnfairLock(initialState: 0)
     private var emit: ((Data) -> Bool)?
 
@@ -106,6 +112,9 @@ final class AudioCapturePipeline: @unchecked Sendable {
     /// untrustworthy, so the caller falls back to uploading the intact file.
     var droppedChunkCount: Int { dropped.withLock { $0 } }
     var meterLevel: Float { meter.withLock { $0 } }
+    /// The loudest sample of the whole recording, which is what separates a
+    /// microphone another app silenced from one that simply heard a quiet room.
+    var peakLevel: Float { peak.withLock { $0 } }
 
     init?(sourceSampleRate: Double, ring: PCMRingBuffer) {
         guard let source = AVAudioFormat(
@@ -177,6 +186,7 @@ final class AudioCapturePipeline: @unchecked Sendable {
         }
         dropped.withLock { $0 = 0 }
         meter.withLock { $0 = 0 }
+        peak.withLock { $0 = 0 }
 
         let source = DispatchSource.makeTimerSource(queue: queue)
         // A 25 ms cadence against a two-second ring leaves ample margin even if
@@ -222,6 +232,9 @@ final class AudioCapturePipeline: @unchecked Sendable {
         inputBuffer.frameLength = AVAudioFrameCount(sampleCount)
 
         meter.withLock { $0 = Self.normalizedLevel(scratch, count: sampleCount) }
+        var loudest: Float = 0
+        vDSP_maxmgv(scratch, 1, &loudest, vDSP_Length(sampleCount))
+        peak.withLock { [loudest] in $0 = max($0, loudest) }
 
         var suppliedInput = false
         var conversionError: NSError?

--- a/ios/VocaPhoneApp/Audio/AudioRecorder.swift
+++ b/ios/VocaPhoneApp/Audio/AudioRecorder.swift
@@ -38,6 +38,9 @@ final class AudioRecorder: NSObject {
     /// or a slower first decode cannot discard the beginning of the transcript.
     private(set) var localPcmChunks: AsyncStream<Data>?
     private(set) var lastDroppedChunkCount = 0
+    /// The loudest sample of the recording that just finished. Zero means iOS
+    /// handed this app silence, not that the user said nothing quietly.
+    private(set) var lastPeakLevel: Float = 0
 
     override init() {
         super.init()
@@ -102,10 +105,50 @@ final class AudioRecorder: NSObject {
         }
     }
 
+    /// Attempts at a microphone another app is in the middle of releasing.
+    private static let startAttempts = 3
+    /// Long enough for a call teardown or a broadcast handoff to complete.
+    private static let startRetryMilliseconds = 150
+
     /// Warms the same graph `start` will capture from. Recording feedback can
     /// therefore play before the tap starts without paying a second setup cost.
-    func prepareForRecording() throws {
-        try ensureEngineRunning()
+    ///
+    /// Another app letting go of the microphone — a call ending, a screen
+    /// recording stopping — is not instantaneous, and iOS reports that gap as an
+    /// ordinary activation failure. Retrying across it turns a dictation that
+    /// would have been lost into one that starts a moment late.
+    func prepareForRecording() async throws {
+        var lastError: (any Error)?
+        for attempt in 0..<Self.startAttempts {
+            if attempt > 0 {
+                try? await Task.sleep(for: .milliseconds(Self.startRetryMilliseconds))
+            }
+            do {
+                try ensureEngineRunning()
+                return
+            } catch {
+                lastError = error
+            }
+        }
+        throw Self.startFailure(lastError)
+    }
+
+    /// The same activation failure means different things to the user depending
+    /// on who else holds the input, so it is read once here rather than shown
+    /// raw as an unexplained Core Audio message.
+    private static func startFailure(_ error: (any Error)?) -> any Error {
+        guard let error else { return RecordingError.inputUnavailable }
+        if error is RecordingError { return error }
+        guard let code = AVAudioSession.ErrorCode(rawValue: (error as NSError).code) else {
+            return error
+        }
+        switch code {
+        case .isBusy, .cannotStartRecording, .cannotInterruptOthers,
+             .siriIsRecording, .insufficientPriority, .resourceNotAvailable:
+            return RecordingError.microphoneBusy
+        default:
+            return error
+        }
     }
 
     /// Starts writing from the already-running microphone engine. When Quick
@@ -234,6 +277,7 @@ final class AudioRecorder: NSObject {
         // caller uploads it.
         pipeline?.finish()
         lastDroppedChunkCount = (pipeline?.droppedChunkCount ?? 0) + (ring?.overflowCount ?? 0)
+        lastPeakLevel = pipeline?.peakLevel ?? 0
         chunkContinuation?.finish()
         chunkContinuation = nil
         pcmChunks = nil
@@ -419,6 +463,7 @@ enum RecordingError: LocalizedError {
     case alreadyRecording
     case inputUnavailable
     case iPhoneMicrophoneUnavailable
+    case microphoneBusy
 
     var errorDescription: String? {
         switch self {
@@ -428,6 +473,9 @@ enum RecordingError: LocalizedError {
             "The microphone input is unavailable."
         case .iPhoneMicrophoneUnavailable:
             "The iPhone microphone is not currently available."
+        case .microphoneBusy:
+            "Another app or a call is using the microphone. "
+                + "Stop that recording, or wait for the call to end, and try again."
         }
     }
 }

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -432,7 +432,7 @@ final class RecordingCoordinator {
             }
 
             let directory = try localAudioDirectory()
-            try recorder.prepareForRecording()
+            try await recorder.prepareForRecording()
             await soundFeedback.play(.start)
             guard let latestRecord = try store.load(id),
                   [.launchingApp, .awaitingReturn].contains(latestRecord.state)
@@ -589,6 +589,24 @@ final class RecordingCoordinator {
                 state: .uploadFailedRecoverable,
                 code: "audio_missing",
                 message: "The recording file is missing."
+            )
+            return
+        }
+
+        // A recording of digital silence is what iOS hands an app whose
+        // microphone another app took mid-session. Transcribing it would spend
+        // the whole wait to report an empty transcript, which tells the user
+        // nothing they can act on.
+        if wasRecording, recorder.lastPeakLevel <= CaptureFormat.silenceThreshold {
+            await streamingBridge.cancel()
+            try? FileManager.default.removeItem(at: output)
+            await fail(
+                &record,
+                state: .transcriptionFailedPermanent,
+                code: "microphone_silenced",
+                message: "Another app or a call was using the microphone, so only "
+                    + "silence was recorded. Try again once it has finished.",
+                recoverable: false
             )
             return
         }
@@ -1097,6 +1115,7 @@ final class RecordingCoordinator {
         case "audio_missing": .audioMissing
         case "gateway_not_configured": .gatewayNotConfigured
         case "microphone_permission_denied": .microphonePermissionDenied
+        case "microphone_silenced": .microphoneSilenced
         case "language_unsupported": .languageUnsupported
         case "server_unavailable": .serverUnavailable
         default:

--- a/ios/VocaPhoneShared/DiagnosticLog.swift
+++ b/ios/VocaPhoneShared/DiagnosticLog.swift
@@ -66,6 +66,9 @@ enum DiagnosticErrorCode: String, Codable, Sendable {
     case gatewayNotConfigured
     case languageUnsupported
     case microphonePermissionDenied
+    /// Recording succeeded but another app held the input, so it captured only
+    /// silence. Distinct from a permission problem, which the user fixes once.
+    case microphoneSilenced
     case quickDictationArmFailed
     case recordingStartFailed
     case serverUnavailable

--- a/ios/VocaPhoneShared/SessionRecord.swift
+++ b/ios/VocaPhoneShared/SessionRecord.swift
@@ -138,7 +138,12 @@ struct SessionRecord: Codable, Equatable, Identifiable, Sendable {
         .launchingApp: [.awaitingReturn, .recording, .permissionDenied, .canceled],
         .awaitingReturn: [.recording, .permissionDenied, .canceled],
         .recording: [.finalizing, .canceled, .expired],
-        .finalizing: [.uploading, .uploadFailedRecoverable, .canceled],
+        // A capture can be known unusable before anything is ever sent: a
+        // microphone another app silenced yields a file that no amount of
+        // retrying will turn into a transcript.
+        .finalizing: [
+            .uploading, .uploadFailedRecoverable, .transcriptionFailedPermanent, .canceled,
+        ],
         .uploading: [.transcribing, .readyToInsert, .serverUnavailable, .uploadFailedRecoverable, .canceled],
         .transcribing: [
             .readyToInsert, .transcriptionFailedRecoverable,

--- a/ios/VocaPhoneTests/AudioCaptureTests.swift
+++ b/ios/VocaPhoneTests/AudioCaptureTests.swift
@@ -88,6 +88,42 @@ struct AudioCaptureTests {
         #expect(abs(emittedSamples - 16_000) < 400)
         #expect(pipeline.droppedChunkCount == 0)
         #expect(pipeline.meterLevel > 0)
+        #expect(pipeline.peakLevel > CaptureFormat.silenceThreshold)
+    }
+
+    /// Digital silence is what iOS hands an app whose microphone another app
+    /// has taken. It has to be told apart from a quiet room, because one is
+    /// worth explaining to the user and the other is just a short recording.
+    @Test func pipelineTellsSilenceApartFromAQuietRoom() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let sourceRate: Double = 48_000
+        func peak(of samples: [Float], named name: String) throws -> Float {
+            let ring = PCMRingBuffer(capacity: Int(sourceRate * 2))
+            let pipeline = try #require(
+                AudioCapturePipeline(sourceSampleRate: sourceRate, ring: ring)
+            )
+            try pipeline.start(writingTo: directory.appendingPathComponent(name)) { _ in true }
+            samples.withUnsafeBufferPointer {
+                #expect(ring.write($0.baseAddress!, count: samples.count))
+            }
+            pipeline.finish()
+            return pipeline.peakLevel
+        }
+
+        let count = Int(sourceRate)
+        let silenced = try peak(of: [Float](repeating: 0, count: count), named: "silence.wav")
+        #expect(silenced <= CaptureFormat.silenceThreshold)
+
+        // A murmur a hundred times quieter than a normal voice is still speech.
+        var murmur = [Float](repeating: 0, count: count)
+        for index in 0..<count {
+            murmur[index] = sin(Float(index) * 0.05) * 0.01
+        }
+        #expect(try peak(of: murmur, named: "murmur.wav") > CaptureFormat.silenceThreshold)
     }
 
     @Test func pipelineCountsChunksTheTransportRefuses() throws {

--- a/ios/VocaPhoneTests/SessionRecordTests.swift
+++ b/ios/VocaPhoneTests/SessionRecordTests.swift
@@ -16,6 +16,20 @@ struct SessionRecordTests {
         }
     }
 
+    /// A microphone another app silenced produces a file that no retry can turn
+    /// into a transcript, so finishing must be able to fail permanently without
+    /// first pretending the recording is worth uploading.
+    @Test func aCaptureKnownUnusableFailsWithoutBeingUploaded() throws {
+        var record = SessionRecord()
+        try record.transition(to: .launchingApp)
+        try record.transition(to: .recording)
+        try record.transition(to: .finalizing)
+        try record.transition(to: .transcriptionFailedPermanent)
+
+        #expect(record.state.isTerminal)
+        #expect(!record.canRetry)
+    }
+
     @Test func sharedStoreRoundTripsAtomically() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
## The bug

Dictation failed — and usually threw away the recording — whenever a second app wanted the microphone. Two reproducible cases:

- **An incoming call during dictation.** Everything captured so far was deleted and the failure was marked unrecoverable.
- **A screen recording with mic enabled.** Dictation appeared healthy for its whole length, then reported that nothing was transcribed.

These turned out to be four separate causes on the shared-input path, not one race.

## Android

| Cause | Fix |
| --- | --- |
| `AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK` aborted the dictation | Ducking asks a *player* to lower its volume; a recorder has none to lower. Any notification chime or navigation prompt was enough to kill a dictation. Now ignored. |
| A refused focus request was fatal | Focus is advisory and the mic is frequently usable without it. The request is still made — it is how a call announces itself mid-dictation — but a refusal no longer stops capture. |
| An interruption deleted the audio | A call at second 44 of a 45-second dictation lost every word. Capture now reports a typed `MicrophoneInterruptedException`, and audio recorded before the interruption is transcribed rather than discarded. This is what iOS already did. |
| Android 10+ capture silencing went undetected | When another app wins the input, Android feeds this one digital zeros and reports no error anywhere — the "nothing was transcribed" case. An `AudioRecordingCallback` now watches `isClientSilenced` (400 ms debounce so a route change does not trip it), with a peak-amplitude backstop for devices where the callback never fires. |

Starting capture also retries 3× across 150 ms: a call ending or a recorder handing the input back is not instantaneous, and Android reports that gap as an ordinary failure.

## iOS

Same shape, different APIs — a retry loop in `prepareForRecording`, `AVAudioSession.ErrorCode` mapped to a new `.microphoneBusy` whose message names the cause instead of surfacing a raw Core Audio string, and peak tracking so a silenced capture fails immediately rather than spending the full transcription wait to report an empty transcript.

## Testing

`android: assembleDebug + testDebugUnitTest + lintDebug` and the full 113-test iOS suite both pass.

New coverage is on the pure, testable parts: `PcmConversion.peak`, `SilentCapture`, `CaptureFormat.silenceThreshold`, the per-cause diagnostic categories, and the new `.finalizing → .transcriptionFailedPermanent` transition.