### PR TITLE
Make every iOS screen state visible without running the app

### DIFF
--- a/.github/workflows/quality-ios.yml
+++ b/.github/workflows/quality-ios.yml
@@ -55,6 +55,13 @@ jobs:
           xcodegen generate --spec project.yml
           git diff --exit-code -- VocaPhone.xcodeproj
 
+      # Seconds on the runner, and the only thing standing between the preview
+      # harness and a shipping build. Runs before the build so a leak fails
+      # fast rather than after twenty minutes of xcodebuild.
+      - name: Fail if preview code is reachable from a release build
+        working-directory: ios
+        run: python3 tools/check-preview-isolation.py
+
       - name: Pick an iOS simulator
         id: simulator
         run: |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,6 +107,41 @@ through `sourceSets` in `app/build.gradle.kts`. Two hand-maintained copies would
 drift, and nothing would notice until the platforms started suggesting different
 words.
 
+## Preview harness (iOS)
+
+Every user-visible state has a `#Preview`, and every preview is built from
+`VocaPhoneApp/App/Previews/`. The point is not tidiness: states like "gateway
+reachable but token rejected", "model failed its integrity check" and
+"transcript ready but the field changed" are expensive enough to reach on a
+device that they were never looked at.
+
+Three pieces:
+
+- **`PreviewFixtures`** — canned `SessionRecord`s, `SetupStatus` combinations,
+  transcription sources, a transcript library, and named `UserDefaults` stores.
+  Stored values go into the *registration* domain, which `UserDefaults` keeps in
+  memory, so opening a canvas cannot rewrite the settings of the app installed
+  on the same simulator.
+- **`PreviewHost` and `PreviewMatrix`** — the environment a screen needs, and the
+  four variants every screen has to survive: default, dark, `.accessibility5`,
+  and right-to-left.
+- **Preview initializers** on `RecordingCoordinator` and `LocalModelManager`.
+  Both are live objects whose designated initializers touch audio, the network,
+  the keychain and the shared container; the preview ones assign state and stop.
+  Both types carry an `isInert` flag that makes their side-effecting entry
+  points return early, because a canvas is live — without it a home preview's
+  `.task` would overwrite the fixture with the real system state within a frame,
+  and Download in a model preview would fetch a gigabyte.
+
+The keyboard's surfaces are all `UIView`s, so they preview through
+`KeyboardViewPreview` in the keyboard target, beside the views themselves.
+
+**The `#if DEBUG` boundary is enforced, not assumed.**
+`ios/tools/check-preview-isolation.py` fails if a preview-only file has code
+outside `#if DEBUG`, or if a preview-only symbol is named from release code. It
+runs in `just ios ci` and in the iOS workflow. `just ios release-build` compiles
+with DEBUG undefined and is the wider version of the same check.
+
 ## Server states
 
 `created → uploaded → transcribing → completed`

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		01A0F8C43B7A8290B87B8228 /* TypingStripPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80C83295868E17F215D9382 /* TypingStripPresentationTests.swift */; };
 		044611DCE2FFB3B38B4BFACE /* TypingFieldPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2CD13AAF5FDF79DD5D0075 /* TypingFieldPolicy.swift */; };
+		044D82D7CA0E7563552B563A /* KeyboardViewPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8E5D91EDE2C0E67DFC0250 /* KeyboardViewPreview.swift */; };
 		057296EB66A8C88C3B2A762C /* TranscriptSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B121356A503DF83BFA0E0D0C /* TranscriptSanitizer.swift */; };
 		0580A3BE7DFF0FB43B4A41BD /* BrandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9711C18238B39EA2E842C0F /* BrandPalette.swift */; };
 		06242790B69C03FE11F749D8 /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = 0942243BD8CB1F3937AD795E /* WhisperKit */; };
@@ -56,6 +57,7 @@
 		2D1CF0D6875DFD7D9BFD10FF /* DictationBarStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7842B22D05FB171B261101A /* DictationBarStyle.swift */; };
 		2D83B6984ABEA15D65169CEE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3BA012C76E8C374857732F67 /* Assets.xcassets */; };
 		2E93E016656B5EA74568DD4F /* PairingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFB4BB0345784837C629340 /* PairingPayload.swift */; };
+		2F1F7D8997BCA83AF5334382 /* PreviewMatrix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CAE08F934281250A314597 /* PreviewMatrix.swift */; };
 		314748D93E078B40FEEEBEBE /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894063AE1B3DDA92C529268D /* AppConfiguration.swift */; };
 		31D729EBEF69158BAAFE66D0 /* KeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98325CD266139FCDEE156D8F /* KeyboardViewController.swift */; };
 		3219DC5DD26E1998A7A0CD5C /* SetupStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342F2B3B437269514C969C77 /* SetupStatus.swift */; };
@@ -99,6 +101,7 @@
 		4F24DEC1FC8411ACBDA6BC50 /* VocaPhoneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934F25D30F7D00565D83CAA0 /* VocaPhoneApp.swift */; };
 		4FB8BA8E9E7B9332FDBCD80C /* LocalModelPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406B0C287866B36EF3109238 /* LocalModelPicker.swift */; };
 		4FDB3D32A404C674AFAB948F /* ModelLanguageSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */; };
+		52151816E957DE430B67B9F8 /* KeyboardViewPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8E5D91EDE2C0E67DFC0250 /* KeyboardViewPreview.swift */; };
 		52B45B602C490B27A6405A45 /* TranscriptionQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E2BF42CAC209DA12464566 /* TranscriptionQuality.swift */; };
 		52D566C02915D934240601EA /* PairingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFB4BB0345784837C629340 /* PairingPayload.swift */; };
 		53A1176717AEAE72A1F5B9F1 /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
@@ -223,13 +226,16 @@
 		CFF7A7DC99B4880EB955D603 /* KeyboardHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858088F81E12EC57E13F9492 /* KeyboardHaptics.swift */; };
 		D0E6AF99E65342BE66CF809A /* LearnedWords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */; };
 		D1CD3C13398FA4514EF57CA7 /* TranscriptHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28ECEDA044D2B1021710F205 /* TranscriptHistoryView.swift */; };
+		D32F9FCE7750E51A69E56F10 /* DesignSystemPreviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71760E0F5AF9B1965E960E1 /* DesignSystemPreviews.swift */; };
 		D347613BCA81EB9BF9AAC2DD /* TranscriptionSourceStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5995603DDA33014FFA52B079 /* TranscriptionSourceStatus.swift */; };
 		D4CA018F48AA244D322B9156 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F3A6E7B826D1389D462944 /* ContentView.swift */; };
 		D4FEC9D26550CB1696FDF424 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */; };
+		D6533E4D830A06E9845CE624 /* KeyboardViewPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8E5D91EDE2C0E67DFC0250 /* KeyboardViewPreview.swift */; };
 		D7038E651848C4EE6B0F722A /* TypingStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AA0EB543777294237739CF /* TypingStripView.swift */; };
 		D7CC096732C721CE14B5F682 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */; };
 		D8EE8A829E13191046F3F183 /* WordComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A6EEE8C98BCBF8D1D70D44 /* WordComposer.swift */; };
 		D9811B8978380027BF95D0D5 /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
+		D9D9DB4E8F749BCC02AD0B5B /* PreviewFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9677581A0FA938AD9C520C /* PreviewFixtures.swift */; };
 		DCAAD00B7ED79568106DAD0C /* DictatedTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575BDB070A428051B623F095 /* DictatedTranscript.swift */; };
 		DCF552B58B7A7A12C517C17B /* PairingPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9E5CE913B4FA5EF8EECD4E /* PairingPayloadTests.swift */; };
 		DEB245BAC4DEE643F2EB38B0 /* DictationPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56047A6705008B5F17F003CE /* DictationPresentationTests.swift */; };
@@ -359,6 +365,7 @@
 		6B6743BB4173E2F719E3D8CB /* TypingWordList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingWordList.swift; sourceTree = "<group>"; };
 		6CF871FC84B4C6B2627A43C2 /* RecordingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingCoordinator.swift; sourceTree = "<group>"; };
 		70B3F1DBA8332A13B095E4BA /* PairingScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScannerView.swift; sourceTree = "<group>"; };
+		70CAE08F934281250A314597 /* PreviewMatrix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewMatrix.swift; sourceTree = "<group>"; };
 		755A4279065D41A705E1F19D /* DesignSystemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemTests.swift; sourceTree = "<group>"; };
 		75FD84E65614D9F94D8EF0AC /* DictationBarComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarComponents.swift; sourceTree = "<group>"; };
 		786DEF44BDB4C70935762971 /* VocaPhoneLiveActivity.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VocaPhoneLiveActivity.entitlements; sourceTree = "<group>"; };
@@ -382,6 +389,7 @@
 		8ACA0C7140D6C997C12CFDD1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		8BF7CAC171521FC372DF2BF0 /* KeyGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyGridView.swift; sourceTree = "<group>"; };
 		8F8CE24C7BC4F4CA618F4B79 /* SmartPunctuationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartPunctuationTests.swift; sourceTree = "<group>"; };
+		8F8E5D91EDE2C0E67DFC0250 /* KeyboardViewPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardViewPreview.swift; sourceTree = "<group>"; };
 		924E5D73CB086A4210BF6052 /* SwipeRecognizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeRecognizerTests.swift; sourceTree = "<group>"; };
 		934F25D30F7D00565D83CAA0 /* VocaPhoneApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocaPhoneApp.swift; sourceTree = "<group>"; };
 		97639A09609D9E6E76153CDB /* KeyboardHapticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHapticsTests.swift; sourceTree = "<group>"; };
@@ -406,10 +414,12 @@
 		B67629F24A2CF6C990BA991A /* en.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = en.txt; sourceTree = "<group>"; };
 		B6B395C37266816A19C38B59 /* SemanticPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticPaletteTests.swift; sourceTree = "<group>"; };
 		B7028AF4B134C7EDD726891E /* VocaPhoneKeyboard.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = VocaPhoneKeyboard.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		B71760E0F5AF9B1965E960E1 /* DesignSystemPreviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemPreviews.swift; sourceTree = "<group>"; };
 		B854354D06D0111DEB123E7A /* SessionRecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRecordTests.swift; sourceTree = "<group>"; };
 		B87128326897BFA30E7B2038 /* KeyLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyLayout.swift; sourceTree = "<group>"; };
 		B9B9027C03A87FBC74CE1130 /* TypingEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingEngine.swift; sourceTree = "<group>"; };
 		BA1F0FABCAE6669D0EB07FC3 /* SwipeAlternates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeAlternates.swift; sourceTree = "<group>"; };
+		BC9677581A0FA938AD9C520C /* PreviewFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewFixtures.swift; sourceTree = "<group>"; };
 		BE0BE99770A5F7F08891E2BD /* KeyboardURLLauncher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeyboardURLLauncher.h; sourceTree = "<group>"; };
 		BE3489C985467C23EB6A90AD /* DictationBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarView.swift; sourceTree = "<group>"; };
 		C304CF763960E5F1D8F76B2B /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
@@ -502,6 +512,7 @@
 				BE0BE99770A5F7F08891E2BD /* KeyboardURLLauncher.h */,
 				88548183D3F0AD213E2268E1 /* KeyboardURLLauncher.m */,
 				98325CD266139FCDEE156D8F /* KeyboardViewController.swift */,
+				8F8E5D91EDE2C0E67DFC0250 /* KeyboardViewPreview.swift */,
 				8BF7CAC171521FC372DF2BF0 /* KeyGridView.swift */,
 				B87128326897BFA30E7B2038 /* KeyLayout.swift */,
 				5118F8CFAAE127CD5FF92076 /* KeyView.swift */,
@@ -635,6 +646,16 @@
 			);
 			sourceTree = "<group>";
 		};
