### PR TITLE
docs: leftover on-device-first copy after #103

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,84 @@ bumps and release tags.
 
 ## Quick start
 
-### 1. Start the gateway natively on macOS
+Download a speech-to-text model on the phone and dictate with no gateway. The
+gateway steps later in this section are optional, for larger models or shared
+compute.
+
+### 1. Configure and install the iPhone app
+
+The Simulator needs no Apple account at all:
+
+```sh
+cd ios
+just doctor   # checks Xcode, xcodegen, and a simulator runtime are present
+just run      # generates the project, builds, boots a simulator, installs, launches
+```
+
+`ios/project.yml` is the real project source; `just run` (and every other iOS
+recipe) regenerates `VocaPhone.xcodeproj` from it before building, so don't
+hand-edit the `.xcodeproj`. Prefer working in Xcode itself? `just edit` does
+the same regeneration, then opens it.
+
+Add the keyboard the same way you would on a device: `just settings` opens
+iOS Settings on the simulator, then **General → Keyboard → Keyboards → Add
+New Keyboard → vocaphone**, with **Allow Full Access** turned on (see
+[privacy.md](docs/privacy.md#full-access) for exactly what that is and isn't
+used for). Typing, autocorrect, and swipe work immediately. For actual
+dictation, **Settings → Transcription → On this iPhone** plus a downloaded
+model is the fastest path with nothing else to configure, or point
+**Settings → Transcription → Gateway** at a gateway from the optional steps below.
+
+**On your own iPhone** (`just device`, phone connected and trusted): code
+signing has to already work in Xcode first. The project ships with VocaHQ's
+own identifiers (`com.vocahq.vocaphone` and friends, team `92962VK378` — see
+[decisions.md](docs/decisions.md)). If you have access to that team, select
+it on all three targets (VocaPhoneApp, VocaPhoneKeyboard,
+VocaPhoneLiveActivity) under **Signing & Capabilities**; automatic signing
+does the rest. If you don't — most outside contributors — either ask a
+maintainer to comment `/build ios` on your pull request for a signed ad-hoc
+IPA (see [CONTRIBUTING.md](CONTRIBUTING.md#on-demand-pr-builds-build)), or run
+it under your own free Apple ID by changing `bundleIdPrefix` and the three
+`PRODUCT_BUNDLE_IDENTIFIER`s in `ios/project.yml`, the App Group string in all
+three `.entitlements` files, and `AppConfiguration.swift`'s
+`appGroupIdentifier`/`keyboardBundleIdentifier` — don't commit that change.
+
+Grant microphone access on first launch, add the keyboard as above, and turn
+on Full Access. Complete the physical-device checklist in [device
+setup](docs/device-setup.md).
+
+### 2. Or install the Android app
+
+Android adds VocaPhone as a selectable voice keyboard. Build and install the APK,
+then follow the guided setup in the app:
+
+```sh
+cd android
+# macOS default; on Linux try $HOME/Android/Sdk
+export ANDROID_HOME="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
+# "full" is the flavor to develop against; "fdroid" is the from-source-only
+# build described under Build flavors below.
+./gradlew assembleFullDebug
+# Uninstall any pre-rename Local Flow build first — application IDs differ, so
+# `adb install -r` will side-install next to io.github.mrsunglasses.localflow.
+adb uninstall io.github.mrsunglasses.localflow 2>/dev/null || true
+adb install -r app/build/outputs/apk/full/debug/vocaphone-fullDebug.apk
+```
+
+In the app: grant microphone and notifications, enable and select VocaPhone in
+Android's keyboard settings, then download an on-device model (no gateway needed).
+If you want the optional gateway path instead, enter the gateway address and
+bearer token from the steps below and run **Test connection**.
+
+See the [Android client guide](android/README.md) for keyboard setup and the
+supported gateway address forms.
+
+### Optional: run a gateway
+
+Skip this if on-device mode already works. A gateway is never required for
+on-device transcription, and the phone never calls one unless you configure it.
+
+### 3. Start the gateway natively on macOS
 
 Install the tools (FFmpeg, plus the WhisperKit and `whisper.cpp` CLIs) and
 launch the server:
@@ -248,7 +325,7 @@ cd server
 ./scripts/install-launch-agent.sh
 ```
 
-### 2. Or start the gateway natively on Linux
+### 4. Or start the gateway natively on Linux
 
 Requires Python 3.12+, [uv](https://docs.astral.sh/uv/), and FFmpeg. On Debian or
 Ubuntu:
@@ -290,7 +367,7 @@ loginctl enable-linger "$USER"
 
 Logs: `journalctl --user -u com.vocahq.vocaphone.gateway.service -f`.
 
-### 3. Or start it with Docker Compose
+### 5. Or start it with Docker Compose
 
 The canonical Compose file is [server/compose.yaml](server/compose.yaml). It
 publishes the gateway only on host loopback by default and stores models,
@@ -318,7 +395,7 @@ curl --fail http://127.0.0.1:8765/health/ready
 Copy [server/.env.example](server/.env.example) if you prefer an editable
 template. Never commit the resulting `.env` file.
 
-### 4. Choose how the phone reaches the gateway
+### 6. Choose how the phone reaches the gateway
 
 The iPhone and Android apps accept any valid `http://` or `https://` gateway URL.
 Choose one of these network arrangements:
@@ -385,72 +462,6 @@ private personal deployment, but it is not mandatory. Follow
 [deployment](docs/deployment.md) and the optional
 [Tailscale guide](docs/tailscale.md) for the relevant host configuration.
 
-### 5. Configure and install the iPhone app
-
-The Simulator needs no Apple account at all:
-
-```sh
-cd ios
-just doctor   # checks Xcode, xcodegen, and a simulator runtime are present
-just run      # generates the project, builds, boots a simulator, installs, launches
-```
-
-`ios/project.yml` is the real project source; `just run` (and every other iOS
-recipe) regenerates `VocaPhone.xcodeproj` from it before building, so don't
-hand-edit the `.xcodeproj`. Prefer working in Xcode itself? `just edit` does
-the same regeneration, then opens it.
-
-Add the keyboard the same way you would on a device: `just settings` opens
-iOS Settings on the simulator, then **General → Keyboard → Keyboards → Add
-New Keyboard → vocaphone**, with **Allow Full Access** turned on (see
-[privacy.md](docs/privacy.md#full-access) for exactly what that is and isn't
-used for). Typing, autocorrect, and swipe work immediately. For actual
-dictation, **Settings → Transcription → On this iPhone** plus a downloaded
-model is the fastest path with nothing else to configure, or point
-**Settings → Transcription → Gateway** at one you started in step 1.
-
-**On your own iPhone** (`just device`, phone connected and trusted): code
-signing has to already work in Xcode first. The project ships with VocaHQ's
-own identifiers (`com.vocahq.vocaphone` and friends, team `92962VK378` — see
-[decisions.md](docs/decisions.md)). If you have access to that team, select
-it on all three targets (VocaPhoneApp, VocaPhoneKeyboard,
-VocaPhoneLiveActivity) under **Signing & Capabilities**; automatic signing
-does the rest. If you don't — most outside contributors — either ask a
-maintainer to comment `/build ios` on your pull request for a signed ad-hoc
-IPA (see [CONTRIBUTING.md](CONTRIBUTING.md#on-demand-pr-builds-build)), or run
-it under your own free Apple ID by changing `bundleIdPrefix` and the three
-`PRODUCT_BUNDLE_IDENTIFIER`s in `ios/project.yml`, the App Group string in all
-three `.entitlements` files, and `AppConfiguration.swift`'s
-`appGroupIdentifier`/`keyboardBundleIdentifier` — don't commit that change.
-
-Grant microphone access on first launch, add the keyboard as above, and turn
-on Full Access. Complete the physical-device checklist in [device
-setup](docs/device-setup.md).
-
-### 6. Or install the Android app
-
-Android adds VocaPhone as a selectable voice keyboard. Build and install the APK,
-then follow the guided setup in the app:
-
-```sh
-cd android
-# macOS default; on Linux try $HOME/Android/Sdk
-export ANDROID_HOME="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
-# "full" is the flavor to develop against; "fdroid" is the from-source-only
-# build described under Build flavors below.
-./gradlew assembleFullDebug
-# Uninstall any pre-rename Local Flow build first — application IDs differ, so
-# `adb install -r` will side-install next to io.github.mrsunglasses.localflow.
-adb uninstall io.github.mrsunglasses.localflow 2>/dev/null || true
-adb install -r app/build/outputs/apk/full/debug/vocaphone-fullDebug.apk
-```
-
-In the app: grant microphone and notifications, enable and select VocaPhone in
-Android's keyboard settings, then either download an on-device model or enter the
-gateway address and bearer token from step 4 and run **Test connection**.
-
-See the [Android client guide](android/README.md) for keyboard setup and the
-supported gateway address forms.
 
 ## Build and test
 

--- a/android/README.md
+++ b/android/README.md
@@ -12,8 +12,8 @@ Android 13+ public beta APKs ship from GitHub Releases. Google Play publication
 is deferred. The shipped APK does not request accessibility-service or overlay
 access.
 
-> Package name and application ID have been updated to `com.vocahq.vocaphone`; the APK
-> output is `vocaphone-debug.apk`.
+> Package name and application ID have been updated to `com.vocahq.vocaphone`;
+> `assembleFullDebug` writes `vocaphone-fullDebug.apk`.
 
 ## Requirements
 
@@ -64,7 +64,7 @@ sherpa models are hidden from the picker when the library is absent.
 
 ## GitHub beta releases
 
-Pushing a tag such as `v0.1.0-beta.8` runs
+Pushing a tag such as `v0.1.0-beta.14` (or the latest prerelease tag) runs
 `.github/workflows/android-beta.yml`. Before tagging, bump `versionCode` and
 `versionName` in `app/build.gradle.kts`; the workflow refuses to publish when
 the tag and APK version do not match.
@@ -82,8 +82,9 @@ public certificate fingerprint, and attaches these files to the prerelease:
 - `SHA256SUMS.txt`
 - `SIGNING-CERTIFICATE-SHA256.txt`
 
-After downloading all three files, verify the APK checksum with
-`sha256sum -c SHA256SUMS.txt` on Linux or
+After downloading the release files (`vocaphone.apk`, `vocaphone-fdroid.apk`,
+`SHA256SUMS.txt`, and `SIGNING-CERTIFICATE-SHA256.txt`), verify the APK
+checksum with `sha256sum -c SHA256SUMS.txt` on Linux or
 `shasum -a 256 -c SHA256SUMS.txt` on macOS. Signing establishes a stable update
 identity and the checksum detects a damaged or changed download; neither
 changes Android's Play Protect treatment for apps installed outside an app store.
@@ -99,13 +100,13 @@ shows up as an actionable repair prompt rather than a silent failure.
    microphone foreground service.
 3. **VocaPhone keyboard** — enable it in Android's keyboard settings, then select
    it from the keyboard picker.
-4. **Gateway address and token** — either **Scan QR code** against the gateway
-   WebUI Overview pairing card, or paste the URL and bearer token, then
-   **Test connection**, which reports reachability, token validity, the active
-   engine, whether it is ready, and whether it supports streaming.
-
-To use the phone without a gateway, open **Speech** during setup or in Settings,
-download the recommended model with **Download and use**, or search the catalog.
+4. **On-device model** — open **Speech** during setup or in Settings, download
+   the recommended model with **Download and use**, or search the catalog. No
+   gateway is required for this path.
+5. **Optional gateway** — if you want shared or larger compute, **Scan QR code**
+   against the gateway WebUI Overview pairing card, or paste the URL and bearer
+   token, then **Test connection**, which reports reachability, token validity,
+   the active engine, whether it is ready, and whether it supports streaming.
 
 The catalog carries 32 whisper.cpp GGML builds from Tiny through Large v3,
 including the q5 and q8 quantizations — a 574 MB Large v3 Turbo q5 is a far
@@ -188,15 +189,17 @@ the Android Tailscale VPN routes the traffic transparently.
 
 - Captured as 16 kHz mono PCM16 and written to a complete WAV in app-private
   storage while recording.
-- Streamed to `/v1/stream` as little-endian float32 frames when the active engine
-  supports it; otherwise, and after a recoverable stream failure, the WAV goes
-  through the batch endpoints. One session UUID is reused throughout, so retries
-  stay idempotent.
+- On-device mode (default): the model runs on the phone and audio never leaves
+  the device.
+- Gateway mode (only if you configured a gateway): streamed to `/v1/stream` as
+  little-endian float32 frames when the active engine supports it; otherwise,
+  and after a recoverable stream failure, the WAV goes through the batch
+  endpoints. One session UUID is reused throughout, so retries stay idempotent.
 - Deleted immediately on success. Kept only for a failed, still-retryable attempt,
   and only for the retention window you choose (1, 6 or 24 hours).
-- The bearer token is encrypted with an AES-GCM key held in the Android Keystore;
-  only the ciphertext and nonce are stored. Backup and device-to-device transfer
-  are disabled.
+- When a gateway is configured, the bearer token is encrypted with an AES-GCM key
+  held in the Android Keystore; only the ciphertext and nonce are stored. Backup
+  and device-to-device transfer are disabled.
 
 ## Diagnostics
 

--- a/docs/device-setup.md
+++ b/docs/device-setup.md
@@ -5,7 +5,7 @@ handoff, background recording, App Group entitlements, or third-party text
 insertion. Complete these steps on the actual iPhone.
 
 New to the project? [The README's iPhone setup
-section](../README.md#5-configure-and-install-the-iphone-app) covers getting
+section](../README.md#1-configure-and-install-the-iphone-app) covers getting
 a build running at all — Simulator first, then a physical device — in
 plainer language than this page. Come back here once you have a build on
 your iPhone and want to run the full acceptance pass.
@@ -22,7 +22,7 @@ The bundle IDs, keyboard bundle ID, and App Group are already final — see
    all three. Automatic signing registers it under your team the first time,
    as long as your team has access to `com.vocahq.vocaphone` and friends —
    see [the README's iPhone setup
-   section](../README.md#5-configure-and-install-the-iphone-app) if it
+   section](../README.md#1-configure-and-install-the-iphone-app) if it
    doesn't.
 3. Connect the iPhone, select it as the run destination, and run VocaPhoneApp.
 

--- a/web/README.md
+++ b/web/README.md
@@ -27,7 +27,7 @@ this directory (see `.github/workflows/pages.yml`). Set Pages source to
 - Publish directory: `web`
 - Canonical URL expected by metadata: `https://vocaphone.vocahq.com/`
 
-Both `/` and `/iphone/` must resolve as HTML routes.
+Both `/`, `/iphone/`, and `/iphone/device-setup/` must resolve as HTML routes.
 
 The Android product images are the original 576×1280 screenshots from
 [VocaPhone PR #70](https://github.com/VocaHQ/vocaphone/pull/70). The website

--- a/web/README.md
+++ b/web/README.md
@@ -11,9 +11,10 @@ npm run dev
 Then open `http://127.0.0.1:4173/`. The iPhone setup guide is available at
 `http://127.0.0.1:4173/iphone/`.
 
-The site uses only local brand assets and system fonts. Android beta links open
-the repository's GitHub Releases page, where each release includes the APK and
-its verification files.
+The site uses only local brand assets and system fonts. The Android install and
+download CTAs point at the current public beta tag
+(`v0.1.0-beta.14`), where the release includes the APK and its verification
+files.
 
 ## Deployment
 

--- a/web/index.html
+++ b/web/index.html
@@ -149,7 +149,7 @@
           <div class="hero-actions">
             <a
               class="button button-primary"
-              href="https://github.com/VocaHQ/vocaphone/releases"
+              href="https://github.com/VocaHQ/vocaphone/releases/tag/v0.1.0-beta.14"
             >
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M7 4h10a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z" />
@@ -699,14 +699,16 @@
               <li><b>Latest</b><span>v0.1.0-beta.14</span></li>
               <li><b>Privacy</b><span>On-device model or optional gateway</span></li>
             </ul>
+            <p class="install-note">
+              Uninstall <code>io.github.mrsunglasses.localflow</code> before
+              sideloading if that older Local Flow build is still installed.
+            </p>
             <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/v0.1.0-beta.14">
               open v0.1.0-beta.14 <span aria-hidden="true">↗</span>
             </a>
             <p class="install-note">
-              Download <code>vocaphone.apk</code> and verify it with the
-              <code>SHA256SUMS.txt</code> included in the same release.
-              If an older Local Flow build (<code>io.github.mrsunglasses.localflow</code>)
-              is still installed, uninstall it before sideloading.
+              Download <code>vocaphone.apk</code> from that tag and verify it with
+              the <code>SHA256SUMS.txt</code> included in the same release.
             </p>
           </article>
 
@@ -759,7 +761,7 @@
           <p>product</p>
           <a href="#why">why VocaPhone</a>
           <a href="#how">how it works</a>
-          <a href="https://github.com/VocaHQ/vocaphone/releases">releases</a>
+          <a href="https://github.com/VocaHQ/vocaphone/releases/tag/v0.1.0-beta.14">releases</a>
         </div>
         <div>
           <p>resources</p>

--- a/web/index.html
+++ b/web/index.html
@@ -574,7 +574,7 @@
               />
             </div>
             <p>Native whisper.cpp and sherpa-onnx models run inside the Android phone and insert text directly.</p>
-            <a href="https://github.com/VocaHQ/vocaphone/releases">get the beta <span>↗</span></a>
+            <a href="https://github.com/VocaHQ/vocaphone/releases/tag/v0.1.0-beta.14">get the beta <span>↗</span></a>
           </article>
         </div>
       </section>
@@ -696,14 +696,17 @@
             <ul class="install-facts">
               <li><b>Requires</b><span>Android 13 or newer</span></li>
               <li><b>Install</b><span>Download and sideload the signed APK</span></li>
+              <li><b>Latest</b><span>v0.1.0-beta.14</span></li>
               <li><b>Privacy</b><span>On-device model or optional gateway</span></li>
             </ul>
-            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases">
-              open Android releases <span aria-hidden="true">↗</span>
+            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/v0.1.0-beta.14">
+              open v0.1.0-beta.14 <span aria-hidden="true">↗</span>
             </a>
             <p class="install-note">
               Download <code>vocaphone.apk</code> and verify it with the
               <code>SHA256SUMS.txt</code> included in the same release.
+              If an older Local Flow build (<code>io.github.mrsunglasses.localflow</code>)
+              is still installed, uninstall it before sideloading.
             </p>
           </article>
 
@@ -738,7 +741,7 @@
           <h2 id="download-title">say less.<br />type more.</h2>
           <p>Download a model to your phone and turn speech into text without sending your voice anywhere.</p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases">get Android beta <span>↗</span></a>
+            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/v0.1.0-beta.14">get Android beta v0.1.0-beta.14 <span>↗</span></a>
             <a class="button button-secondary" href="/iphone/">build for iPhone <span>↗</span></a>
           </div>
           <span class="download-fineprint">no gateway required · free &amp; open source · AGPL-3.0</span>

--- a/web/iphone/device-setup/index.html
+++ b/web/iphone/device-setup/index.html
@@ -1,0 +1,306 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Physical iPhone checklist for VocaPhone: signing, on-device model setup, keyboard enablement, and acceptance gates."
+    />
+    <meta name="theme-color" content="#f4f1e8" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://vocaphone.vocahq.com/iphone/device-setup/" />
+    <meta property="og:title" content="VocaPhone verified device checklist" />
+    <meta
+      property="og:description"
+      content="Sign, install, download an on-device model, and run the physical iPhone acceptance pass."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:site_name" content="VocaPhone" />
+    <meta property="og:url" content="https://vocaphone.vocahq.com/iphone/device-setup/" />
+    <meta property="og:image" content="https://vocaphone.vocahq.com/assets/og-image.png" />
+    <meta
+      property="og:image:secure_url"
+      content="https://vocaphone.vocahq.com/assets/og-image.png"
+    />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="VocaPhone private voice typing, on-device first with an optional self-hosted gateway"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="VocaPhone verified device checklist" />
+    <meta
+      name="twitter:description"
+      content="Physical iPhone signing, on-device model setup, and acceptance gates for VocaPhone."
+    />
+    <meta name="twitter:image" content="https://vocaphone.vocahq.com/assets/og-image.png" />
+    <meta
+      name="twitter:image:alt"
+      content="VocaPhone private voice typing, on-device first with an optional self-hosted gateway"
+    />
+    <title>VocaPhone verified device checklist</title>
+    <link rel="icon" href="../../assets/vocaphone-logo.svg" type="image/svg+xml" />
+    <link rel="icon" href="../../favicon.ico" sizes="any" />
+    <link rel="apple-touch-icon" href="../../assets/apple-touch-icon.png" />
+    <link rel="stylesheet" href="../../styles.css" />
+    <script src="../../script.js" defer></script>
+  </head>
+  <body class="guide-body">
+    <a class="skip-link" href="#checklist-content">Skip to checklist</a>
+
+    <header class="menu-bar guide-menu-bar">
+      <a class="brand-link" href="/" aria-label="VocaPhone home">
+        <img src="../../assets/vocaphone-logo.svg" alt="" width="32" height="32" />
+        <span>vocaphone</span>
+      </a>
+      <a class="guide-back" href="/iphone/">← back to the iPhone guide</a>
+    </header>
+
+    <main class="guide-main" id="checklist-content">
+      <section class="guide-hero dot-field">
+        <div>
+          <span class="section-tag">iPhone · physical device</span>
+          <h1>verified device<br />checklist.</h1>
+          <p>
+            Simulator success is not enough. This pass covers signing, keyboard
+            installation, microphone handoff, on-device models, and text insertion
+            on a real iPhone. iOS 17 or newer. There is no App Store or TestFlight
+            build today — install from source with Xcode.
+          </p>
+        </div>
+        <aside class="guide-summary" aria-label="Before you begin">
+          <span>before you begin</span>
+          <strong>iOS 17+</strong>
+          <strong>physical iPhone</strong>
+          <strong>Apple signing</strong>
+          <strong>Git LFS clone</strong>
+        </aside>
+      </section>
+
+      <section class="guide-content" aria-labelledby="signing-title">
+        <div class="guide-intro">
+          <span class="section-tag">signing</span>
+          <h2 id="signing-title">prerequisites before the phone.</h2>
+          <p>
+            Bundle IDs and the App Group are already final
+            (<code>com.vocahq.vocaphone*</code>, team <code>92962VK378</code> when
+            you have access). Nothing to rename for VocaHQ signing.
+          </p>
+        </div>
+
+        <ol class="guide-steps">
+          <li class="guide-step">
+            <span>01</span>
+            <div>
+              <h3>Open the Xcode project</h3>
+              <p>
+                Run <code>just ios gen</code> if needed, open
+                <code>ios/VocaPhone.xcodeproj</code>, and choose your Apple team on
+                all three targets — App, Keyboard, and Live Activity — under
+                <strong>Signing &amp; Capabilities</strong>.
+              </p>
+            </div>
+          </li>
+          <li class="guide-step">
+            <span>02</span>
+            <div>
+              <h3>Confirm the App Group</h3>
+              <p>
+                Enable the same App Group (<code>group.com.vocahq</code>) on all
+                three targets. Automatic signing registers it the first time your
+                team can use the VocaHQ identifiers.
+              </p>
+            </div>
+          </li>
+          <li class="guide-step">
+            <span>03</span>
+            <div>
+              <h3>Install on the connected iPhone</h3>
+              <p>
+                Select the phone as the run destination and run VocaPhoneApp.
+                Need the short path first?
+                <a href="/iphone/">Use the iPhone install guide</a>.
+              </p>
+            </div>
+          </li>
+        </ol>
+      </section>
+
+      <section class="guide-content" aria-labelledby="on-device-title">
+        <div class="guide-intro">
+          <span class="section-tag">on-device setup</span>
+          <h2 id="on-device-title">model on the phone. gateway optional.</h2>
+          <p>
+            iOS keyboard extensions cannot use the microphone. The companion app
+            records; the speech-to-text model still runs on the iPhone in on-device
+            mode. A gateway is never required for that path.
+          </p>
+        </div>
+
+        <ol class="guide-steps">
+          <li class="guide-step">
+            <span>01</span>
+            <div>
+              <h3>Grant microphone access</h3>
+              <p>Open vocaphone and allow the microphone permission.</p>
+            </div>
+          </li>
+          <li class="guide-step">
+            <span>02</span>
+            <div>
+              <h3>Keep Quick Dictation ready</h3>
+              <p>
+                Leave “Keep Quick Dictation ready for 10 minutes” enabled. Confirm
+                the app shows Quick Dictation as Ready and iOS shows its microphone
+                indicator.
+              </p>
+            </div>
+          </li>
+          <li class="guide-step">
+            <span>03</span>
+            <div>
+              <h3>Choose a transcription source</h3>
+              <p>
+                <strong>On this iPhone</strong> — under
+                <strong>Settings → Transcription</strong>, pick
+                <strong>On this iPhone</strong>, download a model, and wait until
+                it reports <em>verified</em>. Downloaded is not the same claim.
+              </p>
+              <p>
+                <strong>Your gateway</strong> — optional. Under
+                <strong>Settings → Transcription → Gateway</strong>, enter a
+                trusted LAN, Tailscale, or HTTPS URL plus bearer token, or scan the
+                gateway pairing QR. Approve camera and Local Network access when
+                asked.
+              </p>
+            </div>
+          </li>
+          <li class="guide-step">
+            <span>04</span>
+            <div>
+              <h3>Confirm Ready</h3>
+              <p>
+                Transcription should report the selected source as
+                <strong>Ready</strong>. A gateway path should also name the loaded
+                model.
+              </p>
+            </div>
+          </li>
+          <li class="guide-step">
+            <span>05</span>
+            <div>
+              <h3>Microphone and keyboard preferences</h3>
+              <p>
+                Under <strong>Settings → Dictation</strong>, choose Automatic or
+                iPhone Microphone and confirm <strong>Input in use</strong>. Under
+                <strong>Settings → Keyboard</strong>, try Compact, Standard, and
+                Tall in a real host app.
+              </p>
+            </div>
+          </li>
+          <li class="guide-step">
+            <span>06</span>
+            <div>
+              <h3>Enable the keyboard</h3>
+              <p>
+                Open iOS Settings from vocaphone. Under
+                <strong>General → Keyboard → Keyboards</strong>, add vocaphone and
+                enable Full Access. Full Access is for shared session state and for
+                reaching a gateway you configured — not for collecting unrelated
+                typing.
+              </p>
+            </div>
+          </li>
+        </ol>
+      </section>
+
+      <section class="guide-content" aria-labelledby="gate-title">
+        <div class="guide-intro">
+          <span class="section-tag">acceptance</span>
+          <h2 id="gate-title">required phase 1 gate.</h2>
+          <p>
+            Repeat in Notes at least five times, then again while Quick Dictation
+            still shows Ready.
+          </p>
+        </div>
+
+        <ol class="guide-steps">
+          <li class="guide-step">
+            <span>01</span>
+            <div>
+              <h3>Hand-off dictation</h3>
+              <pre><code>Notes → vocaphone keyboard → Start
+→ containing app begins recording → swipe back
+→ keyboard shows active recording → Finish
+→ transcript available → Insert</code></pre>
+            </div>
+          </li>
+          <li class="guide-step">
+            <span>02</span>
+            <div>
+              <h3>Ready-window Dictate</h3>
+              <pre><code>Notes → vocaphone keyboard → Dictate
+→ Notes stays visible → Recording → Finish
+→ transcript available → Insert</code></pre>
+            </div>
+          </li>
+          <li class="guide-step">
+            <span>03</span>
+            <div>
+              <h3>What must hold</h3>
+              <p>
+                Microphone stays active when returning to Notes. Expired ready
+                windows open vocaphone again. Finish stops the recorder. Text
+                inserts directly, never via clipboard. Cancel removes local audio.
+                The keyboard, app, and Live Activity name the same place —
+                “Transcribing on this iPhone” or “Transcribing on your gateway”.
+                Secure fields that block third-party keyboards must fail without a
+                gateway error.
+              </p>
+            </div>
+          </li>
+        </ol>
+
+        <aside class="guide-callout" aria-labelledby="full-doc-title">
+          <div>
+            <span class="section-tag">full checklist</span>
+            <h2 id="full-doc-title">typing and Quick Dictation gates</h2>
+            <p>
+              The repository doc also covers typing intelligence, VoiceOver,
+              swipe, jetsam, Dynamic Island standby, and diagnostics export rules.
+              Use that when you change audio, App Group, or keyboard code.
+            </p>
+          </div>
+          <a
+            class="button button-secondary"
+            href="https://github.com/VocaHQ/vocaphone/blob/main/docs/device-setup.md"
+          >
+            open docs/device-setup.md <span aria-hidden="true">↗</span>
+          </a>
+        </aside>
+
+        <div class="guide-source-links">
+          <p>Need the short install path or the build recipes?</p>
+          <a href="/iphone/">
+            back to the iPhone guide <span aria-hidden="true">→</span>
+          </a>
+          <a href="https://github.com/VocaHQ/vocaphone#build-and-test">
+            read the build documentation <span aria-hidden="true">↗</span>
+          </a>
+        </div>
+      </section>
+    </main>
+
+    <footer class="guide-footer">
+      <a class="brand-link" href="/">
+        <img src="../../assets/vocaphone-logo.svg" alt="" width="34" height="34" />
+        <span>vocaphone</span>
+      </a>
+      <span>open source · private by design · gateway optional</span>
+    </footer>
+  </body>
+</html>

--- a/web/iphone/index.html
+++ b/web/iphone/index.html
@@ -184,8 +184,8 @@ git lfs pull</code></pre>
 
         <div class="guide-source-links">
           <p>Need the complete developer and physical-device details?</p>
-          <a href="https://github.com/VocaHQ/vocaphone/blob/main/docs/device-setup.md">
-            read the verified device checklist <span aria-hidden="true">↗</span>
+          <a href="/iphone/device-setup/">
+            read the verified device checklist <span aria-hidden="true">→</span>
           </a>
           <a href="https://github.com/VocaHQ/vocaphone#build-and-test">
             read the build documentation <span aria-hidden="true">↗</span>

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -10,4 +10,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://vocaphone.vocahq.com/iphone/device-setup/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -158,7 +158,7 @@ test("availability and install paths are honest", () => {
     /href="https:\/\/github\.com\/VocaHQ\/vocaphone#build-and-test"/,
   );
   assert.doesNotMatch(iphoneHtml, /href="\/iphone\/device-setup"/);
-  assert.match(iphoneHtml, /There is no App Store or TestFlight build yet/);
+  assert.match(iphoneHtml, /There is no App Store or\s+TestFlight build yet/);
 });
 
 test("decorative product frames do not expose focusable controls", () => {

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -7,8 +7,17 @@ import { fileURLToPath } from "node:url";
 const siteRoot = fileURLToPath(new URL("..", import.meta.url));
 const html = readFileSync(join(siteRoot, "index.html"), "utf8");
 const iphoneHtml = readFileSync(join(siteRoot, "iphone/index.html"), "utf8");
+const deviceSetupHtml = readFileSync(join(siteRoot, "iphone/device-setup/index.html"), "utf8");
 const css = readFileSync(join(siteRoot, "styles.css"), "utf8");
 const script = readFileSync(join(siteRoot, "script.js"), "utf8");
+
+function androidInstallBlock(source) {
+  const match = source.match(
+    /<article class="install-card reveal">[\s\S]*?<h3>Android<\/h3>[\s\S]*?<\/article>/,
+  );
+  assert.ok(match, "Android install card missing");
+  return match[0];
+}
 
 test("page has one clear title and a landmark structure", () => {
   assert.match(html, /<title>VocaPhone — voice typing that stays yours<\/title>/);
@@ -141,24 +150,43 @@ test("availability and install paths are honest", () => {
   assert.match(html, /SHA256SUMS\.txt/);
   assert.doesNotMatch(html, /href="\/download\/android"/);
   assert.doesNotMatch(html, /releases\/latest/);
+  assert.doesNotMatch(html, /href="https:\/\/github\.com\/VocaHQ\/vocaphone\/releases"/);
   assert.doesNotMatch(html, /free forever/i);
   assert.doesNotMatch(html, /available on (the )?App Store/i);
   assert.doesNotMatch(html, /available on TestFlight/i);
   assert.doesNotMatch(html, /available on F-Droid/i);
 
+  const androidCard = androidInstallBlock(html);
+  const uninstallAt = androidCard.indexOf("io.github.mrsunglasses.localflow");
+  const tagHrefAt = androidCard.indexOf(
+    "https://github.com/VocaHQ/vocaphone/releases/tag/v0.1.0-beta.14",
+  );
+  const checksumAt = androidCard.indexOf("SHA256SUMS.txt");
+  assert.ok(uninstallAt !== -1, "uninstall note missing from Android install block");
+  assert.ok(tagHrefAt !== -1, "pinned beta.14 URL missing from Android install block");
+  assert.ok(checksumAt !== -1, "checksum note missing from Android install block");
+  assert.ok(uninstallAt < tagHrefAt, "uninstall line must lead the Android install block");
+  assert.ok(tagHrefAt < checksumAt, "pinned beta.14 URL must precede the checksum note");
+
   assert.match(iphoneHtml, /The gateway is optional/);
   assert.match(iphoneHtml, /No gateway address or token\s+is needed for this mode/);
   assert.match(iphoneHtml, /iOS does not permit[\s\S]*keyboard extensions to access the microphone/);
-  assert.match(
-    iphoneHtml,
-    /href="https:\/\/github\.com\/VocaHQ\/vocaphone\/blob\/main\/docs\/device-setup\.md"/,
-  );
+  assert.match(iphoneHtml, /href="\/iphone\/device-setup\/"/);
   assert.match(
     iphoneHtml,
     /href="https:\/\/github\.com\/VocaHQ\/vocaphone#build-and-test"/,
   );
-  assert.doesNotMatch(iphoneHtml, /href="\/iphone\/device-setup"/);
   assert.match(iphoneHtml, /There is no App Store or\s+TestFlight build yet/);
+
+  assert.ok(existsSync(join(siteRoot, "iphone/device-setup/index.html")));
+  assert.match(deviceSetupHtml, /There is no App Store or\s+TestFlight\s+build today/);
+  assert.match(deviceSetupHtml, /iOS 17 or newer/);
+  assert.match(deviceSetupHtml, /keyboard extensions cannot use the microphone/);
+  assert.match(deviceSetupHtml, /companion app\s+records/i);
+  assert.match(deviceSetupHtml, /model still runs on the iPhone/);
+  assert.match(deviceSetupHtml, /gateway is never required/);
+  assert.doesNotMatch(deviceSetupHtml, /available on (the )?App Store/i);
+  assert.doesNotMatch(deviceSetupHtml, /available on TestFlight/i);
 });
 
 test("decorative product frames do not expose focusable controls", () => {

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -131,16 +131,34 @@ test("availability and install paths are honest", () => {
   assert.match(html, /Android 13 or newer/);
   assert.match(html, /iOS 17 or newer/);
   assert.match(html, /There is no App Store or TestFlight build today/);
-  assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocaphone\/releases"/);
+  assert.match(
+    html,
+    /href="https:\/\/github\.com\/VocaHQ\/vocaphone\/releases\/tag\/v0\.1\.0-beta\.14"/,
+  );
+  assert.match(html, /v0\.1\.0-beta\.14/);
+  assert.match(html, /io\.github\.mrsunglasses\.localflow/);
   assert.match(html, /href="\/iphone\/"/);
   assert.match(html, /SHA256SUMS\.txt/);
   assert.doesNotMatch(html, /href="\/download\/android"/);
   assert.doesNotMatch(html, /releases\/latest/);
   assert.doesNotMatch(html, /free forever/i);
+  assert.doesNotMatch(html, /available on (the )?App Store/i);
+  assert.doesNotMatch(html, /available on TestFlight/i);
+  assert.doesNotMatch(html, /available on F-Droid/i);
 
   assert.match(iphoneHtml, /The gateway is optional/);
   assert.match(iphoneHtml, /No gateway address or token\s+is needed for this mode/);
   assert.match(iphoneHtml, /iOS does not permit[\s\S]*keyboard extensions to access the microphone/);
+  assert.match(
+    iphoneHtml,
+    /href="https:\/\/github\.com\/VocaHQ\/vocaphone\/blob\/main\/docs\/device-setup\.md"/,
+  );
+  assert.match(
+    iphoneHtml,
+    /href="https:\/\/github\.com\/VocaHQ\/vocaphone#build-and-test"/,
+  );
+  assert.doesNotMatch(iphoneHtml, /href="\/iphone\/device-setup"/);
+  assert.match(iphoneHtml, /There is no App Store or TestFlight build yet/);
 });
 
 test("decorative product frames do not expose focusable controls", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Leftovers #103 did not cover. No gateway submodule, `server/` rename, token-path, Fastlane, new release, or GitHub About/release-note edits.
- **1.** Site Android install block leads with uninstall `io.github.mrsunglasses.localflow`, then the pinned `v0.1.0-beta.14` tag URL (not `/releases` or `/releases/latest`).
- **2.** Root README Quick start is on-device first; Android README leftovers cover first-run, audio path, beta.14, four release files, and `vocaphone-fullDebug.apk`.
- **3.** `/iphone/device-setup/` is a real page (from `docs/device-setup.md`, honest: iOS 17+, source build, no App Store/TestFlight). The iPhone guide checklist links there.

## Verification

- [x] `npm run check` in `web/` (17/17)
- [x] Local static serve: `/iphone/device-setup/` returns 200
- [ ] `just ios ci` (docs/site only; not run)
- [ ] `just android ci` (docs/site only; not run)
- [ ] Gateway changes: none
- [ ] Physical-device test: n/a

## Privacy and security

- [x] No secrets or private tailnet details added
- [x] Docs state on-device default; gateway upload only when configured

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42b3d320-c1fc-4249-ba94-32e39fc68a07?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42b3d320-c1fc-4249-ba94-32e39fc68a07&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

