### PR TITLE
Split the keyboard on large screens

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/LifecycleInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/LifecycleInputMethodService.kt
@@ -89,6 +89,12 @@ abstract class LifecycleInputMethodService : InputMethodService(),
     @Composable
     protected abstract fun KeyboardContent()
 
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        inputComposeView?.requestLayout()
+        window?.window?.decorView?.requestLayout()
+    }
+
     override fun onStartInputView(info: EditorInfo?, restarting: Boolean) {
         super.onStartInputView(info, restarting)
         if (lifecycleRegistry.currentState == Lifecycle.State.STARTED) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SplitKeyboardLayout.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SplitKeyboardLayout.kt
@@ -1,0 +1,102 @@
+package com.vocahq.vocaphone.ime
+
+import com.vocahq.vocaphone.settings.SplitKeyboard
+
+/**
+ * Split layout for a too-wide IME window: keep key order, drop a dead spacer
+ * near mid-row, and turn the spacebar into two space keys so each thumb can
+ * reach one.
+ *
+ * The spacer fraction is HeliBoard's auto formula, `(widthDp - 600) / 600 + 0.15`
+ * clamped to 15-35% of the keyboard width. Auto itself turns on at 600 dp
+ * (sw600dp / a typical unfolded fold inner). One-handed mode is a different
+ * feature and is not handled here.
+ */
+internal object SplitKeyboardLayout {
+    const val AUTO_MIN_WIDTH_DP = 600
+    const val MIN_SPACER_FRACTION = 0.15f
+    const val MAX_SPACER_FRACTION = 0.35f
+
+    fun shouldSplit(mode: SplitKeyboard, widthDp: Int): Boolean = when (mode) {
+        SplitKeyboard.ALWAYS -> true
+        SplitKeyboard.NEVER -> false
+        SplitKeyboard.AUTO -> widthDp >= AUTO_MIN_WIDTH_DP
+    }
+
+    fun spacerFraction(widthDp: Int): Float =
+        ((widthDp - AUTO_MIN_WIDTH_DP) / AUTO_MIN_WIDTH_DP.toFloat() + MIN_SPACER_FRACTION)
+            .coerceIn(MIN_SPACER_FRACTION, MAX_SPACER_FRACTION)
+
+    /** Weight that makes [fraction] of the finished row, given the key weights. */
+    fun spacerWeight(keyWeightSum: Float, fraction: Float): Float {
+        val clamped = fraction.coerceIn(MIN_SPACER_FRACTION, MAX_SPACER_FRACTION)
+        return clamped / (1f - clamped) * keyWeightSum
+    }
+
+    /**
+     * Index of the first key that starts at or past the row's midpoint, so the
+     * spacer sits near the center without reordering keys.
+     */
+    fun insertIndex(weights: List<Float>): Int {
+        if (weights.size <= 1) return weights.size
+        val half = weights.sum() / 2f
+        var before = 0f
+        for (index in weights.indices) {
+            if (before >= half) return index
+            before += weights[index]
+        }
+        return weights.size / 2
+    }
+
+    fun splitRow(row: KeyboardRow, spacerFraction: Float): SplitRow {
+        val spaceIndex = row.keys.indexOfFirst { it.type == KeyboardKeyType.SPACE }
+        val items = if (spaceIndex >= 0) {
+            splitSpaceRow(row.keys, spaceIndex, spacerFraction)
+        } else {
+            splitLetterRow(row.keys, spacerFraction)
+        }
+        return SplitRow(items, row.leadingSpace, row.trailingSpace)
+    }
+
+    private fun splitLetterRow(keys: List<KeyboardKey>, spacerFraction: Float): List<SplitItem> {
+        val insertAt = insertIndex(keys.map { it.weight })
+        val gap = spacerWeight(keys.sumOf { it.weight.toDouble() }.toFloat(), spacerFraction)
+        return buildList {
+            keys.take(insertAt).forEach { add(SplitItem.Key(it)) }
+            add(SplitItem.Gap(gap))
+            keys.drop(insertAt).forEach { add(SplitItem.Key(it)) }
+        }
+    }
+
+    private fun splitSpaceRow(
+        keys: List<KeyboardKey>,
+        spaceIndex: Int,
+        spacerFraction: Float,
+    ): List<SplitItem> {
+        val space = keys[spaceIndex]
+        val half = (space.weight / 2f).coerceAtLeast(0.7f)
+        val left = keys.take(spaceIndex)
+        val right = keys.drop(spaceIndex + 1)
+        val keyWeightSum = left.sumOf { it.weight.toDouble() }.toFloat() +
+            half * 2f +
+            right.sumOf { it.weight.toDouble() }.toFloat()
+        return buildList {
+            left.forEach { add(SplitItem.Key(it)) }
+            add(SplitItem.Key(space.copy(id = "${space.id}-left", weight = half)))
+            add(SplitItem.Gap(spacerWeight(keyWeightSum, spacerFraction)))
+            add(SplitItem.Key(space.copy(id = "${space.id}-right", weight = half)))
+            right.forEach { add(SplitItem.Key(it)) }
+        }
+    }
+}
+
+internal data class SplitRow(
+    val items: List<SplitItem>,
+    val leadingSpace: Float,
+    val trailingSpace: Float,
+)
+
+internal sealed class SplitItem {
+    data class Key(val key: KeyboardKey) : SplitItem()
+    data class Gap(val weight: Float) : SplitItem()
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SplitKeyboardLayout.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SplitKeyboardLayout.kt
@@ -82,12 +82,20 @@ internal object SplitKeyboardLayout {
             right.sumOf { it.weight.toDouble() }.toFloat()
         return buildList {
             left.forEach { add(SplitItem.Key(it)) }
-            add(SplitItem.Key(space.copy(id = "${space.id}-left", weight = half)))
+            add(SplitItem.Key(space.copy(id = "${space.id}$LEFT_SUFFIX", weight = half)))
             add(SplitItem.Gap(spacerWeight(keyWeightSum, spacerFraction)))
-            add(SplitItem.Key(space.copy(id = "${space.id}-right", weight = half)))
+            add(SplitItem.Key(space.copy(id = "${space.id}$RIGHT_SUFFIX", weight = half)))
             right.forEach { add(SplitItem.Key(it)) }
         }
     }
+
+    /** Half of a split spacebar. The wordmark stays off these so it is not painted twice. */
+    fun isSplitSpace(key: KeyboardKey): Boolean =
+        key.type == KeyboardKeyType.SPACE &&
+            (key.id.endsWith(LEFT_SUFFIX) || key.id.endsWith(RIGHT_SUFFIX))
+
+    private const val LEFT_SUFFIX = "-left"
+    private const val RIGHT_SUFFIX = "-right"
 }
 
 internal data class SplitRow(

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
@@ -121,6 +122,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.math.abs
+import kotlin.math.roundToInt
 import java.util.Locale
 
 private enum class PreferencePanel {
@@ -326,6 +328,10 @@ internal fun VocaPhoneKeyboard(
             color = MaterialTheme.colorScheme.surfaceContainerLowest,
             contentColor = MaterialTheme.colorScheme.onSurface,
         ) {
+            BoxWithConstraints(Modifier.fillMaxWidth()) {
+                val widthDp = maxWidth.value.roundToInt()
+                val splitKeys = SplitKeyboardLayout.shouldSplit(settings.splitKeyboard, widthDp)
+                val spacerFraction = SplitKeyboardLayout.spacerFraction(widthDp)
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -479,6 +485,8 @@ internal fun VocaPhoneKeyboard(
                             editor = editor,
                             keyHeight = fittedKeyHeight,
                             showKeyHints = settings.numberKeyHintsEnabled,
+                            split = splitKeys && keyboardState.layer != KeyboardLayer.EMOJI,
+                            spacerFraction = spacerFraction,
                             swipeEnabled = settings.swipeTypingEnabled &&
                                 keyboardState.layer == KeyboardLayer.LETTERS,
                             onSwipe = ::handleSwipe,
@@ -494,6 +502,7 @@ internal fun VocaPhoneKeyboard(
                         )
                     }
                 }
+            }
             }
         }
     }
