### PR TITLE
fix: cross-reference to vocahq

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -767,7 +767,7 @@
         </div>
         <div>
           <p>say hello</p>
-          <a href="https://github.com/VocaHQ">VocaHQ</a>
+          <a href="https://vocahq.com">VocaHQ</a>
           <a href="mailto:hello@vocahq.com">hello@vocahq.com</a>
         </div>
       </nav>


### PR DESCRIPTION
## Summary

Add the link for vocahq in the footer

## Verification

- [ ] `just ios ci` (or note why not)
- [ ] `just android ci` (or note why not)
- [ ] Gateway changes: PR against [vocagateway](https://github.com/VocaHQ/vocagateway) and submodule pin updated here if needed
- [ ] Physical-device test, if keyboard, microphone, background audio, or insertion changed

Maintainers can comment `/build` on this PR for installable Android/iOS
artifacts (see CONTRIBUTING).

## Privacy and security

- [ ] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [ ] Documentation updated for data-flow, permission, retention, or network changes
