### PR TITLE
Move iOS signing to team 92962VK378 and group.com.vocahq

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ consistently in the Xcode project configuration and entitlements:
 - `com.vocahq.vocaphone`
 - `com.vocahq.vocaphone.keyboard`
 - `com.vocahq.vocaphone.liveactivity`
-- `group.com.vocahq.vocaphone`
+- `group.com.vocahq`
 
 Then:
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -16,7 +16,8 @@ identifiers. The following are the final identifiers in use:
 | iOS app bundle ID | `com.vocahq.vocaphone` |
 | iOS keyboard bundle ID | `com.vocahq.vocaphone.keyboard` |
 | iOS Live Activity bundle ID | `com.vocahq.vocaphone.liveactivity` |
-| iOS App Group | `group.com.vocahq.vocaphone` |
+| iOS App Group | `group.com.vocahq` |
+| iOS development team | `92962VK378` |
 | iOS URL scheme | `vocaphone://dictate` |
 | Android application ID | `com.vocahq.vocaphone` |
 | LaunchAgent label | `com.vocahq.vocaphone.gateway` |
@@ -24,8 +25,9 @@ identifiers. The following are the final identifiers in use:
 | Docker image tag | `vocaphone-gateway` |
 | Docker volume | `vocaphone_vocaphone-data` |
 
-Apple Developer portal registration of these bundle identifiers and App Group
-under the existing team is a required follow-up.
+Register the bundle identifiers and App Group on team `92962VK378`. The older
+group (`group.com.vocahq.vocaphone`) belongs to another team and cannot be
+reused here.
 
 Native gateway startups migrate a missing vocaphone bootstrap token (and
 WebUI config) from the Local Flow paths once, and the LaunchAgent/systemd

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -843,19 +843,19 @@
 				LastUpgradeCheck = 2600;
 				TargetAttributes = {
 					2439C57D534B9770D35D98EE = {
-						DevelopmentTeam = A83WCPTTT9;
+						DevelopmentTeam = 92962VK378;
 						ProvisioningStyle = Automatic;
 					};
 					25EE7CD122403ED0C22EE2DE = {
-						DevelopmentTeam = A83WCPTTT9;
+						DevelopmentTeam = 92962VK378;
 						ProvisioningStyle = Automatic;
 					};
 					8064393ED94ED8E4DF68D37C = {
-						DevelopmentTeam = A83WCPTTT9;
+						DevelopmentTeam = 92962VK378;
 						ProvisioningStyle = Automatic;
 					};
 					B1FFCB59AB3A9C83423539EC = {
-						DevelopmentTeam = A83WCPTTT9;
+						DevelopmentTeam = 92962VK378;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -1370,7 +1370,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 17;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = A83WCPTTT9;
+				DEVELOPMENT_TEAM = 92962VK378;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -1439,7 +1439,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 17;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = A83WCPTTT9;
+				DEVELOPMENT_TEAM = 92962VK378;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;

--- a/ios/VocaPhoneApp/VocaPhoneApp.entitlements
+++ b/ios/VocaPhoneApp/VocaPhoneApp.entitlements
@@ -4,7 +4,7 @@
 <dict>
   <key>com.apple.security.application-groups</key>
   <array>
-    <string>group.com.vocahq.vocaphone</string>
+    <string>group.com.vocahq</string>
   </array>
 </dict>
 </plist>

--- a/ios/VocaPhoneKeyboard/VocaPhoneKeyboard.entitlements
+++ b/ios/VocaPhoneKeyboard/VocaPhoneKeyboard.entitlements
@@ -4,7 +4,7 @@
 <dict>
   <key>com.apple.security.application-groups</key>
   <array>
-    <string>group.com.vocahq.vocaphone</string>
+    <string>group.com.vocahq</string>
   </array>
 </dict>
 </plist>

--- a/ios/VocaPhoneLiveActivity/VocaPhoneLiveActivity.entitlements
+++ b/ios/VocaPhoneLiveActivity/VocaPhoneLiveActivity.entitlements
@@ -4,7 +4,7 @@
 <dict>
   <key>com.apple.security.application-groups</key>
   <array>
-    <string>group.com.vocahq.vocaphone</string>
+    <string>group.com.vocahq</string>
   </array>
 </dict>
 </plist>

--- a/ios/VocaPhoneShared/AppConfiguration.swift
+++ b/ios/VocaPhoneShared/AppConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum AppConfiguration {
-    static let appGroupIdentifier = "group.com.vocahq.vocaphone"
+    static let appGroupIdentifier = "group.com.vocahq"
     /// Must match `VocaPhoneKeyboard`'s `PRODUCT_BUNDLE_IDENTIFIER` in
     /// `project.yml`. Only used to spot the keyboard in the user's enabled
     /// list, so drift degrades guided setup rather than breaking dictation.

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -12,7 +12,7 @@ settings:
     MARKETING_VERSION: 0.1.0
     TARGETED_DEVICE_FAMILY: "1"
     CODE_SIGN_STYLE: Automatic
-    DEVELOPMENT_TEAM: A83WCPTTT9
+    DEVELOPMENT_TEAM: 92962VK378
 packages:
   WhisperKit:
     url: https://github.com/argmaxinc/WhisperKit.git


### PR DESCRIPTION
## Summary

The iOS project was signed as team `A83WCPTTT9` with App Group `group.com.vocahq.vocaphone`. That group already belongs to another Apple team, so it cannot be registered on `92962VK378` (Jatin Kumar Malik), which is the account that will publish the App Store build.

This account already has `group.com.vocahq` in the developer portal. The change points Automatic signing and the three entitlements at those values. Bundle IDs stay `com.vocahq.vocaphone`, `.keyboard`, and `.liveactivity`.

A device that still has the old build installed will not share keyboard state with this one. Delete the old app first; the new group is a different container.

## Verification

- [ ] `just ios ci` (not run here: Linux checkout, no Xcode)
- [x] `just android ci` (skipped: Android is untouched)
- [x] Gateway changes (skipped: no `server/` pin change)
- [ ] Physical-device test (App Group and team changed; needs a fresh install once the three App IDs exist on this team)

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added. Team IDs and App Group names are public identifiers.
- [x] `docs/decisions.md` and the README identifier list updated