+		802F6A112F76E45FF7DBEA97 /* Previews */ = {
+			isa = PBXGroup;
+			children = (
+				B71760E0F5AF9B1965E960E1 /* DesignSystemPreviews.swift */,
+				BC9677581A0FA938AD9C520C /* PreviewFixtures.swift */,
+				70CAE08F934281250A314597 /* PreviewMatrix.swift */,
+			);
+			path = Previews;
+			sourceTree = "<group>";
+		};
 		8D08E120B30F4F08A393B134 /* emoji */ = {
 			isa = PBXGroup;
 			children = (
@@ -709,6 +730,7 @@
 				28ECEDA044D2B1021710F205 /* TranscriptHistoryView.swift */,
 				5995603DDA33014FFA52B079 /* TranscriptionSourceStatus.swift */,
 				934F25D30F7D00565D83CAA0 /* VocaPhoneApp.swift */,
+				802F6A112F76E45FF7DBEA97 /* Previews */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -922,6 +944,7 @@
 				6565BFD7DC56DDCECDBC0D7C /* KeyboardStatus.swift in Sources */,
 				BA7DED07F63C388ADD4EC07A /* KeyboardURLLauncher.m in Sources */,
 				31D729EBEF69158BAAFE66D0 /* KeyboardViewController.swift in Sources */,
+				044D82D7CA0E7563552B563A /* KeyboardViewPreview.swift in Sources */,
 				C958410A61E962F39B4F5E4D /* LearnedWords.swift in Sources */,
 				408E48AA90858E8FAF046263 /* LocalModelCatalog.swift in Sources */,
 				939752FDA33E96C811ED23C1 /* LocalTranscriptionPreferences.swift in Sources */,
@@ -965,6 +988,7 @@
 				34C17CDE69437F6E9407758D /* CustomVocabulary.swift in Sources */,
 				BF1BF9FEBFC0373AE2C4187D /* DarwinNotifications.swift in Sources */,
 				0E4F6A827869289078B1F4D5 /* DesignSystem.swift in Sources */,
+				D32F9FCE7750E51A69E56F10 /* DesignSystemPreviews.swift in Sources */,
 				1EE70552DF2972DCE328ED01 /* DiagnosticLog.swift in Sources */,
 				DCAAD00B7ED79568106DAD0C /* DictatedTranscript.swift in Sources */,
 				17A121351047369782528CA2 /* DictationBarComponents.swift in Sources */,
@@ -984,6 +1008,7 @@
 				A568F548D639C064CDA86F0D /* KeyboardPreferences.swift in Sources */,
 				F7432B1674EF3B6924FB89B1 /* KeyboardPreview.swift in Sources */,
 				61D705F2D38349B0A9667F2E /* KeyboardStatus.swift in Sources */,
+				D6533E4D830A06E9845CE624 /* KeyboardViewPreview.swift in Sources */,
 				8468AAFD83E231AD9BB99792 /* KeychainStore.swift in Sources */,
 				4CAE7CAEAD36C1567BFB1D81 /* LearnedWords.swift in Sources */,
 				E9E86F6940BDB4381A8C9FF5 /* LiveActivityManager.swift in Sources */,
@@ -995,6 +1020,8 @@
 				4FDB3D32A404C674AFAB948F /* ModelLanguageSupport.swift in Sources */,
 				52D566C02915D934240601EA /* PairingPayload.swift in Sources */,
 				84EB79403F7CED013A82334F /* PairingScannerView.swift in Sources */,
+				D9D9DB4E8F749BCC02AD0B5B /* PreviewFixtures.swift in Sources */,
+				2F1F7D8997BCA83AF5334382 /* PreviewMatrix.swift in Sources */,
 				B4EE97A67B156A6D5BA0D258 /* QuickDictationAvailability.swift in Sources */,
 				5D5A394AA7E8170CFE4E128B /* RecordingCoordinator.swift in Sources */,
 				A59723F937FABF80B8158883 /* RecordingSoundFeedback.swift in Sources */,
@@ -1109,6 +1136,7 @@
 				4BF2126048D9E40C8999241D /* KeyboardHapticsTests.swift in Sources */,
 				90F0433AE6FE139E90D62F9A /* KeyboardPreferences.swift in Sources */,
 				5673DF7E07F7F800FB847C2A /* KeyboardStatus.swift in Sources */,
+				52151816E957DE430B67B9F8 /* KeyboardViewPreview.swift in Sources */,
 				3C4DE9EF77062407F71ACDCB /* LanguageMenuTests.swift in Sources */,
 				D0E6AF99E65342BE66CF809A /* LearnedWords.swift in Sources */,
 				F1E23C92AD4C90D424DB84D9 /* LocalModelCatalog.swift in Sources */,

--- a/ios/VocaPhoneApp/App/ContentView.swift
+++ b/ios/VocaPhoneApp/App/ContentView.swift
@@ -230,10 +230,15 @@ struct ContentView: View {
                     .lineLimit(3...6)
                     .focused($diagFocused)
                     .task {
+                        // Debug-only, like the return-guide launch argument
+                        // below it. A release build must not change what it
+                        // focuses because of an argument someone passed it.
+#if DEBUG
                         guard ProcessInfo.processInfo.arguments.contains("-diagFocusField")
                         else { return }
                         try? await Task.sleep(for: .milliseconds(600))
                         diagFocused = true
+#endif
                     }
                     .textFieldStyle(.plain)
                     .padding(VocaMetrics.related + 4)
@@ -550,3 +555,148 @@ private struct KeyboardReturnGuide: View {
         }
     }
 }
+
+#if DEBUG
+
+// MARK: - Previews
+
+// Every state `HomeSessionCard.make` can produce, plus the two overlays the
+// home screen owns. These are the states the visual QA matrix asks for and the
+// ones nobody could reach without a gateway to break and a permission to
+// decline.
+
+#Preview("Home — ready to dictate") {
+    PreviewHost(coordinator: .previewIdle()) { ContentView() }
+}
+
+#Preview("Home — first run, nothing set up") {
+    PreviewHost(
+        coordinator: RecordingCoordinator(
+            preview: nil,
+            setupStatus: PreviewFixtures.setupFresh
+        ),
+        hasDictatedOnce: false
+    ) { ContentView() }
+}
+
+#Preview("Home — two steps outstanding") {
+    PreviewHost(
+        coordinator: RecordingCoordinator(
+            preview: nil,
+            setupStatus: PreviewFixtures.setupTwoStepsLeft
+        )
+    ) { ContentView() }
+}
+
+#Preview("Home — Quick Dictation standby") {
+    PreviewHost(coordinator: .previewStandby()) { ContentView() }
+}
+
+#Preview("Home — starting the microphone") {
+    PreviewHost(coordinator: .preview(.launchingApp, startedInApp: false)) { ContentView() }
+}
+
+#Preview("Home — listening in the practice field") {
+    PreviewHost(
+        coordinator: .preview(.recording, meterLevel: 0.62, isRecording: true)
+    ) { ContentView() }
+}
+
+#Preview("Home — transcribing on the gateway") {
+    PreviewHost(coordinator: .preview(.transcribing)) { ContentView() }
+}
+
+#Preview("Home — transcribing on this iPhone") {
+    PreviewHost(
+        coordinator: .preview(
+            .transcribing,
+            processingLocation: .onDevice,
+            setupStatus: SetupStatus(
+                source: PreviewFixtures.onDeviceReady,
+                microphone: .granted,
+                keyboard: .ready(lastSeenAt: Date()),
+                hasDictatedOnce: true
+            )
+        )
+    ) { ContentView() }
+}
+
+#Preview("Home — transcript ready, long") {
+    PreviewHost(
+        coordinator: .preview(.completed, transcript: PreviewFixtures.longTranscript)
+    ) { ContentView() }
+}
+
+#Preview("Home — inserted into another app") {
+    PreviewHost(
+        coordinator: .preview(
+            .completed,
+            transcript: PreviewFixtures.shortTranscript,
+            startedInApp: false
+        )
+    ) { ContentView() }
+}
+
+#Preview("Home — gateway unavailable, audio kept") {
+    PreviewHost(
+        coordinator: .preview(
+            .serverUnavailable,
+            error: PreviewFixtures.gatewayFailure,
+            message: PreviewFixtures.gatewayFailure.message
+        )
+    ) { ContentView() }
+}
+
+#Preview("Home — microphone access denied") {
+    PreviewHost(
+        coordinator: .preview(
+            .permissionDenied,
+            error: PreviewFixtures.permanentFailure,
+            setupStatus: PreviewFixtures.setupMicrophoneDenied,
+            message: "vocaphone cannot record without microphone access."
+        )
+    ) { ContentView() }
+}
+
+#Preview("Home — transcription failed for good") {
+    PreviewHost(
+        coordinator: .preview(
+            .transcriptionFailedPermanent,
+            error: PreviewFixtures.permanentFailure,
+            message: PreviewFixtures.permanentFailure.message
+        )
+    ) { ContentView() }
+}
+
+/// The hand-off overlay, which only appears for a dictation started from
+/// another app — the one home state that covers the whole screen.
+#Preview("Return guide — keyboard is recording") {
+    PreviewHost(
+        coordinator: .preview(
+            .recording,
+            startedInApp: false,
+            meterLevel: 0.48,
+            isRecording: true
+        )
+    ) { ContentView() }
+}
+
+#Preview("Home — matrix", traits: .sizeThatFitsLayout) {
+    PreviewMatrix(coordinator: .preview(.serverUnavailable, error: PreviewFixtures.gatewayFailure)) {
+        ContentView()
+    }
+}
+
+#Preview("Meter — quiet, speaking, loud", traits: .sizeThatFitsLayout) {
+    VStack(spacing: VocaMetrics.grouping) {
+        ForEach([Float(0.05), 0.35, 0.85], id: \.self) { level in
+            PreviewHost(coordinator: .preview(.recording, meterLevel: level, isRecording: true)) {
+                RecordingMeter()
+                    .frame(width: 280)
+                    .padding()
+            }
+        }
+    }
+    .padding()
+}
+#endif

--- a/ios/VocaPhoneApp/App/GatewaySetupView.swift
+++ b/ios/VocaPhoneApp/App/GatewaySetupView.swift
@@ -214,3 +214,49 @@ struct GatewaySetupView: View {
         }
     }
 }
+
+#if DEBUG
+
+// MARK: - Previews
+
+// Reachable, authenticated and model-ready are three different things, and each
+// one failing produces a different sentence. Reaching them on a device means
+// having a gateway and breaking it in three specific ways.
+
+#Preview("Gateway — not paired yet") {
+    PreviewHost(store: PreviewFixtures.gatewayUnpairedStore) {
+        NavigationStack { GatewaySetupView() }
+    }
+}
+
+#Preview("Gateway — ready") {
+    PreviewHost(store: PreviewFixtures.defaults) {
+        NavigationStack { GatewaySetupView() }
+    }
+}
+
+#Preview("Gateway — token rejected") {
+    PreviewHost(store: PreviewFixtures.gatewayTokenRejectedStore) {
+        NavigationStack { GatewaySetupView() }
+    }
+}
+
+#Preview("Gateway — reachable, model not loaded") {
+    PreviewHost(store: PreviewFixtures.gatewayModelNotReadyStore) {
+        NavigationStack { GatewaySetupView() }
+    }
+}
+
+/// The only state in which the address field's footer becomes a warning.
+#Preview("Gateway — unencrypted HTTP warning") {
+    PreviewHost(store: PreviewFixtures.gatewayUnencryptedStore) {
+        NavigationStack { GatewaySetupView() }
+    }
+}
+
+#Preview("Gateway — matrix", traits: .sizeThatFitsLayout) {
+    PreviewMatrix(store: PreviewFixtures.gatewayTokenRejectedStore) {
+        NavigationStack { GatewaySetupView() }
+    }
+}
+#endif

--- a/ios/VocaPhoneApp/App/KeyboardPreview.swift
+++ b/ios/VocaPhoneApp/App/KeyboardPreview.swift
@@ -154,3 +154,41 @@ final class KeyboardPreviewContainer: UIView {
         )
     }
 }
+
+#if DEBUG
+
+// MARK: - Previews
+
+// The height picker's whole argument is that nobody can judge 39 pt against
+// 49 pt from prose. That argument applies to the picker itself: this is the
+// three heights side by side, which is what the setting is choosing between.
+
+#Preview("Keyboard preview — every height", traits: .sizeThatFitsLayout) {
+    HStack(alignment: .top, spacing: 16) {
+        ForEach(KeyboardHeightPreference.allCases) { preference in
+            VStack(spacing: 6) {
+                Text(preference.displayName)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                KeyboardPreview(preference: preference, showsSuggestions: true)
+                    .frame(width: 340)
+            }
+        }
+    }
+    .padding()
+}
+
+#Preview("Keyboard preview — suggestions off", traits: .sizeThatFitsLayout) {
+    KeyboardPreview(preference: .standard, showsSuggestions: false)
+        .frame(width: 360)
+        .padding()
+}
+
+#Preview("Keyboard preview — dark", traits: .sizeThatFitsLayout) {
+    KeyboardPreview(preference: .standard, showsSuggestions: true)
+        .frame(width: 360)
+        .padding()
+        .environment(\.colorScheme, .dark)
+        .background(Color.vocaCanvas)
+}
+#endif

--- a/ios/VocaPhoneApp/App/LocalModelPicker.swift
+++ b/ios/VocaPhoneApp/App/LocalModelPicker.swift
@@ -12,6 +12,13 @@ struct LocalModelPicker: View {
     /// Setup needs its status line refreshed on every change; Settings does not.
     var onChange: () -> Void = {}
 
+#if DEBUG
+    /// Which model a `#Preview` should draw as "In use". Production leaves this
+    /// nil and reads the stored preference, because a canvas must not write the
+    /// developer's real model selection to reach one row state.
+    var previewSelectedModelID: String?
+#endif
+
     @State private var downloadTask: Task<Void, Never>?
     @State private var modelLoadTask: Task<Void, Never>?
     @State private var modelLoadError: String?
@@ -67,6 +74,11 @@ struct LocalModelPicker: View {
         if manager.verifyingModelIDs.contains(model.id) { return .verifying }
         if manager.failedIntegrityModelIDs.contains(model.id) { return .failedIntegrity }
         guard manager.isDownloaded(model.id) else { return .notDownloaded }
+#if DEBUG
+        if let previewSelectedModelID {
+            return previewSelectedModelID == model.id ? .selected : .ready
+        }
+#endif
         return LocalTranscriptionPreferences.modelIdentifier == model.id ? .selected : .ready
     }
 
@@ -284,3 +296,123 @@ struct LocalModelPicker: View {
         }
     }
 }
