### PR TITLE
Mention opt-in usage reporting on the privacy page

### DIFF
--- a/web/privacy/index.html
+++ b/web/privacy/index.html
@@ -76,6 +76,7 @@
           <span>the short version</span>
           <strong>no Voca account</strong>
           <strong>no analytics SDK</strong>
+          <strong>reporting off by default</strong>
           <strong>no subscription</strong>
           <strong>on-device default</strong>
         </aside>
@@ -137,10 +138,39 @@
           </a>
         </aside>
 
+        <div class="guide-intro">
+          <span class="section-tag">optional</span>
+          <h2 id="usage-title">usage reporting is off until you turn it on.</h2>
+          <p>
+            There is no analytics SDK. Play builds can include optional usage
+            reporting, off by default. Guided setup asks once after a working
+            transcript. Settings can change it later. Nothing is queued while
+            it is off. If you opt in, usage events go to a self-hosted Aptabase
+            instance VocaHQ runs at telemetry.vocahq.com. No third-party
+            analytics service is in the path. The sender is hand-rolled against
+            Aptabase's ingest API. Nothing identifying is stored on the phone:
+            no install ID, no IDFV, no ANDROID_ID, no advertising ID.
+          </p>
+          <p>
+            Never sent: transcripts, audio, typed text, character counts,
+            gateway URL, host, or token, model file paths, device model, exact
+            OS build, region, or timezone. If you opt in, sent: setup step
+            reached, transcription source (on-device or gateway, never which
+            gateway), model download outcome, dictation success or fail with
+            fixed reasons, recording length bucketed (&lt;10s, 10-30s, 30-60s,
+            60s+), app version, OS major only, and language subtag only.
+            Settings → Usage reporting → See exactly what's sent shows the
+            literal JSON of the next flush. F-Droid builds compile it out. The
+            iOS keyboard extension has no telemetry code. The Android IME holds
+            the same line; the companion app may report if you opted in.
+          </p>
+        </div>
+
         <div class="guide-source-links">
           <p>
             VocaPhone is free and AGPL-3.0 licensed. There is no Voca account,
-            no analytics SDK, and no subscription.
+            no analytics SDK, and no subscription. Optional usage reporting is
+            off by default.
           </p>
           <a href="mailto:hello@vocahq.com">hello@vocahq.com</a>
         </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2837,6 +2837,11 @@ svg {
   background: #24523f;
 }
 
+.guide-callout + .guide-intro {
+  margin-top: 90px;
+  margin-bottom: 0;
+}
+
 .guide-source-links {
   display: flex;
   flex-wrap: wrap;

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -254,6 +254,12 @@ test("hosted privacy page covers the Play listing facts", () => {
     privacyHtml,
     /Audio leaves the phone only if you deliberately set a gateway you\s+control/,
   );
+  assert.match(privacyHtml, /off until you turn it on|off by default/i);
+  assert.match(privacyHtml, /opt in|optional usage reporting/i);
+  assert.match(privacyHtml, /telemetry\.vocahq\.com/);
+  assert.match(privacyHtml, /self-hosted/);
+  assert.match(privacyHtml, /Never sent:[\s\S]*transcripts[\s\S]*audio/i);
+  assert.match(privacyHtml, /F-Droid[\s\S]{0,80}compil/i);
   assert.match(privacyHtml, /AGPL-3\.0/);
   assert.match(privacyHtml, /hello@vocahq\.com/);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The live privacy page still says only "no analytics SDK" and "no Voca account". That SDK line is still accurate. Current main can also POST usage events to telemetry.vocahq.com if the user turns reporting on.

This adds a short section so the page states the opt-in path instead of stopping at the SDK claim. Reporting stays off until the user turns it on. Events go to the self-hosted Aptabase at telemetry.vocahq.com. The page lists what is sent and what is not, and that F-Droid builds compile the reporter out. The leftover "no analytics SDK" line stays, then says optional reporting is off by default.

Homepage and FAQ already mention opt-in reporting, so those were left alone. The live page stays on the #115 text until this lands.

![Privacy page sidebar with reporting off by default](https://cursor.com/artifacts/c/art-71e6624e-8a65-49ac-8cd0-ca2a4ce1acaf)
![Usage reporting section on the privacy page](https://cursor.com/artifacts/c/art-5a6b03e8-ab0b-41fa-a15c-585e05529539)

## Verification

- [ ] `just ios ci` (web copy only, not run)
- [ ] `just android ci` (web copy only, not run)
- [ ] Gateway changes: not applicable
- [ ] Physical-device test: not applicable
- [x] `npm run check` from `web/` (18 tests, all passing)

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Hosted privacy page updated for the opt-in usage reporting path

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec66c903-c517-4fac-b634-de715893e37e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec66c903-c517-4fac-b634-de715893e37e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

