### PR TITLE
ci(web): deploy the static site to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,45 @@
+name: Deploy website to Pages
+
+# Publishes the static site in web/ to GitHub Pages.
+# After merge: Settings → Pages → Source → GitHub Actions.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check site
+        working-directory: web
+        run: npm run check
+
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: web
+
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/web/README.md
+++ b/web/README.md
@@ -13,17 +13,19 @@ Then open `http://127.0.0.1:4173/`. The iPhone setup guide is available at
 
 The site uses only local brand assets and system fonts. Android beta links open
 the repository's GitHub Releases page, where each release includes the APK and
-its verification files. No hosting provider configuration is committed here.
+its verification files.
 
-## Deployment handoff
+## Deployment
+
+GitHub Actions deploys `web/` to Pages on every push to `main` that touches
+this directory (see `.github/workflows/pages.yml`). Set Pages source to
+**GitHub Actions**, then add the custom domain in repo Settings → Pages.
 
 - Site directory: `web`
-- Build command: `npm run check`
+- Check command: `npm run check`
 - Publish directory: `web`
 - Canonical URL expected by metadata: `https://vocaphone.vocahq.com/`
 
-The deployment owner should configure HTTPS, redirects/pretty URLs, caching,
-security headers, and the production domain in the selected hosting platform.
 Both `/` and `/iphone/` must resolve as HTML routes.
 
 The Android product images are the original 576×1280 screenshots from


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add `.github/workflows/pages.yml` to publish `web/` to GitHub Pages on pushes to `main` (and manual `workflow_dispatch`).
- Update `web/README.md` with the Actions-based deploy steps.

After merge, switch **Settings → Pages → Source** to **GitHub Actions**, then set the custom domain once DNS is ready.

## Verification

- [x] `cd web && npm run check` (17/17 pass)
- [x] `actionlint` on `pages.yml` (clean)
- [ ] `just ios ci` (not applicable)
- [ ] `just android ci` (not applicable)
- [ ] Gateway changes: PR against [vocagateway](https://github.com/VocaHQ/vocagateway) and submodule pin updated here if needed (not applicable)
- [ ] Physical-device test (not applicable)

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for data-flow, permission, retention, or network changes (web deploy docs only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ada0e932-b502-4688-91a8-0585b82d1515?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ada0e932-b502-4688-91a8-0585b82d1515&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

