### PR TITLE
fix: close the code-scanning alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,20 @@ version: 2
 # from silently entering the build — and also what stops those pins from ever
 # moving on their own. One grouped pull request a month keeps them current
 # without turning into a queue of single-line updates that each cost a CI run.
+#
+# The cooldown holds a newly published version back for a week before it is
+# proposed. A compromised release is usually pulled within days of being noticed,
+# and the whole point of pinning SHAs is that nothing enters this build the
+# moment upstream publishes it. Monthly grouping already means a week costs
+# nothing: an update held back today arrives in the same pull request as
+# everything else.
 updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns: ['*']
@@ -20,6 +29,8 @@ updates:
     directory: /.github/actions/setup-android
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns: ['*']

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationService.kt
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat
 import com.vocahq.vocaphone.VocaPhoneApplication
 import com.vocahq.vocaphone.R
 import com.vocahq.vocaphone.core.DictationPhase
+import com.vocahq.vocaphone.ui.MainActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -122,10 +123,24 @@ class DictationService : Service() {
     }
 
     private fun notification(status: String): Notification {
+        // Named explicitly rather than resolved with
+        // `packageManager.getLaunchIntentForPackage`. That call does set a
+        // component, but only after a lookup that returns null when it finds no
+        // launcher activity, and neither the null nor the component is visible
+        // to anything reading this code -- including CodeQL, which reported it
+        // as an implicit PendingIntent handed to a third party (CWE-927).
+        //
+        // The distinction is not academic. A PendingIntent wrapping an intent
+        // with no component runs with this app's identity and can have its
+        // destination filled in by whoever holds it, and a notification's
+        // content intent is held by the system UI. FLAG_IMMUTABLE already
+        // closed that door; naming MainActivity means the door was never built.
         val open = PendingIntent.getActivity(
             this,
             0,
-            packageManager.getLaunchIntentForPackage(packageName),
+            Intent(this, MainActivity::class.java)
+                .setAction(Intent.ACTION_MAIN)
+                .addCategory(Intent.CATEGORY_LAUNCHER),
             PendingIntent.FLAG_IMMUTABLE,
         )
         val cancel = PendingIntent.getService(


### PR DESCRIPTION
All four open alerts. Three are real and fixed here; one is not a bug and is explained below rather than patched.

| # | Tool | Severity | Finding | Action |
|---|---|---|---|---|
| 4 | CodeQL | **high** | Implicit `PendingIntent` (CWE-927) | Fixed |
| 2 | Semgrep | warning | Dependabot missing cooldown | Fixed |
| 1 | Semgrep | warning | Dependabot missing cooldown | Fixed |
| 3 | Semgrep | warning | Exported activity | Not a bug — see below |

## #4 — implicit PendingIntent (high)

`DictationService.notification()` built the notification's content intent from `packageManager.getLaunchIntentForPackage(packageName)`.

That call *does* set a component, so at runtime the intent was never actually implicit — but only after a lookup that returns `null` when it finds no launcher activity, and neither the null nor the component is visible to anything reading the code. CodeQL cannot see through it, and neither can a reviewer.

Worth taking seriously rather than waving off as a false positive. A `PendingIntent` executes with this app's identity; an intent with no component can have its destination filled in by whoever holds it; and a notification's content intent is held by the system UI. `FLAG_IMMUTABLE` was already closing that door. Naming `MainActivity` explicitly means the door was never built — and it drops a nullable platform return at the same time.

Behaviour is unchanged: `ACTION_MAIN` + `CATEGORY_LAUNCHER` against the launcher activity is exactly what `getLaunchIntentForPackage` resolves to, so tapping the notification still resumes the existing task instead of starting a second instance.

`VocaPhoneInputMethodService.kt:598` also calls `getLaunchIntentForPackage`, but it is not flagged and not changed: it null-checks with `?: return` and starts the activity directly rather than wrapping it in a `PendingIntent`, so no capability is handed to anyone.

## #1 and #2 — Dependabot cooldown

Both `package-ecosystem` entries now carry `cooldown: default-days: 7`.

This is close to free here. Updates are already grouped monthly, so a version held back today arrives in the same pull request as everything else, and every action is already pinned to a commit SHA — nothing enters the build the moment upstream publishes. What the cooldown adds is the week in which a compromised release usually gets pulled.

## #3 — exported activity: not fixable, and not a bug

`AndroidManifest.xml:32` is `.ui.MainActivity`, which carries `ACTION_MAIN` + `CATEGORY_LAUNCHER`. **A launcher activity must be exported or the app cannot be launched at all.** Setting `exported="false"` would remove VocaPhone from the launcher; there is no version of this change that is an improvement.

The rule's own remediation is a review instruction — *"ensure that any exported activities do not have privileged access to your application's control plane"* — so I did that review:

- The only things `MainActivity` reads from an incoming intent are `EXTRA_OPEN_SETTINGS` (boolean), `EXTRA_OPEN_MODELS` (boolean) and `EXTRA_SETTINGS_PAGE` (string).
- `SettingsPage.fromExtra` (`SettingsScreen.kt:46`) maps that string through a closed `when` with `else -> HOME`, so an unrecognised value falls back safely.
- Nothing else is read. No URI or file handling, no `setResult`, no credential path, no action taken on behalf of the caller.

The worst a hostile app can do is open VocaPhone on a settings page the user can already reach by tapping the icon.

The other exported component, `VocaPhoneInputMethodService`, is guarded by `android.permission.BIND_INPUT_METHOD`, which only the system holds — that is why it is not flagged.

I have dismissed #3 as a false positive with this reasoning attached. It can be reopened from the Security tab if anyone disagrees.

## Verification

- 887 Android tests green across both flavours
- `compileFullDebugKotlin` and `compileFdroidDebugKotlin` both clean
- `.github/dependabot.yml` re-parsed and asserted structurally: `version: 2`, and `cooldown.default-days == 7` on both entries