### PR TITLE
docs: align public copy with on-device-first product story

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,7 @@ iOS was skipped. You can also run the workflow manually under Actions → PR Bui
 ## License
 
 Contributions are licensed under the [GNU Affero General Public License v3.0](LICENSE)
-(AGPL-3.0), the same family of copyleft license used by
-[VocaMac](https://github.com/VocaHQ/vocamac) (AGPL-3.0) and
-[VocaLinux](https://github.com/VocaHQ/vocalinux) (GPL-3.0). By opening a pull
+(AGPL-3.0), the same license used by
+[VocaMac](https://github.com/VocaHQ/vocamac) and
+[VocaLinux](https://github.com/VocaHQ/vocalinux) (both AGPL-3.0). By opening a pull
 request, you agree that your contribution may be distributed under that license.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 **Voice dictation for iPhone and Android.**
 
-[![Status: in development](https://img.shields.io/badge/status-in%20development-yellow)](#status)
+[![Status: Android beta / iOS source](https://img.shields.io/badge/status-Android%20beta%20%2F%20iOS%20source-yellow)](#status)
 [![Platform: iOS + Android](https://img.shields.io/badge/platform-iOS%20%2B%20Android-lightgrey)](#how-it-works)
-[![Privacy: self-hosted](https://img.shields.io/badge/privacy-self--hosted%20%2F%20no%20cloud%20STT-success)](#privacy-and-platform-boundaries)
+[![Privacy: on-device / optional gateway](https://img.shields.io/badge/privacy-on--device%20%2F%20optional%20gateway-success)](#privacy-and-platform-boundaries)
 [![Part of VocaHQ](https://img.shields.io/badge/family-VocaHQ-1a7f4e)](https://github.com/VocaHQ)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
@@ -20,8 +20,11 @@
 [![Discord](https://img.shields.io/discord/1538633755877580810?logo=discord&logoColor=white&label=Discord)](https://discord.gg/UMJduhcqn)
 [![VocaHQ](https://img.shields.io/badge/VocaHQ-vocahq.com-1a7f4e)](https://vocahq.com)
 
-Speak into your phone. Text shows up where you're typing. Transcription runs on
-hardware you control, not a cloud speech service.
+Speak into your phone. Text shows up where you're typing. Speech-to-text runs
+on your phone by default, or on optional self-hosted VocaGateway — never a cloud
+speech service.
+
+Product site: [vocaphone.vocahq.com](https://vocaphone.vocahq.com)
 
 </div>
 
@@ -35,18 +38,20 @@ the same privacy-first dictation idea that already runs on Linux
 Longer term the goal is straightforward: set Voca up once and use it across
 whatever machines you own. Desktop plus phone is what makes that real.
 
-Dictate from an iPhone or VocaPhone Android keyboard. Audio goes to a
-gateway on your Mac, Linux box, or home server. Local speech models turn it into
-text, and the transcript lands at your cursor. No accounts, no cloud STT, and no
-subscription.
+Dictate from an iPhone or VocaPhone Android keyboard. Download an on-device
+speech-to-text model and transcription stays on the phone. Or point the app at
+optional [VocaGateway](https://github.com/VocaHQ/vocagateway) on a Mac, Linux
+box, or home server you control when you want larger models or shared compute.
+Text lands at your cursor. No accounts, no cloud STT, and no subscription.
+Gateway mode is self-hosted, but it is not on-device.
 
 ## Status
 
 | Client | State |
 | --- | --- |
-| **iOS** | End-to-end flow exercised on a physical iPhone 14 Pro: keyboard handoff, background recording, private Tailscale transcription, direct insertion |
-| **Android** | IME-only release path builds, passes unit tests/lint, and has been installed and selected on a physical Android device |
-| **Gateway** | Runs natively on macOS/Linux or via Docker Compose, with multiple local engine adapters |
+| **Android** | Public beta for Android 13+ — [releases](https://github.com/VocaHQ/vocaphone/releases) · [vocaphone.vocahq.com](https://vocaphone.vocahq.com) |
+| **iOS** | Build from source for iOS 17+ (Mac, Xcode, signing team, physical iPhone) · [iPhone guide](https://vocaphone.vocahq.com/iphone/) |
+| **Gateway** | Optional. Self-host [VocaGateway](https://github.com/VocaHQ/vocagateway) on macOS/Linux or Docker when you want more models or shared compute |
 
 Licensed under [AGPL-3.0](LICENSE): free to use, study, modify, and share, with
 copyleft that also covers modified versions offered as a network service.
@@ -61,29 +66,33 @@ minutes so most later dictations skip another app switch.
 
 On Android, VocaPhone is a normal system keyboard. Select it when you want to
 dictate; it inserts through Android's `InputConnection` with the same styles and
-gateway as iOS.
+transcription choices as iOS.
 
-Both clients send recoverable audio to the same private gateway and insert the
-final transcript at the active cursor.
+Both clients can run speech-to-text on the phone after a model download, or send
+recoverable audio to optional VocaGateway. Either way, the transcript inserts at
+the active cursor. A gateway is never required for on-device mode.
 
 > [!IMPORTANT]
 > iOS keyboard extensions cannot access the microphone. vocaphone records in
 > the containing app, shares only versioned session state with the keyboard, and
 > then inserts through `UITextDocumentProxy`. Quick Dictation can keep that app
 > ready for up to 10 minutes so most later dictations do not require another app
-> switch.
+> switch. The speech-to-text model still runs on the iPhone in on-device mode.
 
 ## Why vocaphone
 
 Most phone dictation means either a cloud API listening to every utterance, or
 an app that only works inside itself. vocaphone is built differently.
 
-Transcription runs on a Mac, Linux desktop, or home server you already own, not
-a vendor's GPU farm. You pick the network path: trusted LAN, private Tailscale,
-or HTTPS behind your own reverse proxy. Bearer tokens are per device. There is
-no analytics SDK and no third-party transcription.
+On-device transcription is the default path: download a speech-to-text model once
+and dictate without a gateway or network. Optional VocaGateway runs on a Mac,
+Linux desktop, or home server you already own when you want larger models or
+shared compute. That path is self-hosted, not on-device. For gateway mode you pick
+the network path: trusted LAN, private Tailscale, or HTTPS behind your own
+reverse proxy. Bearer tokens are per device. There is no analytics SDK and no
+third-party transcription.
 
-Same privacy stance as VocaLinux and VocaMac: free, offline first, and meant to
+Same privacy stance as VocaLinux and VocaMac: free, on-device first, and meant to
 stay that way. We also document the awkward platform bits honestly: iOS keyboard
 limits and Android's keyboard/input-method boundaries.
 
@@ -137,15 +146,18 @@ limits and Android's keyboard/input-method boundaries.
 
 | Platform | Project | Repo | Status |
 | --- | --- | --- | --- |
-| Linux | VocaLinux | [VocaHQ/vocalinux](https://github.com/VocaHQ/vocalinux) | Stable |
+| Linux | VocaLinux | [VocaHQ/vocalinux](https://github.com/VocaHQ/vocalinux) | Available now |
 | macOS | VocaMac | [VocaHQ/vocamac](https://github.com/VocaHQ/vocamac) | Beta |
 | Windows | VocaWin | [VocaHQ/vocawin](https://github.com/VocaHQ/vocawin) | Coming soon |
-| iOS / Android | vocaphone | [VocaHQ/vocaphone](https://github.com/VocaHQ/vocaphone) | In development |
+| iOS / Android | vocaphone | [VocaHQ/vocaphone](https://github.com/VocaHQ/vocaphone) | Android beta / iOS source build · [site](https://vocaphone.vocahq.com) |
 
 Org: [github.com/VocaHQ](https://github.com/VocaHQ). Contact:
 [hello@vocahq.com](mailto:hello@vocahq.com)
 
 ## Choose a gateway deployment
+
+On-device mode needs no gateway. Use this section only when you want optional
+VocaGateway for larger models or shared compute.
 
 | Deployment | Best for | Speech engine | Expected performance |
 | --- | --- | --- | --- |
@@ -434,8 +446,8 @@ adb install -r app/build/outputs/apk/full/debug/vocaphone-fullDebug.apk
 ```
 
 In the app: grant microphone and notifications, enable and select VocaPhone in
-Android's keyboard settings, then enter the gateway address and bearer token from
-step 4 and run **Test connection**.
+Android's keyboard settings, then either download an on-device model or enter the
+gateway address and bearer token from step 4 and run **Test connection**.
 
 See the [Android client guide](android/README.md) for keyboard setup and the
 supported gateway address forms.
@@ -535,9 +547,8 @@ public issue.
 
 vocaphone is licensed under the **GNU Affero General Public License v3.0**
 ([AGPL-3.0](LICENSE)), matching [VocaMac](https://github.com/VocaHQ/vocamac) and
-staying in the same copyleft family as
-[VocaLinux](https://github.com/VocaHQ/vocalinux) (GPL-3.0).
+[VocaLinux](https://github.com/VocaHQ/vocalinux) (both AGPL-3.0).
 
 You may use, study, modify, and redistribute the software under AGPL-3.0. Because
-vocaphone includes a network gateway, AGPL also requires that modified versions
-offered as a network service make their corresponding source available.
+vocaphone includes an optional network gateway, AGPL also requires that modified
+versions offered as a network service make their corresponding source available.

--- a/android/README.md
+++ b/android/README.md
@@ -1,13 +1,16 @@
 # vocaphone for Android
 
-A native Android voice keyboard for the same self-hosted vocaphone gateway the
-iPhone app uses. VocaPhone appears as a normal Android input method: Gboard,
-Samsung Keyboard and other keyboards remain available, while VocaPhone can be
-selected whenever you want to dictate into an editable field. It inserts through
-Android's `InputConnection` and does not read the field.
+A native Android voice keyboard for private speech-to-text on your phone, with
+optional [VocaGateway](https://github.com/VocaHQ/vocagateway) for shared or
+larger compute — the same product as the iPhone app. VocaPhone appears as a
+normal Android input method: Gboard, Samsung Keyboard and other keyboards remain
+available, while VocaPhone can be selected whenever you want to dictate into an
+editable field. It inserts through Android's `InputConnection` and does not read
+the field.
 
-Distributed as a private APK. Google Play publication is deferred. The shipped
-APK does not request accessibility-service or overlay access.
+Android 13+ public beta APKs ship from GitHub Releases. Google Play publication
+is deferred. The shipped APK does not request accessibility-service or overlay
+access.
 
 > Package name and application ID have been updated to `com.vocahq.vocaphone`; the APK
 > output is `vocaphone-debug.apk`.
@@ -15,7 +18,8 @@ APK does not request accessibility-service or overlay access.
 ## Requirements
 
 - Android 13 (API 33) or newer. Google Pixel is the baseline device.
-- A reachable vocaphone gateway, unless you choose on-device transcription.
+- An on-device speech-to-text model, or a reachable VocaGateway if you choose that
+  path.
 - To build: JDK 21 exactly (the JDK bundled with current Android Studio works;
   other machines auto-provision it from `gradle/gradle-daemon-jvm.properties`).
   The version matters because F-Droid rebuilds the app on JDK 21 and

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -25,4 +25,4 @@ The keyboard writes through InputConnection and never reads the contents of the 
 
 The build distributed here is compiled entirely from source. It leaves out the optional sherpa-onnx speech engine, which upstream ships as a prebuilt binary library, so on-device transcription uses the Whisper model catalog. Gateway transcription is unaffected and can use any engine your gateway supports. On supported builds, sherpa-onnx models such as Parakeet are available alongside Whisper.
 
-VocaPhone is part of the Voca family alongside VocaLinux and VocaMac, and is in active development. Expect rough edges and please report them on the issue tracker.
+VocaPhone is part of the Voca family alongside VocaLinux and VocaMac. Android is in public beta; expect rough edges and please report them on the issue tracker.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Visitor-facing copy still told the old gateway-required story. The live site and PRODUCT.md (verified 2026-08-14) are on-device first, with VocaGateway optional and never described as on-device. This PR only updates public docs/status wording. No code or architecture-doc rewrites. Leaves open PR #101 alone.

Sources of truth: [PRODUCT.md](https://github.com/VocaHQ/vocahq/blob/main/PRODUCT.md), [vocaphone.vocahq.com](https://vocaphone.vocahq.com).

## Copy changes

### `README.md`
- Status badge: `in development` → `Android beta / iOS source`
- Privacy badge: `self-hosted / no cloud STT` → `on-device / optional gateway`
- Hero blurb: on-device default + optional VocaGateway; link to https://vocaphone.vocahq.com
- Intro: replace "Audio goes to a gateway on your Mac…" with on-device first / gateway optional; state that gateway mode is not on-device
- Status table: Android 13+ public beta, iOS 17+ source build, gateway optional (replaces device-lab "in development" rows)
- How it works: both clients can transcribe on-device or via optional VocaGateway; gateway not required for on-device
- Keep the honest iOS keyboard microphone limitation; note on-device STT still runs on the iPhone
- Why vocaphone: on-device default; gateway self-hosted but not on-device
- Family table: VocaLinux `Available now`; vocaphone `Android beta / iOS source build` + site link
- Gateway deployment section: one-line note that on-device needs no gateway
- Android quick start: download on-device model **or** configure gateway
- License blurb: VocaLinux AGPL-3.0 (was GPL-3.0); gateway called optional

### `CONTRIBUTING.md`
- License note: VocaLinux AGPL-3.0 (was GPL-3.0)

### `android/README.md`
- Lead: on-device first with optional VocaGateway (was gateway-first)
- Status: Android 13+ public beta from GitHub Releases
- Requirements: on-device model first; gateway only if chosen

### `fastlane/metadata/android/en-US/full_description.txt`
- Closing line: Android public beta (was "in active development")

## Left alone on purpose
- `web/` already matches the live site
- Gateway implementation / deployment docs (including `server/` paths touched by #101)
- Architecture docs
- No invented versions, star counts, TestFlight, or App Store claims
- AGPL-3.0 for this repo unchanged

## Verification

- [x] Docs-only: `just ios ci` / `just android ci` not applicable
- [x] Gateway submodule: unchanged
- [x] Physical-device test: not applicable
- [x] Grep check: old gateway-required / `in development` / VocaLinux `GPL-3.0` strings gone from touched visitor docs

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for the public privacy story (on-device default; gateway optional and not on-device)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b55f33b-4f4c-476d-a368-195d44174e0b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b55f33b-4f4c-476d-a368-195d44174e0b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

