### PR TITLE
Type from the cursor, suggest emoji, and paste copied images

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -77,5 +77,15 @@
                 android:resource="@xml/method" />
         </service>
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.clipboard"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/clipboard_paths" />
+        </provider>
+
     </application>
 </manifest>

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/EmojiSuggestions.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/EmojiSuggestions.kt
@@ -1,0 +1,95 @@
+package com.vocahq.vocaphone.ime
+
+/**
+ * Emoji offered for a word as it is typed: "lol" offers 😂.
+ *
+ * A curated table, not a lookup into [EmojiCatalog]. The catalog's keywords
+ * exist for a deliberate search in the emoji panel. Matched against ordinary
+ * prose they answer "the" with 🤣, "dog" with 💩, and "clock" with 🏫.
+ *
+ * Exact whole words only. A prefix match would put an emoji on the strip
+ * while the user is still two letters into a different word.
+ */
+internal object EmojiSuggestions {
+    const val MINIMUM_LENGTH = 2
+
+    fun glyph(word: String): String? = glyphs(word).firstOrNull()
+
+    fun glyphs(word: String): List<String> {
+        val key = word.lowercase()
+        if (key.length < MINIMUM_LENGTH) return emptyList()
+        val primary = TRIGGERS[key] ?: return emptyList()
+        return (listOf(primary) + EXTRAS[key].orEmpty()).distinct()
+    }
+
+    internal val TRIGGERS: Map<String, String> = mapOf(
+        "lol" to "😂", "lmao" to "🤣", "rofl" to "🤣", "haha" to "😂", "hehe" to "😄",
+        "funny" to "😂", "omg" to "😱", "wow" to "😮", "yay" to "🎉", "oops" to "🙈",
+        "ugh" to "😩", "meh" to "😐", "cool" to "😎", "nice" to "👍", "awesome" to "🤩",
+        "amazing" to "🤩", "perfect" to "👌", "done" to "✅", "agree" to "👍",
+        "congrats" to "🎉", "congratulations" to "🎉", "welcome" to "🤗",
+
+        "love" to "❤️", "loved" to "❤️", "heart" to "❤️", "happy" to "😊", "sad" to "😢",
+        "cry" to "😭", "crying" to "😭", "angry" to "😠", "mad" to "😠", "tired" to "😴",
+        "sleepy" to "😴", "sleep" to "😴", "sick" to "🤒", "scared" to "😱",
+        "confused" to "😕", "bored" to "🥱", "excited" to "🤩", "shy" to "😊",
+        "hungry" to "😋", "thirsty" to "🥤", "stressed" to "😰", "relieved" to "😌",
+
+        "hi" to "👋", "hello" to "👋", "hey" to "👋", "bye" to "👋", "goodbye" to "👋",
+        "thanks" to "🙏", "thankyou" to "🙏", "please" to "🙏", "sorry" to "😔",
+        "hug" to "🤗", "hugs" to "🤗", "kiss" to "😘", "wink" to "😉",
+
+        "ok" to "👌", "okay" to "👌", "clap" to "👏", "applause" to "👏", "bravo" to "👏",
+        "wave" to "👋", "pray" to "🙏", "prayers" to "🙏", "muscle" to "💪",
+        "strong" to "💪", "facepalm" to "🤦", "shrug" to "🤷", "thinking" to "🤔",
+        "eyes" to "👀", "brain" to "🧠",
+
+        "fire" to "🔥", "lit" to "🔥", "skull" to "💀", "ghost" to "👻", "alien" to "👽",
+        "robot" to "🤖", "poop" to "💩", "party" to "🎉", "birthday" to "🎂",
+        "cake" to "🎂", "gift" to "🎁", "present" to "🎁", "balloon" to "🎈",
+        "fireworks" to "🎆", "crown" to "👑", "diamond" to "💎", "trophy" to "🏆",
+        "winner" to "🏆", "medal" to "🥇", "idea" to "💡", "bug" to "🐛",
+        "warning" to "⚠️", "rocket" to "🚀",
+
+        "pizza" to "🍕", "burger" to "🍔", "fries" to "🍟", "coffee" to "☕",
+        "tea" to "🍵", "beer" to "🍺", "wine" to "🍷", "water" to "💧",
+        "breakfast" to "🥞", "lunch" to "🍽️", "dinner" to "🍽️", "snack" to "🍿",
+        "chocolate" to "🍫", "cookie" to "🍪", "icecream" to "🍦", "apple" to "🍎",
+        "banana" to "🍌", "biryani" to "🍛", "chai" to "🍵",
+
+        "dog" to "🐶", "puppy" to "🐶", "cat" to "🐱", "kitten" to "🐱", "bird" to "🐦",
+        "fish" to "🐟", "tree" to "🌳", "flower" to "🌸", "rose" to "🌹",
+        "sun" to "☀️", "sunny" to "☀️", "moon" to "🌙", "star" to "⭐",
+        "rain" to "🌧️", "rainy" to "🌧️", "snow" to "❄️", "storm" to "⛈️",
+        "rainbow" to "🌈", "beach" to "🏖️",
+
+        "home" to "🏠", "house" to "🏠", "office" to "🏢", "school" to "🏫",
+        "hospital" to "🏥", "bank" to "🏦", "gym" to "🏋️", "workout" to "🏋️",
+        "running" to "🏃", "walk" to "🚶", "travel" to "✈️", "vacation" to "✈️",
+        "holiday" to "✈️", "flight" to "✈️", "plane" to "✈️", "airport" to "✈️",
+        "car" to "🚗", "train" to "🚆", "bike" to "🚲", "shopping" to "🛒",
+        "money" to "💰", "cash" to "💰", "salary" to "💰",
+
+        "music" to "🎵", "song" to "🎵", "book" to "📚", "reading" to "📚",
+        "phone" to "📱", "laptop" to "💻", "computer" to "💻", "email" to "📧",
+        "mail" to "📧", "calendar" to "📅", "meeting" to "🗓️", "deadline" to "⏰",
+        "clock" to "⏰", "alarm" to "⏰", "camera" to "📷", "photo" to "📷",
+        "movie" to "🎬", "game" to "🎮", "gaming" to "🎮", "art" to "🎨",
+        "football" to "⚽", "cricket" to "🏏", "basketball" to "🏀",
+
+        "christmas" to "🎄", "halloween" to "🎃", "diwali" to "🪔",
+    )
+
+    // A couple of neighbours for the feeling-words people actually tap.
+    private val EXTRAS: Map<String, List<String>> = mapOf(
+        "sad" to listOf("😭", "😞"),
+        "happy" to listOf("😄", "😁"),
+        "cry" to listOf("😢"),
+        "crying" to listOf("😢"),
+        "love" to listOf("💕", "😍"),
+        "angry" to listOf("😡"),
+        "mad" to listOf("😡"),
+        "lol" to listOf("🤣"),
+        "skull" to listOf("☠️"),
+    )
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/EmojiSuggestions.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/EmojiSuggestions.kt
@@ -19,7 +19,7 @@ internal object EmojiSuggestions {
         val key = word.lowercase()
         if (key.length < MINIMUM_LENGTH) return emptyList()
         val primary = TRIGGERS[key] ?: return emptyList()
-        return (listOf(primary) + EXTRAS[key].orEmpty()).distinct()
+        return (listOf(primary) + EXTRAS[primary].orEmpty()).distinct()
     }
 
     internal val TRIGGERS: Map<String, String> = mapOf(
@@ -78,18 +78,81 @@ internal object EmojiSuggestions {
         "football" to "⚽", "cricket" to "🏏", "basketball" to "🏀",
 
         "christmas" to "🎄", "halloween" to "🎃", "diwali" to "🪔",
+
+        // Extra doors into the same glyphs. Gemoji / chat short names, not
+        // catalog keywords: each one should still mean that emoji.
+        "laugh" to "😂", "laughing" to "😂", "joy" to "😂",
+        "grin" to "😄", "grinning" to "😄",
+        "smile" to "😊", "smiling" to "😊", "blush" to "😊",
+        "unhappy" to "😢", "upset" to "😢", "tear" to "😢",
+        "sob" to "😭", "tears" to "😭",
+        "annoyed" to "😠", "pissed" to "😠",
+        "sleeping" to "😴", "zzz" to "😴", "exhausted" to "😴", "nap" to "😴",
+        "yawn" to "🥱", "yawning" to "🥱",
+        "ill" to "🤒", "unwell" to "🤒",
+        "scream" to "😱", "shocked" to "😱",
+        "nervous" to "😰", "worried" to "😰",
+        "weary" to "😩",
+        "whew" to "😌",
+        "starstruck" to "🤩",
+        "ily" to "❤️",
+        "xoxo" to "😘",
+        "thx" to "🙏", "ty" to "🙏", "thank" to "🙏", "pls" to "🙏",
+        "tada" to "🎉", "hooray" to "🎉",
+        "smh" to "🤦",
+        "idk" to "🤷", "dunno" to "🤷",
+        "think" to "🤔",
+        "flex" to "💪",
+        "thumbsup" to "👍",
+        "howdy" to "👋", "cya" to "👋",
+        "flame" to "🔥", "burn" to "🔥",
+        "dead" to "💀",
+        "poo" to "💩", "crap" to "💩",
+        "spooky" to "👻",
+        "bday" to "🎂",
+        "bulb" to "💡",
+        "launch" to "🚀",
+        "hamburger" to "🍔",
+        "latte" to "☕", "espresso" to "☕", "cafe" to "☕",
+        "doggo" to "🐶", "doggy" to "🐶", "pup" to "🐶",
+        "kitty" to "🐱", "meow" to "🐱",
+        "goodnight" to "🌙", "nite" to "🌙",
+        "airplane" to "✈️",
+        "taxi" to "🚗", "cab" to "🚗",
+        "bicycle" to "🚲",
+        "pic" to "📷",
+        "film" to "🎬",
+        "mobile" to "📱",
+        "tune" to "🎵",
+        "books" to "📚",
+        "soccer" to "⚽",
     )
 
-    // A couple of neighbours for the feeling-words people actually tap.
+    // Related chips, keyed by the primary glyph so every alias shares them.
     private val EXTRAS: Map<String, List<String>> = mapOf(
-        "sad" to listOf("😭", "😞"),
-        "happy" to listOf("😄", "😁"),
-        "cry" to listOf("😢"),
-        "crying" to listOf("😢"),
-        "love" to listOf("💕", "😍"),
-        "angry" to listOf("😡"),
-        "mad" to listOf("😡"),
-        "lol" to listOf("🤣"),
-        "skull" to listOf("☠️"),
+        "😢" to listOf("😭", "😞"),
+        "😊" to listOf("😄", "😁"),
+        "😭" to listOf("😢"),
+        "❤️" to listOf("💕", "😍"),
+        "😠" to listOf("😡"),
+        "😂" to listOf("🤣"),
+        "💀" to listOf("☠️"),
     )
+}
+
+/** Replace the trigger while the cursor is still on it; insert once anything follows. */
+internal object EmojiCommit {
+    fun shouldReplaceTrigger(composing: String, before: CharSequence): Boolean {
+        if (composing.isNotEmpty()) return EmojiSuggestions.glyph(composing) != null
+        if (before.isEmpty() || !isWordChar(before.last())) return false
+        return EmojiSuggestions.glyph(SuggestionEngine.lastWord(before).orEmpty()) != null
+    }
+
+    fun insertText(before: CharSequence, emoji: String): String {
+        val prefix = if (before.isEmpty() || before.last().isWhitespace()) "" else " "
+        return prefix + emoji
+    }
+
+    private fun isWordChar(character: Char): Boolean =
+        character.isLetterOrDigit() || character == '\''
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardEditorConfig.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardEditorConfig.kt
@@ -23,6 +23,7 @@ internal data class KeyboardEditorConfig(
     val dictationAllowed: Boolean,
     val sensitive: Boolean,
     val shiftSync: Int = 0,
+    val cursorSync: Int = 0,
 ) {
     companion object {
         fun empty() = KeyboardEditorConfig(

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -121,6 +121,12 @@ internal data class KeyboardReduction(
 internal data class ClipboardChip(
     val preview: String,
     val fullText: String,
+    val imagePath: String? = null,
+)
+
+internal data class SuggestionItem(
+    val text: String,
+    val isEmoji: Boolean = false,
 )
 
 /** What the single Gboard-style toolbar row should show. */
@@ -133,8 +139,10 @@ internal object KeyboardChrome {
         alreadyPasted: Boolean = false,
     ): ClipboardChip? = clipboard.takeIf { !alreadyPasted }
 
-    fun suggestionsForStrip(suggestions: List<String>, startedTyping: Boolean): List<String> =
-        if (startedTyping) suggestions else emptyList()
+    fun suggestionsForStrip(
+        suggestions: List<SuggestionItem>,
+        startedTyping: Boolean,
+    ): List<SuggestionItem> = if (startedTyping) suggestions else emptyList()
 
     fun suggestionReplacesWord(
         composing: String,
@@ -167,8 +175,45 @@ internal object KeyboardChrome {
 
 internal data class SuggestionStrip(
     val words: List<String>,
+    val emojis: List<String> = emptyList(),
     val replacesWord: Boolean = false,
-)
+) {
+    val items: List<SuggestionItem>
+        get() = words.map { SuggestionItem(it) } + emojis.map { SuggestionItem(it, isEmoji = true) }
+}
+
+/**
+ * Distinguishes a tap in the field from the selection updates [setComposingText]
+ * sends after every letter. Those updates put the cursor on the composing end;
+ * a tap puts it somewhere else, and the next letter has to start there.
+ */
+internal object EditorCursorSync {
+    fun isUserMove(
+        oldSelStart: Int,
+        oldSelEnd: Int,
+        newSelStart: Int,
+        newSelEnd: Int,
+        oldCandidatesStart: Int,
+        oldCandidatesEnd: Int,
+        newCandidatesStart: Int,
+        newCandidatesEnd: Int,
+    ): Boolean {
+        val collapsed = newSelStart == newSelEnd
+        if (collapsed && newCandidatesStart >= 0 && newSelStart == newCandidatesEnd) {
+            return false
+        }
+        if (
+            newCandidatesStart < 0 &&
+            oldCandidatesStart >= 0 &&
+            collapsed &&
+            newSelStart >= oldCandidatesEnd &&
+            newSelStart <= oldCandidatesEnd + 1
+        ) {
+            return false
+        }
+        return newSelStart != oldSelStart || newSelEnd != oldSelEnd
+    }
+}
 
 internal data class WordSpan(
     val word: String,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
@@ -62,7 +62,7 @@ internal class SuggestionDictionary(
         after: String,
         correctionsEnabled: Boolean,
     ): SuggestionStrip {
-        val token = composing.ifEmpty { SuggestionEngine.lastWord(before).orEmpty() }
+        val token = composing.ifEmpty { SuggestionEngine.lastWordForEmoji(before).orEmpty() }
         val emojis = EmojiSuggestions.glyphs(token)
         if (composing.isNotEmpty()) {
             val completions = complete(composing)
@@ -143,6 +143,17 @@ internal object SuggestionEngine {
             start--
         }
         val word = trimmed.substring(start).replace("'", "").lowercase()
+        return word.takeIf { it.any(Char::isLetter) }
+    }
+
+    /** Last word even when a space or period is already sitting after it. */
+    fun lastWordForEmoji(textBeforeCursor: CharSequence): String? {
+        var end = textBeforeCursor.length
+        while (end > 0 && !isWordChar(textBeforeCursor[end - 1])) end--
+        if (end == 0) return null
+        var start = end
+        while (start > 0 && isWordChar(textBeforeCursor[start - 1])) start--
+        val word = textBeforeCursor.subSequence(start, end).toString().replace("'", "").lowercase()
         return word.takeIf { it.any(Char::isLetter) }
     }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
@@ -62,21 +62,23 @@ internal class SuggestionDictionary(
         after: String,
         correctionsEnabled: Boolean,
     ): SuggestionStrip {
+        val token = composing.ifEmpty { SuggestionEngine.lastWord(before).orEmpty() }
+        val emojis = EmojiSuggestions.glyphs(token)
         if (composing.isNotEmpty()) {
             val completions = complete(composing)
             val corrections = if (correctionsEnabled) correct(composing) else emptyList()
-            return SuggestionStrip((completions + corrections).distinct().take(3))
+            return SuggestionStrip((completions + corrections).distinct().take(3), emojis)
         }
         if (correctionsEnabled) {
             val span = SuggestionEngine.wordSpan(before, after)
             if (span != null && span.word.length >= 2) {
                 val nearby = similar(span.word)
                 if (nearby.isNotEmpty()) {
-                    return SuggestionStrip(nearby, replacesWord = true)
+                    return SuggestionStrip(nearby, emojis, replacesWord = true)
                 }
             }
         }
-        return SuggestionStrip(next(SuggestionEngine.lastWord(before).orEmpty()))
+        return SuggestionStrip(next(SuggestionEngine.lastWord(before).orEmpty()), emojis)
     }
 
     fun swipe(path: String, limit: Int = 4): List<String> {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -301,10 +301,20 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         val connection = currentInputConnection ?: return
         connection.finishComposingText()
         val before = runCatching {
-            connection.getTextBeforeCursor(1, 0)?.toString().orEmpty()
+            connection.getTextBeforeCursor(32, 0)?.toString().orEmpty()
         }.getOrDefault("")
-        val prefix = if (before.isEmpty() || before.last().isWhitespace()) "" else " "
-        connection.commitText("$prefix$emoji", 1)
+        val after = runCatching {
+            connection.getTextAfterCursor(32, 0)?.toString().orEmpty()
+        }.getOrDefault("")
+        if (EmojiCommit.shouldReplaceTrigger("", before)) {
+            val span = SuggestionEngine.replaceableWord(before, after)
+            if (span != null) {
+                connection.deleteSurroundingText(span.beforeLength, span.afterLength)
+            }
+            connection.commitText(emoji, 1)
+        } else {
+            connection.commitText(EmojiCommit.insertText(before, emoji), 1)
+        }
         recordEmojiRecent(emoji)
         syncShiftFromCursor()
         refreshEditorText()

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -2,11 +2,15 @@ package com.vocahq.vocaphone.ime
 
 import android.content.ClipDescription
 import android.content.ClipboardManager
+import android.content.Intent
+import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.ExtractedTextRequest
+import android.view.inputmethod.InputConnection
+import android.view.inputmethod.InputContentInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -26,6 +30,8 @@ import com.vocahq.vocaphone.dictation.DictationSource
 import com.vocahq.vocaphone.dictation.InsertionOutcome
 import com.vocahq.vocaphone.dictation.InsertionReport
 import com.vocahq.vocaphone.dictation.TranscriptInserter
+import com.vocahq.vocaphone.settings.ClipboardHistory
+import com.vocahq.vocaphone.settings.ClipboardImages
 import com.vocahq.vocaphone.settings.VocaPhoneSettings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -60,8 +66,11 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
     private var startedImeDictation = false
     private var ignoredClipboardText: String? = null
     private var lastRecordedClip: String? = null
+    private var lastImageSource: String? = null
     private var editorSession = 0
     private var editorConfig by mutableStateOf(KeyboardEditorConfig.empty())
+    private var lastCandidatesStart = -1
+    private var lastCandidatesEnd = -1
 
     override fun onCreate() {
         super.onCreate()
@@ -104,6 +113,7 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
             onLanguageSelected = ::setLanguage,
             onStyleSelected = ::setStyle,
             onSuggestionPicked = ::commitSuggestion,
+            onEmojiSuggestion = ::commitEmojiSuggestion,
             onPasteClipboard = { pasteClipboard(it) },
             onDismissClipboard = ::dismissClipboard,
             onRemoveClipboardHistory = ::removeClipboardHistory,
@@ -116,6 +126,8 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         super.onStartInput(attribute, restarting)
         currentInputType = attribute?.inputType ?: 0
         editorSession += 1
+        lastCandidatesStart = -1
+        lastCandidatesEnd = -1
         val cursorCapsMode = runCatching {
             currentInputConnection?.getCursorCapsMode(currentInputType) ?: 0
         }.getOrDefault(0)
@@ -157,6 +169,22 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
             candidatesStart,
             candidatesEnd,
         )
+        val userMove = EditorCursorSync.isUserMove(
+            oldSelStart,
+            oldSelEnd,
+            newSelStart,
+            newSelEnd,
+            lastCandidatesStart,
+            lastCandidatesEnd,
+            candidatesStart,
+            candidatesEnd,
+        )
+        lastCandidatesStart = candidatesStart
+        lastCandidatesEnd = candidatesEnd
+        if (userMove) {
+            currentInputConnection?.finishComposingText()
+            editorConfig = editorConfig.copy(cursorSync = editorConfig.cursorSync + 1)
+        }
         refreshEditorText()
     }
 
@@ -164,6 +192,8 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         cancelOwnedDictation("editor_finished")
         currentInputType = 0
         editorSession += 1
+        lastCandidatesStart = -1
+        lastCandidatesEnd = -1
         editorConfig = KeyboardEditorConfig.empty().copy(sessionId = editorSession)
         super.onFinishInput()
     }
@@ -267,14 +297,48 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         refreshEditorText()
     }
 
+    private fun commitEmojiSuggestion(emoji: String) {
+        val connection = currentInputConnection ?: return
+        connection.finishComposingText()
+        val before = runCatching {
+            connection.getTextBeforeCursor(1, 0)?.toString().orEmpty()
+        }.getOrDefault("")
+        val prefix = if (before.isEmpty() || before.last().isWhitespace()) "" else " "
+        connection.commitText("$prefix$emoji", 1)
+        recordEmojiRecent(emoji)
+        syncShiftFromCursor()
+        refreshEditorText()
+    }
+
     private fun pasteClipboard(text: String = visibleClipboard.value?.fullText.orEmpty()) {
         if (text.isEmpty()) return
         currentInputConnection?.finishComposingText()
-        currentInputConnection?.commitText(text, 1)
+        val image = ClipboardHistory.parseImage(text)
+        val pasted = if (image != null) {
+            pasteClipboardImage(image.first, image.second)
+        } else {
+            currentInputConnection?.commitText(text, 1) == true
+        }
+        if (!pasted) return
         ignoredClipboardText = text
         if (visibleClipboard.value?.fullText == text) visibleClipboard.value = null
         syncShiftFromCursor()
         refreshEditorText()
+    }
+
+    private fun pasteClipboardImage(mime: String, relativePath: String): Boolean {
+        val file = ClipboardImages.file(this, relativePath)
+        if (!file.exists()) return false
+        val uri = ClipboardImages.contentUri(this, relativePath)
+        currentInputEditorInfo?.packageName?.let { target ->
+            grantUriPermission(target, uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        val info = InputContentInfo(uri, ClipDescription("image", arrayOf(mime)))
+        return currentInputConnection?.commitContent(
+            info,
+            InputConnection.INPUT_CONTENT_GRANT_READ_URI_PERMISSION,
+            null,
+        ) == true
     }
 
     private fun dismissClipboard() {
@@ -360,33 +424,88 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
             }
             val manager = getSystemService(ClipboardManager::class.java)
             val description = manager?.primaryClipDescription
-            val isText = description?.hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN) == true ||
-                description?.hasMimeType(ClipDescription.MIMETYPE_TEXT_HTML) == true
-            if (!isText) {
-                visibleClipboard.value = null
-                return@post
-            }
-            val text = runCatching {
-                manager.primaryClip?.getItemAt(0)?.coerceToText(this)?.toString()
+            val clip = manager?.primaryClip
+            val imageMime = clipImageMime(description)
+            val rawText = runCatching {
+                clip?.getItemAt(0)?.coerceToText(this)?.toString()
             }.getOrNull()?.trim().orEmpty()
-            if (
-                text.isNotEmpty() &&
-                settings.clipboardHistoryEnabled &&
-                text != lastRecordedClip
-            ) {
-                lastRecordedClip = text
-                persistPreference { container.settings.recordClipboardHistory(text) }
-            }
-            visibleClipboard.value = text.takeIf {
-                settings.clipboardChipEnabled && it.isNotEmpty() && it != ignoredClipboardText
-            }?.let { value ->
-                ClipboardChip(
-                    preview = value.replace('\n', ' ').take(24),
-                    fullText = value,
-                )
+            val text = rawText.takeIf { it.isNotEmpty() && !isImageUriText(it, imageMime != null) }
+            when {
+                !text.isNullOrEmpty() -> showClipboardText(text, settings)
+                imageMime != null -> {
+                    val uri = clip?.getItemAt(0)?.uri
+                    if (uri != null) showClipboardImage(uri, imageMime, settings)
+                    else visibleClipboard.value = null
+                }
+                else -> visibleClipboard.value = null
             }
         }
     }
+
+    private fun showClipboardText(text: String, settings: VocaPhoneSettings) {
+        if (settings.clipboardHistoryEnabled && text != lastRecordedClip) {
+            lastRecordedClip = text
+            persistPreference { container.settings.recordClipboardHistory(text) }
+        }
+        visibleClipboard.value = text.takeIf {
+            settings.clipboardChipEnabled && it != ignoredClipboardText
+        }?.let { value ->
+            ClipboardChip(
+                preview = value.replace('\n', ' ').take(24),
+                fullText = value,
+            )
+        }
+    }
+
+    private fun showClipboardImage(uri: Uri, mime: String, settings: VocaPhoneSettings) {
+        val source = uri.toString()
+        val reused = lastRecordedClip
+        if (source == lastImageSource && reused != null && ClipboardHistory.isImage(reused)) {
+            visibleClipboard.value = reused.takeIf {
+                settings.clipboardChipEnabled && it != ignoredClipboardText
+            }?.let {
+                ClipboardChip(
+                    preview = "Image",
+                    fullText = it,
+                    imagePath = ClipboardHistory.parseImage(it)?.second,
+                )
+            }
+            return
+        }
+        scope.launch {
+            val relative = withContext(Dispatchers.IO) {
+                ClipboardImages.cache(this@VocaPhoneInputMethodService, uri, mime)
+            } ?: run {
+                visibleClipboard.value = null
+                return@launch
+            }
+            val encoded = ClipboardHistory.encodeImage(mime, relative)
+            lastImageSource = source
+            if (settings.clipboardHistoryEnabled && encoded != lastRecordedClip) {
+                lastRecordedClip = encoded
+                persistPreference { container.settings.recordClipboardHistory(encoded) }
+            } else {
+                lastRecordedClip = encoded
+            }
+            visibleClipboard.value = encoded.takeIf {
+                settings.clipboardChipEnabled && it != ignoredClipboardText
+            }?.let {
+                ClipboardChip(preview = "Image", fullText = it, imagePath = relative)
+            }
+        }
+    }
+
+    private fun clipImageMime(description: ClipDescription?): String? {
+        if (description == null) return null
+        for (index in 0 until description.mimeTypeCount) {
+            val mime = description.getMimeType(index)
+            if (mime.startsWith("image/")) return mime
+        }
+        return null
+    }
+
+    private fun isImageUriText(text: String, hasImage: Boolean): Boolean =
+        hasImage && (text.startsWith("content://") || text.startsWith("file://"))
 
     private fun performEditorAction() {
         val actionId = editorConfig.editorActionId

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -1,5 +1,6 @@
 package com.vocahq.vocaphone.ime
 
+import android.graphics.BitmapFactory
 import android.os.SystemClock
 import android.view.HapticFeedbackConstants
 import androidx.compose.animation.AnimatedVisibility
@@ -13,18 +14,21 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items as gridItems
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -40,6 +44,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
@@ -58,10 +63,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -100,7 +110,9 @@ import com.vocahq.vocaphone.core.DictationState
 import com.vocahq.vocaphone.core.ModelLanguageSupport
 import com.vocahq.vocaphone.core.TranscriptionLanguage
 import com.vocahq.vocaphone.core.WritingStyle
+import com.vocahq.vocaphone.settings.ClipboardHistory
 import com.vocahq.vocaphone.settings.VocaPhoneSettings
+import java.io.File
 import com.vocahq.vocaphone.ui.theme.VocaPhoneTheme
 import kotlin.math.PI
 import kotlin.math.sin
@@ -135,6 +147,7 @@ internal fun VocaPhoneKeyboard(
     onLanguageSelected: (TranscriptionLanguage) -> Unit,
     onStyleSelected: (WritingStyle) -> Unit,
     onSuggestionPicked: (String, Boolean) -> Unit,
+    onEmojiSuggestion: (String) -> Unit,
     onPasteClipboard: (String) -> Unit,
     onDismissClipboard: () -> Unit,
     onRemoveClipboardHistory: (String) -> Unit,
@@ -162,6 +175,11 @@ internal fun VocaPhoneKeyboard(
     LaunchedEffect(editor.shiftSync) {
         if (editor.shiftSync > 0) {
             keyboardState = keyboardState.copy(shift = editor.initialShift)
+        }
+    }
+    LaunchedEffect(editor.cursorSync) {
+        if (editor.cursorSync > 0) {
+            keyboardState = keyboardState.copy(composing = "")
         }
     }
     LaunchedEffect(settings.asciiEmojiEnabled, emojiCategory) {
@@ -197,9 +215,9 @@ internal fun VocaPhoneKeyboard(
     val stripClipboard = KeyboardChrome.clipboardForStrip(clipboardChip)
     val swipeArmed = KeyboardChrome.swipeWordArmed(swipeWord, editorText.before, editorText.after)
     val stripSuggestions = if (swipeArmed && swipeChoices.isNotEmpty()) {
-        swipeChoices
+        swipeChoices.map { SuggestionItem(it) }
     } else {
-        KeyboardChrome.suggestionsForStrip(suggestionStrip.words, startedTyping)
+        KeyboardChrome.suggestionsForStrip(suggestionStrip.items, startedTyping)
     }
     val swipeReplacesWord = swipeArmed && swipeChoices.isNotEmpty()
 
@@ -343,20 +361,29 @@ internal fun VocaPhoneKeyboard(
                     },
                     onPaste = { onPasteClipboard(clipboardChip?.fullText.orEmpty()) },
                     onDismissClipboard = onDismissClipboard,
-                    onSuggestion = { word ->
-                        val replace = KeyboardChrome.suggestionReplacesWord(
-                            composing = keyboardState.composing,
-                            swipeChoicesActive = swipeReplacesWord,
-                            stripReplacesWord = suggestionStrip.replacesWord,
-                        )
-                        swipeChoices = emptyList()
-                        swipeWord = if (replace) word else null
-                        keyboardState = keyboardState.copy(
-                            composing = "",
-                            lastWasSpace = true,
-                            capitalizeAfterSpace = false,
-                        )
-                        onSuggestionPicked(word, replace)
+                    onSuggestion = { item ->
+                        if (item.isEmoji) {
+                            clearSwipe()
+                            keyboardState = keyboardState.copy(
+                                composing = "",
+                                lastWasSpace = false,
+                            )
+                            onEmojiSuggestion(item.text)
+                        } else {
+                            val replace = KeyboardChrome.suggestionReplacesWord(
+                                composing = keyboardState.composing,
+                                swipeChoicesActive = swipeReplacesWord,
+                                stripReplacesWord = suggestionStrip.replacesWord,
+                            )
+                            swipeChoices = emptyList()
+                            swipeWord = if (replace) item.text else null
+                            keyboardState = keyboardState.copy(
+                                composing = "",
+                                lastWasSpace = true,
+                                capitalizeAfterSpace = false,
+                            )
+                            onSuggestionPicked(item.text, replace)
+                        }
                     },
                 )
                 Spacer(Modifier.height(4.dp))
@@ -482,7 +509,7 @@ private fun DictationBar(
     barHeight: Dp,
     isPreferenceWritePending: Boolean,
     clipboard: ClipboardChip?,
-    suggestions: List<String>,
+    suggestions: List<SuggestionItem>,
     emojiCategory: EmojiCategory?,
     hasEmojiRecents: Boolean,
     asciiEmojiEnabled: Boolean,
@@ -493,7 +520,7 @@ private fun DictationBar(
     onMenuTap: () -> Unit,
     onPaste: () -> Unit,
     onDismissClipboard: () -> Unit,
-    onSuggestion: (String) -> Unit,
+    onSuggestion: (SuggestionItem) -> Unit,
 ) {
     val view = LocalView.current
     val idle = state.phase == DictationPhase.IDLE
@@ -622,17 +649,15 @@ private fun DictationBar(
                 )
                 clipboard != null -> ClipboardChipButton(
                     preview = clipboard.preview,
+                    imagePath = clipboard.imagePath,
                     onClick = onPaste,
                     onLongClick = onDismissClipboard,
                     modifier = Modifier.weight(1f),
                 )
-                suggestions.isNotEmpty() -> suggestions.take(3).forEach { word ->
-                    SuggestionChip(
-                        label = word,
-                        onClick = { onSuggestion(word) },
-                        modifier = Modifier.weight(1f),
-                    )
-                }
+                suggestions.isNotEmpty() -> SuggestionStripRow(
+                    suggestions = suggestions,
+                    onSuggestion = onSuggestion,
+                )
                 else -> Spacer(Modifier.weight(1f))
             }
         }
@@ -800,7 +825,7 @@ private fun ClipboardHistoryPanel(
     PreferencePanelShell(
         title = "Clipboard",
         subtitle = if (items.isEmpty()) {
-            "Copy text to save it here"
+            "Copy text or an image to save it here"
         } else {
             "Tap to paste. Long press to remove."
         },
@@ -836,26 +861,40 @@ private fun ClipboardHistoryPanel(
                     .weight(1f),
                 verticalArrangement = Arrangement.spacedBy(3.dp),
             ) {
-                items(items, key = { it.hashCode().toString() + it.take(12) }) { text ->
+                items(items, key = { it.hashCode().toString() + it.take(12) }) { stored ->
+                    val image = ClipboardHistory.parseImage(stored)
                     Surface(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .pointerInput(text) {
+                            .pointerInput(stored) {
                                 detectTapGestures(
-                                    onTap = { if (enabled) onPaste(text) },
-                                    onLongPress = { if (enabled) onRemove(text) },
+                                    onTap = { if (enabled) onPaste(stored) },
+                                    onLongPress = { if (enabled) onRemove(stored) },
                                 )
                             },
                         shape = RoundedCornerShape(8.dp),
                         color = MaterialTheme.colorScheme.surfaceContainerHigh,
                     ) {
-                        Text(
-                            text = text.replace('\n', ' '),
+                        Row(
                             modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
-                            fontSize = 13.sp,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            if (image != null) {
+                                ClipboardThumb(
+                                    relativePath = image.second,
+                                    modifier = Modifier
+                                        .size(36.dp)
+                                        .clip(RoundedCornerShape(6.dp)),
+                                )
+                            }
+                            Text(
+                                text = ClipboardHistory.preview(stored),
+                                fontSize = 13.sp,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
                     }
                 }
             }
@@ -1248,6 +1287,7 @@ private fun ClipboardChipButton(
     onClick: () -> Unit,
     onLongClick: () -> Unit,
     modifier: Modifier = Modifier,
+    imagePath: String? = null,
 ) {
     val view = LocalView.current
     var dismissing by remember(preview) { mutableStateOf(false) }
@@ -1287,11 +1327,20 @@ private fun ClipboardChipButton(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(6.dp),
         ) {
-            KeyboardIcon(
-                glyph = Glyph.CLIPBOARD,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(16.dp),
-            )
+            if (imagePath != null) {
+                ClipboardThumb(
+                    relativePath = imagePath,
+                    modifier = Modifier
+                        .size(20.dp)
+                        .clip(RoundedCornerShape(4.dp)),
+                )
+            } else {
+                KeyboardIcon(
+                    glyph = Glyph.CLIPBOARD,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(16.dp),
+                )
+            }
             Text(
                 text = preview,
                 fontSize = 14.sp,
@@ -1305,10 +1354,64 @@ private fun ClipboardChipButton(
 }
 
 @Composable
+private fun RowScope.SuggestionStripRow(
+    suggestions: List<SuggestionItem>,
+    onSuggestion: (SuggestionItem) -> Unit,
+) {
+    if (suggestions.size <= 3) {
+        suggestions.forEach { item ->
+            SuggestionChip(
+                label = item.text,
+                emoji = item.isEmoji,
+                onClick = { onSuggestion(item) },
+                modifier = Modifier.weight(1f),
+            )
+        }
+        return
+    }
+    val scroll = rememberScrollState()
+    val fade = MaterialTheme.colorScheme.surfaceContainerLowest
+    Box(
+        modifier = Modifier
+            .weight(1f)
+            .fillMaxHeight()
+            .drawWithContent {
+                drawContent()
+                if (scroll.canScrollForward) {
+                    drawRect(
+                        brush = Brush.horizontalGradient(
+                            0.82f to Color.Transparent,
+                            1f to fade,
+                        ),
+                    )
+                }
+            },
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxHeight()
+                .horizontalScroll(scroll),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            suggestions.forEach { item ->
+                SuggestionChip(
+                    label = item.text,
+                    emoji = item.isEmoji,
+                    onClick = { onSuggestion(item) },
+                    modifier = Modifier.widthIn(min = if (item.isEmoji) 44.dp else 68.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
 private fun SuggestionChip(
     label: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    emoji: Boolean = false,
 ) {
     Surface(
         modifier = modifier
@@ -1324,12 +1427,39 @@ private fun SuggestionChip(
         Box(contentAlignment = Alignment.Center, modifier = Modifier.padding(horizontal = 8.dp)) {
             Text(
                 text = label,
-                fontSize = 14.sp,
+                fontSize = if (emoji) 18.sp else 14.sp,
                 fontWeight = FontWeight.Medium,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
         }
+    }
+}
+
+@Composable
+private fun ClipboardThumb(
+    relativePath: String,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val bitmap = remember(relativePath) {
+        val file = File(context.filesDir, relativePath)
+        if (!file.exists()) {
+            null
+        } else {
+            BitmapFactory.decodeFile(
+                file.absolutePath,
+                BitmapFactory.Options().apply { inSampleSize = 8 },
+            )
+        }
+    }
+    if (bitmap != null) {
+        Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = null,
+            modifier = modifier,
+            contentScale = ContentScale.Crop,
+        )
     }
 }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/ClipboardImages.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/ClipboardImages.kt
@@ -1,0 +1,68 @@
+package com.vocahq.vocaphone.settings
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import java.io.File
+
+internal object ClipboardImages {
+    const val DIR = "clipboard"
+    const val MAX_BYTES = 8 * 1024 * 1024
+
+    fun cache(context: Context, uri: Uri, mime: String): String? {
+        val dir = File(context.filesDir, DIR).apply { mkdirs() }
+        val dest = File(dir, "${System.currentTimeMillis()}.${extension(mime)}")
+        return try {
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                dest.outputStream().use { output ->
+                    val buffer = ByteArray(16 * 1024)
+                    var written = 0L
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        written += read
+                        if (written > MAX_BYTES) {
+                            dest.delete()
+                            return null
+                        }
+                        output.write(buffer, 0, read)
+                    }
+                }
+            } ?: return null
+            if (dest.length() == 0L) {
+                dest.delete()
+                return null
+            }
+            "$DIR/${dest.name}"
+        } catch (_: Exception) {
+            dest.delete()
+            null
+        }
+    }
+
+    fun file(context: Context, relativePath: String): File = File(context.filesDir, relativePath)
+
+    fun contentUri(context: Context, relativePath: String): Uri =
+        FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.clipboard",
+            file(context, relativePath),
+        )
+
+    fun prune(context: Context, keepRelative: Set<String>) {
+        val dir = File(context.filesDir, DIR)
+        if (!dir.isDirectory) return
+        val keep = keepRelative.map { it.substringAfterLast('/') }.toSet()
+        dir.listFiles()?.forEach { file ->
+            if (file.name !in keep) file.delete()
+        }
+    }
+
+    private fun extension(mime: String): String = when {
+        mime.contains("png") -> "png"
+        mime.contains("webp") -> "webp"
+        mime.contains("gif") -> "gif"
+        mime.contains("jpeg") || mime.contains("jpg") -> "jpg"
+        else -> "img"
+    }
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -26,9 +26,12 @@ internal object ClipboardHistory {
     const val MAX_ITEMS = 20
     const val MAX_ITEM_CHARS = 4_000
     const val SEPARATOR = "\u001e"
+    const val IMAGE_PREFIX = "\u001fIMG\u001f"
 
     fun remember(existing: List<String>, incoming: String): List<String> {
-        val text = incoming.trim().take(MAX_ITEM_CHARS)
+        // Image tokens start with U+001F, which Java treats as whitespace.
+        val text = if (isImage(incoming)) incoming.take(MAX_ITEM_CHARS)
+        else incoming.trim().take(MAX_ITEM_CHARS)
         if (text.isEmpty()) return existing
         return (listOf(text) + existing.filter { it != text }).take(MAX_ITEMS)
     }
@@ -37,6 +40,25 @@ internal object ClipboardHistory {
 
     fun decode(stored: String?): List<String> =
         stored?.split(SEPARATOR)?.filter { it.isNotEmpty() }.orEmpty()
+
+    fun isImage(stored: String): Boolean = stored.startsWith(IMAGE_PREFIX)
+
+    fun encodeImage(mime: String, relativePath: String): String =
+        "$IMAGE_PREFIX$mime\u001f$relativePath"
+
+    fun parseImage(stored: String): Pair<String, String>? {
+        if (!isImage(stored)) return null
+        val rest = stored.removePrefix(IMAGE_PREFIX)
+        val sep = rest.indexOf('\u001f')
+        if (sep <= 0 || sep == rest.lastIndex) return null
+        return rest.substring(0, sep) to rest.substring(sep + 1)
+    }
+
+    fun preview(stored: String): String =
+        if (isImage(stored)) "Image" else stored.replace('\n', ' ')
+
+    fun imagePaths(items: List<String>): Set<String> =
+        items.mapNotNull { parseImage(it)?.second }.toSet()
 }
 
 enum class KeyboardHeight(
@@ -248,23 +270,27 @@ class SettingsRepository(private val context: Context) {
     suspend fun setClipboardHistoryEnabled(enabled: Boolean) = put(Keys.CLIPBOARD_HISTORY_ENABLED, enabled)
 
     suspend fun recordClipboardHistory(text: String) {
+        var next: List<String> = emptyList()
         context.dataStore.edit { preferences ->
             val current = ClipboardHistory.decode(preferences[Keys.CLIPBOARD_HISTORY])
-            preferences[Keys.CLIPBOARD_HISTORY] = ClipboardHistory.encode(
-                ClipboardHistory.remember(current, text),
-            )
+            next = ClipboardHistory.remember(current, text)
+            preferences[Keys.CLIPBOARD_HISTORY] = ClipboardHistory.encode(next)
         }
+        ClipboardImages.prune(context, ClipboardHistory.imagePaths(next))
     }
 
     suspend fun removeClipboardHistory(text: String) {
+        var next: List<String> = emptyList()
         context.dataStore.edit { preferences ->
-            val next = ClipboardHistory.decode(preferences[Keys.CLIPBOARD_HISTORY]).filter { it != text }
+            next = ClipboardHistory.decode(preferences[Keys.CLIPBOARD_HISTORY]).filter { it != text }
             preferences[Keys.CLIPBOARD_HISTORY] = ClipboardHistory.encode(next)
         }
+        ClipboardImages.prune(context, ClipboardHistory.imagePaths(next))
     }
 
     suspend fun clearClipboardHistory() {
         context.dataStore.edit { it.remove(Keys.CLIPBOARD_HISTORY) }
+        ClipboardImages.prune(context, emptySet())
     }
 
     suspend fun recordEmojiRecent(emoji: String) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -260,8 +260,8 @@ fun SettingsScreen(
                     )
                     SettingToggle(
                         title = "Clipboard history",
-                        detail = "Save recent clips on this phone. Open them from the " +
-                            "keyboard menu. Off in passwords.",
+                        detail = "Save recent text and images on this phone. Open them " +
+                            "from the keyboard menu. Off in passwords.",
                         checked = settings.clipboardHistoryEnabled,
                         onCheckedChange = onClipboardHistory,
                     )

--- a/android/app/src/main/res/xml/clipboard_paths.xml
+++ b/android/app/src/main/res/xml/clipboard_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path
+        name="clipboard"
+        path="clipboard/" />
+</paths>

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/EditorCursorSyncTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/EditorCursorSyncTest.kt
@@ -1,0 +1,132 @@
+package com.vocahq.vocaphone.ime
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EditorCursorSyncTest {
+
+    @Test
+    fun composingGrowthIsNotAUserMove() {
+        assertFalse(
+            EditorCursorSync.isUserMove(
+                oldSelStart = 10,
+                oldSelEnd = 10,
+                newSelStart = 11,
+                newSelEnd = 11,
+                oldCandidatesStart = -1,
+                oldCandidatesEnd = -1,
+                newCandidatesStart = 10,
+                newCandidatesEnd = 11,
+            ),
+        )
+        assertFalse(
+            EditorCursorSync.isUserMove(
+                oldSelStart = 11,
+                oldSelEnd = 11,
+                newSelStart = 12,
+                newSelEnd = 12,
+                oldCandidatesStart = 10,
+                oldCandidatesEnd = 11,
+                newCandidatesStart = 10,
+                newCandidatesEnd = 12,
+            ),
+        )
+    }
+
+    @Test
+    fun composingBackspaceIsNotAUserMove() {
+        assertFalse(
+            EditorCursorSync.isUserMove(
+                oldSelStart = 12,
+                oldSelEnd = 12,
+                newSelStart = 11,
+                newSelEnd = 11,
+                oldCandidatesStart = 10,
+                oldCandidatesEnd = 12,
+                newCandidatesStart = 10,
+                newCandidatesEnd = 11,
+            ),
+        )
+    }
+
+    @Test
+    fun finishingAWordInPlaceIsNotAUserMove() {
+        assertFalse(
+            EditorCursorSync.isUserMove(
+                oldSelStart = 15,
+                oldSelEnd = 15,
+                newSelStart = 16,
+                newSelEnd = 16,
+                oldCandidatesStart = 10,
+                oldCandidatesEnd = 15,
+                newCandidatesStart = -1,
+                newCandidatesEnd = -1,
+            ),
+        )
+    }
+
+    @Test
+    fun tappingAwayFromComposingIsAUserMove() {
+        assertTrue(
+            EditorCursorSync.isUserMove(
+                oldSelStart = 15,
+                oldSelEnd = 15,
+                newSelStart = 3,
+                newSelEnd = 3,
+                oldCandidatesStart = 10,
+                oldCandidatesEnd = 15,
+                newCandidatesStart = -1,
+                newCandidatesEnd = -1,
+            ),
+        )
+    }
+
+    @Test
+    fun tappingInsideComposingIsAUserMove() {
+        assertTrue(
+            EditorCursorSync.isUserMove(
+                oldSelStart = 15,
+                oldSelEnd = 15,
+                newSelStart = 12,
+                newSelEnd = 12,
+                oldCandidatesStart = 10,
+                oldCandidatesEnd = 15,
+                newCandidatesStart = 10,
+                newCandidatesEnd = 15,
+            ),
+        )
+    }
+
+    @Test
+    fun selectingTextIsAUserMove() {
+        assertTrue(
+            EditorCursorSync.isUserMove(
+                oldSelStart = 15,
+                oldSelEnd = 15,
+                newSelStart = 4,
+                newSelEnd = 9,
+                oldCandidatesStart = -1,
+                oldCandidatesEnd = -1,
+                newCandidatesStart = -1,
+                newCandidatesEnd = -1,
+            ),
+        )
+    }
+
+    @Test
+    fun anUnchangedSelectionIsNotAUserMove() {
+        assertFalse(
+            EditorCursorSync.isUserMove(
+                oldSelStart = 8,
+                oldSelEnd = 8,
+                newSelStart = 8,
+                newSelEnd = 8,
+                oldCandidatesStart = -1,
+                oldCandidatesEnd = -1,
+                newCandidatesStart = -1,
+                newCandidatesEnd = -1,
+            ),
+        )
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/EmojiCommitTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/EmojiCommitTest.kt
@@ -1,0 +1,40 @@
+package com.vocahq.vocaphone.ime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EmojiCommitTest {
+
+    @Test
+    fun tapReplacesTheTriggerWhileStillOnTheWord() {
+        assertTrue(EmojiCommit.shouldReplaceTrigger("sad", ""))
+        assertTrue(EmojiCommit.shouldReplaceTrigger("sad", "I am "))
+        assertTrue(EmojiCommit.shouldReplaceTrigger("", "I am sad"))
+        assertTrue(EmojiCommit.shouldReplaceTrigger("", "sad"))
+    }
+
+    @Test
+    fun tapInsertsOnceAnythingFollowsTheTrigger() {
+        assertFalse(EmojiCommit.shouldReplaceTrigger("", "sad "))
+        assertFalse(EmojiCommit.shouldReplaceTrigger("", "sad."))
+        assertFalse(EmojiCommit.shouldReplaceTrigger("", "sad!"))
+        assertFalse(EmojiCommit.shouldReplaceTrigger("", "sad,"))
+        assertFalse(EmojiCommit.shouldReplaceTrigger("", "I am sad "))
+    }
+
+    @Test
+    fun aNonTriggerWordIsNeverReplaced() {
+        assertFalse(EmojiCommit.shouldReplaceTrigger("the", ""))
+        assertFalse(EmojiCommit.shouldReplaceTrigger("", "the"))
+        assertFalse(EmojiCommit.shouldReplaceTrigger("hap", ""))
+    }
+
+    @Test
+    fun insertKeepsASpaceAfterPunctuationAndNotAfterASpace() {
+        assertEquals("😢", EmojiCommit.insertText("sad ", "😢"))
+        assertEquals(" 😢", EmojiCommit.insertText("sad.", "😢"))
+        assertEquals("😢", EmojiCommit.insertText("", "😢"))
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/EmojiSuggestionsTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/EmojiSuggestionsTest.kt
@@ -1,0 +1,72 @@
+package com.vocahq.vocaphone.ime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EmojiSuggestionsTest {
+
+    @Test
+    fun expectedWordsOfferTheirEmoji() {
+        assertEquals("😂", EmojiSuggestions.glyph("lol"))
+        assertEquals("🍕", EmojiSuggestions.glyph("pizza"))
+        assertEquals("🎂", EmojiSuggestions.glyph("birthday"))
+        assertEquals("🙏", EmojiSuggestions.glyph("thanks"))
+        assertEquals("🔥", EmojiSuggestions.glyph("fire"))
+        assertEquals("😊", EmojiSuggestions.glyph("happy"))
+        assertEquals("😢", EmojiSuggestions.glyph("sad"))
+        assertEquals("💀", EmojiSuggestions.glyph("skull"))
+    }
+
+    @Test
+    fun matchingIgnoresCase() {
+        assertEquals("😂", EmojiSuggestions.glyph("LOL"))
+        assertEquals("🍕", EmojiSuggestions.glyph("Pizza"))
+    }
+
+    @Test
+    fun onlyWholeWordsMatch() {
+        assertNull(EmojiSuggestions.glyph("lolly"))
+        assertNull(EmojiSuggestions.glyph("carefully"))
+        assertEquals("🚗", EmojiSuggestions.glyph("car"))
+        assertNull(EmojiSuggestions.glyph("l"))
+        assertNull(EmojiSuggestions.glyph(""))
+    }
+
+    @Test
+    fun ordinaryProseGetsNothing() {
+        for (word in listOf(
+            "the", "and", "is", "was", "of", "to", "it", "that", "this", "with",
+            "have", "from", "they", "there", "about", "would", "should",
+            "good", "yes", "no", "time", "work", "day", "code", "check", "key",
+        )) {
+            assertNull(word, EmojiSuggestions.glyph(word))
+        }
+    }
+
+    @Test
+    fun feelingWordsOfferRelatedEmoji() {
+        assertEquals(listOf("😢", "😭", "😞"), EmojiSuggestions.glyphs("sad"))
+        assertEquals(listOf("😊", "😄", "😁"), EmojiSuggestions.glyphs("happy"))
+        assertTrue(EmojiSuggestions.glyphs("skull").contains("💀"))
+        assertTrue(EmojiSuggestions.glyphs("skull").size > 1)
+    }
+
+    @Test
+    fun everyEntryIsOneEmojiForOneLowercaseWord() {
+        for ((word, glyph) in EmojiSuggestions.TRIGGERS) {
+            assertEquals(word, word.lowercase())
+            assertTrue(word.length >= EmojiSuggestions.MINIMUM_LENGTH)
+            assertTrue(word, word.all { it.isLetter() })
+            assertTrue(glyph.isNotEmpty())
+            assertTrue(word, glyph.any { !it.isLetter() })
+        }
+    }
+
+    @Test
+    fun theTableIsCuratedRatherThanExhaustive() {
+        assertTrue(EmojiSuggestions.TRIGGERS.size > 100)
+        assertTrue(EmojiSuggestions.TRIGGERS.size < 400)
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/EmojiSuggestionsTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/EmojiSuggestionsTest.kt
@@ -54,6 +54,17 @@ class EmojiSuggestionsTest {
     }
 
     @Test
+    fun aliasesShareTheSameGlyphAndRelatedChips() {
+        assertEquals("😂", EmojiSuggestions.glyph("laugh"))
+        assertEquals("😂", EmojiSuggestions.glyph("lol"))
+        assertEquals("😢", EmojiSuggestions.glyph("unhappy"))
+        assertEquals(EmojiSuggestions.glyphs("sad"), EmojiSuggestions.glyphs("upset"))
+        assertEquals("🙏", EmojiSuggestions.glyph("thx"))
+        assertEquals("🎂", EmojiSuggestions.glyph("bday"))
+        assertEquals("🤷", EmojiSuggestions.glyph("idk"))
+    }
+
+    @Test
     fun everyEntryIsOneEmojiForOneLowercaseWord() {
         for ((word, glyph) in EmojiSuggestions.TRIGGERS) {
             assertEquals(word, word.lowercase())

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardChromeTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardChromeTest.kt
@@ -31,8 +31,8 @@ class KeyboardChromeTest {
 
     @Test
     fun `suggestions only show after typing starts`() {
-        val words = listOf("you", "the")
-        assertEquals(emptyList<String>(), KeyboardChrome.suggestionsForStrip(words, startedTyping = false))
+        val words = listOf(SuggestionItem("you"), SuggestionItem("the"))
+        assertEquals(emptyList<SuggestionItem>(), KeyboardChrome.suggestionsForStrip(words, startedTyping = false))
         assertEquals(words, KeyboardChrome.suggestionsForStrip(words, startedTyping = true))
     }
 

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
@@ -142,6 +142,27 @@ class SuggestionEngineTest {
     }
 
     @Test
+    fun `strip still offers emoji after a period`() {
+        val strip = dictionary.strip(
+            composing = "",
+            before = "sad.",
+            after = "",
+            correctionsEnabled = false,
+        )
+        assertEquals(listOf("😢", "😭", "😞"), strip.emojis)
+        assertTrue(!EmojiCommit.shouldReplaceTrigger("", "sad."))
+    }
+
+    @Test
+    fun lastWordForEmojiSkipsTrailingPunctuation() {
+        assertEquals("sad", SuggestionEngine.lastWordForEmoji("sad."))
+        assertEquals("sad", SuggestionEngine.lastWordForEmoji("sad "))
+        assertEquals("sad", SuggestionEngine.lastWordForEmoji("I am sad!"))
+        assertEquals("happy", SuggestionEngine.lastWord("happy "))
+        assertEquals(null, SuggestionEngine.lastWord("sad."))
+    }
+
+    @Test
     fun `word before deletes the previous token and its trailing space`() {
         assertEquals(5, SuggestionEngine.wordBefore("hello world"))
         assertEquals(6, SuggestionEngine.wordBefore("hello world "))

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
@@ -101,7 +101,44 @@ class SuggestionEngineTest {
             correctionsEnabled = true,
         )
         assertEquals(listOf("first", "same", "other"), strip.words)
+        assertTrue(strip.emojis.isEmpty())
         assertTrue(!strip.replacesWord)
+    }
+
+    @Test
+    fun `strip offers emoji with the word after a space`() {
+        val strip = dictionary.strip(
+            composing = "",
+            before = "happy ",
+            after = "",
+            correctionsEnabled = false,
+        )
+        assertEquals(listOf("😊", "😄", "😁"), strip.emojis)
+        assertTrue(strip.items.any { it.text == "😊" && it.isEmoji })
+        assertTrue(!strip.replacesWord)
+    }
+
+    @Test
+    fun `strip offers emoji while the trigger word is being composed`() {
+        val strip = dictionary.strip(
+            composing = "sad",
+            before = "",
+            after = "",
+            correctionsEnabled = false,
+        )
+        assertEquals(listOf("😢", "😭", "😞"), strip.emojis)
+        assertTrue(strip.words.none { it == "😢" })
+    }
+
+    @Test
+    fun `strip does not offer emoji for a prefix of a trigger`() {
+        val strip = dictionary.strip(
+            composing = "hap",
+            before = "",
+            after = "",
+            correctionsEnabled = false,
+        )
+        assertTrue(strip.emojis.isEmpty())
     }
 
     @Test

--- a/android/app/src/test/java/com/vocahq/vocaphone/settings/ClipboardHistoryTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/settings/ClipboardHistoryTest.kt
@@ -18,4 +18,16 @@ class ClipboardHistoryTest {
         val items = listOf("hello", "line\nbreak")
         assertEquals(items, ClipboardHistory.decode(ClipboardHistory.encode(items)))
     }
+
+    @Test
+    fun imageItemsRoundTripAndKeepTextHistoryWorking() {
+        val image = ClipboardHistory.encodeImage("image/png", "clipboard/1.png")
+        assertEquals("image/png" to "clipboard/1.png", ClipboardHistory.parseImage(image))
+        assertEquals("Image", ClipboardHistory.preview(image))
+        assertEquals("hello", ClipboardHistory.preview("hello"))
+        val mixed = ClipboardHistory.remember(listOf("hello"), image)
+        assertEquals(listOf(image, "hello"), mixed)
+        assertEquals(setOf("clipboard/1.png"), ClipboardHistory.imagePaths(mixed))
+        assertEquals(mixed, ClipboardHistory.decode(ClipboardHistory.encode(mixed)))
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tapping into a field and typing again was still hitting the old composing span. The IME now treats that as a real cursor move: it finishes composing and clears the leftover word on the Compose side, so the next letter starts at the caret.

The suggestion strip uses the same hand-checked emoji table as iOS, not the catalog search. Several words can open the same glyph (`lol` / `laugh` / `joy` for 😂, `sad` / `unhappy` / `upset` for 😢), using gemoji and chat short names rather than catalog keywords. Related chips are keyed by glyph, so those aliases share the same extras.

Tapping an emoji while the cursor is still on the trigger replaces that word. After a space, period, or any other character, the emoji is inserted after it.

If more than three chips are on the row, the row scrolls sideways. A fade on the trailing edge replaces a scrollbar.

Copied images show on the clipboard chip and in history. They are written under the app files directory and pasted with `commitContent`. Text clips are unchanged. Password fields still hide the clipboard.

## Summary

- Cursor moves finish composing so the next keystroke starts at the caret
- Predictive emoji on the suggestion strip, with a sideways swipe when the row overflows
- Emoji tap replaces the trigger word, or inserts after it once anything follows
- Image clips in the clipboard chip and history

## Verification

- [ ] `just ios ci` (or note why not)
- [x] `just android ci` (or note why not)
- [ ] Gateway changes: PR against [vocagateway](https://github.com/VocaHQ/vocagateway) and submodule pin updated here if needed
- [ ] Physical-device test, if keyboard, microphone, background audio, or insertion changed

Android only. From `android/`: `./gradlew testFullDebugUnitTest assembleFullDebug -PskipNative`. 284 unit tests, 283 passed, 1 skipped, 0 failed.

[fullDebug APK](https://cursor.com/artifacts/c/art-2ea3177d-37ec-406d-ba95-957bf12e6fec)

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [ ] Documentation updated for data-flow, permission, retention, or network changes

Image clips are stored under the app files directory (`clipboard/`) and pruned with history. The in-app clipboard settings copy mentions images. No separate docs change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91713df6-c91f-49ad-8a05-ddad2fe0ac42?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91713df6-c91f-49ad-8a05-ddad2fe0ac42&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

