### PR TITLE
fix(android): use VocaPhone app label for F-Droid

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">vocaphone</string>
+    <string name="app_name">VocaPhone</string>
 
     <string name="ime_name">VocaPhone keyboard</string>
 </resources>


### PR DESCRIPTION
## What changed?

A small adjustment has been made to `app_name`, changing it from `vocaphone` to `VocaPhone`.

This requires F-Droid metadata.

