### PR TITLE
fix(android): restore FLAG_ACTIVITY_NEW_TASK on the notification's intent

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationService.kt
@@ -123,24 +123,31 @@ class DictationService : Service() {
     }
 
     private fun notification(status: String): Notification {
-        // Named explicitly rather than resolved with
-        // `packageManager.getLaunchIntentForPackage`. That call does set a
-        // component, but only after a lookup that returns null when it finds no
-        // launcher activity, and neither the null nor the component is visible
-        // to anything reading this code -- including CodeQL, which reported it
-        // as an implicit PendingIntent handed to a third party (CWE-927).
+        // Destination named, and nothing else set.
         //
-        // The distinction is not academic. A PendingIntent wrapping an intent
-        // with no component runs with this app's identity and can have its
-        // destination filled in by whoever holds it, and a notification's
-        // content intent is held by the system UI. FLAG_IMMUTABLE already
-        // closed that door; naming MainActivity means the door was never built.
+        // The action and category this used to carry were copied from what
+        // `packageManager.getLaunchIntentForPackage` builds internally, and they
+        // were doing nothing: an action and a category exist so the system can
+        // *resolve* an intent, and resolution does not happen once a component
+        // is named. What they did do was make CodeQL read this as an implicit
+        // intent handed to a third party (CWE-927), because its rule keys on
+        // `setAction` and does not care that the constructor set a component.
+        //
+        // The rule is crude there but the direction is right: a PendingIntent
+        // runs with this app's identity, an intent with an unfilled destination
+        // can have one supplied by whoever holds it, and a notification's
+        // content intent is held by the system UI. FLAG_IMMUTABLE already closed
+        // that door. This leaves nothing for anyone to fill in.
+        //
+        // FLAG_ACTIVITY_NEW_TASK is not decoration: `getLaunchIntentForPackage`
+        // sets it too, and starting an activity from a Service context needs it.
+        // With the activity at the root of an existing task it brings that task
+        // forward rather than stacking a second copy, which is what tapping an
+        // ongoing notification should do.
         val open = PendingIntent.getActivity(
             this,
             0,
-            Intent(this, MainActivity::class.java)
-                .setAction(Intent.ACTION_MAIN)
-                .addCategory(Intent.CATEGORY_LAUNCHER),
+            Intent(this, MainActivity::class.java).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
             PendingIntent.FLAG_IMMUTABLE,
         )
         val cancel = PendingIntent.getService(


### PR DESCRIPTION
**This does not close CodeQL alert #4.** I dispatched the analysis against this branch before opening the PR, precisely so that claim could be tested rather than assumed — and it failed. Details below; the change here is worth making for a different reason.

## The alert is a false positive

`java/android/implicit-pendingintents` flags both PendingIntents in `DictationService.notification()`, and it keeps flagging the first one after the action and category are removed:

```
flow 1:  new Intent(...) :150  →  setFlags(...) :150  →  getActivity(...)
flow 2:  new Intent(...) :156  →  setAction(...) :156  →  getService(...)
```

Both intents name their destination through `Intent(Context, Class)`. Flow 1 now carries nothing but a flag. The rule does not recognise the two-argument constructor as setting a component in this Kotlin code, so **no arrangement of this code closes the alert** — the earlier attempt in #118 swapped `getLaunchIntentForPackage` for an explicit constructor and the alert simply moved by a line.

Both destinations are safe on inspection: `MainActivity` is this app's own launcher activity, `DictationService` is declared `android:exported="false"`, and both PendingIntents are `FLAG_IMMUTABLE`, so nothing can be filled in by a holder. Flow 2's action is load-bearing — `onStartCommand` dispatches on it — and rewriting it as an extra would be contorting the code to satisfy a heuristic.

Alert #4 is dismissed as a false positive with this evidence attached.

## What this actually fixes

Replacing `packageManager.getLaunchIntentForPackage` with an explicit constructor in #118 quietly dropped `FLAG_ACTIVITY_NEW_TASK`. AOSP's implementation of that method sets it on the intent it returns; the hand-written replacement did not.

That matters: starting an activity from a Service context needs `NEW_TASK`, and with the activity at the root of an existing task it brings that task forward rather than stacking a second copy — which is what tapping an ongoing notification should do. That regression came in with the previous change and is restored here.

The action and category are removed in the same edit because they were doing nothing. Both exist so the system can *resolve* an intent, and resolution does not happen once a component is named. They were copied out of `getLaunchIntentForPackage`'s internals without checking whether they still earned their place.

## Verification

- CodeQL dispatched against this branch: run `32183432131`, analysis `1637347091`, `/language:java-kotlin` — which is how the false positive was established rather than guessed at
- `compileFullDebugKotlin` clean, Android unit tests green