### PR TITLE
Use a colon in the homepage title

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -10,7 +10,7 @@
     <meta name="theme-color" content="#f4f1e8" />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://vocaphone.vocahq.com/" />
-    <meta property="og:title" content="VocaPhone — voice typing that stays yours" />
+    <meta property="og:title" content="VocaPhone: voice typing that stays yours" />
     <meta
       property="og:description"
       content="A private, open-source voice keyboard that runs speech-to-text on your phone or through your own optional VocaGateway."
@@ -32,7 +32,7 @@
       content="VocaPhone voice typing that stays yours, on-device first with an optional gateway"
     />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="VocaPhone — voice typing that stays yours" />
+    <meta name="twitter:title" content="VocaPhone: voice typing that stays yours" />
     <meta
       name="twitter:description"
       content="Private, open-source voice typing that runs on your phone or your optional VocaGateway."
@@ -42,7 +42,7 @@
       name="twitter:image:alt"
       content="VocaPhone voice typing that stays yours, on-device first with an optional gateway"
     />
-    <title>VocaPhone — voice typing that stays yours</title>
+    <title>VocaPhone: voice typing that stays yours</title>
     <link rel="icon" href="assets/vocaphone-logo.svg" type="image/svg+xml" />
     <link rel="icon" href="favicon.ico" sizes="any" />
     <link rel="apple-touch-icon" href="assets/apple-touch-icon.png" />

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -20,7 +20,7 @@ function androidInstallBlock(source) {
 }
 
 test("page has one clear title and a landmark structure", () => {
-  assert.match(html, /<title>VocaPhone — voice typing that stays yours<\/title>/);
+  assert.match(html, /<title>VocaPhone: voice typing that stays yours<\/title>/);
   assert.equal((html.match(/<h1\b/g) || []).length, 1);
   assert.match(html, /<main id="main-content">/);
   assert.match(html, /<nav[^>]+aria-label="Main navigation"/);
@@ -86,7 +86,7 @@ test("production metadata is complete", () => {
     /property="og:image:height" content="630"/,
     /property="og:image:alt"\s+content="VocaPhone voice typing that stays yours, on-device first with an optional gateway"/,
     /name="twitter:card" content="summary_large_image"/,
-    /name="twitter:title" content="VocaPhone — voice typing that stays yours"/,
+    /name="twitter:title" content="VocaPhone: voice typing that stays yours"/,
     /name="twitter:image" content="https:\/\/vocaphone\.vocahq\.com\/assets\/og-image\.png"/,
     /name="twitter:image:alt"\s+content="VocaPhone voice typing that stays yours, on-device first with an optional gateway"/,
   ]) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The homepage document title used an em dash. Linux titles use a colon, so it now reads `VocaPhone: voice typing that stays yours`. Same string on `og:title` and `twitter:title`. The site test that asserted the old title is updated.

iPhone subpage titles and body copy are unchanged.

## Verification

- [x] `npm run check` in `web/` (17/17 passed)
- [ ] `just ios ci` (skipped: web titles only)
- [ ] `just android ci` (skipped: web titles only)
- [ ] Gateway changes: none
- [ ] Physical-device test: not needed (titles only)

Maintainers can comment `/build` on this PR for installable Android/iOS
artifacts (see CONTRIBUTING).

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [ ] Documentation updated for data-flow, permission, retention, or network changes (N/A)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1103d437-fdda-4977-b62f-baf971a1f328?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1103d437-fdda-4977-b62f-baf971a1f328&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

