### PR TITLE
ci: stop CodeQL timing out on Swift and evicting the run that matters

### DIFF
--- a/.github/workflows/codeql-native.yml
+++ b/.github/workflows/codeql-native.yml
@@ -26,9 +26,18 @@ permissions:
   contents: read
   security-events: write
 
+# Analysing the newest commit on main is the whole point, so a newer push
+# supersedes an older run rather than queueing behind it.
+#
+# `false` was actively harmful here. The Swift job can occupy the group for its
+# full timeout, and GitHub keeps only one *pending* run per group: when a second
+# push arrives while one is already waiting, the older pending run is cancelled.
+# That is not the run you want to lose. It cost the analysis of the commit that
+# fixed an open alert -- the fix merged, its run was evicted by the next merge,
+# and the alert stayed open pointing at code that no longer existed.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   HOMEBREW_NO_AUTO_UPDATE: '1'
@@ -68,7 +77,14 @@ jobs:
   ios:
     name: Swift
     runs-on: macos-15
-    timeout-minutes: 30
+    # Sixty rather than the thirty this started with, and the thirty was the bug.
+    # CodeQL traces the compiler, which costs far more than the build itself:
+    # quality-ios.yml builds and tests the same project on the same runner in
+    # seven to eight minutes, while the traced build alone was still going at
+    # twenty-nine. It hit the limit every time, so Swift results never uploaded
+    # and the job held the concurrency group for the full half hour on the way
+    # out.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
The Swift job has never completed on `main`, and separately the analysis that would have closed an open alert was thrown away. Two settings, one failure.

## The timeout was set for an untraced build

CodeQL traces the compiler, which costs far more than the compile itself:

| Workflow | Same project, same `macos-15` runner | Wall time |
|---|---|---|
| `quality-ios.yml` | `xcodebuild` build **and test** | **7–8 min** |
| `codeql-native.yml` | `xcodebuild` build, CodeQL-traced | **still running at 29 min**, limit 30 |

Nothing about the project changed to cause this — the limit was simply never large enough. Every run hit it, so Swift results never uploaded, and the job also held the concurrency group for the full half hour on its way out.

Raised to 60.

## `cancel-in-progress: false` turned that into lost results

GitHub keeps only **one pending run per concurrency group**. When a second push arrives while one is already waiting, it cancels the *older pending* run — and with the Swift job holding the group for its full timeout, something is nearly always waiting.

Here is what that actually cost, from the run history:

```
32180534703  67526269  pending      <- #117, still waiting
32180321840  e65f8b21  cancelled    <- #118, the alert fix. Evicted, never ran.
32177954607  0db42369  in_progress  <- #116, Swift stuck in the traced build
```

The evicted run was the one analysing the commit that **fixed** an open alert. The fix merged, its run was cancelled by the next merge, and alert #4 stayed open pointing at code that no longer existed — which reads exactly like a fix that did not work. That is how this was noticed.

Analysing the newest commit on `main` is the entire point of this workflow, so a newer push should supersede an older run rather than queue behind it and then evict it. Set to `true`.

## Why this looked like "CodeQL Swift is failing"

It was never a code problem, and there is nothing wrong with the Swift analysis. It is a timeout. Earlier runs where Swift showed *cancelled* alongside a Kotlin *failure* were a separate, since-fixed Kotlin issue, which made the pattern harder to read than it should have been.

## Not included

Caching `SourcePackages` would cut the traced build substantially — WhisperKit, swift-transformers, swift-crypto and yyjson all compile from source on every run, and `quality-ios.yml` has no cache either. That is a change to how the build works rather than to how long it is allowed to take, so it belongs in its own PR where its effect on both workflows can be measured.

## Verification

- `actionlint` clean
- YAML re-parsed: `cancel-in-progress` is a boolean `true`, `timeout-minutes` an integer `60` — checked as types, not just as text, since both are keys where a quoted string would be silently accepted and behave differently