### PR TITLE
ci(web): pin Pages CNAME and republish site root

### DIFF
--- a/web/CNAME
+++ b/web/CNAME
@@ -1,0 +1,1 @@
+vocaphone.vocahq.com


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add `web/CNAME` with `vocaphone.vocahq.com` so Pages keeps the custom domain on Actions deploys.
- Merging this re-runs the Pages workflow and republishes `web/` as the site root (the merge of #87 was overwritten by a leftover Jekyll `pages-build-deployment`).

## Verification

- [x] Prior Actions deploy succeeded, then was marked inactive by the legacy Jekyll publish
- [ ] After merge: confirm `/` is the marketing site, not the README theme
- [ ] `just ios ci` / `just android ci`: not applicable

## Privacy and security

- [x] No secrets added
- [x] Docs/CNAME only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ada0e932-b502-4688-91a8-0585b82d1515?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ada0e932-b502-4688-91a8-0585b82d1515&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

