### PR TITLE
Fix slow and flaky Whisper transcription on mobile

### DIFF
--- a/android/app/src/androidTest/java/com/vocahq/vocaphone/local/LocalEngineEndToEndTest.kt
+++ b/android/app/src/androidTest/java/com/vocahq/vocaphone/local/LocalEngineEndToEndTest.kt
@@ -1,7 +1,10 @@
 package com.vocahq.vocaphone.local
 
+import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry
+import com.vocahq.vocaphone.audio.SpeechAudioConditioning
 import java.io.File
+import kotlin.time.measureTime
 import kotlinx.coroutines.runBlocking
 import org.junit.Assume.assumeTrue
 import org.junit.Assert.assertEquals
@@ -51,6 +54,79 @@ class LocalEngineEndToEndTest {
 
         // A second pass must reuse the loaded context rather than reloading.
         assertEquals(transcript, manager.transcribe(speech(), model.id, "en").text)
+    }
+
+    /**
+     * Repeatable physical-device timing for a model that is already downloaded
+     * in the app under test. This deliberately does not assert a duration: the
+     * same model spans phones with radically different CPUs, while the log gives
+     * us comparable numbers for the same audio before and after a change.
+     *
+     *     ./gradlew :app:connectedFullDebugAndroidTest \
+     *       -Pandroid.testInstrumentationRunnerArguments.localModelBenchmark=small
+     */
+    @Test
+    fun anInstalledWhisperModelTranscribesReferenceAudio() = runBlocking {
+        val modelID = InstrumentationRegistry.getArguments()
+            .getString("localModelBenchmark")
+            .orEmpty()
+        assumeTrue(
+            "set localModelBenchmark to an installed Whisper model ID",
+            modelID.isNotEmpty(),
+        )
+        val manager = LocalModelManager(context)
+        val model = requireNotNull(LocalModelCatalog.find(modelID))
+        require(model.engine == LocalModelEngine.WHISPER) { "$modelID is not a Whisper model" }
+        manager.refresh()
+        assumeTrue("$modelID is not downloaded in the target app", manager.isDownloaded(model.id))
+
+        val arguments = InstrumentationRegistry.getArguments()
+        val threads = arguments.getString("localModelBenchmarkThreads")
+            ?.toIntOrNull()
+            ?: WhisperCpuConfig.preferredThreadCount(model.id)
+        val audio = SpeechAudioConditioning.condition(speech())
+        val audioContext = arguments.getString("localModelBenchmarkContext")
+            ?.toIntOrNull()
+            ?: if (model.cropsAudioContext) WhisperCpuConfig.whisperAudioContext(audio.size) else 0
+        val pointer = WhisperLib.initContext(
+            File(manager.directoryFor(model), model.primaryFile.path).absolutePath,
+        )
+        check(pointer != 0L) { "Could not load ${model.displayName}" }
+        try {
+            repeat(2) { run ->
+                val elapsed = measureTime {
+                    check(
+                        WhisperLib.fullTranscribe(
+                            pointer,
+                            threads,
+                            audio,
+                            "en",
+                            0,
+                            1f,
+                            audioContext,
+                            "",
+                        ) == 0,
+                    ) { "${model.displayName} could not decode the reference audio" }
+                }
+                val transcript = buildString {
+                    repeat(WhisperLib.getTextSegmentCount(pointer)) { index ->
+                        append(WhisperLib.getTextSegment(pointer, index))
+                    }
+                }.trim()
+                assertTrue("empty transcript from ${model.displayName}", transcript.isNotBlank())
+                assertTrue(
+                    "unexpected transcript: $transcript",
+                    transcript.lowercase().contains("yellow lamps"),
+                )
+                Log.i(
+                    "VocaPhoneBenchmark",
+                    "${model.id} run ${run + 1}: ${elapsed.inWholeMilliseconds} ms; " +
+                        "threads=$threads; audio_ctx=$audioContext; $transcript",
+                )
+            }
+        } finally {
+            WhisperLib.freeContext(pointer)
+        }
     }
 
     /**

--- a/android/app/src/main/cpp/whisper/CMakeLists.txt
+++ b/android/app/src/main/cpp/whisper/CMakeLists.txt
@@ -52,6 +52,10 @@ include(FetchContent)
 # These have to be set here, at directory scope and before ggml is pulled in,
 # so that they cover ggml's targets as well as ours.
 add_compile_options(
+    # Dictation performance must not depend on whether a developer installed a
+    # debug or release APK. Keep native inference optimized while retaining the
+    # debug symbols supplied by the build type.
+    -O3
     -ffile-prefix-map=${WHISPER_LIB_DIR}=/whisper.cpp
     -ffile-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=/vocaphone
     -ffile-prefix-map=${CMAKE_BINARY_DIR}=/build

--- a/android/app/src/main/cpp/whisper/jni.c
+++ b/android/app/src/main/cpp/whisper/jni.c
@@ -84,7 +84,7 @@ JNIEXPORT jint JNICALL
 Java_com_vocahq_vocaphone_local_WhisperLib_00024Companion_fullTranscribe(
         JNIEnv *env, jobject thiz, jlong context_ptr, jint num_threads,
         jfloatArray audio_data, jstring language_str, jint beam_size,
-        jboolean temperature_fallback, jint audio_context, jstring prompt_str) {
+        jfloat temperature_increment, jint audio_context, jstring prompt_str) {
     UNUSED(thiz);
     struct whisper_context *context = (struct whisper_context *) context_ptr;
     jfloat *audio = (*env)->GetFloatArrayElements(env, audio_data, NULL);
@@ -109,11 +109,10 @@ Java_com_vocahq_vocaphone_local_WhisperLib_00024Companion_fullTranscribe(
     params.language = language;
     params.n_threads = num_threads;
     params.no_context = true;
-    // The client only consumes text. Timestamp tokens add decoder work and
-    // their segment boundaries are never used, so decode one text segment per
-    // 30-second whisper window instead of making the phone predict timestamps
-    // that are immediately discarded.
-    params.no_timestamps = true;
+    // The client does not print timestamps, but the decoder must still be able
+    // to predict their tokens: they are how Whisper cleanly stops after speech.
+    // Suppressing them made short phrases repeat over the padded window.
+    params.no_timestamps = false;
     params.single_segment = true;
     // whisper.cpp defaults greedy.best_of to five. That default is also used
     // for temperature-fallback passes, and it turns a rare retry into five
@@ -124,10 +123,10 @@ Java_com_vocahq_vocaphone_local_WhisperLib_00024Companion_fullTranscribe(
     // rather than stripping them from the text afterwards where a marker the
     // sanitizer has not seen before gets through.
     params.suppress_nst = true;
-    // Zero disables the retry of a window whose result looks degenerate. That
-    // retry is what breaks whisper out of a repetition loop, so only the Fast
-    // setting gives it up.
-    params.temperature_inc = temperature_fallback ? 0.2f : 0.0f;
+    // Zero disables fallback. Balanced passes 1.0 for exactly one retry;
+    // Accurate passes 0.5 for two. The upstream 0.2 default permits five full
+    // decoder retries and caused the multi-second latency spikes seen on phones.
+    params.temperature_inc = temperature_increment;
     // Crops the encoder to the window the caller sized for this recording, so a
     // short dictation stops paying for the thirty-second one whisper otherwise
     // pads it to. Zero leaves whisper's own default in place.
@@ -135,9 +134,9 @@ Java_com_vocahq_vocaphone_local_WhisperLib_00024Companion_fullTranscribe(
 
     __android_log_print(
             ANDROID_LOG_INFO, TAG,
-            "Transcribing %d samples with %d threads, beam=%d, fallback=%d, audio_ctx=%d",
+            "Transcribing %d samples with %d threads, beam=%d, temperature_inc=%.1f, audio_ctx=%d",
             (int) length, (int) num_threads, (int) beam_size,
-            temperature_fallback ? 1 : 0, (int) audio_context);
+            temperature_increment, (int) audio_context);
 
     if (prompt != NULL && prompt[0] != '\0') {
         params.initial_prompt = prompt;

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/ModelLanguageSupport.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/ModelLanguageSupport.kt
@@ -12,6 +12,14 @@ package com.vocahq.vocaphone.core
 object ModelLanguageSupport {
 
     /**
+     * An explicit selection is the output contract. Engine-reported language is
+     * useful only for Automatic; letting it override a selected language makes
+     * the writing-style pass use punctuation from a different script.
+     */
+    fun transcriptLanguage(requested: String, reported: String): String =
+        if (requested == TranscriptionLanguage.AUTOMATIC.wireValue) reported else requested
+
+    /**
      * [modelLanguages] empty means the gateway made no claim — an older build, no
      * model selected, or one the user imported. Nothing is disabled in that case:
      * a client that has not been told must never lock the user out.

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptionQuality.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptionQuality.kt
@@ -47,13 +47,19 @@ enum class TranscriptionQuality(val storedValue: String) {
         }
 
     /**
-     * Whether a window whose result looks degenerate — too repetitive, or too
-     * unlikely — is decoded again at a higher temperature. This is what catches
-     * whisper's repetition loops, and it costs nothing on the windows that
-     * decode cleanly the first time, which is nearly all of them.
+     * Temperature step for a window whose first decode looks degenerate.
+     *
+     * whisper.cpp keeps adding this value until it reaches 1.0. Its usual 0.2
+     * therefore permits five retries, not one, and every retry reruns the whole
+     * decoder. Balanced jumps straight to one rescue pass; Accurate tries the
+     * midpoint first but is still capped at two retries.
      */