+
+#if DEBUG
+
+// MARK: - Previews
+
+// Seven row states, three of which cannot be reached on purpose: verifying
+// lasts seconds, loading needs a real ONNX graph, and failed integrity needs a
+// corrupted download. All three have their own wording, and none of it had ever
+// been looked at.
+
+/// A `List` because the picker builds `Section`s, which have no meaning outside
+/// one.
+private struct ModelPickerPreview: View {
+    let manager: LocalModelManager
+    var selected: String?
+
+    var body: some View {
+        NavigationStack {
+            List {
+                LocalModelPicker(manager: manager, previewSelectedModelID: selected)
+            }
+            .navigationTitle("On-device models")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+#Preview("Models — nothing downloaded") {
+    PreviewHost { ModelPickerPreview(manager: LocalModelManager(preview: [])) }
+}
+
+#Preview("Models — downloading") {
+    PreviewHost {
+        ModelPickerPreview(
+            manager: LocalModelManager(
+                preview: [],
+                downloading: PreviewFixtures.firstModelID,
+                progress: 0.43
+            )
+        )
+    }
+}
+
+#Preview("Models — verifying checksums") {
+    PreviewHost {
+        ModelPickerPreview(
+            manager: LocalModelManager(
+                preview: [],
+                verifying: [PreviewFixtures.firstModelID]
+            )
+        )
+    }
+}
+
+#Preview("Models — failed verification") {
+    PreviewHost {
+        ModelPickerPreview(
+            manager: LocalModelManager(
+                preview: [],
+                failedIntegrity: [PreviewFixtures.firstModelID],
+                message: "The downloaded files do not match their published checksums.",
+                hasError: true
+            )
+        )
+    }
+}
+
+#Preview("Models — loading the engine") {
+    PreviewHost {
+        ModelPickerPreview(
+            manager: LocalModelManager(
+                preview: [PreviewFixtures.firstModelID],
+                loading: PreviewFixtures.firstModelID,
+                loadingMessage: "Building the decoder for the first time…"
+            )
+        )
+    }
+}
+
+/// One model in use, another ready beside it — and every other Download button
+/// disabled by `isBusy` with nothing on screen saying why.
+#Preview("Models — one in use, one downloading") {
+    PreviewHost {
+        ModelPickerPreview(
+            manager: LocalModelManager(
+                preview: [PreviewFixtures.firstModelID, PreviewFixtures.secondModelID],
+                downloading: PreviewFixtures.secondModelID,
+                progress: 0.12
+            ),
+            selected: PreviewFixtures.firstModelID
+        )
+    }
+}
+
+#Preview("Models — ready and in use") {
+    PreviewHost {
+        ModelPickerPreview(
+            manager: LocalModelManager(
+                preview: [PreviewFixtures.firstModelID, PreviewFixtures.secondModelID]
+            ),
+            selected: PreviewFixtures.firstModelID
+        )
+    }
+}
+
+/// The download row puts a label and a percentage at opposite ends of one line,
+/// which is the finding this matrix makes visible.
+#Preview("Models — matrix", traits: .sizeThatFitsLayout) {
+    PreviewMatrix {
+        ModelPickerPreview(
+            manager: LocalModelManager(
+                preview: [PreviewFixtures.firstModelID],
+                downloading: PreviewFixtures.secondModelID,
+                progress: 0.67
+            ),
+            selected: PreviewFixtures.firstModelID
+        )
+    }
+}
+#endif

