### PR TITLE
build(android): prepare beta.9 release

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.vocahq.vocaphone"
         minSdk = 33
         targetSdk = 36
-        versionCode = 8
-        versionName = "0.1.0-beta.8"
+        versionCode = 9
+        versionName = "0.1.0-beta.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
## Problem

The `v0.1.0-beta.9` release workflow built an APK that still declared `0.1.0-beta.8`, so the tag-to-APK verification correctly rejected it.

## Summary

- bump the Android version code from 8 to 9
- set the Android version name to `0.1.0-beta.9`

## Verification

- `cd android && ./gradlew assembleRelease testDebugUnitTest lintRelease`
- `aapt dump badging app/build/outputs/apk/release/vocaphone-release.apk` reports package `com.vocahq.vocaphone`, version code `9`, and version name `0.1.0-beta.9`
- `git diff --check`
