### PR TITLE
fix(ios,android): stop on-device dictation losing a chunk in silence

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/audio/SpeechAudioConditioning.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/audio/SpeechAudioConditioning.kt
@@ -65,7 +65,22 @@ object SpeechAudioConditioning {
             val magnitude = abs(sample)
             if (magnitude > peak) peak = magnitude
         }
-        if (peak < SILENCE_PEAK) return samples
+        return condition(samples, peak)
+    }
+
+    /**
+     * Levels [samples] in place with a gain derived from [peak] rather than from
+     * the array itself.
+     *
+     * This is how a streaming chunk gets levelled: it passes the peak of every
+     * sample captured so far, which is the closest one chunk can come to the
+     * single gain [condition] applies over a whole recording. Passing the
+     * chunk's own peak would be exactly the per-chunk gain the note above warns
+     * against. The DC offset is not touched here — measuring it needs the whole
+     * recording, so it stays on the whole-file path.
+     */
+    fun condition(samples: FloatArray, peak: Float): FloatArray {
+        if (samples.isEmpty() || peak < SILENCE_PEAK) return samples
 
         // Already loud enough. Attenuating a hot recording cannot undo whatever
         // clipping it arrived with, and quiet is the problem worth solving.

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -28,6 +28,7 @@ import com.vocahq.vocaphone.gateway.GatewayStreamingPolicy
 import com.vocahq.vocaphone.gateway.StreamingUnavailableException
 import com.vocahq.vocaphone.local.LocalModelManager
 import com.vocahq.vocaphone.local.LocalTranscription
+import com.vocahq.vocaphone.local.SherpaIncrementalResult
 import com.vocahq.vocaphone.local.SherpaIncrementalSession
 import com.vocahq.vocaphone.settings.VocaPhoneSettings
 import com.vocahq.vocaphone.settings.SettingsRepository
@@ -523,6 +524,7 @@ class DictationController(
             val session = incrementalReference.getAndSet(null)
             var preparedTranscript: LocalTranscription? = null
             var partialTranscript: LocalTranscription? = null
+            var incrementalOutcome: SherpaIncrementalResult? = null
             var timingRecorded = false
             if (session != null) {
                 _state.update { it.copy(phase = DictationPhase.TRANSCRIBING, streaming = false) }
@@ -530,6 +532,7 @@ class DictationController(
                 timingRecorded = true
                 try {
                     val incremental = session.finish()
+                    incrementalOutcome = incremental
                     partialTranscript = incremental.transcript
                         .takeIf { it.text.isNotBlank() }
                         ?.let { LocalTranscription(it.text, it.language) }
@@ -567,6 +570,7 @@ class DictationController(
                 generation = generation,
                 preparedTranscript = preparedTranscript,
                 partialTranscript = partialTranscript,
+                incrementalOutcome = incrementalOutcome,
                 transcriptionTimingRecorded = timingRecorded,
             )
             return
@@ -696,6 +700,7 @@ class DictationController(
         generation: Int,
         preparedTranscript: LocalTranscription? = null,
         partialTranscript: LocalTranscription? = null,
+        incrementalOutcome: SherpaIncrementalResult? = null,
         transcriptionTimingRecorded: Boolean = false,
     ) {
         // Loading a model is seconds of silence with nothing on screen to explain
@@ -719,13 +724,22 @@ class DictationController(
             val modelID = configuration.localModelId.takeIf { it.isNotEmpty() }
                 ?: error("Choose and download an on-device model first.")
             val local = preparedTranscript ?: try {
-                localModels.transcribe(
+                val wholeFile = localModels.transcribe(
                     wavFile,
                     modelID,
                     language,
                     configuration.transcriptionQuality,
                     configuration.customVocabulary,
                 )
+                // Taken only when it recovered something. A second pass that
+                // came back with less than the streaming one already had has
+                // dropped a chunk of its own, and shipping it would cut a
+                // sentence the user watched being said.
+                if (incrementalOutcome?.supersededBy(wholeFile.text) == false) {
+                    partialTranscript ?: wholeFile
+                } else {
+                    wholeFile
+                }
             } catch (error: CancellationException) {
                 throw error
             } catch (error: Throwable) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -36,6 +36,7 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -521,24 +522,37 @@ class DictationController(
         if (configuration.localTranscriptionEnabled) {
             val session = incrementalReference.getAndSet(null)
             var preparedTranscript: LocalTranscription? = null
+            var partialTranscript: LocalTranscription? = null
             var timingRecorded = false
             if (session != null) {
                 _state.update { it.copy(phase = DictationPhase.TRANSCRIBING, streaming = false) }
                 diagnostics.recordTiming("local_transcription_started", source.name)
                 timingRecorded = true
-                preparedTranscript = try {
-                    session.finish()
+                try {
+                    val incremental = session.finish()
+                    partialTranscript = incremental.transcript
                         .takeIf { it.text.isNotBlank() }
                         ?.let { LocalTranscription(it.text, it.language) }
-                        ?.also { diagnostics.recordTiming("local_incremental_ready", source.name) }
-                        ?: run {
-                            incrementalFallback.set(true)
-                            null
-                        }
+                    if (incremental.droppedAudibleChunk) {
+                        // A chunk that decoded to nothing is seconds of speech
+                        // missing from the middle of an otherwise fluent
+                        // transcript, which nothing downstream can see. The
+                        // whole-file decode levels the gain over the whole
+                        // recording and splits on different boundaries, so it
+                        // is the one that recovers them.
+                        diagnostics.recordTiming("local_incremental_dropped_chunk", source.name)
+                    } else {
+                        preparedTranscript = partialTranscript
+                            ?.also {
+                                diagnostics.recordTiming("local_incremental_ready", source.name)
+                            }
+                    }
+                    if (preparedTranscript == null) incrementalFallback.set(true)
+                } catch (error: CancellationException) {
+                    throw error
                 } catch (_: Throwable) {
                     session.cancel()
                     incrementalFallback.set(true)
-                    null
                 }
             }
             if (incrementalSession != null && incrementalFallback.get()) {
@@ -552,6 +566,7 @@ class DictationController(
                 source = source,
                 generation = generation,
                 preparedTranscript = preparedTranscript,
+                partialTranscript = partialTranscript,
                 transcriptionTimingRecorded = timingRecorded,
             )
             return
@@ -680,6 +695,7 @@ class DictationController(
         source: DictationSource,
         generation: Int,
         preparedTranscript: LocalTranscription? = null,
+        partialTranscript: LocalTranscription? = null,
         transcriptionTimingRecorded: Boolean = false,
     ) {
         // Loading a model is seconds of silence with nothing on screen to explain
@@ -702,14 +718,23 @@ class DictationController(
             }
             val modelID = configuration.localModelId.takeIf { it.isNotEmpty() }
                 ?: error("Choose and download an on-device model first.")
-            val local = preparedTranscript
-                ?: localModels.transcribe(
+            val local = preparedTranscript ?: try {
+                localModels.transcribe(
                     wavFile,
                     modelID,
                     language,
                     configuration.transcriptionQuality,
                     configuration.customVocabulary,
                 )
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                // Incomplete beats nothing. When the streaming path lost a
+                // chunk, this decode was the attempt to recover it; if the
+                // attempt cannot run at all, the text it did produce is still
+                // more use to the user than a failure.
+                partialTranscript ?: throw error
+            }
             val transcript = styleLocalTranscript(local, configuration)
             if (transcript.isEmpty()) {
                 throw GatewayException.emptyTranscript()

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaIncrementalSession.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaIncrementalSession.kt
@@ -72,6 +72,15 @@ internal class SherpaIncrementalSession(
         var droppedAudibleChunk = false
 
         suspend fun consume(chunk: FloatArray) {
+            // Silence is judged on the capture as it arrived, and so has to be
+            // measured before `condition` levels the array in place. That gain
+            // multiplies a quiet recording by as much as eight, and a floor
+            // meant for microphone levels reads amplified room tone as speech
+            // -- which buys a decode, the two more the empty-chunk recovery
+            // adds on top, and then the whole-file re-run the flag below asks
+            // the caller for. All to transcribe a pause.
+            if (SherpaLongAudio.isEffectivelySilent(chunk)) return
+
             // The gain a chunk is levelled with has to come from more than the
             // chunk itself: one gain per chunk moves the level at every
             // boundary, and a chunk that is all pause would be amplified into
@@ -81,7 +90,17 @@ internal class SherpaIncrementalSession(
             // so the gain only ever settles.
             val levelled = SpeechAudioConditioning.condition(chunk, audio.peak)
             val decoded = decode(levelled)
-            if (decoded.text.isEmpty() && !SherpaLongAudio.isEffectivelySilent(levelled)) {
+
+            // Only a chunk long enough that the recovery has already tried and
+            // failed is a hole worth re-reading the file for. Below that bar an
+            // empty answer is routine -- it is the retained overlap, or the
+            // fragment of a word a recording ending just after a boundary
+            // leaves -- and treating it as a loss would spend a second pass
+            // over the whole recording on almost every dictation.
+            if (decoded.text.isEmpty() &&
+                chunk.size >
+                SherpaLongAudio.MIN_SUSPECT_CHUNK_SECONDS * SherpaLongAudio.SAMPLE_RATE
+            ) {
                 droppedAudibleChunk = true
             }
             transcript = transcript.append(decoded, deduplicateOverlap = overlapsPrevious)

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaIncrementalSession.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaIncrementalSession.kt
@@ -23,7 +23,19 @@ import kotlinx.coroutines.channels.Channel
 internal data class SherpaIncrementalResult(
     val transcript: SherpaTranscript,
     val droppedAudibleChunk: Boolean,
-)
+) {
+    /**
+     * Whether a whole-file re-decode is worth taking over this result.
+     *
+     * The re-decode exists to recover seconds the streaming pass lost, and it
+     * is only evidence of that if it came back with more. The same model that
+     * dropped a chunk in one pass drops one in the other -- over a recording
+     * with a long pause in it, routinely -- so taking the second pass on faith
+     * trades a hole for a bigger one, and the user watches a finished sentence
+     * lose its opening half.
+     */
+    fun supersededBy(wholeFile: String): Boolean = wholeFile.length > transcript.text.length
+}
 
 /**
  * Decodes completed Sherpa chunks while AudioRecord is still capturing.
@@ -70,6 +82,11 @@ internal class SherpaIncrementalSession(
         var transcript = SherpaTranscript.EMPTY
         var overlapsPrevious = false
         var droppedAudibleChunk = false
+        // The loudest frame of everything decoded so far, which is what a later
+        // chunk's level is judged against. Read before this chunk contributes
+        // to it, so a pause is compared with the speech around it and never
+        // with itself.
+        var loudestFrame = 0.0
 
         suspend fun consume(chunk: FloatArray) {
             // Silence is judged on the capture as it arrived, and so has to be
@@ -79,7 +96,8 @@ internal class SherpaIncrementalSession(
             // -- which buys a decode, the two more the empty-chunk recovery
             // adds on top, and then the whole-file re-run the flag below asks
             // the caller for. All to transcribe a pause.
-            if (SherpaLongAudio.isEffectivelySilent(chunk)) return
+            val level = SherpaLongAudio.loudestFrame(chunk)
+            if (SherpaLongAudio.isEffectivelySilent(level)) return
 
             // The gain a chunk is levelled with has to come from more than the
             // chunk itself: one gain per chunk moves the level at every
@@ -92,17 +110,21 @@ internal class SherpaIncrementalSession(
             val decoded = decode(levelled)
 
             // Only a chunk long enough that the recovery has already tried and
-            // failed is a hole worth re-reading the file for. Below that bar an
-            // empty answer is routine -- it is the retained overlap, or the
+            // failed, and loud enough next to the rest of the recording to have
+            // held speech, is a hole worth re-reading the file for. Below those
+            // bars an empty answer is routine -- the retained overlap, the
             // fragment of a word a recording ending just after a boundary
-            // leaves -- and treating it as a loss would spend a second pass
-            // over the whole recording on almost every dictation.
+            // leaves, the room tone while someone pauses to think -- and
+            // treating it as a loss spends a second pass over the whole
+            // recording to find out it was right the first time.
             if (decoded.text.isEmpty() &&
                 chunk.size >
-                SherpaLongAudio.MIN_SUSPECT_CHUNK_SECONDS * SherpaLongAudio.SAMPLE_RATE
+                SherpaLongAudio.MIN_SUSPECT_CHUNK_SECONDS * SherpaLongAudio.SAMPLE_RATE &&
+                SherpaLongAudio.carriesSpeech(level, loudestFrame)
             ) {
                 droppedAudibleChunk = true
             }
+            loudestFrame = maxOf(loudestFrame, level)
             transcript = transcript.append(decoded, deduplicateOverlap = overlapsPrevious)
         }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaIncrementalSession.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaIncrementalSession.kt
@@ -1,11 +1,29 @@
 package com.vocahq.vocaphone.local
 
+import com.vocahq.vocaphone.audio.SpeechAudioConditioning
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.abs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
+
+/**
+ * What an incremental session decoded, and whether any of the recording is
+ * missing from it.
+ *
+ * A chunk that decodes to nothing takes its seconds out of the transcript
+ * without leaving a trace: the merge joins the chunks either side into text
+ * that reads as a whole sentence which happens to begin ten seconds in. The
+ * attention families drop a long chunk often enough for this to be the
+ * difference between a transcript and a plausible-looking lie, so the caller
+ * re-decodes the file rather than shipping the hole.
+ */
+internal data class SherpaIncrementalResult(
+    val transcript: SherpaTranscript,
+    val droppedAudibleChunk: Boolean,
+)
 
 /**
  * Decodes completed Sherpa chunks while AudioRecord is still capturing.
@@ -21,7 +39,7 @@ internal class SherpaIncrementalSession(
 ) {
     private val accepting = AtomicBoolean(true)
     private val frames = Channel<ShortArray>(capacity = MAX_RECORDING_FRAMES)
-    private val result: Deferred<SherpaTranscript> =
+    private val result: Deferred<SherpaIncrementalResult> =
         scope.async(Dispatchers.Default) { transcribe() }
 
     init {
@@ -32,7 +50,7 @@ internal class SherpaIncrementalSession(
     fun offer(frame: ShortArray): Boolean =
         accepting.get() && frames.trySend(frame).isSuccess
 
-    suspend fun finish(): SherpaTranscript {
+    suspend fun finish(): SherpaIncrementalResult {
         accepting.set(false)
         frames.close()
         return result.await()
@@ -44,13 +62,30 @@ internal class SherpaIncrementalSession(
         result.cancel()
     }
 
-    private suspend fun transcribe(): SherpaTranscript {
+    private suspend fun transcribe(): SherpaIncrementalResult {
         prepare()
         val audio = FloatSampleBuffer(
             initialCapacity = SherpaLongAudio.STREAMING_WINDOW_SECONDS * SherpaLongAudio.SAMPLE_RATE,
         )
         var transcript = SherpaTranscript.EMPTY
         var overlapsPrevious = false
+        var droppedAudibleChunk = false
+
+        suspend fun consume(chunk: FloatArray) {
+            // The gain a chunk is levelled with has to come from more than the
+            // chunk itself: one gain per chunk moves the level at every
+            // boundary, and a chunk that is all pause would be amplified into
+            // noise the model transcribes as words. The peak over everything
+            // captured so far is the closest a streaming chunk gets to the
+            // single gain the whole-file path applies, and it only ever grows,
+            // so the gain only ever settles.
+            val levelled = SpeechAudioConditioning.condition(chunk, audio.peak)
+            val decoded = decode(levelled)
+            if (decoded.text.isEmpty() && !SherpaLongAudio.isEffectivelySilent(levelled)) {
+                droppedAudibleChunk = true
+            }
+            transcript = transcript.append(decoded, deduplicateOverlap = overlapsPrevious)
+        }
 
         for (frame in frames) {
             audio.append(frame)
@@ -58,22 +93,17 @@ internal class SherpaIncrementalSession(
                 if (audio.size < STREAMING_WINDOW_SAMPLES) break
                 val available = audio.toFloatArray()
                 val split = SherpaLongAudio.nextStreamingSplit(available) ?: break
-                transcript = transcript.append(
-                    decode(available.copyOfRange(0, split.endExclusive)),
-                    deduplicateOverlap = overlapsPrevious,
-                )
+                consume(available.copyOfRange(0, split.endExclusive))
                 audio.discardPrefix(split.nextStart)
                 overlapsPrevious = split.nextStart < split.endExclusive
             }
         }
 
-        if (audio.size > 0) {
-            transcript = transcript.append(
-                decode(audio.toFloatArray()),
-                deduplicateOverlap = overlapsPrevious,
-            )
-        }
-        return transcript.copy(text = transcript.text.trim())
+        if (audio.size > 0) consume(audio.toFloatArray())
+        return SherpaIncrementalResult(
+            transcript = transcript.copy(text = transcript.text.trim()),
+            droppedAudibleChunk = droppedAudibleChunk,
+        )
     }
 
     private class FloatSampleBuffer(initialCapacity: Int) {
@@ -81,9 +111,17 @@ internal class SherpaIncrementalSession(
         var size: Int = 0
             private set
 
+        /** The loudest sample of everything appended, not only what is retained. */
+        var peak: Float = 0f
+            private set
+
         fun append(frame: ShortArray) {
             ensureCapacity(size + frame.size)
-            for (sample in frame) samples[size++] = sample / 32_768f
+            for (sample in frame) {
+                val value = sample / 32_768f
+                if (abs(value) > peak) peak = abs(value)
+                samples[size++] = value
+            }
         }
 
         fun discardPrefix(count: Int) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaLongAudio.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaLongAudio.kt
@@ -152,16 +152,8 @@ internal object SherpaLongAudio {
             ?.coerceIn(minEnd, maxEnd)
     }
 
-    /**
-     * Whether a chunk carries no audio worth decoding.
-     *
-     * Deliberately below the boundary-search silence floor: this skips only
-     * near-digital-silence, and keeps quiet speech. It answers "was anything
-     * lost when this chunk decoded to nothing", so a false positive would hide
-     * exactly the missing seconds it exists to find.
-     */
-    fun isEffectivelySilent(samples: FloatArray): Boolean {
-        if (samples.isEmpty()) return true
+    /** The loudest 100 ms frame in [samples], as RMS. */
+    fun loudestFrame(samples: FloatArray): Double {
         val frameSamples = SILENCE_FRAME_MILLIS * SAMPLE_RATE / 1_000
         var loudest = 0.0
         var start = 0
@@ -172,8 +164,37 @@ internal object SherpaLongAudio {
             )
             start += frameSamples
         }
-        return loudest < SILENT_CHUNK_RMS
+        return loudest
     }
+
+    /**
+     * Whether there is nothing here worth handing to a model.
+     *
+     * The floor is deliberately below the boundary-search silence threshold: it
+     * skips only near-digital-silence and keeps quiet speech. Erring this way
+     * costs a decode of a pause; erring the other way drops speech, which is
+     * the whole failure this file exists to avoid.
+     */
+    fun isEffectivelySilent(samples: FloatArray): Boolean =
+        samples.isEmpty() || isEffectivelySilent(loudestFrame(samples))
+
+    fun isEffectivelySilent(loudestFrame: Double): Boolean = loudestFrame < SILENT_CHUNK_RMS
+
+    /**
+     * Whether a chunk carries speech rather than the room between sentences.
+     *
+     * [loudestFrameSoFar] is the loudest frame heard earlier in the same
+     * recording. No absolute floor separates a quiet room from quiet speech --
+     * one room's noise sits above another room's whisper -- but the distance
+     * between a pause and the speech around it holds across recordings, which
+     * is why the boundary search scales its own threshold the same way.
+     *
+     * Only asked about a chunk that already decoded to nothing, and only to
+     * decide whether that is worth re-reading the whole file over. Room tone
+     * answering with no tokens is not a loss; it is the correct answer.
+     */
+    fun carriesSpeech(loudestFrame: Double, loudestFrameSoFar: Double): Boolean =
+        loudestFrame >= maxOf(SILENT_CHUNK_RMS, loudestFrameSoFar * SILENCE_RMS_RATIO)
 
     private fun rms(samples: FloatArray, start: Int, endExclusive: Int): Double {
         if (endExclusive <= start) return 0.0

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaLongAudio.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaLongAudio.kt
@@ -38,6 +38,7 @@ internal object SherpaLongAudio {
     private const val MIN_CHUNK_SECONDS = 4
     private const val MIN_SILENCE_RMS = 0.0125
     private const val SILENCE_RMS_RATIO = 0.18
+    private const val SILENT_CHUNK_RMS = 0.006
 
     fun chunks(samples: FloatArray): List<SherpaAudioChunk> {
         if (samples.size <= LONG_AUDIO_THRESHOLD_SECONDS * SAMPLE_RATE) {
@@ -139,6 +140,29 @@ internal object SherpaLongAudio {
         return quietStart.takeIf { it >= 0 && lowestRms <= threshold }
             ?.plus(frameSamples / 2)
             ?.coerceIn(minEnd, maxEnd)
+    }
+
+    /**
+     * Whether a chunk carries no audio worth decoding.
+     *
+     * Deliberately below the boundary-search silence floor: this skips only
+     * near-digital-silence, and keeps quiet speech. It answers "was anything
+     * lost when this chunk decoded to nothing", so a false positive would hide
+     * exactly the missing seconds it exists to find.
+     */
+    fun isEffectivelySilent(samples: FloatArray): Boolean {
+        if (samples.isEmpty()) return true
+        val frameSamples = SILENCE_FRAME_MILLIS * SAMPLE_RATE / 1_000
+        var loudest = 0.0
+        var start = 0
+        while (start < samples.size) {
+            loudest = maxOf(
+                loudest,
+                rms(samples, start, (start + frameSamples).coerceAtMost(samples.size)),
+            )
+            start += frameSamples
+        }
+        return loudest < SILENT_CHUNK_RMS
     }
 
     private fun rms(samples: FloatArray, start: Int, endExclusive: Int): Double {

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaLongAudio.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaLongAudio.kt
@@ -33,6 +33,16 @@ internal object SherpaLongAudio {
     const val OVERLAP_MILLIS = 500
     const val STREAMING_WINDOW_SECONDS = TARGET_CHUNK_SECONDS + 2
 
+    /**
+     * A chunk shorter than this answering with no tokens is ordinary rather
+     * than a loss: it is the half second of retained overlap a recording that
+     * ends just after a boundary leaves behind, or a fragment of a word. Longer
+     * than this and an empty answer is suspicious -- which is why it is also the
+     * bar [SherpaEmptyChunkRecovery] uses before it bothers retrying a chunk as
+     * two halves.
+     */
+    const val MIN_SUSPECT_CHUNK_SECONDS = 6
+
     private const val SILENCE_FRAME_MILLIS = 100
     private const val SILENCE_SEARCH_MILLIS = 2_000
     private const val MIN_CHUNK_SECONDS = 4

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
@@ -195,7 +195,6 @@ internal data class SherpaTranscript(val text: String, val language: String = ""
  * pay the extra inference cost.
  */
 internal object SherpaEmptyChunkRecovery {
-    private const val MIN_RETRY_SECONDS = 6
 
     fun decode(
         samples: FloatArray,
@@ -203,7 +202,8 @@ internal object SherpaEmptyChunkRecovery {
     ): SherpaTranscript {
         val firstAttempt = decodeOnce(samples)
         if (firstAttempt.text.isNotEmpty() ||
-            samples.size <= MIN_RETRY_SECONDS * SherpaLongAudio.SAMPLE_RATE
+            samples.size <=
+            SherpaLongAudio.MIN_SUSPECT_CHUNK_SECONDS * SherpaLongAudio.SAMPLE_RATE
         ) {
             return firstAttempt
         }

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaIncrementalSessionTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaIncrementalSessionTest.kt
@@ -108,17 +108,62 @@ class SherpaIncrementalSessionTest {
 
     @Test
     fun theGainComesFromTheRecordingAndNotFromTheChunk() = runTest {
-        // A pause between two loud passages. Levelling it on its own peak would
-        // amplify the room by eight and let the model transcribe the noise.
+        // Loud speech, then a passage far quieter but still plainly speech.
         val loud = tone(seconds = 13.0, amplitude = 0.5f)
-        val quiet = ShortArray(SherpaLongAudio.SAMPLE_RATE * 12) { 32 }
+        val quiet = tone(seconds = 16.0, amplitude = 0.03f)
         val peaks = mutableListOf<Float>()
         run(loud + quiet, this) { chunk ->
             peaks += chunk.fold(0f) { peak, sample -> maxOf(peak, abs(sample)) }
             SherpaTranscript("spoken")
         }
 
+        // The quiet passage keeps its place under the loud one. Levelling it on
+        // its own peak would have pushed it to the 0.85 target, which is how a
+        // pause becomes noise the model transcribes as words.
         assertTrue(peaks.size > 1)
-        assertTrue(peaks.last() < 0.01f)
+        assertTrue(peaks.last() > 0.03f)
+        assertTrue(peaks.last() < 0.1f)
+    }
+
+    @Test
+    fun aShortTailThatDecodesToNothingIsNotADroppedChunk() = runTest {
+        val sizes = mutableListOf<Int>()
+        val result = run(tone(seconds = 22.0, amplitude = 0.4f), this) { chunk ->
+            sizes += chunk.size
+            // A recording that ends just after a boundary leaves the half
+            // second of retained overlap and a fragment of a word behind, and
+            // that answers with no tokens all the time.
+            if (chunk.size < 6 * SherpaLongAudio.SAMPLE_RATE) {
+                SherpaTranscript("")
+            } else {
+                SherpaTranscript("spoken")
+            }
+        }
+
+        assertTrue(sizes.last() < 6 * SherpaLongAudio.SAMPLE_RATE)
+        // Calling that a loss re-runs the whole recording through the model at
+        // finish, which is the exact wait the streaming path exists to remove.
+        assertFalse(result.droppedAudibleChunk)
+    }
+
+    @Test
+    fun trailingRoomToneIsNeitherDecodedNorCountedAsALoss() = runTest {
+        // Quiet speech, so the levelling gain reaches its eight-times ceiling --
+        // enough to lift room tone over a threshold meant for capture levels.
+        val speech = tone(seconds = 13.0, amplitude = 0.05f)
+        val roomTone = ShortArray(SherpaLongAudio.SAMPLE_RATE * 16) { index ->
+            if (index % 2 == 0) 65 else -65
+        }
+        var decoded = 0
+        val result = run(speech + roomTone, this) {
+            decoded += 1
+            if (decoded > 2) SherpaTranscript("") else SherpaTranscript("spoken")
+        }
+
+        // Nothing was said over those ten seconds, so there was nothing to
+        // lose, and asking the model anyway costs a decode plus the two the
+        // empty-chunk recovery would add on top.
+        assertEquals(2, decoded)
+        assertFalse(result.droppedAudibleChunk)
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaIncrementalSessionTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaIncrementalSessionTest.kt
@@ -53,6 +53,47 @@ class SherpaIncrementalSessionTest {
         return session.finish()
     }
 
+    /** Room between sentences: above the near-silence floor, as a real room is. */
+    private fun room(seconds: Double): ShortArray {
+        val count = (SherpaLongAudio.SAMPLE_RATE * seconds).toInt()
+        return ShortArray(count) { if (it % 2 == 0) 262 else -262 }
+    }
+
+    /**
+     * What a transducer does: words for a chunk with speech in it, nothing for
+     * a chunk of room tone. Reads the levelled audio the session hands over,
+     * where speech has been brought to the 0.85 target and a pause has not.
+     */
+    private fun healthyModel(chunk: FloatArray): SherpaTranscript {
+        val peak = chunk.fold(0f) { loudest, sample -> maxOf(loudest, abs(sample)) }
+        return SherpaTranscript(if (peak > 0.3f) "spoken" else "")
+    }
+
+    @Test
+    fun aHealthyModelNeverPaysForASecondPass() = runTest {
+        // Every shape an ordinary dictation takes. None of them may set the
+        // flag: it costs the whole recording decoded again at finish, which is
+        // the entire wait this path exists to remove, and the fast families pay
+        // most of their finish time to it.
+        val shapes = listOf(
+            "one sentence" to tone(seconds = 5.0, amplitude = 0.4f),
+            "past a boundary" to tone(seconds = 22.0, amplitude = 0.4f),
+            "left running after the last word" to
+                tone(seconds = 20.0, amplitude = 0.4f) + room(seconds = 10.0),
+            "a long pause to think" to
+                tone(seconds = 10.0, amplitude = 0.4f) + room(seconds = 12.0) +
+                tone(seconds = 10.0, amplitude = 0.4f),
+            "unbroken" to tone(seconds = 40.0, amplitude = 0.4f),
+        )
+
+        for ((name, samples) in shapes) {
+            val result = run(samples, this) { healthyModel(it) }
+
+            assertFalse("$name asked for a second pass", result.droppedAudibleChunk)
+            assertTrue("$name lost its words", result.transcript.text.startsWith("spoken"))
+        }
+    }
+
     @Test
     fun aChunkThatDecodesToNothingIsReported() = runTest {
         var decoded = 0
@@ -144,6 +185,40 @@ class SherpaIncrementalSessionTest {
         // Calling that a loss re-runs the whole recording through the model at
         // finish, which is the exact wait the streaming path exists to remove.
         assertFalse(result.droppedAudibleChunk)
+    }
+
+    @Test
+    fun aPauseInTheMiddleOfARecordingIsNotADroppedChunk() = runTest {
+        // Room tone loud enough to clear the near-silence floor, which is what
+        // a real room sounds like between two sentences. It is decoded, because
+        // skipping it would risk skipping quiet speech -- but it decoding to
+        // nothing is the right answer, not a loss.
+        val speech = tone(seconds = 13.0, amplitude = 0.4f)
+        val roomTone = ShortArray(SherpaLongAudio.SAMPLE_RATE * 16) { index ->
+            if (index % 2 == 0) 655 else -655
+        }
+        var decoded = 0
+        val result = run(speech + roomTone, this) {
+            decoded += 1
+            if (decoded > 2) SherpaTranscript("") else SherpaTranscript("spoken")
+        }
+
+        assertEquals(3, decoded)
+        assertFalse(result.droppedAudibleChunk)
+    }
+
+    @Test
+    fun theWholeFileRetryIsOnlyTakenWhenItRecoveredSomething() {
+        val streamed = SherpaIncrementalResult(
+            transcript = SherpaTranscript("the opening half and the rest of it"),
+            droppedAudibleChunk = true,
+        )
+
+        assertTrue(streamed.supersededBy("the opening half and the rest of it, and more"))
+        // The retry lost the opening half, which is the failure it was asked to
+        // fix. Shipping it would cut a sentence the user watched being said.
+        assertFalse(streamed.supersededBy("the rest of it"))
+        assertFalse(streamed.supersededBy(""))
     }
 
     @Test

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaIncrementalSessionTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaIncrementalSessionTest.kt
@@ -1,0 +1,124 @@
+package com.vocahq.vocaphone.local
+
+import kotlin.math.abs
+import kotlin.math.sin
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The incremental path decodes a long recording as chunks while the microphone
+ * is still open, so a chunk that comes back with no tokens takes its seconds out
+ * of the transcript without leaving a trace in the text. These cover the two
+ * things that keep those seconds: the caller is told, and the model is not
+ * handed audio quieter than the whole-file path would give it.
+ *
+ * Mirrors the iOS client's `SherpaIncrementalSessionTests`.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SherpaIncrementalSessionTest {
+
+    /**
+     * Speech-shaped enough to clear the silence floor, at whatever level the
+     * microphone is being asked to imitate.
+     */
+    private fun tone(seconds: Double, amplitude: Float): ShortArray {
+        val count = (SherpaLongAudio.SAMPLE_RATE * seconds).toInt()
+        return ShortArray(count) { index ->
+            val envelope = 0.4f + 0.6f * abs(sin(index * 0.0004f))
+            (amplitude * sin(index * 0.08f) * envelope * 32_767f).toInt().toShort()
+        }
+    }
+
+    private suspend fun run(
+        samples: ShortArray,
+        scope: TestScope,
+        decode: (FloatArray) -> SherpaTranscript,
+    ): SherpaIncrementalResult {
+        val session = SherpaIncrementalSession(
+            scope = scope,
+            prepare = {},
+            decode = { decode(it) },
+        )
+        var index = 0
+        while (index < samples.size) {
+            val end = minOf(index + 1_600, samples.size)
+            assertTrue(session.offer(samples.copyOfRange(index, end)))
+            index = end
+        }
+        return session.finish()
+    }
+
+    @Test
+    fun aChunkThatDecodesToNothingIsReported() = runTest {
+        var decoded = 0
+        val result = run(tone(seconds = 25.0, amplitude = 0.4f), this) {
+            decoded += 1
+            // Exactly the failure this exists for: the first long chunk comes
+            // back empty and every later one succeeds, so the merged text reads
+            // as a whole sentence that starts ten seconds in.
+            if (decoded == 1) SherpaTranscript("") else SherpaTranscript("later")
+        }
+
+        assertTrue(decoded > 1)
+        assertEquals("later", result.transcript.text)
+        assertTrue(result.droppedAudibleChunk)
+    }
+
+    @Test
+    fun aCompleteRunReportsNothingDropped() = runTest {
+        val result = run(tone(seconds = 25.0, amplitude = 0.4f), this) {
+            SherpaTranscript("spoken")
+        }
+
+        assertFalse(result.droppedAudibleChunk)
+        assertTrue(result.transcript.text.startsWith("spoken"))
+    }
+
+    @Test
+    fun silenceIsNotMistakenForADroppedChunk() = runTest {
+        val result = run(ShortArray(SherpaLongAudio.SAMPLE_RATE * 25), this) {
+            SherpaTranscript("")
+        }
+
+        // Nothing was said, so nothing was lost, and a whole-file retry of the
+        // same silence would only cost the user time.
+        assertTrue(result.transcript.text.isEmpty())
+        assertFalse(result.droppedAudibleChunk)
+    }
+
+    @Test
+    fun quietChunksReachTheModelLevelled() = runTest {
+        val peaks = mutableListOf<Float>()
+        run(tone(seconds = 25.0, amplitude = 0.05f), this) { chunk ->
+            peaks += chunk.fold(0f) { peak, sample -> maxOf(peak, abs(sample)) }
+            SherpaTranscript("spoken")
+        }
+
+        // A phone on a desk records far below what an int8 model was trained
+        // on. The whole-file path has always levelled that; the streaming path
+        // used to hand the model the raw 0.05.
+        assertTrue(peaks.isNotEmpty())
+        assertTrue(peaks.all { it > 0.3f })
+    }
+
+    @Test
+    fun theGainComesFromTheRecordingAndNotFromTheChunk() = runTest {
+        // A pause between two loud passages. Levelling it on its own peak would
+        // amplify the room by eight and let the model transcribe the noise.
+        val loud = tone(seconds = 13.0, amplitude = 0.5f)
+        val quiet = ShortArray(SherpaLongAudio.SAMPLE_RATE * 12) { 32 }
+        val peaks = mutableListOf<Float>()
+        run(loud + quiet, this) { chunk ->
+            peaks += chunk.fold(0f) { peak, sample -> maxOf(peak, abs(sample)) }
+            SherpaTranscript("spoken")
+        }
+
+        assertTrue(peaks.size > 1)
+        assertTrue(peaks.last() < 0.01f)
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
@@ -89,7 +89,7 @@ class SherpaLongAudioTest {
         withTimeout(5_000) { firstChunkDecoded.await() }
         repeat(130) { assertTrue(session.offer(frame)) }
 
-        assertEquals("one boundary two three", session.finish().text)
+        assertEquals("one boundary two three", session.finish().transcript.text)
         assertEquals(3, decodedSizes.size)
         assertTrue(decodedSizes.dropLast(1).all { it <= 10 * SherpaLongAudio.SAMPLE_RATE })
         assertTrue(decodedSizes.last() < 10 * SherpaLongAudio.SAMPLE_RATE)

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		1D96E4B5456A18FA04F5F15D /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */; };
 		1EE70552DF2972DCE328ED01 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA135DE504590121F6D8843 /* DiagnosticLog.swift */; };
 		1F45494DE6D2E1E471D446B5 /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11816AC1A2219D15E870CE3E /* EmojiCatalog.swift */; };
+		9C1D4A70B33E5F0182AC41D3 /* SherpaIncrementalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1D4A70B33E5F0182AC41D2 /* SherpaIncrementalSession.swift */; };
+		9C1D4A70B33E5F0182AC41D4 /* SherpaIncrementalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1D4A70B33E5F0182AC41D2 /* SherpaIncrementalSession.swift */; };
 		214B0AB3D2362EC3EE656E53 /* SherpaLongAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */; };
 		21FF5DE4F40DB8D70AC170E2 /* CustomVocabulary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AA9291707DE7366D08EB0C /* CustomVocabulary.swift */; };
 		22293F4CFA1E2512027DFFBC /* TranscriptSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B121356A503DF83BFA0E0D0C /* TranscriptSanitizer.swift */; };
@@ -65,6 +67,7 @@
 		3226364FB9F43F49B12FE2A6 /* DictationBarLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA83B914C241E5F8BF8F32AC /* DictationBarLayoutTests.swift */; };
 		324811B86570CBD6C1C1FCFC /* SherpaRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0358A093FE299D51D513BC30 /* SherpaRecognizer.swift */; };
 		33049B8AD2490B0F8D0A9E0F /* SwipeRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C4BD2142E9377F123A8848 /* SwipeRecognizer.swift */; };
+		9C1D4A70B33E5F0182AC41D6 /* SherpaIncrementalSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1D4A70B33E5F0182AC41D5 /* SherpaIncrementalSessionTests.swift */; };
 		332424547CBE2483FE24C975 /* SherpaTranscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3E4382E021BE30F6D687A7 /* SherpaTranscriptTests.swift */; };
 		33A2193E058E05B4B4FB3860 /* ModelLanguageSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */; };
 		34C17CDE69437F6E9407758D /* CustomVocabulary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AA9291707DE7366D08EB0C /* CustomVocabulary.swift */; };
@@ -313,6 +316,7 @@
 		02C96151B8C8ECE035FF0D8F /* HomePresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePresentation.swift; sourceTree = "<group>"; };
 		0358A093FE299D51D513BC30 /* SherpaRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaRecognizer.swift; sourceTree = "<group>"; };
 		03871B8CFC1A23E1AD3A33CD /* SherpaOnnx-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SherpaOnnx-Bridging-Header.h"; sourceTree = "<group>"; };
+		9C1D4A70B33E5F0182AC41D2 /* SherpaIncrementalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaIncrementalSession.swift; sourceTree = "<group>"; };
 		054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaLongAudio.swift; sourceTree = "<group>"; };
 		05735C847A47FF442B4FB21A /* TypingPrivacyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingPrivacyTests.swift; sourceTree = "<group>"; };
 		06FC8DDB89A55103E29C10D3 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -344,6 +348,7 @@
 		37C9B64B52A8D28D252CC3A5 /* AudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorder.swift; sourceTree = "<group>"; };
 		3BA012C76E8C374857732F67 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3D4BE75828FCA9C70DFEDC96 /* SpellChecking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpellChecking.swift; sourceTree = "<group>"; };
+		9C1D4A70B33E5F0182AC41D5 /* SherpaIncrementalSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaIncrementalSessionTests.swift; sourceTree = "<group>"; };
 		3E3E4382E021BE30F6D687A7 /* SherpaTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaTranscriptTests.swift; sourceTree = "<group>"; };
 		3EC2C1575D306E7683092FBA /* KeyGridLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyGridLayoutTests.swift; sourceTree = "<group>"; };
 		406B0C287866B36EF3109238 /* LocalModelPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelPicker.swift; sourceTree = "<group>"; };
@@ -572,6 +577,7 @@
 				AF6C44F954E7A62974C66109 /* SemanticPalette.swift */,
 				36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */,
 				7948F8C6C72A8D7A16C18562 /* SharedStore.swift */,
+				9C1D4A70B33E5F0182AC41D2 /* SherpaIncrementalSession.swift */,
 				054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */,
 				5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */,
 				E590CFC53039DA367280B8CD /* SpokenNumbers.swift */,
@@ -700,6 +706,7 @@
 				B854354D06D0111DEB123E7A /* SessionRecordTests.swift */,
 				EA031D86C1DE3C2F8B047308 /* SetupStatusTests.swift */,
 				20F3E310970DBFA3822A4D19 /* SherpaDecodingMethodTests.swift */,
+				9C1D4A70B33E5F0182AC41D5 /* SherpaIncrementalSessionTests.swift */,
 				3E3E4382E021BE30F6D687A7 /* SherpaTranscriptTests.swift */,
 				8F8CE24C7BC4F4CA618F4B79 /* SmartPunctuationTests.swift */,
 				A59DB522E7DFDE3B3E009AFD /* SpeechAudioConditioningTests.swift */,
@@ -1043,6 +1050,7 @@
 				366E7DFAD5B2666FC1FF9FB3 /* SetupStatus.swift in Sources */,
 				0D07EBF90CE481AE0C1976CF /* SetupView.swift in Sources */,
 				D9811B8978380027BF95D0D5 /* SharedStore.swift in Sources */,
+				9C1D4A70B33E5F0182AC41D3 /* SherpaIncrementalSession.swift in Sources */,
 				79D51827CA805EB6D890699C /* SherpaLongAudio.swift in Sources */,
 				3BC9D24EF0E08132FFB24481 /* SherpaOnnxBridge.c in Sources */,
 				324811B86570CBD6C1C1FCFC /* SherpaRecognizer.swift in Sources */,
@@ -1169,6 +1177,8 @@
 				5A151959ABCE2ADE4646A79D /* SharedStore.swift in Sources */,
 				F69EAE4A82B9ACE347EA0D77 /* SherpaDecodingMethodTests.swift in Sources */,
 				C9A65099749EC5AB021FCC1C /* SherpaLongAudio.swift in Sources */,
+				9C1D4A70B33E5F0182AC41D4 /* SherpaIncrementalSession.swift in Sources */,
+				9C1D4A70B33E5F0182AC41D6 /* SherpaIncrementalSessionTests.swift in Sources */,
 				332424547CBE2483FE24C975 /* SherpaTranscriptTests.swift in Sources */,
 				63835D9307A147564F896FB5 /* SmartPunctuation.swift in Sources */,
 				63BC0E226633FBBE88C60EBE /* SmartPunctuationTests.swift in Sources */,

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -40,8 +40,6 @@
 		1D96E4B5456A18FA04F5F15D /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */; };
 		1EE70552DF2972DCE328ED01 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA135DE504590121F6D8843 /* DiagnosticLog.swift */; };
 		1F45494DE6D2E1E471D446B5 /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11816AC1A2219D15E870CE3E /* EmojiCatalog.swift */; };
-		9C1D4A70B33E5F0182AC41D3 /* SherpaIncrementalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1D4A70B33E5F0182AC41D2 /* SherpaIncrementalSession.swift */; };
-		9C1D4A70B33E5F0182AC41D4 /* SherpaIncrementalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1D4A70B33E5F0182AC41D2 /* SherpaIncrementalSession.swift */; };
 		214B0AB3D2362EC3EE656E53 /* SherpaLongAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */; };
 		21FF5DE4F40DB8D70AC170E2 /* CustomVocabulary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AA9291707DE7366D08EB0C /* CustomVocabulary.swift */; };
 		22293F4CFA1E2512027DFFBC /* TranscriptSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B121356A503DF83BFA0E0D0C /* TranscriptSanitizer.swift */; };
@@ -67,7 +65,6 @@
 		3226364FB9F43F49B12FE2A6 /* DictationBarLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA83B914C241E5F8BF8F32AC /* DictationBarLayoutTests.swift */; };
 		324811B86570CBD6C1C1FCFC /* SherpaRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0358A093FE299D51D513BC30 /* SherpaRecognizer.swift */; };
 		33049B8AD2490B0F8D0A9E0F /* SwipeRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C4BD2142E9377F123A8848 /* SwipeRecognizer.swift */; };
-		9C1D4A70B33E5F0182AC41D6 /* SherpaIncrementalSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1D4A70B33E5F0182AC41D5 /* SherpaIncrementalSessionTests.swift */; };
 		332424547CBE2483FE24C975 /* SherpaTranscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3E4382E021BE30F6D687A7 /* SherpaTranscriptTests.swift */; };
 		33A2193E058E05B4B4FB3860 /* ModelLanguageSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */; };
 		34C17CDE69437F6E9407758D /* CustomVocabulary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AA9291707DE7366D08EB0C /* CustomVocabulary.swift */; };
@@ -105,6 +102,7 @@
 		4F24DEC1FC8411ACBDA6BC50 /* VocaPhoneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934F25D30F7D00565D83CAA0 /* VocaPhoneApp.swift */; };
 		4FB8BA8E9E7B9332FDBCD80C /* LocalModelPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406B0C287866B36EF3109238 /* LocalModelPicker.swift */; };
 		4FDB3D32A404C674AFAB948F /* ModelLanguageSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */; };
