### PR TITLE
Make F-Droid APK reproducible and release version 0.1.0-beta.13

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.vocahq.vocaphone"
         minSdk = 33
         targetSdk = 36
-        versionCode = 12
-        versionName = "0.1.0-beta.12"
+        versionCode = 13
+        versionName = "0.1.0-beta.13"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/android/app/src/main/cpp/whisper/CMakeLists.txt
+++ b/android/app/src/main/cpp/whisper/CMakeLists.txt
@@ -4,6 +4,9 @@ project(vocaphone_whisper)
 
 set(CMAKE_CXX_STANDARD 17)
 set(WHISPER_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../third_party/whisper.cpp)
+# Normalised away from the ".." segments, because -ffile-prefix-map below has to
+# match the path the compiler actually receives, and that one is always resolved.
+get_filename_component(WHISPER_LIB_DIR "${WHISPER_LIB_DIR}" ABSOLUTE)
 
 if(NOT EXISTS "${WHISPER_LIB_DIR}/src/whisper.cpp")
     message(FATAL_ERROR "whisper.cpp source is missing from android/third_party/whisper.cpp")
@@ -24,6 +27,42 @@ set(SOURCE_FILES
 
 find_library(LOG_LIB log)
 include(FetchContent)
+
+# Reproducible builds. F-Droid recompiles this native code on its own
+# buildserver and compares the result byte for byte with the APK we sign, so
+# nothing here may depend on where the checkout happens to sit or on what the
+# builder's git can tell us. Three things did, and all three land in .rodata,
+# where stripping cannot reach them:
+#
+#  1. GGML_ABORT and WHISPER_ASSERT expand to __FILE__, so every translation
+#     unit carried the compiling machine's absolute source path.
+#  2. clang records a source location per OpenMP region and does *not* apply
+#     -ffile-prefix-map to those strings, so they carried the path too. ggml
+#     has a complete non-OpenMP path -- its own thread pool in ggml-cpu.c,
+#     which is what upstream's own Android example builds -- so this drops
+#     OpenMP rather than shipping a library nobody else can reproduce. It also
+#     drops libomp.so from the APK.
+#  3. ggml runs `git rev-parse --short HEAD` at configure time and bakes the
+#     answer into libggml-base.so as GGML_COMMIT. An abbreviated hash is only
+#     as long as the local object count requires, so two correct checkouts of
+#     the same commit disagree -- ours prints eight characters, a partial clone
+#     may print seven. Seeding GIT_EXE makes ggml's find_program a no-op, which
+#     leaves the version we parsed from whisper.cpp's own CMakeLists standing.
+#
+# These have to be set here, at directory scope and before ggml is pulled in,
+# so that they cover ggml's targets as well as ours.
+add_compile_options(
+    -ffile-prefix-map=${WHISPER_LIB_DIR}=/whisper.cpp
+    -ffile-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=/vocaphone
+    -ffile-prefix-map=${CMAKE_BINARY_DIR}=/build
+    -no-canonical-prefixes
+)
+if(DEFINED ANDROID_NDK)
+    add_compile_options(-ffile-prefix-map=${ANDROID_NDK}=/ndk)
+endif()
+set(GGML_OPENMP OFF CACHE BOOL "" FORCE)
+set(GIT_EXE "" CACHE FILEPATH "Disabled: ggml must not read git for GGML_COMMIT" FORCE)
+set(GGML_BUILD_COMMIT "whisper-v${WHISPER_VERSION}")
 
 # One library, built for the architecture baseline every device of an ABI is
 # guaranteed to have.

--- a/fdroid/com.vocahq.vocaphone.yml
+++ b/fdroid/com.vocahq.vocaphone.yml
@@ -10,6 +10,16 @@
 # alignment is defined in gradle/gradle-daemon-jvm.properties and in
 # android/app/build.gradle.kts compileOptions; do not change the compiling JDK
 # without reviewing this file first.
+#
+# The fragile half is the whisper/ggml code this flavour compiles from source:
+# it is the only part of the APK that is not already byte-identical between two
+# machines. android/app/src/main/cpp/whisper/CMakeLists.txt keeps it that way by
+# rewriting __FILE__ prefixes, building ggml without OpenMP, and refusing to let
+# ggml read a commit hash out of git. Changing any of those three, or the pinned
+# ndk below, needs a two-path rebuild before it is tagged.
+#
+# 0.1.0-beta.12 is deliberately absent: it was published before those fixes, so
+# its binary cannot be reproduced by anyone, including us.
 
 Categories:
   - Keyboard & IME
@@ -26,11 +36,13 @@ AutoName: VocaPhone
 
 RepoType: git
 Repo: https://github.com/VocaHQ/vocaphone.git
+Binaries: https://github.com/VocaHQ/vocaphone/releases/download/v%v/vocaphone-fdroid.apk
 
 Builds:
-  - versionName: 0.1.0-beta.12
-    versionCode: 12
-    commit: e5ec259acc17e295262d8fe2d33db1223341826c
+
+  - versionName: 0.1.0-beta.13
+    versionCode: 13
+    commit: v0.1.0-beta.13
     subdir: android
     submodules: true
     gradle:
@@ -47,7 +59,9 @@ Builds:
       - web
     ndk: 27.2.12479018
 
+AllowedAPKSigningKeys: e6131446f8afeff13516f78036db9ea26aaa16e01b39f37182bf262ccd1d45b0
+
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 0.1.0-beta.12
-CurrentVersionCode: 12
+CurrentVersion: 0.1.0-beta.13
+CurrentVersionCode: 13


### PR DESCRIPTION
## What changed

This is fixes for reproducible builds. F-Droid recompiles this native code on its own buildserver and compares the result byte for byte with the APK we sign. We are making changes that can fix this and bum apk version.