### PR TITLE
Upload beta AABs to Play Internal testing

### DIFF
--- a/.github/workflows/android-beta.yml
+++ b/.github/workflows/android-beta.yml
@@ -23,6 +23,10 @@ jobs:
   beta:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    env:
+      # steps.if cannot read secrets. This is true only when the Play JSON
+      # secret is non-empty, so the upload step can skip without it.
+      PLAY_SERVICE_ACCOUNT_JSON_SET: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -202,7 +206,7 @@ jobs:
       # internal. If that API name is missing, qa is the only other name
       # to try. Full-flavor AAB only; never fdroid, never production.
       - name: Upload vocaphone.aab to Play Internal testing
-        if: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
+        if: ${{ env.PLAY_SERVICE_ACCOUNT_JSON_SET == 'true' }}
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}

--- a/.github/workflows/android-beta.yml
+++ b/.github/workflows/android-beta.yml
@@ -4,7 +4,9 @@ name: Android beta release
 # APKs plus the full-flavor AAB (Play upload candidate), then publishes them as
 # a workflow artifact and a GitHub prerelease. Checksums and the signing
 # certificate fingerprint are attached so testers can verify what they install.
-# This workflow does not upload to Google Play.
+# After the GitHub Release is published, the full AAB is uploaded to Google Play
+# Internal testing when PLAY_SERVICE_ACCOUNT_JSON is set. That step is skipped
+# if the secret is empty. fdroid artifacts and production are never uploaded.
 on:
   push:
     tags:
@@ -194,4 +196,18 @@ jobs:
             --prerelease \
             --generate-notes \
             "${notes_range[@]}" \
-            --notes "Release-signed APK covering every ABI (arm64-v8a, armeabi-v7a, x86_64) and all Android 13+ devices. Install with \`adb install vocaphone.apk\` or open the APK on the device. \`vocaphone.aab\` is the same full-flavor build as an Android App Bundle for Google Play Console upload (not uploaded by this workflow). SHA-256 checksum and signing-certificate fingerprint files are attached for verification. Android may still scan or restrict APKs installed outside an app store. \`vocaphone-fdroid.apk\` is the same release built without the prebuilt sherpa-onnx and ONNX Runtime libraries, published so F-Droid can verify its own rebuild against it; install \`vocaphone.apk\` unless you specifically want that variant."
+            --notes "Release-signed APK covering every ABI (arm64-v8a, armeabi-v7a, x86_64) and all Android 13+ devices. Install with \`adb install vocaphone.apk\` or open the APK on the device. \`vocaphone.aab\` is the same full-flavor build as an Android App Bundle. This workflow uploads it to Google Play Internal testing when PLAY_SERVICE_ACCOUNT_JSON is set. SHA-256 checksum and signing-certificate fingerprint files are attached for verification. Android may still scan or restrict APKs installed outside an app store. \`vocaphone-fdroid.apk\` is the same release built without the prebuilt sherpa-onnx and ONNX Runtime libraries, published so F-Droid can verify its own rebuild against it; install \`vocaphone.apk\` unless you specifically want that variant."
+      # After the GitHub Release so testers still get APKs if Play fails.
+      # The action defaults to the production track, so tracks must be
+      # internal. If that API name is missing, qa is the only other name
+      # to try. Full-flavor AAB only; never fdroid, never production.
+      - name: Upload vocaphone.aab to Play Internal testing
+        if: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.vocahq.vocaphone
+          releaseFiles: release-assets/vocaphone.aab
+          tracks: internal
+          status: completed
+          releaseName: ${{ github.ref_name }}

--- a/android/README.md
+++ b/android/README.md
@@ -71,14 +71,18 @@ Pushing a tag such as `v0.1.0-beta.14` (or the latest prerelease tag) runs
 the tag and APK version do not match.
 
 The repository needs these GitHub Actions secrets: `KEYSTORE_BASE64`,
-`KEYSTORE_PASSWORD`, `KEY_ALIAS`, and `KEY_PASSWORD`. The workflow builds,
-tests, lints, verifies both APKs (package, version, cert) and the full AAB
-signing cert via `keytool` (package/version come from the matching full APK),
-and attaches these files to the prerelease:
+`KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`, and
+`PLAY_SERVICE_ACCOUNT_JSON` (Play Internal testing upload; the step is skipped
+if it is empty). The workflow builds, tests, lints, verifies both APKs
+(package, version, cert) and the full AAB signing cert via `keytool`
+(package/version come from the matching full APK), and attaches these files
+to the prerelease:
 
 - `vocaphone.apk`