--- a/ios/VocaPhoneApp/App/Previews/DesignSystemPreviews.swift
+++ b/ios/VocaPhoneApp/App/Previews/DesignSystemPreviews.swift
@@ -1,0 +1,120 @@
+#if DEBUG
+import SwiftUI
+
+// The token layer, in one place. Every screen is built from these four shapes,
+// so anything wrong here is wrong everywhere — and the two states that matter
+// most, the disabled primary and the accessibility-size status line, are the two
+// that never appear in a screenshot of a working app.
+//
+// These live apart from `DesignSystem.swift` because the test target compiles
+// that file too, and the fixtures below are in the app target only.
+
+#Preview("Status line — every state", traits: .sizeThatFitsLayout) {
+    ScrollView {
+        VStack(alignment: .leading, spacing: VocaMetrics.grouping) {
+            ForEach(
+                [
+                    VocaStatus.ready,
+                    .recording,
+                    .working,
+                    .attention,
+                    .failed,
+                    .inactive,
+                ],
+                id: \.self
+            ) { status in
+                VocaCard {
+                    VocaStatusLine(
+                        status: status,
+                        title: "Ready to dictate",
+                        detail: "Dictate from any app with the vocaphone keyboard."
+                    )
+                }
+            }
+        }
+        .padding()
+        .frame(width: 380)
+    }
+    .background(Color.vocaCanvas)
+}
+
+/// The one place in the app that already handles accessibility sizes, next to
+/// itself at default size, so the pattern the rest of the app has to adopt is
+/// visible rather than described.
+#Preview("Status line — default beside accessibility 5", traits: .sizeThatFitsLayout) {
+    HStack(alignment: .top, spacing: 20) {
+        ForEach([PreviewVariant.standard, .accessibility]) { variant in
+            VStack(spacing: 8) {
+                Text(variant.label)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                PreviewHost(variant) {
+                    VocaCard(padding: VocaMetrics.grouping) {
+                        VocaStatusLine(
+                            status: .attention,
+                            title: "Gateway unavailable",
+                            detail: "homelabone:8765 did not answer. Your recording is preserved.",
+                            isProminent: true
+                        )
+                    }
+                    .padding()
+                }
+                .frame(width: 340)
+            }
+        }
+    }
+    .padding()
+}
+
+#Preview("Buttons — enabled, disabled, destructive", traits: .sizeThatFitsLayout) {
+    VStack(spacing: VocaMetrics.grouping) {
+        VocaPrimaryButton(title: "Dictate here", symbol: "mic.fill") {}
+        VocaPrimaryButton(title: "Dictate here", symbol: "mic.fill") {}
+            .disabled(true)
+        VocaCopyButton(title: "Copy transcript", value: PreviewFixtures.shortTranscript)
+        VocaCopyButton(title: "Copy transcript", value: nil)
+        VocaDestructiveButton(title: "Delete model") {}
+        // Bare text inside a card is roughly 20 pt tall — half the minimum
+        // target — and this is what the app uses for Cancel today.
+        Button("Cancel", role: .destructive) {}
+            .frame(maxWidth: .infinity)
+            .font(.subheadline)
+    }
+    .padding()
+    .frame(width: 360)
+    .background(Color.vocaCanvas)
+}
+
+#Preview("Cards — light and dark", traits: .sizeThatFitsLayout) {
+    HStack(alignment: .top, spacing: 20) {
+        ForEach([PreviewVariant.standard, .dark]) { variant in
+            PreviewHost(variant) {
+                VStack(alignment: .leading, spacing: VocaMetrics.grouping) {
+                    VocaCard {
+                        VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                            VocaSectionHeader(title: "Latest transcript")
+                            Text(PreviewFixtures.longTranscript)
+                                .font(.body)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                    VocaCard {
+                        VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                            VocaSectionHeader(
+                                title: "Try the keyboard",
+                                action: (title: "Clear", perform: {})
+                            )
+                            Text("A card whose heading carries its own action.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding()
+            }
+            .frame(width: 340)
+        }
+    }
+    .padding()
+}
+#endif

--- a/ios/VocaPhoneApp/App/Previews/PreviewFixtures.swift
+++ b/ios/VocaPhoneApp/App/Previews/PreviewFixtures.swift
@@ -1,0 +1,376 @@
+#if DEBUG
+import Foundation
+import SwiftUI
+
+/// Canned state for every screen, so a `#Preview` can show a state instead of
+/// waiting for one.
+///
+/// The app's models are already pure and already tested — `HomeSessionCard`,
+/// `SetupStatus`, `TranscriptionSourceStatus`, `TranscriptHistoryModel`. What
+/// was missing was values to put in them. Before this file, checking what
+/// "gateway reachable but token rejected" looks like meant building, booting a
+/// simulator, and breaking a gateway on purpose; states that expensive to reach
+/// are states nobody looks at twice.
+///
+/// The whole file is `#if DEBUG`. Nothing here may be referenced from code that
+/// ships — see `tools/check-preview-isolation.sh`, which fails the build if it
+/// is.
+enum PreviewFixtures {
+
+    // MARK: - Transcripts
+
+    /// One sentence — the common case, and the one that must not look padded.
+    static let shortTranscript = "Let's move the review to Thursday afternoon."
+
+    /// Long enough to wrap several times in a card, so clipping and truncation
+    /// show up in the canvas rather than on someone's phone.
+    static let longTranscript = """
+        I've been thinking about the gateway setup and I don't think we should \
+        ask people to run anything before their first dictation. Let them pick \
+        the on-device model, get a transcript back within a minute of \
+        installing, and only mention the gateway when they want a bigger model \
+        than the phone can hold. The current order gets it exactly backwards.
+        """
+
+    /// The pathological case for every fixed-width row and every `HStack` that
+    /// assumes small text: one unbroken run plus a lot of words.
+    static let verboseTranscript = """
+        Reconfirming the Wednesday retrospective, the incident review, and the \
+        quarterly infrastructure-consolidation-and-migration planning session, \
+        all of which are now scheduled against the same afternoon, which means \
+        somebody has to move at least two of them before Friday.
+        """
+
+    // MARK: - Sessions
+
+    /// A session in whatever state is being previewed.
+    ///
+    /// `SessionRecord.transition(to:)` enforces the real state machine, which is
+    /// exactly what a fixture must not have to satisfy: previews need the
+    /// *destination* states, not the paths to them. So the state is assigned.
+    static func record(
+        state: SessionState,
+        transcript: String? = nil,
+        error: SessionFailure? = nil,
+        processingLocation: SessionProcessingLocation? = .gateway,
+        startedInApp: Bool = true,
+        minutesAgo: Double = 0,
+        style: WritingStyle = .casual
+    ) -> SessionRecord {
+        var record = SessionRecord(
+            sessionID: UUID(),
+            state: .idle,
+            sourceDocumentID: startedInApp ? "in-app-test" : "host-field-1",
+            style: style.rawValue,
+            now: Date(timeIntervalSinceNow: -minutesAgo * 60)
+        )
+        record.state = state
+        record.transcript = transcript
+        record.error = error
+        record.processingLocation = processingLocation
+        record.startedInContainingApp = startedInApp ? true : nil
+        return record
+    }
+
+    static let gatewayFailure = SessionFailure(
+        code: "gateway_unreachable",
+        message: "homelabone:8765 did not answer. Your recording is preserved.",
+        recoverable: true
+    )
+
+    static let permanentFailure = SessionFailure(
+        code: "transcription_failed",
+        message: "The gateway returned no text for this recording.",
+        recoverable: false
+    )
+
+    // MARK: - History
+
+    /// Enough transcripts to cross three of `TranscriptHistoryModel`'s four
+    /// heading kinds — Today, Yesterday, a weekday, and a date — because the
+    /// grouping is the part of that screen with arithmetic in it.
+    static var history: [SessionRecord] {
+        [
+            record(state: .completed, transcript: shortTranscript, minutesAgo: 12),
+            record(
+                state: .completed,
+                transcript: longTranscript,
+                processingLocation: .onDevice,
+                minutesAgo: 95,
+                style: .formal
+            ),
+            record(
+                state: .completed,
+                transcript: "Pick up the parcel before six.",
+                minutesAgo: 60 * 26,
+                style: .veryCasual
+            ),
+            record(
+                state: .completed,
+                transcript: verboseTranscript,
+                processingLocation: .onDevice,
+                minutesAgo: 60 * 30
+            ),
+            record(
+                state: .completed,
+                transcript: "Ship the beta on Friday.",
+                processingLocation: nil,
+                minutesAgo: 60 * 24 * 4,
+                style: .excited
+            ),
+            record(
+                state: .completed,
+                transcript: shortTranscript,
+                minutesAgo: 60 * 24 * 20,
+                style: .raw
+            ),
+        ]
+    }
+
+    // MARK: - Transcription sources
+
+    static let gatewayReady = TranscriptionSourceStatus(
+        selected: .gateway,
+        gatewayAddress: "http://homelabone:8765",
+        isGatewayReady: true,
+        gatewayMessage: "Gateway, token, and model are ready."
+    )
+
+    static let gatewayUnconfigured = TranscriptionSourceStatus(selected: .gateway)
+
+    static let gatewayTokenRejected = TranscriptionSourceStatus(
+        selected: .gateway,
+        gatewayAddress: "https://dictation.example.com",
+        isGatewayReady: false,
+        gatewayMessage: "Gateway reachable, but the pairing token was rejected."
+    )
+
+    static let gatewayModelNotReady = TranscriptionSourceStatus(
+        selected: .gateway,
+        gatewayAddress: "http://homelabone:8765",
+        isGatewayReady: false,
+        gatewayMessage: "Gateway reachable; model is not ready."
+    )
+
+    static let onDeviceReady = TranscriptionSourceStatus(
+        selected: .onDevice,
+        onDeviceModelName: "Whisper Base",
+        isOnDeviceReady: true
+    )
+
+    static let onDeviceMissing = TranscriptionSourceStatus(selected: .onDevice)
+
+    // MARK: - Guided setup
+
+    /// Nothing done yet: the state a first launch actually opens in.
+    static let setupFresh = SetupStatus(
+        source: gatewayUnconfigured,
+        microphone: .undetermined,
+        keyboard: .notAdded,
+        hasDictatedOnce: false
+    )
+
+    static let setupMicrophoneDenied = SetupStatus(
+        source: gatewayReady,
+        microphone: .denied,
+        keyboard: .notAdded,
+        hasDictatedOnce: false
+    )
+
+    /// The keyboard is listed but has never reached the shared container, which
+    /// is the single most common stuck point in this product.
+    static let setupKeyboardNeedsFullAccess = SetupStatus(
+        source: onDeviceReady,
+        microphone: .granted,
+        keyboard: .addedButNeverRun,
+        hasDictatedOnce: false
+    )
+
+    static let setupKeyboardSilent = SetupStatus(
+        source: gatewayReady,
+        microphone: .granted,
+        keyboard: .silent(lastSeenAt: Date(timeIntervalSinceNow: -60 * 60 * 24 * 45)),
+        hasDictatedOnce: true
+    )
+
+    /// Dictation works; only the optional trial run is outstanding. This one
+    /// must never produce an attention headline.
+    static let setupReadyToDictate = SetupStatus(
+        source: gatewayReady,
+        microphone: .granted,
+        keyboard: .ready(lastSeenAt: Date(timeIntervalSinceNow: -60 * 8)),
+        hasDictatedOnce: false
+    )
+
+    static let setupComplete = SetupStatus(
+        source: gatewayReady,
+        microphone: .granted,
+        keyboard: .ready(lastSeenAt: Date(timeIntervalSinceNow: -60 * 3)),
+        hasDictatedOnce: true
+    )
+
+    /// Two steps outstanding, so the plural attention headline is reachable.
+    static let setupTwoStepsLeft = SetupStatus(
+        source: gatewayUnconfigured,
+        microphone: .granted,
+        keyboard: .notAdded,
+        hasDictatedOnce: false
+    )
+
+    // MARK: - On-device models
+
+    static var modelIDs: [String] { LocalModelCatalog.usableOnDevice.map(\.id) }
+
+    /// The first model this iPhone can run, used wherever a preview needs "some
+    /// model" rather than a particular one.
+    static var firstModelID: String { modelIDs.first ?? LocalModelCatalog.recommended.id }
+
+    static var secondModelID: String { modelIDs.dropFirst().first ?? firstModelID }
+
+    // MARK: - Stored preferences
+
+    /// A defaults suite that exists only for the life of the preview process.
+    ///
+    /// Preview code writes nothing: every value below goes into the
+    /// *registration* domain, which `UserDefaults` keeps in memory and never
+    /// persists. Without that, opening a canvas would rewrite the settings of
+    /// the app installed on the same simulator — and a preview that changes the
+    /// product is not a preview.
+    nonisolated(unsafe) static let defaults = store(
+        "ready",
+        [
+            "gatewayURL": "http://homelabone:8765",
+            GatewayStatusPreferences.healthMessageKey: "Gateway, token, and model are ready.",
+            GatewayStatusPreferences.engineKey: "faster-whisper · base",
+            GatewayStatusPreferences.engineReadyKey: true,
+        ]
+    )
+
+    /// A named store, so two previews of the same screen can disagree about
+    /// what is in it. `@AppStorage` that names no store reads whichever one
+    /// `PreviewHost` puts in the environment.
+    nonisolated static func store(_ name: String, _ values: [String: Any]) -> UserDefaults {
+        let suite = UserDefaults(suiteName: "com.vocahq.vocaphone.previews.\(name)")
+            ?? .standard
+        suite.register(defaults: values)
+        return suite
+    }
+
+    /// No gateway paired yet — the state the scanner leads in.
+    nonisolated(unsafe) static let gatewayUnpairedStore = store(
+        "unpaired",
+        [
+            "gatewayURL": "",
+            GatewayStatusPreferences.healthMessageKey: "Not tested",
+            GatewayStatusPreferences.engineKey: "",
+            GatewayStatusPreferences.engineReadyKey: false,
+        ]
+    )
+
+    /// Reachable, but the token was refused. Tedious to reach by hand and the
+    /// one gateway failure a user is most likely to hit.
+    nonisolated(unsafe) static let gatewayTokenRejectedStore = store(
+        "token-rejected",
+        [
+            "gatewayURL": "https://dictation.example.com",
+            GatewayStatusPreferences.healthMessageKey:
+                "Gateway reachable, but the pairing token was rejected.",
+            GatewayStatusPreferences.engineKey: "",
+            GatewayStatusPreferences.engineReadyKey: false,
+        ]
+    )
+
+    /// Answering and authenticated, with no speech-to-text model loaded.
+    nonisolated(unsafe) static let gatewayModelNotReadyStore = store(
+        "model-not-ready",
+        [
+            "gatewayURL": "http://homelabone:8765",
+            GatewayStatusPreferences.healthMessageKey: "Gateway reachable; model is not ready.",
+            GatewayStatusPreferences.engineKey: "",
+            GatewayStatusPreferences.engineReadyKey: false,
+        ]
+    )
+
+    /// HTTP against a public-looking host, which is the one case the address
+    /// field warns about.
+    nonisolated(unsafe) static let gatewayUnencryptedStore = store(
+        "unencrypted",
+        [
+            "gatewayURL": "http://dictation.example.com",
+            GatewayStatusPreferences.healthMessageKey: "Not tested",
+            GatewayStatusPreferences.engineKey: "",
+            GatewayStatusPreferences.engineReadyKey: false,
+        ]
+    )
+
+    /// The App Group values that `@AppStorage(store:)` and
+    /// `KeyboardPreferences` read directly, so they cannot be redirected with
+    /// `defaultAppStorage`. Registered, never set, for the same reason.
+    static func registerAppGroupDefaults(hasDictatedOnce: Bool = true) {
+        KeyboardPreferences.defaults?.register(defaults: [
+            KeyboardPreferences.setupCompletedKey: true,
+            KeyboardPreferences.firstDictationKey: hasDictatedOnce,
+            KeyboardPreferences.keyboardHeightKey: KeyboardHeightPreference.standard.rawValue,
+            KeyboardPreferences.writingStyleKey: WritingStyle.casual.rawValue,
+            KeyboardPreferences.transcriptionLanguageKey: TranscriptionLanguage.automatic.rawValue,
+            KeyboardPreferences.typingSuggestionsKey: true,
+            KeyboardPreferences.quickDictationKey: false,
+        ])
+    }
+}
+
+// MARK: - Coordinators
+
+extension RecordingCoordinator {
+    /// The home screen resting on a working setup, with nothing recorded yet.
+    static func previewIdle(
+        setupStatus: SetupStatus = PreviewFixtures.setupComplete
+    ) -> RecordingCoordinator {
+        RecordingCoordinator(
+            preview: nil,
+            setupStatus: setupStatus,
+            transcripts: PreviewFixtures.history
+        )
+    }
+
+    /// A coordinator sitting in one session state, with the setup that state
+    /// implies.
+    static func preview(
+        _ state: SessionState,
+        transcript: String? = nil,
+        error: SessionFailure? = nil,
+        processingLocation: SessionProcessingLocation? = .gateway,
+        startedInApp: Bool = true,
+        setupStatus: SetupStatus = PreviewFixtures.setupComplete,
+        message: String? = nil,
+        meterLevel: Float = 0,
+        isRecording: Bool = false
+    ) -> RecordingCoordinator {
+        RecordingCoordinator(
+            preview: PreviewFixtures.record(
+                state: state,
+                transcript: transcript,
+                error: error,
+                processingLocation: processingLocation,
+                startedInApp: startedInApp
+            ),
+            setupStatus: setupStatus,
+            message: message,
+            meterLevel: meterLevel,
+            isRecording: isRecording,
+            transcripts: PreviewFixtures.history
+        )
+    }
+
+    /// Quick Dictation armed but not recording — the state whose whole job is to
+    /// not look like recording.
+    static func previewStandby() -> RecordingCoordinator {
+        RecordingCoordinator(
+            preview: nil,
+            setupStatus: PreviewFixtures.setupComplete,
+            quickDictationExpiresAt: Date(timeIntervalSinceNow: 60 * 12),
+            transcripts: PreviewFixtures.history
+        )
+    }
+}
+#endif

--- a/ios/VocaPhoneApp/App/Previews/PreviewMatrix.swift
+++ b/ios/VocaPhoneApp/App/Previews/PreviewMatrix.swift
@@ -1,0 +1,152 @@
+#if DEBUG
+import SwiftUI
+
+/// The four ways every screen has to be looked at before it is finished.
+///
+/// The app has been seen in exactly one of them: default size, light, English,
+/// left to right. The design standard asks for the other three — "scalable type
+/// without clipped content or unreachable controls" and "localization-safe
+/// layouts for longer labels and right-to-left scripts" — and until now the only
+/// way to check either was to change a system setting and rebuild.
+enum PreviewVariant: String, CaseIterable, Identifiable {
+    case standard
+    case dark
+    /// `.accessibility5` is the largest size iOS offers, and the one where a
+    /// side-by-side `HStack` stops fitting. Anything that survives it survives
+    /// the four sizes below it.
+    case accessibility
+    /// Arabic, mirrored. Catches hardcoded leading padding, symbols that should
+    /// have flipped, and anything positioned with a fixed offset.
+    case rightToLeft
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .standard: "Default"
+        case .dark: "Dark"
+        case .accessibility: "Accessibility 5"
+        case .rightToLeft: "Right to left"
+        }
+    }
+
+    var colorScheme: ColorScheme {
+        self == .dark ? .dark : .light
+    }
+
+    var dynamicTypeSize: DynamicTypeSize {
+        self == .accessibility ? .accessibility5 : .large
+    }
+
+    var layoutDirection: LayoutDirection {
+        self == .rightToLeft ? .rightToLeft : .leftToRight
+    }
+
+    /// The locale only mirrors the layout and the date formats; the copy stays
+    /// English until there is a String Catalog to translate it from. Seeing an
+    /// English sentence laid out right to left is still the check that matters
+    /// here — it is the *layout* that has never been looked at.
+    var locale: Locale {
+        self == .rightToLeft ? Locale(identifier: "ar") : Locale(identifier: "en_US")
+    }
+}
+
+/// One screen, in one variant, with the environment it needs to render.
+///
+/// Every preview in the app goes through this rather than assembling its own
+/// stack of modifiers, so a screen cannot be previewed against a coordinator or
+/// a defaults store that the next screen does not use.
+struct PreviewHost<Content: View>: View {
+    var variant: PreviewVariant = .standard
+    var coordinator: RecordingCoordinator = .previewIdle()
+    var store: UserDefaults = PreviewFixtures.defaults
+    var content: () -> Content
+
+    init(
+        _ variant: PreviewVariant = .standard,
+        coordinator: RecordingCoordinator = .previewIdle(),
+        store: UserDefaults = PreviewFixtures.defaults,
+        hasDictatedOnce: Bool = true,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.variant = variant
+        self.coordinator = coordinator
+        self.store = store
+        self.content = content
+        // Registration only — see `PreviewFixtures.defaults`. Repeating it per
+        // host is free and means no preview depends on another having run.
+        //
+        // App Group values cannot be redirected the way `defaultAppStorage`
+        // redirects the standard store, so this one is process-wide: two
+        // previews open at once share whichever value rendered last. That is
+        // only visible for the first-run copy on the home screen, and only in a
+        // canvas showing both variants of it simultaneously.
+        PreviewFixtures.registerAppGroupDefaults(hasDictatedOnce: hasDictatedOnce)
+    }
+
+    var body: some View {
+        content()
+            .environment(coordinator)
+            // Redirects every `@AppStorage` that names no store away from the
+            // container the installed app writes to.
+            .defaultAppStorage(store)
+            .environment(\.colorScheme, variant.colorScheme)
+            .environment(\.dynamicTypeSize, variant.dynamicTypeSize)
+            .environment(\.layoutDirection, variant.layoutDirection)
+            .environment(\.locale, variant.locale)
+            .background(Color.vocaCanvas)
+    }
+}
+
+/// The same screen in all four variants, side by side.
+///
+/// Use it as the last preview in a file. The per-state previews above it answer
+/// "does this state read correctly"; this one answers "does it still fit", which
+/// is the question the app has never been asked.
+struct PreviewMatrix<Content: View>: View {
+    var coordinator: RecordingCoordinator = .previewIdle()
+    var store: UserDefaults = PreviewFixtures.defaults
+    var hasDictatedOnce = true
+    var content: () -> Content
+
+    init(
+        coordinator: RecordingCoordinator = .previewIdle(),
+        store: UserDefaults = PreviewFixtures.defaults,
+        hasDictatedOnce: Bool = true,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.coordinator = coordinator
+        self.store = store
+        self.hasDictatedOnce = hasDictatedOnce
+        self.content = content
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 24) {
+            ForEach(PreviewVariant.allCases) { variant in
+                VStack(spacing: 8) {
+                    Text(variant.label)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    PreviewHost(
+                        variant,
+                        coordinator: coordinator,
+                        store: store,
+                        hasDictatedOnce: hasDictatedOnce,
+                        content: content
+                    )
+                        // A phone's worth of width and height, so what clips
+                        // here clips on the device.
+                        .frame(width: 360, height: 760)
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                .strokeBorder(.separator)
+                        )
+                }
+            }
+        }
+        .padding(24)
+    }
+}
+#endif

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -1095,3 +1095,112 @@ struct TranscriptionLanguageList: View {
         .disabled(!selectable)
     }
 }
+
+#if DEBUG
+
+// MARK: - Previews
+
+// All five destinations, plus the hub. The hub's own finding — three rows that
+// read their value as a plain static property and never invalidate — shows up
+// here as a value that does not follow the store the preview supplies.
+
+#Preview("Settings — hub") {
+    PreviewHost(coordinator: .previewIdle()) {
+        NavigationStack { SettingsView() }
+    }
+}
+
+#Preview("Settings — hub, on-device source") {
+    PreviewHost(
+        coordinator: RecordingCoordinator(
+            preview: nil,
+            setupStatus: SetupStatus(
+                source: PreviewFixtures.onDeviceReady,
+                microphone: .granted,
+                keyboard: .ready(lastSeenAt: Date()),
+                hasDictatedOnce: true
+            )
+        )
+    ) {
+        NavigationStack { SettingsView() }
+    }
+}
+
+#Preview("Settings — keyboard") {
+    PreviewHost {
+        NavigationStack { KeyboardSettingsView() }
+    }
+}
+
+#Preview("Settings — dictation") {
+    PreviewHost(coordinator: .previewIdle()) {
+        NavigationStack { DictationSettingsView() }
+    }
+}
+
+#Preview("Settings — transcription, gateway ready") {
+    PreviewHost(coordinator: .previewIdle()) {
+        NavigationStack { TranscriptionSettingsView() }
+    }
+}
+
+#Preview("Settings — transcription, on-device") {
+    PreviewHost(
+        coordinator: RecordingCoordinator(
+            preview: nil,
+            setupStatus: SetupStatus(
+                source: PreviewFixtures.onDeviceReady,
+                microphone: .granted,
+                keyboard: .ready(lastSeenAt: Date()),
+                hasDictatedOnce: true
+            ),
+            models: LocalModelManager(preview: [PreviewFixtures.firstModelID])
+        )
+    ) {
+        NavigationStack { TranscriptionSettingsView() }
+    }
+}
+
+#Preview("Settings — privacy, everything granted") {
+    PreviewHost(coordinator: .previewIdle()) {
+        NavigationStack { PrivacySettingsView() }
+    }
+}
+
+/// The recovery wording for a permission iOS will not prompt for a second time.
+#Preview("Settings — privacy, microphone denied") {
+    PreviewHost(
+        coordinator: RecordingCoordinator(
+            preview: nil,
+            setupStatus: PreviewFixtures.setupMicrophoneDenied
+        )
+    ) {
+        NavigationStack { PrivacySettingsView() }
+    }
+}
+
+#Preview("Settings — diagnostics") {
+    PreviewHost {
+        NavigationStack { DiagnosticsSettingsView() }
+    }
+}
+
+#Preview("Settings — language list") {
+    @Previewable @State var selection = TranscriptionLanguage.automatic.rawValue
+    return PreviewHost {
+        NavigationStack { TranscriptionLanguageList(selection: $selection) }
+    }
+}
+
+#Preview("Settings — hub matrix", traits: .sizeThatFitsLayout) {
+    PreviewMatrix(coordinator: .previewIdle()) {
+        NavigationStack { SettingsView() }
+    }
+}
+
+#Preview("Settings — transcription matrix", traits: .sizeThatFitsLayout) {
+    PreviewMatrix(coordinator: .previewIdle()) {
+        NavigationStack { TranscriptionSettingsView() }
+    }
+}
+#endif