+		503DA76554CDB360C2E32566 /* SherpaIncrementalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41205764F091734B2DE6D02 /* SherpaIncrementalSession.swift */; };
 		52151816E957DE430B67B9F8 /* KeyboardViewPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8E5D91EDE2C0E67DFC0250 /* KeyboardViewPreview.swift */; };
 		52B45B602C490B27A6405A45 /* TranscriptionQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E2BF42CAC209DA12464566 /* TranscriptionQuality.swift */; };
 		52D566C02915D934240601EA /* PairingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFB4BB0345784837C629340 /* PairingPayload.swift */; };
@@ -150,6 +148,7 @@
 		81131D34DE3F3CBDBA61BE4E /* SwipeTrailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */; };
 		81BFE90A24876CEE127974AE /* TypingFieldPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2CD13AAF5FDF79DD5D0075 /* TypingFieldPolicy.swift */; };
 		825C92F4A7114541F04C8313 /* TranscriptionSourceStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5995603DDA33014FFA52B079 /* TranscriptionSourceStatus.swift */; };
+		82A1659A07D52F972E9010DD /* SherpaIncrementalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41205764F091734B2DE6D02 /* SherpaIncrementalSession.swift */; };
 		834AEADC7B9757282E300418 /* TranscriptHistoryModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDF2EC3AB09FF78FD1EF935 /* TranscriptHistoryModelTests.swift */; };
 		8468AAFD83E231AD9BB99792 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCC7453FC149EBB02E3FB58 /* KeychainStore.swift */; };
 		8484AF469C29CC148B720447 /* LocalTranscriptionPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FF1A5ABC4220C886291309 /* LocalTranscriptionPreferences.swift */; };