@@ -1580,6 +1589,8 @@ private fun KeyboardRows(
     editor: KeyboardEditorConfig,
     keyHeight: Dp,
     showKeyHints: Boolean = false,
+    split: Boolean = false,
+    spacerFraction: Float = SplitKeyboardLayout.MIN_SPACER_FRACTION,
     swipeEnabled: Boolean = false,
     onSwipe: (String) -> Unit = {},
     onKey: (KeyboardKey) -> Unit,
@@ -1625,38 +1636,49 @@ private fun KeyboardRows(
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
                     if (row.leadingSpace > 0f) Spacer(Modifier.weight(row.leadingSpace))
-                    row.keys.forEach { key ->
-                        KeyButton(
-                            key = key,
-                            state = state,
-                            editor = editor,
-                            keyHeight = keyHeight,
-                            showKeyHints = showKeyHints,
-                            swipeConsumed = swipeConsumed,
-                            onPress = { onKey(key) },
-                            onHold = { heldMs -> onKeyHold(key, heldMs) },
-                            onCommitText = { text ->
-                                onKey(
-                                    KeyboardKey(
-                                        id = "variant-$text",
-                                        label = text,
-                                        output = text,
-                                    ),
+                    val items = if (split) {
+                        SplitKeyboardLayout.splitRow(row, spacerFraction).items
+                    } else {
+                        row.keys.map { SplitItem.Key(it) }
+                    }
+                    items.forEach { item ->
+                        when (item) {
+                            is SplitItem.Gap -> Spacer(Modifier.weight(item.weight))
+                            is SplitItem.Key -> {
+                                val key = item.key
+                                KeyButton(
+                                    key = key,
+                                    state = state,
+                                    editor = editor,
+                                    keyHeight = keyHeight,
+                                    showKeyHints = showKeyHints,
+                                    swipeConsumed = swipeConsumed,
+                                    onPress = { onKey(key) },
+                                    onHold = { heldMs -> onKeyHold(key, heldMs) },
+                                    onCommitText = { text ->
+                                        onKey(
+                                            KeyboardKey(
+                                                id = "variant-$text",
+                                                label = text,
+                                                output = text,
+                                            ),
+                                        )
+                                    },
+                                    onCursorMove = onCursorMove,
+                                    modifier = Modifier
+                                        .weight(key.weight)
+                                        .onGloballyPositioned { coords ->
+                                            val origin = coords.positionInRoot()
+                                            keyBounds[key.id] = key to Rect(
+                                                origin.x,
+                                                origin.y,
+                                                origin.x + coords.size.width,
+                                                origin.y + coords.size.height,
+                                            )
+                                        },
                                 )
-                            },
-                            onCursorMove = onCursorMove,
-                            modifier = Modifier
-                                .weight(key.weight)
-                                .onGloballyPositioned { coords ->
-                                    val origin = coords.positionInRoot()
-                                    keyBounds[key.id] = key to Rect(
-                                        origin.x,
-                                        origin.y,
-                                        origin.x + coords.size.width,
-                                        origin.y + coords.size.height,
-                                    )
-                                },
-                        )
+                            }
+                        }
                     }
                     if (row.trailingSpace > 0f) Spacer(Modifier.weight(row.trailingSpace))
                 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -447,6 +447,8 @@ internal fun VocaPhoneKeyboard(
                             catalog = emojiCatalog,
                             recents = settings.emojiRecents,
                             category = emojiCategory,
+                            split = splitKeys,
+                            spacerFraction = spacerFraction,
                             onEmoji = { glyph ->
                                 handleKey(
                                     KeyboardKey(
@@ -485,7 +487,7 @@ internal fun VocaPhoneKeyboard(
                             editor = editor,
                             keyHeight = fittedKeyHeight,
                             showKeyHints = settings.numberKeyHintsEnabled,
-                            split = splitKeys && keyboardState.layer != KeyboardLayer.EMOJI,
+                            split = splitKeys,
                             spacerFraction = spacerFraction,
                             swipeEnabled = settings.swipeTypingEnabled &&
                                 keyboardState.layer == KeyboardLayer.LETTERS,
@@ -1481,6 +1483,8 @@ private fun EmojiLayer(
     catalog: List<EmojiEntry>,
     recents: List<String>,
     category: EmojiCategory,
+    split: Boolean = false,
+    spacerFraction: Float = SplitKeyboardLayout.MIN_SPACER_FRACTION,
     onEmoji: (String) -> Unit,
     onKey: (KeyboardKey) -> Unit,
     onKeyHold: (KeyboardKey, Long) -> Unit = { _, _ -> },
@@ -1505,6 +1509,8 @@ private fun EmojiLayer(
             state = state,
             editor = editor,
             keyHeight = keyHeight,
+            split = split,
+            spacerFraction = spacerFraction,
             onKey = onKey,
             onKeyHold = onKeyHold,
             onCursorMove = onCursorMove,
@@ -2054,7 +2060,9 @@ private fun KeyContent(
             ReturnKeyKind.GO -> KeyLabel("Go", tint, utility = true)
             ReturnKeyKind.SEND -> KeyLabel("Send", tint, utility = true)
         }
-        KeyboardKeyType.SPACE -> KeyLabel("VocaPhone", tint.copy(alpha = 0.78f), utility = true)
+        KeyboardKeyType.SPACE -> if (!SplitKeyboardLayout.isSplitSpace(key)) {
+            KeyLabel("VocaPhone", tint.copy(alpha = 0.78f), utility = true)
+        }
         KeyboardKeyType.LAYER_SWITCH -> KeyLabel(displayLabel, tint, utility = true)
         KeyboardKeyType.CHARACTER -> {
             if (hint == null) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -61,6 +61,27 @@ internal object ClipboardHistory {
         items.mapNotNull { parseImage(it)?.second }.toSet()
 }
 
+enum class SplitKeyboard(val storedValue: String) {
+    AUTO("auto"),
+    ALWAYS("always"),
+    NEVER("never"),
+    ;
+
+    val displayName: String
+        get() = when (this) {
+            AUTO -> "Auto"
+            ALWAYS -> "Always"
+            NEVER -> "Never"
+        }
+
+    companion object {
+        val DEFAULT = AUTO
+
+        fun fromStored(value: String?): SplitKeyboard =
+            entries.firstOrNull { it.storedValue == value } ?: DEFAULT
+    }
+}
+
 enum class KeyboardHeight(
     val storedValue: String,
     val keyHeightDp: Int,
@@ -135,6 +156,7 @@ data class VocaPhoneSettings(
     val customVocabulary: String = "",
     val numberRowEnabled: Boolean = false,
     val keyboardHeight: KeyboardHeight = KeyboardHeight.DEFAULT,
+    val splitKeyboard: SplitKeyboard = SplitKeyboard.DEFAULT,
     val suggestionsEnabled: Boolean = true,
     val correctionsEnabled: Boolean = true,
     val numberKeyHintsEnabled: Boolean = true,
@@ -268,6 +290,8 @@ class SettingsRepository(private val context: Context) {
 
     suspend fun setKeyboardHeight(height: KeyboardHeight) = put(Keys.KEYBOARD_HEIGHT, height.storedValue)
 
+    suspend fun setSplitKeyboard(mode: SplitKeyboard) = put(Keys.SPLIT_KEYBOARD, mode.storedValue)
+
     suspend fun setSuggestionsEnabled(enabled: Boolean) = put(Keys.SUGGESTIONS, enabled)
 
     suspend fun setCorrectionsEnabled(enabled: Boolean) = put(Keys.CORRECTIONS, enabled)
@@ -384,6 +408,7 @@ class SettingsRepository(private val context: Context) {
         customVocabulary = this[Keys.CUSTOM_VOCABULARY].orEmpty(),
         numberRowEnabled = this[Keys.NUMBER_ROW] ?: false,
         keyboardHeight = KeyboardHeight.fromStored(this[Keys.KEYBOARD_HEIGHT]),
+        splitKeyboard = SplitKeyboard.fromStored(this[Keys.SPLIT_KEYBOARD]),
         suggestionsEnabled = this[Keys.SUGGESTIONS] ?: true,
         correctionsEnabled = this[Keys.CORRECTIONS] ?: true,
         numberKeyHintsEnabled = this[Keys.NUMBER_KEY_HINTS] ?: true,
@@ -419,6 +444,7 @@ class SettingsRepository(private val context: Context) {
         val CUSTOM_VOCABULARY = stringPreferencesKey("custom_vocabulary")
         val NUMBER_ROW = booleanPreferencesKey("keyboard_number_row")
         val KEYBOARD_HEIGHT = stringPreferencesKey("keyboard_height")
+        val SPLIT_KEYBOARD = stringPreferencesKey("keyboard_split")
         val SUGGESTIONS = booleanPreferencesKey("keyboard_suggestions")
         val CORRECTIONS = booleanPreferencesKey("keyboard_corrections")
         val NUMBER_KEY_HINTS = booleanPreferencesKey("keyboard_number_key_hints")

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
@@ -248,6 +248,7 @@ fun VocaPhoneApp(
                 onCustomVocabulary = { viewModel.setCustomVocabulary(it) },
                 onNumberRow = { viewModel.setNumberRowEnabled(it) },
                 onKeyboardHeight = { viewModel.setKeyboardHeight(it) },
+                onSplitKeyboard = { viewModel.setSplitKeyboard(it) },
                 onSuggestions = { viewModel.setSuggestionsEnabled(it) },
                 onCorrections = { viewModel.setCorrectionsEnabled(it) },
                 onNumberKeyHints = { viewModel.setNumberKeyHintsEnabled(it) },

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -31,6 +31,7 @@ import com.vocahq.vocaphone.local.LocalModelDescriptor
 import com.vocahq.vocaphone.local.LocalModelState
 import com.vocahq.vocaphone.settings.AudioRetention
 import com.vocahq.vocaphone.settings.KeyboardHeight
+import com.vocahq.vocaphone.settings.SplitKeyboard
 import com.vocahq.vocaphone.settings.VocaPhoneSettings
 
 enum class SettingsPage(val title: String) {
@@ -67,6 +68,7 @@ fun SettingsScreen(
     onCustomVocabulary: (String) -> Unit,
     onNumberRow: (Boolean) -> Unit,
     onKeyboardHeight: (KeyboardHeight) -> Unit,
+    onSplitKeyboard: (SplitKeyboard) -> Unit,
     onSuggestions: (Boolean) -> Unit,
     onCorrections: (Boolean) -> Unit,
     onNumberKeyHints: (Boolean) -> Unit,
@@ -155,6 +157,9 @@ fun SettingsScreen(
                             append(" · ")
                             append(settings.keyboardHeight.displayName)
                             if (settings.numberRowEnabled) append(" · number row")
+                            if (settings.splitKeyboard != SplitKeyboard.AUTO) {
+                                append(" · split ${settings.splitKeyboard.displayName.lowercase()}")
+                            }
                         },
                         icon = R.drawable.ic_keyboard,
                         onClick = { onPageChange(SettingsPage.KEYBOARD) },
@@ -221,6 +226,20 @@ fun SettingsScreen(
                         selected = settings.keyboardHeight,
                         label = { it.displayName },
                         onSelect = onKeyboardHeight,
+                    )
+                    Text("Split keyboard", style = MaterialTheme.typography.bodyMedium)
+                    ChipChoiceRow(
+                        options = SplitKeyboard.entries,
+                        selected = settings.splitKeyboard,
+                        label = { it.displayName },
+                        onSelect = onSplitKeyboard,
+                    )
+                    Text(
+                        "Auto splits when the keyboard is at least 600 dp wide, " +
+                            "like a tablet or an unfolded foldable. " +
+                            "A phone-sized portrait keyboard stays in one piece.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     SettingToggle(
                         title = "Suggestions",

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
@@ -23,6 +23,7 @@ import com.vocahq.vocaphone.local.LocalModelIntegrityException
 import com.vocahq.vocaphone.local.LocalModelState
 import com.vocahq.vocaphone.settings.AudioRetention
 import com.vocahq.vocaphone.settings.KeyboardHeight
+import com.vocahq.vocaphone.settings.SplitKeyboard
 import com.vocahq.vocaphone.settings.VocaPhoneSettings
 import com.vocahq.vocaphone.telemetry.TelemetryDownloadOutcome
 import com.vocahq.vocaphone.telemetry.TelemetrySetupStep
@@ -315,6 +316,9 @@ class VocaPhoneViewModel(application: Application) : AndroidViewModel(applicatio
 
     fun setKeyboardHeight(height: KeyboardHeight) =
         viewModelScope.launch { container.settings.setKeyboardHeight(height) }
+
+    fun setSplitKeyboard(mode: SplitKeyboard) =
+        viewModelScope.launch { container.settings.setSplitKeyboard(mode) }
 
     fun setSuggestionsEnabled(enabled: Boolean) =
         viewModelScope.launch { container.settings.setSuggestionsEnabled(enabled) }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SplitKeyboardLayoutTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SplitKeyboardLayoutTest.kt
@@ -34,6 +34,16 @@ class SplitKeyboardLayoutTest {
     }
 
     @Test
+    fun `auto splits phone landscape and fold-cover landscape`() {
+        // Auto is "IME too wide for thumbs", not tablet-only. A phone or
+        // fold cover turned sideways is ~640-900 dp, so it splits. Do not
+        // raise this to sw600dp / 800 dp to spare landscape.
+        assertTrue(SplitKeyboardLayout.shouldSplit(SplitKeyboard.AUTO, 640))
+        assertTrue(SplitKeyboardLayout.shouldSplit(SplitKeyboard.AUTO, 800))
+        assertTrue(SplitKeyboardLayout.shouldSplit(SplitKeyboard.AUTO, 914))
+    }
+
+    @Test
     fun `always and never ignore width`() {
         assertTrue(SplitKeyboardLayout.shouldSplit(SplitKeyboard.ALWAYS, 360))
         assertFalse(SplitKeyboardLayout.shouldSplit(SplitKeyboard.NEVER, 1200))
@@ -82,21 +92,49 @@ class SplitKeyboardLayoutTest {
     @Test
     fun `spacebar becomes two space keys with a gap between them`() {
         val bottom = KeyboardLayouts.rows(KeyboardLayer.LETTERS, KeyboardEditorConfig.empty()).last()
+        assertFalse(
+            SplitKeyboardLayout.isSplitSpace(bottom.keys.first { it.type == KeyboardKeyType.SPACE }),
+        )
         val split = SplitKeyboardLayout.splitRow(bottom, 0.20f)
         val keys = split.items.filterIsInstance<SplitItem.Key>().map { it.key }
         val spaces = keys.filter { it.type == KeyboardKeyType.SPACE }
         assertEquals(2, spaces.size)
-        assertEquals(1, split.items.count { it is SplitItem.Gap })
-        assertTrue(split.items.indexOfFirst { it is SplitItem.Gap } > keys.indexOfFirst { it.type == KeyboardKeyType.SPACE })
-        assertEquals(
-            bottom.keys.map { it.type },
-            keys.map { it.type }.let { types ->
-                val firstSpace = types.indexOf(KeyboardKeyType.SPACE)
-                types.take(firstSpace + 1) + types.drop(firstSpace + 2)
-            },
-        )
+        assertTrue(spaces.all { SplitKeyboardLayout.isSplitSpace(it) })
+        assertGapBetweenSpaces(split.items)
         assertEquals(bottom.keys.first().id, keys.first().id)
         assertEquals(bottom.keys.last().id, keys.last().id)
+    }
+
+    @Test
+    fun `emoji bottom row splits the spacebar and leaves other keys in order`() {
+        val bottom = KeyboardLayouts.rows(KeyboardLayer.EMOJI, KeyboardEditorConfig.empty()).single()
+        val split = SplitKeyboardLayout.splitRow(bottom, 0.20f)
+        val keys = split.items.filterIsInstance<SplitItem.Key>().map { it.key }
+        assertEquals(
+            listOf(
+                KeyboardKeyType.LAYER_SWITCH,
+                KeyboardKeyType.SPACE,
+                KeyboardKeyType.SPACE,
+                KeyboardKeyType.DELETE,
+                KeyboardKeyType.RETURN,
+            ),
+            keys.map { it.type },
+        )
+        assertGapBetweenSpaces(split.items)
+        assertEquals("emoji-letters", keys.first().id)
+        assertEquals("return", keys.last().id)
+    }
+
+    private fun assertGapBetweenSpaces(items: List<SplitItem>) {
+        val gap = items.indexOfFirst { it is SplitItem.Gap }
+        assertEquals(1, items.count { it is SplitItem.Gap })
+        assertTrue(gap > 0 && gap < items.lastIndex)
+        val left = items[gap - 1] as SplitItem.Key
+        val right = items[gap + 1] as SplitItem.Key
+        assertEquals(KeyboardKeyType.SPACE, left.key.type)
+        assertEquals(KeyboardKeyType.SPACE, right.key.type)
+        assertTrue(SplitKeyboardLayout.isSplitSpace(left.key))
+        assertTrue(SplitKeyboardLayout.isSplitSpace(right.key))
     }
 
     @Test

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SplitKeyboardLayoutTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SplitKeyboardLayoutTest.kt
@@ -1,0 +1,122 @@
+package com.vocahq.vocaphone.ime
+
+import com.vocahq.vocaphone.settings.SplitKeyboard
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SplitKeyboardLayoutTest {
+
+    @Test
+    fun `stored values survive a round trip and unknown reads as auto`() {
+        SplitKeyboard.entries.forEach { mode ->
+            assertEquals(mode, SplitKeyboard.fromStored(mode.storedValue))
+        }
+        assertEquals(listOf("auto", "always", "never"), SplitKeyboard.entries.map { it.storedValue })
+        assertEquals(SplitKeyboard.AUTO, SplitKeyboard.fromStored(null))
+        assertEquals(SplitKeyboard.AUTO, SplitKeyboard.fromStored("thumbs"))
+        assertEquals(SplitKeyboard.AUTO, SplitKeyboard.DEFAULT)
+    }
+
+    @Test
+    fun `auto leaves a phone portrait keyboard alone`() {
+        assertFalse(SplitKeyboardLayout.shouldSplit(SplitKeyboard.AUTO, 360))
+        assertFalse(SplitKeyboardLayout.shouldSplit(SplitKeyboard.AUTO, 411))
+        assertFalse(SplitKeyboardLayout.shouldSplit(SplitKeyboard.AUTO, 599))
+    }
+
+    @Test
+    fun `auto splits at 600 dp and stays split on a fold inner`() {
+        assertTrue(SplitKeyboardLayout.shouldSplit(SplitKeyboard.AUTO, 600))
+        assertTrue(SplitKeyboardLayout.shouldSplit(SplitKeyboard.AUTO, 690))
+        assertTrue(SplitKeyboardLayout.shouldSplit(SplitKeyboard.AUTO, 840))
+    }
+
+    @Test
+    fun `always and never ignore width`() {
+        assertTrue(SplitKeyboardLayout.shouldSplit(SplitKeyboard.ALWAYS, 360))
+        assertFalse(SplitKeyboardLayout.shouldSplit(SplitKeyboard.NEVER, 1200))
+    }
+
+    @Test
+    fun `spacer grows from 15 to 35 percent of keyboard width`() {
+        assertEquals(0.15f, SplitKeyboardLayout.spacerFraction(360), 0.0001f)
+        assertEquals(0.15f, SplitKeyboardLayout.spacerFraction(600), 0.0001f)
+        assertEquals(0.25f, SplitKeyboardLayout.spacerFraction(660), 0.0001f)
+        assertEquals(0.35f, SplitKeyboardLayout.spacerFraction(720), 0.0001f)
+        assertEquals(0.35f, SplitKeyboardLayout.spacerFraction(1200), 0.0001f)
+    }
+
+    @Test
+    fun `spacer weight is the fraction of the finished row`() {
+        val keys = 10f
+        val gap = SplitKeyboardLayout.spacerWeight(keys, 0.20f)
+        assertEquals(0.20f, gap / (keys + gap), 0.0001f)
+    }
+
+    @Test
+    fun `letter rows keep order and insert a gap near the middle`() {
+        val qwerty = KeyboardLayouts.rows(KeyboardLayer.LETTERS, KeyboardEditorConfig.empty())[0]
+        val split = SplitKeyboardLayout.splitRow(qwerty, 0.20f)
+        assertEquals(
+            listOf("q", "w", "e", "r", "t", "y", "u", "i", "o", "p"),
+            split.items.filterIsInstance<SplitItem.Key>().map { it.key.output },
+        )
+        assertEquals(5, split.items.indexOfFirst { it is SplitItem.Gap })
+        assertEquals(1, split.items.count { it is SplitItem.Gap })
+    }
+
+    @Test
+    fun `home row splits after five letters so the gap sits near center`() {
+        val home = KeyboardLayouts.rows(KeyboardLayer.LETTERS, KeyboardEditorConfig.empty())[1]
+        val split = SplitKeyboardLayout.splitRow(home, 0.20f)
+        val letters = split.items.filterIsInstance<SplitItem.Key>().map { it.key.output }
+        assertEquals(listOf("a", "s", "d", "f", "g", "h", "j", "k", "l"), letters)
+        assertEquals(
+            listOf("a", "s", "d", "f", "g"),
+            split.items.takeWhile { it is SplitItem.Key }.map { (it as SplitItem.Key).key.output },
+        )
+    }
+
+    @Test
+    fun `spacebar becomes two space keys with a gap between them`() {
+        val bottom = KeyboardLayouts.rows(KeyboardLayer.LETTERS, KeyboardEditorConfig.empty()).last()
+        val split = SplitKeyboardLayout.splitRow(bottom, 0.20f)
+        val keys = split.items.filterIsInstance<SplitItem.Key>().map { it.key }
+        val spaces = keys.filter { it.type == KeyboardKeyType.SPACE }
+        assertEquals(2, spaces.size)
+        assertEquals(1, split.items.count { it is SplitItem.Gap })
+        assertTrue(split.items.indexOfFirst { it is SplitItem.Gap } > keys.indexOfFirst { it.type == KeyboardKeyType.SPACE })
+        assertEquals(
+            bottom.keys.map { it.type },
+            keys.map { it.type }.let { types ->
+                val firstSpace = types.indexOf(KeyboardKeyType.SPACE)
+                types.take(firstSpace + 1) + types.drop(firstSpace + 2)
+            },
+        )
+        assertEquals(bottom.keys.first().id, keys.first().id)
+        assertEquals(bottom.keys.last().id, keys.last().id)
+    }
+
+    @Test
+    fun `number layer rows still split without dropping keys`() {
+        val rows = KeyboardLayouts.rows(KeyboardLayer.NUMBERS, KeyboardEditorConfig.empty())
+        rows.forEach { row ->
+            val split = SplitKeyboardLayout.splitRow(row, 0.15f)
+            val original = row.keys.map { it.id to it.type }
+            val rebuilt = split.items.filterIsInstance<SplitItem.Key>().map { item ->
+                val key = item.key
+                if (key.type == KeyboardKeyType.SPACE) {
+                    "space" to KeyboardKeyType.SPACE
+                } else {
+                    key.id to key.type
+                }
+            }.distinct()
+            val expected = original.map { (id, type) ->
+                if (type == KeyboardKeyType.SPACE) "space" to type else id to type
+            }
+            assertEquals(expected, rebuilt)
+        }
+    }
+}


### PR DESCRIPTION
Unfolded, the letter keyboard is one very wide strip. Keys sit too far apart to type.

<img width="2400" height="1080" alt="image" src="https://github.com/user-attachments/assets/d2905a59-279d-40f2-aab6-027451fab0a9" />


Settings › Keyboard now has Split keyboard: Auto, Always, Never. Auto is the default. It splits when the IME window is at least 600 dp wide, so tablets, unfolded foldables, and other wide windows get two thumb clusters. A normal phone portrait keyboard stays in one piece. Phone landscape and a fold cover in landscape also split under Auto. That is on purpose. The test is whether thumbs can reach, not whether the device is a tablet.

When it splits, key order stays the same. A dead gap (about 15 to 35 percent of the keyboard width) sits near the middle of each row. The spacebar becomes two space keys, including the emoji chrome row. The emoji grid stays full width. The VocaPhone mark is not painted on those half keys. Suggestions, voice, and the toolbar stay full width.

The layout updates when the window resizes. You do not have to restart the IME.

Comment `/build` on this PR for a sideload APK. No new permissions, no network changes, no version bump.
