### PR TITLE
fix(android): stop the clipboard chip covering the suggestion strip

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -134,10 +134,27 @@ internal object KeyboardChrome {
     fun startedTyping(composing: String, textBeforeCursor: CharSequence): Boolean =
         composing.isNotEmpty() || textBeforeCursor.any { !it.isWhitespace() }
 
+    /**
+     * The clip chip and the suggestion strip share one row, so only one of them
+     * can be on screen. The chip is an offer made while the field is idle; the
+     * moment the user types, the row belongs to what they are producing.
+     *
+     * [startedTyping] is what makes that true. Without it the chip outlived the
+     * empty field and sat where the word suggestions should be for the whole
+     * sentence, because the render order in `DictationBar` reaches the clipboard
+     * branch first and never falls through to the suggestions one.
+     *
+     * Deliberately hidden for the rest of the sentence rather than reappearing
+     * whenever suggestions happen to run dry: a paste target that pops back
+     * under a finger already moving toward a word would paste the entire
+     * clipboard into the middle of what they were writing. Clearing the field
+     * brings it back, which is the same condition that first offered it.
+     */
     fun clipboardForStrip(
         clipboard: ClipboardChip?,
+        startedTyping: Boolean,
         alreadyPasted: Boolean = false,
-    ): ClipboardChip? = clipboard.takeIf { !alreadyPasted }
+    ): ClipboardChip? = clipboard.takeIf { !alreadyPasted && !startedTyping }
 
     fun suggestionsForStrip(
         suggestions: List<SuggestionItem>,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -212,7 +212,7 @@ internal fun VocaPhoneKeyboard(
     }
     val clipboardChip = clipboard.takeIf { settings.clipboardChipEnabled && !editor.sensitive }
     val startedTyping = KeyboardChrome.startedTyping(keyboardState.composing, editorText.before)
-    val stripClipboard = KeyboardChrome.clipboardForStrip(clipboardChip)
+    val stripClipboard = KeyboardChrome.clipboardForStrip(clipboardChip, startedTyping)
     val swipeArmed = KeyboardChrome.swipeWordArmed(swipeWord, editorText.before, editorText.after)
     val stripSuggestions = if (swipeArmed && swipeChoices.isNotEmpty()) {
         swipeChoices.map { SuggestionItem(it) }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardChromeTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardChromeTest.kt
@@ -24,9 +24,70 @@ class KeyboardChromeTest {
 
     @Test
     fun `clipboard stays until the clip is used`() {
-        assertEquals(clip, KeyboardChrome.clipboardForStrip(clip))
-        assertNull(KeyboardChrome.clipboardForStrip(null))
-        assertNull(KeyboardChrome.clipboardForStrip(clip, alreadyPasted = true))
+        assertEquals(clip, KeyboardChrome.clipboardForStrip(clip, startedTyping = false))
+        assertNull(KeyboardChrome.clipboardForStrip(null, startedTyping = false))
+        assertNull(
+            KeyboardChrome.clipboardForStrip(clip, startedTyping = false, alreadyPasted = true),
+        )
+    }
+
+    /**
+     * The regression. `DictationBar` renders the clip chip and the suggestion
+     * strip into the same row and reaches the clipboard branch first, so a chip
+     * that outlives the empty field sits where the word suggestions belong for
+     * the rest of the sentence — copy something, start typing, and the strip
+     * never shows a word again.
+     */
+    @Test
+    fun `clipboard yields the strip once typing starts`() {
+        assertNull(KeyboardChrome.clipboardForStrip(clip, startedTyping = true))
+    }
+
+    /**
+     * The two halves of the row have to be mutually exclusive at every point,
+     * not merely at the two ends: whatever the field contains, exactly one of
+     * them may claim it.
+     */
+    @Test
+    fun `the clip chip and the suggestions never both claim the row`() {
+        val words = listOf(SuggestionItem("you"), SuggestionItem("the"))
+        listOf(false, true).forEach { typing ->
+            val chip = KeyboardChrome.clipboardForStrip(clip, startedTyping = typing)
+            val strip = KeyboardChrome.suggestionsForStrip(words, startedTyping = typing)
+            assertFalse(
+                "the clip chip and ${strip.size} suggestions both claimed the row " +
+                    "with startedTyping=$typing",
+                chip != null && strip.isNotEmpty(),
+            )
+        }
+    }
+
+    /**
+     * Swipe alternatives reach the strip without passing through
+     * [KeyboardChrome.suggestionsForStrip], so the exclusion above cannot see
+     * that path. It holds anyway, but for a different reason: arming a swiped
+     * word requires a replaceable word behind the cursor, which is text, which
+     * is already typing. Asserted rather than argued, because the two helpers
+     * are free to drift apart.
+     */
+    @Test
+    fun `an armed swipe word is always typing, so the chip is already gone`() {
+        val before = "the quick "
+        assertTrue(KeyboardChrome.swipeWordArmed("quick", before, ""))
+        assertTrue(KeyboardChrome.startedTyping(composing = "", textBeforeCursor = before))
+        assertNull(
+            KeyboardChrome.clipboardForStrip(
+                clip,
+                startedTyping = KeyboardChrome.startedTyping("", before),
+            ),
+        )
+    }
+
+    /** Clearing the field is the same condition that first offered the chip. */
+    @Test
+    fun `clearing the field offers the clip again`() {
+        assertNull(KeyboardChrome.clipboardForStrip(clip, startedTyping = true))
+        assertEquals(clip, KeyboardChrome.clipboardForStrip(clip, startedTyping = false))
     }
 
     @Test


### PR DESCRIPTION
Copy something, start typing, and the strip kept showing the clip chip instead of word suggestions for the rest of the sentence.

## What was actually wrong

The suggestions were being computed correctly the whole time — `suggestionsForStrip` returned them as soon as typing started. They were never *rendered*.

`DictationBar` draws the chip and the strip into the same row through one `when`, and that `when` tests `clipboard != null` before `suggestions.isNotEmpty()`:

```kotlin
clipboard != null      -> ClipboardChipButton(...)
suggestions.isNotEmpty() -> SuggestionStripRow(...)
```

So as long as a clip existed, the clipboard branch matched and execution never reached the suggestions one. And `clipboardForStrip` only dropped the chip once it had been *pasted* — a clip nobody pastes lives until it is replaced or dismissed. Permanently available, permanently winning.

## The fix

The chip is an offer made while the field is idle; once the user is typing, the row belongs to what they are producing. `clipboardForStrip` now takes `startedTyping` and yields.

Fixed in the model rather than by reordering the branches in the composable, because `KeyboardChrome` already owns this class of decision and is unit-tested — the `when` order becomes unreachable for this case either way.

The chip stays hidden for the rest of the sentence rather than reappearing whenever suggestions happen to run dry. A paste target that pops back under a finger already moving toward a word would paste the whole clipboard into the middle of the sentence. Clearing the field brings it back, which is the same condition that first offered it.

## Behaviour change worth a look before merging

`startedTyping` is true for any non-whitespace before the cursor, not only text typed in this session. So focusing a field that **already has content** — editing a draft reply — no longer offers the chip at all.

That case was already broken in the other direction: the chip sat there and suggestions never appeared. This makes it consistent rather than newly wrong. But if we want the chip back for "paste into an existing draft", that needs state the model does not have today — clearing the visible clip on the first input after it arrives, in `VocaPhoneInputMethodService`. Happy to do that as a follow-up if reviewers prefer it.

## Tests

Three new cases in `KeyboardChromeTest`, plus one that ties the swipe path in:

- `clipboard yields the strip once typing starts` — the regression itself
- `the clip chip and the suggestions never both claim the row` — the exclusion at both ends of the condition, since this whole bug class is two things claiming one row
- `an armed swipe word is always typing, so the chip is already gone` — swipe alternatives reach the strip without passing through `suggestionsForStrip`, so the test above cannot see that path. The exclusion holds there for a different reason (arming a swipe requires a replaceable word behind the cursor, which is text, which is typing) and is now asserted rather than argued
- `clearing the field offers the clip again` — names the transition back, so a future move to session-scoped state has to consider it

**Verified the tests catch the bug:** reverting the one-line change fails exactly those three; restoring it passes. 887 tests green across both flavours, `compileFullDebugKotlin` clean.

## Note for a follow-up, not changed here

`clipboardForStrip`'s `alreadyPasted` parameter has never been passed by production code — the paste path clears `visibleClipboard` in the service instead, which makes the parameter redundant. Pre-existing, and out of scope here.