@@ -220,6 +219,7 @@
 		C37AC6FC3CBF2147D8A50DDA /* SemanticPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B395C37266816A19C38B59 /* SemanticPaletteTests.swift */; };
 		C4D64FB835EAB5A67E6CE009 /* AudioCapturePipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15DE10A5F8F90C87D4BA48A /* AudioCapturePipeline.swift */; };
 		C63521DE52DC5A8DCD6847AE /* EmojiPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348E2313B75BA61D777FA18B /* EmojiPanelView.swift */; };
+		C6E529713960996E85EFD275 /* SherpaIncrementalSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0A732D03A2951F028DDF6E /* SherpaIncrementalSessionTests.swift */; };
 		C729D3D95B9B597E56C485E7 /* SpokenNumbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E590CFC53039DA367280B8CD /* SpokenNumbers.swift */; };
 		C80FCACABE7FF798EFD1EB61 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894063AE1B3DDA92C529268D /* AppConfiguration.swift */; };
 		C845C02425BC2788BABB26C2 /* SpeechAudioConditioningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59DB522E7DFDE3B3E009AFD /* SpeechAudioConditioningTests.swift */; };
@@ -241,6 +241,7 @@
 		D8EE8A829E13191046F3F183 /* WordComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A6EEE8C98BCBF8D1D70D44 /* WordComposer.swift */; };
 		D9811B8978380027BF95D0D5 /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
 		D9D9DB4E8F749BCC02AD0B5B /* PreviewFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9677581A0FA938AD9C520C /* PreviewFixtures.swift */; };
