### PR TITLE
ci: add security scanning and build-size trend tracking

### DIFF
--- a/.github/actions/report-size/action.yml
+++ b/.github/actions/report-size/action.yml
@@ -1,0 +1,119 @@
+name: Report build size
+description: >
+  Compares a component's build size against the most recent size recorded on
+  main and writes the delta to the job summary and, when the token allows it,
+  a pull request comment. On a push to main it also records the new size so
+  the next comparison has something to diff against.
+
+inputs:
+  component:
+    description: Short id used as the cache key and comment marker, e.g. android, ios, web.
+    required: true
+  label:
+    description: Human-readable name shown in the report, e.g. "Android debug APK".
+    required: true
+  bytes:
+    description: Current size of the build output, in bytes.
+    required: true
+  github-token:
+    description: Token used to read/write the pull request comment.
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Restore size history
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.temp }}/size-history-${{ inputs.component }}.json
+        # No run ever saves this exact key, so restore always falls through to
+        # the newest match under restore-keys — the point is to read main's
+        # last recorded size, not this run's own (nonexistent) entry.
+        key: size-history-${{ inputs.component }}-none
+        restore-keys: |
+          size-history-${{ inputs.component }}-
+
+    - name: Compare against the last recorded size
+      id: report
+      shell: bash
+      env:
+        HISTORY_FILE: ${{ runner.temp }}/size-history-${{ inputs.component }}.json
+        REPORT_FILE: ${{ runner.temp }}/size-report-${{ inputs.component }}.md
+        LABEL: ${{ inputs.label }}
+        BYTES: ${{ inputs.bytes }}
+      run: |
+        set -euo pipefail
+        python3 "${{ github.action_path }}/compare.py" \
+          --history-file "$HISTORY_FILE" \
+          --bytes "$BYTES" \
+          --label "$LABEL" \
+          --out "$REPORT_FILE" \
+          >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Update the pull request comment
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      env:
+        COMPONENT: ${{ inputs.component }}
+        REPORT_FILE: ${{ runner.temp }}/size-report-${{ inputs.component }}.md
+      with:
+        # A fork pull request gets a read-only token even though this step's
+        # job declares pull-requests: write, so posting can 403. That's a
+        # permissions gap in this run, not a broken report — the size is
+        # already in the job summary above, so swallow the failure instead of
+        # failing the whole job over a comment.
+        script: |
+          const fs = require('fs');
+          const marker = `<!-- vocaphone-size-report:${process.env.COMPONENT} -->`;
+          const body = `${marker}\n${fs.readFileSync(process.env.REPORT_FILE, 'utf8')}`;
+          try {
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100
+            });
+            const existing = comments.find(c => c.body && c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body
+              });
+            }
+          } catch (err) {
+            core.warning(`Could not post the size report comment (likely a fork PR's read-only token): ${err.message}`);
+          }
+
+    - name: Record size on main
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      shell: bash
+      env:
+        HISTORY_FILE: ${{ runner.temp }}/size-history-${{ inputs.component }}.json
+        BYTES: ${{ inputs.bytes }}
+        SHA: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+        python3 "${{ github.action_path }}/record.py" \
+          --history-file "$HISTORY_FILE" \
+          --bytes "$BYTES" \
+          --sha "$SHA"
+
+    - name: Save size history
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.temp }}/size-history-${{ inputs.component }}.json
+        # A cache key is immutable once written, so each run on main gets its
+        # own key and the restore step's restore-keys prefix finds the newest
+        # one — the same pattern quality-android.yml's Gradle cache uses.
+        key: size-history-${{ inputs.component }}-${{ github.sha }}

--- a/.github/actions/report-size/action.yml
+++ b/.github/actions/report-size/action.yml
@@ -58,6 +58,7 @@ runs:
         COMPONENT: ${{ inputs.component }}
         REPORT_FILE: ${{ runner.temp }}/size-report-${{ inputs.component }}.md
       with:
+        github-token: ${{ inputs.github-token }}
         # A fork pull request gets a read-only token even though this step's
         # job declares pull-requests: write, so posting can 403. That's a
         # permissions gap in this run, not a broken report — the size is

--- a/.github/actions/report-size/compare.py
+++ b/.github/actions/report-size/compare.py
@@ -6,7 +6,12 @@ import os
 
 def human(n):
     sign = "-" if n < 0 else ""
-    return f"{sign}{abs(n) / 1024:.1f} KiB"
+    n = float(abs(n))
+    for unit in ("B", "KB", "MB", "GB"):
+        if n < 1024 or unit == "GB":
+            return f"{sign}{int(n)} {unit}" if unit == "B" else f"{sign}{n:.1f} {unit}"
+        n /= 1024
+    return f"{sign}{n:.1f} GB"  # unreachable, satisfies static analysis
 
 
 def main():

