### PR TITLE
Prepare 0.1.0-beta.16 for the Play AAB

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.vocahq.vocaphone"
         minSdk = 33
         targetSdk = 36
-        versionCode = 15
-        versionName = "0.1.0-beta.15"
+        versionCode = 16
+        versionName = "0.1.0-beta.16"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/docs/play-store.md
+++ b/docs/play-store.md
@@ -19,8 +19,8 @@ Upload the full AAB. Never upload the fdroid APK or an fdroid bundle to
 Play. The fdroid flavour drops prebuilt sherpa-onnx / ONNX Runtime so F-Droid
 can rebuild from source; Play testers should get the full catalog.
 
-Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 14,
-`versionName` `0.1.0-beta.14`. Keep that until the next Play-bound tag needs a
+Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 16,
+`versionName` `0.1.0-beta.16`. Keep that until the next Play-bound tag needs a
 bump; the beta workflow refuses to publish when the tag and APK version disagree.
 
 `dependenciesInfo.includeInApk` / `includeInBundle` stay `false` so AGP does

--- a/fastlane/metadata/android/en-US/changelogs/16.txt
+++ b/fastlane/metadata/android/en-US/changelogs/16.txt
@@ -1,0 +1,1 @@
+First GitHub beta that also ships vocaphone.aab for Play Internal testing. Includes the usage-reporting opt-in and the hosted privacy page that landed after beta.15.

--- a/fdroid/com.vocahq.vocaphone.yml
+++ b/fdroid/com.vocahq.vocaphone.yml
@@ -40,9 +40,9 @@ Repo: https://github.com/VocaHQ/vocaphone.git
 Binaries: https://github.com/VocaHQ/vocaphone/releases/download/v%v/vocaphone-fdroid.apk
 
 Builds:
-  - versionName: 0.1.0-beta.15
-    versionCode: 15
-    commit: v0.1.0-beta.15
+  - versionName: 0.1.0-beta.16
+    versionCode: 16
+    commit: v0.1.0-beta.16
     subdir: android/app
     submodules: true
     gradle:
@@ -62,5 +62,5 @@ AllowedAPKSigningKeys: e6131446f8afeff13516f78036db9ea26aaa16e01b39f37182bf262cc
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 0.1.0-beta.15
-CurrentVersionCode: 15
+CurrentVersion: 0.1.0-beta.16
+CurrentVersionCode: 16


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#109 is on main, so the next beta tag will attach vocaphone.aab. Play Console will not take an APK. v0.1.0-beta.15 already exists with APKs only. Leave that release alone.

Android is now versionCode 16 / versionName 0.1.0-beta.16. Tag after merge. The beta workflow refuses to publish if those disagree.

F-Droid metadata uses the same numbers. The commit field stays in tag form (`v0.1.0-beta.16`), matching how 15 is written. play-store.md still said the tree was 14. That sentence now says 16. Changelog is `fastlane/metadata/android/en-US/changelogs/16.txt`.

iOS CURRENT_PROJECT_VERSION is unchanged. The site still points at beta.14, which is a real tag.

This PR does not create or push a tag.

## Verification

- [x] `just ios ci` (or note why not): skipped. iOS version is unchanged.
- [x] `just android ci` (or note why not): skipped. Version bump only.
- [x] Gateway changes: none
- [x] Physical-device test: not applicable

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation: only the version sentence in play-store.md

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5ce5d80-5ef2-4fb0-a94f-f6ce5ccafa6b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5ce5d80-5ef2-4fb0-a94f-f6ce5ccafa6b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