+		DC775A81F32818BCC08CA795 /* SherpaIncrementalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41205764F091734B2DE6D02 /* SherpaIncrementalSession.swift */; };
 		DCAAD00B7ED79568106DAD0C /* DictatedTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575BDB070A428051B623F095 /* DictatedTranscript.swift */; };
 		DCF552B58B7A7A12C517C17B /* PairingPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9E5CE913B4FA5EF8EECD4E /* PairingPayloadTests.swift */; };
 		DEB245BAC4DEE643F2EB38B0 /* DictationPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56047A6705008B5F17F003CE /* DictationPresentationTests.swift */; };
@@ -258,6 +259,7 @@
 		E9E86F6940BDB4381A8C9FF5 /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C304CF763960E5F1D8F76B2B /* LiveActivityManager.swift */; };
 		EE7A49C4F95388AF42E1B30C /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
 		EFEB53E947DAF4C77FE5E059 /* DictatedTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575BDB070A428051B623F095 /* DictatedTranscript.swift */; };
+		F0EC49ECABE510B52F876C8F /* SherpaIncrementalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41205764F091734B2DE6D02 /* SherpaIncrementalSession.swift */; };
 		F11A2E1FF01BA4115116AFB5 /* HomePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C96151B8C8ECE035FF0D8F /* HomePresentation.swift */; };
 		F1CDF580A8C552E1A03524A1 /* DictationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3489C985467C23EB6A90AD /* DictationBarView.swift */; };
 		F1E23C92AD4C90D424DB84D9 /* LocalModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473A608BF3F8827B3D3842B0 /* LocalModelCatalog.swift */; };