--- a/.github/actions/report-size/compare.py
+++ b/.github/actions/report-size/compare.py
@@ -1,0 +1,57 @@
+"""Format a size comparison against the last entry recorded on main."""
+import argparse
+import json
+import os
+
+
+def human(n):
+    sign = "-" if n < 0 else ""
+    return f"{sign}{abs(n) / 1024:.1f} KiB"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--history-file")
+    parser.add_argument("--bytes", type=int, required=True)
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    prev_bytes = None
+    if args.history_file and os.path.exists(args.history_file):
+        try:
+            with open(args.history_file) as f:
+                history = json.load(f)
+            if history:
+                prev_bytes = history[-1]["bytes"]
+        except (json.JSONDecodeError, KeyError, IndexError):
+            prev_bytes = None
+
+    lines = [f"### {args.label} size", ""]
+    if prev_bytes is not None:
+        delta = args.bytes - prev_bytes
+        pct = (delta / prev_bytes * 100) if prev_bytes else 0.0
+        lines += [
+            "| | |",
+            "|---|---|",
+            f"| Current | {human(args.bytes)} |",
+            f"| main (last recorded) | {human(prev_bytes)} |",
+            f"| Change | {'+' if delta >= 0 else ''}{human(delta)} ({pct:+.2f}%) |",
+        ]
+    else:
+        lines += [
+            "No recorded size on main yet — nothing to compare against.",
+            "",
+            "| | |",
+            "|---|---|",
+            f"| Current | {human(args.bytes)} |",
+        ]
+
+    text = "\n".join(lines) + "\n"
+    with open(args.out, "w") as f:
+        f.write(text)
+    print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/report-size/compare.py
+++ b/.github/actions/report-size/compare.py
@@ -29,7 +29,11 @@ def main():
                 history = json.load(f)
             if history:
                 prev_bytes = history[-1]["bytes"]
-        except (json.JSONDecodeError, KeyError, IndexError):
+        except (json.JSONDecodeError, KeyError, IndexError, TypeError):
+            # TypeError covers valid JSON that isn't the list-of-entries shape
+            # this file is supposed to hold (e.g. a stale or incompatible
+            # cache) - degrade to "no recorded size" like any other malformed
+            # history file instead of crashing the job.
             prev_bytes = None
 
     lines = [f"### {args.label} size", ""]

--- a/.github/actions/report-size/record.py
+++ b/.github/actions/report-size/record.py
@@ -1,0 +1,37 @@
+"""Append the current size to the history file recorded on main."""
+import argparse
+import datetime
+import json
+import os
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--history-file", required=True)
+    parser.add_argument("--bytes", type=int, required=True)
+    parser.add_argument("--sha", required=True)
+    args = parser.parse_args()
+
+    history = []
+    if os.path.exists(args.history_file):
+        try:
+            with open(args.history_file) as f:
+                history = json.load(f)
+        except json.JSONDecodeError:
+            history = []
+
+    history.append(
+        {
+            "sha": args.sha,
+            "date": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "bytes": args.bytes,
+        }
+    )
+
+    # Keep the file small - the comparison only ever reads the last entry.
+    with open(args.history_file, "w") as f:
+        json.dump(history[-50:], f)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/codeql-native.yml
+++ b/.github/workflows/codeql-native.yml
@@ -1,0 +1,105 @@
+name: CodeQL (native)
+
+# Kotlin and Swift both need a real compile to analyze, and a Swift compile
+# only happens on a macOS runner, which bills at ten times the Linux rate
+# (same reasoning as quality-ios.yml). Gating a full CodeQL build behind every
+# pull request would make that the most expensive check in the repo for no
+# proportionate benefit, so this runs after merge and once a week instead —
+# continuous coverage without taxing every review cycle. Semgrep
+# (semgrep.yml) covers Kotlin and Swift on pull requests instead, since it
+# needs no build.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'android/**'
+      - '!android/**.md'
+      - 'ios/**'
+      - '!ios/**.md'
+      - '.github/actions/setup-android/action.yml'
+      - '.github/workflows/codeql-native.yml'
+  schedule:
+    - cron: '32 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  HOMEBREW_NO_AUTO_UPDATE: '1'
+  HOMEBREW_NO_INSTALL_CLEANUP: '1'
+  HOMEBREW_NO_ENV_HINTS: '1'
+
+jobs:
+  android:
+    name: Kotlin/Java
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-android
+        with:
+          cache-read-only: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: java-kotlin
+          source-root: android
+          build-mode: manual
+
+      - name: Build (traced by CodeQL)
+        working-directory: android
+        run: ./gradlew assembleFullDebug
+
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: /language:java-kotlin
+
+  ios:
+    name: Swift
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: true
+          persist-credentials: false
+
+      - run: brew install xcodegen
+
+      - name: Generate Xcode project
+        working-directory: ios
+        run: xcodegen generate --spec project.yml
+
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: swift
+          source-root: ios
+          build-mode: manual
+
+      - name: Build (traced by CodeQL)
+        working-directory: ios
+        run: |
+          xcodebuild \
+            -project VocaPhone.xcodeproj \
+            -scheme VocaPhone \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath "${{ runner.temp }}/DerivedData" \
+            -disableAutomaticPackageResolution \
+            CODE_SIGNING_ALLOWED=NO \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            build
+
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: /language:swift