-- `vocaphone.aab`: full-flavor Android App Bundle for Play Console upload.
-  CI does not push it to Play; see [docs/play-store.md](../docs/play-store.md).
+- `vocaphone.aab`: full-flavor Android App Bundle. CI uploads it to Play
+  Internal testing when `PLAY_SERVICE_ACCOUNT_JSON` is set; see
+  [docs/play-store.md](../docs/play-store.md). This tag workflow never uploads
+  to production and never uploads the fdroid flavour.
 - `vocaphone-fdroid.apk`: the `fdroid` flavour of the same tag. It exists so
   F-Droid can verify a from-source rebuild against it byte-for-byte and then
   publish this same signed APK (F-Droid "reproducible builds"). Install

--- a/docs/play-store.md
+++ b/docs/play-store.md
@@ -4,18 +4,25 @@ How to take a VocaPhone Android beta tag from GitHub Releases into Play Console.
 This is Console and listing work. The app is not listed on Play until that work
 is finished; there is no store URL to publish yet.
 
-Beta tags already attach a signed full-flavor AAB as `vocaphone.aab`. CI does
-not upload to Play (no Play API secrets in this repository yet).
+Beta tags attach a signed full-flavor AAB as `vocaphone.aab`. When
+`PLAY_SERVICE_ACCOUNT_JSON` is set, the beta tag workflow uploads that AAB to
+Internal testing after the GitHub Release is published. The step is skipped if
+the secret is empty, so testers still get the GitHub APKs if Play is unset or
+fails. This tag workflow never uploads to production.
+
+The Play Developer API account is
+`vocaphone-play-upload@level-approach-506001-h1.iam.gserviceaccount.com`.
+It can view this app and release it to testing tracks only.
 
 ## What to upload
 
 | Artifact | Flavor | Use |
 | --- | --- | --- |
-| `vocaphone.aab` | `full` | Play Console upload |
+| `vocaphone.aab` | `full` | Play Internal testing (CI when the secret is set) |
 | `vocaphone.apk` | `full` | Sideload / GitHub beta |
 | `vocaphone-fdroid.apk` | `fdroid` | F-Droid rebuild verification only |
 
-Upload the full AAB. Never upload the fdroid APK or an fdroid bundle to
+Upload the full AAB only. Never upload the fdroid APK or an fdroid bundle to
 Play. The fdroid flavour drops prebuilt sherpa-onnx / ONNX Runtime so F-Droid
 can rebuild from source; Play testers should get the full catalog.
 
@@ -46,9 +53,9 @@ purpose.
 
 ## Track order
 
-Ship closed testing first (internal or closed track), then open testing if you
-want a wider beta, then production. Do not jump straight to production for the
-first upload.
+The beta tag workflow uses the Play API track name `internal`. If that name is
+missing, `qa` is the only other name to try. Wider testing and production stay
+in Console. This tag workflow never uploads to production.
 
 ## Permissions (Console justification notes)
 
@@ -76,7 +83,8 @@ privacy policy URL (a live page, not a repo-relative path).
 
 ## Listing assets
 
-Fastlane metadata lives under `fastlane/metadata/android/en-US/`:
+Fastlane stays metadata only. It does not upload binaries. Copy lives under
+`fastlane/metadata/android/en-US/`:
 
 - `title.txt`, `short_description.txt`, `full_description.txt`
 - `images/icon.png` (512×512)
@@ -105,7 +113,8 @@ PY
 4. Data safety form (no analytics; on-device default; gateway optional)
 5. Content rating questionnaire
 6. Closed testing track before production
-7. Upload `vocaphone.aab` from the matching beta GitHub Release
+7. Confirm Internal testing received `vocaphone.aab` from the beta tag workflow
+   (upload by hand from the matching GitHub Release if the secret was unset)
 8. Confirm listing copy and graphics in Fastlane match what you paste into Console
 
 ## Building the AAB locally


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Beta tags already attach `vocaphone.aab`. This adds a Play upload after the GitHub Release so testers still get the APKs if Play fails.

The new step uses `r0adkll/upload-google-play` pinned at `e738b9dd8f2476ea806d921b64aacd24f34515a5` (v1.1.5). It sends only `release-assets/vocaphone.aab` to package `com.vocahq.vocaphone` on the `internal` track as a completed release named after the tag. The action defaults to production, so `tracks: internal` is required.

GitHub and actionlint reject `secrets` in `steps.if`. The job sets `PLAY_SERVICE_ACCOUNT_JSON_SET` from `PLAY_SERVICE_ACCOUNT_JSON != ''`, and the upload step runs only when that is `true`. The JSON itself is still passed only as `serviceAccountJsonPlainText`.

fdroid artifacts stay off Play. This tag workflow does not upload to production. Fastlane is still listing copy only.

`docs/play-store.md` and the Android README now match that.

No version bump. No Fastlane supply. No gradle-play-publisher.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e49e8d02-cc3f-4ff3-91fd-9f6ed61c3584?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e49e8d02-cc3f-4ff3-91fd-9f6ed61c3584&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