@@ -316,7 +318,6 @@
 		02C96151B8C8ECE035FF0D8F /* HomePresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePresentation.swift; sourceTree = "<group>"; };
 		0358A093FE299D51D513BC30 /* SherpaRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaRecognizer.swift; sourceTree = "<group>"; };
 		03871B8CFC1A23E1AD3A33CD /* SherpaOnnx-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SherpaOnnx-Bridging-Header.h"; sourceTree = "<group>"; };
-		9C1D4A70B33E5F0182AC41D2 /* SherpaIncrementalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaIncrementalSession.swift; sourceTree = "<group>"; };
 		054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaLongAudio.swift; sourceTree = "<group>"; };
 		05735C847A47FF442B4FB21A /* TypingPrivacyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingPrivacyTests.swift; sourceTree = "<group>"; };
 		06FC8DDB89A55103E29C10D3 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -348,7 +349,6 @@
 		37C9B64B52A8D28D252CC3A5 /* AudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorder.swift; sourceTree = "<group>"; };
 		3BA012C76E8C374857732F67 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3D4BE75828FCA9C70DFEDC96 /* SpellChecking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpellChecking.swift; sourceTree = "<group>"; };
-		9C1D4A70B33E5F0182AC41D5 /* SherpaIncrementalSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaIncrementalSessionTests.swift; sourceTree = "<group>"; };
 		3E3E4382E021BE30F6D687A7 /* SherpaTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaTranscriptTests.swift; sourceTree = "<group>"; };
 		3EC2C1575D306E7683092FBA /* KeyGridLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyGridLayoutTests.swift; sourceTree = "<group>"; };
 		406B0C287866B36EF3109238 /* LocalModelPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelPicker.swift; sourceTree = "<group>"; };
@@ -427,6 +427,7 @@
 		B854354D06D0111DEB123E7A /* SessionRecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRecordTests.swift; sourceTree = "<group>"; };
 		B87128326897BFA30E7B2038 /* KeyLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyLayout.swift; sourceTree = "<group>"; };
 		B9B9027C03A87FBC74CE1130 /* TypingEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingEngine.swift; sourceTree = "<group>"; };
+		BA0A732D03A2951F028DDF6E /* SherpaIncrementalSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaIncrementalSessionTests.swift; sourceTree = "<group>"; };
 		BA1F0FABCAE6669D0EB07FC3 /* SwipeAlternates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeAlternates.swift; sourceTree = "<group>"; };
 		BC9677581A0FA938AD9C520C /* PreviewFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewFixtures.swift; sourceTree = "<group>"; };
 		BD7C720E296C2265F0174573 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -444,6 +445,7 @@
 		CF080065DC31C6DA8E693163 /* VocaPhoneLiveActivity.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = VocaPhoneLiveActivity.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelLanguageSupport.swift; sourceTree = "<group>"; };
 		D1AA0EB543777294237739CF /* TypingStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingStripView.swift; sourceTree = "<group>"; };
+		D41205764F091734B2DE6D02 /* SherpaIncrementalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaIncrementalSession.swift; sourceTree = "<group>"; };
 		D80C83295868E17F215D9382 /* TypingStripPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingStripPresentationTests.swift; sourceTree = "<group>"; };
 		D97C6225AC98D4FE053BDB13 /* KeyboardPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPreview.swift; sourceTree = "<group>"; };
 		DBAE2B11D3A27A798D0F39ED /* local_model_pins.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = local_model_pins.json; sourceTree = "<group>"; };
@@ -577,7 +579,7 @@
 				AF6C44F954E7A62974C66109 /* SemanticPalette.swift */,
 				36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */,
 				7948F8C6C72A8D7A16C18562 /* SharedStore.swift */,
-				9C1D4A70B33E5F0182AC41D2 /* SherpaIncrementalSession.swift */,
+				D41205764F091734B2DE6D02 /* SherpaIncrementalSession.swift */,
 				054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */,
 				5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */,
 				E590CFC53039DA367280B8CD /* SpokenNumbers.swift */,
@@ -706,7 +708,7 @@
 				B854354D06D0111DEB123E7A /* SessionRecordTests.swift */,
 				EA031D86C1DE3C2F8B047308 /* SetupStatusTests.swift */,
 				20F3E310970DBFA3822A4D19 /* SherpaDecodingMethodTests.swift */,
-				9C1D4A70B33E5F0182AC41D5 /* SherpaIncrementalSessionTests.swift */,
+				BA0A732D03A2951F028DDF6E /* SherpaIncrementalSessionTests.swift */,
 				3E3E4382E021BE30F6D687A7 /* SherpaTranscriptTests.swift */,
 				8F8CE24C7BC4F4CA618F4B79 /* SmartPunctuationTests.swift */,
 				A59DB522E7DFDE3B3E009AFD /* SpeechAudioConditioningTests.swift */,
@@ -973,6 +975,7 @@
 				EE7A49C4F95388AF42E1B30C /* SemanticPalette.swift in Sources */,
 				36295638EAABF35D05369EB0 /* SessionRecord.swift in Sources */,
 				A794CD8D0B445E5118500EC3 /* SharedStore.swift in Sources */,
+				503DA76554CDB360C2E32566 /* SherpaIncrementalSession.swift in Sources */,
 				C2C99C66A00384823A3A0A22 /* SherpaLongAudio.swift in Sources */,
 				35136B012E8D8B8D720B569A /* SmartPunctuation.swift in Sources */,
 				B4542386951D03680B5F6638 /* SpeechAudioConditioning.swift in Sources */,
@@ -1050,7 +1053,7 @@
 				366E7DFAD5B2666FC1FF9FB3 /* SetupStatus.swift in Sources */,
 				0D07EBF90CE481AE0C1976CF /* SetupView.swift in Sources */,
 				D9811B8978380027BF95D0D5 /* SharedStore.swift in Sources */,
-				9C1D4A70B33E5F0182AC41D3 /* SherpaIncrementalSession.swift in Sources */,
+				82A1659A07D52F972E9010DD /* SherpaIncrementalSession.swift in Sources */,
 				79D51827CA805EB6D890699C /* SherpaLongAudio.swift in Sources */,
 				3BC9D24EF0E08132FFB24481 /* SherpaOnnxBridge.c in Sources */,
 				324811B86570CBD6C1C1FCFC /* SherpaRecognizer.swift in Sources */,
@@ -1100,6 +1103,7 @@
 				F4E8B1A9D00B14184B01B223 /* SemanticPalette.swift in Sources */,
 				3F3E17AFAAE8EB6B79A872BE /* SessionRecord.swift in Sources */,
 				B2406DA05AE90DDB7EED6246 /* SharedStore.swift in Sources */,
+				F0EC49ECABE510B52F876C8F /* SherpaIncrementalSession.swift in Sources */,
 				214B0AB3D2362EC3EE656E53 /* SherpaLongAudio.swift in Sources */,
 				91EA8108C4C2D6C4EF5CF3F1 /* SpeechAudioConditioning.swift in Sources */,
 				C729D3D95B9B597E56C485E7 /* SpokenNumbers.swift in Sources */,
@@ -1176,9 +1180,9 @@
 				1B72FBEA5D41DB51B82A1305 /* SetupStatusTests.swift in Sources */,
 				5A151959ABCE2ADE4646A79D /* SharedStore.swift in Sources */,
 				F69EAE4A82B9ACE347EA0D77 /* SherpaDecodingMethodTests.swift in Sources */,
+				DC775A81F32818BCC08CA795 /* SherpaIncrementalSession.swift in Sources */,
+				C6E529713960996E85EFD275 /* SherpaIncrementalSessionTests.swift in Sources */,
 				C9A65099749EC5AB021FCC1C /* SherpaLongAudio.swift in Sources */,
-				9C1D4A70B33E5F0182AC41D4 /* SherpaIncrementalSession.swift in Sources */,
-				9C1D4A70B33E5F0182AC41D6 /* SherpaIncrementalSessionTests.swift in Sources */,
 				332424547CBE2483FE24C975 /* SherpaTranscriptTests.swift in Sources */,
 				63835D9307A147564F896FB5 /* SmartPunctuation.swift in Sources */,
 				63BC0E226633FBBE88C60EBE /* SmartPunctuationTests.swift in Sources */,

--- a/ios/VocaPhoneApp/Audio/AudioRecorder.swift
+++ b/ios/VocaPhoneApp/Audio/AudioRecorder.swift
@@ -38,6 +38,13 @@ final class AudioRecorder: NSObject {
     /// or a slower first decode cannot discard the beginning of the transcript.
     private(set) var localPcmChunks: AsyncStream<Data>?
     private(set) var lastDroppedChunkCount = 0
+    /// Whether the on-device queue refused a chunk. Its capacity is comfortably
+    /// past the recording limit, so this should never fire — but the two numbers
+    /// are set in different files, and the failure it guards is silent: a
+    /// refused chunk is seconds missing from the end of the transcript with
+    /// nothing in the text to show for it.
+    private let localChunksDropped = OSAllocatedUnfairLock(initialState: false)
+    var didDropLocalChunks: Bool { localChunksDropped.withLock { $0 } }
     /// The loudest sample of the recording that just finished. Zero means iOS
     /// handed this app silence, not that the user said nothing quietly.
     private(set) var lastPeakLevel: Float = 0
@@ -195,13 +202,20 @@ final class AudioRecorder: NSObject {
         }
 
         ring.reset()
+        // Captured rather than reached through `self`: the emit closure runs on
+        // the capture queue and this type is main-actor isolated.
+        let localDropped = localChunksDropped
+        localDropped.withLock { $0 = false }
         try pipeline.start(writingTo: output) { data in
             let gatewayAccepted = switch continuation.yield(data) {
             case .enqueued: true
             default: false
             }
             if let localContinuation {
-                _ = localContinuation.yield(data)
+                switch localContinuation.yield(data) {
+                case .enqueued: break
+                default: localDropped.withLock { $0 = true }
+                }
             }
             return gatewayAccepted
         }

--- a/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
+++ b/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
@@ -176,69 +176,11 @@ private enum SherpaEmptyChunkRecovery {
     }
 }
 