--- a/.github/workflows/codeql-web.yml
+++ b/.github/workflows/codeql-web.yml
@@ -1,0 +1,54 @@
+name: CodeQL (web)
+
+# JavaScript/TypeScript needs no build step to analyze, so this runs on every
+# pull request like the other quality gates. See codeql-native.yml for why
+# Kotlin and Swift analysis runs on a different schedule.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '!web/**.md'
+      - '.github/workflows/codeql-web.yml'
+  pull_request:
+    branches: [main]
+    # A draft pull request is filtered out below; listing ready_for_review makes
+    # the checks start the moment it stops being a draft.
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'web/**'
+      - '!web/**.md'
+      - '.github/workflows/codeql-web.yml'
+  schedule:
+    # Catches newly published CodeQL query packs even in a week nobody
+    # touches web/.
+    - cron: '17 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: javascript-typescript
+          source-root: web
+          build-mode: none
+
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/quality-android.yml
+++ b/.github/workflows/quality-android.yml
@@ -8,7 +8,7 @@ on:
       # Prose next to the code it documents cannot break the build.
       - '!android/**.md'
       - '.github/actions/setup-android/action.yml'
-      - '.github/actions/report-size/action.yml'
+      - '.github/actions/report-size/**'
       - '.github/workflows/quality-android.yml'
   pull_request:
     branches: [main]
@@ -19,7 +19,7 @@ on:
       - 'android/**'
       - '!android/**.md'
       - '.github/actions/setup-android/action.yml'
-      - '.github/actions/report-size/action.yml'
+      - '.github/actions/report-size/**'
       - '.github/workflows/quality-android.yml'
   workflow_dispatch:
 

--- a/.github/workflows/quality-android.yml
+++ b/.github/workflows/quality-android.yml
@@ -8,6 +8,7 @@ on:
       # Prose next to the code it documents cannot break the build.
       - '!android/**.md'
       - '.github/actions/setup-android/action.yml'
+      - '.github/actions/report-size/action.yml'
       - '.github/workflows/quality-android.yml'
   pull_request:
     branches: [main]
@@ -18,11 +19,16 @@ on:
       - 'android/**'
       - '!android/**.md'
       - '.github/actions/setup-android/action.yml'
+      - '.github/actions/report-size/action.yml'
       - '.github/workflows/quality-android.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
+  # Lets report-size post/update its size comment on same-repo pull requests.
+  # Fork pull requests get a read-only token regardless, which the action
+  # already tolerates.
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -54,3 +60,18 @@ jobs:
       - name: Fail if the checked-in Room schema is stale
         run: git diff --exit-code -- app/schemas
         working-directory: android
+
+      - name: Measure Android debug APK size
+        id: size
+        working-directory: android
+        run: |
+          set -euo pipefail
+          apk=app/build/outputs/apk/full/debug/vocaphone-fullDebug.apk
+          echo "bytes=$(stat -c%s "$apk")" >> "$GITHUB_OUTPUT"
+
+      - name: Report APK size vs. main
+        uses: ./.github/actions/report-size
+        with:
+          component: android
+          label: Android debug APK
+          bytes: ${{ steps.size.outputs.bytes }}

--- a/.github/workflows/quality-ios.yml
+++ b/.github/workflows/quality-ios.yml
@@ -160,9 +160,13 @@ jobs:
           DERIVED_DATA: ${{ runner.temp }}/DerivedData
         run: |
           set -euo pipefail
-          app=$(find "$DERIVED_DATA/Build/Products" -maxdepth 2 -name 'VocaPhone.app' | head -1)
+          # The app target is named VocaPhoneApp (see ios/project.yml), and
+          # nothing overrides PRODUCT_NAME, so the built bundle is
+          # VocaPhoneApp.app - not VocaPhone.app, which is only the scheme
+          # and .xcodeproj name.
+          app=$(find "$DERIVED_DATA/Build/Products" -maxdepth 2 -name 'VocaPhoneApp.app' | head -1)
           if [ -z "$app" ]; then
