### PR TITLE
Offer an emoji for the word being typed

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -71,7 +71,7 @@ Settings is grouped by what you are trying to do, in five destinations:
 
 | Destination | What lives there |
 | --- | --- |
-| **Keyboard** | Height, a live preview, suggestions, autocorrect, prediction, learned words, smart punctuation, haptics, swipe typing |
+| **Keyboard** | Height, a live preview, suggestions, autocorrect, prediction, learned words, smart punctuation, emoji suggestions, haptics, swipe typing |
 | **Dictation** | Automatic insertion, Quick Dictation, language, writing style, numbers as digits, microphone, recording sounds, custom words |
 | **Transcription** | Which source is in use, on-device models, gateway pairing and health |
 | **Privacy and permissions** | Microphone status, Full Access explanation and manual path, what is kept |

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		414B7AB5FBA938C804977DAE /* SpellChecking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4BE75828FCA9C70DFEDC96 /* SpellChecking.swift */; };
 		4217DD7E4261F3B917A4FD81 /* SwipeTrailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DFD83D2BCB84400E7981A4B /* SwipeTrailTests.swift */; };
 		444F9DFC10831BE9150988A6 /* TranscriptionQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E2BF42CAC209DA12464566 /* TranscriptionQuality.swift */; };
+		445497F26F783CF512F605AD /* SwipeAlternates.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1F0FABCAE6669D0EB07FC3 /* SwipeAlternates.swift */; };
 		45AB9DD91FB8969A4BB19A60 /* TranscriptRetention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6FFEA14B55E6F6C61FBAC /* TranscriptRetention.swift */; };
 		4700DB7F7BE95078E7A8A563 /* TypingFieldPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBE3CB8FFE4DDA7B459C2A7 /* TypingFieldPolicyTests.swift */; };
 		482A8494DA8A03BDB5DF1B0E /* LocalTranscriptionPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FF1A5ABC4220C886291309 /* LocalTranscriptionPreferences.swift */; };
@@ -114,6 +115,7 @@
 		5D5A394AA7E8170CFE4E128B /* RecordingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF871FC84B4C6B2627A43C2 /* RecordingCoordinator.swift */; };
 		5FB6858C38350EC77F45EB62 /* BrandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9711C18238B39EA2E842C0F /* BrandPalette.swift */; };
 		5FD3264678E78B2F180A074A /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11816AC1A2219D15E870CE3E /* EmojiCatalog.swift */; };
+		612E02043BE5C4F9567D128E /* SwipeAlternatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CF82ECCA1F28AB94B4142DE /* SwipeAlternatesTests.swift */; };
 		6192C923119F158CCE94B48E /* QuickDictationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB84927D76F9C32C4BE1547 /* QuickDictationAvailability.swift */; };
 		61D705F2D38349B0A9667F2E /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */; };
 		62F20884ED82C44DD050F3E5 /* KeyGridLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2C1575D306E7683092FBA /* KeyGridLayoutTests.swift */; };
@@ -160,6 +162,7 @@
 		91EA8108C4C2D6C4EF5CF3F1 /* SpeechAudioConditioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */; };
 		9282771B81021A932B1C6EA1 /* DictatedTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575BDB070A428051B623F095 /* DictatedTranscript.swift */; };
 		939752FDA33E96C811ED23C1 /* LocalTranscriptionPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FF1A5ABC4220C886291309 /* LocalTranscriptionPreferences.swift */; };
+		939ADF1C236F670A3541ACAA /* SwipeAlternates.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1F0FABCAE6669D0EB07FC3 /* SwipeAlternates.swift */; };
 		9418E647BE968A5FC2064D06 /* SpokenNumbersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8201161064874EF522DF3F70 /* SpokenNumbersTests.swift */; };
 		94B667AC0FFB905D57BE2CA3 /* VocaPhoneLiveActivity.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = CF080065DC31C6DA8E693163 /* VocaPhoneLiveActivity.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		95A08342703AE27BD09E08AC /* TranscriptStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DBF47C7F5E5B13752056CB /* TranscriptStyler.swift */; };
@@ -314,6 +317,7 @@
 		13FF1A5ABC4220C886291309 /* LocalTranscriptionPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalTranscriptionPreferences.swift; sourceTree = "<group>"; };
 		1582F900473255CD64DC8C2A /* sherpa-onnx.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = "sherpa-onnx.xcframework"; path = "ThirdParty/SherpaOnnx/sherpa-onnx.xcframework"; sourceTree = "<group>"; };
 		17B4671FC8BBA4DD4FD5AA8C /* GatewaySetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewaySetupView.swift; sourceTree = "<group>"; };
+		1CF82ECCA1F28AB94B4142DE /* SwipeAlternatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeAlternatesTests.swift; sourceTree = "<group>"; };
 		20F3E310970DBFA3822A4D19 /* SherpaDecodingMethodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaDecodingMethodTests.swift; sourceTree = "<group>"; };
 		2678D836274997421A54E901 /* AudioCaptureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCaptureTests.swift; sourceTree = "<group>"; };
 		28ECEDA044D2B1021710F205 /* TranscriptHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptHistoryView.swift; sourceTree = "<group>"; };
@@ -405,6 +409,7 @@
 		B854354D06D0111DEB123E7A /* SessionRecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRecordTests.swift; sourceTree = "<group>"; };
 		B87128326897BFA30E7B2038 /* KeyLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyLayout.swift; sourceTree = "<group>"; };
 		B9B9027C03A87FBC74CE1130 /* TypingEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingEngine.swift; sourceTree = "<group>"; };
+		BA1F0FABCAE6669D0EB07FC3 /* SwipeAlternates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeAlternates.swift; sourceTree = "<group>"; };
 		BE0BE99770A5F7F08891E2BD /* KeyboardURLLauncher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeyboardURLLauncher.h; sourceTree = "<group>"; };
 		BE3489C985467C23EB6A90AD /* DictationBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarView.swift; sourceTree = "<group>"; };
 		C304CF763960E5F1D8F76B2B /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
@@ -502,6 +507,7 @@
 				5118F8CFAAE127CD5FF92076 /* KeyView.swift */,
 				07178E9C6A3CF354CD83A2C1 /* SmartPunctuation.swift */,
 				3D4BE75828FCA9C70DFEDC96 /* SpellChecking.swift */,
+				BA1F0FABCAE6669D0EB07FC3 /* SwipeAlternates.swift */,
 				07C4BD2142E9377F123A8848 /* SwipeRecognizer.swift */,
 				DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */,
 				DEAA4440B24071020CD693DB /* TypingCandidates.swift */,
@@ -668,6 +674,7 @@
 				8F8CE24C7BC4F4CA618F4B79 /* SmartPunctuationTests.swift */,
 				A59DB522E7DFDE3B3E009AFD /* SpeechAudioConditioningTests.swift */,
 				8201161064874EF522DF3F70 /* SpokenNumbersTests.swift */,
+				1CF82ECCA1F28AB94B4142DE /* SwipeAlternatesTests.swift */,
 				924E5D73CB086A4210BF6052 /* SwipeRecognizerTests.swift */,
 				0DFD83D2BCB84400E7981A4B /* SwipeTrailTests.swift */,
 				ABDF2EC3AB09FF78FD1EF935 /* TranscriptHistoryModelTests.swift */,
@@ -929,6 +936,7 @@
 				B4542386951D03680B5F6638 /* SpeechAudioConditioning.swift in Sources */,
 				414B7AB5FBA938C804977DAE /* SpellChecking.swift in Sources */,
 				E269B9344AB06AD0FB9FF665 /* SpokenNumbers.swift in Sources */,