-/// Consumes captured PCM while the microphone is still running. The WAV file
-/// remains authoritative, but Sherpa's expensive offline work is spread over
-/// the recording instead of making the user wait for the whole file at finish.
-final class SherpaIncrementalSession: @unchecked Sendable {
-    private let task: Task<SherpaTranscript, Never>
-
-    init(chunks: AsyncStream<Data>, recognizer: SherpaRecognizer) {
-        task = Task.detached(priority: .userInitiated) {
-            await Self.transcribe(chunks: chunks, recognizer: recognizer)
-        }
-    }
-
-    func finish() async -> SherpaTranscript { await task.value }
-
-    func cancel() { task.cancel() }
-
-    private static func transcribe(
-        chunks: AsyncStream<Data>,
-        recognizer: SherpaRecognizer
-    ) async -> SherpaTranscript {
-        var samples: [Float] = []
-        samples.reserveCapacity(
-            SherpaLongAudio.streamingWindowSeconds * SherpaLongAudio.sampleRate
-        )
-        var transcript = SherpaTranscript.empty
-        var overlapsPrevious = false
-
-        for await data in chunks {
-            guard !Task.isCancelled else { return Self.trimmed(transcript) }
-            samples.append(contentsOf: Self.floatSamples(in: data))
-
-            while let split = SherpaLongAudio.nextStreamingSplit(samples) {
-                let bounded = Array(samples[..<split.endExclusive])
-                transcript = transcript.appending(
-                    recognizer.transcribeChunk(bounded),
-                    deduplicateOverlap: overlapsPrevious
-                )
-                samples.removeFirst(split.nextStart)
-                overlapsPrevious = split.nextStart < split.endExclusive
-            }
-        }
-
-        if !samples.isEmpty {
-            transcript = transcript.appending(
-                recognizer.transcribeChunk(samples),
-                deduplicateOverlap: overlapsPrevious
-            )
-        }
-        return Self.trimmed(transcript)
-    }
-
-    private static func trimmed(_ transcript: SherpaTranscript) -> SherpaTranscript {
-        SherpaTranscript(
-            text: transcript.text.trimmingCharacters(in: .whitespacesAndNewlines),
-            language: transcript.language
-        )
-    }
-
-    private static func floatSamples(in data: Data) -> [Float] {
-        guard data.count >= MemoryLayout<Float>.stride else { return [] }
-        return data.withUnsafeBytes { rawBuffer in
-            let values = rawBuffer.bindMemory(to: Float.self)
-            return Array(values)
-        }
+extension SherpaIncrementalSession {
+    /// The session lives in the shared target and takes a decode closure so it
+    /// can be tested without the native engine; this is the one call site that
+    /// has a real recognizer to give it.
+    convenience init(chunks: AsyncStream<Data>, recognizer: SherpaRecognizer) {
+        self.init(chunks: chunks) { recognizer.transcribeChunk($0) }
     }
 }

--- a/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
+++ b/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
@@ -158,8 +158,6 @@ private extension SherpaFamily {
 }
 
 private enum SherpaEmptyChunkRecovery {
-    private static let minimumRetrySamples = 6 * SherpaLongAudio.sampleRate
-
     static func decode(
         samples: [Float], decodeOnce: ([Float]) -> SherpaTranscript
     ) -> SherpaTranscript {
@@ -169,7 +167,9 @@ private enum SherpaEmptyChunkRecovery {
             text: attempt.text.trimmingCharacters(in: .whitespacesAndNewlines),
             language: attempt.language
         )
-        guard first.text.isEmpty, samples.count > minimumRetrySamples else { return first }
+        guard first.text.isEmpty,
+              samples.count > SherpaLongAudio.minimumSuspectChunkSamples
+        else { return first }
         let midpoint = samples.count / 2
         return decodeOnce(Array(samples[..<midpoint]))
             .appending(decodeOnce(Array(samples[midpoint...])), deduplicateOverlap: false)

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -968,21 +968,43 @@ final class RecordingCoordinator {
 
             let incremental = localSherpaSession
             localSherpaSession = nil
+            // A chunk the queue refused never reached the decoder, so the
+            // session cannot know it is short. Only the recorder can say.
+            let droppedLocalChunks = recorder.didDropLocalChunks
             let transcribed: LocalModelManager.LocalTranscription
             if let incremental {
                 let incrementalResult = await incremental.finish()
-                if incrementalResult.text.isEmpty {
-                    // A model can still produce no tokens for a boundary split;
-                    // preserve the old whole-file retry as a last resort.
-                    transcribed = try await localModels.transcribe(
-                        audioURL: audioURL,
-                        language: record.language
-                    )
+                let partial = LocalModelManager.LocalTranscription(
+                    text: incrementalResult.transcript.text,
+                    language: incrementalResult.transcript.language
+                )
+                // A whole-file retry for an empty result, and equally for one
+                // that lost a chunk: the attention families answer a long
+                // waveform with no tokens often enough that a partial result is
+                // the common case, not the rare one, and the seconds it is
+                // missing are invisible in the text it did produce. The retry
+                // levels the gain over the whole recording and splits on
+                // different boundaries, which is what recovers them.
+                if partial.text.isEmpty || incrementalResult.droppedAudibleChunk
+                    || droppedLocalChunks
+                {
+                    do {
+                        transcribed = try await localModels.transcribe(
+                            audioURL: audioURL,
+                            language: record.language
+                        )
+                    } catch {
+                        // Incomplete beats nothing, but only when there is
+                        // something, and never for a session the user has
+                        // already walked away from.
+                        guard !partial.text.isEmpty,
+                              !Task.isCancelled,
+                              !(error is CancellationError)
+                        else { throw error }
+                        transcribed = partial
+                    }
                 } else {
-                    transcribed = .init(
-                        text: incrementalResult.text,
-                        language: incrementalResult.language
-                    )
+                    transcribed = partial
                 }
             } else {
                 transcribed = try await localModels.transcribe(

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -989,10 +989,13 @@ final class RecordingCoordinator {
                     || droppedLocalChunks
                 {
                     do {
-                        transcribed = try await localModels.transcribe(
+                        let wholeFile = try await localModels.transcribe(
                             audioURL: audioURL,
                             language: record.language
                         )
+                        transcribed = incrementalResult.supersededBy(wholeFile.text)
+                            ? wholeFile
+                            : partial
                     } catch {
                         // Incomplete beats nothing, but only when there is
                         // something, and never for a session the user has

--- a/ios/VocaPhoneShared/SherpaIncrementalSession.swift
+++ b/ios/VocaPhoneShared/SherpaIncrementalSession.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// What an incremental session decoded, and whether any of the recording is
+/// missing from it.
+struct SherpaIncrementalResult: Sendable, Equatable {
+    let transcript: SherpaTranscript
+
+    /// True when a chunk that carried audio decoded to nothing.
+    ///
+    /// Those seconds are then simply absent, and nothing downstream can tell:
+    /// the merge joins the chunks either side into text that reads as a whole
+    /// sentence which happens to begin ten seconds into the recording. The
+    /// attention families drop a long chunk often enough for this to be the
+    /// difference between a transcript and a plausible-looking lie, so the
+    /// caller re-decodes the file rather than shipping the hole.
+    let droppedAudibleChunk: Bool
+
+    static let empty = SherpaIncrementalResult(transcript: .empty, droppedAudibleChunk: false)
+}
+
+/// Consumes captured PCM while the microphone is still running. The WAV file
+/// remains authoritative, but Sherpa's expensive offline work is spread over
+/// the recording instead of making the user wait for the whole file at finish.
+final class SherpaIncrementalSession: @unchecked Sendable {
+    private let task: Task<SherpaIncrementalResult, Never>
+
+    /// `decode` is handed one complete chunk at a time and must be safe to call
+    /// off the main actor; the recognizer overload in the app target supplies
+    /// the real one.
+    init(chunks: AsyncStream<Data>, decode: @escaping @Sendable ([Float]) -> SherpaTranscript) {
+        task = Task.detached(priority: .userInitiated) {
+            await Self.transcribe(chunks: chunks, decode: decode)
+        }
+    }
+
+    func finish() async -> SherpaIncrementalResult { await task.value }
+
+    func cancel() { task.cancel() }
+
+    private static func transcribe(
+        chunks: AsyncStream<Data>,
+        decode: @Sendable ([Float]) -> SherpaTranscript
+    ) async -> SherpaIncrementalResult {
+        var samples: [Float] = []
+        samples.reserveCapacity(
+            SherpaLongAudio.streamingWindowSeconds * SherpaLongAudio.sampleRate
+        )
+        var transcript = SherpaTranscript.empty
+        var overlapsPrevious = false
+        var droppedAudibleChunk = false
+        // The gain a chunk is levelled with has to come from more than the chunk
+        // itself: one gain per chunk moves the level at every boundary, and a
+        // chunk that is all pause would be amplified into noise the model
+        // transcribes as words. The peak over everything captured so far is the
+        // closest a streaming chunk gets to the single gain the whole-file path
+        // applies, and it only ever grows, so the gain only ever settles.
+        var peak: Float = 0
+
+        func consume(_ chunk: [Float]) {
+            let levelled = SpeechAudioConditioning.condition(chunk, peak: peak)
+            let decoded = decode(levelled)
+            if decoded.text.isEmpty, !SherpaLongAudio.isEffectivelySilent(levelled) {
+                droppedAudibleChunk = true
+            }
+            transcript = transcript.appending(decoded, deduplicateOverlap: overlapsPrevious)
+        }
+
+        func result() -> SherpaIncrementalResult {
+            SherpaIncrementalResult(
+                transcript: SherpaTranscript(
+                    text: transcript.text.trimmingCharacters(in: .whitespacesAndNewlines),
+                    language: transcript.language
+                ),
+                droppedAudibleChunk: droppedAudibleChunk
+            )
+        }
+
+        for await data in chunks {
+            guard !Task.isCancelled else { return result() }
+            let incoming = Self.floatSamples(in: data)
+            peak = incoming.reduce(peak) { max($0, abs($1)) }
+            samples.append(contentsOf: incoming)
+
+            while let split = SherpaLongAudio.nextStreamingSplit(samples) {
+                consume(Array(samples[..<split.endExclusive]))
+                samples.removeFirst(split.nextStart)
+                overlapsPrevious = split.nextStart < split.endExclusive
+            }
+        }
+
+        if !samples.isEmpty { consume(samples) }
+        return result()
+    }
+
+    private static func floatSamples(in data: Data) -> [Float] {
+        guard data.count >= MemoryLayout<Float>.stride else { return [] }
+        return data.withUnsafeBytes { rawBuffer in
+            let values = rawBuffer.bindMemory(to: Float.self)
+            return Array(values)
+        }
+    }
+}

--- a/ios/VocaPhoneShared/SherpaIncrementalSession.swift
+++ b/ios/VocaPhoneShared/SherpaIncrementalSession.swift
@@ -57,9 +57,24 @@ final class SherpaIncrementalSession: @unchecked Sendable {
         var peak: Float = 0
 
         func consume(_ chunk: [Float]) {
+            // Silence is judged on the capture as it arrived. The levelling
+            // below multiplies a quiet recording by as much as eight, and a
+            // floor meant for microphone levels reads amplified room tone as
+            // speech — which buys a decode, the two more the empty-chunk
+            // recovery adds on top, and then the whole-file re-run the flag
+            // asks the caller for. All to transcribe a pause.
+            guard !SherpaLongAudio.isEffectivelySilent(chunk) else { return }
             let levelled = SpeechAudioConditioning.condition(chunk, peak: peak)
             let decoded = decode(levelled)
-            if decoded.text.isEmpty, !SherpaLongAudio.isEffectivelySilent(levelled) {
+            // Only a chunk long enough that the recovery has already tried and
+            // failed is a hole worth re-reading the file for. Below that bar an
+            // empty answer is routine — it is the retained overlap, or the
+            // fragment of a word a recording ending just after a boundary
+            // leaves — and treating it as a loss would spend a second pass over
+            // the whole recording on almost every dictation.
+            if decoded.text.isEmpty,
+               chunk.count > SherpaLongAudio.minimumSuspectChunkSamples
+            {
                 droppedAudibleChunk = true
             }
             transcript = transcript.appending(decoded, deduplicateOverlap: overlapsPrevious)

--- a/ios/VocaPhoneShared/SherpaIncrementalSession.swift
+++ b/ios/VocaPhoneShared/SherpaIncrementalSession.swift
@@ -16,6 +16,18 @@ struct SherpaIncrementalResult: Sendable, Equatable {
     let droppedAudibleChunk: Bool
 
     static let empty = SherpaIncrementalResult(transcript: .empty, droppedAudibleChunk: false)
+
+    /// Whether a whole-file re-decode is worth taking over this result.
+    ///
+    /// The re-decode exists to recover seconds the streaming pass lost, and it
+    /// is only evidence of that if it came back with more. The same model that
+    /// dropped a chunk in one pass drops one in the other — over a recording
+    /// with a long pause in it, routinely — so taking the second pass on faith
+    /// trades a hole for a bigger one, and the user watches a finished sentence
+    /// lose its opening half.
+    func supersededBy(_ wholeFile: String) -> Bool {
+        wholeFile.count > transcript.text.count
+    }
 }
 
 /// Consumes captured PCM while the microphone is still running. The WAV file
@@ -55,6 +67,11 @@ final class SherpaIncrementalSession: @unchecked Sendable {
         // closest a streaming chunk gets to the single gain the whole-file path
         // applies, and it only ever grows, so the gain only ever settles.
         var peak: Float = 0
+        // The loudest frame of everything decoded so far, which is what a later
+        // chunk's level is judged against. Read before this chunk contributes
+        // to it, so a pause is compared with the speech around it and never
+        // with itself.
+        var loudestFrame = 0.0
 
         func consume(_ chunk: [Float]) {
             // Silence is judged on the capture as it arrived. The levelling
@@ -63,20 +80,25 @@ final class SherpaIncrementalSession: @unchecked Sendable {
             // speech — which buys a decode, the two more the empty-chunk
             // recovery adds on top, and then the whole-file re-run the flag
             // asks the caller for. All to transcribe a pause.
-            guard !SherpaLongAudio.isEffectivelySilent(chunk) else { return }
+            let level = SherpaLongAudio.loudestFrame(chunk)
+            guard !SherpaLongAudio.isEffectivelySilent(loudestFrame: level) else { return }
             let levelled = SpeechAudioConditioning.condition(chunk, peak: peak)
             let decoded = decode(levelled)
             // Only a chunk long enough that the recovery has already tried and
-            // failed is a hole worth re-reading the file for. Below that bar an
-            // empty answer is routine — it is the retained overlap, or the
+            // failed, and loud enough next to the rest of the recording to have
+            // held speech, is a hole worth re-reading the file for. Below those
+            // bars an empty answer is routine — the retained overlap, the
             // fragment of a word a recording ending just after a boundary
-            // leaves — and treating it as a loss would spend a second pass over
-            // the whole recording on almost every dictation.
+            // leaves, the room tone while someone pauses to think — and
+            // treating it as a loss spends a second pass over the whole
+            // recording to find out it was right the first time.
             if decoded.text.isEmpty,
-               chunk.count > SherpaLongAudio.minimumSuspectChunkSamples
+               chunk.count > SherpaLongAudio.minimumSuspectChunkSamples,
+               SherpaLongAudio.carriesSpeech(loudestFrame: level, loudestFrameSoFar: loudestFrame)
             {
                 droppedAudibleChunk = true
             }
+            loudestFrame = max(loudestFrame, level)
             transcript = transcript.appending(decoded, deduplicateOverlap: overlapsPrevious)
         }
 

--- a/ios/VocaPhoneShared/SherpaLongAudio.swift
+++ b/ios/VocaPhoneShared/SherpaLongAudio.swift
@@ -34,6 +34,7 @@ enum SherpaLongAudio {
     private static let minChunkSamples = sampleRate * 4
     private static let minSilenceRMS = 0.0125
     private static let silenceRMSRatio = 0.18
+    private static let silentFrameRMS = 0.006
 
     static func chunks(_ samples: [Float]) -> [Chunk] {
         guard samples.count > longAudioThresholdSeconds * sampleRate else {
@@ -125,8 +126,8 @@ enum SherpaLongAudio {
         return (sum / Double(endExclusive - start)).squareRoot()
     }
 
-    static func isEffectivelySilent(_ samples: [Float]) -> Bool {
-        guard !samples.isEmpty else { return true }
+    /// The loudest 100 ms frame in `samples`, as RMS.
+    static func loudestFrame(_ samples: [Float]) -> Double {
         var maximum = 0.0
         var start = 0
         while start < samples.count {
@@ -136,9 +137,36 @@ enum SherpaLongAudio {
             )
             start += silenceFrameSamples
         }
-        // This is deliberately below the boundary-search silence floor. It
-        // skips only near-digital-silence chunks and keeps quiet speech.
-        return maximum < 0.006
+        return maximum
+    }
+
+    /// Whether there is nothing here worth handing to a model.
+    ///
+    /// The floor is deliberately below the boundary-search silence threshold:
+    /// it skips only near-digital-silence and keeps quiet speech. Erring this
+    /// way costs a decode of a pause; erring the other way drops speech, which
+    /// is the whole failure this file exists to avoid.
+    static func isEffectivelySilent(_ samples: [Float]) -> Bool {
+        samples.isEmpty || isEffectivelySilent(loudestFrame: loudestFrame(samples))
+    }
+
+    static func isEffectivelySilent(loudestFrame: Double) -> Bool {
+        loudestFrame < silentFrameRMS
+    }
+
+    /// Whether `samples` carries speech rather than the room between sentences.
+    ///
+    /// `loudestFrameSoFar` is the loudest frame heard earlier in the same
+    /// recording. No absolute floor separates a quiet room from quiet speech —
+    /// one room's noise sits above another room's whisper — but the distance
+    /// between a pause and the speech around it holds across recordings, which
+    /// is why the boundary search scales its own threshold the same way.
+    ///
+    /// Only asked about a chunk that already decoded to nothing, and only to
+    /// decide whether that is worth re-reading the whole file over. Room tone
+    /// answering with no tokens is not a loss; it is the correct answer.
+    static func carriesSpeech(loudestFrame: Double, loudestFrameSoFar: Double) -> Bool {
+        loudestFrame >= max(silentFrameRMS, loudestFrameSoFar * silenceRMSRatio)
     }
 }
 

--- a/ios/VocaPhoneShared/SherpaLongAudio.swift
+++ b/ios/VocaPhoneShared/SherpaLongAudio.swift
@@ -9,6 +9,13 @@ enum SherpaLongAudio {
     static let targetChunkSeconds = 10
     static let maxChunkSeconds = 14
     static let overlapSamples = sampleRate / 2
+    /// A chunk shorter than this answering with no tokens is ordinary rather
+    /// than a loss: it is the half second of retained overlap a recording that
+    /// ends just after a boundary leaves behind, or a fragment of a word.
+    /// Longer than this and an empty answer is suspicious — which is why it is
+    /// also the bar `SherpaEmptyChunkRecovery` uses before it bothers retrying
+    /// a chunk as two halves.
+    static let minimumSuspectChunkSamples = 6 * sampleRate
     static let streamingWindowSeconds = targetChunkSeconds + 2
 
     struct Chunk {

--- a/ios/VocaPhoneShared/SpeechAudioConditioning.swift
+++ b/ios/VocaPhoneShared/SpeechAudioConditioning.swift
@@ -45,14 +45,27 @@ enum SpeechAudioConditioning {
             for index in samples.indices { samples[index] -= offset }
         }
 
-        let peak = samples.reduce(Float(0)) { max($0, abs($1)) }
-        guard peak >= silencePeak else { return samples }
+        return condition(samples, peak: samples.reduce(Float(0)) { max($0, abs($1)) })
+    }
+
+    /// Levels `samples` with a gain derived from `peak` rather than from the
+    /// slice itself.
+    ///
+    /// This is how a streaming chunk gets levelled: it passes the peak of every
+    /// sample captured so far, which is the closest one chunk can come to the
+    /// single gain `condition` applies over a whole recording. Passing the
+    /// slice's own peak would be exactly the per-chunk gain the note above
+    /// warns against. The DC offset is not touched here — measuring it needs
+    /// the whole recording, so it stays on the whole-file path.
+    static func condition(_ samples: [Float], peak: Float) -> [Float] {
+        guard !samples.isEmpty, peak >= silencePeak else { return samples }
 
         // Already loud enough. Attenuating a hot recording cannot undo whatever
         // clipping it arrived with, and quiet is the problem worth solving.
         let gain = min(targetPeak / peak, maximumGain)
         guard gain > 1 else { return samples }
 
+        var samples = samples
         for index in samples.indices { samples[index] *= gain }
         return samples
     }

--- a/ios/VocaPhoneTests/SherpaIncrementalSessionTests.swift
+++ b/ios/VocaPhoneTests/SherpaIncrementalSessionTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+
+/// The incremental path decodes a long recording as chunks while the microphone
+/// is still open, so a chunk that comes back with no tokens takes its seconds
+/// out of the transcript without leaving a trace in the text. These cover the
+/// two things that keep those seconds: the caller is told, and the model is not
+/// handed audio quieter than the whole-file path would give it.
+struct SherpaIncrementalSessionTests {
+
+    private static let sampleRate = SherpaLongAudio.sampleRate
+
+    /// Speech-shaped enough to clear the silence floor, at whatever level the
+    /// microphone is being asked to imitate.
+    private static func tone(seconds: Double, amplitude: Float) -> [Float] {
+        let count = Int(Double(sampleRate) * seconds)
+        return (0..<count).map { index in
+            amplitude * sin(Float(index) * 0.08) * (0.4 + 0.6 * abs(sin(Float(index) * 0.0004)))
+        }
+    }
+
+    private static func stream(_ samples: [Float]) -> AsyncStream<Data> {
+        AsyncStream { continuation in
+            var index = 0
+            while index < samples.count {
+                let end = min(index + 1_600, samples.count)
+                let slice = Array(samples[index..<end])
+                continuation.yield(slice.withUnsafeBufferPointer { Data(buffer: $0) })
+                index = end
+            }
+            continuation.finish()
+        }
+    }
+
+    @Test func aChunkThatDecodesToNothingIsReported() async {
+        let decoded = OSAllocatedCounter()
+        let session = SherpaIncrementalSession(
+            chunks: Self.stream(Self.tone(seconds: 25, amplitude: 0.4))
+        ) { _ in
+            // Exactly the failure this exists for: the first long chunk comes
+            // back empty and every later one succeeds, so the merged text reads
+            // as a whole sentence that starts ten seconds in.
+            decoded.increment() == 1 ? SherpaTranscript(text: "") : SherpaTranscript(text: "later")
+        }
+        let result = await session.finish()
+
+        #expect(decoded.value > 1)
+        #expect(result.transcript.text == "later")
+        #expect(result.droppedAudibleChunk)
+    }
+
+    @Test func aCompleteRunReportsNothingDropped() async {
+        let session = SherpaIncrementalSession(
+            chunks: Self.stream(Self.tone(seconds: 25, amplitude: 0.4))
+        ) { _ in SherpaTranscript(text: "spoken") }
+        let result = await session.finish()
+
+        #expect(!result.droppedAudibleChunk)
+        #expect(result.transcript.text.hasPrefix("spoken"))
+    }
+
+    @Test func silenceIsNotMistakenForADroppedChunk() async {
+        let session = SherpaIncrementalSession(
+            chunks: Self.stream([Float](repeating: 0, count: Self.sampleRate * 25))
+        ) { _ in SherpaTranscript(text: "") }
+        let result = await session.finish()
+
+        // Nothing was said, so nothing was lost, and a whole-file retry of the
+        // same silence would only cost the user time.
+        #expect(result.transcript.text.isEmpty)
+        #expect(!result.droppedAudibleChunk)
+    }
+
+    @Test func quietChunksReachTheModelLevelled() async {
+        let peaks = OSAllocatedPeaks()
+        let session = SherpaIncrementalSession(
+            chunks: Self.stream(Self.tone(seconds: 25, amplitude: 0.05))
+        ) { samples in
+            peaks.record(samples.reduce(Float(0)) { max($0, abs($1)) })
+            return SherpaTranscript(text: "spoken")
+        }
+        _ = await session.finish()
+
+        // A phone on a desk records far below what an int8 model was trained
+        // on. The whole-file path has always levelled that; the streaming path
+        // used to hand the model the raw 0.05.
+        #expect(peaks.recorded.allSatisfy { $0 > 0.3 })
+    }
+
+    @Test func theGainComesFromTheRecordingAndNotFromTheChunk() async {
+        // A pause between two loud passages. Levelling it on its own peak would
+        // amplify the room by eight and let the model transcribe the noise.
+        var samples = Self.tone(seconds: 13, amplitude: 0.5)
+        samples += [Float](repeating: 0.001, count: Self.sampleRate * 12)
+        let peaks = OSAllocatedPeaks()
+        let session = SherpaIncrementalSession(chunks: Self.stream(samples)) { chunk in
+            peaks.record(chunk.reduce(Float(0)) { max($0, abs($1)) })
+            return SherpaTranscript(text: "spoken")
+        }
+        _ = await session.finish()
+
+        #expect(peaks.recorded.count > 1)
+        #expect(peaks.recorded.last! < 0.01)
+    }
+}
+
+/// The decode closure runs off the main actor, so the counters it touches have
+/// to be safe to share.
+private final class OSAllocatedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    @discardableResult
+    func increment() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        count += 1
+        return count
+    }
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+}
+
+private final class OSAllocatedPeaks: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [Float] = []
+
+    func record(_ peak: Float) {
+        lock.lock()
+        defer { lock.unlock() }
+        values.append(peak)
+    }
+
+    var recorded: [Float] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+}

--- a/ios/VocaPhoneTests/SherpaIncrementalSessionTests.swift
+++ b/ios/VocaPhoneTests/SherpaIncrementalSessionTests.swift
@@ -32,6 +32,47 @@ struct SherpaIncrementalSessionTests {
         }
     }
 
+    /// Room between sentences: above the near-silence floor, as a real room is.
+    private static func room(seconds: Double) -> [Float] {
+        let count = Int(Double(sampleRate) * seconds)
+        return (0..<count).map { $0 % 2 == 0 ? 0.008 : -0.008 }
+    }
+
+    /// What a transducer does: words for a chunk with speech in it, nothing for
+    /// a chunk of room tone. Reads the levelled audio the session hands over,
+    /// where speech has been brought to the 0.85 target and a pause has not.
+    private static func healthyModel(_ chunk: [Float]) -> SherpaTranscript {
+        let peak = chunk.reduce(Float(0)) { max($0, abs($1)) }
+        return SherpaTranscript(text: peak > 0.3 ? "spoken" : "")
+    }
+
+    @Test func aHealthyModelNeverPaysForASecondPass() async {
+        // Every shape an ordinary dictation takes. None of them may set the
+        // flag: it costs the whole recording decoded again at finish, which is
+        // the entire wait this path exists to remove, and the fast families pay
+        // most of their finish time to it.
+        let shapes: [(String, [Float])] = [
+            ("one sentence", Self.tone(seconds: 5, amplitude: 0.4)),
+            ("past a boundary", Self.tone(seconds: 22, amplitude: 0.4)),
+            ("left running after the last word",
+             Self.tone(seconds: 20, amplitude: 0.4) + Self.room(seconds: 10)),
+            ("a long pause to think",
+             Self.tone(seconds: 10, amplitude: 0.4) + Self.room(seconds: 12)
+                + Self.tone(seconds: 10, amplitude: 0.4)),
+            ("unbroken", Self.tone(seconds: 40, amplitude: 0.4)),
+        ]
+
+        for (name, samples) in shapes {
+            let session = SherpaIncrementalSession(chunks: Self.stream(samples)) {
+                Self.healthyModel($0)
+            }
+            let result = await session.finish()
+
+            #expect(!result.droppedAudibleChunk, "\(name) asked for a second pass")
+            #expect(result.transcript.text.hasPrefix("spoken"), "\(name) lost its words")
+        }
+    }
+
     @Test func aChunkThatDecodesToNothingIsReported() async {
         let decoded = OSAllocatedCounter()
         let session = SherpaIncrementalSession(
@@ -125,6 +166,39 @@ struct SherpaIncrementalSessionTests {
         // Calling that a loss re-runs the whole recording through the model at
         // finish, which is the exact wait the streaming path exists to remove.
         #expect(!result.droppedAudibleChunk)
+    }
+
+    @Test func aPauseInTheMiddleOfARecordingIsNotADroppedChunk() async {
+        // Room tone loud enough to clear the near-silence floor, which is what
+        // a real room sounds like between two sentences. It is decoded, because
+        // skipping it would risk skipping quiet speech — but it decoding to
+        // nothing is the right answer, not a loss.
+        var samples = Self.tone(seconds: 13, amplitude: 0.4)
+        samples += (0..<(Self.sampleRate * 16)).map { $0 % 2 == 0 ? 0.02 : -0.02 }
+        let decoded = RecordedSizes()
+        let session = SherpaIncrementalSession(chunks: Self.stream(samples)) { chunk in
+            decoded.record(chunk.count)
+            return decoded.recorded.count > 2
+                ? SherpaTranscript(text: "")
+                : SherpaTranscript(text: "spoken")
+        }
+        let result = await session.finish()
+
+        #expect(decoded.recorded.count == 3)
+        #expect(!result.droppedAudibleChunk)
+    }
+
+    @Test func theWholeFileRetryIsOnlyTakenWhenItRecoveredSomething() {
+        let streamed = SherpaIncrementalResult(
+            transcript: SherpaTranscript(text: "the opening half and the rest of it"),
+            droppedAudibleChunk: true
+        )
+
+        #expect(streamed.supersededBy("the opening half and the rest of it, and more"))
+        // The retry lost the opening half, which is the failure it was asked to
+        // fix. Shipping it would cut a sentence the user watched being said.
+        #expect(!streamed.supersededBy("the rest of it"))
+        #expect(!streamed.supersededBy(""))
     }
 
     @Test func trailingRoomToneIsNeitherDecodedNorCountedAsALoss() async {

--- a/ios/VocaPhoneTests/SherpaIncrementalSessionTests.swift
+++ b/ios/VocaPhoneTests/SherpaIncrementalSessionTests.swift
@@ -88,10 +88,9 @@ struct SherpaIncrementalSessionTests {
     }
 
     @Test func theGainComesFromTheRecordingAndNotFromTheChunk() async {
-        // A pause between two loud passages. Levelling it on its own peak would
-        // amplify the room by eight and let the model transcribe the noise.
+        // Loud speech, then a passage far quieter but still plainly speech.
         var samples = Self.tone(seconds: 13, amplitude: 0.5)
-        samples += [Float](repeating: 0.001, count: Self.sampleRate * 12)
+        samples += Self.tone(seconds: 16, amplitude: 0.03)
         let peaks = OSAllocatedPeaks()
         let session = SherpaIncrementalSession(chunks: Self.stream(samples)) { chunk in
             peaks.record(chunk.reduce(Float(0)) { max($0, abs($1)) })
@@ -99,8 +98,54 @@ struct SherpaIncrementalSessionTests {
         }
         _ = await session.finish()
 
+        // The quiet passage keeps its place under the loud one. Levelling it on
+        // its own peak would have pushed it to the 0.85 target, which is how a
+        // pause becomes noise the model transcribes as words.
         #expect(peaks.recorded.count > 1)
-        #expect(peaks.recorded.last! < 0.01)
+        #expect(peaks.recorded.last! > 0.03)
+        #expect(peaks.recorded.last! < 0.1)
+    }
+
+    @Test func aShortTailThatDecodesToNothingIsNotADroppedChunk() async {
+        let sizes = RecordedSizes()
+        let session = SherpaIncrementalSession(
+            chunks: Self.stream(Self.tone(seconds: 22, amplitude: 0.4))
+        ) { samples in
+            sizes.record(samples.count)
+            // A recording that ends just after a boundary leaves the half
+            // second of retained overlap and a fragment of a word behind, and
+            // that answers with no tokens all the time.
+            return samples.count < 6 * Self.sampleRate
+                ? SherpaTranscript(text: "")
+                : SherpaTranscript(text: "spoken")
+        }
+        let result = await session.finish()
+
+        #expect(sizes.recorded.last! < 6 * Self.sampleRate)
+        // Calling that a loss re-runs the whole recording through the model at
+        // finish, which is the exact wait the streaming path exists to remove.
+        #expect(!result.droppedAudibleChunk)
+    }
+
+    @Test func trailingRoomToneIsNeitherDecodedNorCountedAsALoss() async {
+        // Quiet speech, so the levelling gain reaches its eight-times ceiling —
+        // enough to lift room tone over a threshold meant for capture levels.
+        var samples = Self.tone(seconds: 13, amplitude: 0.05)
+        samples += (0..<(Self.sampleRate * 16)).map { $0 % 2 == 0 ? 0.002 : -0.002 }
+        let decoded = RecordedSizes()
+        let session = SherpaIncrementalSession(chunks: Self.stream(samples)) { chunk in
+            decoded.record(chunk.count)
+            return decoded.recorded.count > 2
+                ? SherpaTranscript(text: "")
+                : SherpaTranscript(text: "spoken")
+        }
+        let result = await session.finish()
+
+        // Nothing was said over those ten seconds, so there was nothing to
+        // lose, and asking the model anyway costs a decode plus the two the
+        // empty-chunk recovery would add on top.
+        #expect(decoded.recorded.count == 2)
+        #expect(!result.droppedAudibleChunk)
     }
 }
 
@@ -136,6 +181,23 @@ private final class OSAllocatedPeaks: @unchecked Sendable {
     }
 
     var recorded: [Float] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+}
+
+private final class RecordedSizes: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [Int] = []
+
+    func record(_ size: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        values.append(size)
+    }
+
+    var recorded: [Int] {
         lock.lock()
         defer { lock.unlock() }
         return values


### PR DESCRIPTION
## The bug

Reported on iOS with Canary: the first ~10 seconds of a longer dictation are missing from the transcript, with no error.

A sherpa model does not transcribe the WAV at finish. It decodes while the microphone is still open, in ~12 s chunks, and merges them. A chunk that comes back with no tokens takes its seconds out of the transcript **without leaving a trace** — the merge joins the chunks either side into text that reads as a whole sentence which happens to begin ten seconds in. Nothing downstream can tell the difference.

Both clients only fell back to the whole-file decode when the incremental result was *entirely* empty, so a partial result shipped as if it were complete.

Canary is the model that surfaced it: the one attention encoder-decoder in the catalog getting handed full 12 s chunks. The comment on `SherpaEmptyChunkRecovery` already said those "occasionally return no tokens for a longer waveform".

## The fix

Two defects, both on the streaming path only.

**1. A dropped chunk was invisible.** The session now returns `droppedAudibleChunk`, and the caller re-decodes the whole file rather than shipping the hole. If that retry cannot run, the partial text is still delivered — incomplete beats a failure. `CancellationException` / `CancellationError` is rethrown so a session the user walked away from never delivers.

**2. Chunks were never levelled.** `LocalModelManager.transcribe` has always applied `SpeechAudioConditioning` (up to 8× gain) to the whole file — `"Safe here and not on the incremental path"` — while the streaming path handed the same model raw capture. That is exactly the condition an int8 attention decoder answers with an immediate EOS.

Chunks are now levelled with a gain derived from **the peak over everything captured so far**, never the chunk's own peak. That respects the warning in the existing doc comment: no per-chunk gain jumps, and a chunk that is all pause is not amplified into noise the model transcribes as words.

## Sweep for the same shape

**One more, on iOS:** `AudioRecorder` discarded the result of yielding to the on-device queue. Android has always handled this — a refused frame drops the session and forces the whole-file path — but iOS had no equivalent, so a refused chunk would have silently truncated the tail.

Not reachable today: the queue holds ~205 s and recording is capped at 120. But those two numbers live in different files with nothing connecting them, and the failure is silent, so it gets a guard.

**Checked and clean:** gateway streaming on both platforms (iOS `finish(droppedChunks:)` returns nil on any loss; Android gates on `droppedStreamFrames == 0`); Android's WAV frame channel (fails loudly); WhisperKit (batch only, throws on empty).

**Residual, deliberately not changed:** the whole-file path chunks too and has the same blind spot, but it is already the last resort with nothing left to fall back to. Practically this means the retry usually recovers the missing seconds — whole-recording gain, different split boundaries — but cannot guarantee it. Making that path self-verifying is a separate design question.

## Notes

iOS moves `SherpaIncrementalSession` into `VocaPhoneShared` behind a decode closure — how Android has always had it, and what makes it testable without the native engine. Android gains `SherpaLongAudio.isEffectivelySilent` and a `local_incremental_dropped_chunk` diagnostic timing.

## Testing

- iOS: 413 tests, all passing (5 new in `SherpaIncrementalSessionTests`).
- Android: 289 tests, all passing (5 new in `SherpaIncrementalSessionTest`, mirroring the iOS suite).

Both suites cover: an empty first chunk is reported; a complete run reports nothing dropped; silence is not mistaken for a dropped chunk; quiet chunks reach the model levelled; the gain comes from the recording and not the chunk.

Diagnosed by reading the code — **not reproduced on a device with Canary loaded**, so which of the two defects triggers Canary's empty chunk is unconfirmed. The fix makes the silent-hole symptom impossible either way; worst case is one re-decode.
