### PR TITLE
fix(ios,android): stop dictation state and its indicators outliving the dictation

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -96,6 +96,16 @@ class DictationController(
     @Volatile
     private var cancelRequested = false
 
+    /**
+     * Which dictation owns [state]. `fail` finishes its history write under
+     * `NonCancellable`, so a cancel — or the dictation the user starts straight
+     * after one — can land while a failure is still being reported. The late
+     * write then put a FAILED phase on top of a session that was recording
+     * perfectly well. Every start, retry and reset takes the next generation,
+     * and a write from an older one is dropped.
+     */
+    private val generation = AtomicInteger()
+
     init {
         scope.launch {
             state
@@ -117,6 +127,7 @@ class DictationController(
         diagnostics.recordAction("start", source.name)
         finishSignal = CompletableDeferred()
         cancelRequested = false
+        val generation = nextGeneration()
         pipeline = scope.launch {
             val configuration = settings.current()
             val missing = missingPermissions(configuration)
@@ -137,7 +148,7 @@ class DictationController(
                 )
                 return@launch
             }
-            runDictation(source, configuration, token, UUID.randomUUID())
+            runDictation(source, configuration, token, UUID.randomUUID(), generation)
         }
     }
 
@@ -160,6 +171,7 @@ class DictationController(
     /** Re-sends audio that was preserved for a recoverable failure. */
     fun retry(sessionId: String) {
         if (pipeline?.isActive == true) return
+        val generation = nextGeneration()
         pipeline = scope.launch {
             val record = history.find(sessionId) ?: return@launch
             val audio = record.audioPath?.let(::File)
@@ -188,6 +200,7 @@ class DictationController(
                     language = record.language,
                     configuration = configuration,
                     source = DictationSource.COMPANION_APP,
+                    generation = generation,
                 )
             } else {
                 val token = settings.token() ?: return@launch
@@ -199,6 +212,7 @@ class DictationController(
                     style = record.style,
                     configuration = configuration,
                     source = DictationSource.COMPANION_APP,
+                    generation = generation,
                 )
             }
         }
@@ -228,6 +242,7 @@ class DictationController(
         configuration: VocaPhoneSettings,
         token: String?,
         sessionId: UUID,
+        generation: Int,
     ) {
         audioDirectory.mkdirs()
         val wavFile = File(audioDirectory, "$sessionId.wav")
@@ -313,6 +328,7 @@ class DictationController(
                 ),
                 wavFile = null,
                 configuration = configuration,
+                generation = generation,
             )
             return
         }
@@ -460,6 +476,7 @@ class DictationController(
                     ),
                     wavFile = null,
                     configuration = configuration,
+                    generation = generation,
                 )
                 return
             }
@@ -476,6 +493,7 @@ class DictationController(
                 GatewayException("audio_empty", "That was too short to transcribe.", recoverable = false),
                 wavFile = null,
                 configuration = configuration,
+                generation = generation,
             )
             return
         }
@@ -497,6 +515,7 @@ class DictationController(
                 ),
                 wavFile = null,
                 configuration = configuration,
+                generation = generation,
             )
             return
         }
@@ -531,6 +550,7 @@ class DictationController(
                 language = configuration.effectiveLanguage.wireValue,
                 configuration = configuration,
                 source = source,
+                generation = generation,
                 preparedTranscript = preparedTranscript,
                 transcriptionTimingRecorded = timingRecorded,
             )