-            echo "No VocaPhone.app found under $DERIVED_DATA/Build/Products" >&2
+            echo "No VocaPhoneApp.app found under $DERIVED_DATA/Build/Products" >&2
             exit 1
           fi
           bytes=$(find "$app" -type f -exec stat -f%z {} + | awk '{sum += $1} END {print sum}')

--- a/.github/workflows/quality-ios.yml
+++ b/.github/workflows/quality-ios.yml
@@ -8,7 +8,7 @@ on:
       # Prose next to the code it documents cannot break the build, and macOS
       # minutes bill at ten times the Linux rate.
       - '!ios/**.md'
-      - '.github/actions/report-size/action.yml'
+      - '.github/actions/report-size/**'
       - '.github/workflows/quality-ios.yml'
   pull_request:
     branches: [main]
@@ -18,7 +18,7 @@ on:
     paths:
       - 'ios/**'
       - '!ios/**.md'
-      - '.github/actions/report-size/action.yml'
+      - '.github/actions/report-size/**'
       - '.github/workflows/quality-ios.yml'
   workflow_dispatch:
 

--- a/.github/workflows/quality-ios.yml
+++ b/.github/workflows/quality-ios.yml
@@ -8,6 +8,7 @@ on:
       # Prose next to the code it documents cannot break the build, and macOS
       # minutes bill at ten times the Linux rate.
       - '!ios/**.md'
+      - '.github/actions/report-size/action.yml'
       - '.github/workflows/quality-ios.yml'
   pull_request:
     branches: [main]
@@ -17,11 +18,16 @@ on:
     paths:
       - 'ios/**'
       - '!ios/**.md'
+      - '.github/actions/report-size/action.yml'
       - '.github/workflows/quality-ios.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
+  # Lets report-size post/update its size comment on same-repo pull requests.
+  # Fork pull requests get a read-only token regardless, which the action
+  # already tolerates.
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -147,3 +153,28 @@ jobs:
           path: ${{ runner.temp }}/VocaPhone.xcresult
           retention-days: 7
           if-no-files-found: ignore
+
+      - name: Measure app bundle size
+        id: size
+        env:
+          DERIVED_DATA: ${{ runner.temp }}/DerivedData
+        run: |
+          set -euo pipefail
+          app=$(find "$DERIVED_DATA/Build/Products" -maxdepth 2 -name 'VocaPhone.app' | head -1)
+          if [ -z "$app" ]; then
+            echo "No VocaPhone.app found under $DERIVED_DATA/Build/Products" >&2
+            exit 1
+          fi
+          bytes=$(find "$app" -type f -exec stat -f%z {} + | awk '{sum += $1} END {print sum}')
+          echo "bytes=$bytes" >> "$GITHUB_OUTPUT"
+
+      # This is the unsigned Debug-simulator build the tests above already
+      # produced, not the signed Release device build TestFlight ships — it
+      # moves with the code the same way a Release build would, at zero extra
+      # xcodebuild cost, which is what a trend comparison needs.
+      - name: Report app bundle size vs. main
+        uses: ./.github/actions/report-size
+        with:
+          component: ios
+          label: iOS app bundle (Debug, simulator)
+          bytes: ${{ steps.size.outputs.bytes }}

--- a/.github/workflows/quality-web.yml
+++ b/.github/workflows/quality-web.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - 'web/**'
       - '!web/**.md'
-      - '.github/actions/report-size/action.yml'
+      - '.github/actions/report-size/**'
       - '.github/workflows/quality-web.yml'
   pull_request:
     branches: [main]
@@ -16,7 +16,7 @@ on:
     paths:
       - 'web/**'
       - '!web/**.md'
-      - '.github/actions/report-size/action.yml'
+      - '.github/actions/report-size/**'
       - '.github/workflows/quality-web.yml'
   workflow_dispatch:
 

