### PR TITLE
Host a short privacy page for the Play listing

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -9,7 +9,8 @@ npm run dev
 ```
 
 Then open `http://127.0.0.1:4173/`. The iPhone setup guide is available at
-`http://127.0.0.1:4173/iphone/`.
+`http://127.0.0.1:4173/iphone/`. The consumer privacy page is at
+`http://127.0.0.1:4173/privacy/`.
 
 The site uses only local brand assets and system fonts. The Android install and
 download CTAs point at the current public beta tag
@@ -27,7 +28,8 @@ this directory (see `.github/workflows/pages.yml`). Set Pages source to
 - Publish directory: `web`
 - Canonical URL expected by metadata: `https://vocaphone.vocahq.com/`
 
-Both `/`, `/iphone/`, and `/iphone/device-setup/` must resolve as HTML routes.
+`/`, `/iphone/`, `/iphone/device-setup/`, and `/privacy/` must resolve as HTML
+routes.
 
 The Android product images are the original 576×1280 screenshots from
 [VocaPhone PR #70](https://github.com/VocaHQ/vocaphone/pull/70). The website

--- a/web/index.html
+++ b/web/index.html
@@ -767,7 +767,7 @@
           <p>resources</p>
           <a href="https://github.com/VocaHQ/vocaphone">GitHub</a>
           <a href="https://github.com/VocaHQ/vocagateway">VocaGateway</a>
-          <a href="https://github.com/VocaHQ/vocaphone/blob/main/docs/privacy.md">privacy</a>
+          <a href="/privacy/">privacy</a>
           <a href="https://github.com/VocaHQ/vocaphone/blob/main/SUPPORT.md">support</a>
         </div>
         <div>

--- a/web/privacy/index.html
+++ b/web/privacy/index.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="VocaPhone is a voice dictation keyboard. Transcription stays on your device by default, or on a self-hosted gateway you already own. No Voca account, no analytics SDK, no subscription."
+    />
+    <meta name="theme-color" content="#f4f1e8" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://vocaphone.vocahq.com/privacy/" />
+    <meta property="og:title" content="VocaPhone privacy" />
+    <meta
+      property="og:description"
+      content="On-device is the default. Audio leaves the phone only if you set a gateway you control."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:site_name" content="VocaPhone" />
+    <meta property="og:url" content="https://vocaphone.vocahq.com/privacy/" />
+    <meta property="og:image" content="https://vocaphone.vocahq.com/assets/og-image.png" />
+    <meta
+      property="og:image:secure_url"
+      content="https://vocaphone.vocahq.com/assets/og-image.png"
+    />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="VocaPhone private voice typing, on-device first with an optional self-hosted gateway"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="VocaPhone privacy" />
+    <meta
+      name="twitter:description"
+      content="On-device is the default. Audio leaves the phone only if you set a gateway you control."
+    />
+    <meta name="twitter:image" content="https://vocaphone.vocahq.com/assets/og-image.png" />
+    <meta
+      name="twitter:image:alt"
+      content="VocaPhone private voice typing, on-device first with an optional self-hosted gateway"
+    />
+    <title>VocaPhone privacy</title>
+    <link rel="icon" href="../assets/vocaphone-logo.svg" type="image/svg+xml" />
+    <link rel="icon" href="../favicon.ico" sizes="any" />
+    <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png" />
+    <link rel="stylesheet" href="../styles.css" />
+    <script src="../script.js" defer></script>
+  </head>
+  <body class="guide-body">
+    <a class="skip-link" href="#privacy-content">Skip to privacy</a>
+
+    <header class="menu-bar guide-menu-bar">
+      <a class="brand-link" href="/" aria-label="VocaPhone home">
+        <img src="../assets/vocaphone-logo.svg" alt="" width="32" height="32" />
+        <span>vocaphone</span>
+      </a>
+      <a class="guide-back" href="/">← back to the website</a>
+    </header>
+
+    <main class="guide-main" id="privacy-content">
+      <section class="guide-hero dot-field">
+        <div>
+          <span class="section-tag">privacy</span>
+          <h1>what happens<br />to your voice.</h1>
+          <p>
+            VocaPhone is a voice dictation keyboard. Transcription never
+            touches a cloud speech service. It runs on your own device, or on a
+            machine you already own and administer through a self-hosted
+            gateway.
+          </p>
+        </div>
+        <aside class="guide-summary" aria-label="Privacy facts">
+          <span>the short version</span>
+          <strong>no Voca account</strong>
+          <strong>no analytics SDK</strong>
+          <strong>no subscription</strong>
+          <strong>on-device default</strong>
+        </aside>
+      </section>
+
+      <section class="guide-content" aria-labelledby="on-device-title">
+        <div class="guide-intro">
+          <span class="section-tag">the default</span>
+          <h2 id="on-device-title">on-device is the default.</h2>
+          <p>
+            Recording and speech-to-text happen on the phone. After a
+            transcript is safely stored, the successful audio file is deleted.
+          </p>
+        </div>
+
+        <ol class="guide-steps">
+          <li class="guide-step">
+            <span>01</span>
+            <div>
+              <h3>Android recordings</h3>
+              <p>
+                Audio is captured as 16 kHz mono PCM16 and written to a WAV in
+                app-private storage while recording. The file is deleted
+                immediately on success. It is kept only for a failed
+                still-retryable attempt, for the retention window you choose
+                (1, 6 or 24 hours).
+              </p>
+            </div>
+          </li>
+
+          <li class="guide-step">
+            <span>02</span>
+            <div>
+              <h3>What the keyboard can see</h3>
+              <p>
+                The keyboard writes through InputConnection and does not read
+                the field for dictation. Camera is requested only for Scan QR
+                pairing. The microphone is used only while a dictation is
+                running.
+              </p>
+            </div>
+          </li>
+        </ol>
+
+        <aside class="guide-callout" aria-labelledby="gateway-title">
+          <div>
+            <span class="section-tag">optional path</span>
+            <h2 id="gateway-title">audio leaves only if you set a gateway.</h2>
+            <p>
+              Audio leaves the phone only if you deliberately set a gateway you
+              control. That audio goes to that gateway, not to VocaHQ. The
+              gateway is self-hosted, but it is not on-device. Use a trusted
+              LAN, encrypted private network, or HTTPS to protect gateway
+              traffic.
+            </p>
+          </div>
+          <a class="button button-secondary" href="https://github.com/VocaHQ/vocagateway">
+            explore VocaGateway <span aria-hidden="true">↗</span>
+          </a>
+        </aside>
+
+        <div class="guide-source-links">
+          <p>
+            VocaPhone is free and AGPL-3.0 licensed. There is no Voca account,
+            no analytics SDK, and no subscription.
+          </p>
+          <a href="mailto:hello@vocahq.com">hello@vocahq.com</a>
+        </div>
+      </section>
+    </main>
+
+    <footer class="guide-footer">
+      <a class="brand-link" href="/">
+        <img src="../assets/vocaphone-logo.svg" alt="" width="34" height="34" />
+        <span>vocaphone</span>
+      </a>
+      <span>open source · private by design · gateway optional</span>
+    </footer>
+  </body>
+</html>

--- a/web/privacy/index.html
+++ b/web/privacy/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="VocaPhone is a voice dictation keyboard. Transcription stays on your device by default, or on a self-hosted gateway you already own. No Voca account, no analytics SDK, no subscription."
+      content="VocaPhone is a voice dictation keyboard. Transcription never touches a cloud speech service. On-device is the default. Audio leaves the phone only if you set a gateway you control."
     />
     <meta name="theme-color" content="#f4f1e8" />
     <meta name="robots" content="index, follow" />

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -6,6 +6,11 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://vocaphone.vocahq.com/privacy/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://vocaphone.vocahq.com/iphone/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -8,6 +8,8 @@ const siteRoot = fileURLToPath(new URL("..", import.meta.url));
 const html = readFileSync(join(siteRoot, "index.html"), "utf8");
 const iphoneHtml = readFileSync(join(siteRoot, "iphone/index.html"), "utf8");
 const deviceSetupHtml = readFileSync(join(siteRoot, "iphone/device-setup/index.html"), "utf8");
+const privacyHtml = readFileSync(join(siteRoot, "privacy/index.html"), "utf8");
+const sitemap = readFileSync(join(siteRoot, "sitemap.xml"), "utf8");
 const css = readFileSync(join(siteRoot, "styles.css"), "utf8");
 const script = readFileSync(join(siteRoot, "script.js"), "utf8");
 
@@ -232,4 +234,26 @@ test("visual treatment stays flat", () => {
 test("motion has a reduced-motion fallback", () => {
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
   assert.match(script, /setTimeout\([\s\S]*revealNodes[\s\S]*is-visible/);
+});
+
+test("hosted privacy page covers the Play listing facts", () => {
+  assert.ok(existsSync(join(siteRoot, "privacy/index.html")));
+  assert.equal((privacyHtml.match(/<h1\b/g) || []).length, 1);
+  assert.match(
+    privacyHtml,
+    /rel="canonical" href="https:\/\/vocaphone\.vocahq\.com\/privacy\/"/,
+  );
+  assert.match(html, /href="\/privacy\/"/);
+  assert.doesNotMatch(html, /docs\/privacy\.md/);
+  assert.match(sitemap, /<loc>https:\/\/vocaphone\.vocahq\.com\/privacy\/<\/loc>/);
+
+  assert.match(privacyHtml, /no Voca account/i);
+  assert.match(privacyHtml, /no analytics SDK/i);
+  assert.match(privacyHtml, /on-device is the default/i);
+  assert.match(
+    privacyHtml,
+    /Audio leaves the phone only if you deliberately set a gateway you\s+control/,
+  );
+  assert.match(privacyHtml, /AGPL-3\.0/);
+  assert.match(privacyHtml, /hello@vocahq\.com/);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Play Console will not accept a GitHub blob as the privacy policy URL. This hosts a short consumer page at `/privacy/` so the listing can use `https://vocaphone.vocahq.com/privacy`.

The homepage footer now points at that page instead of `docs/privacy.md`. The sitemap, site README, and `web` tests cover the new route.

The live URL will 404 until this lands on `main` and Pages deploys.

## Verification

- [x] `npm run check` from `web/` (18 tests, all passing)
- [ ] `just ios ci` — website only, no app changes
- [ ] `just android ci` — website only, no app changes
- [ ] Gateway changes: none
- [ ] Physical-device test: none. Keyboard, microphone, and insertion are untouched.

Maintainers can comment `/build` on this PR for installable Android/iOS
artifacts (see CONTRIBUTING).

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Hosted page restates the public facts already on the site: on-device default, no Voca account, no analytics SDK, audio leaves only if the user sets a gateway they control

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8486db5a-76d5-40c4-a77a-d4dbc41bd327?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8486db5a-76d5-40c4-a77a-d4dbc41bd327&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

