### PR TITLE
Make Android first-run setup short enough to finish

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -144,7 +144,8 @@ data class VocaPhoneSettings(
      */
     val modelLanguages: Set<String> = emptySet(),
     val modelDetectsLanguage: Boolean = false,
-    val localTranscriptionEnabled: Boolean = false,
+    /** First-run default is this phone. Gateway is opt-in from setup or settings. */
+    val localTranscriptionEnabled: Boolean = true,
     val localModelId: String = "",
     /** Governs the on-device engines only; the gateway decides for itself. */
     val transcriptionQuality: TranscriptionQuality = TranscriptionQuality.DEFAULT,
@@ -402,7 +403,7 @@ class SettingsRepository(private val context: Context) {
         lastEngineCheckedAtMillis = this[Keys.LAST_ENGINE_CHECKED_AT],
         modelLanguages = this[Keys.MODEL_LANGUAGES].orEmpty(),
         modelDetectsLanguage = this[Keys.MODEL_DETECTS_LANGUAGE] ?: false,
-        localTranscriptionEnabled = this[Keys.LOCAL_TRANSCRIPTION_ENABLED] ?: false,
+        localTranscriptionEnabled = this[Keys.LOCAL_TRANSCRIPTION_ENABLED] ?: true,
         localModelId = this[Keys.LOCAL_MODEL_ID].orEmpty(),
         transcriptionQuality = TranscriptionQuality.fromStored(this[Keys.TRANSCRIPTION_QUALITY]),
         customVocabulary = this[Keys.CUSTOM_VOCABULARY].orEmpty(),

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/LocalModelPicker.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/LocalModelPicker.kt
@@ -128,7 +128,13 @@ fun LocalModelPicker(
         )
     }
 
-    if (state.downloading != null || state.preparing != null) {
+    if (
+        showPickerBusyBanner(
+            downloadingId = state.downloading,
+            preparingName = state.preparing,
+            recommended = sections.recommended,
+        )
+    ) {
         ModelBusyBanner(state = state, onCancelDownload = onCancelDownload)
     }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/LocalModelPicker.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/LocalModelPicker.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -40,11 +42,14 @@ import com.vocahq.vocaphone.local.LocalModelCatalog
 import com.vocahq.vocaphone.local.LocalModelDescriptor
 import com.vocahq.vocaphone.local.LocalModelState
 
+internal const val MORE_MODELS_LABEL = "More models"
+
 /**
  * The on-device model list, shared by setup and settings.
  *
- * Recommended and installed models stay on screen. Everything else is reached
- * through search and filters rather than a raw dump or a hidden catalog.
+ * Settings shows the filtered catalog on the page. Setup passes [compact] so
+ * only the recommended model and any installed models stay on screen. The
+ * rest opens from More models.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -57,6 +62,7 @@ fun LocalModelPicker(
     onCancelDownload: () -> Unit = {},
     onDelete: ((LocalModelDescriptor) -> Unit)? = null,
     usingGateway: Boolean = false,
+    compact: Boolean = false,
 ) {
     val usable = remember(state.totalRamGB) {
         LocalModelCatalog.usableOnDevice(state.totalRamGB).sortedBy { it.sizeBytes }
@@ -74,17 +80,35 @@ fun LocalModelPicker(
     var sizeFilter by remember { mutableStateOf(ModelSizeFilter.ANY) }
     var languageFilter by remember { mutableStateOf(ModelLanguageFilter.ANY) }
     var inspecting by remember { mutableStateOf<LocalModelDescriptor?>(null) }
+    var catalogOpen by remember { mutableStateOf(false) }
+    val catalogSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     val filtered = remember(usable, query, engineFilter, sizeFilter, languageFilter) {
         filterModelCatalog(usable, query, engineFilter, sizeFilter, languageFilter)
     }
-    val recommendedVisible = filtered.any { it.id == recommended.id }
-    val installedModels = filtered.filter {
-        it.id in state.downloaded && !(recommendedVisible && it.id == recommended.id)
+    val recommendedVisible = if (compact) {
+        usable.any { it.id == recommended.id }
+    } else {
+        filtered.any { it.id == recommended.id }
+    }
+    val installedModels = if (compact) {
+        usable.filter { it.id in state.downloaded && it.id != recommended.id }
+    } else {
+        filtered.filter {
+            it.id in state.downloaded && !(recommendedVisible && it.id == recommended.id)
+        }
     }
     val availableModels = filtered.filter {
         it.id !in state.downloaded && !(recommendedVisible && it.id == recommended.id)
     }
+    val sections = modelPickerSections(
+        recommended = recommended,
+        showRecommended = recommendedVisible,
+        installed = installedModels,
+        available = availableModels,
+        compact = compact,
+        catalogOpen = catalogOpen,
+    )
     val busy = state.downloading != null || state.preparing != null
 
     if (usable.isEmpty()) {
@@ -120,76 +144,98 @@ fun LocalModelPicker(
         )
     }
 
-    if (recommendedVisible) {
+    sections.recommended?.let { model ->
         RecommendedModelCard(
-            model = recommended,
+            model = model,
             profile = profile,
             state = state,
-            selected = selectedModelId == recommended.id,
+            selected = selectedModelId == model.id,
             busy = busy,
+            compact = compact,
             onSelect = onSelect,
             onDownloadAndUse = onDownloadAndUse,
             onCancelDownload = onCancelDownload,
         )
     }
 
-    OutlinedTextField(
-        value = query,
-        onValueChange = { query = it },
-        modifier = Modifier.fillMaxWidth(),
-        singleLine = true,
-        label = { Text("Find a model") },
-        placeholder = { Text("Name, language, or engine") },
-    )
-    ChipChoiceRow(
-        options = ModelEngineFilter.entries,
-        selected = engineFilter,
-        label = { it.displayName },
-        onSelect = { engineFilter = it },
-    )
-    ChipChoiceRow(
-        options = ModelSizeFilter.entries,
-        selected = sizeFilter,
-        label = { it.displayName },
-        onSelect = { sizeFilter = it },
-    )
-    ChipChoiceRow(
-        options = ModelLanguageFilter.entries,
-        selected = languageFilter,
-        label = { it.displayName },
-        onSelect = { languageFilter = it },
-    )
-
-    if (installedModels.isNotEmpty()) {
-        ModelSectionHeading("Installed")
-        ModelTileGrid(
-            models = installedModels,
+    if (compact) {
+        if (sections.installed.isNotEmpty()) {
+            ModelSectionHeading("Installed")
+            ModelTileGrid(
+                models = sections.installed,
+                state = state,
+                selectedModelId = selectedModelId,
+                onInspect = { inspecting = it },
+            )
+        }
+        TextButton(
+            onClick = { catalogOpen = true },
+            contentPadding = PaddingValues(horizontal = 0.dp),
+        ) {
+            Text(MORE_MODELS_LABEL)
+        }
+    } else {
+        ModelCatalogSearch(
+            query = query,
+            onQuery = { query = it },
+            engineFilter = engineFilter,
+            onEngine = { engineFilter = it },
+            sizeFilter = sizeFilter,
+            onSize = { sizeFilter = it },
+            languageFilter = languageFilter,
+            onLanguage = { languageFilter = it },
+        )
+        if (sections.installed.isNotEmpty()) {
+            ModelSectionHeading("Installed")
+            ModelTileGrid(
+                models = sections.installed,
+                state = state,
+                selectedModelId = selectedModelId,
+                onInspect = { inspecting = it },
+            )
+        }
+        AvailableModelCatalog(
+            available = sections.catalog,
+            filteredEmpty = filtered.isEmpty(),
             state = state,
             selectedModelId = selectedModelId,
             onInspect = { inspecting = it },
         )
     }
 
-    ModelSectionHeading(
-        if (availableModels.isEmpty()) "Catalog" else "Catalog (${availableModels.size})",
-    )
-    when {
-        availableModels.isEmpty() && filtered.isEmpty() -> Text(
-            "No models match. Clear the search or a filter.",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        availableModels.isEmpty() -> Text(
-            "Every matching model is already installed.",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        else -> ModelTileGrid(
-            models = availableModels,
-            state = state,
-            selectedModelId = selectedModelId,
-            onInspect = { inspecting = it },
-        )
+    if (compact && catalogOpen) {
+        ModalBottomSheet(
+            onDismissRequest = { catalogOpen = false },
+            sheetState = catalogSheetState,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 28.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(MORE_MODELS_LABEL, style = MaterialTheme.typography.titleLarge)
+                ModelCatalogSearch(
+                    query = query,
+                    onQuery = { query = it },
+                    engineFilter = engineFilter,
+                    onEngine = { engineFilter = it },
+                    sizeFilter = sizeFilter,
+                    onSize = { sizeFilter = it },
+                    languageFilter = languageFilter,
+                    onLanguage = { languageFilter = it },
+                )
+                AvailableModelCatalog(
+                    available = sections.catalog,
+                    filteredEmpty = filtered.isEmpty(),
+                    state = state,
+                    selectedModelId = selectedModelId,
+                    onInspect = { inspecting = it },
+                )
+            }
+        }
     }
 
     state.message?.let {
@@ -266,6 +312,7 @@ private fun RecommendedModelCard(
     state: LocalModelState,
     selected: Boolean,
     busy: Boolean,
+    compact: Boolean,
     onSelect: (LocalModelDescriptor) -> Unit,
     onDownloadAndUse: (LocalModelDescriptor) -> Unit,
     onCancelDownload: () -> Unit,
@@ -274,15 +321,17 @@ private fun RecommendedModelCard(
         Text("Recommended for this phone", style = MaterialTheme.typography.titleSmall)
         Text(model.displayName, style = MaterialTheme.typography.titleMedium)
         Text(
-            model.catalogMeta(),
+            if (compact) model.setupMeta() else model.catalogMeta(),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Text(
-            profile.summary(),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        if (!compact) {
+            Text(
+                profile.summary(),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
         ModelActions(
             model = model,
             state = state,
@@ -294,6 +343,76 @@ private fun RecommendedModelCard(
             onDownload = onDownloadAndUse,
             onCancelDownload = onCancelDownload,
             onDelete = null,
+        )
+    }
+}
+
+@Composable
+private fun ModelCatalogSearch(
+    query: String,
+    onQuery: (String) -> Unit,
+    engineFilter: ModelEngineFilter,
+    onEngine: (ModelEngineFilter) -> Unit,
+    sizeFilter: ModelSizeFilter,
+    onSize: (ModelSizeFilter) -> Unit,
+    languageFilter: ModelLanguageFilter,
+    onLanguage: (ModelLanguageFilter) -> Unit,
+) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQuery,
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true,
+        label = { Text("Find a model") },
+        placeholder = { Text("Name, language, or engine") },
+    )
+    ChipChoiceRow(
+        options = ModelEngineFilter.entries,
+        selected = engineFilter,
+        label = { it.displayName },
+        onSelect = onEngine,
+    )
+    ChipChoiceRow(
+        options = ModelSizeFilter.entries,
+        selected = sizeFilter,
+        label = { it.displayName },
+        onSelect = onSize,
+    )
+    ChipChoiceRow(
+        options = ModelLanguageFilter.entries,
+        selected = languageFilter,
+        label = { it.displayName },
+        onSelect = onLanguage,
+    )
+}
+
+@Composable
+private fun AvailableModelCatalog(
+    available: List<LocalModelDescriptor>,
+    filteredEmpty: Boolean,
+    state: LocalModelState,
+    selectedModelId: String,
+    onInspect: (LocalModelDescriptor) -> Unit,
+) {
+    ModelSectionHeading(
+        if (available.isEmpty()) "Catalog" else "Catalog (${available.size})",
+    )
+    when {
+        available.isEmpty() && filteredEmpty -> Text(
+            "No models match. Clear the search or a filter.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        available.isEmpty() -> Text(
+            "Every matching model is already installed.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        else -> ModelTileGrid(
+            models = available,
+            state = state,
+            selectedModelId = selectedModelId,
+            onInspect = onInspect,
         )
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
@@ -188,6 +188,7 @@ fun VocaPhoneApp(
                 settings = settings,
                 localModels = localModels,
                 onOpenGateway = { showingGateway = true },
+                onLocalTranscriptionEnabled = viewModel::setLocalTranscriptionEnabled,
                 onLocalModel = viewModel::setLocalModel,
                 onDownloadLocalModel = viewModel::downloadLocalModel,
                 onDownloadAndUseLocalModel = viewModel::downloadAndUseLocalModel,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
@@ -188,7 +188,6 @@ fun VocaPhoneApp(
                 settings = settings,
                 localModels = localModels,
                 onOpenGateway = { showingGateway = true },
-                onLocalTranscriptionEnabled = viewModel::setLocalTranscriptionEnabled,
                 onLocalModel = viewModel::setLocalModel,
                 onDownloadLocalModel = viewModel::downloadLocalModel,
                 onDownloadAndUseLocalModel = viewModel::downloadAndUseLocalModel,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/ModelCatalogQuery.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/ModelCatalogQuery.kt
@@ -36,6 +36,39 @@ fun LocalModelDescriptor.catalogMeta(recommended: Boolean = false): String = bui
     if (recommended) append(" · recommended")
 }
 
+/** Size and languages only. First-run does not need engine or hardware. */
+fun LocalModelDescriptor.setupMeta(): String = "$sizeLabel · $languages"
+
+/**
+ * What the model picker puts on the page.
+ *
+ * Compact setup keeps the catalog off the page until More models is opened.
+ * Settings always shows the filtered catalog inline.
+ */
+data class ModelPickerSections(
+    val recommended: LocalModelDescriptor?,
+    val installed: List<LocalModelDescriptor>,
+    val catalog: List<LocalModelDescriptor>,
+    val showCatalog: Boolean,
+)
+
+fun modelPickerSections(
+    recommended: LocalModelDescriptor,
+    showRecommended: Boolean,
+    installed: List<LocalModelDescriptor>,
+    available: List<LocalModelDescriptor>,
+    compact: Boolean,
+    catalogOpen: Boolean,
+): ModelPickerSections {
+    val showCatalog = !compact || catalogOpen
+    return ModelPickerSections(
+        recommended = recommended.takeIf { showRecommended },
+        installed = installed,
+        catalog = if (showCatalog) available else emptyList(),
+        showCatalog = showCatalog,
+    )
+}
+
 fun filterModelCatalog(
     models: List<LocalModelDescriptor>,
     query: String,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/ModelCatalogQuery.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/ModelCatalogQuery.kt
@@ -52,6 +52,21 @@ data class ModelPickerSections(
     val showCatalog: Boolean,
 )
 
+/** One progress UI: the recommended card owns its own download or load. */
+fun showPickerBusyBanner(
+    downloadingId: String?,
+    preparingName: String?,
+    recommended: LocalModelDescriptor?,
+): Boolean {
+    if (preparingName != null) {
+        return recommended == null || preparingName != recommended.displayName
+    }
+    if (downloadingId != null) {
+        return recommended == null || downloadingId != recommended.id
+    }
+    return false
+}
+
 fun modelPickerSections(
     recommended: LocalModelDescriptor,
     showRecommended: Boolean,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
@@ -6,6 +6,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -14,8 +15,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,9 +37,6 @@ internal object SetupCopy {
     val LOGO = R.drawable.ic_vocaphone_logo
     const val TITLE = "Set up VocaPhone"
     const val INTRO = "Turn on the keyboard, allow the microphone, then download a model."
-    const val USE_GATEWAY = "Use a gateway instead"
-    const val GATEWAY_SETTINGS = "Gateway settings"
-    const val USING_GATEWAY = "Using your gateway."
     const val START = "Start dictating"
 
     fun keyboardStatus(status: ImeSetupStatus): String = when {
@@ -64,6 +62,7 @@ fun SetupScreen(
     settings: VocaPhoneSettings,
     localModels: LocalModelState,
     onOpenGateway: () -> Unit,
+    onLocalTranscriptionEnabled: (Boolean) -> Unit,
     onLocalModel: (LocalModelDescriptor) -> Unit,
     onDownloadLocalModel: (LocalModelDescriptor) -> Unit,
     onDownloadAndUseLocalModel: (LocalModelDescriptor) -> Unit,
@@ -122,32 +121,21 @@ fun SetupScreen(
             }
 
             Section("Speech") {
-                if (!settings.localTranscriptionEnabled && settings.isConfigured) {
-                    Text(
-                        SetupCopy.USING_GATEWAY,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                LocalModelPicker(
-                    state = localModels,
-                    selectedModelId = settings.localModelId,
+                SpeechSourceCard(
+                    settings = settings,
                     compact = true,
-                    onSelect = onLocalModel,
-                    onDownload = onDownloadLocalModel,
-                    onDownloadAndUse = onDownloadAndUseLocalModel,
-                    onCancelDownload = onCancelLocalModelDownload,
+                    onOpenGateway = onOpenGateway,
+                    onLocalTranscriptionEnabled = onLocalTranscriptionEnabled,
                 )
-                TextButton(
-                    onClick = onOpenGateway,
-                    contentPadding = androidx.compose.foundation.layout.PaddingValues(0.dp),
-                ) {
-                    Text(
-                        if (settings.isConfigured) {
-                            SetupCopy.GATEWAY_SETTINGS
-                        } else {
-                            SetupCopy.USE_GATEWAY
-                        },
+                if (settings.localTranscriptionEnabled) {
+                    LocalModelPicker(
+                        state = localModels,
+                        selectedModelId = settings.localModelId,
+                        compact = true,
+                        onSelect = onLocalModel,
+                        onDownload = onDownloadLocalModel,
+                        onDownloadAndUse = onDownloadAndUseLocalModel,
+                        onCancelDownload = onCancelLocalModelDownload,
                     )
                 }
             }
@@ -189,13 +177,6 @@ fun SetupScreen(
                 enabled = status.isReadyToDictate,
                 modifier = Modifier.fillMaxWidth(),
             )
-            if (!status.isReadyToDictate) {
-                Text(
-                    status.stillToDo,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
         }
     }
 }
@@ -244,5 +225,25 @@ private fun SetupProgress(status: SetupStatus, modifier: Modifier = Modifier) {
             progress = { status.completedStepCount.toFloat() / status.stepCount },
             modifier = Modifier.fillMaxWidth(),
         )
+        if (status.remainingLabels.isNotEmpty()) {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                status.remainingLabels.forEach { label ->
+                    Surface(
+                        color = MaterialTheme.colorScheme.surfaceVariant,
+                        shape = MaterialTheme.shapes.small,
+                    ) {
+                        Text(
+                            label,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                        )
+                    }
+                }
+            }
+        }
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
@@ -32,6 +32,8 @@ import com.vocahq.vocaphone.local.LocalModelState
 import com.vocahq.vocaphone.settings.VocaPhoneSettings
 
 internal object SetupCopy {
+    /** Vector mark. Adaptive mipmaps crash painterResource. */
+    val LOGO = R.drawable.ic_vocaphone_logo
     const val TITLE = "Set up VocaPhone"
     const val INTRO = "Turn on the keyboard, allow the microphone, then download a model."
     const val USE_GATEWAY = "Use a gateway instead"
@@ -87,7 +89,7 @@ fun SetupScreen(
         ) {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 Image(
-                    painter = painterResource(R.mipmap.ic_launcher),
+                    painter = painterResource(SetupCopy.LOGO),
                     contentDescription = "VocaPhone",
                     modifier = Modifier.size(56.dp),
                 )

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
@@ -3,31 +3,58 @@ package com.vocahq.vocaphone.ui
 import android.Manifest
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.vocahq.vocaphone.BuildConfig
+import com.vocahq.vocaphone.R
 import com.vocahq.vocaphone.local.LocalModelDescriptor
 import com.vocahq.vocaphone.local.LocalModelState
 import com.vocahq.vocaphone.settings.VocaPhoneSettings
 
+internal object SetupCopy {
+    const val TITLE = "Set up VocaPhone"
+    const val INTRO = "Turn on the keyboard, allow the microphone, then download a model."
+    const val USE_GATEWAY = "Use a gateway instead"
+    const val GATEWAY_SETTINGS = "Gateway settings"
+    const val USING_GATEWAY = "Using your gateway."
+    const val START = "Start dictating"
+
+    fun keyboardStatus(status: ImeSetupStatus): String = when {
+        status.selected -> "VocaPhone is the selected keyboard."
+        status.enabled -> "Choose VocaPhone from the keyboard list."
+        else -> "Turn on the VocaPhone keyboard."
+    }
+
+    fun keyboardAction(status: ImeSetupStatus): String? = when {
+        status.selected -> null
+        status.enabled -> "Choose VocaPhone keyboard"
+        else -> "Enable keyboard"
+    }
+}
+
 /**
- * Guided setup for the IME path. VocaPhone does not request accessibility or
- * overlay access; the keyboard inserts through Android's InputConnection.
+ * Guided setup for the IME path. Short enough to finish without scrolling
+ * past a catalog.
  */
 @Composable
 fun SetupScreen(
@@ -35,7 +62,6 @@ fun SetupScreen(
     settings: VocaPhoneSettings,
     localModels: LocalModelState,
     onOpenGateway: () -> Unit,
-    onLocalTranscriptionEnabled: (Boolean) -> Unit,
     onLocalModel: (LocalModelDescriptor) -> Unit,
     onDownloadLocalModel: (LocalModelDescriptor) -> Unit,
     onDownloadAndUseLocalModel: (LocalModelDescriptor) -> Unit,
@@ -47,110 +73,127 @@ fun SetupScreen(
     onFinish: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val context = androidx.compose.ui.platform.LocalContext.current
     val requestPermission = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { }
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(SectionSpacing),
-    ) {
-        Text("Set up VocaPhone", style = MaterialTheme.typography.headlineSmall)
-        Text(
-            "Turn on the keyboard, grant the microphone, then download a model " +
-                "or point the app at a gateway you control.",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-
-        SetupProgress(status)
-
-        ImeSetupCard(status.ime)
-
-        Section("Permissions") {
-            ChecklistRow(
-                title = "Microphone",
-                detail = "Records only while you are dictating.",
-                satisfied = status.microphone,
-                actionLabel = "Grant",
-                onAction = { requestPermission.launch(Manifest.permission.RECORD_AUDIO) },
-            )
-            ChecklistRow(
-                title = "Notifications",
-                detail = "Shows the ongoing recording notification Android requires.",
-                satisfied = status.notifications,
-                actionLabel = "Grant",
-                onAction = { requestPermission.launch(Manifest.permission.POST_NOTIFICATIONS) },
-            )
-        }
-
-        SettingsCategory(
-            title = "Speech",
-            supporting = "Download a model for this phone, or use a gateway. " +
-                "Every on-device file is SHA-256 checked before it can load.",
+    Column(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(SectionSpacing),
         ) {
-            SpeechSourceCard(
-                settings = settings,
-                onOpenGateway = onOpenGateway,
-                onLocalTranscriptionEnabled = onLocalTranscriptionEnabled,
-            )
-            if (settings.localTranscriptionEnabled) {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Image(
+                    painter = painterResource(R.mipmap.ic_launcher),
+                    contentDescription = "VocaPhone",
+                    modifier = Modifier.size(56.dp),
+                )
+                Text(SetupCopy.TITLE, style = MaterialTheme.typography.headlineSmall)
+                Text(
+                    SetupCopy.INTRO,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                SetupProgress(status)
+            }
+
+            ImeSetupCard(status.ime)
+
+            Section("Permissions") {
+                ChecklistRow(
+                    title = "Microphone",
+                    detail = "Only while you dictate.",
+                    satisfied = status.microphone,
+                    actionLabel = "Grant",
+                    onAction = { requestPermission.launch(Manifest.permission.RECORD_AUDIO) },
+                )
+                ChecklistRow(
+                    title = "Notifications",
+                    detail = "Shown while you record.",
+                    satisfied = status.notifications,
+                    actionLabel = "Grant",
+                    onAction = { requestPermission.launch(Manifest.permission.POST_NOTIFICATIONS) },
+                )
+            }
+
+            Section("Speech") {
+                if (!settings.localTranscriptionEnabled && settings.isConfigured) {
+                    Text(
+                        SetupCopy.USING_GATEWAY,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
                 LocalModelPicker(
                     state = localModels,
                     selectedModelId = settings.localModelId,
+                    compact = true,
                     onSelect = onLocalModel,
                     onDownload = onDownloadLocalModel,
                     onDownloadAndUse = onDownloadAndUseLocalModel,
                     onCancelDownload = onCancelLocalModelDownload,
                 )
-            } else {
+                TextButton(
+                    onClick = onOpenGateway,
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(0.dp),
+                ) {
+                    Text(
+                        if (settings.isConfigured) {
+                            SetupCopy.GATEWAY_SETTINGS
+                        } else {
+                            SetupCopy.USE_GATEWAY
+                        },
+                    )
+                }
+            }
+
+            // Last, and only once the checklist is done: asking for usage reporting
+            // before the user has a working transcript is asking a favour of someone
+            // still deciding whether the app is worth their time.
+            //
+            // The BuildConfig check is repeated here even though the card checks it
+            // too, because the payload view below is a separate call. Without it R8
+            // keeps that composable — and the ingest path string inside it — in the
+            // F-Droid APK, where nothing can ever reach it.
+            if (BuildConfig.TELEMETRY && status.isReadyToDictate && !settings.telemetryAsked) {
+                var showingPayload by remember { mutableStateOf(false) }
+                UsageReportingSetupCard(
+                    onDecision = onTelemetryDecision,
+                    onSeePayload = { showingPayload = !showingPayload },
+                )
+                if (showingPayload) {
+                    PendingPayloadView(
+                        payload = telemetryPayload(),
+                        pendingCount = telemetryPendingCount(),
+                        deliveryStatus = telemetryDeliveryStatus(),
+                    )
+                }
+            }
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            PrimaryButton(
+                text = SetupCopy.START,
+                onClick = onFinish,
+                enabled = status.isReadyToDictate,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            if (!status.isReadyToDictate) {
                 Text(
-                    "On-device models are off while you use a gateway.",
+                    status.stillToDo,
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-        }
-
-        // Last, and only once the checklist is done: asking for usage reporting
-        // before the user has a working transcript is asking a favour of someone
-        // still deciding whether the app is worth their time.
-        //
-        // The BuildConfig check is repeated here even though the card checks it
-        // too, because the payload view below is a separate call. Without it R8
-        // keeps that composable — and the ingest path string inside it — in the
-        // F-Droid APK, where nothing can ever reach it.
-        if (BuildConfig.TELEMETRY && status.isReadyToDictate && !settings.telemetryAsked) {
-            var showingPayload by remember { mutableStateOf(false) }
-            UsageReportingSetupCard(
-                onDecision = onTelemetryDecision,
-                onSeePayload = { showingPayload = !showingPayload },
-            )
-            if (showingPayload) {
-                PendingPayloadView(
-                    payload = telemetryPayload(),
-                    pendingCount = telemetryPendingCount(),
-                    deliveryStatus = telemetryDeliveryStatus(),
-                )
-            }
-        }
-
-        PrimaryButton(
-            text = "Start dictating",
-            onClick = onFinish,
-            enabled = status.isReadyToDictate,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        if (!status.isReadyToDictate) {
-            Text(
-                "Still to do: " + status.remainingSteps.joinToString { it.label },
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
         }
     }
 }
@@ -158,32 +201,25 @@ fun SetupScreen(
 /** Setup handoff for enabling and selecting the system keyboard. */
 @Composable
 internal fun ImeSetupCard(status: ImeSetupStatus, modifier: Modifier = Modifier) {
-    val context = androidx.compose.ui.platform.LocalContext.current
+    val context = LocalContext.current
+    val action = SetupCopy.keyboardAction(status)
     Notice(modifier = modifier) {
         Text("VocaPhone keyboard", style = MaterialTheme.typography.titleSmall)
         Text(
-            "The microphone lives inside VocaPhone's keyboard. It inserts through " +
-                "Android's text connection and does not read the contents of the field.",
-            style = MaterialTheme.typography.bodyMedium,
-        )
-        Text(
-            when {
-                status.selected -> "VocaPhone is the selected keyboard."
-                status.enabled -> "VocaPhone is enabled. Select it from the keyboard picker."
-                else -> "VocaPhone is not enabled as a keyboard yet."
-            },
+            SetupCopy.keyboardStatus(status),
             style = MaterialTheme.typography.labelLarge,
             color = MaterialTheme.colorScheme.primary,
         )
-        SecondaryButton(
-            text = if (status.enabled) "Keyboard settings" else "Enable keyboard",
-            onClick = { ImeSetup.openSettings(context) },
-            modifier = Modifier.fillMaxWidth(),
-        )
-        if (status.enabled && !status.selected) {
+        if (action != null) {
             SecondaryButton(
-                text = "Choose VocaPhone keyboard",
-                onClick = { ImeSetup.showPicker(context) },
+                text = action,
+                onClick = {
+                    if (status.enabled) {
+                        ImeSetup.showPicker(context)
+                    } else {
+                        ImeSetup.openSettings(context)
+                    }
+                },
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupStatus.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupStatus.kt
@@ -43,9 +43,9 @@ data class SetupStatus(
     val isReadyToDictate: Boolean
         get() = remainingSteps.isEmpty()
 
-    /** Plain remaining-step line under Start dictating. */
-    val stillToDo: String
-        get() = "Still to do: " + remainingSteps.joinToString { it.label }
+    /** Short labels for chips under the header progress. */
+    val remainingLabels: List<String>
+        get() = remainingSteps.map { it.label }
 
     companion object {
         fun read(context: Context, gatewayConfigured: Boolean): SetupStatus {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupStatus.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupStatus.kt
@@ -43,6 +43,10 @@ data class SetupStatus(
     val isReadyToDictate: Boolean
         get() = remainingSteps.isEmpty()
 
+    /** Plain remaining-step line under Start dictating. */
+    val stillToDo: String
+        get() = "Still to do: " + remainingSteps.joinToString { it.label }
+
     companion object {
         fun read(context: Context, gatewayConfigured: Boolean): SetupStatus {
             val ime = ImeSetup.read(context)

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SpeechSource.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SpeechSource.kt
@@ -15,6 +15,20 @@ data class SpeechSourceCopy(
     val engineLabel: String,
 )
 
+data class SpeechSourceSelection(
+    val localEnabled: Boolean,
+    val openGateway: Boolean,
+)
+
+/** Tile tap: stay on this phone, or flip to gateway and open setup if needed. */
+fun speechSourceSelection(
+    wantLocal: Boolean,
+    gatewayConfigured: Boolean,
+): SpeechSourceSelection = SpeechSourceSelection(
+    localEnabled = wantLocal,
+    openGateway = !wantLocal && !gatewayConfigured,
+)
+
 fun speechSourceCopy(
     localEnabled: Boolean,
     localModelName: String?,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SpeechSourceCard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SpeechSourceCard.kt
@@ -31,6 +31,7 @@ fun SpeechSourceCard(
     onOpenGateway: () -> Unit,
     onLocalTranscriptionEnabled: (Boolean) -> Unit,
     onOpenModels: (() -> Unit)? = null,
+    compact: Boolean = false,
 ) {
     val context = LocalContext.current
     val localModel = LocalModelCatalog.find(settings.localModelId)
@@ -45,12 +46,14 @@ fun SpeechSourceCard(
     val localOn = copy.localSelected
 
     FeaturedCard {
-        Text("Speech", style = MaterialTheme.typography.titleSmall)
-        Text(
-            "Transcribe on this phone, or send audio to a gateway you run.",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        if (!compact) {
+            Text("Speech", style = MaterialTheme.typography.titleSmall)
+            Text(
+                "Transcribe on this phone, or send audio to a gateway you run.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -59,7 +62,11 @@ fun SpeechSourceCard(
                 title = "On this phone",
                 subtitle = copy.localDetail,
                 selected = localOn,
-                onClick = { onLocalTranscriptionEnabled(true) },
+                onClick = {
+                    val choice = speechSourceSelection(true, settings.isConfigured)
+                    onLocalTranscriptionEnabled(choice.localEnabled)
+                    if (choice.openGateway) onOpenGateway()
+                },
                 modifier = Modifier.weight(1f),
             )
             SourceChoiceTile(
@@ -67,11 +74,23 @@ fun SpeechSourceCard(
                 subtitle = copy.gatewayDetail,
                 selected = !localOn,
                 onClick = {
-                    onLocalTranscriptionEnabled(false)
-                    if (!settings.isConfigured) onOpenGateway()
+                    val choice = speechSourceSelection(false, settings.isConfigured)
+                    onLocalTranscriptionEnabled(choice.localEnabled)
+                    if (choice.openGateway) onOpenGateway()
                 },
                 modifier = Modifier.weight(1f),
             )
+        }
+        if (compact) {
+            if (!localOn) {
+                TextButton(
+                    onClick = onOpenGateway,
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(0.dp),
+                ) {
+                    Text(if (settings.isConfigured) "Gateway settings" else "Set up a gateway")
+                }
+            }
+            return@FeaturedCard
         }
         if (localOn) {
             if (localModel != null) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SpeechSourceCard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SpeechSourceCard.kt
@@ -3,8 +3,11 @@ package com.vocahq.vocaphone.ui
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -55,7 +58,9 @@ fun SpeechSourceCard(
             )
         }
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(IntrinsicSize.Max),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             SourceChoiceTile(
@@ -67,7 +72,7 @@ fun SpeechSourceCard(
                     onLocalTranscriptionEnabled(choice.localEnabled)
                     if (choice.openGateway) onOpenGateway()
                 },
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.weight(1f).fillMaxHeight(),
             )
             SourceChoiceTile(
                 title = "Gateway",
@@ -78,7 +83,7 @@ fun SpeechSourceCard(
                     onLocalTranscriptionEnabled(choice.localEnabled)
                     if (choice.openGateway) onOpenGateway()
                 },
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.weight(1f).fillMaxHeight(),
             )
         }
         if (compact) {
@@ -161,7 +166,9 @@ private fun SourceChoiceTile(
         border = if (selected) BorderStroke(1.dp, colors.primary) else null,
     ) {
         Column(
-            modifier = Modifier.padding(12.dp),
+            modifier = Modifier
+                .fillMaxHeight()
+                .padding(12.dp),
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             Text(

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/DiagnosticsReportTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/DiagnosticsReportTest.kt
@@ -69,10 +69,11 @@ class DiagnosticsReportTest {
         val report = diagnosticsReport(info, VocaPhoneSettings(), SetupStatus())
 
         assertTrue(report.contains("Gateway: not configured"))
-        assertTrue(report.contains("Engine: unknown (not ready)"))
-        assertTrue(report.contains("Streaming: batch upload"))
+        assertTrue(report.contains("Speech: On this phone"))
+        assertTrue(report.contains("Local model: none"))
         assertTrue(report.contains("Setup: missing"))
         assertTrue(report.contains(SetupStep.MICROPHONE.label))
+        assertFalse(report.contains("Engine: unknown (not ready)"))
     }
 
     @Test

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/DiagnosticsReportTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/DiagnosticsReportTest.kt
@@ -23,6 +23,7 @@ class DiagnosticsReportTest {
         lastEngine = "moonshine:en",
         lastEngineReady = true,
         lastStreamingSupported = true,
+        localTranscriptionEnabled = false,
     )
 
     private val ready = SetupStatus(

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/ModelCatalogQueryTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/ModelCatalogQueryTest.kt
@@ -3,6 +3,7 @@ package com.vocahq.vocaphone.ui
 import com.vocahq.vocaphone.local.LocalModelCatalog
 import com.vocahq.vocaphone.local.LocalModelEngine
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -129,5 +130,33 @@ class ModelCatalogQueryTest {
 
         assertTrue(sections.showCatalog)
         assertTrue(sections.catalog.size == available.size)
+    }
+
+    @Test
+    fun recommendedDownloadDoesNotAlsoShowTheBusyBanner() {
+        val recommended = LocalModelCatalog.find("tiny-q5_1")!!
+
+        assertFalse(
+            showPickerBusyBanner(
+                downloadingId = recommended.id,
+                preparingName = null,
+                recommended = recommended,
+            ),
+        )
+        assertFalse(
+            showPickerBusyBanner(
+                downloadingId = null,
+                preparingName = recommended.displayName,
+                recommended = recommended,
+            ),
+        )
+        assertTrue(
+            showPickerBusyBanner(
+                downloadingId = "large-v3-turbo-q5_0",
+                preparingName = null,
+                recommended = recommended,
+            ),
+        )
+        assertFalse(showPickerBusyBanner(null, null, recommended))
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/ModelCatalogQueryTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/ModelCatalogQueryTest.kt
@@ -2,6 +2,7 @@ package com.vocahq.vocaphone.ui
 
 import com.vocahq.vocaphone.local.LocalModelCatalog
 import com.vocahq.vocaphone.local.LocalModelEngine
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -57,5 +58,76 @@ class ModelCatalogQueryTest {
         assertTrue(meta.contains("MB"))
         assertTrue(meta.contains("Whisper"))
         assertTrue(meta.contains("recommended"))
+    }
+
+    @Test
+    fun setupMetaIsOnlySizeAndLanguages() {
+        val model = LocalModelCatalog.find("tiny-q5_1")!!
+        val meta = model.setupMeta()
+        assertTrue(meta.contains("MB"))
+        assertTrue(meta.contains(model.languages))
+        assertTrue(!meta.contains("Whisper"))
+        assertTrue(!meta.contains("RAM"))
+        assertTrue(!meta.contains("GHz"))
+        assertTrue(!meta.contains("cores"))
+        assertTrue(!meta.contains("budget"))
+        assertTrue(!meta.contains("SHA-256"))
+    }
+
+    @Test
+    fun compactSetupDoesNotExposeTheCatalogUntilMoreModelsOpens() {
+        val recommended = models.first()
+        val available = models.drop(1)
+        val closed = modelPickerSections(
+            recommended = recommended,
+            showRecommended = true,
+            installed = emptyList(),
+            available = available,
+            compact = true,
+            catalogOpen = false,
+        )
+        val open = modelPickerSections(
+            recommended = recommended,
+            showRecommended = true,
+            installed = emptyList(),
+            available = available,
+            compact = true,
+            catalogOpen = true,
+        )
+
+        assertTrue(models.size >= 30)
+        assertTrue(!closed.showCatalog)
+        assertTrue(closed.catalog.isEmpty())
+        assertTrue(closed.recommended?.id == recommended.id)
+        val withInstalled = modelPickerSections(
+            recommended = recommended,
+            showRecommended = true,
+            installed = listOf(available.first()),
+            available = available,
+            compact = true,
+            catalogOpen = false,
+        )
+        assertEquals(available.first().id, withInstalled.installed.single().id)
+        assertTrue(withInstalled.catalog.isEmpty())
+        assertTrue(open.showCatalog)
+        assertTrue(open.catalog.size == available.size)
+        assertTrue(open.catalog.size >= 30)
+    }
+
+    @Test
+    fun settingsKeepsTheCatalogOnThePage() {
+        val recommended = models.first()
+        val available = models.drop(1)
+        val sections = modelPickerSections(
+            recommended = recommended,
+            showRecommended = true,
+            installed = emptyList(),
+            available = available,
+            compact = false,
+            catalogOpen = false,
+        )
+
+        assertTrue(sections.showCatalog)
+        assertTrue(sections.catalog.size == available.size)
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupCopyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupCopyTest.kt
@@ -27,9 +27,6 @@ class SetupCopyTest {
         val copy = listOf(
             SetupCopy.TITLE,
             SetupCopy.INTRO,
-            SetupCopy.USE_GATEWAY,
-            SetupCopy.GATEWAY_SETTINGS,
-            SetupCopy.USING_GATEWAY,
             SetupCopy.START,
             MORE_MODELS_LABEL,
         )

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupCopyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupCopyTest.kt
@@ -1,5 +1,6 @@
 package com.vocahq.vocaphone.ui
 
+import com.vocahq.vocaphone.R
 import com.vocahq.vocaphone.settings.VocaPhoneSettings
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -8,6 +9,12 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SetupCopyTest {
+
+    @Test
+    fun setupLogoIsTheExistingVectorNotTheAdaptiveMipmap() {
+        assertEquals(R.drawable.ic_vocaphone_logo, SetupCopy.LOGO)
+        assertTrue(SetupCopy.LOGO != R.mipmap.ic_launcher)
+    }
 
     @Test
     fun firstRunDefaultsToOnThisPhone() {

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupCopyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupCopyTest.kt
@@ -1,0 +1,53 @@
+package com.vocahq.vocaphone.ui
+
+import com.vocahq.vocaphone.settings.VocaPhoneSettings
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SetupCopyTest {
+
+    @Test
+    fun firstRunDefaultsToOnThisPhone() {
+        assertTrue(VocaPhoneSettings().localTranscriptionEnabled)
+        assertFalse(VocaPhoneSettings().isConfigured)
+    }
+
+    @Test
+    fun introStaysShortAndPlain() {
+        val copy = listOf(
+            SetupCopy.TITLE,
+            SetupCopy.INTRO,
+            SetupCopy.USE_GATEWAY,
+            SetupCopy.GATEWAY_SETTINGS,
+            SetupCopy.USING_GATEWAY,
+            SetupCopy.START,
+            MORE_MODELS_LABEL,
+        )
+        copy.forEach { line ->
+            assertTrue(line.isNotBlank())
+            assertFalse(line.contains("—"))
+            assertFalse(line.contains("–"))
+            assertFalse(line.contains("SHA-256"))
+            assertFalse(line.contains("InputConnection"))
+            assertFalse(line.contains("gateway you control"))
+        }
+        assertTrue(SetupCopy.INTRO.length < 90)
+    }
+
+    @Test
+    fun keyboardCardHasOneStatusAndOneAction() {
+        val off = ImeSetupStatus()
+        val enabled = ImeSetupStatus(enabled = true)
+        val selected = ImeSetupStatus(enabled = true, selected = true)
+
+        assertEquals("Turn on the VocaPhone keyboard.", SetupCopy.keyboardStatus(off))
+        assertEquals("Enable keyboard", SetupCopy.keyboardAction(off))
+        assertEquals("Choose VocaPhone from the keyboard list.", SetupCopy.keyboardStatus(enabled))
+        assertEquals("Choose VocaPhone keyboard", SetupCopy.keyboardAction(enabled))
+        assertEquals("VocaPhone is the selected keyboard.", SetupCopy.keyboardStatus(selected))
+        assertNull(SetupCopy.keyboardAction(selected))
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupStatusTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupStatusTest.kt
@@ -44,15 +44,24 @@ class SetupStatusTest {
         assertEquals(SetupStep.entries, status.remainingSteps)
         assertEquals(0, status.completedStepCount)
         assertEquals(
-            "Still to do: Microphone, Notifications, VocaPhone keyboard, Speech source",
-            status.stillToDo,
+            listOf("Microphone", "Notifications", "VocaPhone keyboard", "Speech source"),
+            status.remainingLabels,
         )
     }
 
     @Test
-    fun `remaining copy names only the unfinished steps`() {
+    fun `remaining labels name only the unfinished steps`() {
         val status = complete.copy(keyboard = false, gatewayConfigured = false)
 
-        assertEquals("Still to do: VocaPhone keyboard, Speech source", status.stillToDo)
+        assertEquals(listOf("VocaPhone keyboard", "Speech source"), status.remainingLabels)
+        assertTrue(complete.remainingLabels.isEmpty())
+    }
+
+    @Test
+    fun remainingLabelsSkipTheStillToDoSentence() {
+        val status = complete.copy(gatewayConfigured = false)
+
+        assertEquals(listOf("Speech source"), status.remainingLabels)
+        assertFalse(status.remainingLabels.joinToString().contains("Still to do"))
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupStatusTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupStatusTest.kt
@@ -43,5 +43,16 @@ class SetupStatusTest {
         assertFalse(status.isReadyToDictate)
         assertEquals(SetupStep.entries, status.remainingSteps)
         assertEquals(0, status.completedStepCount)
+        assertEquals(
+            "Still to do: Microphone, Notifications, VocaPhone keyboard, Speech source",
+            status.stillToDo,
+        )
+    }
+
+    @Test
+    fun `remaining copy names only the unfinished steps`() {
+        val status = complete.copy(keyboard = false, gatewayConfigured = false)
+
+        assertEquals("Still to do: VocaPhone keyboard, Speech source", status.stillToDo)
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/SpeechSourceCopyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/SpeechSourceCopyTest.kt
@@ -59,6 +59,30 @@ class SpeechSourceCopyTest {
     }
 
     @Test
+    fun firstRunPicksOnThisPhoneAndLeavesGatewayClosed() {
+        val choice = speechSourceSelection(wantLocal = true, gatewayConfigured = false)
+
+        assertTrue(choice.localEnabled)
+        assertFalse(choice.openGateway)
+    }
+
+    @Test
+    fun pickingGatewayOpensSetupWhenItIsNotConfigured() {
+        val choice = speechSourceSelection(wantLocal = false, gatewayConfigured = false)
+
+        assertFalse(choice.localEnabled)
+        assertTrue(choice.openGateway)
+    }
+
+    @Test
+    fun pickingAConfiguredGatewayDoesNotReopenSetup() {
+        val choice = speechSourceSelection(wantLocal = false, gatewayConfigured = true)
+
+        assertFalse(choice.localEnabled)
+        assertFalse(choice.openGateway)
+    }
+
+    @Test
     fun unconfiguredGatewayIsNamedAsSuch() {
         val copy = speechSourceCopy(
             localEnabled = false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The first-run screen put every on-device model on one page. Start dictating sat under Catalog (37), and a fresh install opened on Gateway even though a model on the phone is enough to finish.

Setup is a short page now. The existing vector logo sits at the top, then one line of copy, progress, keyboard, permissions, and speech. Start dictating stays pinned and turns on when SetupStatus.isReadyToDictate. A new install uses this phone for speech.

Speech uses the same On this phone / Gateway tiles as Settings. Those two tiles now share a height, so a two-line subtitle does not make one card taller than the other. Tapping Gateway opens the existing gateway screen when it is not configured. The catalog stays behind More models.

Downloading the recommended model shows progress only on that card. The extra banner is reserved for a different model from More models.

The leftover Still to do line under Start dictating is gone. Unfinished steps sit as small labels under the header progress.

The setup logo is R.drawable.ic_vocaphone_logo. painterResource is not used on a mipmap. Settings still shows the full picker. iOS setup is unchanged. Version numbers are unchanged.

Android unit tests cover the speech tiles, one download banner, remaining-step labels, and the existing SetupStatus and catalog filter cases.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6254805e-533d-45ac-8105-d34798f5d39a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6254805e-533d-45ac-8105-d34798f5d39a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