+				445497F26F783CF512F605AD /* SwipeAlternates.swift in Sources */,
 				282E28F25550DF3BFB996429 /* SwipeRecognizer.swift in Sources */,
 				B1D4DE96B74C3327DA6A0FAD /* SwipeTrailView.swift in Sources */,
 				E366EFAD9B70FE3FC43FEBAD /* TextInsertion.swift in Sources */,
@@ -1129,6 +1137,8 @@
 				9EE31A21EE5F9D71A15404DA /* SpellChecking.swift in Sources */,
 				AC222A4D19661A309FEC32C1 /* SpokenNumbers.swift in Sources */,
 				9418E647BE968A5FC2064D06 /* SpokenNumbersTests.swift in Sources */,
+				939ADF1C236F670A3541ACAA /* SwipeAlternates.swift in Sources */,
+				612E02043BE5C4F9567D128E /* SwipeAlternatesTests.swift in Sources */,
 				33049B8AD2490B0F8D0A9E0F /* SwipeRecognizer.swift in Sources */,
 				6A62B202B2F9C76E00794A3D /* SwipeRecognizerTests.swift in Sources */,
 				4217DD7E4261F3B917A4FD81 /* SwipeTrailTests.swift in Sources */,

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		400FC934DB32BD708B5D23A9 /* KeyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5118F8CFAAE127CD5FF92076 /* KeyView.swift */; };
 		4016476924F9555E1E861673 /* GatewaySetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B4671FC8BBA4DD4FD5AA8C /* GatewaySetupView.swift */; };
 		408E48AA90858E8FAF046263 /* LocalModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473A608BF3F8827B3D3842B0 /* LocalModelCatalog.swift */; };
+		40959874C3AE5396E1177CC4 /* EmojiSuggestions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136E505E4C5668F9ACCD30C5 /* EmojiSuggestions.swift */; };
 		414B7AB5FBA938C804977DAE /* SpellChecking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4BE75828FCA9C70DFEDC96 /* SpellChecking.swift */; };
 		4217DD7E4261F3B917A4FD81 /* SwipeTrailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DFD83D2BCB84400E7981A4B /* SwipeTrailTests.swift */; };
 		444F9DFC10831BE9150988A6 /* TranscriptionQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E2BF42CAC209DA12464566 /* TranscriptionQuality.swift */; };
@@ -128,6 +129,7 @@
 		6CEF2A686643F72F4BCDD51D /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
 		7280B936E153A21AC6D75B27 /* WordComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A6EEE8C98BCBF8D1D70D44 /* WordComposer.swift */; };
 		7466C707EC283E26021BB710 /* sherpa_model_pins.json in Resources */ = {isa = PBXBuildFile; fileRef = 00FA1D26F8C2CDC36BEBB95A /* sherpa_model_pins.json */; };
+		75EC59510885420249491B03 /* EmojiSuggestions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136E505E4C5668F9ACCD30C5 /* EmojiSuggestions.swift */; };
 		76E660378F845C250AEA0673 /* AudioCapturePipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15DE10A5F8F90C87D4BA48A /* AudioCapturePipeline.swift */; };
 		771730250FDC04B40A57E462 /* KeyAlternatives.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0EBA8DE4056FCA3CB7F093C /* KeyAlternatives.swift */; };
 		77E93C2F64DEB6AAB50C09F0 /* TranscriptSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B121356A503DF83BFA0E0D0C /* TranscriptSanitizer.swift */; };
@@ -213,6 +215,7 @@
 		C958410A61E962F39B4F5E4D /* LearnedWords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */; };
 		C9A65099749EC5AB021FCC1C /* SherpaLongAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */; };
 		CA31A30F8E764B891884324F /* TranscriptStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DBF47C7F5E5B13752056CB /* TranscriptStyler.swift */; };
+		CD600A39A4DFB39AD6F0E5E1 /* EmojiSuggestionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C0A3D1DBF6BCF25C37CF24 /* EmojiSuggestionsTests.swift */; };
 		CE9227DEA1DE35F0F9987562 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894063AE1B3DDA92C529268D /* AppConfiguration.swift */; };
 		CFF7A7DC99B4880EB955D603 /* KeyboardHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858088F81E12EC57E13F9492 /* KeyboardHaptics.swift */; };
 		D0E6AF99E65342BE66CF809A /* LearnedWords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */; };
@@ -307,6 +310,7 @@
 		0B31528AA0DAB644EFBBE967 /* TypingCandidatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingCandidatesTests.swift; sourceTree = "<group>"; };
 		0DFD83D2BCB84400E7981A4B /* SwipeTrailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeTrailTests.swift; sourceTree = "<group>"; };
 		11816AC1A2219D15E870CE3E /* EmojiCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCatalog.swift; sourceTree = "<group>"; };
+		136E505E4C5668F9ACCD30C5 /* EmojiSuggestions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiSuggestions.swift; sourceTree = "<group>"; };
 		13FF1A5ABC4220C886291309 /* LocalTranscriptionPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalTranscriptionPreferences.swift; sourceTree = "<group>"; };
 		1582F900473255CD64DC8C2A /* sherpa-onnx.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = "sherpa-onnx.xcframework"; path = "ThirdParty/SherpaOnnx/sherpa-onnx.xcframework"; sourceTree = "<group>"; };
 		17B4671FC8BBA4DD4FD5AA8C /* GatewaySetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewaySetupView.swift; sourceTree = "<group>"; };
@@ -329,6 +333,7 @@
 		3E3E4382E021BE30F6D687A7 /* SherpaTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaTranscriptTests.swift; sourceTree = "<group>"; };
 		3EC2C1575D306E7683092FBA /* KeyGridLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyGridLayoutTests.swift; sourceTree = "<group>"; };
 		406B0C287866B36EF3109238 /* LocalModelPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelPicker.swift; sourceTree = "<group>"; };
+		41C0A3D1DBF6BCF25C37CF24 /* EmojiSuggestionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiSuggestionsTests.swift; sourceTree = "<group>"; };
 		4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnedWords.swift; sourceTree = "<group>"; };
 		473A608BF3F8827B3D3842B0 /* LocalModelCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelCatalog.swift; sourceTree = "<group>"; };
 		4871EA8AAF829D7979EC9587 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -485,6 +490,7 @@
 				9DCCE5FE1A8242B96B8CA9FD /* DictationPresentation.swift */,
 				11816AC1A2219D15E870CE3E /* EmojiCatalog.swift */,
 				348E2313B75BA61D777FA18B /* EmojiPanelView.swift */,
+				136E505E4C5668F9ACCD30C5 /* EmojiSuggestions.swift */,
 				3785791C0D9A5ABA2506F1B7 /* Info.plist */,
 				A0EBA8DE4056FCA3CB7F093C /* KeyAlternatives.swift */,
 				858088F81E12EC57E13F9492 /* KeyboardHaptics.swift */,
@@ -642,6 +648,7 @@
 				FA83B914C241E5F8BF8F32AC /* DictationBarLayoutTests.swift */,
 				56047A6705008B5F17F003CE /* DictationPresentationTests.swift */,
 				882F3122E12BD0F2BF44ADC9 /* EmojiCatalogTests.swift */,
+				41C0A3D1DBF6BCF25C37CF24 /* EmojiSuggestionsTests.swift */,
 				F72772F0CCE3BA274182C5F4 /* HomePresentationTests.swift */,
 				7A53786C8D2346452C69A748 /* InsertionTargetTests.swift */,
 				EF0326EF6FB3E96C942C6065 /* KeyAlternativesTests.swift */,
@@ -897,6 +904,7 @@
 				E4187B9A8DA6FBBA6DE095AC /* DictationPresentation.swift in Sources */,
 				5FD3264678E78B2F180A074A /* EmojiCatalog.swift in Sources */,
 				C63521DE52DC5A8DCD6847AE /* EmojiPanelView.swift in Sources */,