--- a/.github/workflows/quality-web.yml
+++ b/.github/workflows/quality-web.yml
@@ -1,0 +1,69 @@
+name: Quality (web)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '!web/**.md'
+      - '.github/actions/report-size/action.yml'
+      - '.github/workflows/quality-web.yml'
+  pull_request:
+    branches: [main]
+    # A draft pull request is filtered out below; listing ready_for_review makes
+    # the checks start the moment it stops being a draft.
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'web/**'
+      - '!web/**.md'
+      - '.github/actions/report-size/action.yml'
+      - '.github/workflows/quality-web.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Lets report-size post/update its size comment on same-repo pull requests.
+  # Fork pull requests get a read-only token regardless, which the action
+  # already tolerates.
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # A superseded pull request push is wasted minutes, but a run on main is the
+  # record for a merged commit, so let that one finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  web:
+    # Work in progress re-runs the checks on every push. The checks that
+    # matter run when the author marks the pull request ready.
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check site
+        working-directory: web
+        run: npm run check
+
+      - name: Measure page weight
+        id: size
+        working-directory: web
+        run: |
+          set -euo pipefail
+          # Only what a browser actually fetches: markup, script, styles, and
+          # images. package.json/README/robots.txt/sitemap.xml/tests are real
+          # files in the folder but never ship to a visitor.
+          bytes=$(find assets favicon.ico index.html iphone/index.html script.js site.webmanifest styles.css \
+            -type f -exec stat -c%s {} + | awk '{sum += $1} END {print sum}')
+          echo "bytes=$bytes" >> "$GITHUB_OUTPUT"
+
+      - name: Report page weight vs. main
+        uses: ./.github/actions/report-size
+        with:
+          component: web
+          label: Web site page weight
+          bytes: ${{ steps.size.outputs.bytes }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,62 @@
+name: Semgrep
+
+# Semgrep is pattern-based rather than a real compile, so it covers Kotlin
+# and Swift on every pull request at Linux-runner cost — the coverage
+# codeql-native.yml deliberately doesn't give PRs because a full compile on
+# every push would be the most expensive check in the repo (see the comment
+# there). This is a new check on an existing codebase: findings upload to the
+# Security tab but don't fail the build yet, so a backlog of pre-existing
+# findings doesn't block unrelated PRs on day one. Once that backlog is
+# triaged, add `--error` to the semgrep scan command below to start failing
+# builds on new findings.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    # A draft pull request is filtered out below; listing ready_for_review makes
+    # the check start the moment it stops being a draft.
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    - cron: '47 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  semgrep:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The server and whisper.cpp submodules are third-party/separate-repo
+          # code with their own review process; scan only what this repo owns.
+          persist-credentials: false
+
+      - name: Install Semgrep
+        env:
+          SEMGREP_VERSION: 1.173.0
+        run: pip install "semgrep==${SEMGREP_VERSION}"
+
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config p/security-audit \
+            --config p/secrets \
+            --config p/owasp-top-ten \
+            --sarif --output semgrep.sarif \
+            --metrics off
+
+      - uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        if: always()
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep


### PR DESCRIPTION
## Summary
- Add CodeQL: JS/TS runs on every PR (no build needed); Kotlin/Swift run on push-to-main + weekly instead of every PR, since a full compile-and-trace on a macOS runner for Swift would be the most expensive check in the repo for a per-PR gate.
- Add Semgrep (`p/security-audit`, `p/secrets`, `p/owasp-top-ten`) across the whole repo on every PR — cheap enough to cover Kotlin/Swift/JS on every review cycle, filling the gap CodeQL leaves at PR time. Findings upload to the Security tab but don't fail the build yet, so a pre-existing backlog doesn't block unrelated PRs on day one.
- Add a `report-size` composite action that compares each PR's Android/iOS/web build size against the last one recorded on `main` (via `actions/cache`, no bot commits) and posts the delta to the job summary and a PR comment. Wired into `quality-android.yml` and `quality-ios.yml` using builds they already produce, so it adds no build cost.
- Add `quality-web.yml`, which runs the existing `web/tests` suite on pull requests (previously it only ran after merge, via the Pages deploy) plus web page-weight tracking.

## Security audit (manual, not part of the diff)
Also did a manual read-only security pass over `android/`, `ios/`, and `web/`. No Critical/High findings. Two Medium items worth a follow-up, left untouched here since both are deliberate existing decisions:
- Android's `network_security_config.xml` trusts user-installed CA certs for all hosts, not just self-hosted/private ones.
- iOS's `PrivacyInfo.xcprivacy` declares zero collected data types despite the app shipping audio/transcripts off-device.

## Test plan
- [x] `actionlint` clean across all workflow files
- [x] `python3 -m py_compile` on the new `compare.py`/`record.py` helpers, plus a manual smoke test of both size-comparison output paths (with and without prior history)
- [ ] First real run on this PR will exercise `quality-android`/`quality-ios`/`quality-web`/`codeql-web`/`semgrep` end-to-end
- [ ] `codeql-native.yml` only runs on push-to-main/schedule, so it won't run on this PR — verify manually via `workflow_dispatch` after merge