### PR TITLE
Prepare 0.1.0-beta.17

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.vocahq.vocaphone"
         minSdk = 33
         targetSdk = 36
-        versionCode = 16
-        versionName = "0.1.0-beta.16"
+        versionCode = 17
+        versionName = "0.1.0-beta.17"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/docs/play-store.md
+++ b/docs/play-store.md
@@ -26,8 +26,8 @@ Upload the full AAB only. Never upload the fdroid APK or an fdroid bundle to
 Play. The fdroid flavour drops prebuilt sherpa-onnx / ONNX Runtime so F-Droid
 can rebuild from source; Play testers should get the full catalog.
 
-Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 16,
-`versionName` `0.1.0-beta.16`. Keep that until the next Play-bound tag needs a
+Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 17,
+`versionName` `0.1.0-beta.17`. Keep that until the next Play-bound tag needs a
 bump; the beta workflow refuses to publish when the tag and APK version disagree.
 
 `dependenciesInfo.includeInApk` / `includeInBundle` stay `false` so AGP does

--- a/fastlane/metadata/android/en-US/changelogs/17.txt
+++ b/fastlane/metadata/android/en-US/changelogs/17.txt
@@ -1,0 +1,1 @@
+First-run setup is a short page now. Start dictating turns on once the phone is ready. Large screens get a split keyboard.

--- a/fdroid/com.vocahq.vocaphone.yml
+++ b/fdroid/com.vocahq.vocaphone.yml
@@ -40,9 +40,9 @@ Repo: https://github.com/VocaHQ/vocaphone.git
 Binaries: https://github.com/VocaHQ/vocaphone/releases/download/v%v/vocaphone-fdroid.apk
 
 Builds:
-  - versionName: 0.1.0-beta.16
-    versionCode: 16
-    commit: v0.1.0-beta.16
+  - versionName: 0.1.0-beta.17
+    versionCode: 17
+    commit: v0.1.0-beta.17
     subdir: android/app
     submodules: true
     gradle:
@@ -62,5 +62,5 @@ AllowedAPKSigningKeys: e6131446f8afeff13516f78036db9ea26aaa16e01b39f37182bf262cc
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 0.1.0-beta.16
-CurrentVersionCode: 16
+CurrentVersion: 0.1.0-beta.17
+CurrentVersionCode: 17


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Android is versionCode 17 / 0.1.0-beta.17. First-run setup and the split keyboard landed after beta.16, and the next tag has to match versionName or the beta workflow will refuse to publish.

F-Droid metadata is the same numbers. The commit field is still the tag form, v0.1.0-beta.17. play-store.md and the Play changelog follow.

iOS marketing version is still 1.0. This PR does not create or push a tag.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b78a7e7-6959-44c6-a347-c6510b119e98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b78a7e7-6959-44c6-a347-c6510b119e98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