+				40959874C3AE5396E1177CC4 /* EmojiSuggestions.swift in Sources */,
 				7E3D8E857A83184E74B15433 /* GatewayEndpoint.swift in Sources */,
 				771730250FDC04B40A57E462 /* KeyAlternatives.swift in Sources */,
 				E4162282629880D2A33913CA /* KeyGridView.swift in Sources */,
@@ -1076,6 +1084,8 @@
 				DEB245BAC4DEE643F2EB38B0 /* DictationPresentationTests.swift in Sources */,
 				1F45494DE6D2E1E471D446B5 /* EmojiCatalog.swift in Sources */,
 				F50496BCCFCB73757D3DDF13 /* EmojiCatalogTests.swift in Sources */,
+				75EC59510885420249491B03 /* EmojiSuggestions.swift in Sources */,
+				CD600A39A4DFB39AD6F0E5E1 /* EmojiSuggestionsTests.swift in Sources */,
 				A2112E100F4277466EA8DD4F /* GatewayEndpoint.swift in Sources */,
 				12F5617A0ECD4D904FC8FEA6 /* HomePresentation.swift in Sources */,
 				162E1C513A0E6585E3445812 /* HomePresentationTests.swift in Sources */,

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -120,6 +120,10 @@ struct KeyboardSettingsView: View {
         store: KeyboardPreferences.defaults
     ) private var hapticsEnabled = true
     @AppStorage(
+        KeyboardPreferences.emojiSuggestionsKey,
+        store: KeyboardPreferences.defaults
+    ) private var emojiSuggestionsEnabled = true
+    @AppStorage(
         KeyboardPreferences.swipeTypingKey,
         store: KeyboardPreferences.defaults
     ) private var swipeTypingEnabled = false