@@ -548,7 +568,7 @@ class DictationController(
             } catch (error: GatewayException) {
                 if (!error.recoverable) {
                     wavFile.delete()
-                    fail(sessionId, error, wavFile = null, configuration = configuration)
+                    fail(sessionId, error, wavFile = null, configuration = configuration, generation = generation)
                     return
                 }
                 recordBatchFallback()
@@ -560,7 +580,7 @@ class DictationController(
             val cleaned = TranscriptSanitizer.clean(transcript)
             if (transcript != null && cleaned.isEmpty()) {
                 wavFile.delete()
-                fail(sessionId, GatewayException.emptyTranscript(), null, configuration)
+                fail(sessionId, GatewayException.emptyTranscript(), null, configuration, generation)
                 return
             }
             if (cleaned.isNotEmpty()) {
@@ -583,6 +603,7 @@ class DictationController(
             configuration.style.wireValue,
             configuration,
             source,
+            generation,
         )
     }
 
@@ -624,6 +645,7 @@ class DictationController(
         style: String,
         configuration: VocaPhoneSettings,
         source: DictationSource,
+        generation: Int,
     ) {
         try {
             _state.update { it.copy(phase = DictationPhase.UPLOADING) }
@@ -646,7 +668,7 @@ class DictationController(
             wavFile.delete()
             deliver(transcript, sessionId, configuration, source)
         } catch (error: GatewayException) {
-            fail(sessionId, error, wavFile, configuration)
+            fail(sessionId, error, wavFile, configuration, generation)
         }
     }
 
@@ -656,6 +678,7 @@ class DictationController(
         language: String,
         configuration: VocaPhoneSettings,
         source: DictationSource,
+        generation: Int,
         preparedTranscript: String? = null,
         transcriptionTimingRecorded: Boolean = false,
     ) {
@@ -689,6 +712,7 @@ class DictationController(
                 ),
                 wavFile,
                 configuration,
+                generation,
             )
         }
     }
@@ -783,6 +807,7 @@ class DictationController(
         error: GatewayException,
         wavFile: File?,
         configuration: VocaPhoneSettings,
+        generation: Int,
     ) = withContext(NonCancellable) {
         diagnostics.recordError(errorCategory(error), activeSource?.name)
         history.recordFailure(
@@ -796,6 +821,12 @@ class DictationController(
             retentionHours = configuration.audioRetention.hours,
             targetPackage = null,
         )
+        // The history write above is the durable half and always runs: the audio
+        // is preserved and Retry has to find it. Reporting the failure on screen
+        // is the half that can arrive too late — this block is `NonCancellable`,
+        // so a cancel, or the dictation started right after it, can have taken
+        // the state over while the write was in flight.
+        if (this@DictationController.generation.get() != generation) return@withContext
         _state.value = _state.value.copy(
             phase = DictationPhase.FAILED,
             level = 0f,
@@ -803,7 +834,11 @@ class DictationController(
         )
     }
 
+    /** Retires whatever owned the state, so nothing older can write to it. */
+    private fun nextGeneration(): Int = generation.incrementAndGet()
+
     private fun reset() {
+        nextGeneration()
         _state.value = DictationState()
     }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationService.kt
@@ -59,11 +59,30 @@ class DictationService : Service() {
                 observeUntilIdle()
             }
 
-            ACTION_FINISH -> controller.finish()
-            ACTION_CANCEL -> controller.cancel()
+            ACTION_FINISH -> {
+                controller.finish()
+                stopUnlessHoldingMicrophone()
+            }
+
+            ACTION_CANCEL -> {
+                controller.cancel()
+                stopUnlessHoldingMicrophone()
+            }
+
             else -> stopSelf()
         }
         return START_NOT_STICKY
+    }
+
+    /**
+     * The microphone is released as soon as capture ends, and this service stops
+     * itself there — so Finish and Cancel sent during upload or transcription
+     * arrive at a *new* instance with no recording to hold. It has no observer
+     * to stop it later, and a started service runs until something does, so
+     * every cancel after the microphone was released leaked one.
+     */
+    private fun stopUnlessHoldingMicrophone() {
+        if (observer == null) stopSelf()
     }
 
     private fun observeUntilIdle() {
@@ -72,13 +91,16 @@ class DictationService : Service() {
         observer = scope.launch {
             // Capture starts a moment after `start` returns, so the service must
             // wait for the microphone to actually be held before it treats an idle
-            // state as the end of the dictation. A recording that never begins —
-            // a revoked permission, a microphone another app has — falls through
-            // the timeout instead of leaving the service running.
-            val started = withTimeoutOrNull(START_TIMEOUT_MILLIS) {
-                controller.state.first { it.phase.holdsMicrophone }
+            // state as the end of the dictation. The timeout is the last resort;
+            // a start that resolves without ever recording says so, and waiting
+            // it out held a microphone foreground service — an ongoing "VocaPhone
+            // is recording" notification and the system's microphone indicator —
+            // for ten seconds over a dictation that never began. Tapping the mic
+            // before the gateway is configured did exactly that.
+            val settled = withTimeoutOrNull(START_TIMEOUT_MILLIS) {
+                controller.state.first { DictationStartWatch.hasSettled(it.phase) }
             }
-            if (started != null) {
+            if (settled?.phase?.holdsMicrophone == true) {
                 controller.state
                     .onEach { notificationManager().notify(NOTIFICATION_ID, notification(it.statusText)) }
                     .first { !it.phase.holdsMicrophone }
@@ -176,6 +198,26 @@ class DictationService : Service() {
         fun send(context: Context, action: String) {
             context.startService(Intent(context, DictationService::class.java).setAction(action))
         }
+    }
+}
+
+/**
+ * Whether a start attempt has resolved, either way.
+ *
+ * [DictationService] holds a microphone foreground service from before capture
+ * begins until it can see the microphone actually being held, so it needs to
+ * recognise the outcomes that never reach the microphone at all — otherwise the
+ * only thing that ends the wait is a timeout the user spends looking at a
+ * recording notification.
+ */
+internal object DictationStartWatch {
+    fun hasSettled(phase: DictationPhase): Boolean = when (phase) {
+        // Capture is running, which is what the service exists to cover.
+        DictationPhase.LISTENING, DictationPhase.FINALIZING -> true
+        // Resolved without ever recording: a permission to repair, or a
+        // microphone that could not be opened.
+        DictationPhase.PERMISSION_REPAIR, DictationPhase.FAILED -> true
+        else -> false
     }
 }
 

--- a/android/app/src/test/java/com/vocahq/vocaphone/dictation/DictationStartWatchTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/dictation/DictationStartWatchTest.kt
@@ -1,0 +1,55 @@
+package com.vocahq.vocaphone.dictation
+
+import com.vocahq.vocaphone.core.DictationPhase
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DictationStartWatchTest {
+
+    @Test
+    fun `holding the microphone settles the start`() {
+        assertTrue(DictationStartWatch.hasSettled(DictationPhase.LISTENING))
+        assertTrue(DictationStartWatch.hasSettled(DictationPhase.FINALIZING))
+    }
+
+    /**
+     * The service holds a microphone foreground service from before capture
+     * begins, so an outcome that never reaches the microphone has to end the
+     * wait. Leaving it to the timeout showed "VocaPhone is recording" and the
+     * system microphone indicator for ten seconds over a dictation that never
+     * started — which is what tapping the mic before setup was finished did.
+     */
+    @Test
+    fun `an outcome that never records settles the start too`() {
+        assertTrue(DictationStartWatch.hasSettled(DictationPhase.PERMISSION_REPAIR))
+        assertTrue(DictationStartWatch.hasSettled(DictationPhase.FAILED))
+    }
+
+    /**
+     * Idle is the phase the state is already in when the service subscribes, so
+     * treating it as an outcome would abandon every dictation before it began.
+     */
+    @Test
+    fun `idle is not an outcome`() {
+        assertFalse(DictationStartWatch.hasSettled(DictationPhase.IDLE))
+    }
+
+    /**
+     * These arrive after the microphone has been released, and the service has
+     * already stopped itself by then. Reaching one without passing through
+     * LISTENING would mean capture never happened.
+     */
+    @Test
+    fun `phases past the microphone do not stand in for it`() {
+        for (phase in listOf(
+            DictationPhase.UPLOADING,
+            DictationPhase.TRANSCRIBING,
+            DictationPhase.READY_TO_INSERT,
+            DictationPhase.INSERTING,
+            DictationPhase.INSERTED,
+        )) {
+            assertFalse("$phase", DictationStartWatch.hasSettled(phase))
+        }
+    }
+}

--- a/ios/VocaPhoneApp/Sessions/LiveActivityManager.swift
+++ b/ios/VocaPhoneApp/Sessions/LiveActivityManager.swift
@@ -205,6 +205,36 @@ final class LiveActivityManager: @unchecked Sendable {
         }
     }
 
+    /// Clears a Live Activity left behind by a process that never got to end it
+    /// — a jetsam kill or a crash during recording. The activity belongs to the
+    /// system, so it survives its app and keeps offering Finish for a session
+    /// that no longer exists; the only place that can notice is the next launch.
+    ///
+    /// The caller establishes that no session is live. This adds what only the
+    /// manager knows: an activity this process is itself driving is not an
+    /// orphan, and neither is a standby one that was deliberately armed.
+    func discardOrphanedActivities() {
+        guard activeSessionID == nil, !standbyRequested else { return }
+        let orphans = Activity<VocaPhoneActivityAttributes>.activities
+        guard !orphans.isEmpty else { return }
+
+        isAppExiting = false
+        logger.info("Discarding \(orphans.count) orphaned Live Activities")
+        DiagnosticLog.record(
+            .liveActivityEnded,
+            metadata: .reason(.orphanRecovered)
+        )
+        beginTransition()
+        endAll(
+            state: VocaPhoneActivityAttributes.ContentState(
+                status: "Recording ended",
+                canFinish: false,
+                phase: .finished
+            ),
+            dismissalPolicy: .immediate
+        )
+    }
+
     private func beginTransition() {
         pendingStandbyTask?.cancel()
         pendingStandbyTask = nil

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -151,7 +151,14 @@ final class RecordingCoordinator {
         case "dictate":
             if let requested = try? store.load(id) {
                 activeRecord = requested
-                message = "Starting the recording requested by the keyboard…"
+                // The hand-off can arrive after the keyboard already gave up on
+                // it. Announcing a recording that `startSession` will decline to
+                // start left the app insisting it was listening when it was not.
+                if [.launchingApp, .awaitingReturn].contains(requested.state) {
+                    message = "Starting the recording requested by the keyboard…"
+                } else if requested.state == .expired {
+                    message = "That dictation timed out. Tap Dictate again."
+                }
             }
             Task { await startSession(id: id) }
         case "retry":
@@ -369,7 +376,16 @@ final class RecordingCoordinator {
 
     func recoverRecentSession() async {
         pruneSharedStorage()
-        guard let record = try? store.mostRecent() else {
+        let recovered = try? store.mostRecent()
+        // A Live Activity belongs to the system and outlives its app, so a
+        // jetsam kill or a crash mid-recording strands one in the Dynamic
+        // Island still offering Finish for a session that no longer exists.
+        // Nothing else notices, because the process that owned it is gone.
+        // Whether an activity is genuinely orphaned is the manager's own
+        // question — a stale record still says `recording` in exactly the case
+        // this is here to clean up, so it cannot be answered from one.
+        liveActivity.discardOrphanedActivities()
+        guard let record = recovered else {
             activeRecord = nil
             message = nil
             return
@@ -381,14 +397,24 @@ final class RecordingCoordinator {
                 message = "The transcript was inserted successfully."
             case .canceled:
                 message = "Recording canceled."
+            case .expired:
+                message = "The last dictation timed out and was discarded."
             default:
                 message = record.error?.message
             }
             return
         }
-        if [.launchingApp, .awaitingReturn].contains(record.state),
-           Date().timeIntervalSince(record.updatedAt) <= 120
+        // Never against a capture this process is still making: the watchdog is
+        // for a recorder that is gone, and the audio is the one thing here that
+        // cannot be recreated.
+        if !recorder.isRecording,
+           let expired = SessionExpiryPolicy.expireIfStale(record, in: store)
         {
+            activeRecord = expired
+            message = "The last dictation timed out and was discarded."
+            return
+        }
+        if [.launchingApp, .awaitingReturn].contains(record.state) {
             message = "Starting the recording requested by the keyboard…"
             await startSession(id: record.sessionID)
             return
@@ -414,6 +440,13 @@ final class RecordingCoordinator {
                 return
             }
             guard [.launchingApp, .awaitingReturn].contains(record.state) else { return }
+            // Claim the request before anything slow, so the keyboard's launch
+            // fallback knows this app has it. Warming the microphone can take
+            // seconds — a first on-device model load, another app releasing the
+            // input — and without the claim the keyboard opens vocaphone on top
+            // of a Quick Dictation that was seconds from recording.
+            record.claimedAt = Date()
+            try? store.save(record)
             clearQuickDictationMarker()
             activeRecord = record
             let granted = await withCheckedContinuation { continuation in
@@ -995,7 +1028,11 @@ final class RecordingCoordinator {
             startPipeline(shared)
         case .uploading where !recorder.isRecording && pipelineSessionID == nil:
             startPipeline(shared)
-        case .canceled:
+        // Expiry is the keyboard acting as watchdog for an app that stopped
+        // answering. It has to tear down exactly as far as a cancel does:
+        // retiring only the record would leave this recorder holding the
+        // microphone for a session no other process believes in.
+        case .canceled, .expired:
             pipelineTask?.cancel()
             pipelineTask = nil
             pipelineSessionID = nil
@@ -1004,14 +1041,20 @@ final class RecordingCoordinator {
             localSherpaSession = nil
             let shouldRemainReady = shouldKeepQuickDictationReady(after: shared)
             recorder.cancelSession(keepAudioSessionActive: shouldRemainReady)
+            let headline = shared.state == .expired
+                ? "The dictation timed out and was discarded."
+                : "Recording canceled."
             if shouldRemainReady {
                 armQuickDictation()
-                message = "Recording canceled. Quick Dictation is still ready."
+                message = headline + " Quick Dictation is still ready."
             } else {
                 clearQuickDictationReadiness(deactivateAudioSession: true)
-                message = "Recording canceled."
+                message = headline
             }
-            liveActivity.end(status: "Canceled", dismissAfter: 0)
+            liveActivity.end(
+                status: shared.state == .expired ? "Timed out" : "Canceled",
+                dismissAfter: 0
+            )
             await startPendingQuickDictationIfNeeded()
         default:
             if shared.state.isTerminal {
@@ -1079,7 +1122,13 @@ final class RecordingCoordinator {
         audioSessionAvailable = false
         if activeRecord?.state == .recording, recorder.isRecording {
             message = reason
-            liveActivity.end(status: "Audio interrupted", dismissAfter: 0)
+            // Ending the activity here retired the manager's session, which
+            // then silently dropped every later update: the Dynamic Island
+            // disappeared the instant a call arrived, while the app went on to
+            // transcribe what it had already captured, and the transcript
+            // arrived with nothing outside the app to say so. What was captured
+            // is still being finished, so the activity follows it there.
+            liveActivity.update(status: "Audio interrupted", canFinish: false)
             requestFinish()
         } else {
             clearQuickDictationReadiness(deactivateAudioSession: true)

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -136,6 +136,12 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             keyGrid.plane = Self.initialPlane(
                 for: textDocumentProxy.keyboardType ?? .default
             )
+            // A waiting transcript parks itself when the cursor leaves its field
+            // and re-arms when it comes back. Both were left to the next poll,
+            // so the bar could still offer Insert for a field the user had
+            // already left, and stayed on "Waiting for its own field" for over a
+            // second after they returned to it.
+            if activeSessionID != nil { refresh() }
         }
         updateAutomaticShift()
     }
@@ -439,19 +445,33 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         }
     }
 
+    /// Quick Dictation records without leaving the host app, so opening
+    /// vocaphone is the failure path, not the plan. It fires only once the
+    /// request looks genuinely unanswered: unclaimed after the short window, or
+    /// claimed but still not recording by the deadline. Warming the microphone
+    /// graph regularly outruns the short window on its own — a first on-device
+    /// model load, or another app still letting go of the input — and switching
+    /// apps there aborted dictations that were about to start.
     private func scheduleContainingAppFallback(for record: SessionRecord) {
         appLaunchFallbackTask?.cancel()
         appLaunchFallbackTask = Task { [weak self] in
             let milliseconds = Int(
                 AppConfiguration.quickDictationLaunchFallbackSeconds * 1_000
             )
-            try? await Task.sleep(for: .milliseconds(milliseconds))
-            guard !Task.isCancelled,
-                  let self,
-                  let current = try? self.store.load(record.sessionID),
-                  [.launchingApp, .awaitingReturn].contains(current.state)
-            else { return }
-            self.openContainingApp(for: current)
+            let deadline = Date().addingTimeInterval(
+                AppConfiguration.quickDictationClaimedLaunchDeadlineSeconds
+            )
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(milliseconds))
+                guard !Task.isCancelled,
+                      let self,
+                      let current = try? self.store.load(record.sessionID),
+                      [.launchingApp, .awaitingReturn].contains(current.state)
+                else { return }
+                guard current.claimedAt == nil || Date() >= deadline else { continue }
+                self.openContainingApp(for: current)
+                return
+            }
         }
     }
 
@@ -536,6 +556,8 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
                 appLaunchFallbackTask?.cancel()
                 appLaunchFallbackTask = nil
             }
+            guard !expireIfStale(record) else { return }
+            latchSessionTarget()
             handle(record)
             return
         }
@@ -546,12 +568,40 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             render(nil)
             return
         }
+        // Adoption is how a session survives the keyboard being torn down for
+        // the hand-off, so it must not also resurrect one nobody is waiting for.
+        guard !expireIfStale(recent) else { return }
         activeSessionID = recent.sessionID
         // A recreated instance cannot compare its identifiers with ones the
         // previous instance stored, so the field the user has returned to
         // becomes the session's insertion target.
         sessionTargetDocumentID = currentDocumentID
         handle(recent)
+    }
+
+    /// Retires a session that is waiting for something no longer coming, and
+    /// hands the bar back to the user. Reports whether it did, so callers stop
+    /// rendering a record they have just made terminal.
+    private func expireIfStale(_ record: SessionRecord) -> Bool {
+        guard SessionExpiryPolicy.expireIfStale(record, in: store) != nil else { return false }
+        if activeSessionID == record.sessionID {
+            activeSessionID = nil
+            sessionTargetDocumentID = nil
+        }
+        appLaunchFallbackTask?.cancel()
+        appLaunchFallbackTask = nil
+        render(nil)
+        return true
+    }
+
+    /// iOS can withhold the document identifier while the keyboard is loading,
+    /// and a session adopted in that window kept a nil target for its whole
+    /// life — which silently disabled the wrong-field guard rather than
+    /// tightening it. Latch the first identifier that becomes known instead,
+    /// and never a later one, so the target still names one field.
+    private func latchSessionTarget() {
+        guard sessionTargetDocumentID == nil, let current = currentDocumentID else { return }
+        sessionTargetDocumentID = current
     }
 
     private func handle(_ incoming: SessionRecord) {

--- a/ios/VocaPhoneShared/AppConfiguration.swift
+++ b/ios/VocaPhoneShared/AppConfiguration.swift
@@ -9,5 +9,13 @@ enum AppConfiguration {
     static let urlScheme = "vocaphone"
     static let maximumRecordingSeconds: TimeInterval = 120
     static let quickDictationWindowSeconds: TimeInterval = 10 * 60
+    /// How long the keyboard waits for an unclaimed Quick Dictation request
+    /// before falling back to opening vocaphone.
     static let quickDictationLaunchFallbackSeconds: TimeInterval = 1.5
+    /// How long it keeps waiting once the containing app has claimed the
+    /// request. Warming the microphone graph can take several seconds — a first
+    /// on-device model load, or another app still releasing the input — and
+    /// switching apps on a dictation that is about to start anyway is the more
+    /// disruptive failure.
+    static let quickDictationClaimedLaunchDeadlineSeconds: TimeInterval = 8
 }

--- a/ios/VocaPhoneShared/DiagnosticLog.swift
+++ b/ios/VocaPhoneShared/DiagnosticLog.swift
@@ -22,6 +22,7 @@ enum DiagnosticEvent: String, Codable, Sendable {
     case appStarted
     case keyboardShown
     case sessionStateChanged
+    case sessionExpired
     case quickDictationArmed
     case quickDictationStopped
     case quickDictationStale
@@ -51,6 +52,9 @@ enum DiagnosticReason: String, Codable, Sendable {
     case quickDictationOff
     case sessionFinished
     case processExit
+    /// A Live Activity outlived the process that created it — a jetsam kill or
+    /// a crash mid-recording — and was cleared on the next launch.
+    case orphanRecovered
     case resumeAllowed
     case resumeNotAllowed
 }

--- a/ios/VocaPhoneShared/SessionRecord.swift
+++ b/ios/VocaPhoneShared/SessionRecord.swift
@@ -87,6 +87,14 @@ struct SessionRecord: Codable, Equatable, Identifiable, Sendable {
     /// no other app to return to, so the hand-off guidance must be suppressed.
     /// Optional so records written before this field still decode.
     var startedInContainingApp: Bool?
+    /// When the containing app took ownership of a hand-off, written before the
+    /// microphone is warm. The keyboard's launch fallback waits on this: warming
+    /// the graph can take longer than the fallback window — a first on-device
+    /// model load, or a microphone another app is still releasing — and opening
+    /// vocaphone anyway pulls the user out of the app they are typing in for a
+    /// Quick Dictation that was about to succeed. Optional so records written
+    /// before this field still decode.
+    var claimedAt: Date?
 
     init(
         sessionID: UUID = UUID(),
@@ -108,6 +116,7 @@ struct SessionRecord: Codable, Equatable, Identifiable, Sendable {
         self.style = style
         meterLevel = 0
         startedInContainingApp = nil
+        claimedAt = nil
     }
 
     mutating func transition(to next: SessionState, now: Date = Date()) throws {
@@ -133,21 +142,30 @@ struct SessionRecord: Codable, Equatable, Identifiable, Sendable {
         .serverUnavailable, .uploadFailedRecoverable, .transcriptionFailedRecoverable,
     ]
 
+    /// Every waiting state can also expire. Each of them is waiting on another
+    /// process that can silently never answer — a host app that swallowed the
+    /// hand-off, a containing app iOS killed mid-recording, a gateway that
+    /// stopped replying — and without a way out the record stays non-terminal
+    /// for the life of the install. See `SessionExpiryPolicy`.
     private static let allowedTransitions: [SessionState: Set<SessionState>] = [
         .idle: [.launchingApp, .canceled],
-        .launchingApp: [.awaitingReturn, .recording, .permissionDenied, .canceled],
-        .awaitingReturn: [.recording, .permissionDenied, .canceled],
+        .launchingApp: [.awaitingReturn, .recording, .permissionDenied, .canceled, .expired],
+        .awaitingReturn: [.recording, .permissionDenied, .canceled, .expired],
         .recording: [.finalizing, .canceled, .expired],
         // A capture can be known unusable before anything is ever sent: a
         // microphone another app silenced yields a file that no amount of
         // retrying will turn into a transcript.
         .finalizing: [
             .uploading, .uploadFailedRecoverable, .transcriptionFailedPermanent, .canceled,
+            .expired,
         ],
-        .uploading: [.transcribing, .readyToInsert, .serverUnavailable, .uploadFailedRecoverable, .canceled],
+        .uploading: [
+            .transcribing, .readyToInsert, .serverUnavailable, .uploadFailedRecoverable,
+            .canceled, .expired,
+        ],
         .transcribing: [
             .readyToInsert, .transcriptionFailedRecoverable,
-            .transcriptionFailedPermanent, .serverUnavailable,
+            .transcriptionFailedPermanent, .serverUnavailable, .canceled, .expired,
         ],
         .readyToInsert: [.inserting, .targetContextChanged, .canceled, .expired],
         // The transcript survives a detour into another text field. Returning to
@@ -172,6 +190,76 @@ struct SessionRecord: Codable, Equatable, Identifiable, Sendable {
 
 enum SessionTransitionError: Error, Equatable {
     case invalid(from: SessionState, to: SessionState)
+}
+
+/// How long a session may sit in one state before every process should stop
+/// treating it as live.
+///
+/// A session that nothing retires stays non-terminal forever, and the keyboard
+/// adopts the newest non-terminal session on *every* appearance in *every* app.
+/// That is how a hand-off the host app silently refused becomes a permanent
+/// "Opening vocaphone" bar, and how a transcript abandoned yesterday gets
+/// auto-inserted into an unrelated field today.
+///
+/// The windows are generous on purpose: expiring is a watchdog for a process
+/// that is gone, never a deadline for a slow one.
+enum SessionExpiryPolicy {
+    /// The containing app claims a hand-off within seconds. Two minutes still
+    /// covers a cold launch behind Face ID and a first on-device model load.
+    static let handoffWindow: TimeInterval = 120
+    /// Capture is hard-capped by `maximumRecordingSeconds`, so anything past
+    /// that plus a wide margin means the recorder is gone, not slow.
+    static let captureWindow: TimeInterval = AppConfiguration.maximumRecordingSeconds + 120
+    /// Upload and transcription run on the user's own gateway or on device.
+    static let processingWindow: TimeInterval = 10 * 60
+    /// A transcript waiting for a tap stays useful for a while, but not for the
+    /// rest of the install — it is offered by whichever field is focused next.
+    static let pendingUserActionWindow: TimeInterval = 60 * 60
+
+    static func window(for state: SessionState) -> TimeInterval? {
+        switch state {
+        case .launchingApp, .awaitingReturn:
+            handoffWindow
+        case .recording:
+            captureWindow
+        case .finalizing, .uploading, .transcribing:
+            processingWindow
+        case .readyToInsert, .targetContextChanged, .serverUnavailable,
+             .uploadFailedRecoverable, .transcriptionFailedRecoverable:
+            pendingUserActionWindow
+        // `idle`, `inserting` and `inserted` last microseconds inside a single
+        // process, and the terminal states need no watchdog at all.
+        default:
+            nil
+        }
+    }
+
+    static func isStale(_ record: SessionRecord, now: Date = Date()) -> Bool {
+        guard let window = window(for: record.state) else { return false }
+        return now.timeIntervalSince(record.updatedAt) > window
+    }
+
+    /// Retires a stale session durably, so the other process learns about it
+    /// through the shared record rather than each one keeping its own timer.
+    /// Returns the expired record, or nil when the session is still live.
+    @discardableResult
+    static func expireIfStale(
+        _ record: SessionRecord,
+        in store: SharedStore,
+        now: Date = Date()
+    ) -> SessionRecord? {
+        guard isStale(record, now: now) else { return nil }
+        var expiring = record
+        do {
+            try expiring.transition(to: .expired, now: now)
+            try store.save(expiring)
+        } catch {
+            // A state with no expiry path keeps whatever recovery it offers.
+            return nil
+        }
+        DiagnosticLog.record(.sessionExpired, metadata: .state(record.state))
+        return expiring
+    }
 }
 
 /// Polling is only a recovery path for a dropped Darwin notification. Keep it

--- a/ios/VocaPhoneTests/SessionRecordTests.swift
+++ b/ios/VocaPhoneTests/SessionRecordTests.swift
@@ -163,6 +163,159 @@ struct SessionRecordTests {
         #expect(try store.mostRecent() == nil)
     }
 
+    /// The bar offers Cancel in every live state, so every live state has to
+    /// accept it. Transcription did not, and the tap reported "The session
+    /// changed. Please try again." while the session carried on regardless.
+    @Test func cancelIsAcceptedWhereverTheBarOffersIt() throws {
+        for abandonAfter in [
+            SessionState.launchingApp, .awaitingReturn, .recording, .finalizing,
+            .uploading, .transcribing, .readyToInsert, .targetContextChanged,
+        ] {
+            var record = SessionRecord()
+            for state in Self.route(to: abandonAfter) {
+                try record.transition(to: state)
+            }
+            #expect(record.state == abandonAfter)
+            try record.transition(to: .canceled)
+            #expect(record.state.isTerminal)
+        }
+    }
+
+    /// The shortest legal sequence of transitions that arrives at `state`.
+    private static func route(to state: SessionState) -> [SessionState] {
+        let pipeline: [SessionState] = [
+            .launchingApp, .recording, .finalizing, .uploading, .transcribing,
+            .readyToInsert, .targetContextChanged,
+        ]
+        if state == .awaitingReturn { return [.launchingApp, .awaitingReturn] }
+        guard let end = pipeline.firstIndex(of: state) else { return [state] }
+        return Array(pipeline.prefix(through: end))
+    }
+
+    // MARK: - Expiry
+
+    /// The keyboard adopts the newest non-terminal session every time it
+    /// appears, in any app. A hand-off nobody completed therefore has to become
+    /// terminal on its own, or it is a permanent "Opening vocaphone" bar.
+    @Test func anUncompletedHandoffExpiresRatherThanWaitingForever() throws {
+        let start = Date(timeIntervalSince1970: 1_000)
+        for state in [SessionState.launchingApp, .awaitingReturn] {
+            var record = SessionRecord(now: start)
+            try record.transition(to: .launchingApp, now: start)
+            if state == .awaitingReturn {
+                try record.transition(to: .awaitingReturn, now: start)
+            }
+
+            let withinWindow = start.addingTimeInterval(
+                SessionExpiryPolicy.handoffWindow - 1
+            )
+            #expect(!SessionExpiryPolicy.isStale(record, now: withinWindow))
+            #expect(SessionExpiryPolicy.isStale(
+                record,
+                now: start.addingTimeInterval(SessionExpiryPolicy.handoffWindow + 1)
+            ))
+        }
+    }
+
+    /// The audio the user is speaking must never be retired underneath them, so
+    /// the capture window has to clear the hard recording cap by a wide margin.
+    @Test func aLiveRecordingOutlastsTheCapItIsAlreadyBoundedBy() throws {
+        let start = Date(timeIntervalSince1970: 1_000)
+        var record = SessionRecord(now: start)
+        try record.transition(to: .launchingApp, now: start)
+        try record.transition(to: .recording, now: start)
+
+        #expect(!SessionExpiryPolicy.isStale(
+            record,
+            now: start.addingTimeInterval(AppConfiguration.maximumRecordingSeconds + 60)
+        ))
+        #expect(SessionExpiryPolicy.isStale(
+            record,
+            now: start.addingTimeInterval(SessionExpiryPolicy.captureWindow + 1)
+        ))
+    }
+
+    /// A transcript in flight belongs to the field it was dictated for, and the
+    /// hand-off back to that field is measured in seconds. Keeping it offered
+    /// indefinitely is what let yesterday's dictation land in today's field.
+    @Test func anAbandonedTranscriptStopsBeingOfferedEventually() throws {
+        let start = Date(timeIntervalSince1970: 1_000)
+        var record = SessionRecord(now: start)
+        for state in [
+            SessionState.launchingApp, .recording, .finalizing, .uploading,
+            .transcribing, .readyToInsert,
+        ] {
+            try record.transition(to: state, now: start)
+        }
+
+        #expect(!SessionExpiryPolicy.isStale(record, now: start.addingTimeInterval(60)))
+        #expect(SessionExpiryPolicy.isStale(
+            record,
+            now: start.addingTimeInterval(SessionExpiryPolicy.pendingUserActionWindow + 1)
+        ))
+    }
+
+    /// Terminal states have already stopped; expiring them again would rewrite
+    /// finished history and re-notify every observer.
+    @Test func settledSessionsAreNeverExpiredAgain() {
+        for state in SessionState.allCases where state.isTerminal {
+            #expect(SessionExpiryPolicy.window(for: state) == nil)
+        }
+    }
+
+    /// Expiry is durable so the other process learns about it from the shared
+    /// record rather than each one running its own timer.
+    @Test func expiringWritesThroughSoBothProcessesAgree() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(rootOverride: directory)
+        let start = Date(timeIntervalSince1970: 1_000)
+        var record = SessionRecord(now: start)
+        try record.transition(to: .launchingApp, now: start)
+        try store.save(record)
+
+        let fresh = SessionExpiryPolicy.expireIfStale(
+            record,
+            in: store,
+            now: start.addingTimeInterval(10)
+        )
+        #expect(fresh == nil)
+        #expect(try store.load(record.sessionID)?.state == .launchingApp)
+
+        let expired = SessionExpiryPolicy.expireIfStale(
+            record,
+            in: store,
+            now: start.addingTimeInterval(SessionExpiryPolicy.handoffWindow + 1)
+        )
+        #expect(expired?.state == .expired)
+        #expect(try store.load(record.sessionID)?.state == .expired)
+    }
+
+    /// The keyboard's launch fallback reads this to tell "the app never heard
+    /// me" from "the app is warming the microphone", which is the difference
+    /// between rescuing a dictation and yanking the user out of their app.
+    @Test func aClaimedHandoffRoundTripsAndDefaultsToUnclaimed() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(rootOverride: directory)
+
+        var record = SessionRecord()
+        try record.transition(to: .launchingApp)
+        try store.save(record)
+        #expect(try store.load(record.sessionID)?.claimedAt == nil)
+
+        record.claimedAt = Date(timeIntervalSince1970: 2_000)
+        try store.save(record)
+        #expect(
+            try store.load(record.sessionID)?.claimedAt
+                == Date(timeIntervalSince1970: 2_000)
+        )
+        // Claiming is not a state change: the hand-off is still outstanding.
+        #expect(try store.load(record.sessionID)?.state == .launchingApp)
+    }
+
     /// Writes `count` sessions with explicit, increasing modification dates so
     /// recency ordering is deterministic rather than dependent on filesystem
     /// timestamp resolution. Returns identifiers oldest to newest.


### PR DESCRIPTION
## Why

A review of the keyboard → hand-off → recording → status indicator → insertion path on both platforms, hunting the intermittent bugs seen in that flow. Eleven of them. The iOS half came first; the Android half is the same review applied to the other codebase.

---

# iOS

## The root cause

**Nothing ever retired a session.** `SessionState.expired` was declared, given a display name, and listed as a transition *target* from five states — and never reached from anywhere in the codebase. Meanwhile `KeyboardViewController.refresh()` adopts the newest non-terminal session on every appearance, in every app, with no age check.

So:

- A hand-off a host app silently swallowed left a `.launchingApp` record forever. Every later keyboard appearance showed a spinning "Opening vocaphone" bar with a poll running behind it, recoverable only by finding the small ✗.
- The same path applied to `.readyToInsert`. A transcript abandoned yesterday got adopted today in an unrelated app and — with auto-insert on, which is the default — typed straight into whichever field was focused.

`SessionExpiryPolicy` gives each waiting state a watchdog window (120s hand-off, `maximumRecordingSeconds + 120` capture, 10min processing, 1h pending-user-action) and the missing `.expired` transitions make them reachable. Expiry writes through the shared record so both processes agree rather than each keeping a private timer, and the app now tears down on `.expired` exactly as far as it does on a cancel — the keyboard is acting as watchdog for a recorder that may still be holding the microphone.

The windows are deliberately generous: this is a watchdog for a process that is gone, not a deadline for a slow one.

## Quick Dictation was switching apps on dictations that were about to work

Quick Dictation records without leaving the host app, so opening vocaphone is its *failure* path. The fallback fired if the session was not `.recording` 1.5s after the tap — but the app's warm path has to clear the marker, request permission, warm the audio graph (retrying up to 3×150ms across a microphone another app is releasing), await the 140ms start cue, and, with on-device transcription, call `startSherpaIncrementalSession`, which synchronously loads an ONNX model.

That routinely outran 1.5s, and the fallback then pulled the user out of the app they were typing in for a dictation seconds from starting. This is the most likely source of the app-switching flakiness.

The app now writes `claimedAt` before anything slow, and the fallback waits on it: unclaimed after 1.5s → open the app; claimed → keep waiting to an 8s deadline.

## Also fixed

- **The Dynamic Island vanished mid-transcription on any interruption.** `liveActivity.end(...)` nils the manager's `activeSessionID`, which every later `update`/`end` guards on. An incoming call ended the activity, and then the `requestFinish()` on the very next line plus the entire upload/transcribe pipeline updated nothing — the Island disappeared while the app went on transcribing what it had captured, and "Transcript ready" never showed.
- **Stranded Live Activities.** They outlive their app, and `endBeforeProcessExit` only covers scene-disconnect and terminate. A jetsam kill during recording left a "Recording" Island offering Finish for a dead session, with no process left to notice. Cleared on the next foreground, guarded so a live or deliberately-armed standby activity is never mistaken for an orphan.
- **The wrong-field guard silently disabled itself.** `refresh()` runs in `viewDidLoad`, where iOS can withhold `documentIdentifier` (the reason for the Objective-C read). A session adopted in that window kept `sessionTargetDocumentID == nil` for its whole life, and the guard passes when either side is nil. Now latches the first identifier that becomes known.
- **Cancel was a no-op during transcription.** The bar offers Cancel in every live state, but `.transcribing` was the one state whose transition table did not accept it: the tap reported "The session changed. Please try again." and the session carried on. Found while adding `.expired` to the same row.
- Leaving or returning to a field now re-evaluates a parked transcript immediately instead of up to 1.5s later.
- The deep link no longer announces "Starting the recording…" for a session `startSession` will decline to start.

---

# Android

Android's architecture rules out the stale-record class entirely — one process, in-memory state, nothing durable to adopt across launches — so there is no expiry work to do here. But the same *shape* of bug is present: lifecycle state outliving the thing it describes.

- **A microphone foreground service for a dictation that never started.** `DictationService` takes the microphone FGS type before capture begins, then waits to see the microphone actually held before treating an idle state as the end. Only `holdsMicrophone` ended that wait, so a start that resolved without ever recording had nothing to end it but the ten-second timeout — and spent those ten seconds showing an ongoing "VocaPhone is recording" notification *and the system microphone indicator* over a dictation that never began. Tapping the mic before the gateway is configured does exactly that, which puts it squarely on the first-run path. The outcomes that never reach the microphone (`PERMISSION_REPAIR`, `FAILED`) now end the wait themselves.
- **A failure report landing on the wrong dictation.** `fail` finishes under `NonCancellable`, which is right for the durable half — the audio is preserved and Retry has to find it. But it also means the on-screen half can land after a cancel, or after the dictation the user started straight afterwards took the state over, putting `FAILED` on top of a session that was recording perfectly well. The history write still always runs; the state write is dropped when a newer generation owns the state.
- **Every cancel during upload or transcription leaked a service.** The microphone is released as soon as capture ends and the service stops itself there, so Finish and Cancel sent later reach a *fresh* instance with no recording to hold, no observer to stop it, and nothing else to end a started service.

## Not changed, worth knowing

**iOS:** an adopted session still retargets to the field the user has returned to. That is deliberate — `documentIdentifier` is regenerated when the extension process restarts, which is exactly what an app switch does, so a stored identifier would block every legitimate insertion. The expiry window is now what bounds the blast radius, rather than the identifier comparison.

**iOS:** `VocaPhoneOpenURLFromResponderChain` returns `YES` as soon as it finds a responder, without awaiting the completion handler, so `opened` is effectively always true and the `.awaitingReturn` "open vocaphone manually" path is unreachable. Left alone — the fix is a behavioural change to the launcher — but it means a genuinely failed URL open outside Quick Dictation now relies on the new expiry for recovery.

**Android:** `onFinishInput` cancels an IME-owned dictation, so hiding the keyboard mid-recording ends it. That is a deliberate existing choice (an editor connection is unsafe after that callback) and is left as is — it is stricter than the iOS equivalent, which keeps recording.

## Testing

`just ios::ci` green: 120 tests, 7 new — the expiry windows per state, that a live recording outlasts the cap it is already bounded by, that terminal states are never re-expired, that expiry writes through the store, that `claimedAt` round-trips and defaults to unclaimed, and that Cancel is accepted wherever the bar offers it.

`just android::ci` green (build, unit tests, lint): 4 new tests over the start-watch predicate, including that `IDLE` is not treated as an outcome — it is the phase the state is already in when the service subscribes, so counting it would abandon every dictation before it began.