--- a/ios/VocaPhoneApp/App/SetupView.swift
+++ b/ios/VocaPhoneApp/App/SetupView.swift
@@ -402,3 +402,130 @@ struct SetupStepLabel: View {
         .accessibilityValue(isComplete ? "Done" : "Not done")
     }
 }
+
+#if DEBUG
+
+// MARK: - Previews
+
+// Guided setup is four steps that each complete somewhere else — iOS Settings,
+// a permission alert, the keyboard itself — so reaching a particular
+// combination on a device means undoing real system state. These are the
+// combinations that change what the screen says.
+
+#Preview("Setup — nothing done yet") {
+    PreviewHost(
+        coordinator: RecordingCoordinator(
+            preview: nil,
+            setupStatus: PreviewFixtures.setupFresh
+        ),
+        store: PreviewFixtures.gatewayUnpairedStore
+    ) {
+        NavigationStack { SetupView() }
+    }
+}
+
+#Preview("Setup — microphone declined") {
+    PreviewHost(
+        coordinator: RecordingCoordinator(
+            preview: nil,
+            setupStatus: PreviewFixtures.setupMicrophoneDenied
+        )
+    ) {
+        NavigationStack { SetupView() }
+    }
+}
+
+/// The most common stuck point: listed under Keyboards, never granted Full
+/// Access, so the extension has never reached the shared container.
+#Preview("Setup — keyboard needs Full Access") {
+    PreviewHost(
+        coordinator: RecordingCoordinator(
+            preview: nil,
+            setupStatus: PreviewFixtures.setupKeyboardNeedsFullAccess,
+            models: LocalModelManager(preview: [PreviewFixtures.firstModelID])
+        )
+    ) {
+        NavigationStack { SetupView() }
+    }
+}
+
+#Preview("Setup — keyboard has gone silent") {
+    PreviewHost(
+        coordinator: RecordingCoordinator(
+            preview: nil,
+            setupStatus: PreviewFixtures.setupKeyboardSilent
+        )
+    ) {
+        NavigationStack { SetupView() }
+    }
+}
+
+/// Dictation works and only the optional trial run is outstanding — the state
+/// that must *not* warn on the home screen.
+#Preview("Setup — ready, test dictation left") {
+    PreviewHost(
+        coordinator: RecordingCoordinator(
+            preview: nil,
+            setupStatus: PreviewFixtures.setupReadyToDictate
+        )
+    ) {
+        NavigationStack { SetupView() }
+    }
+}
+
+#Preview("Setup — recording the test dictation") {
+    PreviewHost(
+        coordinator: .preview(
+            .recording,
+            setupStatus: PreviewFixtures.setupReadyToDictate,
+            message: "Listening…",
+            meterLevel: 0.55,
+            isRecording: true
+        )
+    ) {
+        NavigationStack { SetupView() }
+    }
+}
+
+#Preview("Setup — complete") {
+    PreviewHost(
+        coordinator: RecordingCoordinator(
+            preview: nil,
+            setupStatus: PreviewFixtures.setupComplete
+        )
+    ) {
+        NavigationStack { SetupView() }
+    }
+}
+
+/// The five hardcoded `padding(.leading, 32)` indents in this file are the
+/// reason this matrix exists: at `.accessibility5` they eat a third of the
+/// width, and right to left they land on the wrong side.
+#Preview("Setup — matrix", traits: .sizeThatFitsLayout) {
+    PreviewMatrix(
+        coordinator: RecordingCoordinator(
+            preview: nil,
+            setupStatus: PreviewFixtures.setupFresh
+        ),
+        store: PreviewFixtures.gatewayUnpairedStore
+    ) {
+        NavigationStack { SetupView() }
+    }
+}
+
+#Preview("Setup step label — done and not done", traits: .sizeThatFitsLayout) {
+    PreviewHost {
+        VStack(alignment: .leading, spacing: VocaMetrics.grouping) {
+            ForEach(SetupStep.allCases) { step in
+                SetupStepLabel(
+                    step: step,
+                    detail: PreviewFixtures.setupKeyboardNeedsFullAccess.detail(for: step),
+                    isComplete: PreviewFixtures.setupKeyboardNeedsFullAccess.isSatisfied(step)
+                )
+            }
+        }
+        .padding()
+        .frame(width: 380)
+    }
+}
+#endif

--- a/ios/VocaPhoneApp/App/TranscriptHistoryView.swift
+++ b/ios/VocaPhoneApp/App/TranscriptHistoryView.swift
@@ -14,6 +14,17 @@ struct TranscriptHistoryView: View {
     @State private var copiedID: UUID?
     @State private var pendingDeletion: SessionRecord?
 
+    init() {}
+
+#if DEBUG
+    /// Preview seam: the filter is `@State`, so a canvas has no other way to
+    /// reach "nothing matches" — the state most easily confused with "no
+    /// transcripts yet", and the one whose wording exists to tell them apart.
+    init(previewFilter: TranscriptHistoryModel.Filter) {
+        _filter = State(initialValue: previewFilter)
+    }
+#endif
+
     private var sections: [TranscriptHistoryModel.Section] {
         TranscriptHistoryModel.sections(
             TranscriptHistoryModel.filtered(records, filter: filter)
@@ -234,3 +245,104 @@ struct TranscriptDetailView: View {
         (record.transcript ?? "").split(whereSeparator: \.isWhitespace).count
     }
 }
+
+#if DEBUG
+
+// MARK: - Previews
+
+// The populated state is the one the search, the filters and the day grouping
+// were built for, and the one that needs ninety real dictations to reach.
+
+#Preview("History — populated") {
+    PreviewHost(coordinator: .previewIdle()) {
+        NavigationStack { TranscriptHistoryView() }
+    }
+}
+
+#Preview("History — no transcripts yet") {
+    PreviewHost(
+        coordinator: RecordingCoordinator(
+            preview: nil,
+            setupStatus: PreviewFixtures.setupComplete,
+            transcripts: []
+        )
+    ) {
+        NavigationStack { TranscriptHistoryView() }
+    }
+}
+
+#Preview("History — nothing matches the search") {
+    PreviewHost(coordinator: .previewIdle()) {
+        NavigationStack {
+            TranscriptHistoryView(
+                previewFilter: TranscriptHistoryModel.Filter(query: "quarterly budget")
+            )
+        }
+    }
+}
+
+#Preview("History — nothing matches the filters") {
+    PreviewHost(coordinator: .previewIdle()) {
+        NavigationStack {
+            TranscriptHistoryView(
+                previewFilter: TranscriptHistoryModel.Filter(route: .onDevice, style: .excited)
+            )
+        }
+    }
+}
+
+/// The row's metadata is a three-item `HStack` with no wrapping, which is the
+/// finding this matrix exists to make visible.
+#Preview("History — matrix", traits: .sizeThatFitsLayout) {
+    PreviewMatrix(coordinator: .previewIdle()) {
+        NavigationStack { TranscriptHistoryView() }
+    }
+}
+
+#Preview("Transcript detail — long") {
+    PreviewHost {
+        NavigationStack {
+            TranscriptDetailView(
+                record: PreviewFixtures.record(
+                    state: .completed,
+                    transcript: PreviewFixtures.longTranscript,
+                    processingLocation: .onDevice,
+                    style: .formal
+                ),
+                delete: {}
+            )
+        }
+    }
+}
+
+/// A record written before the route was stored, which is the only case that
+/// says "Not recorded" rather than naming a place.
+#Preview("Transcript detail — route unknown") {
+    PreviewHost {
+        NavigationStack {
+            TranscriptDetailView(
+                record: PreviewFixtures.record(
+                    state: .completed,
+                    transcript: PreviewFixtures.shortTranscript,
+                    processingLocation: nil
+                ),
+                delete: {}
+            )
+        }
+    }
+}
+
+#Preview("Transcript detail — matrix", traits: .sizeThatFitsLayout) {
+    PreviewMatrix {
+        NavigationStack {
+            TranscriptDetailView(
+                record: PreviewFixtures.record(
+                    state: .completed,
+                    transcript: PreviewFixtures.verboseTranscript
+                ),
+                delete: {}
+            )
+        }
+    }
+}
+#endif