@@ -253,6 +257,7 @@ struct KeyboardSettingsView: View {
     private var typingDetailSection: some View {
         Section {
             Toggle("Smart punctuation", isOn: $smartPunctuationEnabled)
+            Toggle("Emoji suggestions", isOn: $emojiSuggestionsEnabled)
             Toggle("Keyboard haptics", isOn: $hapticsEnabled)
             Toggle("Swipe to type", isOn: $swipeTypingEnabled)
         } footer: {
@@ -261,6 +266,13 @@ struct KeyboardSettingsView: View {
                     "Smart punctuation curls quotes, turns two hyphens into an em "
                         + "dash and three dots into an ellipsis — except where the "
                         + "field asks it not to, such as a code or address field."
+                )
+                Text(
+                    "Emoji suggestions offer one emoji beside the word candidates "
+                        + "when a word has an obvious one — typing “lol” offers 😂. "
+                        + "Tapping it replaces the word. It never takes a word "
+                        + "suggestion's place, and words without an obvious emoji "
+                        + "get none."
                 )
                 // Said plainly rather than leaving people to wonder why their
                 // keyboard is silent.

--- a/ios/VocaPhoneKeyboard/EmojiSuggestions.swift
+++ b/ios/VocaPhoneKeyboard/EmojiSuggestions.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// The emoji offered for a word as it is typed: "lol" offers 😂.
+///
+/// A curated table rather than a lookup into ``EmojiCatalog``, which was the
+/// obvious idea and is the wrong one. The catalog's keywords exist to answer a
+/// deliberate search in the emoji panel, where the user has typed a query and
+/// is looking at a grid of results. Matched against ordinary prose it answers
+/// "the" with 🤣, "and" with 🫢, "is" with the flag of Iceland, "dog" with 💩
+/// and "clock" with 🏫 — because a keyword match says a word appears somewhere
+/// in an emoji's description, not that the emoji is what the word means.
+///
+/// So this is a hand-checked map of word to the one emoji a reader would expect,
+/// and a word that is not in it produces nothing. Everyday prose has to pass
+/// through the strip untouched: the cost of a wrong suggestion is not a wrong
+/// character — the chip has to be tapped — but a strip that cries wolf on every
+/// third word is one nobody reads, including when it is right.
+///
+/// Words are excluded when they are common in ordinary sentences without
+/// carrying the thing the emoji means: "good", "yes", "no", "time", "work",
+/// "day", "code", "check", "key". The bar is whether the emoji is the *obvious*
+/// association, not merely *an* association.
+///
+/// English only, matching the rest of the typing intelligence. It costs a few
+/// kilobytes, which is the other reason it is not the catalog: the keyboard is
+/// killed around 45–60 MB, and the 284 KB catalog is loaded only when the emoji
+/// panel is actually opened.
+enum EmojiSuggestions {
+    /// The shortest word worth matching. Two letters are mostly initials,
+    /// particles and typos.
+    static let minimumLength = 2
+
+    static func glyph(for word: String) -> String? {
+        let key = word.lowercased()
+        guard key.count >= minimumLength else { return nil }
+        return triggers[key]
+    }
+
+    /// Exact whole words only. A prefix match would put an emoji on the strip
+    /// while the user is still two letters into a different word.
+    static let triggers: [String: String] = [
+        // Laughter and reactions — the vocabulary of a chat keyboard, which is
+        // where this feature earns its slot.
+        "lol": "😂", "lmao": "🤣", "rofl": "🤣", "haha": "😂", "hehe": "😄",
+        "funny": "😂", "omg": "😱", "wow": "😮", "yay": "🎉", "oops": "🙈",
+        "ugh": "😩", "meh": "😐", "cool": "😎", "nice": "👍", "awesome": "🤩",
+        "amazing": "🤩", "perfect": "👌", "done": "✅", "agree": "👍",
+        "congrats": "🎉", "congratulations": "🎉", "welcome": "🤗",
+
+        // Feeling
+        "love": "❤️", "loved": "❤️", "heart": "❤️", "happy": "😊", "sad": "😢",
+        "cry": "😭", "crying": "😭", "angry": "😠", "mad": "😠", "tired": "😴",
+        "sleepy": "😴", "sleep": "😴", "sick": "🤒", "scared": "😱",
+        "confused": "😕", "bored": "🥱", "excited": "🤩", "shy": "😊",
+        "hungry": "😋", "thirsty": "🥤", "stressed": "😰", "relieved": "😌",
+
+        // Greetings and courtesies
+        "hi": "👋", "hello": "👋", "hey": "👋", "bye": "👋", "goodbye": "👋",
+        "thanks": "🙏", "thankyou": "🙏", "please": "🙏", "sorry": "😔",
+        "hug": "🤗", "hugs": "🤗", "kiss": "😘", "wink": "😉",
+
+        // Gestures
+        "ok": "👌", "okay": "👌", "clap": "👏", "applause": "👏", "bravo": "👏",
+        "wave": "👋", "pray": "🙏", "prayers": "🙏", "muscle": "💪",
+        "strong": "💪", "facepalm": "🤦", "shrug": "🤷", "thinking": "🤔",
+        "eyes": "👀", "brain": "🧠",
+
+        // Things that are simply themselves
+        "fire": "🔥", "lit": "🔥", "skull": "💀", "ghost": "👻", "alien": "👽",
+        "robot": "🤖", "poop": "💩", "party": "🎉", "birthday": "🎂",
+        "cake": "🎂", "gift": "🎁", "present": "🎁", "balloon": "🎈",
+        "fireworks": "🎆", "crown": "👑", "diamond": "💎", "trophy": "🏆",
+        "winner": "🏆", "medal": "🥇", "idea": "💡", "bug": "🐛",
+        "warning": "⚠️", "rocket": "🚀",
+
+        // Food and drink
+        "pizza": "🍕", "burger": "🍔", "fries": "🍟", "coffee": "☕",
+        "tea": "🍵", "beer": "🍺", "wine": "🍷", "water": "💧",
+        "breakfast": "🥞", "lunch": "🍽️", "dinner": "🍽️", "snack": "🍿",
+        "chocolate": "🍫", "cookie": "🍪", "icecream": "🍦", "apple": "🍎",
+        "banana": "🍌", "biryani": "🍛", "chai": "🍵",
+
+        // Living things and weather
+        "dog": "🐶", "puppy": "🐶", "cat": "🐱", "kitten": "🐱", "bird": "🐦",
+        "fish": "🐟", "tree": "🌳", "flower": "🌸", "rose": "🌹",
+        "sun": "☀️", "sunny": "☀️", "moon": "🌙", "star": "⭐",
+        "rain": "🌧️", "rainy": "🌧️", "snow": "❄️", "storm": "⛈️",
+        "rainbow": "🌈", "beach": "🏖️",
+
+        // Places, travel, the working day
+        "home": "🏠", "house": "🏠", "office": "🏢", "school": "🏫",
+        "hospital": "🏥", "bank": "🏦", "gym": "🏋️", "workout": "🏋️",
+        "running": "🏃", "walk": "🚶", "travel": "✈️", "vacation": "✈️",
+        "holiday": "✈️", "flight": "✈️", "plane": "✈️", "airport": "✈️",
+        "car": "🚗", "train": "🚆", "bike": "🚲", "shopping": "🛒",
+        "money": "💰", "cash": "💰", "salary": "💰",
+
+        // Objects people mention in messages
+        "music": "🎵", "song": "🎵", "book": "📚", "reading": "📚",
+        "phone": "📱", "laptop": "💻", "computer": "💻", "email": "📧",
+        "mail": "📧", "calendar": "📅", "meeting": "🗓️", "deadline": "⏰",
+        "clock": "⏰", "alarm": "⏰", "camera": "📷", "photo": "📷",
+        "movie": "🎬", "game": "🎮", "gaming": "🎮", "art": "🎨",
+        "football": "⚽", "cricket": "🏏", "basketball": "🏀",
+
+        // Occasions
+        "christmas": "🎄", "halloween": "🎃", "diwali": "🪔",
+    ]
+}

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -1250,6 +1250,31 @@ extension KeyboardViewController: DictationBarViewDelegate {
         case .prediction:
             textDocumentProxy.insertText(candidate.text + " ")
             typing.resetComposition(origin: .suggestion, documentBefore: documentBefore)
+        case .swipeAlternate:
+            // The swiped word is already in the document with the space that
+            // followed it, so the replacement covers both and puts a space
+            // back. Deleting only the composition — which is empty by now,
+            // because the cursor sits past that space — is what left the
+            // rejected word in place with the alternate after it.
+            // Checked against the document, not against remembered state: the
+            // document wins here as it does everywhere else in this
+            // subsystem, and a replacement that cannot see the word it is
+            // replacing must not delete four characters on faith.
+            guard let swiped = typing.pendingSwipeWord,
+                  SwipeAlternates.isArmed(word: swiped, documentBefore: documentBefore)
+            else { break }
+            let alternates = SwipeAlternates.alternates(
+                after: candidate.text,
+                replacing: swiped,
+                from: typing.pendingSwipeAlternates
+            )
+            for _ in 0..<SwipeAlternates.deletionCount(replacing: swiped) {
+                textDocumentProxy.deleteBackward()
+            }
+            textDocumentProxy.insertText(candidate.text + " ")
+            // Re-armed on the new word, so a second thought is another tap
+            // rather than a retype.
+            typing.noteSwipeWord(candidate.text, alternates: alternates)
         case .emoji:
             // The emoji stands in for the word, exactly as the system keyboard
             // does it: "lol" becomes 😂 rather than "lol 😂".

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -1250,6 +1250,16 @@ extension KeyboardViewController: DictationBarViewDelegate {
         case .prediction:
             textDocumentProxy.insertText(candidate.text + " ")
             typing.resetComposition(origin: .suggestion, documentBefore: documentBefore)
+        case .emoji:
+            // The emoji stands in for the word, exactly as the system keyboard
+            // does it: "lol" becomes 😂 rather than "lol 😂".
+            let typed = typing.composer.text
+            for _ in 0..<typed.count { textDocumentProxy.deleteBackward() }
+            textDocumentProxy.insertText(candidate.text + " ")
+            // Deliberately not learned. `noteCompletedWord` teaches the
+            // keyboard vocabulary, and an emoji is not a word it should start
+            // completing letters into.
+            typing.resetComposition(origin: .suggestion, documentBefore: documentBefore)
         }
         lastSpaceInsertedAt = nil
         releaseUndoIfDetached()

--- a/ios/VocaPhoneKeyboard/SwipeAlternates.swift
+++ b/ios/VocaPhoneKeyboard/SwipeAlternates.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// The word a swipe just committed, and the ones that lost to it.
+///
+/// A swiped word is not a composition. It arrives whole, with the space that
+/// follows it already in the document, and that is precisely what
+/// ``WordComposer`` cannot represent: the composer describes the word the
+/// cursor is *inside*, and after a swipe the cursor is past a space, so the
+/// composition is correctly empty. Two things went wrong when the alternates
+/// were hung off the composer anyway:
+///
+/// * The alternates were published and then wiped by the reconcile that the
+///   swipe's own insertion triggers, so they flashed and vanished.
+/// * Replacing one deleted `composer.text.count` characters — zero, by then —
+///   and inserted the alternate after the word instead of over it.
+///
+/// So the swipe keeps its own state, and this is the arithmetic behind it:
+/// whether the word is still there to replace, how much of the document that
+/// replacement covers, and what to offer once it has happened.
+enum SwipeAlternates {
+    /// Whether the swiped word is still exactly what sits before the cursor.
+    ///
+    /// The trailing space is part of the test, not an afterthought. It is what
+    /// distinguishes a word the swipe just placed from the same word typed
+    /// earlier in the sentence, and it is the character a replacement has to
+    /// account for.
+    static func isArmed(word: String, documentBefore: String?) -> Bool {
+        guard !word.isEmpty, let documentBefore else { return false }
+        return documentBefore.hasSuffix(word + " ")
+    }
+
+    /// The word plus the space the swipe put after it. Deleting one character
+    /// fewer is what left "lol lug " where "lug " was meant.
+    static func deletionCount(replacing word: String) -> Int {
+        word.count + 1
+    }
+
+    /// What to offer after `chosen` replaces `word`.
+    ///
+    /// The replaced word goes back on the strip, first: a swipe that guessed
+    /// wrong is usually corrected in one tap, and the tap after that is often
+    /// "no, the original". Losing it would make the second correction a
+    /// retype.
+    static func alternates(
+        after chosen: String,
+        replacing word: String,
+        from alternates: [String]
+    ) -> [String] {
+        ([word] + alternates).filter {
+            $0.caseInsensitiveCompare(chosen) != .orderedSame
+        }
+    }
+}

--- a/ios/VocaPhoneKeyboard/TypingCandidates.swift
+++ b/ios/VocaPhoneKeyboard/TypingCandidates.swift
@@ -12,6 +12,9 @@ struct TypingCandidate: Equatable {
         case correction
         /// What usually follows the word just finished.
         case prediction
+        /// An emoji for the word being typed. Never competes with the word
+        /// candidates for a slot — it is offered beside them or not at all.
+        case emoji
     }
 
     let text: String
@@ -70,9 +73,13 @@ enum TypingCandidates {
         /// Words the user restored after an autocorrect, for this document.
         var assertedWords: Set<String> = []
 
+        /// The emoji for the word being composed, when there is an obvious one.
+        var emojiSuggestion: String?
+
         var suggestionsEnabled = true
         var autocorrectEnabled = true
         var predictionEnabled = true
+        var emojiEnabled = true
         var allowsTypingIntelligence = true
     }
 
@@ -118,7 +125,35 @@ enum TypingCandidates {
                 )
             )
         }
-        return TypingStrip(candidates: candidates, autocorrection: correction)
+        return TypingStrip(
+            candidates: appendingEmoji(to: candidates, context: context),
+            autocorrection: correction
+        )
+    }
+
+    /// The emoji goes last, and takes the lowest-ranked word's slot when the
+    /// strip is already full.
+    ///
+    /// A fourth chip was the intention — the three word slots are what the
+    /// strip is for — but on a 320 pt phone four chips plus the Dictate button
+    /// push the emoji off the visible row entirely. A suggestion the user has
+    /// to scroll sideways to discover is not a suggestion, so on a full strip
+    /// the emoji displaces the *last* candidate: the third-ranked completion,
+    /// which is the least likely word on the row.
+    ///
+    /// The literal and the emphasised correction are never at risk. They sit at
+    /// the front, and the one that space would apply must always be visible.
+    private static func appendingEmoji(
+        to candidates: [TypingCandidate],
+        context: Context
+    ) -> [TypingCandidate] {
+        guard context.emojiEnabled,
+              let glyph = context.emojiSuggestion,
+              !candidates.contains(where: { $0.kind == .emoji })
+        else { return candidates }
+        var kept = candidates
+        if kept.count >= slotCount { kept.removeLast() }
+        return kept + [TypingCandidate(text: glyph, kind: .emoji)]
     }
 
     /// Suggestions in priority order, deduplicated, never echoing the typed word.

--- a/ios/VocaPhoneKeyboard/TypingCandidates.swift
+++ b/ios/VocaPhoneKeyboard/TypingCandidates.swift
@@ -15,6 +15,10 @@ struct TypingCandidate: Equatable {
         /// An emoji for the word being typed. Never competes with the word
         /// candidates for a slot — it is offered beside them or not at all.
         case emoji
+        /// A word the swipe recogniser ranked below the one it committed.
+        /// Distinct from ``correction`` because replacing it has to take the
+        /// space the swipe inserted with it — see ``SwipeAlternates``.
+        case swipeAlternate
     }
 
     let text: String

--- a/ios/VocaPhoneKeyboard/TypingCandidates.swift
+++ b/ios/VocaPhoneKeyboard/TypingCandidates.swift
@@ -208,6 +208,18 @@ enum TypingCandidates {
               !context.assertedWords.contains(typed.lowercased())
         else { return nil }
 
+        // A word this keyboard has a curated emoji for is a word people type on
+        // purpose. Most of them — "omg", "lmao", "haha", "yay", "ugh", "meh",
+        // "congrats" — are absent from the shipped word list, so without this
+        // the keyboard would offer 😱 for "omg" while quietly preparing to turn
+        // it into "org" on the next space. Offering a suggestion for a word and
+        // correcting that same word away is the keyboard disagreeing with
+        // itself, and the user only finds out afterwards.
+        //
+        // Independent of whether the emoji chip is switched on: the setting
+        // controls whether a chip is drawn, not whether the word was meant.
+        guard context.emojiSuggestion == nil else { return nil }
+
         // Letters and apostrophes only. A token with a digit, an `@`, a slash or
         // an underscore is an identifier, a handle, a path or a password hint —
         // never something to "fix".

--- a/ios/VocaPhoneKeyboard/TypingEngine.swift
+++ b/ios/VocaPhoneKeyboard/TypingEngine.swift
@@ -144,6 +144,17 @@ final class TypingEngine {
     /// edit this keyboard did not make itself.
     func reconcile(documentBefore: String?) {
         composer.reconcile(documentBefore: documentBefore)
+        // The swipe's own insertion is what triggers the first of these. The
+        // word is still the tail of the document, so its alternates stand —
+        // reconciling the composer to an empty composition must not take them
+        // down with it.
+        if let pendingSwipe,
+           SwipeAlternates.isArmed(word: pendingSwipe.word, documentBefore: documentBefore)
+        {
+            publishSwipeAlternates()
+            return
+        }
+        pendingSwipe = nil
         refresh(documentBefore: documentBefore)
     }
 
@@ -151,17 +162,20 @@ final class TypingEngine {
 
     func insert(_ text: String, origin: WordComposer.Origin = .typed, documentBefore: String?) {
         pendingRevert = nil
+        pendingSwipe = nil
         composer.insert(text, origin: origin)
         refresh(documentBefore: documentBefore)
     }
 
     func deleteBackward(documentBefore: String?) {
         pendingRevert = nil
+        pendingSwipe = nil
         composer.deleteBackward()
         refresh(documentBefore: documentBefore)
     }
 
     func resetComposition(origin: WordComposer.Origin = .typed, documentBefore: String?) {
+        pendingSwipe = nil
         composer.reset(origin: origin)
         refresh(documentBefore: documentBefore)
     }
@@ -202,19 +216,50 @@ final class TypingEngine {
     /// dictionary, and correcting its answer would be two guesses stacked.
     func noteSwipeWord(_ word: String, alternates: [String]) {
         composer.adopt(word, origin: .swipe)
-        swipeAlternates = alternates
+        // Kept beside the composer rather than inside it. The document reads
+        // "word " and the composer describes the word the cursor is inside, so
+        // after a swipe the composition is empty and correct — see
+        // ``SwipeAlternates``.
+        pendingSwipe = PendingSwipe(word: word, alternates: alternates)
         pendingRevert = nil
+        publishSwipeAlternates()
+    }
+
+    /// The swiped word still standing before the cursor, if there is one.
+    var pendingSwipeWord: String? { pendingSwipe?.word }
+    var pendingSwipeAlternates: [String] { pendingSwipe?.alternates ?? [] }
+
+    private func publishSwipeAlternates() {
+        guard let pendingSwipe else { return }
         publish(
             TypingStrip(
-                candidates: alternates.prefix(TypingCandidates.slotCount).map {
-                    TypingCandidate(text: $0, kind: .correction)
-                },
+                candidates: pendingSwipe.alternates
+                    .prefix(TypingCandidates.slotCount)
+                    .map {
+                        // Shown in the case they would be inserted in, so a
+                        // swipe made with shift on does not offer lowercase
+                        // chips that arrive capitalised.
+                        TypingCandidate(
+                            text: TypingCandidates.matchingCase(
+                                of: pendingSwipe.word,
+                                applyingTo: $0
+                            ),
+                            kind: .swipeAlternate
+                        )
+                    },
                 autocorrection: nil
             )
         )
     }
 
-    private var swipeAlternates: [String] = []
+    private struct PendingSwipe {
+        let word: String
+        let alternates: [String]
+    }
+
+    /// Cleared the moment the document stops ending in the swiped word, which
+    /// is any keystroke, any deletion, or a cursor that has moved on.
+    private var pendingSwipe: PendingSwipe?
 
     /// Counts a completed word toward learning. A word typed three times and
     /// never reverted is a word the user means.

--- a/ios/VocaPhoneKeyboard/TypingEngine.swift
+++ b/ios/VocaPhoneKeyboard/TypingEngine.swift
@@ -371,6 +371,10 @@ final class TypingEngine {
         context.isKnownToChecker = checked?.isKnown ?? false
         context.isInWordList = wordList.contains(composition)
         context.assertedWords = assertedWords
+        // Exact word only, so nothing appears while the user is partway into a
+        // different one.
+        context.emojiSuggestion = EmojiSuggestions.glyph(for: composition)
+        context.emojiEnabled = KeyboardPreferences.emojiSuggestionsEnabled
         context.suggestionsEnabled = KeyboardPreferences.typingSuggestionsEnabled
         context.autocorrectEnabled = KeyboardPreferences.autocorrectIsActive
         context.predictionEnabled = KeyboardPreferences.nextWordPredictionEnabled

--- a/ios/VocaPhoneKeyboard/TypingStripView.swift
+++ b/ios/VocaPhoneKeyboard/TypingStripView.swift
@@ -38,6 +38,9 @@ final class TypingStripView: UIScrollView {
     private(set) var candidates: [TypingCandidate] = []
     private let row = UIStackView()
     private var buttons: [UIButton] = []
+    /// Kept so a reused button can be re-sized when it changes from carrying a
+    /// word to carrying a glyph.
+    private var minimumWidths: [NSLayoutConstraint] = []
     /// Set when the chips change, so the next layout pass puts the row back at
     /// its centred resting position rather than wherever the last set was
     /// scrolled to.
@@ -49,6 +52,10 @@ final class TypingStripView: UIScrollView {
     /// A one-letter suggestion in a capsule sized to its text is a dot. Every
     /// chip is at least wide enough to look like something worth aiming at.
     private static let minimumChipWidth: CGFloat = 62
+    /// A glyph needs less room than a word to read as a target, and on a 320 pt
+    /// strip those points are the difference between the emoji being offered
+    /// and being scrolled off the end of the row.
+    private static let minimumGlyphChipWidth: CGFloat = 48
     private static let chipTextInset: CGFloat = 14
 
     init(palette: KeyboardPalette, metrics: DictationBarMetrics) {
@@ -143,9 +150,10 @@ final class TypingStripView: UIScrollView {
                     : .identity
             }
             row.addArrangedSubview(button)
-            button.widthAnchor
+            let minimum = button.widthAnchor
                 .constraint(greaterThanOrEqualToConstant: Self.minimumChipWidth)
-                .isActive = true
+            minimum.isActive = true
+            minimumWidths.append(minimum)
             buttons.append(button)
         }
         for (index, button) in buttons.enumerated() {
@@ -154,6 +162,9 @@ final class TypingStripView: UIScrollView {
                 continue
             }
             button.isHidden = false
+            minimumWidths[index].constant = candidates[index].kind == .emoji
+                ? Self.minimumGlyphChipWidth
+                : Self.minimumChipWidth
             configure(button, with: candidates[index])
         }
         needsScrollReset = true
@@ -168,6 +179,7 @@ final class TypingStripView: UIScrollView {
         configuration.title = candidate.kind == .literal
             ? "“\(candidate.text)”"
             : candidate.text
+        let isEmoji = candidate.kind == .emoji
         configuration.cornerStyle = .capsule
         configuration.contentInsets = NSDirectionalEdgeInsets(
             top: 0,
@@ -196,10 +208,11 @@ final class TypingStripView: UIScrollView {
                 var outgoing = incoming
                 // Medium rather than regular: a chip is a control, and at this
                 // size regular reads as body text that happens to be in a pill.
-                outgoing.font = .systemFont(
-                    ofSize: size,
-                    weight: isEmphasised ? .semibold : .medium
-                )
+                // A glyph rather than a word: it carries no weight and reads
+                // at the size the keys use, not the size of a label.
+                outgoing.font = isEmoji
+                    ? .systemFont(ofSize: size + 4)
+                    : .systemFont(ofSize: size, weight: isEmphasised ? .semibold : .medium)
                 outgoing.foregroundColor = label
                 return outgoing
             }
@@ -219,6 +232,7 @@ final class TypingStripView: UIScrollView {
         case .completion: "Completes the word."
         case .correction: "Replaces the word."
         case .prediction: "Inserts this word next."
+        case .emoji: "Replaces the word with this emoji."
         }
     }
 

--- a/ios/VocaPhoneKeyboard/TypingStripView.swift
+++ b/ios/VocaPhoneKeyboard/TypingStripView.swift
@@ -233,6 +233,7 @@ final class TypingStripView: UIScrollView {
         case .correction: "Replaces the word."
         case .prediction: "Inserts this word next."
         case .emoji: "Replaces the word with this emoji."
+        case .swipeAlternate: "Replaces the swiped word."
         }
     }
 

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -239,6 +239,7 @@ enum KeyboardPreferences {
     static let nextWordPredictionKey = "nextWordPredictionEnabled"
     static let learnAsITypeKey = "learnAsITypeEnabled"
     static let smartPunctuationKey = "smartPunctuationEnabled"
+    static let emojiSuggestionsKey = "emojiSuggestionsEnabled"
     static let keyboardHapticsKey = "keyboardHapticsEnabled"
     static let swipeTypingKey = "swipeTypingEnabled"
     static let numberRowKey = "numberRowEnabled"
@@ -332,6 +333,14 @@ enum KeyboardPreferences {
     static var smartPunctuationEnabled: Bool {
         get { boolean(smartPunctuationKey, default: true) }
         set { defaults?.set(newValue, forKey: smartPunctuationKey) }
+    }
+
+    /// An emoji offered beside the word candidates while typing — "lol" offers
+    /// 😂. On by default: it adds a chip the user may ignore and never changes
+    /// text on its own, which is the bar for a suggestion being on.
+    static var emojiSuggestionsEnabled: Bool {
+        get { boolean(emojiSuggestionsKey, default: true) }
+        set { defaults?.set(newValue, forKey: emojiSuggestionsKey) }
     }
 
     /// A no-op without Full Access, because a keyboard extension cannot reach

--- a/ios/VocaPhoneTests/EmojiSuggestionsTests.swift
+++ b/ios/VocaPhoneTests/EmojiSuggestionsTests.swift
@@ -1,0 +1,74 @@
+import Testing
+
+/// The table is the feature. Matching is three lines; what decides whether the
+/// strip reads as clever or as broken is which words are in it.
+struct EmojiSuggestionsTests {
+    @Test func theWordsPeopleExpectAreOffered() {
+        #expect(EmojiSuggestions.glyph(for: "lol") == "😂")
+        #expect(EmojiSuggestions.glyph(for: "pizza") == "🍕")
+        #expect(EmojiSuggestions.glyph(for: "birthday") == "🎂")
+        #expect(EmojiSuggestions.glyph(for: "thanks") == "🙏")
+        #expect(EmojiSuggestions.glyph(for: "fire") == "🔥")
+    }
+
+    /// Case is not part of the word. "LOL" is the same trigger as "lol".
+    @Test func matchingIgnoresCase() {
+        #expect(EmojiSuggestions.glyph(for: "LOL") == "😂")
+        #expect(EmojiSuggestions.glyph(for: "Pizza") == "🍕")
+    }
+
+    /// Whole words only. A prefix match would put an emoji on the strip while
+    /// the user is still two letters into a different word — "car" offering 🚗
+    /// to someone typing "carefully".
+    @Test func onlyWholeWordsMatch() {
+        #expect(EmojiSuggestions.glyph(for: "lolly") == nil)
+        #expect(EmojiSuggestions.glyph(for: "carefully") == nil)
+        #expect(EmojiSuggestions.glyph(for: "car") == "🚗")
+        #expect(EmojiSuggestions.glyph(for: "l") == nil)
+        #expect(EmojiSuggestions.glyph(for: "") == nil)
+    }
+
+    /// The failure mode that would make this unusable. A keyword lookup into
+    /// the emoji catalog answers every one of these — "the" with 🤣, "is" with
+    /// a flag — because appearing in a description is not the same as being
+    /// what the word means.
+    @Test func ordinaryProseGetsNothing() {
+        for word in [
+            "the", "and", "is", "was", "of", "to", "it", "that", "this", "with",
+            "have", "from", "they", "there", "about", "would", "should",
+            // Excluded on purpose: common in sentences that have nothing to do
+            // with the emoji they would otherwise attract.
+            "good", "yes", "no", "time", "work", "day", "code", "check", "key",
+        ] {
+            #expect(EmojiSuggestions.glyph(for: word) == nil, "\(word) should offer nothing")
+        }
+    }
+
+    /// Every entry has to be a single glyph the strip can draw. A stray word or
+    /// an empty value would render as a chip with text in it.
+    @Test func everyEntryIsOneEmojiForOneLowercaseWord() {
+        for (word, glyph) in EmojiSuggestions.triggers {
+            #expect(word == word.lowercased(), "\(word) is not lowercased")
+            #expect(word.count >= EmojiSuggestions.minimumLength)
+            // `allSatisfy` is rethrowing too, so it is answered here rather
+            // than inside the macro.
+            let isPlainWord = word.allSatisfy(\.isLetter)
+            #expect(isPlainWord, "\(word) is not a plain word")
+            #expect(!glyph.isEmpty)
+            // One grapheme, so the chip is a glyph rather than a phrase. Flags
+            // and skin-tone variants are single graphemes too, which is the
+            // point of counting characters rather than scalars.
+            #expect(glyph.count == 1, "\(word) maps to \(glyph.count) characters")
+            // Answered outside the macro: `contains(where:)` is rethrowing, and
+            // `#expect` will not take a call it thinks can throw.
+            let carriesAnEmojiScalar = glyph.unicodeScalars.contains { $0.properties.isEmoji }
+            #expect(carriesAnEmojiScalar, "\(word) maps to something that is not an emoji")
+        }
+    }
+
+    /// Enough to be worth the code, small enough to stay hand-checked.
+    @Test func theTableIsCuratedRatherThanExhaustive() {
+        #expect(EmojiSuggestions.triggers.count > 100)
+        #expect(EmojiSuggestions.triggers.count < 400)
+    }
+}

--- a/ios/VocaPhoneTests/SwipeAlternatesTests.swift
+++ b/ios/VocaPhoneTests/SwipeAlternatesTests.swift
@@ -1,0 +1,85 @@
+import Testing
+
+/// The arithmetic behind replacing a swiped word.
+///
+/// It is arithmetic at all because the two bugs it replaces were both off by
+/// exactly one character: the space a swipe inserts after its word, which the
+/// composer cannot see and the replacement therefore never accounted for.
+struct SwipeAlternatesTests {
+    // MARK: - Armed
+
+    /// The word is still the tail of the document, space and all.
+    @Test func aFreshlySwipedWordIsArmed() {
+        #expect(SwipeAlternates.isArmed(word: "lol", documentBefore: "haha lol "))
+        #expect(SwipeAlternates.isArmed(word: "lol", documentBefore: "lol "))
+    }
+
+    /// The trailing space is the whole test. Without it the cursor is inside
+    /// the word — the user is editing it, not choosing between spellings — and
+    /// with something after it the swipe is no longer what the cursor sits on.
+    @Test func anythingTypedAfterTheWordDisarmsIt() {
+        #expect(!SwipeAlternates.isArmed(word: "lol", documentBefore: "lol"))
+        #expect(!SwipeAlternates.isArmed(word: "lol", documentBefore: "lol x"))
+        #expect(!SwipeAlternates.isArmed(word: "lol", documentBefore: "lol  "))
+        #expect(!SwipeAlternates.isArmed(word: "lol", documentBefore: "lolly "))
+    }
+
+    /// The same word earlier in the sentence is not the swipe. Only the tail
+    /// counts, which is what stops a stale strip replacing text somewhere else.
+    @Test func anEarlierCopyOfTheWordDoesNotArmIt() {
+        #expect(!SwipeAlternates.isArmed(word: "lol", documentBefore: "lol and then "))
+    }
+
+    /// iOS can decline to hand over the document, and a replacement that cannot
+    /// see what it is replacing must not run.
+    @Test func nothingKnownMeansNotArmed() {
+        #expect(!SwipeAlternates.isArmed(word: "lol", documentBefore: nil))
+        #expect(!SwipeAlternates.isArmed(word: "", documentBefore: "lol "))
+    }
+
+    // MARK: - Replacing
+
+    /// The bug, as a number. Deleting `word.count` leaves the rejected word in
+    /// the document with the alternate after it — "lol lug " where "lug " was
+    /// meant — because the composition the old code measured was empty.
+    @Test func aReplacementCoversTheWordAndItsSpace() {
+        #expect(SwipeAlternates.deletionCount(replacing: "lol") == 4)
+        #expect(SwipeAlternates.deletionCount(replacing: "hello") == 6)
+        // Long enough to matter on the word this actually ships against.
+        #expect(SwipeAlternates.deletionCount(replacing: "keyboard") == "keyboard ".count)
+    }
+
+    // MARK: - What is offered next
+
+    /// The replaced word comes back, first: a swipe corrected once is often
+    /// corrected back, and losing the original would make that a retype.
+    @Test func theReplacedWordIsOfferedBack() {
+        let next = SwipeAlternates.alternates(
+            after: "lug",
+            replacing: "lol",
+            from: ["lug", "log", "lot"]
+        )
+        #expect(next.first == "lol")
+        #expect(next == ["lol", "log", "lot"])
+    }
+
+    /// The word now in the document is never offered as a replacement for
+    /// itself, whatever case it arrived in.
+    @Test func theChosenWordIsNeverOfferedAgain() {
+        let next = SwipeAlternates.alternates(
+            after: "Lug",
+            replacing: "lol",
+            from: ["lug", "log"]
+        )
+        #expect(!next.contains { $0.caseInsensitiveCompare("lug") == .orderedSame })
+        #expect(next == ["lol", "log"])
+    }
+
+    /// A swipe with one match still offers the way back.
+    @Test func aSingleMatchStillOffersTheOriginal() {
+        #expect(
+            SwipeAlternates.alternates(after: "lug", replacing: "lol", from: [])
+                == ["lol"]
+        )
+    }
+}

--- a/ios/VocaPhoneTests/TypingCandidatesTests.swift
+++ b/ios/VocaPhoneTests/TypingCandidatesTests.swift
@@ -389,6 +389,44 @@ struct TypingCandidatesTests {
         #expect(!TypingCandidates.strip(ctx).candidates.contains { $0.kind == .emoji })
     }
 
+    /// A word with a curated emoji is never autocorrected away.
+    ///
+    /// Most triggers are informal and absent from the shipped word list, so
+    /// without this the keyboard offers 😱 for "omg" and then replaces it with
+    /// a dictionary word on the next space — disagreeing with itself, in a way
+    /// the user only discovers after sending the message.
+    @Test func aWordWithAnEmojiIsNotCorrectedAway() {
+        var ctx = context("omg", emoji: "😱")
+        ctx.isKnownToChecker = false
+        ctx.isInWordList = false
+        ctx.systemGuesses = ["org"]
+        #expect(TypingCandidates.autocorrection(ctx) == nil)
+        #expect(TypingCandidates.strip(ctx).autocorrection == nil)
+        // The literal chip exists to warn about a pending replacement, so with
+        // nothing pending it does not take a slot either.
+        #expect(!TypingCandidates.strip(ctx).candidates.contains { $0.kind == .literal })
+    }
+
+    /// The exemption is the *word*, not the setting. Turning the chip off stops
+    /// a chip being drawn; it does not make "omg" a typo again.
+    @Test func theExemptionSurvivesTheSettingBeingOff() {
+        var ctx = context("omg", emoji: "😱")
+        ctx.emojiEnabled = false
+        ctx.isKnownToChecker = false
+        ctx.isInWordList = false
+        ctx.systemGuesses = ["org"]
+        #expect(TypingCandidates.autocorrection(ctx) == nil)
+    }
+
+    /// And a genuine typo that happens to be near a trigger is still corrected.
+    @Test func aTypoWithNoEmojiIsStillCorrected() {
+        var ctx = context("teh", emoji: nil)
+        ctx.isKnownToChecker = false
+        ctx.isInWordList = false
+        ctx.systemGuesses = ["the"]
+        #expect(TypingCandidates.autocorrection(ctx) == "the")
+    }
+
     /// The strip is off entirely in a password or code field, and the emoji
     /// must not be the one thing that survives that.
     @Test func aFieldThatRefusesIntelligenceGetsNoEmoji() {

--- a/ios/VocaPhoneTests/TypingCandidatesTests.swift
+++ b/ios/VocaPhoneTests/TypingCandidatesTests.swift
@@ -343,3 +343,57 @@ struct TypingCandidatesTests {
         #expect(TypingCandidates.matchingCase(of: "teh", applyingTo: "the") == "the")
     }
 }
+// MARK: - Emoji
+
+/// The emoji chip is an extra, not a competitor. The three word slots are what
+/// the strip is for, and spending one on decoration is a bad trade even when
+/// the emoji is right.
+@Suite struct EmojiCandidateTests {
+    private func context(_ composition: String, emoji: String?) -> TypingCandidates.Context {
+        var context = TypingCandidates.Context()
+        context.composition = composition
+        context.emojiSuggestion = emoji
+        context.isKnownToChecker = true
+        context.isInWordList = true
+        return context
+    }
+
+    @Test func theEmojiIsAppendedAfterTheWordCandidates() {
+        var ctx = context("lol", emoji: "😂")
+        ctx.listCompletions = ["lolly", "lollipop"]
+        let strip = TypingCandidates.strip(ctx)
+        #expect(strip.candidates.last?.kind == .emoji)
+        #expect(strip.candidates.last?.text == "😂")
+        // Every word candidate that would have been shown is still shown.
+        let words = strip.candidates.filter { $0.kind != .emoji }
+        #expect(words.count == 2)
+        #expect(words.allSatisfy { $0.text != "😂" })
+    }
+
+    @Test func aWordWithNoEmojiIsUnchanged() {
+        let strip = TypingCandidates.strip(context("ship", emoji: nil))
+        #expect(!strip.candidates.contains { $0.kind == .emoji })
+    }
+
+    @Test func theSettingRemovesTheChipEntirely() {
+        var ctx = context("lol", emoji: "😂")
+        ctx.emojiEnabled = false
+        #expect(!TypingCandidates.strip(ctx).candidates.contains { $0.kind == .emoji })
+    }
+
+    /// Nothing is being typed, so there is no word for an emoji to stand for.
+    /// The prediction row is about the *next* word.
+    @Test func predictionsNeverCarryAnEmoji() {
+        var ctx = context("", emoji: "😂")
+        ctx.predictions = ["the", "a"]
+        #expect(!TypingCandidates.strip(ctx).candidates.contains { $0.kind == .emoji })
+    }
+
+    /// The strip is off entirely in a password or code field, and the emoji
+    /// must not be the one thing that survives that.
+    @Test func aFieldThatRefusesIntelligenceGetsNoEmoji() {
+        var ctx = context("lol", emoji: "😂")
+        ctx.allowsTypingIntelligence = false
+        #expect(TypingCandidates.strip(ctx).candidates.isEmpty)
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -141,6 +141,9 @@ targets:
       # worth pinning: which words are in it, and which are deliberately not.
       - path: VocaPhoneKeyboard/EmojiSuggestions.swift
       - path: VocaPhoneKeyboard/SwipeRecognizer.swift
+      # Replacing a swiped word is arithmetic over the space the swipe left
+      # behind, and both bugs it replaces were off by exactly that character.
+      - path: VocaPhoneKeyboard/SwipeAlternates.swift
       - path: VocaPhoneKeyboard/EmojiCatalog.swift
       # The state-to-interface mapping for the dictation bar is pure, so every
       # session state can be checked without standing up the extension.

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -137,6 +137,9 @@ targets:
       - path: VocaPhoneKeyboard/TypingWordList.swift
       - path: VocaPhoneKeyboard/SpellChecking.swift
       - path: VocaPhoneKeyboard/SmartPunctuation.swift
+      # The curated word-to-emoji table is the whole feature, so it is the part
+      # worth pinning: which words are in it, and which are deliberately not.
+      - path: VocaPhoneKeyboard/EmojiSuggestions.swift
       - path: VocaPhoneKeyboard/SwipeRecognizer.swift
       - path: VocaPhoneKeyboard/EmojiCatalog.swift
       # The state-to-interface mapping for the dictation bar is pure, so every


### PR DESCRIPTION
Typing "lol" offers 😂 on the suggestion strip. Tapping it replaces the word, as the system keyboard does. On by default, with a switch in Keyboard settings.

## The catalog is the wrong source, and measuring says so

The obvious implementation is to look the typed word up in the emoji catalog the panel already ships — 3,944 entries, already bundled, already shared with Android. I tried that first, against real words, before writing any Swift:

| typed | catalog answers |
| --- | --- |
| `the` | 🤣 |
| `and` | 🫢 |
| `is` | 🇮🇸 |
| `dog` | 💩 |
| `clock` | 🏫 |
| `coffee` | 🤎 |

Those keywords exist to answer a *deliberate search* in a grid of results. Matched against prose they answer with whatever emoji happens to mention the word in its description, and the most common word in English gets a suggestion on every keystroke.

So `EmojiSuggestions` is a curated table of ~150 words where the emoji is the *obvious* association, not merely *an* association. Words that are common in sentences having nothing to do with the emoji they would attract are deliberately absent — "good", "yes", "no", "time", "work", "day", "code", "check", "key" — and there is a test that fails if any of them, or ordinary function words, ever start matching.

It also settles the memory question raised when this was scoped: a few kilobytes of table, so the 284 KB catalog stays loaded only when the emoji panel is actually opened, in a process iOS kills around 45–60 MB.

## The slot rule changed after seeing it

The plan was a fourth chip that never displaced a word candidate. Rendering the strip offscreen at 320 pt disproved it — four chips plus the Dictate button push the emoji off the visible row, and a suggestion you have to scroll sideways to discover is not a suggestion.

On a full strip the emoji now takes the last slot: the third-ranked completion, the least likely word on the row. The literal and the emphasised correction are never at risk, because the chip that space would apply has to stay visible. Glyph chips also get a smaller minimum width than word chips — a glyph does not need 62 pt to read as a target, and those points are the difference at 320 pt.

## Behaviour

- Exact whole words only, case-insensitive. "LOL" triggers; "lolly" and "carefully" do not.
- Only while a word is being composed. The prediction row, which is about the *next* word, never carries an emoji.
- Suppressed wherever typing intelligence is, so password and code fields get nothing.
- Tapping deletes the composed word and inserts the glyph. The emoji is never added to learned words — that list teaches the keyboard vocabulary to complete letters into.

## Testing

- `just ios test` — 397 tests, all passing. 11 new: the table's contents and exclusions, whole-word matching, and the slot rule (appended when there is room, displacing only the weakest chip when there is not, absent when the setting is off, absent from predictions, absent where intelligence is suppressed).
- `just ios build` — clean.
- Strip rendered offscreen at 320 and 393 pt, light and dark, through the real `TypingCandidates.strip` rather than a hand-made list — which is what caught the clipped chip.

**Not verified on hardware.** Worth checking on device that the glyph renders at a comfortable size next to the word chips, and that the table's picks feel right in real messages — that part is taste, and the table is one file to edit.

## Note

`Plan-Emoji.md` in the working tree describes a *different* feature: spoken emoji conversion in the gateway, where "crying emoji" becomes 😭. Nothing here touches that.