-    val whisperTemperatureFallback: Boolean
-        get() = this != FAST
+    val whisperTemperatureIncrement: Float
+        get() = when (this) {
+            FAST -> 0f
+            BALANCED -> 1f
+            ACCURATE -> 0.5f
+        }
 
     /**
      * What to ask a sherpa model for *if its family supports beam search*.

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -17,6 +17,7 @@ import com.vocahq.vocaphone.core.DictationFailure
 import com.vocahq.vocaphone.core.DictationPhase
 import com.vocahq.vocaphone.core.DictationState
 import com.vocahq.vocaphone.core.MissingPermission
+import com.vocahq.vocaphone.core.ModelLanguageSupport
 import com.vocahq.vocaphone.core.TranscriptSanitizer
 import com.vocahq.vocaphone.core.TranscriptStyler
 import com.vocahq.vocaphone.data.HistoryRepository
@@ -789,7 +790,10 @@ class DictationController(
     ): String = TranscriptStyler.apply(
         TranscriptSanitizer.clean(local.text),
         configuration.style,
-        local.language.ifEmpty { configuration.effectiveLanguage.wireValue },
+        ModelLanguageSupport.transcriptLanguage(
+            requested = configuration.effectiveLanguage.wireValue,
+            reported = local.language,
+        ),
     )
 
     private suspend fun deliver(

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/DeviceProfile.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/DeviceProfile.kt
@@ -113,10 +113,11 @@ fun DeviceProfile.fits(model: LocalModelDescriptor): Boolean {
  * Higher is better. Family beats file size: a transducer that fits this
  * phone's class is preferred over a larger Whisper weight.
  *
- * Whisper entries are scored by distance from the class this tier wants
- * (tiny on constrained, small on standard, turbo on fast, full large on
- * high-RAM flagship). q5 is the phone default; full precision only wins
- * on flagship. Adding a catalog row does not need a new branch here.
+ * Whisper entries are scored by distance from the class this tier wants.
+ * RAM alone never promotes an old phone to a large encoder: devices without a
+ * declared Android media performance class stay on base, including the
+ * Snapdragon 845 generation. q5 is the phone default; adding a catalog row
+ * does not need a new branch here.
  */
 fun scoreModel(model: LocalModelDescriptor, profile: DeviceProfile): Int {
     if (!profile.fits(model)) return Int.MIN_VALUE
@@ -135,7 +136,7 @@ fun scoreModel(model: LocalModelDescriptor, profile: DeviceProfile): Int {
     return score
 }
 
-private fun whisperClass(id: String): Int = when {
+internal fun whisperClass(id: String): Int = when {
     "large-v3-turbo" in id -> 5
     "large" in id -> 6
     "medium" in id -> 4
@@ -146,20 +147,24 @@ private fun whisperClass(id: String): Int = when {
 
 private fun whisperTarget(profile: DeviceProfile): Int = when (profile.tier) {
     DeviceTier.CONSTRAINED -> 1
-    DeviceTier.STANDARD -> 3
-    DeviceTier.FAST -> 5
-    DeviceTier.FLAGSHIP -> if (profile.totalRamGB >= 16) 6 else 5
+    DeviceTier.STANDARD -> 2
+    DeviceTier.FAST -> if (profile.performanceClass >= 31) 3 else 2
+    DeviceTier.FLAGSHIP -> when {
+        profile.performanceClass >= 34 -> 5
+        else -> 3
+    }
 }
 
 private fun whisperClassScore(id: String, profile: DeviceProfile): Int {
     val distance = abs(whisperClass(id) - whisperTarget(profile))
     var score = 50 - distance * 12
+    val declaredFlagship = profile.performanceClass >= 34
     score += when {
-        "q5" in id && profile.tier == DeviceTier.FLAGSHIP -> -4
+        "q5" in id && declaredFlagship -> -4
         "q5" in id -> 10
-        "q8" in id && profile.tier == DeviceTier.FLAGSHIP -> -2
+        "q8" in id && declaredFlagship -> -2
         "q8" in id -> 2
-        profile.tier == DeviceTier.FLAGSHIP -> 8
+        declaredFlagship -> 8
         else -> -6
     }
     return score

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelCatalog.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelCatalog.kt
@@ -73,6 +73,8 @@ data class LocalModelDescriptor(
     val languageCodes: Set<String> = emptySet(),
     /** True when the model decides the language itself and ignores the request. */
     val detectsLanguage: Boolean = false,
+    /** Whether short recordings may use a cropped whisper encoder window. */
+    val cropsAudioContext: Boolean = false,
 ) {
     val sizeLabel: String
         get() = if (sizeBytes >= 1_000_000_000) {
@@ -232,16 +234,29 @@ object LocalModelCatalog {
             ?: all.first()
     }
 
+    /** The fastest sensible Whisper fallback for this CPU class. */
+    fun recommendedWhisper(profile: DeviceProfile): LocalModelDescriptor =
+        whisper.filter { profile.fits(it) }
+            .maxByOrNull { scoreModel(it, profile) }
+            ?: whisper.filter { isUsableOnDevice(it, profile.totalRamGB, sherpaAvailable = false) }
+                .minByOrNull { it.sizeBytes }
+            ?: whisper.first()
+
     /**
-     * Warn only when a slower Whisper class is selected. Sherpa file size is
-     * not a speed signal, so a working Parakeet must not look "too big".
+     * Warn only when a slower Whisper class or full-precision variant is
+     * selected. Sherpa file size is not a speed signal, so a working Parakeet
+     * must not look "too big".
      */
     fun needsHeavierWarning(
         selected: LocalModelDescriptor,
-        recommended: LocalModelDescriptor,
-    ): Boolean = selected.id != recommended.id &&
-        selected.engine == LocalModelEngine.WHISPER &&
-        selected.minimumRamGB > recommended.minimumRamGB
+        profile: DeviceProfile,
+    ): Boolean {
+        if (selected.engine != LocalModelEngine.WHISPER) return false
+        val recommended = recommendedWhisper(profile)
+        return whisperClass(selected.id) > whisperClass(recommended.id) ||
+            (whisperClass(selected.id) == whisperClass(recommended.id) &&
+                selected.sizeBytes > recommended.sizeBytes * 2)
+    }
 
     fun isUsableOnDevice(
         model: LocalModelDescriptor,
@@ -275,6 +290,10 @@ object LocalModelCatalog {
         languages = languages,
         englishOnly = englishOnly,
         languageCodes = if (englishOnly) setOf("en") else emptySet(),
+        // The larger encoders are much more sensitive to an off-distribution
+        // cropped window. Tiny through small retain the short-dictation speedup;
+        // medium and large keep Whisper's trained thirty-second context.
+        cropsAudioContext = !name.startsWith("medium") && !name.startsWith("large"),
     )
 
     fun downloadUrl(model: LocalModelDescriptor, file: PinnedFile): String =

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
@@ -437,6 +437,7 @@ class LocalModelManager(
             resolvedLanguage,
             quality,
             CustomVocabulary.whisperPrompt(vocabulary),
+            model.cropsAudioContext,
         ) ?: error("Local transcription engine is not loaded")
     }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import com.vocahq.vocaphone.audio.CaptureFormat
 import com.vocahq.vocaphone.audio.SpeechAudioConditioning
 import com.vocahq.vocaphone.core.CustomVocabulary
+import com.vocahq.vocaphone.core.ModelLanguageSupport
 import com.vocahq.vocaphone.core.TranscriptionQuality
 import java.io.File
 import java.io.FileInputStream
@@ -32,13 +33,14 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 
 /**
- * What an on-device engine produced, and the language it actually decoded.
+ * What an on-device engine produced, and the language that governs its output.
  *
  * The language matters because the writing styles punctuate by script — a
  * Devanagari sentence ends in a danda, not a full stop — and with Automatic
  * selected the request says only "auto". Whisper detects and reports; the
  * sherpa bridges do not expose it, so they leave this empty and the styler
- * falls back to inspecting the text.
+ * falls back to inspecting the text. An explicit selection stays authoritative
+ * even if an engine reports something contradictory.
  */
 /** App-private folder that holds downloaded on-device models. */
 const val LOCAL_MODELS_DIR = "local-models"
@@ -429,7 +431,10 @@ class LocalModelManager(
         sherpaRecognizer?.let { recognizer ->
             return@withLock withContext(Dispatchers.Default) {
                 val result = recognizer.transcribe(samples)
-                LocalTranscription(result.text, result.language)
+                LocalTranscription(
+                    result.text,
+                    ModelLanguageSupport.transcriptLanguage(resolvedLanguage, result.language),
+                )
             }
         }
         whisperContext?.transcribe(
@@ -438,6 +443,7 @@ class LocalModelManager(
             quality,
             CustomVocabulary.whisperPrompt(vocabulary),
             model.cropsAudioContext,
+            WhisperCpuConfig.preferredThreadCount(model.id),
         ) ?: error("Local transcription engine is not loaded")
     }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/WhisperContext.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/WhisperContext.kt
@@ -1,5 +1,6 @@
 package com.vocahq.vocaphone.local
 
+import com.vocahq.vocaphone.core.ModelLanguageSupport
 import com.vocahq.vocaphone.core.TranscriptionQuality
 import java.util.concurrent.Executors
 import kotlin.math.ceil
@@ -19,12 +20,13 @@ internal class WhisperContext private constructor(private var pointer: Long) {
         quality: TranscriptionQuality,
         prompt: String,
         cropAudioContext: Boolean,
+        threads: Int,
     ): LocalTranscription =
         withContext(scope.coroutineContext) {
             check(pointer != 0L) { "Whisper context has been released" }
             val status = WhisperLib.fullTranscribe(
                 pointer,
-                WhisperCpuConfig.preferredThreadCount,
+                threads,
                 samples,
                 if (language == "auto") "auto" else language,
                 quality.whisperBeamSize,
@@ -45,9 +47,13 @@ internal class WhisperContext private constructor(private var pointer: Long) {
                         append(WhisperLib.getTextSegment(pointer, index))
                     }
                 }.trim(),
-                // Only meaningful when "auto" was asked for; otherwise it echoes
-                // the request back, which is the same answer either way.
-                language = WhisperLib.getDetectedLanguage(pointer),
+                // Detection is meaningful only for Automatic. With an explicit
+                // selection, the user's requested output language remains the
+                // contract even if the engine reports something contradictory.
+                language = ModelLanguageSupport.transcriptLanguage(
+                    requested = language,
+                    reported = WhisperLib.getDetectedLanguage(pointer),
+                ),
             )
         }
 
@@ -67,17 +73,25 @@ internal class WhisperContext private constructor(private var pointer: Long) {
 }
 
 internal object WhisperCpuConfig {
-    val preferredThreadCount: Int
-        get() = whisperThreadCount(Runtime.getRuntime().availableProcessors())
+    fun preferredThreadCount(modelID: String): Int = whisperThreadCount(
+        availableProcessors = Runtime.getRuntime().availableProcessors(),
+        modelID = modelID,
+    )
 
     /**
-     * Whisper's encoder is the dominant cost on phones. Keep two cores free for
-     * Android and the UI, but let an eight-core POCO-class device use six for
-     * the actual model pass; capping it at four leaves sustained CPU throughput
-     * unused and makes even greedy decoding feel stalled.
+     * Quantized Tiny through Small finish soon enough to use six workers
+     * profitably. Full-precision Small and every larger model sustain the load
+     * long enough that recruiting the efficiency cores heats a heterogeneous
+     * phone and throttles the following pass. A POCO F1 running the same
+     * 6.6-second full-precision Small sample twice measured 20.8/45.9 seconds
+     * with six workers and 16.4/18.7 seconds with four.
      */
-    internal fun whisperThreadCount(availableProcessors: Int): Int =
-        (availableProcessors - 2).coerceIn(2, 6)
+    internal fun whisperThreadCount(availableProcessors: Int, modelID: String): Int {
+        val modelClass = whisperClass(modelID)
+        val fullPrecisionSmall = modelClass == 3 && "-q" !in modelID
+        val ceiling = if (fullPrecisionSmall || modelClass >= 4) 4 else 6
+        return (availableProcessors - 2).coerceIn(2, ceiling)
+    }
 
     /** 20 ms of audio at 16 kHz, which is one unit of whisper's encoder window. */
     private const val SAMPLES_PER_AUDIO_CONTEXT = 320

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/WhisperContext.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/WhisperContext.kt
@@ -18,6 +18,7 @@ internal class WhisperContext private constructor(private var pointer: Long) {
         language: String,
         quality: TranscriptionQuality,
         prompt: String,
+        cropAudioContext: Boolean,
     ): LocalTranscription =
         withContext(scope.coroutineContext) {
             check(pointer != 0L) { "Whisper context has been released" }
@@ -27,8 +28,8 @@ internal class WhisperContext private constructor(private var pointer: Long) {
                 samples,
                 if (language == "auto") "auto" else language,
                 quality.whisperBeamSize,
-                quality.whisperTemperatureFallback,
-                WhisperCpuConfig.whisperAudioContext(samples.size),
+                quality.whisperTemperatureIncrement,
+                if (cropAudioContext) WhisperCpuConfig.whisperAudioContext(samples.size) else 0,
                 prompt,
             )
             // A failed decode returns no segments, which would otherwise be
@@ -88,10 +89,10 @@ internal object WhisperCpuConfig {
      * Below roughly this much context the decoder degenerates whatever the audio
      * length, so short dictations stop here rather than shrinking to fit.
      */
-    private const val MINIMUM_AUDIO_CONTEXT = 448
+    private const val MINIMUM_AUDIO_CONTEXT = 768
 
     /** How much context to ask for beyond the audio itself. */
-    private const val AUDIO_CONTEXT_MARGIN = 1.5
+    private const val AUDIO_CONTEXT_MARGIN = 2.0
 
     /**
      * The encoder window to ask for, or zero to leave whisper's default.
@@ -104,9 +105,9 @@ internal object WhisperCpuConfig {
      * The margin is what makes this safe rather than merely fast. Sized close to
      * the speech, the decoder falls into a repetition loop, and the temperature
      * retries that follow leave the dictation both slower than it started and
-     * wrong — so this asks for half as much context again as the audio needs, and
-     * never less than [MINIMUM_AUDIO_CONTEXT]. Past twenty seconds the full window
-     * is the smaller ask, and long recordings whisper already splits into
+     * wrong — so this asks for twice as much context as the audio needs, and never
+     * less than [MINIMUM_AUDIO_CONTEXT]. Past fifteen seconds the full window is
+     * the smaller ask, and long recordings whisper already splits into
      * thirty-second windows are left exactly as they were.
      */
     internal fun whisperAudioContext(sampleCount: Int): Int {

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/WhisperLib.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/WhisperLib.kt
@@ -66,7 +66,7 @@ internal class WhisperLib {
             audioData: FloatArray,
             language: String,
             beamSize: Int,
-            temperatureFallback: Boolean,
+            temperatureIncrement: Float,
             audioContext: Int,
             prompt: String,
         ): Int

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/LocalModelPicker.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/LocalModelPicker.kt
@@ -109,7 +109,7 @@ fun LocalModelPicker(
     }
 
     if (selectedModel != null &&
-        LocalModelCatalog.needsHeavierWarning(selectedModel, recommended)
+        LocalModelCatalog.needsHeavierWarning(selectedModel, profile)
     ) {
         OversizedModelNotice(
             recommended = recommended,
@@ -308,9 +308,8 @@ private fun OversizedModelNotice(
 ) {
     Notice(tone = NoticeTone.Attention) {
         Text(
-            "This model asks for more RAM than the one we suggest for this phone, " +
-                "so dictation can take longer. ${recommended.displayName} is the " +
-                "match we would start with.",
+            "This Whisper model can be slow on this phone. " +
+                "${recommended.displayName} is the faster match we would start with.",
             style = MaterialTheme.typography.bodySmall,
         )
         SecondaryButton(

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/ModelLanguageSupportTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/ModelLanguageSupportTest.kt
@@ -12,6 +12,14 @@ class ModelLanguageSupportTest {
     private val englishOnly = setOf("en")
 
     @Test
+    fun `an explicit language remains the transcript output contract`() {
+        assertEquals("hi", ModelLanguageSupport.transcriptLanguage("hi", "en"))
+        assertEquals("en", ModelLanguageSupport.transcriptLanguage("en", "hi"))
+        assertEquals("hi", ModelLanguageSupport.transcriptLanguage("auto", "hi"))
+        assertEquals("", ModelLanguageSupport.transcriptLanguage("auto", ""))
+    }
+
+    @Test
     fun `a model that detects its own language offers only Automatic`() {
         // Dolphin ignores the requested language, so offering Hindi promises
         // something it cannot deliver — it returned Cyrillic for a short Hindi clip.

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptionQualityTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptionQualityTest.kt
@@ -11,4 +11,11 @@ class TranscriptionQualityTest {
         assertEquals(0, TranscriptionQuality.BALANCED.whisperBeamSize)
         assertEquals(3, TranscriptionQuality.ACCURATE.whisperBeamSize)
     }
+
+    @Test
+    fun `whisper fallback reaches rescue temperatures in at most two retries`() {
+        assertEquals(0f, TranscriptionQuality.FAST.whisperTemperatureIncrement)
+        assertEquals(1f, TranscriptionQuality.BALANCED.whisperTemperatureIncrement)
+        assertEquals(0.5f, TranscriptionQuality.ACCURATE.whisperTemperatureIncrement)
+    }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/DeviceProfileTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/DeviceProfileTest.kt
@@ -58,11 +58,11 @@ class DeviceProfileTest {
             LocalModelCatalog.recommended(profile(2, sherpa = false)).id,
         )
         assertEquals(
-            "small-q5_1",
+            "base-q5_1",
             LocalModelCatalog.recommended(profile(4, sherpa = false)).id,
         )
         assertEquals(
-            "large-v3-turbo-q5_0",
+            "base-q5_1",
             LocalModelCatalog.recommended(profile(8, mpc = 0, sherpa = false)).id,
         )
         assertEquals(
@@ -70,9 +70,23 @@ class DeviceProfileTest {
             LocalModelCatalog.recommended(profile(12, mpc = 34, sherpa = false)).id,
         )
         assertEquals(
-            "large-v3",
+            "small-q5_1",
             LocalModelCatalog.recommended(profile(16, sherpa = false)).id,
         )
+    }
+
+    @Test
+    fun `poco class hardware stays on base whisper without a sherpa runtime`() {
+        val pocoF1 = profile(
+            ram = 6,
+            cores = 8,
+            mpc = 0,
+            khz = 2_800_000,
+            sherpa = false,
+        )
+        assertEquals(DeviceTier.FAST, pocoF1.tier)
+        assertEquals("base-q5_1", LocalModelCatalog.recommendedWhisper(pocoF1).id)
+        assertEquals("base-q5_1", LocalModelCatalog.recommended(pocoF1).id)
     }
 
     @Test

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/LocalPerformancePolicyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/LocalPerformancePolicyTest.kt
@@ -1,6 +1,7 @@
 package com.vocahq.vocaphone.local
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -17,29 +18,46 @@ class LocalPerformancePolicyTest {
     fun `short dictations crop the encoder window instead of padding to thirty seconds`() {
         // A two-second dictation needs 100 units of context; the floor is what
         // keeps the decoder out of a repetition loop at that length.
-        assertEquals(448, WhisperCpuConfig.whisperAudioContext(2 * 16000))
-        assertEquals(448, WhisperCpuConfig.whisperAudioContext(5 * 16000))
+        assertEquals(768, WhisperCpuConfig.whisperAudioContext(2 * 16000))
+        assertEquals(768, WhisperCpuConfig.whisperAudioContext(5 * 16000))
         // Past the floor the window tracks the audio, with margin over the 550
         // units eleven seconds actually occupies.
-        assertEquals(825, WhisperCpuConfig.whisperAudioContext(11 * 16000))
+        assertEquals(1100, WhisperCpuConfig.whisperAudioContext(11 * 16000))
     }
 
     @Test
     fun `long recordings keep whispers own window`() {
-        // At twenty seconds the margin already reaches the full window, and a
+        // At fifteen seconds the margin already reaches the full window, and a
         // recording whisper splits into thirty-second windows must not be cropped.
-        assertEquals(0, WhisperCpuConfig.whisperAudioContext(20 * 16000))
+        assertEquals(0, WhisperCpuConfig.whisperAudioContext(15 * 16000))
         assertEquals(0, WhisperCpuConfig.whisperAudioContext(120 * 16000))
     }
 
     @Test
+    fun `only small whisper families use a cropped encoder window`() {
+        assertTrue(LocalModelCatalog.find("tiny-q5_1")!!.cropsAudioContext)
+        assertTrue(LocalModelCatalog.find("small-q5_1")!!.cropsAudioContext)
+        assertFalse(LocalModelCatalog.find("medium-q5_0")!!.cropsAudioContext)
+        assertFalse(LocalModelCatalog.find("large-v3-turbo-q5_0")!!.cropsAudioContext)
+    }
+
+    @Test
     fun `parakeet is not treated as heavier than a smaller whisper`() {
+        val poco = DeviceProfile(
+            totalRamGB = 6,
+            cpuCores = 8,
+            abi = "arm64-v8a",
+            maxCpuKHz = 2_800_000,
+            sherpaAvailable = true,
+        )
         val parakeet = LocalModelCatalog.find("parakeet-tdt-0.6b-v3")!!
         val whisperBase = LocalModelCatalog.find("base-q5_1")!!
+        val whisperSmall = LocalModelCatalog.find("small-q5_1")!!
         val whisperLarge = LocalModelCatalog.find("large-v3")!!
         assertTrue(parakeet.sizeBytes > whisperBase.sizeBytes)
-        assertTrue(!LocalModelCatalog.needsHeavierWarning(parakeet, whisperBase))
-        assertTrue(LocalModelCatalog.needsHeavierWarning(whisperLarge, parakeet))
-        assertTrue(!LocalModelCatalog.needsHeavierWarning(whisperBase, parakeet))
+        assertFalse(LocalModelCatalog.needsHeavierWarning(parakeet, poco))
+        assertTrue(LocalModelCatalog.needsHeavierWarning(whisperLarge, poco))
+        assertTrue(LocalModelCatalog.needsHeavierWarning(whisperSmall, poco))
+        assertFalse(LocalModelCatalog.needsHeavierWarning(whisperBase, poco))
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/LocalPerformancePolicyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/LocalPerformancePolicyTest.kt
@@ -9,9 +9,11 @@ class LocalPerformancePolicyTest {
 
     @Test
     fun `whisper worker count is capped for sustained phone inference`() {
-        assertEquals(2, WhisperCpuConfig.whisperThreadCount(4))
-        assertEquals(6, WhisperCpuConfig.whisperThreadCount(8))
-        assertEquals(6, WhisperCpuConfig.whisperThreadCount(16))
+        assertEquals(2, WhisperCpuConfig.whisperThreadCount(4, "base-q5_1"))
+        assertEquals(6, WhisperCpuConfig.whisperThreadCount(8, "base-q5_1"))
+        assertEquals(6, WhisperCpuConfig.whisperThreadCount(8, "small-q5_1"))
+        assertEquals(4, WhisperCpuConfig.whisperThreadCount(8, "small"))
+        assertEquals(4, WhisperCpuConfig.whisperThreadCount(16, "large-v3-q5_0"))
     }
 
     @Test

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		AC222A4D19661A309FEC32C1 /* SpokenNumbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E590CFC53039DA367280B8CD /* SpokenNumbers.swift */; };
 		ACDADCAF73BF41FE2355ED15 /* VocaPhoneKeyboard.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B7028AF4B134C7EDD726891E /* VocaPhoneKeyboard.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		AD2CCDE7DC189E63810890BB /* SwipeRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C4BD2142E9377F123A8848 /* SwipeRecognizer.swift */; };
+		AE4E1B1B8CB72567DEF58A40 /* TranscriptionQualityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCAE41267FF8113463CFFF96 /* TranscriptionQualityTests.swift */; };
 		B063AE9288450BE04769F7DD /* TypingCandidates.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAA4440B24071020CD693DB /* TypingCandidates.swift */; };
 		B0DF0FF5821BD7E8C839065C /* GatewayClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4211FAA8E574AEF57D788FA /* GatewayClient.swift */; };
 		B1D4DE96B74C3327DA6A0FAD /* SwipeTrailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */; };
@@ -465,6 +466,7 @@
 		F72772F0CCE3BA274182C5F4 /* HomePresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePresentationTests.swift; sourceTree = "<group>"; };
 		FA83B914C241E5F8BF8F32AC /* DictationBarLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarLayoutTests.swift; sourceTree = "<group>"; };
 		FC2CD13AAF5FDF79DD5D0075 /* TypingFieldPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingFieldPolicy.swift; sourceTree = "<group>"; };
+		FCAE41267FF8113463CFFF96 /* TranscriptionQualityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionQualityTests.swift; sourceTree = "<group>"; };
 		FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInsertion.swift; sourceTree = "<group>"; };
 		FF28F6F60B7FDEA4EB183B6F /* LocalModelCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelCatalogTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -717,6 +719,7 @@
 				924E5D73CB086A4210BF6052 /* SwipeRecognizerTests.swift */,
 				0DFD83D2BCB84400E7981A4B /* SwipeTrailTests.swift */,
 				ABDF2EC3AB09FF78FD1EF935 /* TranscriptHistoryModelTests.swift */,
+				FCAE41267FF8113463CFFF96 /* TranscriptionQualityTests.swift */,
 				B154124C04655D1A36F1B4E4 /* TranscriptionSourceTests.swift */,
 				C8E491E7E805F47388A668E1 /* TranscriptSanitizerTests.swift */,
 				A45A3914F898AD0570486806 /* TranscriptStylerTests.swift */,
@@ -1206,6 +1209,7 @@
 				3948B010FEE4F51B8CE2074D /* TranscriptStyler.swift in Sources */,
 				7E26A729562A6F474635AFEC /* TranscriptStylerTests.swift in Sources */,
 				444F9DFC10831BE9150988A6 /* TranscriptionQuality.swift in Sources */,
+				AE4E1B1B8CB72567DEF58A40 /* TranscriptionQualityTests.swift in Sources */,
 				D347613BCA81EB9BF9AAC2DD /* TranscriptionSourceStatus.swift in Sources */,
 				F9BE6A9D183361BABE1E286E /* TranscriptionSourceTests.swift in Sources */,
 				AA0483D40117344580501ABD /* TypingCandidates.swift in Sources */,

--- a/ios/VocaPhoneApp/Models/LocalModelManager.swift
+++ b/ios/VocaPhoneApp/Models/LocalModelManager.swift
@@ -916,6 +916,7 @@ final class LocalModelManager {
                 task: .transcribe,
                 language: requested,
                 temperature: 0,
+                temperatureIncrementOnFallback: quality.whisperKitTemperatureIncrement,
                 temperatureFallbackCount: quality.whisperKitTemperatureFallbackCount,
                 usePrefillPrompt: true,
                 usePrefillCache: true,
@@ -925,6 +926,9 @@ final class LocalModelManager {
                 // has to ask for detection in so many words.
                 detectLanguage: requested == nil,
                 skipSpecialTokens: true,
+                // Timestamp tokens are not shown, but Whisper needs to predict
+                // them to stop cleanly instead of repeating into padded audio.
+                withoutTimestamps: false,
                 promptTokens: promptTokens,
                 // WhisperKit defaults this off where Whisper itself defaults it
                 // on. Leaving it off lets a window open on a blank token, which

--- a/ios/VocaPhoneApp/Models/LocalModelManager.swift
+++ b/ios/VocaPhoneApp/Models/LocalModelManager.swift
@@ -836,13 +836,14 @@ final class LocalModelManager {
         }
     }
 
-    /// What an on-device engine produced, and the language it actually decoded.
+    /// What an on-device engine produced, and the language that governs its output.
     ///
     /// The language matters because the writing styles punctuate by script — a
     /// Devanagari sentence ends in a danda, not a full stop — and with Automatic
     /// selected the request says only "auto". WhisperKit detects and reports;
     /// the sherpa bridge does not expose it, so it leaves this empty and the
-    /// styler falls back to inspecting the text.
+    /// styler falls back to inspecting the text. An explicit selection stays
+    /// authoritative even if an engine reports something contradictory.
     struct LocalTranscription: Sendable {
         let text: String
         let language: String
@@ -902,7 +903,7 @@ final class LocalModelManager {
                 folder: folder,
                 tokenizerFolder: tokenizerFolder
             )
-            let requested = descriptor.englishOnly ? "en" : (language == "auto" ? nil : language)
+            let requested = resolvedLanguage == "auto" ? nil : resolvedLanguage
             let quality = LocalTranscriptionPreferences.quality
             // Tokenized here rather than stored, because the tokens only mean
             // anything against the tokenizer of the model that is loaded.
@@ -942,9 +943,16 @@ final class LocalModelManager {
             guard !text.isEmpty else {
                 throw LocalModelManagerError.modelNotDownloaded("empty transcript")
             }
-            // Only meaningful when "auto" was asked for; otherwise it echoes the
-            // request back, which is the same answer either way.
-            return LocalTranscription(text: text, language: results.first?.language ?? "")
+            // Detection is meaningful only for Automatic. With an explicit
+            // selection, the user's requested output language remains the
+            // contract even if the engine reports something contradictory.
+            return LocalTranscription(
+                text: text,
+                language: ModelLanguageSupport.transcriptLanguage(
+                    requested: resolvedLanguage,
+                    reported: results.first?.language ?? ""
+                )
+            )
 
         case .sherpaOnnx:
             let sherpaRecognizer = try await ensureSherpaRecognizer(
@@ -958,7 +966,13 @@ final class LocalModelManager {
             guard !decoded.text.isEmpty else {
                 throw LocalModelManagerError.modelNotDownloaded("empty transcript")
             }
-            return LocalTranscription(text: decoded.text, language: decoded.language)
+            return LocalTranscription(
+                text: decoded.text,
+                language: ModelLanguageSupport.transcriptLanguage(
+                    requested: resolvedLanguage,
+                    reported: decoded.language
+                )
+            )
         }
     }
 

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -1023,9 +1023,10 @@ final class RecordingCoordinator {
             record.transcript = DictatedTranscript.finished(
                 text,
                 style: WritingStyle(rawValue: record.style) ?? .casual,
-                language: transcribed.language.isEmpty
-                    ? record.language
-                    : transcribed.language,
+                language: ModelLanguageSupport.transcriptLanguage(
+                    requested: record.language,
+                    reported: transcribed.language
+                ),
                 numbersAsDigits: KeyboardPreferences.numbersAsDigits
             )
             record.error = nil

--- a/ios/VocaPhoneShared/LocalModelCatalog.swift
+++ b/ios/VocaPhoneShared/LocalModelCatalog.swift
@@ -598,21 +598,25 @@ enum LocalModelCatalog {
     /// Everything this iPhone can actually run, smallest first.
     static var usableOnDevice: [LocalModelDescriptor] { all.filter(isUsableOnDevice) }
 
-    /// Best quality that fits, rather than a memory ladder that disagreed with
-    /// the models' own floors.
+    /// Fast, multilingual default that fits. A model fitting in memory is not a
+    /// promise that its encoder is interactive on a phone; Parakeet is preferred
+    /// where available, with compact Whisper builds as the universal fallback.
     static var recommended: LocalModelDescriptor {
+        recommended(deviceMemoryGB: deviceMemoryGB)
+    }
+
+    static func recommended(deviceMemoryGB: Int) -> LocalModelDescriptor {
         let preference = [
-            "openai_whisper-large-v3-v20240930_turbo_632MB",
-            "openai_whisper-large-v3-v20240930_626MB",
-            "openai_whisper-large-v3-v20240930_547MB",
-            "openai_whisper-small_216MB",
+            "parakeet-tdt-0.6b-v3",
+            "openai_whisper-base",
             "openai_whisper-tiny",
+            "sense-voice",
         ]
         for id in preference {
-            if let descriptor = descriptor(for: id), isUsableOnDevice(descriptor) {
+            if let descriptor = descriptor(for: id), deviceMemoryGB >= descriptor.minimumRamGB {
                 return descriptor
             }
         }
-        return usableOnDevice.first ?? all[0]
+        return all.first { deviceMemoryGB >= $0.minimumRamGB } ?? all[0]
     }
 }

--- a/ios/VocaPhoneShared/ModelLanguageSupport.swift
+++ b/ios/VocaPhoneShared/ModelLanguageSupport.swift
@@ -13,6 +13,14 @@ import Foundation
 /// same conclusion as the containing app.
 enum ModelLanguageSupport {
 
+    /// An explicit selection is the output contract. The engine's reported
+    /// language is useful only for Automatic; allowing it to replace a selected
+    /// language makes the writing-style pass choose punctuation for another
+    /// script even though the decoder was pinned to the user's selection.
+    static func transcriptLanguage(requested: String, reported: String) -> String {
+        requested == TranscriptionLanguage.automatic.rawValue ? reported : requested
+    }
+
     /// `modelLanguages` empty means the gateway made no claim — an older build,
     /// no model selected, or one the user imported. Nothing is disabled then: a
     /// client that has not been told must never lock the user out.

--- a/ios/VocaPhoneShared/TranscriptionQuality.swift
+++ b/ios/VocaPhoneShared/TranscriptionQuality.swift
@@ -46,8 +46,18 @@ enum TranscriptionQuality: String, Codable, CaseIterable, Identifiable, Sendable
     var whisperKitTemperatureFallbackCount: Int {
         switch self {
         case .fast: 0
-        case .balanced: 3
-        case .accurate: 5
+        case .balanced: 1
+        case .accurate: 2
+        }
+    }
+
+    /// Reaches Whisper's useful temperature range in the bounded pass count
+    /// above instead of spending four to six full decoder runs stepping by 0.2.
+    var whisperKitTemperatureIncrement: Float {
+        switch self {
+        case .fast: 0
+        case .balanced: 1
+        case .accurate: 0.5
         }
     }
 

--- a/ios/VocaPhoneTests/LocalModelCatalogTests.swift
+++ b/ios/VocaPhoneTests/LocalModelCatalogTests.swift
@@ -16,6 +16,12 @@ struct LocalModelCatalogTests {
         #expect(LocalModelCatalog.descriptor(for: "sense-voice")?.detectsLanguageAutomatically == true)
     }
 
+    @Test func recommendationPrefersFastMultilingualSherpaThenCompactWhisper() {
+        #expect(LocalModelCatalog.recommended(deviceMemoryGB: 4).id == "parakeet-tdt-0.6b-v3")
+        #expect(LocalModelCatalog.recommended(deviceMemoryGB: 3).id == "openai_whisper-base")
+        #expect(LocalModelCatalog.recommended(deviceMemoryGB: 2).id == "sense-voice")
+    }
+
     @Test func longAudioStreamingUsesBoundedWindows() {
         let samples = [Float](
             repeating: 0.05,

--- a/ios/VocaPhoneTests/ModelLanguageSupportTests.swift
+++ b/ios/VocaPhoneTests/ModelLanguageSupportTests.swift
@@ -2,6 +2,13 @@ import Foundation
 import Testing
 
 struct ModelLanguageSupportTests {
+    @Test func explicitLanguageRemainsTheTranscriptOutputContract() {
+        #expect(ModelLanguageSupport.transcriptLanguage(requested: "hi", reported: "en") == "hi")
+        #expect(ModelLanguageSupport.transcriptLanguage(requested: "en", reported: "hi") == "en")
+        #expect(ModelLanguageSupport.transcriptLanguage(requested: "auto", reported: "hi") == "hi")
+        #expect(ModelLanguageSupport.transcriptLanguage(requested: "auto", reported: "") == "")
+    }
+
     private let dolphin: Set<String> = ["hi", "bn", "ta", "zh", "ja"]
     private let englishOnly: Set<String> = ["en"]
 

--- a/ios/VocaPhoneTests/TranscriptionQualityTests.swift
+++ b/ios/VocaPhoneTests/TranscriptionQualityTests.swift
@@ -1,0 +1,13 @@
+import Testing
+
+struct TranscriptionQualityTests {
+    @Test func whisperFallbackIsBoundedToThePromisedNumberOfRetries() {
+        #expect(TranscriptionQuality.fast.whisperKitTemperatureFallbackCount == 0)
+        #expect(TranscriptionQuality.balanced.whisperKitTemperatureFallbackCount == 1)
+        #expect(TranscriptionQuality.accurate.whisperKitTemperatureFallbackCount == 2)
+
+        #expect(TranscriptionQuality.fast.whisperKitTemperatureIncrement == 0)
+        #expect(TranscriptionQuality.balanced.whisperKitTemperatureIncrement == 1)
+        #expect(TranscriptionQuality.accurate.whisperKitTemperatureIncrement == 0.5)
+    }
+}


### PR DESCRIPTION
## Problem

Whisper could take four to six full decoder passes when a difficult window triggered temperature fallback. Android also suppressed the timestamp tokens Whisper uses to stop cleanly, applied an aggressive cropped encoder window to every model family, and could recommend oversized Whisper models to older high-RAM phones. On a POCO F1, using six workers for full-precision Whisper Small also caused severe sustained throttling. On iOS, the picker recommended a large Whisper variant even when a substantially faster multilingual Sherpa model was available.

Both mobile clients could also let an engine-reported language override an explicitly selected language after decoding, causing the writing-style pass to use punctuation for the wrong script.

Together these made Whisper latency unpredictable and could produce repetition, long stalls, or output formatting that did not follow the selected language.

## Summary

- Bound Whisper fallback to one retry for Balanced and two for Accurate on Android and iOS, while covering the useful temperature range.
- Keep Android timestamp stop tokens while continuing to hide timestamp output.
- Retain cropped short-dictation contexts for Tiny through Small with a safer floor and margin; use Whisper full context for Medium and Large.
- Compile Android ggml inference with optimization in Debug as well as Release.
- Use four Android Whisper workers for full-precision Small and all larger models; retain up to six for quantized Tiny, Base, and Small models where short-run throughput benefits.
- Recommend Base Q5 on older Android hardware without a media performance class and show a truthful speed warning for heavier Whisper choices.
- Prefer multilingual Parakeet on supported iPhones, with compact Whisper variants as the fallback.
- Keep an explicit output-language selection authoritative through Android and iOS decoding metadata and script-specific transcript styling; use model detection only for Automatic.
- Add regression coverage for fallback bounds, audio-context and worker policy, language resolution, device recommendations, warnings, and an opt-in physical-device benchmark.

## Android compatibility

The POCO F1 is a regression profile, not a device-specific code path. VocaPhone supports Android 13 and newer (`minSdk 33`) and packages native Whisper for every configured ABI:

- `arm64-v8a` includes an ARMv8.0 baseline plus v8.2, v8.6, and v9.x backends selected only after ggml checks the CPU features.
- `armeabi-v7a` and `x86_64` use their compiled-in baseline CPU backends.
- Full and F-Droid APKs both contain Whisper and ggml for all three ABIs; Full additionally contains Sherpa for both Arm ABIs.
- RAM, core count, clock, media performance class, ABI, and model weight class influence safe recommendations and worker count. They do not gate Whisper to a phone model or chipset.

This does not claim support for Android versions below 13 or ABIs outside the three configured by the app.

## Verification

- `:app:testFullDebugUnitTest :app:testFdroidDebugUnitTest` — 298 tests passed in each flavor.
- `:app:lintFullDebug` — passed.
- `:app:externalNativeBuildFullDebug` — x86_64, armeabi-v7a, and arm64-v8a passed.
- `:app:externalNativeBuildFullRelease` — x86_64, armeabi-v7a, and arm64-v8a passed.
- `:app:assembleFullDebug :app:assembleFdroidDebug` — passed.
- `:app:assembleFullRelease :app:assembleFdroidRelease` — passed, including release lint checks.
- APK badging confirmed `minSdk 33` and native code for arm64-v8a, armeabi-v7a, and x86_64 in both distributions.
- Current iOS simulator test run — 421 tests in 51 suites passed.
- `just release-build` — passed.
- `git diff --check origin/main...HEAD` — passed.

## Physical-device verification

Tested the full-precision 487 MB Whisper Small model on a POCO F1 running Android 14 with a fixed 6.625-second English reference sample. The transcript stayed identical and correct across runs.

- Previous six-worker production policy: 20,790 ms, then 45,945 ms on the immediate repeat.
- New four-worker production policy: 16,089 ms, then 18,604 ms on the immediate repeat.

That is about 23% faster on the first pass and 60% faster on the sustained repeat, while avoiding the prior thermal collapse. The exact Full release APK from this branch was locally debug-key signed for device installation, installed without clearing app data, and launched successfully. This verifies the release build on this POCO F1; it is not a production-signing claim or proof of identical timings on every supported Android phone.