--- a/ios/VocaPhoneApp/Models/LocalModelManager.swift
+++ b/ios/VocaPhoneApp/Models/LocalModelManager.swift
@@ -22,6 +22,23 @@ final class LocalModelManager {
     /// that never happened, and it needs a different sentence.
     private(set) var failedIntegrityModelIDs: Set<String> = []
 
+#if DEBUG
+    /// True only for a manager built by the preview initializer below. A canvas
+    /// is live, so without this a tap on Download in a preview would fetch a
+    /// gigabyte from Hugging Face, and Delete would remove a real model.
+    private(set) var isPreviewFixture = false
+#endif
+
+    /// Whether this instance declines to touch the network or the filesystem.
+    /// Always `false` outside DEBUG.
+    private var isInert: Bool {
+#if DEBUG
+        isPreviewFixture
+#else
+        false
+#endif
+    }
+
     private var whisperKit: WhisperKit?
     private var sherpaRecognizer: SherpaRecognizer?
     private var loadedModelID: String?
@@ -47,6 +64,38 @@ final class LocalModelManager {
     init() {
         refresh()
     }
+
+#if DEBUG
+    /// A manager frozen in one state, for `#Preview` only.
+    ///
+    /// The designated initializer stats every catalog entry and can start a
+    /// background hashing pass, so a canvas built on it would show whatever
+    /// this developer happens to have downloaded — which is never the state
+    /// being previewed, and never the interesting ones: verifying, loading, or
+    /// failed integrity.
+    init(
+        preview downloaded: Set<String> = [],
+        downloading: String? = nil,
+        progress: Double = 0,
+        loading: String? = nil,
+        loadingMessage: String? = nil,
+        verifying: Set<String> = [],
+        failedIntegrity: Set<String> = [],
+        message: String? = nil,
+        hasError: Bool = false
+    ) {
+        isPreviewFixture = true
+        downloadedModelIDs = downloaded
+        downloadingModelID = downloading
+        self.progress = progress
+        loadingModelID = loading
+        self.loadingMessage = loadingMessage
+        verifyingModelIDs = verifying
+        failedIntegrityModelIDs = failedIntegrity
+        self.message = message
+        self.hasError = hasError
+    }
+#endif
 
     /// Stat-only pass, safe to run on the main actor during launch.
     func refresh() {
@@ -329,6 +378,7 @@ final class LocalModelManager {
     /// exactly the kind of false readiness the source card exists to prevent —
     /// ``delete(_:)`` already clears it.
     func deleteReportingResult(_ descriptor: LocalModelDescriptor) {
+        guard !isInert else { return }
         do {
             try delete(descriptor)
             failedIntegrityModelIDs.remove(descriptor.id)
@@ -436,6 +486,7 @@ final class LocalModelManager {
     }
 
     func download(_ descriptor: LocalModelDescriptor) async throws {
+        guard !isInert else { return }
         downloadingModelID = descriptor.id
         progress = 0
         message = nil

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -17,6 +17,36 @@ final class RecordingCoordinator {
     /// snapshotted here and refreshed deliberately rather than polled.
     private(set) var setupStatus = SetupStatus()
 
+#if DEBUG
+    /// True only for a coordinator built by the preview initializer below.
+    ///
+    /// A `#Preview` is live, not a screenshot: `ContentView`'s `.task` runs the
+    /// moment the canvas appears. Unguarded, `refreshSetupStatus` would replace
+    /// the fixture with whatever this developer's simulator happens to be
+    /// within a frame — so every home and setup preview would show one state,
+    /// the real one. `prepareQuickDictationIfEnabled` would arm the microphone
+    /// for a canvas nobody is speaking into.
+    private(set) var isPreviewFixture = false
+    /// `isRecording` is derived from the live `AudioRecorder`, which a canvas
+    /// has no way to start. A fixture sets the answer instead of producing it.
+    fileprivate var previewIsRecording = false
+    /// Stands in for the session files on disk. `nonisolated(unsafe)` because
+    /// `loadRecentTranscripts` is nonisolated by design, and this is written
+    /// once during construction and only read afterwards.
+    @ObservationIgnored nonisolated(unsafe) fileprivate var previewTranscripts: [SessionRecord]?
+#endif
+
+    /// Whether this instance declines to touch audio, the network, the shared
+    /// container, or the system's own state. Always `false` outside DEBUG,
+    /// where the initializer that can set it does not exist.
+    private var isInert: Bool {
+#if DEBUG
+        isPreviewFixture
+#else
+        false
+#endif
+    }
+
     private let recorder = AudioRecorder()
     private let store = SharedStore.shared
     private var pollingTask: Task<Void, Never>?
@@ -34,13 +64,21 @@ final class RecordingCoordinator {
     private let streamingBridge = StreamingAudioBridge()
     private let soundFeedback = RecordingSoundFeedback()
     private var localSherpaSession: SherpaIncrementalSession?
-    let localModels = LocalModelManager()
+    let localModels: LocalModelManager
 
-    var isRecording: Bool { activeRecord?.state == .recording && recorder.isRecording }
+    var isRecording: Bool {
+#if DEBUG
+        if isPreviewFixture { return previewIsRecording }
+#endif
+        return activeRecord?.state == .recording && recorder.isRecording
+    }
     var hasError: Bool { activeRecord?.error != nil }
     var transcript: String? { activeRecord?.transcript }
     var isQuickDictationReady: Bool {
         guard let quickDictationExpiresAt else { return false }
+#if DEBUG
+        if isPreviewFixture { return quickDictationExpiresAt > Date() }
+#endif
         return recorder.isStandbyActive && quickDictationExpiresAt > Date()
     }
     /// Only true for a dictation started from another app, which is the only
@@ -60,10 +98,15 @@ final class RecordingCoordinator {
         !recorder.isRecording && startingSessionID == nil
     }
     var microphoneAccess: MicrophoneAccess {
+#if DEBUG
+        // A fixture's setup status is the single answer for every surface that
+        // asks; the canvas has no audio session to ask instead.
+        if isPreviewFixture { return setupStatus.microphone }
+#endif
         switch recorder.recordPermission {
-        case .granted: .granted
-        case .denied: .denied
-        default: .undetermined
+        case .granted: return .granted
+        case .denied: return .denied
+        default: return .undetermined
         }
     }
 
@@ -72,6 +115,7 @@ final class RecordingCoordinator {
     /// exposes no API for whether a keyboard extension is installed, and a
     /// permission can be revoked from Settings while the app is suspended.
     func refreshSetupStatus() {
+        guard !isInert else { return }
         let refreshed = SetupStatus(
             source: transcriptionSource,
             microphone: microphoneAccess,
@@ -94,6 +138,9 @@ final class RecordingCoordinator {
     /// say what switching would get you without presenting the unselected route
     /// as broken.
     var transcriptionSource: TranscriptionSourceStatus {
+#if DEBUG
+        if isPreviewFixture { return setupStatus.source }
+#endif
         let modelID = LocalTranscriptionPreferences.modelIdentifier
         let descriptor = modelID.flatMap(LocalModelCatalog.descriptor(for:))
         return TranscriptionSourceStatus(
@@ -128,6 +175,7 @@ final class RecordingCoordinator {
     /// too — a card describing a transcript that no longer exists is worse than
     /// an empty one.
     func deleteTranscript(_ id: UUID) async {
+        guard !isInert else { return }
         await Task.detached(priority: .userInitiated) {
             try? SharedStore.shared.delete(id)
         }.value
@@ -138,6 +186,7 @@ final class RecordingCoordinator {
     }
 
     func deleteAllTranscripts() async {
+        guard !isInert else { return }
         await Task.detached(priority: .userInitiated) {
             try? SharedStore.shared.deleteAllSessions()
         }.value
@@ -146,7 +195,10 @@ final class RecordingCoordinator {
     }
 
     nonisolated func loadRecentTranscripts(limit: Int = 50) async -> [SessionRecord] {
-        await Task.detached(priority: .userInitiated) {
+#if DEBUG
+        if let previewTranscripts { return Array(previewTranscripts.prefix(limit)) }
+#endif
+        return await Task.detached(priority: .userInitiated) {
             ((try? SharedStore.shared.recent(limit: limit)) ?? [])
                 .filter { !($0.transcript ?? "").isEmpty }
         }.value
@@ -161,6 +213,7 @@ final class RecordingCoordinator {
     }
 
     init() {
+        localModels = LocalModelManager()
         // A process exit can leave an otherwise valid-looking availability
         // marker behind. The new app process is not warm until it arms audio.
         try? store.clearQuickDictationAvailability()
@@ -184,7 +237,42 @@ final class RecordingCoordinator {
         DiagnosticLog.record(.appStarted)
     }
 
+#if DEBUG
+    /// A coordinator frozen in one state, for `#Preview` only.
+    ///
+    /// Deliberately not a `convenience init`: the designated initializer above
+    /// clears the Quick Dictation marker, installs Darwin observers, reads the
+    /// keychain and writes a diagnostic event. A canvas should do none of that.
+    /// This one assigns the state being previewed and stops.
+    ///
+    /// Every stored property it does not name keeps its inline default, so a
+    /// new one added above cannot silently leave a fixture half-built.
+    init(
+        preview record: SessionRecord? = nil,
+        setupStatus: SetupStatus = SetupStatus(),
+        message: String? = nil,
+        meterLevel: Float = 0,
+        isRecording: Bool = false,
+        quickDictationExpiresAt: Date? = nil,
+        microphoneName: String? = nil,
+        transcripts: [SessionRecord]? = nil,
+        models: LocalModelManager = LocalModelManager(preview: [])
+    ) {
+        localModels = models
+        isPreviewFixture = true
+        previewIsRecording = isRecording
+        previewTranscripts = transcripts
+        activeRecord = record
+        self.setupStatus = setupStatus
+        self.message = message
+        self.meterLevel = meterLevel
+        self.quickDictationExpiresAt = quickDictationExpiresAt
+        currentMicrophoneName = microphoneName
+    }
+#endif
+
     func handleDeepLink(_ url: URL) {
+        guard !isInert else { return }
         guard url.scheme == AppConfiguration.urlScheme,
               let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let value = components.queryItems?.first(where: { $0.name == "session" })?.value,
@@ -219,6 +307,7 @@ final class RecordingCoordinator {
     /// failed transcription, and Retry is the action that spends it — a new
     /// recording is the one that throws it away.
     func retryPreservedRecording() {
+        guard !isInert else { return }
         guard var record = activeRecord, record.canRetry else { return }
         do {
             record.error = nil
@@ -233,6 +322,7 @@ final class RecordingCoordinator {
     }
 
     func requestMicrophonePermission() {
+        guard !isInert else { return }
         recorder.requestPermission { [weak self] granted in
             guard let self else { return }
             if granted {
@@ -248,6 +338,7 @@ final class RecordingCoordinator {
     }
 
     func prepareQuickDictationIfEnabled() {
+        guard !isInert else { return }
         debugQuickDictation(
             "prepare enabled=\(KeyboardPreferences.quickDictationEnabled) "
                 + "permission=\(recorder.recordPermission.rawValue) "
@@ -263,6 +354,7 @@ final class RecordingCoordinator {
     }
 
     func setQuickDictationEnabled(_ enabled: Bool) {
+        guard !isInert else { return }
         KeyboardPreferences.quickDictationEnabled = enabled
         if enabled {
             if recorder.recordPermission == .granted {
@@ -276,6 +368,7 @@ final class RecordingCoordinator {
     }
 
     func stopQuickDictation() {
+        guard !isInert else { return }
         KeyboardPreferences.quickDictationEnabled = false
         clearQuickDictationReadiness(deactivateAudioSession: true)
         message = "Quick Dictation is off. The keyboard will open vocaphone next time."
@@ -292,6 +385,7 @@ final class RecordingCoordinator {
     /// A gateway configured last week may be unreachable today, so the setup
     /// checklist re-verifies rather than trusting the stored result.
     func refreshGatewayHealth() async {
+        guard !isInert else { return }
         defer { refreshSetupStatus() }
         guard let value = UserDefaults.standard.string(forKey: "gatewayURL"),
               let baseURL = GatewayEndpoint.validatedURL(from: value),
@@ -344,6 +438,7 @@ final class RecordingCoordinator {
     }
 
     func setMicrophonePreference(_ preference: MicrophonePreference) {
+        guard !isInert else { return }
         guard !recorder.isRecording, startingSessionID == nil else {
             message = "Finish the current recording before changing microphones."
             return
@@ -364,6 +459,7 @@ final class RecordingCoordinator {
     }
 
     func startInAppTest() {
+        guard !isInert else { return }
         guard !recorder.isRecording else { return }
         var record = SessionRecord(
             state: .idle,
@@ -384,6 +480,7 @@ final class RecordingCoordinator {
     }
 
     func requestFinish() {
+        guard !isInert else { return }
         guard var record = activeRecord, record.state == .recording else { return }
         DiagnosticLog.record(.finishRequested)
         do {
@@ -398,6 +495,7 @@ final class RecordingCoordinator {
     }
 
     func cancel() {
+        guard !isInert else { return }
         pipelineTask?.cancel()
         pipelineTask = nil
         pipelineSessionID = nil
@@ -445,6 +543,7 @@ final class RecordingCoordinator {
     }
 
     func recoverRecentSession() async {
+        guard !isInert else { return }
         pruneSharedStorage()
         let recovered = try? store.mostRecent()
         // A Live Activity belongs to the system and outlives its app, so a

--- a/ios/VocaPhoneKeyboard/DictationBarView.swift
+++ b/ios/VocaPhoneKeyboard/DictationBarView.swift
@@ -831,3 +831,137 @@ final class DictationBarView: UIView, TypingStripViewDelegate {
         ] + controlHeights + secondarySizes)
     }
 }
+
+#if DEBUG
+import SwiftUI
+
+// MARK: - Previews
+
+// The bar is one control that becomes eight different things. `DictationBarModel`
+// is pure and already tested, but what the model turns into on screen — the
+// accent, the pulse, which secondaries fit, how the strip and status layouts
+// differ — had only ever been seen in the two or three states that are easy to
+// reach from a host app.
+
+private struct DictationBarPreview: View {
+    var context: DictationContext
+    var dark = false
+    var preference: KeyboardHeightPreference = .standard
+
+    var body: some View {
+        let metrics = KeyboardPreviewEnvironment.barMetrics(preference)
+        let palette = KeyboardPreviewEnvironment.palette(dark: dark)
+        return KeyboardViewPreview {
+            DictationBarView(metrics: metrics, palette: palette)
+        } configure: { bar in
+            bar.metrics = metrics
+            bar.palette = palette
+            bar.apply(DictationBarModel.make(context), animated: false)
+        }
+        .frame(width: 360, height: metrics.stripHeight)
+        .background(Color(palette.background))
+    }
+}
+
+private struct DictationBarGallery: View {
+    var dark = false
+
+    private var states: [(String, DictationContext)] {
+        [
+            (
+                "Idle, suggestions",
+                DictationContext(
+                    state: .idle,
+                    candidates: KeyboardPreviewEnvironment.candidates
+                )
+            ),
+            ("Idle, no suggestions", DictationContext(state: .idle)),
+            (
+                "No Full Access",
+                DictationContext(state: .idle, hasFullAccess: false)
+            ),
+            ("Opening vocaphone", DictationContext(state: .launchingApp)),
+            ("Recording", DictationContext(state: .recording)),
+            (
+                "Transcribing on the gateway",
+                DictationContext(state: .transcribing, processingLocation: .gateway)
+            ),
+            (
+                "Transcribing on this iPhone",
+                DictationContext(state: .transcribing, processingLocation: .onDevice)
+            ),
+            (
+                "Ready to insert",
+                DictationContext(
+                    state: .readyToInsert,
+                    transcript: "Let's move the review to Thursday afternoon."
+                )
+            ),
+            (
+                "Field changed while transcribing",
+                DictationContext(
+                    state: .targetContextChanged,
+                    transcript: "Let's move the review to Thursday afternoon."
+                )
+            ),
+            (
+                "Inserted, undo available",
+                DictationContext(state: .inserted, canUndo: true)
+            ),
+            (
+                "Gateway unavailable, can retry",
+                DictationContext(
+                    state: .serverUnavailable,
+                    errorMessage: "Your gateway did not answer. The recording is kept.",
+                    canRetry: true
+                )
+            ),
+            (
+                "Transcription failed for good",
+                DictationContext(
+                    state: .transcriptionFailedPermanent,
+                    errorMessage: "No text came back for this recording."
+                )
+            ),
+        ]
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(states, id: \.0) { name, context in
+                Text(name)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                DictationBarPreview(context: context, dark: dark)
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview("Dictation bar — every state", traits: .sizeThatFitsLayout) {
+    DictationBarGallery()
+}
+
+#Preview("Dictation bar — every state, dark", traits: .sizeThatFitsLayout) {
+    DictationBarGallery(dark: true)
+}
+
+#Preview("Dictation bar — every height", traits: .sizeThatFitsLayout) {
+    VStack(alignment: .leading, spacing: 10) {
+        ForEach(KeyboardHeightPreference.allCases) { preference in
+            Text(preference.displayName)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            DictationBarPreview(
+                context: DictationContext(
+                    state: .idle,
+                    candidates: KeyboardPreviewEnvironment.candidates
+                ),
+                preference: preference
+            )
+        }
+    }
+    .padding()
+}
+#endif

--- a/ios/VocaPhoneKeyboard/EmojiPanelView.swift
+++ b/ios/VocaPhoneKeyboard/EmojiPanelView.swift
@@ -342,3 +342,96 @@ final class EmojiCell: UICollectionViewCell {
         accessibilityLabel = glyph
     }
 }
+
+#if DEBUG
+import SwiftUI
+
+// MARK: - Previews
+
+// The panel occupies exactly the key grid's space, so it is previewed at the
+// grid's resolved height for each of the three keyboard heights. What matters
+// here is that ABC, space, delete and return stay pinned at the bottom: this is
+// the surface a user can otherwise get stuck in.
+
+/// `EmojiCatalog` builds only in the keyboard and the test target, so the
+/// fixture lives beside the view that needs it rather than in the shared
+/// preview helpers, which the app target also compiles.
+private enum EmojiPanelFixture {
+    /// Small enough to write down, large enough that the grid, the category bar
+    /// and search all have something to draw.
+    static let emojiCatalog = EmojiCatalog(entries: [
+        EmojiEntry(glyph: "😀", category: .smileys, keywords: "grinning face smile happy"),
+        EmojiEntry(glyph: "😅", category: .smileys, keywords: "grinning sweat relief nervous"),
+        EmojiEntry(glyph: "🙂", category: .smileys, keywords: "slightly smiling face"),
+        EmojiEntry(glyph: "😍", category: .smileys, keywords: "heart eyes love"),
+        EmojiEntry(glyph: "🤔", category: .smileys, keywords: "thinking face hmm"),
+        EmojiEntry(glyph: "😴", category: .smileys, keywords: "sleeping face tired"),
+        EmojiEntry(glyph: "👋", category: .people, keywords: "waving hand hello goodbye"),
+        EmojiEntry(glyph: "👍", category: .people, keywords: "thumbs up yes approve"),
+        EmojiEntry(glyph: "🙏", category: .people, keywords: "folded hands please thanks"),
+        EmojiEntry(glyph: "🐻", category: .animals, keywords: "bear face"),
+        EmojiEntry(glyph: "🐈", category: .animals, keywords: "cat pet"),
+        EmojiEntry(glyph: "🌱", category: .animals, keywords: "seedling plant grow"),
+        EmojiEntry(glyph: "🍔", category: .food, keywords: "hamburger burger food"),
+        EmojiEntry(glyph: "☕", category: .food, keywords: "hot beverage coffee tea"),
+        EmojiEntry(glyph: "✈️", category: .travel, keywords: "airplane flight travel"),
+        EmojiEntry(glyph: "🚲", category: .travel, keywords: "bicycle bike ride"),
+        EmojiEntry(glyph: "⚽", category: .activities, keywords: "soccer ball football"),
+        EmojiEntry(glyph: "🎧", category: .activities, keywords: "headphone music listen"),
+        EmojiEntry(glyph: "💡", category: .objects, keywords: "light bulb idea"),
+        EmojiEntry(glyph: "🔑", category: .objects, keywords: "key unlock"),
+        EmojiEntry(glyph: "❤️", category: .symbols, keywords: "red heart love"),
+        EmojiEntry(glyph: "✅", category: .symbols, keywords: "check mark done"),
+        EmojiEntry(glyph: "🚩", category: .flags, keywords: "triangular flag"),
+    ])
+}
+
+private struct EmojiPanelPreview: View {
+    var preference: KeyboardHeightPreference = .standard
+    var dark = false
+    var catalog: EmojiCatalog = EmojiPanelFixture.emojiCatalog
+
+    var body: some View {
+        let metrics = KeyboardPreviewEnvironment.gridMetrics(preference)
+        let palette = KeyboardPreviewEnvironment.palette(dark: dark)
+        return KeyboardViewPreview {
+            EmojiPanelView(palette: palette, metrics: metrics)
+        } configure: { panel in
+            panel.palette = palette
+            panel.metrics = metrics
+            panel.catalog = catalog
+        }
+        .frame(width: 360, height: metrics.gridHeight)
+        .background(Color(palette.background))
+    }
+}
+
+#Preview("Emoji panel — standard", traits: .sizeThatFitsLayout) {
+    EmojiPanelPreview().padding()
+}
+
+#Preview("Emoji panel — dark", traits: .sizeThatFitsLayout) {
+    EmojiPanelPreview(dark: true).padding()
+}
+
+#Preview("Emoji panel — every height", traits: .sizeThatFitsLayout) {
+    HStack(alignment: .top, spacing: 16) {
+        ForEach(KeyboardHeightPreference.allCases) { preference in
+            VStack(spacing: 6) {
+                Text(preference.displayName)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                EmojiPanelPreview(preference: preference)
+            }
+        }
+    }
+    .padding()
+}
+
+/// A catalog that failed to load is a real state — the shared TSV lives in a
+/// resource bundle the extension has to find — and it must not read as a broken
+/// keyboard.
+#Preview("Emoji panel — empty catalog", traits: .sizeThatFitsLayout) {
+    EmojiPanelPreview(catalog: .empty).padding()
+}
+#endif

--- a/ios/VocaPhoneKeyboard/KeyboardViewPreview.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewPreview.swift
@@ -25,10 +25,14 @@ struct KeyboardViewPreview<V: UIView>: UIViewRepresentable {
 /// The palette and metrics the extension resolves at runtime, so a preview is
 /// sized and coloured the way the keyboard will be rather than the way a canvas
 /// would default to.
+///
+/// `@MainActor`: on newer SDKs, `UITraitCollection`'s builder closure mutates
+/// `verticalSizeClass`, which UIKit now annotates as main-actor-only. Every
+/// real caller here is already on the main actor — a `View` body or a
+/// `UIViewRepresentable` method — so this just makes that explicit rather than
+/// implicit, which is what the stricter SDK requires.
+@MainActor
 enum KeyboardPreviewEnvironment {
-    /// `UITraitCollection`'s builder initializer is main-actor isolated, so
-    /// this is computed rather than stored: a `static let` would need a
-    /// nonisolated default value it cannot have.
     static var traits: UITraitCollection {
         UITraitCollection { $0.verticalSizeClass = .regular }
     }

--- a/ios/VocaPhoneKeyboard/KeyboardViewPreview.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewPreview.swift
@@ -1,0 +1,58 @@
+#if DEBUG
+import SwiftUI
+import UIKit
+
+/// Puts one of the keyboard's UIKit views in an Xcode canvas.
+///
+/// Every surface in this extension is a `UIView`, and until now the only way to
+/// look at any of them was to build the extension, install the keyboard, grant
+/// Full Access, switch to it in another app, and then type the exact thing that
+/// produces the state. That is why the strip, the emoji panel and half the
+/// dictation bar's states had never been seen anywhere but a default-size,
+/// left-to-right, English simulator.
+///
+/// Interaction stays on: these are the real views, so a chip really is tappable
+/// in the canvas — it simply has no text document to act on.
+struct KeyboardViewPreview<V: UIView>: UIViewRepresentable {
+    let make: () -> V
+    var configure: (V) -> Void = { _ in }
+
+    func makeUIView(context: Context) -> V { make() }
+
+    func updateUIView(_ view: V, context: Context) { configure(view) }
+}
+
+/// The palette and metrics the extension resolves at runtime, so a preview is
+/// sized and coloured the way the keyboard will be rather than the way a canvas
+/// would default to.
+enum KeyboardPreviewEnvironment {
+    /// `UITraitCollection`'s builder initializer is main-actor isolated, so
+    /// this is computed rather than stored: a `static let` would need a
+    /// nonisolated default value it cannot have.
+    static var traits: UITraitCollection {
+        UITraitCollection { $0.verticalSizeClass = .regular }
+    }
+
+    static func palette(dark: Bool) -> KeyboardPalette { KeyboardPalette(isDark: dark) }
+
+    static func gridMetrics(
+        _ preference: KeyboardHeightPreference = .standard
+    ) -> KeyboardMetrics {
+        KeyboardMetrics.resolved(for: traits, preference: preference)
+    }
+
+    static func barMetrics(
+        _ preference: KeyboardHeightPreference = .standard
+    ) -> DictationBarMetrics {
+        DictationBarMetrics.resolved(for: traits, preference: preference)
+    }
+
+    /// Recognisable words rather than plausible corrections: a preview must
+    /// never look like it is proposing to change text nobody typed.
+    static let candidates = [
+        TypingCandidate(text: "keyboard", kind: .completion),
+        TypingCandidate(text: "keeping", kind: .completion),
+        TypingCandidate(text: "kept", kind: .completion),
+    ]
+}
+#endif

--- a/ios/VocaPhoneKeyboard/TypingStripView.swift
+++ b/ios/VocaPhoneKeyboard/TypingStripView.swift
@@ -246,3 +246,69 @@ final class TypingStripView: UIScrollView {
         chipDelegate?.typingStrip(self, didChoose: candidates[sender.tag])
     }
 }
+
+#if DEBUG
+import SwiftUI
+
+// MARK: - Previews
+
+// Zero to three chips, light and dark. Three ordinary words nearly always fit
+// and the row centres; the long set is the case that scrolls, which is the
+// behaviour this view exists for and the one nobody had looked at.
+
+private struct StripPreview: View {
+    var candidates: [TypingCandidate]
+    var dark = false
+
+    var body: some View {
+        let metrics = KeyboardPreviewEnvironment.barMetrics()
+        return KeyboardViewPreview {
+            TypingStripView(
+                palette: KeyboardPreviewEnvironment.palette(dark: dark),
+                metrics: metrics
+            )
+        } configure: { strip in
+            strip.palette = KeyboardPreviewEnvironment.palette(dark: dark)
+            strip.apply(candidates, animated: false)
+        }
+        .frame(width: 360, height: metrics.stripHeight)
+        .background(Color(KeyboardPreviewEnvironment.palette(dark: dark).background))
+    }
+}
+
+#Preview("Typing strip — 0 to 3 chips", traits: .sizeThatFitsLayout) {
+    VStack(spacing: 12) {
+        StripPreview(candidates: [])
+        StripPreview(candidates: Array(KeyboardPreviewEnvironment.candidates.prefix(1)))
+        StripPreview(candidates: Array(KeyboardPreviewEnvironment.candidates.prefix(2)))
+        StripPreview(candidates: KeyboardPreviewEnvironment.candidates)
+    }
+    .padding()
+}
+
+#Preview("Typing strip — dark", traits: .sizeThatFitsLayout) {
+    VStack(spacing: 12) {
+        StripPreview(candidates: KeyboardPreviewEnvironment.candidates, dark: true)
+        StripPreview(candidates: [], dark: true)
+    }
+    .padding()
+}
+
+/// One-letter and glyph chips have their own minimum widths, and a long set is
+/// the only case that scrolls rather than fits.
+#Preview("Typing strip — short, glyph and overflowing", traits: .sizeThatFitsLayout) {
+    VStack(spacing: 12) {
+        StripPreview(candidates: [
+            TypingCandidate(text: "a", kind: .completion),
+            TypingCandidate(text: "I", kind: .completion),
+            TypingCandidate(text: "🎉", kind: .emoji),
+        ])
+        StripPreview(candidates: [
+            TypingCandidate(text: "internationalization", kind: .completion),
+            TypingCandidate(text: "interoperability", kind: .completion),
+            TypingCandidate(text: "interchangeable", kind: .completion),
+        ])
+    }
+    .padding()
+}
+#endif

--- a/ios/VocaPhoneLiveActivity/VocaPhoneLiveActivity.swift
+++ b/ios/VocaPhoneLiveActivity/VocaPhoneLiveActivity.swift
@@ -176,3 +176,112 @@ private struct VocaPhoneLogo: View {
             .accessibilityLabel("vocaphone")
     }
 }
+
+#if DEBUG
+
+// MARK: - Previews
+
+// The Lock Screen and the Dynamic Island are the two surfaces that cannot be
+// reached from the app at all: seeing one meant starting a real dictation and
+// locking the phone. All four phases are here, plus the two end states —
+// including the "Needs attention" one, which is the whole message a failed
+// dictation currently gets.
+
+private let previewAttributes = VocaPhoneActivityAttributes(
+    sessionID: "preview-session",
+    startedAt: Date(timeIntervalSinceNow: -42)
+)
+
+private extension VocaPhoneActivityAttributes.ContentState {
+    /// Armed, not recording. iOS lights the same microphone indicator either
+    /// way, so this is the state that must never read as a capture.
+    static let standby = VocaPhoneActivityAttributes.ContentState(
+        status: "Quick Dictation on standby",
+        canFinish: false,
+        phase: .standby
+    )
+
+    static let recording = VocaPhoneActivityAttributes.ContentState(
+        status: "Recording",
+        canFinish: true,
+        phase: .recording,
+        sessionID: "preview-session",
+        startedAt: Date(timeIntervalSinceNow: -42)
+    )
+
+    static let processing = VocaPhoneActivityAttributes.ContentState(
+        status: "Transcribing on your gateway",
+        canFinish: false,
+        phase: .processing
+    )
+
+    static let finished = VocaPhoneActivityAttributes.ContentState(
+        status: "Transcript ready",
+        canFinish: false,
+        phase: .finished
+    )
+
+    static let failed = VocaPhoneActivityAttributes.ContentState(
+        status: "Needs attention",
+        canFinish: false,
+        phase: .processing
+    )
+
+    /// The longest status the app produces, against the tightest budget on the
+    /// Lock Screen.
+    static let longStatus = VocaPhoneActivityAttributes.ContentState(
+        status: "Transcribing on this iPhone — no audio leaves the device",
+        canFinish: false,
+        phase: .processing
+    )
+}
+
+#Preview("Live Activity — Lock Screen", as: .content, using: previewAttributes) {
+    VocaPhoneRecordingActivity()
+} contentStates: {
+    VocaPhoneActivityAttributes.ContentState.standby
+    VocaPhoneActivityAttributes.ContentState.recording
+    VocaPhoneActivityAttributes.ContentState.processing
+    VocaPhoneActivityAttributes.ContentState.finished
+    VocaPhoneActivityAttributes.ContentState.failed
+    VocaPhoneActivityAttributes.ContentState.longStatus
+}
+
+#Preview(
+    "Live Activity — expanded",
+    as: .dynamicIsland(.expanded),
+    using: previewAttributes
+) {
+    VocaPhoneRecordingActivity()
+} contentStates: {
+    VocaPhoneActivityAttributes.ContentState.standby
+    VocaPhoneActivityAttributes.ContentState.recording
+    VocaPhoneActivityAttributes.ContentState.processing
+    VocaPhoneActivityAttributes.ContentState.finished
+}
+
+/// The compact trailing region is where `"•••"` lives, with no accessible name.
+#Preview(
+    "Live Activity — compact",
+    as: .dynamicIsland(.compact),
+    using: previewAttributes
+) {
+    VocaPhoneRecordingActivity()
+} contentStates: {
+    VocaPhoneActivityAttributes.ContentState.standby
+    VocaPhoneActivityAttributes.ContentState.recording
+    VocaPhoneActivityAttributes.ContentState.processing
+    VocaPhoneActivityAttributes.ContentState.finished
+}
+
+#Preview(
+    "Live Activity — minimal",
+    as: .dynamicIsland(.minimal),
+    using: previewAttributes
+) {
+    VocaPhoneRecordingActivity()
+} contentStates: {
+    VocaPhoneActivityAttributes.ContentState.recording
+    VocaPhoneActivityAttributes.ContentState.processing
+}
+#endif

--- a/ios/justfile
+++ b/ios/justfile
@@ -124,10 +124,36 @@ test *only: gen
     xcodebuild {{ sim_flags }} -destination "platform=iOS Simulator,id=${udid}" \
         ${filters[@]+"${filters[@]}"} test-without-building
 
+# A Release build proves the same thing, but only by compiling WhisperKit twice.
+# This takes under a second, so it can run on every change instead of on the
+# ones somebody remembers.
+#
+# Fail if any preview or debug-only symbol is reachable from a release build.
+[group('test')]
+lint-previews:
+    @python3 '{{ justfile_directory() }}/tools/check-preview-isolation.py'
+
+# The exit gate for the preview harness: `just ios lint-previews` catches a
+# named symbol, this catches everything else — anything the canvas depends on
+# that a shipping build would still have to link.
+#
+# Compile the app with DEBUG undefined.
+[group('test')]
+release-build: gen
+    #!/usr/bin/env bash
+    set -euo pipefail
+    udid="$({{ just_executable() }} _udid)"
+    xcodebuild -project {{ project }} -scheme {{ scheme }} -sdk iphonesimulator \
+        -configuration Release -derivedDataPath '{{ derived }}Release' \
+        -disableAutomaticPackageResolution \
+        CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO \
+        -destination "platform=iOS Simulator,id=${udid}" -quiet build
+
 # Everything CI checks for iOS: a non-stale project, then a build and the tests.
 [group('test')]
 ci: gen
     @git diff --exit-code -- {{ project }} || { echo "VocaPhone.xcodeproj is stale — commit the regenerated project." >&2; exit 1; }
+    @{{ just_executable() }} lint-previews
     @{{ just_executable() }} test
 
 # Build and install on a connected iPhone. Signing must already work in Xcode.

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -46,6 +46,10 @@ targets:
       - path: VocaPhoneKeyboard/WordComposer.swift
       - path: VocaPhoneKeyboard/TypingWordList.swift
       - path: VocaPhoneKeyboard/SwipeRecognizer.swift
+      # The canvas host for the keyboard's UIKit views. Whole file is
+      # `#if DEBUG`; it is here because the app target compiles the strip
+      # and the bar, and a preview in either file needs it in scope.
+      - path: VocaPhoneKeyboard/KeyboardViewPreview.swift
     resources:
       - VocaPhoneApp/Models/local_model_pins.json
       - VocaPhoneApp/Models/sherpa_model_pins.json
@@ -167,6 +171,9 @@ targets:
       # Search, filter and day-grouping for the transcript library. The grouping
       # arithmetic is the part that goes wrong at midnight and across zones.
       - path: VocaPhoneApp/App/TranscriptHistoryModel.swift
+      # Same reason as the app target: the strip and the bar carry their
+      # own previews, and this is what those previews are built from.
+      - path: VocaPhoneKeyboard/KeyboardViewPreview.swift
     settings:
       base:
         GENERATE_INFOPLIST_FILE: YES

--- a/ios/tools/check-preview-isolation.py
+++ b/ios/tools/check-preview-isolation.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Fail if any preview or debug-only symbol is reachable from a release build.
+
+The design standard's implementation guidance is "keep design-preview and debug
+states out of release behavior". The preview harness is the largest amount of
+debug-only code this app has ever carried, so the rule needs something that
+enforces it rather than a convention.
+
+Two checks:
+
+1. Files that exist only for previews must be wrapped in ``#if DEBUG`` from
+   their first line of code to their last.
+2. No preview-only symbol may be referenced from outside a ``#if DEBUG``
+   region, anywhere in the iOS sources.
+
+A Release build would catch the second one too, but only by compiling the whole
+app plus WhisperKit — this runs in under a second, so it can sit in CI beside
+the tests instead of doubling the macOS minutes.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Sources only. `build/` holds checked-out Swift packages, which are not ours.
+SOURCE_DIRS = (
+    "VocaPhoneApp",
+    "VocaPhoneKeyboard",
+    "VocaPhoneLiveActivity",
+    "VocaPhoneShared",
+    "VocaPhoneActivityShared",
+    "VocaPhoneTests",
+)
+
+# Files whose entire contents exist for the canvas.
+PREVIEW_ONLY_FILES = (
+    "VocaPhoneApp/App/Previews/PreviewFixtures.swift",
+    "VocaPhoneApp/App/Previews/PreviewMatrix.swift",
+    "VocaPhoneApp/App/Previews/DesignSystemPreviews.swift",
+    "VocaPhoneKeyboard/KeyboardViewPreview.swift",
+)
+
+# Symbols that must never be named outside a DEBUG region. Word-boundary
+# matched, so `preview` inside `KeyboardPreview` — a real, shipping view — does
+# not trip the check.
+DEBUG_ONLY_SYMBOLS = (
+    "PreviewFixtures",
+    "PreviewHost",
+    "PreviewMatrix",
+    "PreviewVariant",
+    "KeyboardViewPreview",
+    "KeyboardPreviewEnvironment",
+    "isPreviewFixture",
+    "previewIsRecording",
+    "previewTranscripts",
+    "previewSelectedModelID",
+    "previewFilter",
+    "previewIdle",
+    "previewStandby",
+)
+
+SYMBOL_PATTERN = re.compile(r"\b(" + "|".join(DEBUG_ONLY_SYMBOLS) + r")\b")
+PREVIEW_MACRO = re.compile(r"#Preview\b")
+
+
+def swift_files() -> list[Path]:
+    files: list[Path] = []
+    for directory in SOURCE_DIRS:
+        files.extend(sorted((ROOT / directory).rglob("*.swift")))
+    return files
+
+
+def debug_regions(lines: list[str]) -> list[bool]:
+    """For each line, whether it compiles only when DEBUG is defined.
+
+    Tracks conditional-compilation nesting rather than matching text, so a
+    `#Preview` inside `#if DEBUG` … `#else` counts as release code — which it
+    is.
+    """
+    inside: list[bool] = []
+    # One frame per open `#if`: (is this branch DEBUG-only, was any branch so far)
+    stack: list[tuple[bool, bool]] = []
+
+    def in_debug() -> bool:
+        # A file with no conditionals at all is release code, so an empty stack
+        # is False — `all([])` is True, which is exactly the wrong answer here.
+        return bool(stack) and all(frame[0] for frame in stack)
+
+    for raw in lines:
+        line = raw.strip()
+        if line.startswith("#if"):
+            is_debug = bool(re.fullmatch(r"#if\s+DEBUG", line))
+            stack.append((is_debug, is_debug))
+            inside.append(in_debug())
+            continue
+        if line.startswith("#elseif") or line.startswith("#else"):
+            if stack:
+                was_debug = re.fullmatch(r"#elseif\s+DEBUG", line) is not None
+                stack[-1] = (was_debug, stack[-1][1])
+            inside.append(in_debug())
+            continue
+        if line.startswith("#endif"):
+            if stack:
+                stack.pop()
+            inside.append(in_debug())
+            continue
+        inside.append(in_debug())
+    return inside
+
+
+def check_wrapped(path: Path, failures: list[str]) -> None:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    flags = debug_regions(lines)
+    for number, (line, is_debug) in enumerate(zip(lines, flags), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("//"):
+            continue
+        if stripped.startswith("#if") or stripped.startswith("#endif"):
+            continue
+        if not is_debug:
+            failures.append(
+                f"{path.relative_to(ROOT)}:{number}: preview-only file has code "
+                f"outside `#if DEBUG`"
+            )
+            return
+
+
+def check_references(path: Path, failures: list[str]) -> None:
+    relative = str(path.relative_to(ROOT))
+    if relative in PREVIEW_ONLY_FILES:
+        return
+    lines = path.read_text(encoding="utf-8").splitlines()
+    flags = debug_regions(lines)
+    for number, (line, is_debug) in enumerate(zip(lines, flags), start=1):
+        if is_debug:
+            continue
+        stripped = line.strip()
+        if stripped.startswith("//") or stripped.startswith("///"):
+            continue
+        match = SYMBOL_PATTERN.search(line)
+        if match:
+            failures.append(
+                f"{relative}:{number}: `{match.group(1)}` is preview-only and is "
+                f"referenced outside `#if DEBUG`"
+            )
+        if PREVIEW_MACRO.search(line):
+            failures.append(
+                f"{relative}:{number}: `#Preview` outside `#if DEBUG`"
+            )
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for relative in PREVIEW_ONLY_FILES:
+        path = ROOT / relative
+        if not path.exists():
+            failures.append(f"{relative}: listed as preview-only but does not exist")
+            continue
+        check_wrapped(path, failures)
+
+    for path in swift_files():
+        check_references(path, failures)
+
+    if failures:
+        print("Preview code is reachable from a release build:\n", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        print(
+            "\nWrap it in `#if DEBUG`, or move it into a preview-only file.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Preview isolation: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`grep -r '#Preview'` across the app, keyboard and Live Activity targets returned
**zero**. Every visual check meant building, booting a simulator and driving it
into the state by hand — so states like "gateway reachable but the token was
rejected", "the model failed its integrity check" and "transcript ready but the
field changed" were never actually looked at. The last release roughly doubled
the user-visible surface in one commit, and none of it had been seen outside a
default-size, left-to-right, English simulator.

This is the harness. **Nothing a user can see changes.**

## Fixtures

- `PreviewFixtures` holds canned `SessionRecord`s for every session state, six
  `SetupStatus` combinations, five transcription sources, and a transcript
  library spanning all four of the day headings the history grouping produces.
  Short, long and verbose transcripts, so clipping shows up in a canvas rather
  than on someone's phone.
- Stored preferences go into `UserDefaults`' **registration domain** rather than
  being written. Registration is per-process and never persisted, so opening a
  canvas cannot rewrite the settings of the app installed on the same simulator.
  Screens driven entirely by `@AppStorage` get a named store each, which is how
  the four gateway states can differ.

## Variants

`PreviewHost` supplies the environment; `PreviewMatrix` renders a screen four
ways at once — default, dark, `.accessibility5`, and right-to-left. Only the
first has ever been looked at, and the next PR (size and direction) is built
entirely on this.

The fourth variant is right-to-left rather than the pseudo-long copy originally
planned: there is no String Catalog to pseudo-localize from yet, so the layout is
mirrored and long copy comes from the fixtures instead.

## Live objects

`RecordingCoordinator` and `LocalModelManager` gain preview initializers that
assign state instead of producing it. Their designated initializers clear the
Quick Dictation marker, install Darwin observers, read the keychain, stat every
catalog entry and write a diagnostic event — none of which belongs in a canvas.

Both also gain an `isInert` flag that makes their side-effecting entry points
return early. **This is not optional:** a preview is live, so `ContentView`'s
`.task` would replace the fixture with the real system state within a frame,
`prepareQuickDictationIfEnabled` would arm the microphone, Download would fetch a
model, and Delete would remove one. `isInert` is a `false` literal outside DEBUG.

## Coverage — 81 previews

| Surface | States |
| --- | --- |
| Home | 13, including the hand-off overlay |
| Guided setup | 7, plus the step label at every state |
| Settings | the hub and all five destinations |
| Gateway | unpaired, ready, token rejected, model not ready, unencrypted HTTP |
| Model rows | all 7, three of which cannot be reached on purpose |
| History | populated, empty, no search match, no filter match, detail |
| Keyboard | strip 0–3 chips, emoji panel at every height, bar in 12 states |
| Live Activity | 4 phases × 4 presentations, plus both end states |

The keyboard's surfaces are all `UIView`s, so they preview through
`KeyboardViewPreview` in the keyboard target, beside the views themselves.

## Keeping it out of the shipping app

- The practice field's `-diagFocusField` launch argument was a debug hook with no
  `#if DEBUG` around it, unlike the return-guide argument twenty lines below.
  Now guarded. The consequence was mild; the rule exists so the next hook has a
  precedent.
- `ios/tools/check-preview-isolation.py` fails if a preview-only file has code
  outside `#if DEBUG`, or if a preview-only symbol is named from release code. It
  tracks conditional-compilation nesting rather than matching text, runs in under
  a second, and is wired into `just ios ci` and the iOS workflow — a Release
  build proves the same thing but only by compiling WhisperKit twice.
- `just ios release-build` compiles with DEBUG undefined and is the wider version
  of the same check.

## Verification

- Debug build green.
- Release build with DEBUG undefined links clean.
- All **408** tests pass.
- The isolation checker was tested in both directions: a deliberately planted
  leak is caught, and fixing that test exposed a real bug in the checker itself
  (`all()` over an empty stack is `True`, so files with no conditionals were
  being treated as debug-only).

**Not verified:** whether each canvas *renders* correctly. That needs Xcode open,
and it is the first thing to do before the size-and-direction pass.
