### PR TITLE
Generate the emoji catalog from Unicode and CLDR

### DIFF
--- a/.github/workflows/quality-android.yml
+++ b/.github/workflows/quality-android.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'android/**'
+      # The keyboard reads the shared word list and emoji catalog from
+      # here; app/build.gradle.kts merges them into the asset root.
+      - 'assets/keyboard/**'
       # Prose next to the code it documents cannot break the build.
       - '!android/**.md'
       - '.github/actions/setup-android/action.yml'
@@ -17,6 +20,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'android/**'
+      # The keyboard reads the shared word list and emoji catalog from
+      # here; app/build.gradle.kts merges them into the asset root.
+      - 'assets/keyboard/**'
       - '!android/**.md'
       - '.github/actions/setup-android/action.yml'
       - '.github/actions/report-size/**'

--- a/.github/workflows/quality-assets.yml
+++ b/.github/workflows/quality-assets.yml
@@ -1,0 +1,53 @@
+name: Quality (shared assets)
+
+# The keyboard assets at the repository root are read by both platforms, so
+# they belong to neither platform's workflow. This one checks that the
+# generated ones still match their generator: the emoji catalog is 3,781 lines
+# nobody reviews by eye, and a hand edit to it is silently undone by the next
+# person to run --write.
+#
+# Nothing here needs the network. tools/unicode/ carries the pinned Unicode and
+# CLDR sources, which is what makes this check mean the same thing on every run
+# and lets F-Droid rebuild the catalog from this tree alone.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'assets/keyboard/**'
+      - 'tools/**'
+      - '.github/workflows/quality-assets.yml'
+  pull_request:
+    branches: [main]
+    # A draft pull request is filtered out below; listing ready_for_review makes
+    # the checks start the moment it stops being a draft.
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'assets/keyboard/**'
+      - 'tools/**'
+      - '.github/workflows/quality-assets.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # A superseded pull request push is wasted minutes, but a run on main is the
+  # record for a merged commit, so let that one finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  assets:
+    # Work in progress re-runs the checks on every push. The checks that
+    # matter run when the author marks the pull request ready.
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Fail if the emoji catalog does not match its generator
+        run: python3 tools/generate-emoji-catalog.py --check

--- a/.github/workflows/quality-ios.yml
+++ b/.github/workflows/quality-ios.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     paths:
       - 'ios/**'
+      # EmojiCatalogTests asserts against the real shared catalog, so a
+      # change to it has to run this suite. Worth the macOS minutes: it is
+      # the only check that the file both keyboards ship still parses.
+      - 'assets/keyboard/**'
       # Prose next to the code it documents cannot break the build, and macOS
       # minutes bill at ten times the Linux rate.
       - '!ios/**.md'
@@ -17,6 +21,10 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'ios/**'
+      # EmojiCatalogTests asserts against the real shared catalog, so a
+      # change to it has to run this suite. Worth the macOS minutes: it is
+      # the only check that the file both keyboards ship still parses.
+      - 'assets/keyboard/**'
       - '!ios/**.md'
       - '.github/actions/report-size/**'
       - '.github/workflows/quality-ios.yml'

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ android/*.hprof
 
 # Local Netlify folder
 .netlify
+
+# Pinned Unicode and CLDR sources, re-downloaded on demand by
+# tools/generate-emoji-catalog.py.
+tools/.cache/

--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,3 @@ android/*.hprof
 
 # Local Netlify folder
 .netlify
-
-# Pinned Unicode and CLDR sources, re-downloaded on demand by
-# tools/generate-emoji-catalog.py.
-tools/.cache/

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/EmojiSuggestionsTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/EmojiSuggestionsTest.kt
@@ -80,4 +80,36 @@ class EmojiSuggestionsTest {
         assertTrue(EmojiSuggestions.TRIGGERS.size > 100)
         assertTrue(EmojiSuggestions.TRIGGERS.size < 400)
     }
+
+    /**
+     * Every glyph the strip can offer is one the shipped catalog also carries.
+     *
+     * The trigger table is curated by hand and stays that way -- CLDR's
+     * keywords are for a deliberate search in the emoji panel, and matched
+     * against ordinary prose they answer "the" with an emoji. What the table
+     * has no way to catch on its own is a glyph that nothing can draw. The
+     * catalog is generated from a pinned Unicode release, so agreeing with it
+     * is what rules out pasting in a draft codepoint that renders as a blank
+     * box on every phone in the field.
+     */
+    @Test
+    fun `every offered emoji exists in the shipped catalog`() {
+        val catalog = generateSequence(java.io.File("").absoluteFile) { it.parentFile }
+            .map { java.io.File(it, "assets/keyboard/emoji/catalog.tsv") }
+            .firstOrNull(java.io.File::isFile)
+        org.junit.Assume.assumeTrue(
+            "assets/keyboard is only present in the repository",
+            catalog != null,
+        )
+        val known = catalog!!.readLines()
+            .mapNotNull { line -> line.substringBefore('\t').takeIf { it.isNotEmpty() } }
+            .toSet()
+
+        val offered = EmojiSuggestions.TRIGGERS.keys
+            .flatMap { EmojiSuggestions.glyphs(it) }
+            .toSortedSet()
+        assertTrue("the catalog looks empty", known.size > 1_000)
+        val missing = offered.filterNot { it in known }
+        assertEquals("offered but not in the catalog", emptyList<String>(), missing)
+    }
 }

--- a/assets/keyboard/emoji/catalog.tsv
+++ b/assets/keyboard/emoji/catalog.tsv
@@ -1,3944 +1,3781 @@
-😀	smileys	grinning face face smile happy joy :d grin smiley
-😃	smileys	grinning face with big eyes face happy joy haha :d :) smile funny mouth open smiley smiling
-😄	smileys	grinning face with smiling eyes face happy joy funny haha laugh like :d :) smile eye grin mouth open pleased smiley
-😁	smileys	beaming face with smiling eyes face happy smile joy kawaii eye grin grinning
-😆	smileys	grinning squinting face happy joy lol satisfied haha face glad xd laugh big closed eyes grin laughing mouth open smile smiling tightly
-😅	smileys	grinning face with sweat face hot happy laugh sweat smile relief cold exercise mouth open smiling
-🤣	smileys	rolling on the floor laughing face rolling floor laughing lol haha rofl laugh rotfl
-😂	smileys	face with tears of joy face cry tears weep happy happytears haha crying laugh laughing lol tear
-🙂	smileys	slightly smiling face face smile fine happy this
-🙃	smileys	upside-down face upside down face face flipped silly smile sarcasm
-🫠	smileys	melting face hot heat disappear dissolve dread liquid melt sarcasm
-😉	smileys	winking face face happy mischievous secret ;) smile eye flirt wink winky
-😊	smileys	smiling face with smiling eyes face smile happy flushed crush embarrassed shy joy ^^ blush eye proud smiley
-😇	smileys	smiling face with halo face angel heaven halo innocent fairy fantasy smile tale
-🥰	smileys	smiling face with hearts face love like affection valentines infatuation crush hearts adore eyes three
-😍	smileys	smiling face with heart-eyes smiling face with heart eyes face love like affection valentines infatuation crush heart eye shaped smile
-🤩	smileys	star-struck star struck face smile starry eyes grinning excited eyed wow
-😘	smileys	face blowing a kiss face love like affection valentines infatuation kiss blow flirt heart kissing throwing
-😗	smileys	kissing face love like face 3 valentines infatuation kiss duck kissy whistling
-☺️	smileys	smiling face face blush massage happiness happy outlined pleased relaxed smile smiley white
-😚	smileys	kissing face with closed eyes face love like affection valentines infatuation kiss eye kissy
-😙	smileys	kissing face with smiling eyes face affection valentines infatuation kiss eye kissy smile whistle whistling
-🥲	smileys	smiling face with tear sad cry pretend grateful happy proud relieved smile touched
-😋	smileys	face savoring food happy joy tongue smile face silly yummy nom delicious savouring goofy hungry lick licking lips smiling um yum
-😛	smileys	face with tongue face prank childish playful mischievous smile tongue cheeky out stuck
-😜	smileys	winking face with tongue face prank childish playful mischievous smile wink tongue crazy eye joke out silly stuck
-🤪	smileys	zany face face goofy crazy excited eye eyes grinning large one small wacky wild
-😝	smileys	squinting face with tongue face prank playful mischievous smile tongue closed eye eyes horrible out stuck taste tightly
-🤑	smileys	money-mouth face money mouth face face rich dollar money eyes sign
-🤗	smileys	smiling face with open hands hugging face face smile hug hands hugs open smiling
-🤭	smileys	face with hand over mouth face whoops shock surprise blushing covering eyes quiet smiling
-🫢	smileys	face with open eyes and hand over mouth silence secret shock surprise amazement awe disbelief embarrass gasp scared
-🫣	smileys	face with peeking eye scared frightening embarrassing shy captivated peep stare
-🤫	smileys	shushing face face quiet shhh closed covering finger hush lips shh shush silence
-🤔	smileys	thinking face face hmmm think consider chin shade thinker throwing thumb
-🫡	smileys	saluting face respect salute ok sunny troops yes
-🤐	smileys	zipper-mouth face zipper mouth face face sealed zipper secret hush lips silence zip
-🤨	smileys	face with raised eyebrow face distrust scepticism disapproval disbelief surprise suspicious colbert mild one rock skeptic
-😐	smileys	neutral face indifference meh :| neutral deadpan faced mouth straight
-😑	smileys	expressionless face face indifferent - - meh deadpan inexpressive mouth straight unexpressive
-😶	smileys	face without mouth face blank mouthless mute no quiet silence silent
-🫥	smileys	dotted line face invisible lonely isolation depression depressed disappear hide introvert
-😶‍🌫️	smileys	face in clouds shower steam dream absentminded brain fog forgetful haze head impractical unrealistic
-😏	smileys	smirking face face smile mean prank smug sarcasm flirting sexual smirk suggestive
-😒	smileys	unamused face indifference bored straight face serious sarcasm unimpressed skeptical dubious ugh side eye dissatisfied meh unhappy
-🙄	smileys	face with rolling eyes face eyeroll frustrated eye roll
-😬	smileys	grimacing face face grimace teeth awkward eek nervous
-😮‍💨	smileys	face exhaling relieve relief tired sigh exhale gasp groan whisper whistle
-🤥	smileys	lying face face lie pinocchio liar long nose
-🫨	smileys	shaking face dizzy shock blurry earthquake
-🙂‍↔️	smileys	head shaking horizontally disapprove indiffernt left
-🙂‍↕️	smileys	head shaking vertically down nod
-😌	smileys	relieved face face relaxed phew massage happiness content pleased whew
-😔	smileys	pensive face face sad depressed upset dejected sadface sorrowful
-😪	smileys	sleepy face face tired rest nap bubble side sleep snot tear
-🤤	smileys	drooling face face drool
-😴	smileys	sleeping face face tired sleepy night zzz sleep snoring
-🫩	smileys	face with bags under eyes tired sleepy exhausted
-😷	smileys	face with medical mask face sick ill disease covid cold coronavirus doctor medicine surgical
-🤒	smileys	face with thermometer sick temperature thermometer cold fever covid ill
-🤕	smileys	face with head-bandage face with head bandage injured clumsy bandage hurt bandaged injury
-🤢	smileys	nauseated face face vomit gross green sick throw up ill barf disgust disgusted green face
-🤮	smileys	face vomiting face sick barf ill mouth open puke spew throwing up vomit
-🤧	smileys	sneezing face face gesundheit sneeze sick allergy achoo
-🥵	smileys	hot face face feverish heat red sweating overheated stroke
-🥶	smileys	cold face face blue freezing frozen frostbite icicles ice
-🥴	smileys	woozy face face dizzy intoxicated tipsy wavy drunk eyes groggy mouth uneven
-😵	smileys	face with crossed-out eyes dizzy face spent unconscious xox dizzy cross crossed dead eyes knocked out spiral eyes
-😵‍💫	smileys	face with spiral eyes sick ill confused nauseous nausea dizzy hypnotized trouble whoa
-🤯	smileys	exploding head face shocked mind blown blowing explosion mad
-🤠	smileys	cowboy hat face face cowgirl hat
-🥳	smileys	partying face face celebration woohoo birthday hat horn party
-🥸	smileys	disguised face pretent brows glasses moustache disguise incognito nose
-😎	smileys	smiling face with sunglasses face cool smile summer beach sunglass best bright eye eyewear friends glasses mutual snapchat sun weather
-🤓	smileys	nerd face face nerdy geek dork glasses smiling
-🧐	smileys	face with monocle face stuffy wealthy rich exploration inspection
-😕	smileys	confused face face indifference huh weird hmmm :/ meh nonplussed puzzled s
-🫤	smileys	face with diagonal mouth skeptic confuse frustrated indifferent confused disappointed meh skeptical unsure
-😟	smileys	worried face face concern nervous :( sad sadface
-🙁	smileys	slightly frowning face face frowning disappointed sad upset frown unhappy
-☹️	smileys	frowning face face sad upset frown megafrown unhappy white
-😮	smileys	face with open mouth face surprise impressed wow whoa :o surprised sympathy
-😯	smileys	hushed face face woo shh silence speechless stunned surprise surprised
-😲	smileys	astonished face face xox surprised poisoned amazed drunk face gasp gasping shocked totally
-😳	smileys	flushed face face blush shy flattered blushing dazed embarrassed eyes open shame wide
-🫪	smileys	distorted face surprised fluttered wide-eyed
-🥺	smileys	pleading face face begging mercy cry tears sad grievance eyes glossy puppy simp
-🥹	smileys	face holding back tears touched gratitude cry angry proud resist sad
-😦	smileys	frowning face with open mouth face aw what frown yawning
-😧	smileys	anguished face face stunned nervous pained
-😨	smileys	fearful face face scared terrified nervous fear oops shocked surprised
-😰	smileys	anxious face with sweat face nervous sweat blue cold concerned face mouth open rushed
-😥	smileys	sad but relieved face face phew sweat nervous disappointed eyebrow whew
-😢	smileys	crying face face tears sad depressed upset :'( cry tear
-😭	smileys	loudly crying face sobbing face cry tears sad upset depressed bawling sob tear
-😱	smileys	face screaming in fear face munch scared omg alone fearful home horror scream shocked
-😖	smileys	confounded face face confused sick unwell oops :s mouth quivering scrunched
-😣	smileys	persevering face face sick no upset oops eyes helpless persevere scrunched struggling
-😞	smileys	disappointed face face sad upset depressed :( sadface
-😓	smileys	downcast face with sweat face hot sad tired exercise cold hard work
-😩	smileys	weary face face tired sleepy sad frustrated upset distraught wailing
-😫	smileys	tired face sick whine upset frustrated distraught exhausted fed up
-🥱	smileys	yawning face tired sleepy bored yawn
-😤	smileys	face with steam from nose face gas phew proud pride triumph airing frustrated grievances look mad smug steaming won
-😡	smileys	enraged face pouting face angry mad hate despise enraged grumpy pout rage red
-😠	smileys	angry face mad face annoyed frustrated anger grumpy
-🤬	smileys	face with symbols on mouth face swearing cursing cussing profanity expletive covering foul grawlix over serious
-😈	smileys	smiling face with horns devil horns evil fairy fantasy happy imp purple red devil smile tale
-👿	smileys	angry face with horns devil angry horns demon evil fairy fantasy goblin imp purple sad tale
-💀	smileys	skull dead skeleton creepy death body danger face fairy grey halloween monster poison tale
-☠️	smileys	skull and crossbones poison danger deadly scary death pirate evil body face halloween monster
-💩	smileys	pile of poo hankey shitface fail turd shit comic crap dirt dog dung face monster poop smiling bad needs improvement
-🤡	smileys	clown face face mock
-👹	smileys	ogre monster red mask halloween scary creepy devil demon japanese ogre creature face fairy fantasy oni tale shrek
-👺	smileys	goblin red evil mask monster scary creepy japanese goblin creature face fairy fantasy long nose tale tengu
-👻	smileys	ghost halloween spooky scary creature disappear face fairy fantasy ghoul monster tale
-👽	smileys	alien ufo paul weird outer space creature et extraterrestrial face fairy fantasy monster tale external
-👾	smileys	alien monster game arcade play creature extraterrestrial face fairy fantasy invader retro space tale ufo video
-🤖	smileys	robot computer machine bot face monster
-😺	smileys	grinning cat animal cats happy smile face mouth open smiley smiling
-😸	smileys	grinning cat with smiling eyes animal cats smile eye face grin happy
-😹	smileys	cat with tears of joy animal cats haha happy tears face laughing tear
-😻	smileys	smiling cat with heart-eyes smiling cat with heart eyes animal love like affection cats valentines heart eye face loving cat shaped smile
-😼	smileys	cat with wry smile animal cats smirk face ironic smirking
-😽	smileys	kissing cat animal cats kiss closed eye eyes face
-🙀	smileys	weary cat animal cats munch scared scream face fear horror oh screaming surprised
-😿	smileys	crying cat animal tears weep sad cats upset cry face sad cat tear
-😾	smileys	pouting cat animal cats face grumpy
-🙈	smileys	see-no-evil monkey see no evil monkey monkey animal nature haha blind covering eyes face forbidden gesture ignore mizaru not prohibited
-🙉	smileys	hear-no-evil monkey hear no evil monkey animal monkey nature covering deaf ears face forbidden gesture kikazaru not prohibited
-🙊	smileys	speak-no-evil monkey speak no evil monkey monkey animal nature omg covering face forbidden gesture hush iwazaru mouth mute not no speaking prohibited ignore
-💌	smileys	love letter email like affection envelope valentines heart mail note romance
-💘	smileys	heart with arrow love like heart affection valentines cupid lovestruck romance
-💝	smileys	heart with ribbon love valentines box chocolate chocolates gift valentine
-💖	smileys	sparkling heart love like affection valentines excited sparkle sparkly stars heart
-💗	smileys	growing heart like love affection valentines pink excited heartpulse multiple nervous pulse triple
-💓	smileys	beating heart love like affection valentines pink heart alarm heartbeat pulsating wifi
-💞	smileys	revolving hearts love like affection valentines heart two
-💕	smileys	two hearts love like affection valentines heart pink small
-💟	smileys	heart decoration purple-square love like
-❣️	smileys	heart exclamation decoration love above an as dot heavy mark ornament punctuation red
-💔	smileys	broken heart sad sorry break heart heartbreak breaking brokenhearted
-❤️‍🔥	smileys	heart on fire passionate enthusiastic burn love lust sacred
-❤️‍🩹	smileys	mending heart broken heart bandage wounded bandaged healing healthier improving recovering recuperating unbroken well
-❤️	smileys	red heart love like valentines black heavy
-🩷	smileys	pink heart valentines
-🧡	smileys	orange heart love like affection valentines
-💛	smileys	yellow heart love like affection valentines bf gold snapchat
-💚	smileys	green heart love like affection valentines nct
-💙	smileys	blue heart love like affection valentines brand neutral
-🩵	smileys	light blue heart ice baby blue
-💜	smileys	purple heart love like affection valentines bts emoji
-🤎	smileys	brown heart coffee
-🖤	smileys	black heart evil dark wicked
-🩶	smileys	grey heart silver monochrome
-🤍	smileys	white heart pure
-💋	smileys	kiss mark face lips love like affection valentines heart kissing lipstick romance
-💯	smileys	hundred points score perfect numbers century exam quiz test pass hundred 100 full keep symbol
-💢	smileys	anger symbol angry mad comic pop sign vein
-🫯	smileys	fight cloud brawl conflict
-💥	smileys	collision bomb explode explosion blown bang boom comic impact red spark symbol break
-💫	smileys	dizzy star sparkle shoot magic circle comic symbol animations transitions
-💦	smileys	sweat droplets water drip oops comic drops plewds splashing symbol workout
-💨	smileys	dashing away wind air fast shoo fart smoke puff blow comic dash gust running steam symbol vaping
-🕳️	smileys	hole embarrassing
-💬	smileys	speech balloon bubble words message talk chatting chat comic comment dialog text literals
-👁️‍🗨️	smileys	eye in speech bubble info am i witness
-🗨️	smileys	left speech bubble words message talk chatting dialog
-🗯️	smileys	right anger bubble caption speech thinking mad angry balloon zag zig
-💭	smileys	thought balloon bubble cloud speech thinking dream comic
-💤	smileys	zzz sleepy tired dream bedtime boring comic sign sleep sleeping symbol
-👋	people	waving hand wave hands gesture goodbye solong farewell hello hi palm body sign
-👋🏻	people	waving hand: light skin tone
-👋🏼	people	waving hand: medium-light skin tone
-👋🏽	people	waving hand: medium skin tone
-👋🏾	people	waving hand: medium-dark skin tone
-👋🏿	people	waving hand: dark skin tone
-🤚	people	raised back of hand fingers raised backhand body
-🤚🏻	people	raised back of hand: light skin tone
-🤚🏼	people	raised back of hand: medium-light skin tone
-🤚🏽	people	raised back of hand: medium skin tone
-🤚🏾	people	raised back of hand: medium-dark skin tone
-🤚🏿	people	raised back of hand: dark skin tone
-🖐️	people	hand with fingers splayed hand fingers palm body finger five raised
-🖐🏻	people	hand with fingers splayed: light skin tone
-🖐🏼	people	hand with fingers splayed: medium-light skin tone
-🖐🏽	people	hand with fingers splayed: medium skin tone
-🖐🏾	people	hand with fingers splayed: medium-dark skin tone
-🖐🏿	people	hand with fingers splayed: dark skin tone
-✋	people	raised hand fingers stop highfive palm ban body five high
-✋🏻	people	raised hand: light skin tone
-✋🏼	people	raised hand: medium-light skin tone
-✋🏽	people	raised hand: medium skin tone
-✋🏾	people	raised hand: medium-dark skin tone
-✋🏿	people	raised hand: dark skin tone
-🖖	people	vulcan salute hand fingers spock star trek between body finger middle part prosper raised ring split
-🖖🏻	people	vulcan salute: light skin tone
-🖖🏼	people	vulcan salute: medium-light skin tone
-🖖🏽	people	vulcan salute: medium skin tone
-🖖🏾	people	vulcan salute: medium-dark skin tone
-🖖🏿	people	vulcan salute: dark skin tone
-🫱	people	rightwards hand palm offer right rightward
-🫱🏻	people	rightwards hand: light skin tone
-🫱🏼	people	rightwards hand: medium-light skin tone
-🫱🏽	people	rightwards hand: medium skin tone
-🫱🏾	people	rightwards hand: medium-dark skin tone
-🫱🏿	people	rightwards hand: dark skin tone
-🫲	people	leftwards hand palm offer left leftward
-🫲🏻	people	leftwards hand: light skin tone
-🫲🏼	people	leftwards hand: medium-light skin tone
-🫲🏽	people	leftwards hand: medium skin tone
-🫲🏾	people	leftwards hand: medium-dark skin tone
-🫲🏿	people	leftwards hand: dark skin tone
-🫳	people	palm down hand palm drop dismiss shoo
-🫳🏻	people	palm down hand: light skin tone
-🫳🏼	people	palm down hand: medium-light skin tone
-🫳🏽	people	palm down hand: medium skin tone
-🫳🏾	people	palm down hand: medium-dark skin tone
-🫳🏿	people	palm down hand: dark skin tone
-🫴	people	palm up hand lift offer demand beckon catch come
-🫴🏻	people	palm up hand: light skin tone
-🫴🏼	people	palm up hand: medium-light skin tone
-🫴🏽	people	palm up hand: medium skin tone
-🫴🏾	people	palm up hand: medium-dark skin tone
-🫴🏿	people	palm up hand: dark skin tone
-🫷	people	leftwards pushing hand highfive pressing stop
-🫷🏻	people	leftwards pushing hand: light skin tone
-🫷🏼	people	leftwards pushing hand: medium-light skin tone
-🫷🏽	people	leftwards pushing hand: medium skin tone
-🫷🏾	people	leftwards pushing hand: medium-dark skin tone
-🫷🏿	people	leftwards pushing hand: dark skin tone
-🫸	people	rightwards pushing hand highfive pressing stop
-🫸🏻	people	rightwards pushing hand: light skin tone
-🫸🏼	people	rightwards pushing hand: medium-light skin tone
-🫸🏽	people	rightwards pushing hand: medium skin tone
-🫸🏾	people	rightwards pushing hand: medium-dark skin tone
-🫸🏿	people	rightwards pushing hand: dark skin tone
-👌	people	ok hand fingers limbs perfect ok okay body sign
-👌🏻	people	ok hand: light skin tone
-👌🏼	people	ok hand: medium-light skin tone
-👌🏽	people	ok hand: medium skin tone
-👌🏾	people	ok hand: medium-dark skin tone
-👌🏿	people	ok hand: dark skin tone
-🤌	people	pinched fingers size tiny small che finger gesture hand interrogation ma purse sarcastic vuoi
-🤌🏻	people	pinched fingers: light skin tone
-🤌🏼	people	pinched fingers: medium-light skin tone
-🤌🏽	people	pinched fingers: medium skin tone
-🤌🏾	people	pinched fingers: medium-dark skin tone
-🤌🏿	people	pinched fingers: dark skin tone
-🤏	people	pinching hand tiny small size amount body little
-🤏🏻	people	pinching hand: light skin tone
-🤏🏼	people	pinching hand: medium-light skin tone
-🤏🏽	people	pinching hand: medium skin tone
-🤏🏾	people	pinching hand: medium-dark skin tone
-🤏🏿	people	pinching hand: dark skin tone
-✌️	people	victory hand fingers ohyeah hand peace victory two air body quotes sign v
-✌🏻	people	victory hand: light skin tone
-✌🏼	people	victory hand: medium-light skin tone
-✌🏽	people	victory hand: medium skin tone
-✌🏾	people	victory hand: medium-dark skin tone
-✌🏿	people	victory hand: dark skin tone
-🤞	people	crossed fingers good lucky body cross finger hand hopeful index luck middle
-🤞🏻	people	crossed fingers: light skin tone
-🤞🏼	people	crossed fingers: medium-light skin tone
-🤞🏽	people	crossed fingers: medium skin tone
-🤞🏾	people	crossed fingers: medium-dark skin tone
-🤞🏿	people	crossed fingers: dark skin tone
-🫰	people	hand with index finger and thumb crossed heart love money expensive snap
-🫰🏻	people	hand with index finger and thumb crossed: light skin tone
-🫰🏼	people	hand with index finger and thumb crossed: medium-light skin tone
-🫰🏽	people	hand with index finger and thumb crossed: medium skin tone
-🫰🏾	people	hand with index finger and thumb crossed: medium-dark skin tone
-🫰🏿	people	hand with index finger and thumb crossed: dark skin tone
-🤟	people	love-you gesture love you gesture hand fingers gesture body i ily sign
-🤟🏻	people	love-you gesture: light skin tone
-🤟🏼	people	love-you gesture: medium-light skin tone
-🤟🏽	people	love-you gesture: medium skin tone
-🤟🏾	people	love-you gesture: medium-dark skin tone
-🤟🏿	people	love-you gesture: dark skin tone
-🤘	people	sign of the horns hand fingers evil eye sign of horns rock on body devil finger heavy metal
-🤘🏻	people	sign of the horns: light skin tone
-🤘🏼	people	sign of the horns: medium-light skin tone
-🤘🏽	people	sign of the horns: medium skin tone
-🤘🏾	people	sign of the horns: medium-dark skin tone
-🤘🏿	people	sign of the horns: dark skin tone
-🤙	people	call me hand hands gesture shaka body phone sign
-🤙🏻	people	call me hand: light skin tone
-🤙🏼	people	call me hand: medium-light skin tone
-🤙🏽	people	call me hand: medium skin tone
-🤙🏾	people	call me hand: medium-dark skin tone
-🤙🏿	people	call me hand: dark skin tone
-👈	people	backhand index pointing left direction fingers hand left body finger point white
-👈🏻	people	backhand index pointing left: light skin tone
-👈🏼	people	backhand index pointing left: medium-light skin tone
-👈🏽	people	backhand index pointing left: medium skin tone
-👈🏾	people	backhand index pointing left: medium-dark skin tone
-👈🏿	people	backhand index pointing left: dark skin tone
-👉	people	backhand index pointing right fingers hand direction right body finger point white
-👉🏻	people	backhand index pointing right: light skin tone
-👉🏼	people	backhand index pointing right: medium-light skin tone
-👉🏽	people	backhand index pointing right: medium skin tone
-👉🏾	people	backhand index pointing right: medium-dark skin tone
-👉🏿	people	backhand index pointing right: dark skin tone
-👆	people	backhand index pointing up fingers hand direction up body finger middle point white
-👆🏻	people	backhand index pointing up: light skin tone
-👆🏼	people	backhand index pointing up: medium-light skin tone
-👆🏽	people	backhand index pointing up: medium skin tone
-👆🏾	people	backhand index pointing up: medium-dark skin tone
-👆🏿	people	backhand index pointing up: dark skin tone
-🖕	people	middle finger hand fingers rude middle flipping bird body dito extended fu medio middle finger reversed
-🖕🏻	people	middle finger: light skin tone
-🖕🏼	people	middle finger: medium-light skin tone
-🖕🏽	people	middle finger: medium skin tone
-🖕🏾	people	middle finger: medium-dark skin tone
-🖕🏿	people	middle finger: dark skin tone
-👇	people	backhand index pointing down fingers hand direction down body finger point white
-👇🏻	people	backhand index pointing down: light skin tone
-👇🏼	people	backhand index pointing down: medium-light skin tone
-👇🏽	people	backhand index pointing down: medium skin tone
-👇🏾	people	backhand index pointing down: medium-dark skin tone
-👇🏿	people	backhand index pointing down: dark skin tone
-☝️	people	index pointing up hand fingers direction up body finger point secret white
-☝🏻	people	index pointing up: light skin tone
-☝🏼	people	index pointing up: medium-light skin tone
-☝🏽	people	index pointing up: medium skin tone
-☝🏾	people	index pointing up: medium-dark skin tone
-☝🏿	people	index pointing up: dark skin tone
-🫵	people	index pointing at the viewer you recruit point
-🫵🏻	people	index pointing at the viewer: light skin tone
-🫵🏼	people	index pointing at the viewer: medium-light skin tone
-🫵🏽	people	index pointing at the viewer: medium skin tone
-🫵🏾	people	index pointing at the viewer: medium-dark skin tone
-🫵🏿	people	index pointing at the viewer: dark skin tone
-👍	people	thumbs up thumbsup yes awesome good agree accept cool hand like +1 approve body ok sign thumb
-👍🏻	people	thumbs up: light skin tone
-👍🏼	people	thumbs up: medium-light skin tone
-👍🏽	people	thumbs up: medium skin tone
-👍🏾	people	thumbs up: medium-dark skin tone
-👍🏿	people	thumbs up: dark skin tone
-👎	people	thumbs down thumbsdown no dislike hand -1 bad body bury disapprove sign thumb
-👎🏻	people	thumbs down: light skin tone
-👎🏼	people	thumbs down: medium-light skin tone
-👎🏽	people	thumbs down: medium skin tone
-👎🏾	people	thumbs down: medium-dark skin tone
-👎🏿	people	thumbs down: dark skin tone
-✊	people	raised fist fingers hand grasp body clenched power pump punch
-✊🏻	people	raised fist: light skin tone
-✊🏼	people	raised fist: medium-light skin tone
-✊🏽	people	raised fist: medium skin tone
-✊🏾	people	raised fist: medium-dark skin tone
-✊🏿	people	raised fist: dark skin tone
-👊	people	oncoming fist angry violence fist hit attack hand body bro brofist bump clenched closed facepunch fisted punch sign
-👊🏻	people	oncoming fist: light skin tone
-👊🏼	people	oncoming fist: medium-light skin tone
-👊🏽	people	oncoming fist: medium skin tone
-👊🏾	people	oncoming fist: medium-dark skin tone
-👊🏿	people	oncoming fist: dark skin tone
-🤛	people	left-facing fist left facing fist hand fistbump body bump leftwards
-🤛🏻	people	left-facing fist: light skin tone
-🤛🏼	people	left-facing fist: medium-light skin tone
-🤛🏽	people	left-facing fist: medium skin tone
-🤛🏾	people	left-facing fist: medium-dark skin tone
-🤛🏿	people	left-facing fist: dark skin tone
-🤜	people	right-facing fist right facing fist hand fistbump body bump rightwards right fist
-🤜🏻	people	right-facing fist: light skin tone
-🤜🏼	people	right-facing fist: medium-light skin tone
-🤜🏽	people	right-facing fist: medium skin tone
-🤜🏾	people	right-facing fist: medium-dark skin tone
-🤜🏿	people	right-facing fist: dark skin tone
-👏	people	clapping hands hands praise applause congrats yay body clap golf hand round sign
-👏🏻	people	clapping hands: light skin tone
-👏🏼	people	clapping hands: medium-light skin tone
-👏🏽	people	clapping hands: medium skin tone
-👏🏾	people	clapping hands: medium-dark skin tone
-👏🏿	people	clapping hands: dark skin tone
-🙌	people	raising hands gesture hooray yea celebration hands air arms banzai body both festivus hallelujah hand miracle person praise raised two
-🙌🏻	people	raising hands: light skin tone
-🙌🏼	people	raising hands: medium-light skin tone
-🙌🏽	people	raising hands: medium skin tone
-🙌🏾	people	raising hands: medium-dark skin tone
-🙌🏿	people	raising hands: dark skin tone
-🫶	people	heart hands love appreciation support
-🫶🏻	people	heart hands: light skin tone
-🫶🏼	people	heart hands: medium-light skin tone
-🫶🏽	people	heart hands: medium skin tone
-🫶🏾	people	heart hands: medium-dark skin tone
-🫶🏿	people	heart hands: dark skin tone
-👐	people	open hands fingers butterfly hands open body hand hug jazz sign
-👐🏻	people	open hands: light skin tone
-👐🏼	people	open hands: medium-light skin tone
-👐🏽	people	open hands: medium skin tone
-👐🏾	people	open hands: medium-dark skin tone
-👐🏿	people	open hands: dark skin tone
-🤲	people	palms up together hands gesture cupped prayer body dua facing
-🤲🏻	people	palms up together: light skin tone
-🤲🏼	people	palms up together: medium-light skin tone
-🤲🏽	people	palms up together: medium skin tone
-🤲🏾	people	palms up together: medium-dark skin tone
-🤲🏿	people	palms up together: dark skin tone
-🤝	people	handshake agreement shake deal hand hands meeting shaking
-🤝🏻	people	handshake: light skin tone
-🤝🏼	people	handshake: medium-light skin tone
-🤝🏽	people	handshake: medium skin tone
-🤝🏾	people	handshake: medium-dark skin tone
-🤝🏿	people	handshake: dark skin tone
-🫱🏻‍🫲🏼	people	handshake: light skin tone, medium-light skin tone
-🫱🏻‍🫲🏽	people	handshake: light skin tone, medium skin tone
-🫱🏻‍🫲🏾	people	handshake: light skin tone, medium-dark skin tone
-🫱🏻‍🫲🏿	people	handshake: light skin tone, dark skin tone
-🫱🏼‍🫲🏻	people	handshake: medium-light skin tone, light skin tone
-🫱🏼‍🫲🏽	people	handshake: medium-light skin tone, medium skin tone
-🫱🏼‍🫲🏾	people	handshake: medium-light skin tone, medium-dark skin tone
-🫱🏼‍🫲🏿	people	handshake: medium-light skin tone, dark skin tone
-🫱🏽‍🫲🏻	people	handshake: medium skin tone, light skin tone
-🫱🏽‍🫲🏼	people	handshake: medium skin tone, medium-light skin tone
-🫱🏽‍🫲🏾	people	handshake: medium skin tone, medium-dark skin tone
-🫱🏽‍🫲🏿	people	handshake: medium skin tone, dark skin tone
-🫱🏾‍🫲🏻	people	handshake: medium-dark skin tone, light skin tone
-🫱🏾‍🫲🏼	people	handshake: medium-dark skin tone, medium-light skin tone
-🫱🏾‍🫲🏽	people	handshake: medium-dark skin tone, medium skin tone
-🫱🏾‍🫲🏿	people	handshake: medium-dark skin tone, dark skin tone
-🫱🏿‍🫲🏻	people	handshake: dark skin tone, light skin tone
-🫱🏿‍🫲🏼	people	handshake: dark skin tone, medium-light skin tone
-🫱🏿‍🫲🏽	people	handshake: dark skin tone, medium skin tone
-🫱🏿‍🫲🏾	people	handshake: dark skin tone, medium-dark skin tone
-🙏	people	folded hands please hope wish namaste highfive pray thank you thanks appreciate ask body bow five gesture hand high person prayer pressed together
-🙏🏻	people	folded hands: light skin tone
-🙏🏼	people	folded hands: medium-light skin tone
-🙏🏽	people	folded hands: medium skin tone
-🙏🏾	people	folded hands: medium-dark skin tone
-🙏🏿	people	folded hands: dark skin tone
-✍️	people	writing hand lower left ballpoint pen stationery write compose body
-✍🏻	people	writing hand: light skin tone
-✍🏼	people	writing hand: medium-light skin tone
-✍🏽	people	writing hand: medium skin tone
-✍🏾	people	writing hand: medium-dark skin tone
-✍🏿	people	writing hand: dark skin tone
-💅	people	nail polish nail care beauty manicure finger fashion nail slay body cosmetics fingers nonchalant
-💅🏻	people	nail polish: light skin tone
-💅🏼	people	nail polish: medium-light skin tone
-💅🏽	people	nail polish: medium skin tone
-💅🏾	people	nail polish: medium-dark skin tone
-💅🏿	people	nail polish: dark skin tone
-🤳	people	selfie camera phone arm hand
-🤳🏻	people	selfie: light skin tone
-🤳🏼	people	selfie: medium-light skin tone
-🤳🏽	people	selfie: medium skin tone
-🤳🏾	people	selfie: medium-dark skin tone
-🤳🏿	people	selfie: dark skin tone
-💪	people	flexed biceps arm flex hand summer strong biceps bicep body comic feats flexing muscle muscles strength workout
-💪🏻	people	flexed biceps: light skin tone
-💪🏼	people	flexed biceps: medium-light skin tone
-💪🏽	people	flexed biceps: medium skin tone
-💪🏾	people	flexed biceps: medium-dark skin tone
-💪🏿	people	flexed biceps: dark skin tone
-🦾	people	mechanical arm accessibility body prosthetic
-🦿	people	mechanical leg accessibility body prosthetic
-🦵	people	leg kick limb body
-🦵🏻	people	leg: light skin tone
-🦵🏼	people	leg: medium-light skin tone
-🦵🏽	people	leg: medium skin tone
-🦵🏾	people	leg: medium-dark skin tone
-🦵🏿	people	leg: dark skin tone
-🦶	people	foot kick stomp body
-🦶🏻	people	foot: light skin tone
-🦶🏼	people	foot: medium-light skin tone
-🦶🏽	people	foot: medium skin tone
-🦶🏾	people	foot: medium-dark skin tone
-🦶🏿	people	foot: dark skin tone
-👂	people	ear face hear sound listen body ears hearing listening nose
-👂🏻	people	ear: light skin tone
-👂🏼	people	ear: medium-light skin tone
-👂🏽	people	ear: medium skin tone
-👂🏾	people	ear: medium-dark skin tone
-👂🏿	people	ear: dark skin tone
-🦻	people	ear with hearing aid accessibility body hard
-🦻🏻	people	ear with hearing aid: light skin tone
-🦻🏼	people	ear with hearing aid: medium-light skin tone
-🦻🏽	people	ear with hearing aid: medium skin tone
-🦻🏾	people	ear with hearing aid: medium-dark skin tone
-🦻🏿	people	ear with hearing aid: dark skin tone
-👃	people	nose smell sniff body smelling sniffing stinky
-👃🏻	people	nose: light skin tone
-👃🏼	people	nose: medium-light skin tone
-👃🏽	people	nose: medium skin tone
-👃🏾	people	nose: medium-dark skin tone
-👃🏿	people	nose: dark skin tone
-🧠	people	brain smart intelligent body organ
-🫀	people	anatomical heart health heartbeat cardiology organ pulse
-🫁	people	lungs breathe breath exhalation inhalation organ respiration
-🦷	people	tooth teeth dentist body
-🦴	people	bone skeleton body
-👀	people	eyes look watch stalk peek see body eye eyeballs face shifty wide
-👁️	people	eye face look see watch stare body single
-👅	people	tongue mouth playful body out taste
-👄	people	mouth kiss body kissing lips
-🫦	people	biting lip flirt sexy pain worry anxious fear flirting nervous uncomfortable worried
-👶	people	baby child boy girl toddler newborn young
-👶🏻	people	baby: light skin tone
-👶🏼	people	baby: medium-light skin tone
-👶🏽	people	baby: medium skin tone
-👶🏾	people	baby: medium-dark skin tone
-👶🏿	people	baby: dark skin tone
-🧒	people	child gender-neutral young boy gender girl inclusive neutral person unspecified
-🧒🏻	people	child: light skin tone
-🧒🏼	people	child: medium-light skin tone
-🧒🏽	people	child: medium skin tone
-🧒🏾	people	child: medium-dark skin tone
-🧒🏿	people	child: dark skin tone
-👦	people	boy man male guy teenager child young
-👦🏻	people	boy: light skin tone
-👦🏼	people	boy: medium-light skin tone
-👦🏽	people	boy: medium skin tone
-👦🏾	people	boy: medium-dark skin tone
-👦🏿	people	boy: dark skin tone
-👧	people	girl female woman teenager child maiden virgin virgo young zodiac
-👧🏻	people	girl: light skin tone
-👧🏼	people	girl: medium-light skin tone
-👧🏽	people	girl: medium skin tone
-👧🏾	people	girl: medium-dark skin tone
-👧🏿	people	girl: dark skin tone
-🧑	people	person gender-neutral adult female gender inclusive male man men neutral unspecified woman women
-🧑🏻	people	person: light skin tone
-🧑🏼	people	person: medium-light skin tone
-🧑🏽	people	person: medium skin tone
-🧑🏾	people	person: medium-dark skin tone
-🧑🏿	people	person: dark skin tone
-👱	people	person: blond hair person blond hair hairstyle blonde haired man
-👱🏻	people	person: light skin tone, blond hair
-👱🏼	people	person: medium-light skin tone, blond hair
-👱🏽	people	person: medium skin tone, blond hair
-👱🏾	people	person: medium-dark skin tone, blond hair
-👱🏿	people	person: dark skin tone, blond hair
-👨	people	man mustache father dad guy classy sir moustache adult male men
-👨🏻	people	man: light skin tone
-👨🏼	people	man: medium-light skin tone
-👨🏽	people	man: medium skin tone
-👨🏾	people	man: medium-dark skin tone
-👨🏿	people	man: dark skin tone
-🧔	people	person: beard man beard person bewhiskered bearded
-🧔🏻	people	person: light skin tone, beard
-🧔🏼	people	person: medium-light skin tone, beard
-🧔🏽	people	person: medium skin tone, beard
-🧔🏾	people	person: medium-dark skin tone, beard
-🧔🏿	people	person: dark skin tone, beard
-🧔‍♂️	people	man: beard man beard facial hair bearded bewhiskered male men
-🧔🏻‍♂️	people	man: light skin tone, beard
-🧔🏼‍♂️	people	man: medium-light skin tone, beard
-🧔🏽‍♂️	people	man: medium skin tone, beard
-🧔🏾‍♂️	people	man: medium-dark skin tone, beard
-🧔🏿‍♂️	people	man: dark skin tone, beard
-🧔‍♀️	people	woman: beard woman beard facial hair bearded bewhiskered female women
-🧔🏻‍♀️	people	woman: light skin tone, beard
-🧔🏼‍♀️	people	woman: medium-light skin tone, beard
-🧔🏽‍♀️	people	woman: medium skin tone, beard
-🧔🏾‍♀️	people	woman: medium-dark skin tone, beard
-🧔🏿‍♀️	people	woman: dark skin tone, beard
-👨‍🦰	people	man: red hair man red hair hairstyle adult ginger haired male men redhead
-👨🏻‍🦰	people	man: light skin tone, red hair
-👨🏼‍🦰	people	man: medium-light skin tone, red hair
-👨🏽‍🦰	people	man: medium skin tone, red hair
-👨🏾‍🦰	people	man: medium-dark skin tone, red hair
-👨🏿‍🦰	people	man: dark skin tone, red hair
-👨‍🦱	people	man: curly hair man curly hair hairstyle adult haired male men
-👨🏻‍🦱	people	man: light skin tone, curly hair
-👨🏼‍🦱	people	man: medium-light skin tone, curly hair
-👨🏽‍🦱	people	man: medium skin tone, curly hair
-👨🏾‍🦱	people	man: medium-dark skin tone, curly hair
-👨🏿‍🦱	people	man: dark skin tone, curly hair
-👨‍🦳	people	man: white hair man white hair old elder adult haired male men
-👨🏻‍🦳	people	man: light skin tone, white hair
-👨🏼‍🦳	people	man: medium-light skin tone, white hair
-👨🏽‍🦳	people	man: medium skin tone, white hair
-👨🏾‍🦳	people	man: medium-dark skin tone, white hair
-👨🏿‍🦳	people	man: dark skin tone, white hair
-👨‍🦲	people	man: bald man bald hairless adult hair male men no
-👨🏻‍🦲	people	man: light skin tone, bald
-👨🏼‍🦲	people	man: medium-light skin tone, bald
-👨🏽‍🦲	people	man: medium skin tone, bald
-👨🏾‍🦲	people	man: medium-dark skin tone, bald
-👨🏿‍🦲	people	man: dark skin tone, bald
-👩	people	woman female girls lady adult women yellow
-👩🏻	people	woman: light skin tone
-👩🏼	people	woman: medium-light skin tone
-👩🏽	people	woman: medium skin tone
-👩🏾	people	woman: medium-dark skin tone
-👩🏿	people	woman: dark skin tone
-👩‍🦰	people	woman: red hair woman red hair hairstyle adult female ginger haired redhead women
-👩🏻‍🦰	people	woman: light skin tone, red hair
-👩🏼‍🦰	people	woman: medium-light skin tone, red hair
-👩🏽‍🦰	people	woman: medium skin tone, red hair
-👩🏾‍🦰	people	woman: medium-dark skin tone, red hair
-👩🏿‍🦰	people	woman: dark skin tone, red hair
-🧑‍🦰	people	person: red hair person red hair hairstyle adult gender haired unspecified
-🧑🏻‍🦰	people	person: light skin tone, red hair
-🧑🏼‍🦰	people	person: medium-light skin tone, red hair
-🧑🏽‍🦰	people	person: medium skin tone, red hair
-🧑🏾‍🦰	people	person: medium-dark skin tone, red hair
-🧑🏿‍🦰	people	person: dark skin tone, red hair
-👩‍🦱	people	woman: curly hair woman curly hair hairstyle adult female haired women
-👩🏻‍🦱	people	woman: light skin tone, curly hair
-👩🏼‍🦱	people	woman: medium-light skin tone, curly hair
-👩🏽‍🦱	people	woman: medium skin tone, curly hair
-👩🏾‍🦱	people	woman: medium-dark skin tone, curly hair
-👩🏿‍🦱	people	woman: dark skin tone, curly hair
-🧑‍🦱	people	person: curly hair person curly hair hairstyle adult gender haired unspecified
-🧑🏻‍🦱	people	person: light skin tone, curly hair
-🧑🏼‍🦱	people	person: medium-light skin tone, curly hair
-🧑🏽‍🦱	people	person: medium skin tone, curly hair
-🧑🏾‍🦱	people	person: medium-dark skin tone, curly hair
-🧑🏿‍🦱	people	person: dark skin tone, curly hair
-👩‍🦳	people	woman: white hair woman white hair old elder adult female haired women
-👩🏻‍🦳	people	woman: light skin tone, white hair
-👩🏼‍🦳	people	woman: medium-light skin tone, white hair
-👩🏽‍🦳	people	woman: medium skin tone, white hair
-👩🏾‍🦳	people	woman: medium-dark skin tone, white hair
-👩🏿‍🦳	people	woman: dark skin tone, white hair
-🧑‍🦳	people	person: white hair person white hair elder old adult gender haired unspecified
-🧑🏻‍🦳	people	person: light skin tone, white hair
-🧑🏼‍🦳	people	person: medium-light skin tone, white hair
-🧑🏽‍🦳	people	person: medium skin tone, white hair
-🧑🏾‍🦳	people	person: medium-dark skin tone, white hair
-🧑🏿‍🦳	people	person: dark skin tone, white hair
-👩‍🦲	people	woman: bald woman bald hairless adult female hair no women
-👩🏻‍🦲	people	woman: light skin tone, bald
-👩🏼‍🦲	people	woman: medium-light skin tone, bald
-👩🏽‍🦲	people	woman: medium skin tone, bald
-👩🏾‍🦲	people	woman: medium-dark skin tone, bald
-👩🏿‍🦲	people	woman: dark skin tone, bald
-🧑‍🦲	people	person: bald person bald hairless adult gender hair no unspecified
-🧑🏻‍🦲	people	person: light skin tone, bald
-🧑🏼‍🦲	people	person: medium-light skin tone, bald
-🧑🏽‍🦲	people	person: medium skin tone, bald
-🧑🏾‍🦲	people	person: medium-dark skin tone, bald
-🧑🏿‍🦲	people	person: dark skin tone, bald
-👱‍♀️	people	woman: blond hair woman blond hair woman female girl blonde person haired women
-👱🏻‍♀️	people	woman: light skin tone, blond hair
-👱🏼‍♀️	people	woman: medium-light skin tone, blond hair
-👱🏽‍♀️	people	woman: medium skin tone, blond hair
-👱🏾‍♀️	people	woman: medium-dark skin tone, blond hair
-👱🏿‍♀️	people	woman: dark skin tone, blond hair
-👱‍♂️	people	man: blond hair man blond hair man male boy blonde guy person haired men
-👱🏻‍♂️	people	man: light skin tone, blond hair
-👱🏼‍♂️	people	man: medium-light skin tone, blond hair
-👱🏽‍♂️	people	man: medium skin tone, blond hair
-👱🏾‍♂️	people	man: medium-dark skin tone, blond hair
-👱🏿‍♂️	people	man: dark skin tone, blond hair
-🧓	people	older person human elder senior gender-neutral adult female gender male man men neutral old unspecified woman women
-🧓🏻	people	older person: light skin tone
-🧓🏼	people	older person: medium-light skin tone
-🧓🏽	people	older person: medium skin tone
-🧓🏾	people	older person: medium-dark skin tone
-🧓🏿	people	older person: dark skin tone
-👴	people	old man human male men old elder senior adult elderly grandpa older
-👴🏻	people	old man: light skin tone
-👴🏼	people	old man: medium-light skin tone
-👴🏽	people	old man: medium skin tone
-👴🏾	people	old man: medium-dark skin tone
-👴🏿	people	old man: dark skin tone
-👵	people	old woman human female women lady old elder senior adult elderly grandma nanna older
-👵🏻	people	old woman: light skin tone
-👵🏼	people	old woman: medium-light skin tone
-👵🏽	people	old woman: medium skin tone
-👵🏾	people	old woman: medium-dark skin tone
-👵🏿	people	old woman: dark skin tone
-🙍	people	person frowning worried frown gesture sad woman
-🙍🏻	people	person frowning: light skin tone
-🙍🏼	people	person frowning: medium-light skin tone
-🙍🏽	people	person frowning: medium skin tone
-🙍🏾	people	person frowning: medium-dark skin tone
-🙍🏿	people	person frowning: dark skin tone
-🙍‍♂️	people	man frowning male boy man sad depressed discouraged unhappy frown gesture men
-🙍🏻‍♂️	people	man frowning: light skin tone
-🙍🏼‍♂️	people	man frowning: medium-light skin tone
-🙍🏽‍♂️	people	man frowning: medium skin tone
-🙍🏾‍♂️	people	man frowning: medium-dark skin tone
-🙍🏿‍♂️	people	man frowning: dark skin tone
-🙍‍♀️	people	woman frowning female girl woman sad depressed discouraged unhappy frown gesture women
-🙍🏻‍♀️	people	woman frowning: light skin tone
-🙍🏼‍♀️	people	woman frowning: medium-light skin tone
-🙍🏽‍♀️	people	woman frowning: medium skin tone
-🙍🏾‍♀️	people	woman frowning: medium-dark skin tone
-🙍🏿‍♀️	people	woman frowning: dark skin tone
-🙎	people	person pouting upset blank face fed gesture look up
-🙎🏻	people	person pouting: light skin tone
-🙎🏼	people	person pouting: medium-light skin tone
-🙎🏽	people	person pouting: medium skin tone
-🙎🏾	people	person pouting: medium-dark skin tone
-🙎🏿	people	person pouting: dark skin tone
-🙎‍♂️	people	man pouting male boy man gesture men
-🙎🏻‍♂️	people	man pouting: light skin tone
-🙎🏼‍♂️	people	man pouting: medium-light skin tone
-🙎🏽‍♂️	people	man pouting: medium skin tone
-🙎🏾‍♂️	people	man pouting: medium-dark skin tone
-🙎🏿‍♂️	people	man pouting: dark skin tone
-🙎‍♀️	people	woman pouting female girl woman gesture women
-🙎🏻‍♀️	people	woman pouting: light skin tone
-🙎🏼‍♀️	people	woman pouting: medium-light skin tone
-🙎🏽‍♀️	people	woman pouting: medium skin tone
-🙎🏾‍♀️	people	woman pouting: medium-dark skin tone
-🙎🏿‍♀️	people	woman pouting: dark skin tone
-🙅	people	person gesturing no decline arms deal denied face forbidden gesture good halt hand not ok prohibited stop x
-🙅🏻	people	person gesturing no: light skin tone
-🙅🏼	people	person gesturing no: medium-light skin tone
-🙅🏽	people	person gesturing no: medium skin tone
-🙅🏾	people	person gesturing no: medium-dark skin tone
-🙅🏿	people	person gesturing no: dark skin tone
-🙅‍♂️	people	man gesturing no male boy man nope denied forbidden gesture good halt hand men ng not ok prohibited stop
-🙅🏻‍♂️	people	man gesturing no: light skin tone
-🙅🏼‍♂️	people	man gesturing no: medium-light skin tone
-🙅🏽‍♂️	people	man gesturing no: medium skin tone
-🙅🏾‍♂️	people	man gesturing no: medium-dark skin tone
-🙅🏿‍♂️	people	man gesturing no: dark skin tone
-🙅‍♀️	people	woman gesturing no female girl woman nope denied forbidden gesture good halt hand ng not ok prohibited stop women
-🙅🏻‍♀️	people	woman gesturing no: light skin tone
-🙅🏼‍♀️	people	woman gesturing no: medium-light skin tone
-🙅🏽‍♀️	people	woman gesturing no: medium skin tone
-🙅🏾‍♀️	people	woman gesturing no: medium-dark skin tone
-🙅🏿‍♀️	people	woman gesturing no: dark skin tone
-🙆	people	person gesturing ok agree ballerina face gesture hand hands head
-🙆🏻	people	person gesturing ok: light skin tone
-🙆🏼	people	person gesturing ok: medium-light skin tone
-🙆🏽	people	person gesturing ok: medium skin tone
-🙆🏾	people	person gesturing ok: medium-dark skin tone
-🙆🏿	people	person gesturing ok: dark skin tone
-🙆‍♂️	people	man gesturing ok men boy male blue human man gesture hand
-🙆🏻‍♂️	people	man gesturing ok: light skin tone
-🙆🏼‍♂️	people	man gesturing ok: medium-light skin tone
-🙆🏽‍♂️	people	man gesturing ok: medium skin tone
-🙆🏾‍♂️	people	man gesturing ok: medium-dark skin tone
-🙆🏿‍♂️	people	man gesturing ok: dark skin tone
-🙆‍♀️	people	woman gesturing ok women girl female pink human woman gesture hand
-🙆🏻‍♀️	people	woman gesturing ok: light skin tone
-🙆🏼‍♀️	people	woman gesturing ok: medium-light skin tone
-🙆🏽‍♀️	people	woman gesturing ok: medium skin tone
-🙆🏾‍♀️	people	woman gesturing ok: medium-dark skin tone
-🙆🏿‍♀️	people	woman gesturing ok: dark skin tone
-💁	people	person tipping hand information attendant bellhop concierge desk female flick girl hair help sassy woman women
-💁🏻	people	person tipping hand: light skin tone
-💁🏼	people	person tipping hand: medium-light skin tone
-💁🏽	people	person tipping hand: medium skin tone
-💁🏾	people	person tipping hand: medium-dark skin tone
-💁🏿	people	person tipping hand: dark skin tone
-💁‍♂️	people	man tipping hand male boy man human information desk help men sassy
-💁🏻‍♂️	people	man tipping hand: light skin tone
-💁🏼‍♂️	people	man tipping hand: medium-light skin tone
-💁🏽‍♂️	people	man tipping hand: medium skin tone
-💁🏾‍♂️	people	man tipping hand: medium-dark skin tone
-💁🏿‍♂️	people	man tipping hand: dark skin tone
-💁‍♀️	people	woman tipping hand female girl woman human information desk help sassy women
-💁🏻‍♀️	people	woman tipping hand: light skin tone
-💁🏼‍♀️	people	woman tipping hand: medium-light skin tone
-💁🏽‍♀️	people	woman tipping hand: medium skin tone
-💁🏾‍♀️	people	woman tipping hand: medium-dark skin tone
-💁🏿‍♀️	people	woman tipping hand: dark skin tone
-🙋	people	person raising hand question answering gesture happy one raised up
-🙋🏻	people	person raising hand: light skin tone
-🙋🏼	people	person raising hand: medium-light skin tone
-🙋🏽	people	person raising hand: medium skin tone
-🙋🏾	people	person raising hand: medium-dark skin tone
-🙋🏿	people	person raising hand: dark skin tone
-🙋‍♂️	people	man raising hand male boy man gesture happy men one raised
-🙋🏻‍♂️	people	man raising hand: light skin tone
-🙋🏼‍♂️	people	man raising hand: medium-light skin tone
-🙋🏽‍♂️	people	man raising hand: medium skin tone
-🙋🏾‍♂️	people	man raising hand: medium-dark skin tone
-🙋🏿‍♂️	people	man raising hand: dark skin tone
-🙋‍♀️	people	woman raising hand female girl woman gesture happy one raised women
-🙋🏻‍♀️	people	woman raising hand: light skin tone
-🙋🏼‍♀️	people	woman raising hand: medium-light skin tone
-🙋🏽‍♀️	people	woman raising hand: medium skin tone
-🙋🏾‍♀️	people	woman raising hand: medium-dark skin tone
-🙋🏿‍♀️	people	woman raising hand: dark skin tone
-🧏	people	deaf person accessibility ear hear
-🧏🏻	people	deaf person: light skin tone
-🧏🏼	people	deaf person: medium-light skin tone
-🧏🏽	people	deaf person: medium skin tone
-🧏🏾	people	deaf person: medium-dark skin tone
-🧏🏿	people	deaf person: dark skin tone
-🧏‍♂️	people	deaf man accessibility male men
-🧏🏻‍♂️	people	deaf man: light skin tone
-🧏🏼‍♂️	people	deaf man: medium-light skin tone
-🧏🏽‍♂️	people	deaf man: medium skin tone
-🧏🏾‍♂️	people	deaf man: medium-dark skin tone
-🧏🏿‍♂️	people	deaf man: dark skin tone
-🧏‍♀️	people	deaf woman accessibility female women
-🧏🏻‍♀️	people	deaf woman: light skin tone
-🧏🏼‍♀️	people	deaf woman: medium-light skin tone
-🧏🏽‍♀️	people	deaf woman: medium skin tone
-🧏🏾‍♀️	people	deaf woman: medium-dark skin tone
-🧏🏿‍♀️	people	deaf woman: dark skin tone
-🙇	people	person bowing respectiful apology bow boy cute deeply dogeza gesture man massage respect sorry thanks
-🙇🏻	people	person bowing: light skin tone
-🙇🏼	people	person bowing: medium-light skin tone
-🙇🏽	people	person bowing: medium skin tone
-🙇🏾	people	person bowing: medium-dark skin tone
-🙇🏿	people	person bowing: dark skin tone
-🙇‍♂️	people	man bowing man male boy apology bow deeply favor gesture men respect sorry thanks
-🙇🏻‍♂️	people	man bowing: light skin tone
-🙇🏼‍♂️	people	man bowing: medium-light skin tone
-🙇🏽‍♂️	people	man bowing: medium skin tone
-🙇🏾‍♂️	people	man bowing: medium-dark skin tone
-🙇🏿‍♂️	people	man bowing: dark skin tone
-🙇‍♀️	people	woman bowing woman female girl apology bow deeply favor gesture respect sorry thanks women
-🙇🏻‍♀️	people	woman bowing: light skin tone
-🙇🏼‍♀️	people	woman bowing: medium-light skin tone
-🙇🏽‍♀️	people	woman bowing: medium skin tone
-🙇🏾‍♀️	people	woman bowing: medium-dark skin tone
-🙇🏿‍♀️	people	woman bowing: dark skin tone
-🤦	people	person facepalming disappointed disbelief exasperation face facepalm head hitting palm picard smh
-🤦🏻	people	person facepalming: light skin tone
-🤦🏼	people	person facepalming: medium-light skin tone
-🤦🏽	people	person facepalming: medium skin tone
-🤦🏾	people	person facepalming: medium-dark skin tone
-🤦🏿	people	person facepalming: dark skin tone
-🤦‍♂️	people	man facepalming man male boy disbelief exasperation face facepalm men palm
-🤦🏻‍♂️	people	man facepalming: light skin tone
-🤦🏼‍♂️	people	man facepalming: medium-light skin tone
-🤦🏽‍♂️	people	man facepalming: medium skin tone
-🤦🏾‍♂️	people	man facepalming: medium-dark skin tone
-🤦🏿‍♂️	people	man facepalming: dark skin tone
-🤦‍♀️	people	woman facepalming woman female girl disbelief exasperation face facepalm palm women
-🤦🏻‍♀️	people	woman facepalming: light skin tone
-🤦🏼‍♀️	people	woman facepalming: medium-light skin tone
-🤦🏽‍♀️	people	woman facepalming: medium skin tone
-🤦🏾‍♀️	people	woman facepalming: medium-dark skin tone
-🤦🏿‍♀️	people	woman facepalming: dark skin tone
-🤷	people	person shrugging regardless doubt ignorance indifference shrug shruggie ¯\
-🤷🏻	people	person shrugging: light skin tone
-🤷🏼	people	person shrugging: medium-light skin tone
-🤷🏽	people	person shrugging: medium skin tone
-🤷🏾	people	person shrugging: medium-dark skin tone
-🤷🏿	people	person shrugging: dark skin tone
-🤷‍♂️	people	man shrugging man male boy confused indifferent doubt ignorance indifference men shrug
-🤷🏻‍♂️	people	man shrugging: light skin tone
-🤷🏼‍♂️	people	man shrugging: medium-light skin tone
-🤷🏽‍♂️	people	man shrugging: medium skin tone
-🤷🏾‍♂️	people	man shrugging: medium-dark skin tone
-🤷🏿‍♂️	people	man shrugging: dark skin tone
-🤷‍♀️	people	woman shrugging woman female girl confused indifferent doubt ignorance indifference shrug women
-🤷🏻‍♀️	people	woman shrugging: light skin tone
-🤷🏼‍♀️	people	woman shrugging: medium-light skin tone
-🤷🏽‍♀️	people	woman shrugging: medium skin tone
-🤷🏾‍♀️	people	woman shrugging: medium-dark skin tone
-🤷🏿‍♀️	people	woman shrugging: dark skin tone
-🧑‍⚕️	people	health worker hospital dentist doctor healthcare md nurse physician professional therapist
-🧑🏻‍⚕️	people	health worker: light skin tone
-🧑🏼‍⚕️	people	health worker: medium-light skin tone
-🧑🏽‍⚕️	people	health worker: medium skin tone
-🧑🏾‍⚕️	people	health worker: medium-dark skin tone
-🧑🏿‍⚕️	people	health worker: dark skin tone
-👨‍⚕️	people	man health worker doctor nurse therapist healthcare man human dentist male md men physician professional
-👨🏻‍⚕️	people	man health worker: light skin tone
-👨🏼‍⚕️	people	man health worker: medium-light skin tone
-👨🏽‍⚕️	people	man health worker: medium skin tone
-👨🏾‍⚕️	people	man health worker: medium-dark skin tone
-👨🏿‍⚕️	people	man health worker: dark skin tone
-👩‍⚕️	people	woman health worker doctor nurse therapist healthcare woman human dentist female md physician professional women
-👩🏻‍⚕️	people	woman health worker: light skin tone
-👩🏼‍⚕️	people	woman health worker: medium-light skin tone
-👩🏽‍⚕️	people	woman health worker: medium skin tone
-👩🏾‍⚕️	people	woman health worker: medium-dark skin tone
-👩🏿‍⚕️	people	woman health worker: dark skin tone
-🧑‍🎓	people	student learn education graduate pupil school
-🧑🏻‍🎓	people	student: light skin tone
-🧑🏼‍🎓	people	student: medium-light skin tone
-🧑🏽‍🎓	people	student: medium skin tone
-🧑🏾‍🎓	people	student: medium-dark skin tone
-🧑🏿‍🎓	people	student: dark skin tone
-👨‍🎓	people	man student graduate man human education graduation male men pupil school
-👨🏻‍🎓	people	man student: light skin tone
-👨🏼‍🎓	people	man student: medium-light skin tone
-👨🏽‍🎓	people	man student: medium skin tone
-👨🏾‍🎓	people	man student: medium-dark skin tone
-👨🏿‍🎓	people	man student: dark skin tone
-👩‍🎓	people	woman student graduate woman human education female graduation pupil school women
-👩🏻‍🎓	people	woman student: light skin tone
-👩🏼‍🎓	people	woman student: medium-light skin tone
-👩🏽‍🎓	people	woman student: medium skin tone
-👩🏾‍🎓	people	woman student: medium-dark skin tone
-👩🏿‍🎓	people	woman student: dark skin tone
-🧑‍🏫	people	teacher professor education educator instructor
-🧑🏻‍🏫	people	teacher: light skin tone
-🧑🏼‍🏫	people	teacher: medium-light skin tone
-🧑🏽‍🏫	people	teacher: medium skin tone
-🧑🏾‍🏫	people	teacher: medium-dark skin tone
-🧑🏿‍🏫	people	teacher: dark skin tone
-👨‍🏫	people	man teacher instructor professor man human education educator male men school
-👨🏻‍🏫	people	man teacher: light skin tone
-👨🏼‍🏫	people	man teacher: medium-light skin tone
-👨🏽‍🏫	people	man teacher: medium skin tone
-👨🏾‍🏫	people	man teacher: medium-dark skin tone
-👨🏿‍🏫	people	man teacher: dark skin tone
-👩‍🏫	people	woman teacher instructor professor woman human education educator female school women
-👩🏻‍🏫	people	woman teacher: light skin tone
-👩🏼‍🏫	people	woman teacher: medium-light skin tone
-👩🏽‍🏫	people	woman teacher: medium skin tone
-👩🏾‍🏫	people	woman teacher: medium-dark skin tone
-👩🏿‍🏫	people	woman teacher: dark skin tone
-🧑‍⚖️	people	judge law court justice scales
-🧑🏻‍⚖️	people	judge: light skin tone
-🧑🏼‍⚖️	people	judge: medium-light skin tone
-🧑🏽‍⚖️	people	judge: medium skin tone
-🧑🏾‍⚖️	people	judge: medium-dark skin tone
-🧑🏿‍⚖️	people	judge: dark skin tone
-👨‍⚖️	people	man judge justice court man human law male men scales
-👨🏻‍⚖️	people	man judge: light skin tone
-👨🏼‍⚖️	people	man judge: medium-light skin tone
-👨🏽‍⚖️	people	man judge: medium skin tone
-👨🏾‍⚖️	people	man judge: medium-dark skin tone
-👨🏿‍⚖️	people	man judge: dark skin tone
-👩‍⚖️	people	woman judge justice court woman human female law scales women
-👩🏻‍⚖️	people	woman judge: light skin tone
-👩🏼‍⚖️	people	woman judge: medium-light skin tone
-👩🏽‍⚖️	people	woman judge: medium skin tone
-👩🏾‍⚖️	people	woman judge: medium-dark skin tone
-👩🏿‍⚖️	people	woman judge: dark skin tone
-🧑‍🌾	people	farmer crops farm farming gardener rancher worker
-🧑🏻‍🌾	people	farmer: light skin tone
-🧑🏼‍🌾	people	farmer: medium-light skin tone
-🧑🏽‍🌾	people	farmer: medium skin tone
-🧑🏾‍🌾	people	farmer: medium-dark skin tone
-🧑🏿‍🌾	people	farmer: dark skin tone
-👨‍🌾	people	man farmer rancher gardener man human farm farming male men worker
-👨🏻‍🌾	people	man farmer: light skin tone
-👨🏼‍🌾	people	man farmer: medium-light skin tone
-👨🏽‍🌾	people	man farmer: medium skin tone
-👨🏾‍🌾	people	man farmer: medium-dark skin tone
-👨🏿‍🌾	people	man farmer: dark skin tone
-👩‍🌾	people	woman farmer rancher gardener woman human farm farming female women worker
-👩🏻‍🌾	people	woman farmer: light skin tone
-👩🏼‍🌾	people	woman farmer: medium-light skin tone
-👩🏽‍🌾	people	woman farmer: medium skin tone
-👩🏾‍🌾	people	woman farmer: medium-dark skin tone
-👩🏿‍🌾	people	woman farmer: dark skin tone
-🧑‍🍳	people	cook food kitchen culinary chef cooking service
-🧑🏻‍🍳	people	cook: light skin tone
-🧑🏼‍🍳	people	cook: medium-light skin tone
-🧑🏽‍🍳	people	cook: medium skin tone
-🧑🏾‍🍳	people	cook: medium-dark skin tone
-🧑🏿‍🍳	people	cook: dark skin tone
-👨‍🍳	people	man cook chef man human cooking food male men service
-👨🏻‍🍳	people	man cook: light skin tone
-👨🏼‍🍳	people	man cook: medium-light skin tone
-👨🏽‍🍳	people	man cook: medium skin tone
-👨🏾‍🍳	people	man cook: medium-dark skin tone
-👨🏿‍🍳	people	man cook: dark skin tone
-👩‍🍳	people	woman cook chef woman human cooking female food service women
-👩🏻‍🍳	people	woman cook: light skin tone
-👩🏼‍🍳	people	woman cook: medium-light skin tone
-👩🏽‍🍳	people	woman cook: medium skin tone
-👩🏾‍🍳	people	woman cook: medium-dark skin tone
-👩🏿‍🍳	people	woman cook: dark skin tone
-🧑‍🔧	people	mechanic worker technician electrician person plumber repair tradesperson
-🧑🏻‍🔧	people	mechanic: light skin tone
-🧑🏼‍🔧	people	mechanic: medium-light skin tone
-🧑🏽‍🔧	people	mechanic: medium skin tone
-🧑🏾‍🔧	people	mechanic: medium-dark skin tone
-🧑🏿‍🔧	people	mechanic: dark skin tone
-👨‍🔧	people	man mechanic plumber man human wrench electrician male men person repair tradesperson
-👨🏻‍🔧	people	man mechanic: light skin tone
-👨🏼‍🔧	people	man mechanic: medium-light skin tone
-👨🏽‍🔧	people	man mechanic: medium skin tone
-👨🏾‍🔧	people	man mechanic: medium-dark skin tone
-👨🏿‍🔧	people	man mechanic: dark skin tone
-👩‍🔧	people	woman mechanic plumber woman human wrench electrician female person repair tradesperson women
-👩🏻‍🔧	people	woman mechanic: light skin tone
-👩🏼‍🔧	people	woman mechanic: medium-light skin tone
-👩🏽‍🔧	people	woman mechanic: medium skin tone
-👩🏾‍🔧	people	woman mechanic: medium-dark skin tone
-👩🏿‍🔧	people	woman mechanic: dark skin tone
-🧑‍🏭	people	factory worker labor assembly industrial welder
-🧑🏻‍🏭	people	factory worker: light skin tone
-🧑🏼‍🏭	people	factory worker: medium-light skin tone
-🧑🏽‍🏭	people	factory worker: medium skin tone
-🧑🏾‍🏭	people	factory worker: medium-dark skin tone
-🧑🏿‍🏭	people	factory worker: dark skin tone
-👨‍🏭	people	man factory worker assembly industrial man human male men welder
-👨🏻‍🏭	people	man factory worker: light skin tone
-👨🏼‍🏭	people	man factory worker: medium-light skin tone
-👨🏽‍🏭	people	man factory worker: medium skin tone
-👨🏾‍🏭	people	man factory worker: medium-dark skin tone
-👨🏿‍🏭	people	man factory worker: dark skin tone
-👩‍🏭	people	woman factory worker assembly industrial woman human female welder women
-👩🏻‍🏭	people	woman factory worker: light skin tone
-👩🏼‍🏭	people	woman factory worker: medium-light skin tone
-👩🏽‍🏭	people	woman factory worker: medium skin tone
-👩🏾‍🏭	people	woman factory worker: medium-dark skin tone
-👩🏿‍🏭	people	woman factory worker: dark skin tone
-🧑‍💼	people	office worker business accountant adviser analyst architect banker clerk manager
-🧑🏻‍💼	people	office worker: light skin tone
-🧑🏼‍💼	people	office worker: medium-light skin tone
-🧑🏽‍💼	people	office worker: medium skin tone
-🧑🏾‍💼	people	office worker: medium-dark skin tone
-🧑🏿‍💼	people	office worker: dark skin tone
-👨‍💼	people	man office worker business manager man human accountant adviser analyst architect banker businessman ceo clerk male men
-👨🏻‍💼	people	man office worker: light skin tone
-👨🏼‍💼	people	man office worker: medium-light skin tone
-👨🏽‍💼	people	man office worker: medium skin tone
-👨🏾‍💼	people	man office worker: medium-dark skin tone
-👨🏿‍💼	people	man office worker: dark skin tone
-👩‍💼	people	woman office worker business manager woman human accountant adviser analyst architect banker businesswoman ceo clerk female women
-👩🏻‍💼	people	woman office worker: light skin tone
-👩🏼‍💼	people	woman office worker: medium-light skin tone
-👩🏽‍💼	people	woman office worker: medium skin tone
-👩🏾‍💼	people	woman office worker: medium-dark skin tone
-👩🏿‍💼	people	woman office worker: dark skin tone
-🧑‍🔬	people	scientist chemistry biologist chemist engineer lab mathematician physicist technician
-🧑🏻‍🔬	people	scientist: light skin tone
-🧑🏼‍🔬	people	scientist: medium-light skin tone
-🧑🏽‍🔬	people	scientist: medium skin tone
-🧑🏾‍🔬	people	scientist: medium-dark skin tone
-🧑🏿‍🔬	people	scientist: dark skin tone
-👨‍🔬	people	man scientist biologist chemist engineer physicist man human lab male mathematician men research technician
-👨🏻‍🔬	people	man scientist: light skin tone
-👨🏼‍🔬	people	man scientist: medium-light skin tone
-👨🏽‍🔬	people	man scientist: medium skin tone
-👨🏾‍🔬	people	man scientist: medium-dark skin tone
-👨🏿‍🔬	people	man scientist: dark skin tone
-👩‍🔬	people	woman scientist biologist chemist engineer physicist woman human female lab mathematician research technician women
-👩🏻‍🔬	people	woman scientist: light skin tone
-👩🏼‍🔬	people	woman scientist: medium-light skin tone
-👩🏽‍🔬	people	woman scientist: medium skin tone
-👩🏾‍🔬	people	woman scientist: medium-dark skin tone
-👩🏿‍🔬	people	woman scientist: dark skin tone
-🧑‍💻	people	technologist computer coder engineer laptop software technology developer
-🧑🏻‍💻	people	technologist: light skin tone
-🧑🏼‍💻	people	technologist: medium-light skin tone
-🧑🏽‍💻	people	technologist: medium skin tone
-🧑🏾‍💻	people	technologist: medium-dark skin tone
-🧑🏿‍💻	people	technologist: dark skin tone
-👨‍💻	people	man technologist coder developer engineer programmer software man human laptop computer blogger male men technology
-👨🏻‍💻	people	man technologist: light skin tone
-👨🏼‍💻	people	man technologist: medium-light skin tone
-👨🏽‍💻	people	man technologist: medium skin tone
-👨🏾‍💻	people	man technologist: medium-dark skin tone
-👨🏿‍💻	people	man technologist: dark skin tone
-👩‍💻	people	woman technologist coder developer engineer programmer software woman human laptop computer blogger female technology women
-👩🏻‍💻	people	woman technologist: light skin tone
-👩🏼‍💻	people	woman technologist: medium-light skin tone
-👩🏽‍💻	people	woman technologist: medium skin tone
-👩🏾‍💻	people	woman technologist: medium-dark skin tone
-👩🏿‍💻	people	woman technologist: dark skin tone
-🧑‍🎤	people	singer song artist performer actor entertainer music musician rock rocker rockstar star
-🧑🏻‍🎤	people	singer: light skin tone
-🧑🏼‍🎤	people	singer: medium-light skin tone
-🧑🏽‍🎤	people	singer: medium skin tone
-🧑🏾‍🎤	people	singer: medium-dark skin tone
-🧑🏿‍🎤	people	singer: dark skin tone
-👨‍🎤	people	man singer rockstar entertainer man human actor aladdin bowie male men music musician rock rocker sane star
-👨🏻‍🎤	people	man singer: light skin tone
-👨🏼‍🎤	people	man singer: medium-light skin tone
-👨🏽‍🎤	people	man singer: medium skin tone
-👨🏾‍🎤	people	man singer: medium-dark skin tone
-👨🏿‍🎤	people	man singer: dark skin tone
-👩‍🎤	people	woman singer rockstar entertainer woman human actor female music musician rock rocker star women
-👩🏻‍🎤	people	woman singer: light skin tone
-👩🏼‍🎤	people	woman singer: medium-light skin tone
-👩🏽‍🎤	people	woman singer: medium skin tone
-👩🏾‍🎤	people	woman singer: medium-dark skin tone
-👩🏿‍🎤	people	woman singer: dark skin tone
-🧑‍🎨	people	artist painting draw creativity art paint painter palette
-🧑🏻‍🎨	people	artist: light skin tone
-🧑🏼‍🎨	people	artist: medium-light skin tone
-🧑🏽‍🎨	people	artist: medium skin tone
-🧑🏾‍🎨	people	artist: medium-dark skin tone
-🧑🏿‍🎨	people	artist: dark skin tone
-👨‍🎨	people	man artist painter man human art male men paint palette
-👨🏻‍🎨	people	man artist: light skin tone
-👨🏼‍🎨	people	man artist: medium-light skin tone
-👨🏽‍🎨	people	man artist: medium skin tone
-👨🏾‍🎨	people	man artist: medium-dark skin tone
-👨🏿‍🎨	people	man artist: dark skin tone
-👩‍🎨	people	woman artist painter woman human art female paint palette women
-👩🏻‍🎨	people	woman artist: light skin tone
-👩🏼‍🎨	people	woman artist: medium-light skin tone
-👩🏽‍🎨	people	woman artist: medium skin tone
-👩🏾‍🎨	people	woman artist: medium-dark skin tone
-👩🏿‍🎨	people	woman artist: dark skin tone
-🧑‍✈️	people	pilot fly plane airplane aviation aviator
-🧑🏻‍✈️	people	pilot: light skin tone
-🧑🏼‍✈️	people	pilot: medium-light skin tone
-🧑🏽‍✈️	people	pilot: medium skin tone
-🧑🏾‍✈️	people	pilot: medium-dark skin tone
-🧑🏿‍✈️	people	pilot: dark skin tone
-👨‍✈️	people	man pilot aviator plane man human airplane aviation male men
-👨🏻‍✈️	people	man pilot: light skin tone
-👨🏼‍✈️	people	man pilot: medium-light skin tone
-👨🏽‍✈️	people	man pilot: medium skin tone
-👨🏾‍✈️	people	man pilot: medium-dark skin tone
-👨🏿‍✈️	people	man pilot: dark skin tone
-👩‍✈️	people	woman pilot aviator plane woman human airplane aviation female women
-👩🏻‍✈️	people	woman pilot: light skin tone
-👩🏼‍✈️	people	woman pilot: medium-light skin tone
-👩🏽‍✈️	people	woman pilot: medium skin tone
-👩🏾‍✈️	people	woman pilot: medium-dark skin tone
-👩🏿‍✈️	people	woman pilot: dark skin tone
-🧑‍🚀	people	astronaut outerspace moon planets rocket space stars
-🧑🏻‍🚀	people	astronaut: light skin tone
-🧑🏼‍🚀	people	astronaut: medium-light skin tone
-🧑🏽‍🚀	people	astronaut: medium skin tone
-🧑🏾‍🚀	people	astronaut: medium-dark skin tone
-🧑🏿‍🚀	people	astronaut: dark skin tone
-👨‍🚀	people	man astronaut space rocket man human cosmonaut male men moon planets stars
-👨🏻‍🚀	people	man astronaut: light skin tone
-👨🏼‍🚀	people	man astronaut: medium-light skin tone
-👨🏽‍🚀	people	man astronaut: medium skin tone
-👨🏾‍🚀	people	man astronaut: medium-dark skin tone
-👨🏿‍🚀	people	man astronaut: dark skin tone
-👩‍🚀	people	woman astronaut space rocket woman human cosmonaut female moon planets stars women
-👩🏻‍🚀	people	woman astronaut: light skin tone
-👩🏼‍🚀	people	woman astronaut: medium-light skin tone
-👩🏽‍🚀	people	woman astronaut: medium skin tone
-👩🏾‍🚀	people	woman astronaut: medium-dark skin tone
-👩🏿‍🚀	people	woman astronaut: dark skin tone
+😀	smileys	grinning face cheerful cheery grin happy laugh nice smile smiling teeth
+😃	smileys	grinning face with big eyes awesome grin happy mouth open smile smiling teeth yay
+😄	smileys	grinning face with smiling eyes eye grin happy laugh lol mouth open smile
+😁	smileys	beaming face with smiling eyes eye grin grinning happy nice smile teeth
+😆	smileys	grinning squinting face closed eyes haha hahaha happy laugh lol mouth open rofl smile smiling
+😅	smileys	grinning face with sweat cold dejected excited mouth nervous open smile smiling stress stressed
+🤣	smileys	rolling on the floor laughing crying face funny haha happy hehe hilarious joy laugh lmao lol rofl roflmao tear
+😂	smileys	face with tears of joy crying feels funny haha happy hehe hilarious laugh lmao lol rofl roflmao tear
+🙂	smileys	slightly smiling face happy smile
+🙃	smileys	upside down face hehe smile
+🫠	smileys	melting face disappear dissolve embarrassed haha heat hot liquid lol melt sarcasm sarcastic
+😉	smileys	winking face flirt heartbreaker sexy slide tease wink winks
+😊	smileys	smiling face with eyes blush eye glad satisfied smile
+😇	smileys	smiling face with halo angel angelic angels blessed fairy fairytale fantasy happy innocent peaceful smile spirit tale
+🥰	smileys	smiling face with hearts 3 adore crush heart ily love romance smile you
+😍	smileys	smiling face with heart eyes 143 bae eye feels hearts ily kisses love romance romantic smile xoxo
+🤩	smileys	star struck excited eyes face grinning smile starry eyed wow
+😘	smileys	face blowing a kiss adorbs bae flirt heart ily love lover miss muah romantic smooch xoxo you
+😗	smileys	kissing face 143 date dating flirt ily kiss love smooch smooches xoxo you
+☺️	smileys	smiling face happy outlined relaxed smile
+😚	smileys	kissing face with closed eyes 143 bae blush date dating eye flirt ily kisses smooches xoxo
+😙	smileys	kissing face with smiling eyes 143 closed date dating eye flirt ily kiss kisses love night smile
+🥲	smileys	smiling face with tear glad grateful happy joy pain proud relieved smile smiley touched
+😋	smileys	face savoring food delicious eat full hungry savor smile smiling tasty um yum yummy
+😛	smileys	face with tongue awesome cool nice party stuck out sweet
+😜	smileys	winking face with tongue crazy epic eye funny joke loopy nutty party stuck out wacky weirdo wink yolo
+🤪	smileys	zany face crazy eye eyes goofy large small
+😝	smileys	squinting face with tongue closed eye eyes gross horrible omg stuck out taste whatever yolo
+🤑	smileys	money mouth face paid
+🤗	smileys	smiling face with open hands hug hugging
+🤭	smileys	face with hand over mouth giggle giggling oops realization secret shock sudden surprise whoops
+🫢	smileys	face with open eyes and hand over mouth amazement awe disbelief embarrass gasp omg quiet scared shock surprise
+🫣	smileys	face with peeking eye captivated embarrass hide hiding peek peep scared shy stare
+🤫	smileys	shushing face quiet shh shush
+🤔	smileys	thinking face chin consider hmm ponder pondering wondering
+🫡	smileys	saluting face good luck ma am ok respect salute sir troops yes
+🤐	smileys	zipper mouth face keep quiet secret shut zip
+🤨	smileys	face with raised eyebrow disapproval disbelief distrust emoji hmm mild skeptic skeptical skepticism surprise what
+😐	smileys	neutral face awkward blank deadpan expressionless fine jealous meh oh shade straight unamused unhappy unimpressed whatever
+😑	smileys	expressionless face awkward dead fine inexpressive jealous meh not oh omg straight uh unhappy unimpressed whatever
+😶	smileys	face without mouth awkward blank expressionless mouthless mute quiet secret silence silent speechless
+🫥	smileys	dotted line face depressed disappear hidden hide introvert invisible meh whatever wtv
+😶‍🌫️	smileys	face in clouds absentminded fog head
+😏	smileys	smirking face boss dapper flirt homie kidding leer shade slick sly smirk smug snicker suave suspicious swag
+😒	smileys	unamused face bored fine jealous jel jelly pissed smh ugh uhh unhappy weird whatever
+🙄	smileys	face with rolling eyes eyeroll shade ugh whatever
+😬	smileys	grimacing face awk awkward dentist grimace grinning smile smiling
+😮‍💨	smileys	face exhaling blow blowing exhale exhausted gasp groan relief sigh smiley smoke whisper whistle
+🤥	smileys	lying face liar lie pinocchio
+🫨	smileys	shaking face crazy daze earthquake omg panic shock surprise vibrate whoa wow
+🙂‍↔️	smileys	head shaking horizontally no shake
+🙂‍↕️	smileys	head shaking vertically nod yes
+😌	smileys	relieved face calm peace relief zen
+😔	smileys	pensive face awful bored dejected died disappointed losing lost sad sucks
+😪	smileys	sleepy face crying good night sad sleep sleeping tired
+🤤	smileys	drooling face
+😴	smileys	sleeping face bed bedtime good goodnight nap night sleep tired whatever yawn zzz
+🫩	smileys	face with bags under eyes bored exhausted fatigued late sleepy tired weary
+😷	smileys	face with medical mask cold dentist dermatologist doctor dr germs medicine sick
+🤒	smileys	face with thermometer ill sick
+🤕	smileys	face with head bandage hurt injury ouch
+🤢	smileys	nauseated face gross nasty sick vomit
+🤮	smileys	face vomiting barf ew gross puke sick spew throw up vomit
+🤧	smileys	sneezing face fever flu gesundheit sick sneeze
+🥵	smileys	hot face dying feverish heat panting red faced stroke sweating tongue
+🥶	smileys	cold face blue faced freezing frostbite icicles subzero teeth
+🥴	smileys	woozy face dizzy drunk eyes intoxicated mouth tipsy uneven wavy
+😵	smileys	face with crossed out eyes dead dizzy feels knocked sick tired
+😵‍💫	smileys	face with spiral eyes confused dizzy hypnotized omg smiley trouble whoa woah woozy
+🤯	smileys	exploding head blown explode mind mindblown no shocked way
+🤠	smileys	cowboy hat face cowgirl
+🥳	smileys	partying face bday birthday celebrate celebration excited happy hat hooray horn party
+🥸	smileys	disguised face disguise eyebrow glasses incognito moustache mustache nose person spy tache tash
+😎	smileys	smiling face with sunglasses awesome beach bright bro chilling cool rad relaxed shades slay smile style swag win
+🤓	smileys	nerd face brainy clever expert geek gifted glasses intelligent smart
+🧐	smileys	face with monocle classy fancy rich stuffy wealthy
+😕	smileys	confused face befuddled confusing dunno frown hm meh not sad sorry sure
+🫤	smileys	face with diagonal mouth confused confusion disappointed doubt doubtful frustrated frustration meh skeptical unsure whatever wtv
+😟	smileys	worried face anxious butterflies nerves nervous sad stress stressed surprised worry
+🙁	smileys	slightly frowning face frown sad
+☹️	smileys	frowning face frown sad
+😮	smileys	face with open mouth believe forgot omg shocked surprised sympathy unbelievable unreal whoa wow you
+😯	smileys	hushed face epic omg stunned surprised whoa woah
+😲	smileys	astonished face cost no omg shocked totally way
+😳	smileys	flushed face amazed awkward crazy dazed dead disbelief embarrassed geez heat hot impressed jeez what wow
+🥺	smileys	pleading face begging big eyes mercy not please pretty puppy sad why
+🥹	smileys	face holding back tears admiration aww cry embarrassed feelings grateful gratitude joy please proud resist sad
+😦	smileys	frowning face with open mouth caught frown guard scared scary surprise what wow
+😧	smileys	anguished face forgot scared scary stressed surprise unhappy what wow
+😨	smileys	fearful face afraid anxious blame fear scared worried
+😰	smileys	anxious face with sweat blue cold eek mouth nervous open rushed scared yikes
+😥	smileys	sad but relieved face anxious call close complicated disappointed not sweat time whew
+😢	smileys	crying face awful cry feels miss sad tear triste unhappy
+😭	smileys	loudly crying face bawling cry sad sob tear tears unhappy
+😱	smileys	face screaming in fear epic fearful munch scared scream screamer shocked surprised woah
+😖	smileys	confounded face annoyed confused cringe distraught feels frustrated mad sad
+😣	smileys	persevering face concentrate concentration focus headache persevere
+😞	smileys	disappointed face awful blame dejected fail losing sad unhappy
+😓	smileys	downcast face with sweat close cold feels headache nervous sad scared yikes
+😩	smileys	weary face crying fail feels hungry mad nooo sad sleepy tired unhappy
+😫	smileys	tired face cost feels nap sad sneeze
+🥱	smileys	yawning face bedtime bored goodnight nap night sleep sleepy tired whatever yawn zzz
+😤	smileys	face with steam from nose anger angry feels fume fuming furious fury mad triumph unhappy won
+😡	smileys	enraged face anger angry feels mad maddening pouting rage red shade unhappy upset
+😠	smileys	angry face anger blame feels frustrated mad maddening rage shade unhappy upset
+🤬	smileys	face with symbols on mouth censor cursing cussing mad pissed swearing
+😈	smileys	smiling face with horns demon devil evil fairy fairytale fantasy purple shade smile tale
+👿	smileys	angry face with horns demon devil evil fairy fairytale fantasy imp mischievous purple shade tale
+💀	smileys	skull body dead death face fairy fairytale i m lmao monster tale yolo
+☠️	smileys	skull and crossbones bone dead death face monster
+💩	smileys	pile of poo bs comic doo dung face fml monster poop smelly smh stink stinks stinky turd
+🤡	smileys	clown face
+👹	smileys	ogre creature devil face fairy fairytale fantasy mask monster scary tale
+👺	smileys	goblin angry creature face fairy fairytale fantasy mask mean monster tale
+👻	smileys	ghost boo creature excited face fairy fairytale fantasy halloween haunting monster scary silly tale
+👽	smileys	alien creature extraterrestrial face fairy fairytale fantasy monster space tale ufo
+👾	smileys	alien monster creature extraterrestrial face fairy fairytale fantasy game gamer games pixelated space tale ufo
+🤖	smileys	robot face monster
+😺	smileys	grinning cat animal face mouth open smile smiling
+😸	smileys	grinning cat with smiling eyes animal eye face grin smile
+😹	smileys	cat with tears of joy animal face laugh laughing lol tear
+😻	smileys	smiling cat with heart eyes animal eye face love smile
+😼	smileys	cat with wry smile animal face ironic
+😽	smileys	kissing cat animal closed eye eyes face kiss
+🙀	smileys	weary cat animal face oh surprised
+😿	smileys	crying cat animal cry face sad tear
+😾	smileys	pouting cat animal face
+🙈	smileys	see no evil monkey embarrassed face forbidden forgot gesture hide omg prohibited scared secret smh watch
+🙉	smileys	hear no evil monkey animal ears face forbidden gesture listen not prohibited secret shh tmi
+🙊	smileys	speak no evil monkey animal face forbidden gesture not oops prohibited quiet secret stealth
+💌	smileys	love letter heart mail romance valentine
+💘	smileys	heart with arrow 143 adorbs cupid date emotion ily love romance valentine
+💝	smileys	heart with ribbon 143 anniversary emotion ily kisses valentine xoxo
+💖	smileys	sparkling heart 143 emotion excited good ily kisses morning night sparkle xoxo
+💗	smileys	growing heart 143 emotion excited heartpulse ily kisses muah nervous pulse xoxo
+💓	smileys	beating heart 143 cardio emotion heartbeat ily love pulsating pulse
+💞	smileys	revolving hearts 143 adorbs anniversary emotion heart
+💕	smileys	two hearts 143 anniversary date dating emotion heart ily kisses love loving xoxo
+💟	smileys	heart decoration 143 emotion hearth purple white
+❣️	smileys	heart exclamation heavy mark punctuation
+💔	smileys	broken heart break crushed emotion heartbroken lonely sad
+❤️‍🔥	smileys	heart on fire burn love lust sacred
+❤️‍🩹	smileys	mending heart healthier improving recovering recuperating well
+❤️	smileys	red heart emotion love
+🩷	smileys	pink heart 143 adorable cute emotion ily like love special sweet
+🧡	smileys	orange heart 143
+💛	smileys	yellow heart 143 cardiac emotion ily love
+💚	smileys	green heart 143 emotion ily love romantic
+💙	smileys	blue heart 143 emotion ily love romance
+🩵	smileys	light blue heart 143 cute cyan emotion ily like love sky special teal
+💜	smileys	purple heart 143 bestest emotion ily love
+🤎	smileys	brown heart 143
+🖤	smileys	black heart evil wicked
+🩶	smileys	grey heart 143 emotion gray ily love silver slate special
+🤍	smileys	white heart 143
+💋	smileys	kiss mark dating emotion heart kissing lips romance sexy
+💯	smileys	hundred points 100 a agree clearly definitely faithful fleek full keep perfect point score true truth yup
+💢	smileys	anger symbol angry comic mad upset
+💥	smileys	collision bomb boom collide comic explode
+💫	smileys	dizzy comic shining shooting star stars
+💦	smileys	sweat droplets comic drip droplet drops splashing squirt water wet work workout
+💨	smileys	dashing away cloud comic dash fart fast go gone gotta running smoke
+🕳️	smileys	hole
+💬	smileys	speech balloon bubble comic dialog message sms talk text typing
+👁️‍🗨️	smileys	eye in speech bubble balloon witness
+🗨️	smileys	left speech bubble balloon dialog
+🗯️	smileys	right anger bubble angry balloon mad
+💭	smileys	thought balloon bubble cartoon cloud comic daydream decisions dream idea invent invention realize think thoughts wonder
+💤	smileys	zzz comic good goodnight night sleep sleeping sleepy tired
+👋	people	waving hand bye cya g2g greetings gtg hello hey hi later outtie ttfn ttyl wave yo you
+👋🏻	people	waving hand light skin tone bye cya g2g greetings gtg hello hey hi later outtie ttfn ttyl wave yo you
+👋🏼	people	waving hand medium light skin tone bye cya g2g greetings gtg hello hey hi later outtie ttfn ttyl wave yo you
+👋🏽	people	waving hand medium skin tone bye cya g2g greetings gtg hello hey hi later outtie ttfn ttyl wave yo you
+👋🏾	people	waving hand medium dark skin tone bye cya g2g greetings gtg hello hey hi later outtie ttfn ttyl wave yo you
+👋🏿	people	waving hand dark skin tone bye cya g2g greetings gtg hello hey hi later outtie ttfn ttyl wave yo you
+🤚	people	raised back of hand backhand
+🤚🏻	people	raised back of hand light skin tone backhand
+🤚🏼	people	raised back of hand medium light skin tone backhand
+🤚🏽	people	raised back of hand medium skin tone backhand
+🤚🏾	people	raised back of hand medium dark skin tone backhand
+🤚🏿	people	raised back of hand dark skin tone backhand
+🖐️	people	hand with fingers splayed finger raised stop
+🖐🏻	people	hand with fingers splayed light skin tone finger raised stop
+🖐🏼	people	hand with fingers splayed medium light skin tone finger raised stop
+🖐🏽	people	hand with fingers splayed medium skin tone finger raised stop
+🖐🏾	people	hand with fingers splayed medium dark skin tone finger raised stop
+🖐🏿	people	hand with fingers splayed dark skin tone finger raised stop
+✋	people	raised hand 5 five high stop
+✋🏻	people	raised hand light skin tone 5 five high stop
+✋🏼	people	raised hand medium light skin tone 5 five high stop
+✋🏽	people	raised hand medium skin tone 5 five high stop
+✋🏾	people	raised hand medium dark skin tone 5 five high stop
+✋🏿	people	raised hand dark skin tone 5 five high stop
+🖖	people	vulcan salute finger hand hands
+🖖🏻	people	vulcan salute light skin tone finger hand hands
+🖖🏼	people	vulcan salute medium light skin tone finger hand hands
+🖖🏽	people	vulcan salute medium skin tone finger hand hands
+🖖🏾	people	vulcan salute medium dark skin tone finger hand hands
+🖖🏿	people	vulcan salute dark skin tone finger hand hands
+🫱	people	rightwards hand handshake hold reach right rightward shake
+🫱🏻	people	rightwards hand light skin tone handshake hold reach right rightward shake
+🫱🏼	people	rightwards hand medium light skin tone handshake hold reach right rightward shake
+🫱🏽	people	rightwards hand medium skin tone handshake hold reach right rightward shake
+🫱🏾	people	rightwards hand medium dark skin tone handshake hold reach right rightward shake
+🫱🏿	people	rightwards hand dark skin tone handshake hold reach right rightward shake
+🫲	people	leftwards hand handshake hold left leftward reach shake
+🫲🏻	people	leftwards hand light skin tone handshake hold left leftward reach shake
+🫲🏼	people	leftwards hand medium light skin tone handshake hold left leftward reach shake
+🫲🏽	people	leftwards hand medium skin tone handshake hold left leftward reach shake
+🫲🏾	people	leftwards hand medium dark skin tone handshake hold left leftward reach shake
+🫲🏿	people	leftwards hand dark skin tone handshake hold left leftward reach shake
+🫳	people	palm down hand dismiss drop dropped pick shoo up
+🫳🏻	people	palm down hand light skin tone dismiss drop dropped pick shoo up
+🫳🏼	people	palm down hand medium light skin tone dismiss drop dropped pick shoo up
+🫳🏽	people	palm down hand medium skin tone dismiss drop dropped pick shoo up
+🫳🏾	people	palm down hand medium dark skin tone dismiss drop dropped pick shoo up
+🫳🏿	people	palm down hand dark skin tone dismiss drop dropped pick shoo up
+🫴	people	palm up hand beckon catch come hold know lift me offer tell
+🫴🏻	people	palm up hand light skin tone beckon catch come hold know lift me offer tell
+🫴🏼	people	palm up hand medium light skin tone beckon catch come hold know lift me offer tell
+🫴🏽	people	palm up hand medium skin tone beckon catch come hold know lift me offer tell
+🫴🏾	people	palm up hand medium dark skin tone beckon catch come hold know lift me offer tell
+🫴🏿	people	palm up hand dark skin tone beckon catch come hold know lift me offer tell
+🫷	people	leftwards pushing hand block five halt high hold leftward pause push refuse slap stop wait
+🫷🏻	people	leftwards pushing hand light skin tone block five halt high hold leftward pause push refuse slap stop wait
+🫷🏼	people	leftwards pushing hand medium light skin tone block five halt high hold leftward pause push refuse slap stop wait
+🫷🏽	people	leftwards pushing hand medium skin tone block five halt high hold leftward pause push refuse slap stop wait
+🫷🏾	people	leftwards pushing hand medium dark skin tone block five halt high hold leftward pause push refuse slap stop wait
+🫷🏿	people	leftwards pushing hand dark skin tone block five halt high hold leftward pause push refuse slap stop wait
+🫸	people	rightwards pushing hand block five halt high hold pause push refuse rightward slap stop wait
+🫸🏻	people	rightwards pushing hand light skin tone block five halt high hold pause push refuse rightward slap stop wait
+🫸🏼	people	rightwards pushing hand medium light skin tone block five halt high hold pause push refuse rightward slap stop wait
+🫸🏽	people	rightwards pushing hand medium skin tone block five halt high hold pause push refuse rightward slap stop wait
+🫸🏾	people	rightwards pushing hand medium dark skin tone block five halt high hold pause push refuse rightward slap stop wait
+🫸🏿	people	rightwards pushing hand dark skin tone block five halt high hold pause push refuse rightward slap stop wait
+👌	people	ok hand awesome bet dope fleek fosho got gotcha legit okay pinch rad sure sweet three
+👌🏻	people	ok hand light skin tone awesome bet dope fleek fosho got gotcha legit okay pinch rad sure sweet three
+👌🏼	people	ok hand medium light skin tone awesome bet dope fleek fosho got gotcha legit okay pinch rad sure sweet three
+👌🏽	people	ok hand medium skin tone awesome bet dope fleek fosho got gotcha legit okay pinch rad sure sweet three
+👌🏾	people	ok hand medium dark skin tone awesome bet dope fleek fosho got gotcha legit okay pinch rad sure sweet three
+👌🏿	people	ok hand dark skin tone awesome bet dope fleek fosho got gotcha legit okay pinch rad sure sweet three
+🤌	people	pinched fingers gesture hand hold huh interrogation patience relax sarcastic ugh what zip
+🤌🏻	people	pinched fingers light skin tone gesture hand hold huh interrogation patience relax sarcastic ugh what zip
+🤌🏼	people	pinched fingers medium light skin tone gesture hand hold huh interrogation patience relax sarcastic ugh what zip
+🤌🏽	people	pinched fingers medium skin tone gesture hand hold huh interrogation patience relax sarcastic ugh what zip
+🤌🏾	people	pinched fingers medium dark skin tone gesture hand hold huh interrogation patience relax sarcastic ugh what zip
+🤌🏿	people	pinched fingers dark skin tone gesture hand hold huh interrogation patience relax sarcastic ugh what zip
+🤏	people	pinching hand amount bit fingers little small sort
+🤏🏻	people	pinching hand light skin tone amount bit fingers little small sort
+🤏🏼	people	pinching hand medium light skin tone amount bit fingers little small sort
+🤏🏽	people	pinching hand medium skin tone amount bit fingers little small sort
+🤏🏾	people	pinching hand medium dark skin tone amount bit fingers little small sort
+🤏🏿	people	pinching hand dark skin tone amount bit fingers little small sort
+✌️	people	victory hand peace v
+✌🏻	people	victory hand light skin tone peace v
+✌🏼	people	victory hand medium light skin tone peace v
+✌🏽	people	victory hand medium skin tone peace v
+✌🏾	people	victory hand medium dark skin tone peace v
+✌🏿	people	victory hand dark skin tone peace v
+🤞	people	crossed fingers cross finger hand luck
+🤞🏻	people	crossed fingers light skin tone cross finger hand luck
+🤞🏼	people	crossed fingers medium light skin tone cross finger hand luck
+🤞🏽	people	crossed fingers medium skin tone cross finger hand luck
+🤞🏾	people	crossed fingers medium dark skin tone cross finger hand luck
+🤞🏿	people	crossed fingers dark skin tone cross finger hand luck
+🫰	people	hand with index finger and thumb crossed 3 expensive heart love money snap
+🫰🏻	people	hand with index finger and thumb crossed light skin tone 3 expensive heart love money snap
+🫰🏼	people	hand with index finger and thumb crossed medium light skin tone 3 expensive heart love money snap
+🫰🏽	people	hand with index finger and thumb crossed medium skin tone 3 expensive heart love money snap
+🫰🏾	people	hand with index finger and thumb crossed medium dark skin tone 3 expensive heart love money snap
+🫰🏿	people	hand with index finger and thumb crossed dark skin tone 3 expensive heart love money snap
+🤟	people	love you gesture fingers hand ily three
+🤟🏻	people	love you gesture light skin tone fingers hand ily three
+🤟🏼	people	love you gesture medium light skin tone fingers hand ily three
+🤟🏽	people	love you gesture medium skin tone fingers hand ily three
+🤟🏾	people	love you gesture medium dark skin tone fingers hand ily three
+🤟🏿	people	love you gesture dark skin tone fingers hand ily three
+🤘	people	sign of the horns finger hand rock on
+🤘🏻	people	sign of the horns light skin tone finger hand rock on
+🤘🏼	people	sign of the horns medium light skin tone finger hand rock on
+🤘🏽	people	sign of the horns medium skin tone finger hand rock on
+🤘🏾	people	sign of the horns medium dark skin tone finger hand rock on
+🤘🏿	people	sign of the horns dark skin tone finger hand rock on
+🤙	people	call me hand hang loose shaka
+🤙🏻	people	call me hand light skin tone hang loose shaka
+🤙🏼	people	call me hand medium light skin tone hang loose shaka
+🤙🏽	people	call me hand medium skin tone hang loose shaka
+🤙🏾	people	call me hand medium dark skin tone hang loose shaka
+🤙🏿	people	call me hand dark skin tone hang loose shaka
+👈	people	backhand index pointing left finger hand point
+👈🏻	people	backhand index pointing left light skin tone finger hand point
+👈🏼	people	backhand index pointing left medium light skin tone finger hand point
+👈🏽	people	backhand index pointing left medium skin tone finger hand point
+👈🏾	people	backhand index pointing left medium dark skin tone finger hand point
+👈🏿	people	backhand index pointing left dark skin tone finger hand point
+👉	people	backhand index pointing right finger hand point
+👉🏻	people	backhand index pointing right light skin tone finger hand point
+👉🏼	people	backhand index pointing right medium light skin tone finger hand point
+👉🏽	people	backhand index pointing right medium skin tone finger hand point
+👉🏾	people	backhand index pointing right medium dark skin tone finger hand point
+👉🏿	people	backhand index pointing right dark skin tone finger hand point
+👆	people	backhand index pointing up finger hand point
+👆🏻	people	backhand index pointing up light skin tone finger hand point
+👆🏼	people	backhand index pointing up medium light skin tone finger hand point
+👆🏽	people	backhand index pointing up medium skin tone finger hand point
+👆🏾	people	backhand index pointing up medium dark skin tone finger hand point
+👆🏿	people	backhand index pointing up dark skin tone finger hand point
+🖕	people	middle finger hand
+🖕🏻	people	middle finger light skin tone hand
+🖕🏼	people	middle finger medium light skin tone hand
+🖕🏽	people	middle finger medium skin tone hand
+🖕🏾	people	middle finger medium dark skin tone hand
+🖕🏿	people	middle finger dark skin tone hand
+👇	people	backhand index pointing down finger hand point
+👇🏻	people	backhand index pointing down light skin tone finger hand point
+👇🏼	people	backhand index pointing down medium light skin tone finger hand point
+👇🏽	people	backhand index pointing down medium skin tone finger hand point
+👇🏾	people	backhand index pointing down medium dark skin tone finger hand point
+👇🏿	people	backhand index pointing down dark skin tone finger hand point
+☝️	people	index pointing up finger hand point this
+☝🏻	people	index pointing up light skin tone finger hand point this
+☝🏼	people	index pointing up medium light skin tone finger hand point this
+☝🏽	people	index pointing up medium skin tone finger hand point this
+☝🏾	people	index pointing up medium dark skin tone finger hand point this
+☝🏿	people	index pointing up dark skin tone finger hand point this
+🫵	people	index pointing at the viewer finger hand poke you
+🫵🏻	people	index pointing at the viewer light skin tone finger hand poke you
+🫵🏼	people	index pointing at the viewer medium light skin tone finger hand poke you
+🫵🏽	people	index pointing at the viewer medium skin tone finger hand poke you
+🫵🏾	people	index pointing at the viewer medium dark skin tone finger hand poke you
+🫵🏿	people	index pointing at the viewer dark skin tone finger hand poke you
+👍	people	thumbs up 1 good hand like thumb yes
+👍🏻	people	thumbs up light skin tone 1 good hand like thumb yes
+👍🏼	people	thumbs up medium light skin tone 1 good hand like thumb yes
+👍🏽	people	thumbs up medium skin tone 1 good hand like thumb yes
+👍🏾	people	thumbs up medium dark skin tone 1 good hand like thumb yes
+👍🏿	people	thumbs up dark skin tone 1 good hand like thumb yes
+👎	people	thumbs down 1 bad dislike good hand no nope thumb
+👎🏻	people	thumbs down light skin tone 1 bad dislike good hand no nope thumb
+👎🏼	people	thumbs down medium light skin tone 1 bad dislike good hand no nope thumb
+👎🏽	people	thumbs down medium skin tone 1 bad dislike good hand no nope thumb
+👎🏾	people	thumbs down medium dark skin tone 1 bad dislike good hand no nope thumb
+👎🏿	people	thumbs down dark skin tone 1 bad dislike good hand no nope thumb
+✊	people	raised fist clenched hand punch solidarity
+✊🏻	people	raised fist light skin tone clenched hand punch solidarity
+✊🏼	people	raised fist medium light skin tone clenched hand punch solidarity
+✊🏽	people	raised fist medium skin tone clenched hand punch solidarity
+✊🏾	people	raised fist medium dark skin tone clenched hand punch solidarity
+✊🏿	people	raised fist dark skin tone clenched hand punch solidarity
+👊	people	oncoming fist absolutely agree boom bro bruh bump clenched correct hand knuckle pound punch rock ttyl
+👊🏻	people	oncoming fist light skin tone absolutely agree boom bro bruh bump clenched correct hand knuckle pound punch rock ttyl
+👊🏼	people	oncoming fist medium light skin tone absolutely agree boom bro bruh bump clenched correct hand knuckle pound punch rock ttyl
+👊🏽	people	oncoming fist medium skin tone absolutely agree boom bro bruh bump clenched correct hand knuckle pound punch rock ttyl
+👊🏾	people	oncoming fist medium dark skin tone absolutely agree boom bro bruh bump clenched correct hand knuckle pound punch rock ttyl
+👊🏿	people	oncoming fist dark skin tone absolutely agree boom bro bruh bump clenched correct hand knuckle pound punch rock ttyl
+🤛	people	left facing fist leftwards
+🤛🏻	people	left facing fist light skin tone leftwards
+🤛🏼	people	left facing fist medium light skin tone leftwards
+🤛🏽	people	left facing fist medium skin tone leftwards
+🤛🏾	people	left facing fist medium dark skin tone leftwards
+🤛🏿	people	left facing fist dark skin tone leftwards
+🤜	people	right facing fist rightwards
+🤜🏻	people	right facing fist light skin tone rightwards
+🤜🏼	people	right facing fist medium light skin tone rightwards
+🤜🏽	people	right facing fist medium skin tone rightwards
+🤜🏾	people	right facing fist medium dark skin tone rightwards
+🤜🏿	people	right facing fist dark skin tone rightwards
+👏	people	clapping hands applause approval awesome clap congrats congratulations excited good great hand homie job nice prayed well yay
+👏🏻	people	clapping hands light skin tone applause approval awesome clap congrats congratulations excited good great hand homie job nice prayed well yay
+👏🏼	people	clapping hands medium light skin tone applause approval awesome clap congrats congratulations excited good great hand homie job nice prayed well yay
+👏🏽	people	clapping hands medium skin tone applause approval awesome clap congrats congratulations excited good great hand homie job nice prayed well yay
+👏🏾	people	clapping hands medium dark skin tone applause approval awesome clap congrats congratulations excited good great hand homie job nice prayed well yay
+👏🏿	people	clapping hands dark skin tone applause approval awesome clap congrats congratulations excited good great hand homie job nice prayed well yay
+🙌	people	raising hands celebration gesture hand hooray praise raised
+🙌🏻	people	raising hands light skin tone celebration gesture hand hooray praise raised
+🙌🏼	people	raising hands medium light skin tone celebration gesture hand hooray praise raised
+🙌🏽	people	raising hands medium skin tone celebration gesture hand hooray praise raised
+🙌🏾	people	raising hands medium dark skin tone celebration gesture hand hooray praise raised
+🙌🏿	people	raising hands dark skin tone celebration gesture hand hooray praise raised
+🫶	people	heart hands 3 love you
+🫶🏻	people	heart hands light skin tone 3 love you
+🫶🏼	people	heart hands medium light skin tone 3 love you
+🫶🏽	people	heart hands medium skin tone 3 love you
+🫶🏾	people	heart hands medium dark skin tone 3 love you
+🫶🏿	people	heart hands dark skin tone 3 love you
+👐	people	open hands hand hug jazz swerve
+👐🏻	people	open hands light skin tone hand hug jazz swerve
+👐🏼	people	open hands medium light skin tone hand hug jazz swerve
+👐🏽	people	open hands medium skin tone hand hug jazz swerve
+👐🏾	people	open hands medium dark skin tone hand hug jazz swerve
+👐🏿	people	open hands dark skin tone hand hug jazz swerve
+🤲	people	palms up together cupped dua hands pray prayer wish
+🤲🏻	people	palms up together light skin tone cupped dua hands pray prayer wish
+🤲🏼	people	palms up together medium light skin tone cupped dua hands pray prayer wish
+🤲🏽	people	palms up together medium skin tone cupped dua hands pray prayer wish
+🤲🏾	people	palms up together medium dark skin tone cupped dua hands pray prayer wish
+🤲🏿	people	palms up together dark skin tone cupped dua hands pray prayer wish
+🤝	people	handshake agreement deal hand meeting shake
+🤝🏻	people	handshake light skin tone agreement deal hand meeting shake
+🤝🏼	people	handshake medium light skin tone agreement deal hand meeting shake
+🤝🏽	people	handshake medium skin tone agreement deal hand meeting shake
+🤝🏾	people	handshake medium dark skin tone agreement deal hand meeting shake
+🤝🏿	people	handshake dark skin tone agreement deal hand meeting shake
+🫱🏻‍🫲🏼	people	handshake light skin tone medium agreement deal hand meeting shake
+🫱🏻‍🫲🏽	people	handshake light skin tone medium agreement deal hand meeting shake
+🫱🏻‍🫲🏾	people	handshake light skin tone medium dark agreement deal hand meeting shake
+🫱🏻‍🫲🏿	people	handshake light skin tone dark agreement deal hand meeting shake
+🫱🏼‍🫲🏻	people	handshake medium light skin tone agreement deal hand meeting shake
+🫱🏼‍🫲🏽	people	handshake medium light skin tone agreement deal hand meeting shake
+🫱🏼‍🫲🏾	people	handshake medium light skin tone dark agreement deal hand meeting shake
+🫱🏼‍🫲🏿	people	handshake medium light skin tone dark agreement deal hand meeting shake
+🫱🏽‍🫲🏻	people	handshake medium skin tone light agreement deal hand meeting shake
+🫱🏽‍🫲🏼	people	handshake medium skin tone light agreement deal hand meeting shake
+🫱🏽‍🫲🏾	people	handshake medium skin tone dark agreement deal hand meeting shake
+🫱🏽‍🫲🏿	people	handshake medium skin tone dark agreement deal hand meeting shake
+🫱🏾‍🫲🏻	people	handshake medium dark skin tone light agreement deal hand meeting shake
+🫱🏾‍🫲🏼	people	handshake medium dark skin tone light agreement deal hand meeting shake
+🫱🏾‍🫲🏽	people	handshake medium dark skin tone agreement deal hand meeting shake
+🫱🏾‍🫲🏿	people	handshake medium dark skin tone agreement deal hand meeting shake
+🫱🏿‍🫲🏻	people	handshake dark skin tone light agreement deal hand meeting shake
+🫱🏿‍🫲🏼	people	handshake dark skin tone medium light agreement deal hand meeting shake
+🫱🏿‍🫲🏽	people	handshake dark skin tone medium agreement deal hand meeting shake
+🫱🏿‍🫲🏾	people	handshake dark skin tone medium agreement deal hand meeting shake
+🙏	people	folded hands appreciate ask beg blessed bow cmon five gesture hand high please pray thanks thx
+🙏🏻	people	folded hands light skin tone appreciate ask beg blessed bow cmon five gesture hand high please pray thanks thx
+🙏🏼	people	folded hands medium light skin tone appreciate ask beg blessed bow cmon five gesture hand high please pray thanks thx
+🙏🏽	people	folded hands medium skin tone appreciate ask beg blessed bow cmon five gesture hand high please pray thanks thx
+🙏🏾	people	folded hands medium dark skin tone appreciate ask beg blessed bow cmon five gesture hand high please pray thanks thx
+🙏🏿	people	folded hands dark skin tone appreciate ask beg blessed bow cmon five gesture hand high please pray thanks thx
+✍️	people	writing hand write
+✍🏻	people	writing hand light skin tone write
+✍🏼	people	writing hand medium light skin tone write
+✍🏽	people	writing hand medium skin tone write
+✍🏾	people	writing hand medium dark skin tone write
+✍🏿	people	writing hand dark skin tone write
+💅	people	nail polish bored care cosmetics done makeup manicure whatever
+💅🏻	people	nail polish light skin tone bored care cosmetics done makeup manicure whatever
+💅🏼	people	nail polish medium light skin tone bored care cosmetics done makeup manicure whatever
+💅🏽	people	nail polish medium skin tone bored care cosmetics done makeup manicure whatever
+💅🏾	people	nail polish medium dark skin tone bored care cosmetics done makeup manicure whatever
+💅🏿	people	nail polish dark skin tone bored care cosmetics done makeup manicure whatever
+🤳	people	selfie camera phone
+🤳🏻	people	selfie light skin tone camera phone
+🤳🏼	people	selfie medium light skin tone camera phone
+🤳🏽	people	selfie medium skin tone camera phone
+🤳🏾	people	selfie medium dark skin tone camera phone
+🤳🏿	people	selfie dark skin tone camera phone
+💪	people	flexed biceps arm beast bench bodybuilder bro curls flex gains gym jacked muscle press ripped strong weightlift
+💪🏻	people	flexed biceps light skin tone arm beast bench bodybuilder bro curls flex gains gym jacked muscle press ripped strong weightlift
+💪🏼	people	flexed biceps medium light skin tone arm beast bench bodybuilder bro curls flex gains gym jacked muscle press ripped strong weightlift
+💪🏽	people	flexed biceps medium skin tone arm beast bench bodybuilder bro curls flex gains gym jacked muscle press ripped strong weightlift
+💪🏾	people	flexed biceps medium dark skin tone arm beast bench bodybuilder bro curls flex gains gym jacked muscle press ripped strong weightlift
+💪🏿	people	flexed biceps dark skin tone arm beast bench bodybuilder bro curls flex gains gym jacked muscle press ripped strong weightlift
+🦾	people	mechanical arm accessibility prosthetic
+🦿	people	mechanical leg accessibility prosthetic
+🦵	people	leg bent foot kick knee limb
+🦵🏻	people	leg light skin tone bent foot kick knee limb
+🦵🏼	people	leg medium light skin tone bent foot kick knee limb
+🦵🏽	people	leg medium skin tone bent foot kick knee limb
+🦵🏾	people	leg medium dark skin tone bent foot kick knee limb
+🦵🏿	people	leg dark skin tone bent foot kick knee limb
+🦶	people	foot ankle feet kick stomp
+🦶🏻	people	foot light skin tone ankle feet kick stomp
+🦶🏼	people	foot medium light skin tone ankle feet kick stomp
+🦶🏽	people	foot medium skin tone ankle feet kick stomp
+🦶🏾	people	foot medium dark skin tone ankle feet kick stomp
+🦶🏿	people	foot dark skin tone ankle feet kick stomp
+👂	people	ear body ears hear hearing listen listening sound
+👂🏻	people	ear light skin tone body ears hear hearing listen listening sound
+👂🏼	people	ear medium light skin tone body ears hear hearing listen listening sound
+👂🏽	people	ear medium skin tone body ears hear hearing listen listening sound
+👂🏾	people	ear medium dark skin tone body ears hear hearing listen listening sound
+👂🏿	people	ear dark skin tone body ears hear hearing listen listening sound
+🦻	people	ear with hearing aid accessibility hard
+🦻🏻	people	ear with hearing aid light skin tone accessibility hard
+🦻🏼	people	ear with hearing aid medium light skin tone accessibility hard
+🦻🏽	people	ear with hearing aid medium skin tone accessibility hard
+🦻🏾	people	ear with hearing aid medium dark skin tone accessibility hard
+🦻🏿	people	ear with hearing aid dark skin tone accessibility hard
+👃	people	nose body noses nosey odor smell smells
+👃🏻	people	nose light skin tone body noses nosey odor smell smells
+👃🏼	people	nose medium light skin tone body noses nosey odor smell smells
+👃🏽	people	nose medium skin tone body noses nosey odor smell smells
+👃🏾	people	nose medium dark skin tone body noses nosey odor smell smells
+👃🏿	people	nose dark skin tone body noses nosey odor smell smells
+🧠	people	brain intelligent smart
+🫀	people	anatomical heart beat cardiology heartbeat organ pulse real red
+🫁	people	lungs breath breathe exhalation inhalation lung organ respiration
+🦷	people	tooth dentist pearly teeth white
+🦴	people	bone bones dog skeleton wishbone
+👀	people	eyes body eye face googly look looking omg peep see seeing
+👁️	people	eye 1 body one
+👅	people	tongue body lick slurp
+👄	people	mouth beauty body kiss kissing lips lipstick
+🫦	people	biting lip anxious bite fear flirt flirting kiss lipstick nervous sexy uncomfortable worried worry
+👶	people	baby babies children goo infant newborn pregnant young
+👶🏻	people	baby light skin tone babies children goo infant newborn pregnant young
+👶🏼	people	baby medium light skin tone babies children goo infant newborn pregnant young
+👶🏽	people	baby medium skin tone babies children goo infant newborn pregnant young
+👶🏾	people	baby medium dark skin tone babies children goo infant newborn pregnant young
+👶🏿	people	baby dark skin tone babies children goo infant newborn pregnant young
+🧒	people	child bright eyed grandchild kid young younger
+🧒🏻	people	child light skin tone bright eyed grandchild kid young younger
+🧒🏼	people	child medium light skin tone bright eyed grandchild kid young younger
+🧒🏽	people	child medium skin tone bright eyed grandchild kid young younger
+🧒🏾	people	child medium dark skin tone bright eyed grandchild kid young younger
+🧒🏿	people	child dark skin tone bright eyed grandchild kid young younger
+👦	people	boy bright eyed child grandson kid son young younger
+👦🏻	people	boy light skin tone bright eyed child grandson kid son young younger
+👦🏼	people	boy medium light skin tone bright eyed child grandson kid son young younger
+👦🏽	people	boy medium skin tone bright eyed child grandson kid son young younger
+👦🏾	people	boy medium dark skin tone bright eyed child grandson kid son young younger
+👦🏿	people	boy dark skin tone bright eyed child grandson kid son young younger
+👧	people	girl bright eyed child daughter granddaughter kid virgo young younger zodiac
+👧🏻	people	girl light skin tone bright eyed child daughter granddaughter kid virgo young younger zodiac
+👧🏼	people	girl medium light skin tone bright eyed child daughter granddaughter kid virgo young younger zodiac
+👧🏽	people	girl medium skin tone bright eyed child daughter granddaughter kid virgo young younger zodiac
+👧🏾	people	girl medium dark skin tone bright eyed child daughter granddaughter kid virgo young younger zodiac
+👧🏿	people	girl dark skin tone bright eyed child daughter granddaughter kid virgo young younger zodiac
+🧑	people	person adult
+🧑🏻	people	person light skin tone adult
+🧑🏼	people	person medium light skin tone adult
+🧑🏽	people	person medium skin tone adult
+🧑🏾	people	person medium dark skin tone adult
+🧑🏿	people	person dark skin tone adult
+👱	people	person blond hair haired human
+👱🏻	people	person light skin tone blond hair haired human
+👱🏼	people	person medium light skin tone blond hair haired human
+👱🏽	people	person medium skin tone blond hair haired human
+👱🏾	people	person medium dark skin tone blond hair haired human
+👱🏿	people	person dark skin tone blond hair haired human
+👨	people	man adult bro
+👨🏻	people	man light skin tone adult bro
+👨🏼	people	man medium light skin tone adult bro
+👨🏽	people	man medium skin tone adult bro
+👨🏾	people	man medium dark skin tone adult bro
+👨🏿	people	man dark skin tone adult bro
+🧔	people	person beard bearded whiskers
+🧔🏻	people	person light skin tone beard bearded whiskers
+🧔🏼	people	person medium light skin tone beard bearded whiskers
+🧔🏽	people	person medium skin tone beard bearded whiskers
+🧔🏾	people	person medium dark skin tone beard bearded whiskers
+🧔🏿	people	person dark skin tone beard bearded whiskers
+🧔‍♂️	people	man beard bearded whiskers
+🧔🏻‍♂️	people	man light skin tone beard bearded whiskers
+🧔🏼‍♂️	people	man medium light skin tone beard bearded whiskers
+🧔🏽‍♂️	people	man medium skin tone beard bearded whiskers
+🧔🏾‍♂️	people	man medium dark skin tone beard bearded whiskers
+🧔🏿‍♂️	people	man dark skin tone beard bearded whiskers
+🧔‍♀️	people	woman beard bearded whiskers
+🧔🏻‍♀️	people	woman light skin tone beard bearded whiskers
+🧔🏼‍♀️	people	woman medium light skin tone beard bearded whiskers
+🧔🏽‍♀️	people	woman medium skin tone beard bearded whiskers
+🧔🏾‍♀️	people	woman medium dark skin tone beard bearded whiskers
+🧔🏿‍♀️	people	woman dark skin tone beard bearded whiskers
+👨‍🦰	people	man red hair adult bro
+👨🏻‍🦰	people	man light skin tone red hair adult bro
+👨🏼‍🦰	people	man medium light skin tone red hair adult bro
+👨🏽‍🦰	people	man medium skin tone red hair adult bro
+👨🏾‍🦰	people	man medium dark skin tone red hair adult bro
+👨🏿‍🦰	people	man dark skin tone red hair adult bro
+👨‍🦱	people	man curly hair adult bro
+👨🏻‍🦱	people	man light skin tone curly hair adult bro
+👨🏼‍🦱	people	man medium light skin tone curly hair adult bro
+👨🏽‍🦱	people	man medium skin tone curly hair adult bro
+👨🏾‍🦱	people	man medium dark skin tone curly hair adult bro
+👨🏿‍🦱	people	man dark skin tone curly hair adult bro
+👨‍🦳	people	man white hair adult bro
+👨🏻‍🦳	people	man light skin tone white hair adult bro
+👨🏼‍🦳	people	man medium light skin tone white hair adult bro
+👨🏽‍🦳	people	man medium skin tone white hair adult bro
+👨🏾‍🦳	people	man medium dark skin tone white hair adult bro
+👨🏿‍🦳	people	man dark skin tone white hair adult bro
+👨‍🦲	people	man bald adult bro
+👨🏻‍🦲	people	man light skin tone bald adult bro
+👨🏼‍🦲	people	man medium light skin tone bald adult bro
+👨🏽‍🦲	people	man medium skin tone bald adult bro
+👨🏾‍🦲	people	man medium dark skin tone bald adult bro
+👨🏿‍🦲	people	man dark skin tone bald adult bro
+👩	people	woman adult lady
+👩🏻	people	woman light skin tone adult lady
+👩🏼	people	woman medium light skin tone adult lady
+👩🏽	people	woman medium skin tone adult lady
+👩🏾	people	woman medium dark skin tone adult lady
+👩🏿	people	woman dark skin tone adult lady
+👩‍🦰	people	woman red hair adult lady
+👩🏻‍🦰	people	woman light skin tone red hair adult lady
+👩🏼‍🦰	people	woman medium light skin tone red hair adult lady
+👩🏽‍🦰	people	woman medium skin tone red hair adult lady
+👩🏾‍🦰	people	woman medium dark skin tone red hair adult lady
+👩🏿‍🦰	people	woman dark skin tone red hair adult lady
+🧑‍🦰	people	person red hair adult
+🧑🏻‍🦰	people	person light skin tone red hair adult
+🧑🏼‍🦰	people	person medium light skin tone red hair adult
+🧑🏽‍🦰	people	person medium skin tone red hair adult
+🧑🏾‍🦰	people	person medium dark skin tone red hair adult
+🧑🏿‍🦰	people	person dark skin tone red hair adult
+👩‍🦱	people	woman curly hair adult lady
+👩🏻‍🦱	people	woman light skin tone curly hair adult lady
+👩🏼‍🦱	people	woman medium light skin tone curly hair adult lady
+👩🏽‍🦱	people	woman medium skin tone curly hair adult lady
+👩🏾‍🦱	people	woman medium dark skin tone curly hair adult lady
+👩🏿‍🦱	people	woman dark skin tone curly hair adult lady
+🧑‍🦱	people	person curly hair adult
+🧑🏻‍🦱	people	person light skin tone curly hair adult
+🧑🏼‍🦱	people	person medium light skin tone curly hair adult
+🧑🏽‍🦱	people	person medium skin tone curly hair adult
+🧑🏾‍🦱	people	person medium dark skin tone curly hair adult
+🧑🏿‍🦱	people	person dark skin tone curly hair adult
+👩‍🦳	people	woman white hair adult lady
+👩🏻‍🦳	people	woman light skin tone white hair adult lady
+👩🏼‍🦳	people	woman medium light skin tone white hair adult lady
+👩🏽‍🦳	people	woman medium skin tone white hair adult lady
+👩🏾‍🦳	people	woman medium dark skin tone white hair adult lady
+👩🏿‍🦳	people	woman dark skin tone white hair adult lady
+🧑‍🦳	people	person white hair adult
+🧑🏻‍🦳	people	person light skin tone white hair adult
+🧑🏼‍🦳	people	person medium light skin tone white hair adult
+🧑🏽‍🦳	people	person medium skin tone white hair adult
+🧑🏾‍🦳	people	person medium dark skin tone white hair adult
+🧑🏿‍🦳	people	person dark skin tone white hair adult
+👩‍🦲	people	woman bald adult lady
+👩🏻‍🦲	people	woman light skin tone bald adult lady
+👩🏼‍🦲	people	woman medium light skin tone bald adult lady
+👩🏽‍🦲	people	woman medium skin tone bald adult lady
+👩🏾‍🦲	people	woman medium dark skin tone bald adult lady
+👩🏿‍🦲	people	woman dark skin tone bald adult lady
+🧑‍🦲	people	person bald adult
+🧑🏻‍🦲	people	person light skin tone bald adult
+🧑🏼‍🦲	people	person medium light skin tone bald adult
+🧑🏽‍🦲	people	person medium skin tone bald adult
+🧑🏾‍🦲	people	person medium dark skin tone bald adult
+🧑🏿‍🦲	people	person dark skin tone bald adult
+👱‍♀️	people	woman blond hair haired blonde
+👱🏻‍♀️	people	woman light skin tone blond hair haired blonde
+👱🏼‍♀️	people	woman medium light skin tone blond hair haired blonde
+👱🏽‍♀️	people	woman medium skin tone blond hair haired blonde
+👱🏾‍♀️	people	woman medium dark skin tone blond hair haired blonde
+👱🏿‍♀️	people	woman dark skin tone blond hair haired blonde
+👱‍♂️	people	man blond hair haired
+👱🏻‍♂️	people	man light skin tone blond hair haired
+👱🏼‍♂️	people	man medium light skin tone blond hair haired
+👱🏽‍♂️	people	man medium skin tone blond hair haired
+👱🏾‍♂️	people	man medium dark skin tone blond hair haired
+👱🏿‍♂️	people	man dark skin tone blond hair haired
+🧓	people	older person adult elderly grandparent old wise
+🧓🏻	people	older person light skin tone adult elderly grandparent old wise
+🧓🏼	people	older person medium light skin tone adult elderly grandparent old wise
+🧓🏽	people	older person medium skin tone adult elderly grandparent old wise
+🧓🏾	people	older person medium dark skin tone adult elderly grandparent old wise
+🧓🏿	people	older person dark skin tone adult elderly grandparent old wise
+👴	people	old man adult bald elderly gramps grandfather grandpa wise
+👴🏻	people	old man light skin tone adult bald elderly gramps grandfather grandpa wise
+👴🏼	people	old man medium light skin tone adult bald elderly gramps grandfather grandpa wise
+👴🏽	people	old man medium skin tone adult bald elderly gramps grandfather grandpa wise
+👴🏾	people	old man medium dark skin tone adult bald elderly gramps grandfather grandpa wise
+👴🏿	people	old man dark skin tone adult bald elderly gramps grandfather grandpa wise
+👵	people	old woman adult elderly grandma grandmother granny lady wise
+👵🏻	people	old woman light skin tone adult elderly grandma grandmother granny lady wise
+👵🏼	people	old woman medium light skin tone adult elderly grandma grandmother granny lady wise
+👵🏽	people	old woman medium skin tone adult elderly grandma grandmother granny lady wise
+👵🏾	people	old woman medium dark skin tone adult elderly grandma grandmother granny lady wise
+👵🏿	people	old woman dark skin tone adult elderly grandma grandmother granny lady wise
+🙍	people	person frowning annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍🏻	people	person frowning light skin tone annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍🏼	people	person frowning medium light skin tone annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍🏽	people	person frowning medium skin tone annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍🏾	people	person frowning medium dark skin tone annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍🏿	people	person frowning dark skin tone annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍‍♂️	people	man frowning annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍🏻‍♂️	people	man frowning light skin tone annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍🏼‍♂️	people	man frowning medium light skin tone annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍🏽‍♂️	people	man frowning medium skin tone annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍🏾‍♂️	people	man frowning medium dark skin tone annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍🏿‍♂️	people	man frowning dark skin tone annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍‍♀️	people	woman frowning annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍🏻‍♀️	people	woman frowning light skin tone annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍🏼‍♀️	people	woman frowning medium light skin tone annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍🏽‍♀️	people	woman frowning medium skin tone annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍🏾‍♀️	people	woman frowning medium dark skin tone annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙍🏿‍♀️	people	woman frowning dark skin tone annoyed disappointed disgruntled disturbed frown frustrated gesture irritated upset
+🙎	people	person pouting disappointed downtrodden frown grimace scowl sulk upset whine
+🙎🏻	people	person pouting light skin tone disappointed downtrodden frown grimace scowl sulk upset whine
+🙎🏼	people	person pouting medium light skin tone disappointed downtrodden frown grimace scowl sulk upset whine
+🙎🏽	people	person pouting medium skin tone disappointed downtrodden frown grimace scowl sulk upset whine
+🙎🏾	people	person pouting medium dark skin tone disappointed downtrodden frown grimace scowl sulk upset whine
+🙎🏿	people	person pouting dark skin tone disappointed downtrodden frown grimace scowl sulk upset whine
+🙎‍♂️	people	man pouting disappointed downtrodden frown grimace scowl sulk upset whine
+🙎🏻‍♂️	people	man pouting light skin tone disappointed downtrodden frown grimace scowl sulk upset whine
+🙎🏼‍♂️	people	man pouting medium light skin tone disappointed downtrodden frown grimace scowl sulk upset whine
+🙎🏽‍♂️	people	man pouting medium skin tone disappointed downtrodden frown grimace scowl sulk upset whine
+🙎🏾‍♂️	people	man pouting medium dark skin tone disappointed downtrodden frown grimace scowl sulk upset whine
+🙎🏿‍♂️	people	man pouting dark skin tone disappointed downtrodden frown grimace scowl sulk upset whine
+🙎‍♀️	people	woman pouting disappointed downtrodden frown grimace scowl sulk upset whine
+🙎🏻‍♀️	people	woman pouting light skin tone disappointed downtrodden frown grimace scowl sulk upset whine
+🙎🏼‍♀️	people	woman pouting medium light skin tone disappointed downtrodden frown grimace scowl sulk upset whine
+🙎🏽‍♀️	people	woman pouting medium skin tone disappointed downtrodden frown grimace scowl sulk upset whine
+🙎🏾‍♀️	people	woman pouting medium dark skin tone disappointed downtrodden frown grimace scowl sulk upset whine
+🙎🏿‍♀️	people	woman pouting dark skin tone disappointed downtrodden frown grimace scowl sulk upset whine
+🙅	people	person gesturing no forbidden gesture hand not prohibit
+🙅🏻	people	person gesturing no light skin tone forbidden gesture hand not prohibit
+🙅🏼	people	person gesturing no medium light skin tone forbidden gesture hand not prohibit
+🙅🏽	people	person gesturing no medium skin tone forbidden gesture hand not prohibit
+🙅🏾	people	person gesturing no medium dark skin tone forbidden gesture hand not prohibit
+🙅🏿	people	person gesturing no dark skin tone forbidden gesture hand not prohibit
+🙅‍♂️	people	man gesturing no forbidden gesture hand not prohibit
+🙅🏻‍♂️	people	man gesturing no light skin tone forbidden gesture hand not prohibit
+🙅🏼‍♂️	people	man gesturing no medium light skin tone forbidden gesture hand not prohibit
+🙅🏽‍♂️	people	man gesturing no medium skin tone forbidden gesture hand not prohibit
+🙅🏾‍♂️	people	man gesturing no medium dark skin tone forbidden gesture hand not prohibit
+🙅🏿‍♂️	people	man gesturing no dark skin tone forbidden gesture hand not prohibit
+🙅‍♀️	people	woman gesturing no forbidden gesture hand not prohibit
+🙅🏻‍♀️	people	woman gesturing no light skin tone forbidden gesture hand not prohibit
+🙅🏼‍♀️	people	woman gesturing no medium light skin tone forbidden gesture hand not prohibit
+🙅🏽‍♀️	people	woman gesturing no medium skin tone forbidden gesture hand not prohibit
+🙅🏾‍♀️	people	woman gesturing no medium dark skin tone forbidden gesture hand not prohibit
+🙅🏿‍♀️	people	woman gesturing no dark skin tone forbidden gesture hand not prohibit
+🙆	people	person gesturing ok exercise gesture hand omg
+🙆🏻	people	person gesturing ok light skin tone exercise gesture hand omg
+🙆🏼	people	person gesturing ok medium light skin tone exercise gesture hand omg
+🙆🏽	people	person gesturing ok medium skin tone exercise gesture hand omg
+🙆🏾	people	person gesturing ok medium dark skin tone exercise gesture hand omg
+🙆🏿	people	person gesturing ok dark skin tone exercise gesture hand omg
+🙆‍♂️	people	man gesturing ok exercise gesture hand omg
+🙆🏻‍♂️	people	man gesturing ok light skin tone exercise gesture hand omg
+🙆🏼‍♂️	people	man gesturing ok medium light skin tone exercise gesture hand omg
+🙆🏽‍♂️	people	man gesturing ok medium skin tone exercise gesture hand omg
+🙆🏾‍♂️	people	man gesturing ok medium dark skin tone exercise gesture hand omg
+🙆🏿‍♂️	people	man gesturing ok dark skin tone exercise gesture hand omg
+🙆‍♀️	people	woman gesturing ok exercise gesture hand omg
+🙆🏻‍♀️	people	woman gesturing ok light skin tone exercise gesture hand omg
+🙆🏼‍♀️	people	woman gesturing ok medium light skin tone exercise gesture hand omg
+🙆🏽‍♀️	people	woman gesturing ok medium skin tone exercise gesture hand omg
+🙆🏾‍♀️	people	woman gesturing ok medium dark skin tone exercise gesture hand omg
+🙆🏿‍♀️	people	woman gesturing ok dark skin tone exercise gesture hand omg
+💁	people	person tipping hand fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁🏻	people	person tipping hand light skin tone fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁🏼	people	person tipping hand medium light skin tone fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁🏽	people	person tipping hand medium skin tone fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁🏾	people	person tipping hand medium dark skin tone fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁🏿	people	person tipping hand dark skin tone fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁‍♂️	people	man tipping hand fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁🏻‍♂️	people	man tipping hand light skin tone fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁🏼‍♂️	people	man tipping hand medium light skin tone fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁🏽‍♂️	people	man tipping hand medium skin tone fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁🏾‍♂️	people	man tipping hand medium dark skin tone fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁🏿‍♂️	people	man tipping hand dark skin tone fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁‍♀️	people	woman tipping hand fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁🏻‍♀️	people	woman tipping hand light skin tone fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁🏼‍♀️	people	woman tipping hand medium light skin tone fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁🏽‍♀️	people	woman tipping hand medium skin tone fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁🏾‍♀️	people	woman tipping hand medium dark skin tone fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+💁🏿‍♀️	people	woman tipping hand dark skin tone fetch flick flip gossip sarcasm sarcastic sassy seriously whatever
+🙋	people	person raising hand gesture here know me pick question raise
+🙋🏻	people	person raising hand light skin tone gesture here know me pick question raise
+🙋🏼	people	person raising hand medium light skin tone gesture here know me pick question raise
+🙋🏽	people	person raising hand medium skin tone gesture here know me pick question raise
+🙋🏾	people	person raising hand medium dark skin tone gesture here know me pick question raise
+🙋🏿	people	person raising hand dark skin tone gesture here know me pick question raise
+🙋‍♂️	people	man raising hand gesture here know me pick question raise
+🙋🏻‍♂️	people	man raising hand light skin tone gesture here know me pick question raise
+🙋🏼‍♂️	people	man raising hand medium light skin tone gesture here know me pick question raise
+🙋🏽‍♂️	people	man raising hand medium skin tone gesture here know me pick question raise
+🙋🏾‍♂️	people	man raising hand medium dark skin tone gesture here know me pick question raise
+🙋🏿‍♂️	people	man raising hand dark skin tone gesture here know me pick question raise
+🙋‍♀️	people	woman raising hand gesture here know me pick question raise
+🙋🏻‍♀️	people	woman raising hand light skin tone gesture here know me pick question raise
+🙋🏼‍♀️	people	woman raising hand medium light skin tone gesture here know me pick question raise
+🙋🏽‍♀️	people	woman raising hand medium skin tone gesture here know me pick question raise
+🙋🏾‍♀️	people	woman raising hand medium dark skin tone gesture here know me pick question raise
+🙋🏿‍♀️	people	woman raising hand dark skin tone gesture here know me pick question raise
+🧏	people	deaf person accessibility ear gesture hear
+🧏🏻	people	deaf person light skin tone accessibility ear gesture hear
+🧏🏼	people	deaf person medium light skin tone accessibility ear gesture hear
+🧏🏽	people	deaf person medium skin tone accessibility ear gesture hear
+🧏🏾	people	deaf person medium dark skin tone accessibility ear gesture hear
+🧏🏿	people	deaf person dark skin tone accessibility ear gesture hear
+🧏‍♂️	people	deaf man accessibility ear gesture hear
+🧏🏻‍♂️	people	deaf man light skin tone accessibility ear gesture hear
+🧏🏼‍♂️	people	deaf man medium light skin tone accessibility ear gesture hear
+🧏🏽‍♂️	people	deaf man medium skin tone accessibility ear gesture hear
+🧏🏾‍♂️	people	deaf man medium dark skin tone accessibility ear gesture hear
+🧏🏿‍♂️	people	deaf man dark skin tone accessibility ear gesture hear
+🧏‍♀️	people	deaf woman accessibility ear gesture hear
+🧏🏻‍♀️	people	deaf woman light skin tone accessibility ear gesture hear
+🧏🏼‍♀️	people	deaf woman medium light skin tone accessibility ear gesture hear
+🧏🏽‍♀️	people	deaf woman medium skin tone accessibility ear gesture hear
+🧏🏾‍♀️	people	deaf woman medium dark skin tone accessibility ear gesture hear
+🧏🏿‍♀️	people	deaf woman dark skin tone accessibility ear gesture hear
+🙇	people	person bowing apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇🏻	people	person bowing light skin tone apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇🏼	people	person bowing medium light skin tone apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇🏽	people	person bowing medium skin tone apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇🏾	people	person bowing medium dark skin tone apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇🏿	people	person bowing dark skin tone apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇‍♂️	people	man bowing apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇🏻‍♂️	people	man bowing light skin tone apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇🏼‍♂️	people	man bowing medium light skin tone apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇🏽‍♂️	people	man bowing medium skin tone apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇🏾‍♂️	people	man bowing medium dark skin tone apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇🏿‍♂️	people	man bowing dark skin tone apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇‍♀️	people	woman bowing apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇🏻‍♀️	people	woman bowing light skin tone apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇🏼‍♀️	people	woman bowing medium light skin tone apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇🏽‍♀️	people	woman bowing medium skin tone apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇🏾‍♀️	people	woman bowing medium dark skin tone apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🙇🏿‍♀️	people	woman bowing dark skin tone apology ask beg bow favor forgive gesture meditate meditation pity regret sorry
+🤦	people	person facepalming again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦🏻	people	person facepalming light skin tone again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦🏼	people	person facepalming medium light skin tone again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦🏽	people	person facepalming medium skin tone again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦🏾	people	person facepalming medium dark skin tone again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦🏿	people	person facepalming dark skin tone again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦‍♂️	people	man facepalming again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦🏻‍♂️	people	man facepalming light skin tone again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦🏼‍♂️	people	man facepalming medium light skin tone again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦🏽‍♂️	people	man facepalming medium skin tone again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦🏾‍♂️	people	man facepalming medium dark skin tone again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦🏿‍♂️	people	man facepalming dark skin tone again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦‍♀️	people	woman facepalming again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦🏻‍♀️	people	woman facepalming light skin tone again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦🏼‍♀️	people	woman facepalming medium light skin tone again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦🏽‍♀️	people	woman facepalming medium skin tone again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦🏾‍♀️	people	woman facepalming medium dark skin tone again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤦🏿‍♀️	people	woman facepalming dark skin tone again bewilder disbelief exasperation facepalm no not oh omg shock smh
+🤷	people	person shrugging doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷🏻	people	person shrugging light skin tone doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷🏼	people	person shrugging medium light skin tone doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷🏽	people	person shrugging medium skin tone doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷🏾	people	person shrugging medium dark skin tone doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷🏿	people	person shrugging dark skin tone doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷‍♂️	people	man shrugging doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷🏻‍♂️	people	man shrugging light skin tone doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷🏼‍♂️	people	man shrugging medium light skin tone doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷🏽‍♂️	people	man shrugging medium skin tone doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷🏾‍♂️	people	man shrugging medium dark skin tone doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷🏿‍♂️	people	man shrugging dark skin tone doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷‍♀️	people	woman shrugging doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷🏻‍♀️	people	woman shrugging light skin tone doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷🏼‍♀️	people	woman shrugging medium light skin tone doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷🏽‍♀️	people	woman shrugging medium skin tone doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷🏾‍♀️	people	woman shrugging medium dark skin tone doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🤷🏿‍♀️	people	woman shrugging dark skin tone doubt dunno guess idk ignorance indifference knows maybe shrug whatever who
+🧑‍⚕️	people	health worker doctor healthcare nurse therapist
+🧑🏻‍⚕️	people	health worker light skin tone doctor healthcare nurse therapist
+🧑🏼‍⚕️	people	health worker medium light skin tone doctor healthcare nurse therapist
+🧑🏽‍⚕️	people	health worker medium skin tone doctor healthcare nurse therapist
+🧑🏾‍⚕️	people	health worker medium dark skin tone doctor healthcare nurse therapist
+🧑🏿‍⚕️	people	health worker dark skin tone doctor healthcare nurse therapist
+👨‍⚕️	people	man health worker doctor healthcare nurse therapist
+👨🏻‍⚕️	people	man health worker light skin tone doctor healthcare nurse therapist
+👨🏼‍⚕️	people	man health worker medium light skin tone doctor healthcare nurse therapist
+👨🏽‍⚕️	people	man health worker medium skin tone doctor healthcare nurse therapist
+👨🏾‍⚕️	people	man health worker medium dark skin tone doctor healthcare nurse therapist
+👨🏿‍⚕️	people	man health worker dark skin tone doctor healthcare nurse therapist
+👩‍⚕️	people	woman health worker doctor healthcare nurse therapist
+👩🏻‍⚕️	people	woman health worker light skin tone doctor healthcare nurse therapist
+👩🏼‍⚕️	people	woman health worker medium light skin tone doctor healthcare nurse therapist
+👩🏽‍⚕️	people	woman health worker medium skin tone doctor healthcare nurse therapist
+👩🏾‍⚕️	people	woman health worker medium dark skin tone doctor healthcare nurse therapist
+👩🏿‍⚕️	people	woman health worker dark skin tone doctor healthcare nurse therapist
+🧑‍🎓	people	student graduate
+🧑🏻‍🎓	people	student light skin tone graduate
+🧑🏼‍🎓	people	student medium light skin tone graduate
+🧑🏽‍🎓	people	student medium skin tone graduate
+🧑🏾‍🎓	people	student medium dark skin tone graduate
+🧑🏿‍🎓	people	student dark skin tone graduate
+👨‍🎓	people	man student graduate
+👨🏻‍🎓	people	man student light skin tone graduate
+👨🏼‍🎓	people	man student medium light skin tone graduate
+👨🏽‍🎓	people	man student medium skin tone graduate
+👨🏾‍🎓	people	man student medium dark skin tone graduate
+👨🏿‍🎓	people	man student dark skin tone graduate
+👩‍🎓	people	woman student graduate
+👩🏻‍🎓	people	woman student light skin tone graduate
+👩🏼‍🎓	people	woman student medium light skin tone graduate
+👩🏽‍🎓	people	woman student medium skin tone graduate
+👩🏾‍🎓	people	woman student medium dark skin tone graduate
+👩🏿‍🎓	people	woman student dark skin tone graduate
+🧑‍🏫	people	teacher instructor lecturer professor
+🧑🏻‍🏫	people	teacher light skin tone instructor lecturer professor
+🧑🏼‍🏫	people	teacher medium light skin tone instructor lecturer professor
+🧑🏽‍🏫	people	teacher medium skin tone instructor lecturer professor
+🧑🏾‍🏫	people	teacher medium dark skin tone instructor lecturer professor
+🧑🏿‍🏫	people	teacher dark skin tone instructor lecturer professor
+👨‍🏫	people	man teacher instructor lecturer professor
+👨🏻‍🏫	people	man teacher light skin tone instructor lecturer professor
+👨🏼‍🏫	people	man teacher medium light skin tone instructor lecturer professor
+👨🏽‍🏫	people	man teacher medium skin tone instructor lecturer professor
+👨🏾‍🏫	people	man teacher medium dark skin tone instructor lecturer professor
+👨🏿‍🏫	people	man teacher dark skin tone instructor lecturer professor
+👩‍🏫	people	woman teacher instructor lecturer professor
+👩🏻‍🏫	people	woman teacher light skin tone instructor lecturer professor
+👩🏼‍🏫	people	woman teacher medium light skin tone instructor lecturer professor
+👩🏽‍🏫	people	woman teacher medium skin tone instructor lecturer professor
+👩🏾‍🏫	people	woman teacher medium dark skin tone instructor lecturer professor
+👩🏿‍🏫	people	woman teacher dark skin tone instructor lecturer professor
+🧑‍⚖️	people	judge justice law scales
+🧑🏻‍⚖️	people	judge light skin tone justice law scales
+🧑🏼‍⚖️	people	judge medium light skin tone justice law scales
+🧑🏽‍⚖️	people	judge medium skin tone justice law scales
+🧑🏾‍⚖️	people	judge medium dark skin tone justice law scales
+🧑🏿‍⚖️	people	judge dark skin tone justice law scales
+👨‍⚖️	people	man judge justice law scales
+👨🏻‍⚖️	people	man judge light skin tone justice law scales
+👨🏼‍⚖️	people	man judge medium light skin tone justice law scales
+👨🏽‍⚖️	people	man judge medium skin tone justice law scales
+👨🏾‍⚖️	people	man judge medium dark skin tone justice law scales
+👨🏿‍⚖️	people	man judge dark skin tone justice law scales
+👩‍⚖️	people	woman judge justice law scales
+👩🏻‍⚖️	people	woman judge light skin tone justice law scales
+👩🏼‍⚖️	people	woman judge medium light skin tone justice law scales
+👩🏽‍⚖️	people	woman judge medium skin tone justice law scales
+👩🏾‍⚖️	people	woman judge medium dark skin tone justice law scales
+👩🏿‍⚖️	people	woman judge dark skin tone justice law scales
+🧑‍🌾	people	farmer gardener rancher
+🧑🏻‍🌾	people	farmer light skin tone gardener rancher
+🧑🏼‍🌾	people	farmer medium light skin tone gardener rancher
+🧑🏽‍🌾	people	farmer medium skin tone gardener rancher
+🧑🏾‍🌾	people	farmer medium dark skin tone gardener rancher
+🧑🏿‍🌾	people	farmer dark skin tone gardener rancher
+👨‍🌾	people	man farmer gardener rancher
+👨🏻‍🌾	people	man farmer light skin tone gardener rancher
+👨🏼‍🌾	people	man farmer medium light skin tone gardener rancher
+👨🏽‍🌾	people	man farmer medium skin tone gardener rancher
+👨🏾‍🌾	people	man farmer medium dark skin tone gardener rancher
+👨🏿‍🌾	people	man farmer dark skin tone gardener rancher
+👩‍🌾	people	woman farmer gardener rancher
+👩🏻‍🌾	people	woman farmer light skin tone gardener rancher
+👩🏼‍🌾	people	woman farmer medium light skin tone gardener rancher
+👩🏽‍🌾	people	woman farmer medium skin tone gardener rancher
+👩🏾‍🌾	people	woman farmer medium dark skin tone gardener rancher
+👩🏿‍🌾	people	woman farmer dark skin tone gardener rancher
+🧑‍🍳	people	cook chef
+🧑🏻‍🍳	people	cook light skin tone chef
+🧑🏼‍🍳	people	cook medium light skin tone chef
+🧑🏽‍🍳	people	cook medium skin tone chef
+🧑🏾‍🍳	people	cook medium dark skin tone chef
+🧑🏿‍🍳	people	cook dark skin tone chef
+👨‍🍳	people	man cook chef
+👨🏻‍🍳	people	man cook light skin tone chef
+👨🏼‍🍳	people	man cook medium light skin tone chef
+👨🏽‍🍳	people	man cook medium skin tone chef
+👨🏾‍🍳	people	man cook medium dark skin tone chef
+👨🏿‍🍳	people	man cook dark skin tone chef
+👩‍🍳	people	woman cook chef
+👩🏻‍🍳	people	woman cook light skin tone chef
+👩🏼‍🍳	people	woman cook medium light skin tone chef
+👩🏽‍🍳	people	woman cook medium skin tone chef
+👩🏾‍🍳	people	woman cook medium dark skin tone chef
+👩🏿‍🍳	people	woman cook dark skin tone chef
+🧑‍🔧	people	mechanic electrician plumber tradesperson
+🧑🏻‍🔧	people	mechanic light skin tone electrician plumber tradesperson
+🧑🏼‍🔧	people	mechanic medium light skin tone electrician plumber tradesperson
+🧑🏽‍🔧	people	mechanic medium skin tone electrician plumber tradesperson
+🧑🏾‍🔧	people	mechanic medium dark skin tone electrician plumber tradesperson
+🧑🏿‍🔧	people	mechanic dark skin tone electrician plumber tradesperson
+👨‍🔧	people	man mechanic electrician plumber tradesperson
+👨🏻‍🔧	people	man mechanic light skin tone electrician plumber tradesperson
+👨🏼‍🔧	people	man mechanic medium light skin tone electrician plumber tradesperson
+👨🏽‍🔧	people	man mechanic medium skin tone electrician plumber tradesperson
+👨🏾‍🔧	people	man mechanic medium dark skin tone electrician plumber tradesperson
+👨🏿‍🔧	people	man mechanic dark skin tone electrician plumber tradesperson
+👩‍🔧	people	woman mechanic electrician plumber tradesperson
+👩🏻‍🔧	people	woman mechanic light skin tone electrician plumber tradesperson
+👩🏼‍🔧	people	woman mechanic medium light skin tone electrician plumber tradesperson
+👩🏽‍🔧	people	woman mechanic medium skin tone electrician plumber tradesperson
+👩🏾‍🔧	people	woman mechanic medium dark skin tone electrician plumber tradesperson
+👩🏿‍🔧	people	woman mechanic dark skin tone electrician plumber tradesperson
+🧑‍🏭	people	factory worker assembly industrial
+🧑🏻‍🏭	people	factory worker light skin tone assembly industrial
+🧑🏼‍🏭	people	factory worker medium light skin tone assembly industrial
+🧑🏽‍🏭	people	factory worker medium skin tone assembly industrial
+🧑🏾‍🏭	people	factory worker medium dark skin tone assembly industrial
+🧑🏿‍🏭	people	factory worker dark skin tone assembly industrial
+👨‍🏭	people	man factory worker assembly industrial
+👨🏻‍🏭	people	man factory worker light skin tone assembly industrial
+👨🏼‍🏭	people	man factory worker medium light skin tone assembly industrial
+👨🏽‍🏭	people	man factory worker medium skin tone assembly industrial
+👨🏾‍🏭	people	man factory worker medium dark skin tone assembly industrial
+👨🏿‍🏭	people	man factory worker dark skin tone assembly industrial
+👩‍🏭	people	woman factory worker assembly industrial
+👩🏻‍🏭	people	woman factory worker light skin tone assembly industrial
+👩🏼‍🏭	people	woman factory worker medium light skin tone assembly industrial
+👩🏽‍🏭	people	woman factory worker medium skin tone assembly industrial
+👩🏾‍🏭	people	woman factory worker medium dark skin tone assembly industrial
+👩🏿‍🏭	people	woman factory worker dark skin tone assembly industrial
+🧑‍💼	people	office worker architect business manager white collar
+🧑🏻‍💼	people	office worker light skin tone architect business manager white collar
+🧑🏼‍💼	people	office worker medium light skin tone architect business manager white collar
+🧑🏽‍💼	people	office worker medium skin tone architect business manager white collar
+🧑🏾‍💼	people	office worker medium dark skin tone architect business manager white collar
+🧑🏿‍💼	people	office worker dark skin tone architect business manager white collar
+👨‍💼	people	man office worker architect business manager white collar
+👨🏻‍💼	people	man office worker light skin tone architect business manager white collar
+👨🏼‍💼	people	man office worker medium light skin tone architect business manager white collar
+👨🏽‍💼	people	man office worker medium skin tone architect business manager white collar
+👨🏾‍💼	people	man office worker medium dark skin tone architect business manager white collar
+👨🏿‍💼	people	man office worker dark skin tone architect business manager white collar
+👩‍💼	people	woman office worker architect business manager white collar
+👩🏻‍💼	people	woman office worker light skin tone architect business manager white collar
+👩🏼‍💼	people	woman office worker medium light skin tone architect business manager white collar
+👩🏽‍💼	people	woman office worker medium skin tone architect business manager white collar
+👩🏾‍💼	people	woman office worker medium dark skin tone architect business manager white collar
+👩🏿‍💼	people	woman office worker dark skin tone architect business manager white collar
+🧑‍🔬	people	scientist biologist chemist engineer mathematician physicist
+🧑🏻‍🔬	people	scientist light skin tone biologist chemist engineer mathematician physicist
+🧑🏼‍🔬	people	scientist medium light skin tone biologist chemist engineer mathematician physicist
+🧑🏽‍🔬	people	scientist medium skin tone biologist chemist engineer mathematician physicist
+🧑🏾‍🔬	people	scientist medium dark skin tone biologist chemist engineer mathematician physicist
+🧑🏿‍🔬	people	scientist dark skin tone biologist chemist engineer mathematician physicist
+👨‍🔬	people	man scientist biologist chemist engineer mathematician physicist
+👨🏻‍🔬	people	man scientist light skin tone biologist chemist engineer mathematician physicist
+👨🏼‍🔬	people	man scientist medium light skin tone biologist chemist engineer mathematician physicist
+👨🏽‍🔬	people	man scientist medium skin tone biologist chemist engineer mathematician physicist
+👨🏾‍🔬	people	man scientist medium dark skin tone biologist chemist engineer mathematician physicist
+👨🏿‍🔬	people	man scientist dark skin tone biologist chemist engineer mathematician physicist
+👩‍🔬	people	woman scientist biologist chemist engineer mathematician physicist
+👩🏻‍🔬	people	woman scientist light skin tone biologist chemist engineer mathematician physicist
+👩🏼‍🔬	people	woman scientist medium light skin tone biologist chemist engineer mathematician physicist
+👩🏽‍🔬	people	woman scientist medium skin tone biologist chemist engineer mathematician physicist
+👩🏾‍🔬	people	woman scientist medium dark skin tone biologist chemist engineer mathematician physicist
+👩🏿‍🔬	people	woman scientist dark skin tone biologist chemist engineer mathematician physicist
+🧑‍💻	people	technologist coder computer developer inventor software
+🧑🏻‍💻	people	technologist light skin tone coder computer developer inventor software
+🧑🏼‍💻	people	technologist medium light skin tone coder computer developer inventor software
+🧑🏽‍💻	people	technologist medium skin tone coder computer developer inventor software
+🧑🏾‍💻	people	technologist medium dark skin tone coder computer developer inventor software
+🧑🏿‍💻	people	technologist dark skin tone coder computer developer inventor software
+👨‍💻	people	man technologist coder computer developer inventor software
+👨🏻‍💻	people	man technologist light skin tone coder computer developer inventor software
+👨🏼‍💻	people	man technologist medium light skin tone coder computer developer inventor software
+👨🏽‍💻	people	man technologist medium skin tone coder computer developer inventor software
+👨🏾‍💻	people	man technologist medium dark skin tone coder computer developer inventor software
+👨🏿‍💻	people	man technologist dark skin tone coder computer developer inventor software
+👩‍💻	people	woman technologist coder computer developer inventor software
+👩🏻‍💻	people	woman technologist light skin tone coder computer developer inventor software
+👩🏼‍💻	people	woman technologist medium light skin tone coder computer developer inventor software
+👩🏽‍💻	people	woman technologist medium skin tone coder computer developer inventor software
+👩🏾‍💻	people	woman technologist medium dark skin tone coder computer developer inventor software
+👩🏿‍💻	people	woman technologist dark skin tone coder computer developer inventor software
+🧑‍🎤	people	singer actor entertainer rock rockstar star
+🧑🏻‍🎤	people	singer light skin tone actor entertainer rock rockstar star
+🧑🏼‍🎤	people	singer medium light skin tone actor entertainer rock rockstar star
+🧑🏽‍🎤	people	singer medium skin tone actor entertainer rock rockstar star
+🧑🏾‍🎤	people	singer medium dark skin tone actor entertainer rock rockstar star
+🧑🏿‍🎤	people	singer dark skin tone actor entertainer rock rockstar star
+👨‍🎤	people	man singer actor entertainer rock rockstar star
+👨🏻‍🎤	people	man singer light skin tone actor entertainer rock rockstar star
+👨🏼‍🎤	people	man singer medium light skin tone actor entertainer rock rockstar star
+👨🏽‍🎤	people	man singer medium skin tone actor entertainer rock rockstar star
+👨🏾‍🎤	people	man singer medium dark skin tone actor entertainer rock rockstar star
+👨🏿‍🎤	people	man singer dark skin tone actor entertainer rock rockstar star
+👩‍🎤	people	woman singer actor entertainer rock rockstar star
+👩🏻‍🎤	people	woman singer light skin tone actor entertainer rock rockstar star
+👩🏼‍🎤	people	woman singer medium light skin tone actor entertainer rock rockstar star
+👩🏽‍🎤	people	woman singer medium skin tone actor entertainer rock rockstar star
+👩🏾‍🎤	people	woman singer medium dark skin tone actor entertainer rock rockstar star
+👩🏿‍🎤	people	woman singer dark skin tone actor entertainer rock rockstar star
+🧑‍🎨	people	artist palette
+🧑🏻‍🎨	people	artist light skin tone palette
+🧑🏼‍🎨	people	artist medium light skin tone palette
+🧑🏽‍🎨	people	artist medium skin tone palette
+🧑🏾‍🎨	people	artist medium dark skin tone palette
+🧑🏿‍🎨	people	artist dark skin tone palette
+👨‍🎨	people	man artist palette
+👨🏻‍🎨	people	man artist light skin tone palette
+👨🏼‍🎨	people	man artist medium light skin tone palette
+👨🏽‍🎨	people	man artist medium skin tone palette
+👨🏾‍🎨	people	man artist medium dark skin tone palette
+👨🏿‍🎨	people	man artist dark skin tone palette
+👩‍🎨	people	woman artist palette
+👩🏻‍🎨	people	woman artist light skin tone palette
+👩🏼‍🎨	people	woman artist medium light skin tone palette
+👩🏽‍🎨	people	woman artist medium skin tone palette
+👩🏾‍🎨	people	woman artist medium dark skin tone palette
+👩🏿‍🎨	people	woman artist dark skin tone palette
+🧑‍✈️	people	pilot plane
+🧑🏻‍✈️	people	pilot light skin tone plane
+🧑🏼‍✈️	people	pilot medium light skin tone plane
+🧑🏽‍✈️	people	pilot medium skin tone plane
+🧑🏾‍✈️	people	pilot medium dark skin tone plane
+🧑🏿‍✈️	people	pilot dark skin tone plane
+👨‍✈️	people	man pilot plane
+👨🏻‍✈️	people	man pilot light skin tone plane
+👨🏼‍✈️	people	man pilot medium light skin tone plane
+👨🏽‍✈️	people	man pilot medium skin tone plane
+👨🏾‍✈️	people	man pilot medium dark skin tone plane
+👨🏿‍✈️	people	man pilot dark skin tone plane
+👩‍✈️	people	woman pilot plane
+👩🏻‍✈️	people	woman pilot light skin tone plane
+👩🏼‍✈️	people	woman pilot medium light skin tone plane
+👩🏽‍✈️	people	woman pilot medium skin tone plane
+👩🏾‍✈️	people	woman pilot medium dark skin tone plane
+👩🏿‍✈️	people	woman pilot dark skin tone plane
+🧑‍🚀	people	astronaut rocket space
+🧑🏻‍🚀	people	astronaut light skin tone rocket space
+🧑🏼‍🚀	people	astronaut medium light skin tone rocket space
+🧑🏽‍🚀	people	astronaut medium skin tone rocket space
+🧑🏾‍🚀	people	astronaut medium dark skin tone rocket space
+🧑🏿‍🚀	people	astronaut dark skin tone rocket space
+👨‍🚀	people	man astronaut rocket space
+👨🏻‍🚀	people	man astronaut light skin tone rocket space
+👨🏼‍🚀	people	man astronaut medium light skin tone rocket space
+👨🏽‍🚀	people	man astronaut medium skin tone rocket space
+👨🏾‍🚀	people	man astronaut medium dark skin tone rocket space
+👨🏿‍🚀	people	man astronaut dark skin tone rocket space
+👩‍🚀	people	woman astronaut rocket space
+👩🏻‍🚀	people	woman astronaut light skin tone rocket space
+👩🏼‍🚀	people	woman astronaut medium light skin tone rocket space
+👩🏽‍🚀	people	woman astronaut medium skin tone rocket space
+👩🏾‍🚀	people	woman astronaut medium dark skin tone rocket space
+👩🏿‍🚀	people	woman astronaut dark skin tone rocket space
 🧑‍🚒	people	firefighter fire firetruck
-🧑🏻‍🚒	people	firefighter: light skin tone
-🧑🏼‍🚒	people	firefighter: medium-light skin tone
-🧑🏽‍🚒	people	firefighter: medium skin tone
-🧑🏾‍🚒	people	firefighter: medium-dark skin tone
-🧑🏿‍🚒	people	firefighter: dark skin tone
-👨‍🚒	people	man firefighter fireman man human fire firetruck male men
-👨🏻‍🚒	people	man firefighter: light skin tone
-👨🏼‍🚒	people	man firefighter: medium-light skin tone
-👨🏽‍🚒	people	man firefighter: medium skin tone
-👨🏾‍🚒	people	man firefighter: medium-dark skin tone
-👨🏿‍🚒	people	man firefighter: dark skin tone
-👩‍🚒	people	woman firefighter fireman woman human female fire firetruck women
-👩🏻‍🚒	people	woman firefighter: light skin tone
-👩🏼‍🚒	people	woman firefighter: medium-light skin tone
-👩🏽‍🚒	people	woman firefighter: medium skin tone
-👩🏾‍🚒	people	woman firefighter: medium-dark skin tone
-👩🏿‍🚒	people	woman firefighter: dark skin tone
-👮	people	police officer cop law policeman policewoman
-👮🏻	people	police officer: light skin tone
-👮🏼	people	police officer: medium-light skin tone
-👮🏽	people	police officer: medium skin tone
-👮🏾	people	police officer: medium-dark skin tone
-👮🏿	people	police officer: dark skin tone
-👮‍♂️	people	man police officer man police law legal enforcement arrest 911 cop male men policeman
-👮🏻‍♂️	people	man police officer: light skin tone
-👮🏼‍♂️	people	man police officer: medium-light skin tone
-👮🏽‍♂️	people	man police officer: medium skin tone
-👮🏾‍♂️	people	man police officer: medium-dark skin tone
-👮🏿‍♂️	people	man police officer: dark skin tone
-👮‍♀️	people	woman police officer woman police law legal enforcement arrest 911 female cop policewoman women
-👮🏻‍♀️	people	woman police officer: light skin tone
-👮🏼‍♀️	people	woman police officer: medium-light skin tone
-👮🏽‍♀️	people	woman police officer: medium skin tone
-👮🏾‍♀️	people	woman police officer: medium-dark skin tone
-👮🏿‍♀️	people	woman police officer: dark skin tone
-🕵️	people	detective human spy eye or private sleuth
-🕵🏻	people	detective: light skin tone
-🕵🏼	people	detective: medium-light skin tone
-🕵🏽	people	detective: medium skin tone
-🕵🏾	people	detective: medium-dark skin tone
-🕵🏿	people	detective: dark skin tone
-🕵️‍♂️	people	man detective crime male men sleuth spy
-🕵🏻‍♂️	people	man detective: light skin tone
-🕵🏼‍♂️	people	man detective: medium-light skin tone
-🕵🏽‍♂️	people	man detective: medium skin tone
-🕵🏾‍♂️	people	man detective: medium-dark skin tone
-🕵🏿‍♂️	people	man detective: dark skin tone
-🕵️‍♀️	people	woman detective human spy detective female woman sleuth women
-🕵🏻‍♀️	people	woman detective: light skin tone
-🕵🏼‍♀️	people	woman detective: medium-light skin tone
-🕵🏽‍♀️	people	woman detective: medium skin tone
-🕵🏾‍♀️	people	woman detective: medium-dark skin tone
-🕵🏿‍♀️	people	woman detective: dark skin tone
-💂	people	guard protect british guardsman
-💂🏻	people	guard: light skin tone
-💂🏼	people	guard: medium-light skin tone
-💂🏽	people	guard: medium skin tone
-💂🏾	people	guard: medium-dark skin tone
-💂🏿	people	guard: dark skin tone
-💂‍♂️	people	man guard uk gb british male guy royal guardsman men
-💂🏻‍♂️	people	man guard: light skin tone
-💂🏼‍♂️	people	man guard: medium-light skin tone
-💂🏽‍♂️	people	man guard: medium skin tone
-💂🏾‍♂️	people	man guard: medium-dark skin tone
-💂🏿‍♂️	people	man guard: dark skin tone
-💂‍♀️	people	woman guard uk gb british female royal woman guardsman guardswoman women
-💂🏻‍♀️	people	woman guard: light skin tone
-💂🏼‍♀️	people	woman guard: medium-light skin tone
-💂🏽‍♀️	people	woman guard: medium skin tone
-💂🏾‍♀️	people	woman guard: medium-dark skin tone
-💂🏿‍♀️	people	woman guard: dark skin tone
-🥷	people	ninja ninjutsu skills japanese fighter hidden stealth
-🥷🏻	people	ninja: light skin tone
-🥷🏼	people	ninja: medium-light skin tone
-🥷🏽	people	ninja: medium skin tone
-🥷🏾	people	ninja: medium-dark skin tone
-🥷🏿	people	ninja: dark skin tone
-👷	people	construction worker labor build builder face hard hat helmet safety add ci update ci
-👷🏻	people	construction worker: light skin tone
-👷🏼	people	construction worker: medium-light skin tone
-👷🏽	people	construction worker: medium skin tone
-👷🏾	people	construction worker: medium-dark skin tone
-👷🏿	people	construction worker: dark skin tone
-👷‍♂️	people	man construction worker male human wip guy build construction worker labor helmet men
-👷🏻‍♂️	people	man construction worker: light skin tone
-👷🏼‍♂️	people	man construction worker: medium-light skin tone
-👷🏽‍♂️	people	man construction worker: medium skin tone
-👷🏾‍♂️	people	man construction worker: medium-dark skin tone
-👷🏿‍♂️	people	man construction worker: dark skin tone
-👷‍♀️	people	woman construction worker female human wip build construction worker labor woman helmet women
-👷🏻‍♀️	people	woman construction worker: light skin tone
-👷🏼‍♀️	people	woman construction worker: medium-light skin tone
-👷🏽‍♀️	people	woman construction worker: medium skin tone
-👷🏾‍♀️	people	woman construction worker: medium-dark skin tone
-👷🏿‍♀️	people	woman construction worker: dark skin tone
-🫅	people	person with crown royalty power monarch noble regal
-🫅🏻	people	person with crown: light skin tone
-🫅🏼	people	person with crown: medium-light skin tone
-🫅🏽	people	person with crown: medium skin tone
-🫅🏾	people	person with crown: medium-dark skin tone
-🫅🏿	people	person with crown: dark skin tone
-🤴	people	prince boy man male crown royal king fairy fantasy men tale
-🤴🏻	people	prince: light skin tone
-🤴🏼	people	prince: medium-light skin tone
-🤴🏽	people	prince: medium skin tone
-🤴🏾	people	prince: medium-dark skin tone
-🤴🏿	people	prince: dark skin tone
-👸	people	princess girl woman female blond crown royal queen blonde fairy fantasy tale tiara women
-👸🏻	people	princess: light skin tone
-👸🏼	people	princess: medium-light skin tone
-👸🏽	people	princess: medium skin tone
-👸🏾	people	princess: medium-dark skin tone
-👸🏿	people	princess: dark skin tone
-👳	people	person wearing turban headdress arab man muslim sikh
-👳🏻	people	person wearing turban: light skin tone
-👳🏼	people	person wearing turban: medium-light skin tone
-👳🏽	people	person wearing turban: medium skin tone
-👳🏾	people	person wearing turban: medium-dark skin tone
-👳🏿	people	person wearing turban: dark skin tone
-👳‍♂️	people	man wearing turban male indian hinduism arabs men
-👳🏻‍♂️	people	man wearing turban: light skin tone
-👳🏼‍♂️	people	man wearing turban: medium-light skin tone
-👳🏽‍♂️	people	man wearing turban: medium skin tone
-👳🏾‍♂️	people	man wearing turban: medium-dark skin tone
-👳🏿‍♂️	people	man wearing turban: dark skin tone
-👳‍♀️	people	woman wearing turban female indian hinduism arabs woman women
-👳🏻‍♀️	people	woman wearing turban: light skin tone
-👳🏼‍♀️	people	woman wearing turban: medium-light skin tone
-👳🏽‍♀️	people	woman wearing turban: medium skin tone
-👳🏾‍♀️	people	woman wearing turban: medium-dark skin tone
-👳🏿‍♀️	people	woman wearing turban: dark skin tone
-👲	people	person with skullcap man with skullcap male boy chinese asian cap gua hat mao person pi
-👲🏻	people	person with skullcap: light skin tone
-👲🏼	people	person with skullcap: medium-light skin tone
-👲🏽	people	person with skullcap: medium skin tone
-👲🏾	people	person with skullcap: medium-dark skin tone
-👲🏿	people	person with skullcap: dark skin tone
-🧕	people	woman with headscarf female hijab mantilla tichel
-🧕🏻	people	woman with headscarf: light skin tone
-🧕🏼	people	woman with headscarf: medium-light skin tone
-🧕🏽	people	woman with headscarf: medium skin tone
-🧕🏾	people	woman with headscarf: medium-dark skin tone
-🧕🏿	people	woman with headscarf: dark skin tone
-🤵	people	person in tuxedo man in tuxedo couple marriage wedding groom male men person suit
-🤵🏻	people	person in tuxedo: light skin tone
-🤵🏼	people	person in tuxedo: medium-light skin tone
-🤵🏽	people	person in tuxedo: medium skin tone
-🤵🏾	people	person in tuxedo: medium-dark skin tone
-🤵🏿	people	person in tuxedo: dark skin tone
-🤵‍♂️	people	man in tuxedo formal fashion groom male men person suit wedding
-🤵🏻‍♂️	people	man in tuxedo: light skin tone
-🤵🏼‍♂️	people	man in tuxedo: medium-light skin tone
-🤵🏽‍♂️	people	man in tuxedo: medium skin tone
-🤵🏾‍♂️	people	man in tuxedo: medium-dark skin tone
-🤵🏿‍♂️	people	man in tuxedo: dark skin tone
-🤵‍♀️	people	woman in tuxedo formal fashion female wedding women
-🤵🏻‍♀️	people	woman in tuxedo: light skin tone
-🤵🏼‍♀️	people	woman in tuxedo: medium-light skin tone
-🤵🏽‍♀️	people	woman in tuxedo: medium skin tone
-🤵🏾‍♀️	people	woman in tuxedo: medium-dark skin tone
-🤵🏿‍♀️	people	woman in tuxedo: dark skin tone
-👰	people	person with veil bride with veil couple marriage wedding woman bride person
-👰🏻	people	person with veil: light skin tone
-👰🏼	people	person with veil: medium-light skin tone
-👰🏽	people	person with veil: medium skin tone
-👰🏾	people	person with veil: medium-dark skin tone
-👰🏿	people	person with veil: dark skin tone
-👰‍♂️	people	man with veil wedding marriage bride male men
-👰🏻‍♂️	people	man with veil: light skin tone
-👰🏼‍♂️	people	man with veil: medium-light skin tone
-👰🏽‍♂️	people	man with veil: medium skin tone
-👰🏾‍♂️	people	man with veil: medium-dark skin tone
-👰🏿‍♂️	people	man with veil: dark skin tone
-👰‍♀️	people	woman with veil wedding marriage bride female women
-👰🏻‍♀️	people	woman with veil: light skin tone
-👰🏼‍♀️	people	woman with veil: medium-light skin tone
-👰🏽‍♀️	people	woman with veil: medium skin tone
-👰🏾‍♀️	people	woman with veil: medium-dark skin tone
-👰🏿‍♀️	people	woman with veil: dark skin tone
-🤰	people	pregnant woman baby female pregnancy pregnant lady women
-🤰🏻	people	pregnant woman: light skin tone
-🤰🏼	people	pregnant woman: medium-light skin tone
-🤰🏽	people	pregnant woman: medium skin tone
-🤰🏾	people	pregnant woman: medium-dark skin tone
-🤰🏿	people	pregnant woman: dark skin tone
-🫃	people	pregnant man baby belly bloated full
-🫃🏻	people	pregnant man: light skin tone
-🫃🏼	people	pregnant man: medium-light skin tone
-🫃🏽	people	pregnant man: medium skin tone
-🫃🏾	people	pregnant man: medium-dark skin tone
-🫃🏿	people	pregnant man: dark skin tone
-🫄	people	pregnant person baby belly bloated full
-🫄🏻	people	pregnant person: light skin tone
-🫄🏼	people	pregnant person: medium-light skin tone
-🫄🏽	people	pregnant person: medium skin tone
-🫄🏾	people	pregnant person: medium-dark skin tone
-🫄🏿	people	pregnant person: dark skin tone
-🤱	people	breast-feeding breast feeding nursing baby breastfeeding child female infant milk mother woman women
-🤱🏻	people	breast-feeding: light skin tone
-🤱🏼	people	breast-feeding: medium-light skin tone
-🤱🏽	people	breast-feeding: medium skin tone
-🤱🏾	people	breast-feeding: medium-dark skin tone
-🤱🏿	people	breast-feeding: dark skin tone
-👩‍🍼	people	woman feeding baby birth food bottle child female infant milk nursing women
-👩🏻‍🍼	people	woman feeding baby: light skin tone
-👩🏼‍🍼	people	woman feeding baby: medium-light skin tone
-👩🏽‍🍼	people	woman feeding baby: medium skin tone
-👩🏾‍🍼	people	woman feeding baby: medium-dark skin tone
-👩🏿‍🍼	people	woman feeding baby: dark skin tone
-👨‍🍼	people	man feeding baby birth food bottle child infant male men milk nursing
-👨🏻‍🍼	people	man feeding baby: light skin tone
-👨🏼‍🍼	people	man feeding baby: medium-light skin tone
-👨🏽‍🍼	people	man feeding baby: medium skin tone
-👨🏾‍🍼	people	man feeding baby: medium-dark skin tone
-👨🏿‍🍼	people	man feeding baby: dark skin tone
-🧑‍🍼	people	person feeding baby birth food bottle child infant milk nursing
-🧑🏻‍🍼	people	person feeding baby: light skin tone
-🧑🏼‍🍼	people	person feeding baby: medium-light skin tone
-🧑🏽‍🍼	people	person feeding baby: medium skin tone
-🧑🏾‍🍼	people	person feeding baby: medium-dark skin tone
-🧑🏿‍🍼	people	person feeding baby: dark skin tone
-👼	people	baby angel heaven wings halo cherub cupid face fairy fantasy putto tale
-👼🏻	people	baby angel: light skin tone
-👼🏼	people	baby angel: medium-light skin tone
-👼🏽	people	baby angel: medium skin tone
-👼🏾	people	baby angel: medium-dark skin tone
-👼🏿	people	baby angel: dark skin tone
-🎅	people	santa claus festival man male xmas father christmas activity celebration men nicholas saint sinterklaas
-🎅🏻	people	santa claus: light skin tone
-🎅🏼	people	santa claus: medium-light skin tone
-🎅🏽	people	santa claus: medium skin tone
-🎅🏾	people	santa claus: medium-dark skin tone
-🎅🏿	people	santa claus: dark skin tone
-🤶	people	mrs. claus mrs claus woman female xmas mother christmas activity celebration mrs. santa women
-🤶🏻	people	mrs. claus: light skin tone
-🤶🏼	people	mrs. claus: medium-light skin tone
-🤶🏽	people	mrs. claus: medium skin tone
-🤶🏾	people	mrs. claus: medium-dark skin tone
-🤶🏿	people	mrs. claus: dark skin tone
-🧑‍🎄	people	mx claus christmas activity celebration mx. santa
-🧑🏻‍🎄	people	mx claus: light skin tone
-🧑🏼‍🎄	people	mx claus: medium-light skin tone
-🧑🏽‍🎄	people	mx claus: medium skin tone
-🧑🏾‍🎄	people	mx claus: medium-dark skin tone
-🧑🏿‍🎄	people	mx claus: dark skin tone
-🦸	people	superhero marvel fantasy good hero heroine superpower superpowers
-🦸🏻	people	superhero: light skin tone
-🦸🏼	people	superhero: medium-light skin tone
-🦸🏽	people	superhero: medium skin tone
-🦸🏾	people	superhero: medium-dark skin tone
-🦸🏿	people	superhero: dark skin tone
-🦸‍♂️	people	man superhero man male good hero superpowers fantasy men superpower
-🦸🏻‍♂️	people	man superhero: light skin tone
-🦸🏼‍♂️	people	man superhero: medium-light skin tone
-🦸🏽‍♂️	people	man superhero: medium skin tone
-🦸🏾‍♂️	people	man superhero: medium-dark skin tone
-🦸🏿‍♂️	people	man superhero: dark skin tone
-🦸‍♀️	people	woman superhero woman female good heroine superpowers fantasy hero superpower women
-🦸🏻‍♀️	people	woman superhero: light skin tone
-🦸🏼‍♀️	people	woman superhero: medium-light skin tone
-🦸🏽‍♀️	people	woman superhero: medium skin tone
-🦸🏾‍♀️	people	woman superhero: medium-dark skin tone
-🦸🏿‍♀️	people	woman superhero: dark skin tone
-🦹	people	supervillain marvel bad criminal evil fantasy superpower superpowers villain
-🦹🏻	people	supervillain: light skin tone
-🦹🏼	people	supervillain: medium-light skin tone
-🦹🏽	people	supervillain: medium skin tone
-🦹🏾	people	supervillain: medium-dark skin tone
-🦹🏿	people	supervillain: dark skin tone
-🦹‍♂️	people	man supervillain man male evil bad criminal hero superpowers fantasy men superpower villain
-🦹🏻‍♂️	people	man supervillain: light skin tone
-🦹🏼‍♂️	people	man supervillain: medium-light skin tone
-🦹🏽‍♂️	people	man supervillain: medium skin tone
-🦹🏾‍♂️	people	man supervillain: medium-dark skin tone
-🦹🏿‍♂️	people	man supervillain: dark skin tone
-🦹‍♀️	people	woman supervillain woman female evil bad criminal heroine superpowers fantasy superpower villain women
-🦹🏻‍♀️	people	woman supervillain: light skin tone
-🦹🏼‍♀️	people	woman supervillain: medium-light skin tone
-🦹🏽‍♀️	people	woman supervillain: medium skin tone
-🦹🏾‍♀️	people	woman supervillain: medium-dark skin tone
-🦹🏿‍♀️	people	woman supervillain: dark skin tone
-🧙	people	mage magic fantasy sorcerer sorceress witch wizard
-🧙🏻	people	mage: light skin tone
-🧙🏼	people	mage: medium-light skin tone
-🧙🏽	people	mage: medium skin tone
-🧙🏾	people	mage: medium-dark skin tone
-🧙🏿	people	mage: dark skin tone
-🧙‍♂️	people	man mage man male mage sorcerer fantasy men wizard
-🧙🏻‍♂️	people	man mage: light skin tone
-🧙🏼‍♂️	people	man mage: medium-light skin tone
-🧙🏽‍♂️	people	man mage: medium skin tone
-🧙🏾‍♂️	people	man mage: medium-dark skin tone
-🧙🏿‍♂️	people	man mage: dark skin tone
-🧙‍♀️	people	woman mage woman female mage witch fantasy sorceress wizard women
-🧙🏻‍♀️	people	woman mage: light skin tone
-🧙🏼‍♀️	people	woman mage: medium-light skin tone
-🧙🏽‍♀️	people	woman mage: medium skin tone
-🧙🏾‍♀️	people	woman mage: medium-dark skin tone
-🧙🏿‍♀️	people	woman mage: dark skin tone
-🧚	people	fairy wings magical fantasy oberon puck titania
-🧚🏻	people	fairy: light skin tone
-🧚🏼	people	fairy: medium-light skin tone
-🧚🏽	people	fairy: medium skin tone
-🧚🏾	people	fairy: medium-dark skin tone
-🧚🏿	people	fairy: dark skin tone
-🧚‍♂️	people	man fairy man male fantasy men oberon puck
-🧚🏻‍♂️	people	man fairy: light skin tone
-🧚🏼‍♂️	people	man fairy: medium-light skin tone
-🧚🏽‍♂️	people	man fairy: medium skin tone
-🧚🏾‍♂️	people	man fairy: medium-dark skin tone
-🧚🏿‍♂️	people	man fairy: dark skin tone
-🧚‍♀️	people	woman fairy woman female fantasy titania wings women
-🧚🏻‍♀️	people	woman fairy: light skin tone
-🧚🏼‍♀️	people	woman fairy: medium-light skin tone
-🧚🏽‍♀️	people	woman fairy: medium skin tone
-🧚🏾‍♀️	people	woman fairy: medium-dark skin tone
-🧚🏿‍♀️	people	woman fairy: dark skin tone
-🧛	people	vampire blood twilight dracula fantasy undead
-🧛🏻	people	vampire: light skin tone
-🧛🏼	people	vampire: medium-light skin tone
-🧛🏽	people	vampire: medium skin tone
-🧛🏾	people	vampire: medium-dark skin tone
-🧛🏿	people	vampire: dark skin tone
-🧛‍♂️	people	man vampire man male dracula fantasy men undead
-🧛🏻‍♂️	people	man vampire: light skin tone
-🧛🏼‍♂️	people	man vampire: medium-light skin tone
-🧛🏽‍♂️	people	man vampire: medium skin tone
-🧛🏾‍♂️	people	man vampire: medium-dark skin tone
-🧛🏿‍♂️	people	man vampire: dark skin tone
-🧛‍♀️	people	woman vampire woman female fantasy undead unded women
-🧛🏻‍♀️	people	woman vampire: light skin tone
-🧛🏼‍♀️	people	woman vampire: medium-light skin tone
-🧛🏽‍♀️	people	woman vampire: medium skin tone
-🧛🏾‍♀️	people	woman vampire: medium-dark skin tone
-🧛🏿‍♀️	people	woman vampire: dark skin tone
-🧜	people	merperson sea fantasy merboy mergirl mermaid merman merwoman
-🧜🏻	people	merperson: light skin tone
-🧜🏼	people	merperson: medium-light skin tone
-🧜🏽	people	merperson: medium skin tone
-🧜🏾	people	merperson: medium-dark skin tone
-🧜🏿	people	merperson: dark skin tone
-🧜‍♂️	people	merman man male triton fantasy men mermaid
-🧜🏻‍♂️	people	merman: light skin tone
-🧜🏼‍♂️	people	merman: medium-light skin tone
-🧜🏽‍♂️	people	merman: medium skin tone
-🧜🏾‍♂️	people	merman: medium-dark skin tone
-🧜🏿‍♂️	people	merman: dark skin tone
-🧜‍♀️	people	mermaid woman female merwoman ariel fantasy women
-🧜🏻‍♀️	people	mermaid: light skin tone
-🧜🏼‍♀️	people	mermaid: medium-light skin tone
-🧜🏽‍♀️	people	mermaid: medium skin tone
-🧜🏾‍♀️	people	mermaid: medium-dark skin tone
-🧜🏿‍♀️	people	mermaid: dark skin tone
-🧝	people	elf magical ears fantasy legolas pointed
-🧝🏻	people	elf: light skin tone
-🧝🏼	people	elf: medium-light skin tone
-🧝🏽	people	elf: medium skin tone
-🧝🏾	people	elf: medium-dark skin tone
-🧝🏿	people	elf: dark skin tone
-🧝‍♂️	people	man elf man male ears fantasy magical men pointed
-🧝🏻‍♂️	people	man elf: light skin tone
-🧝🏼‍♂️	people	man elf: medium-light skin tone
-🧝🏽‍♂️	people	man elf: medium skin tone
-🧝🏾‍♂️	people	man elf: medium-dark skin tone
-🧝🏿‍♂️	people	man elf: dark skin tone
-🧝‍♀️	people	woman elf woman female ears fantasy magical pointed women
-🧝🏻‍♀️	people	woman elf: light skin tone
-🧝🏼‍♀️	people	woman elf: medium-light skin tone
-🧝🏽‍♀️	people	woman elf: medium skin tone
-🧝🏾‍♀️	people	woman elf: medium-dark skin tone
-🧝🏿‍♀️	people	woman elf: dark skin tone
-🧞	people	genie magical wishes djinn djinni fantasy jinni
-🧞‍♂️	people	man genie man male djinn fantasy men
-🧞‍♀️	people	woman genie woman female djinn fantasy women
-🧟	people	zombie dead fantasy undead walking
-🧟‍♂️	people	man zombie man male dracula undead walking dead fantasy men
-🧟‍♀️	people	woman zombie woman female undead walking dead fantasy women
-🧌	people	troll mystical monster fairy fantasy tale shrek
-🫈	people	hairy creature sasquatch bigfoot treeman
-💆	people	person getting massage relax face head massaging salon spa
-💆🏻	people	person getting massage: light skin tone
-💆🏼	people	person getting massage: medium-light skin tone
-💆🏽	people	person getting massage: medium skin tone
-💆🏾	people	person getting massage: medium-dark skin tone
-💆🏿	people	person getting massage: dark skin tone
-💆‍♂️	people	man getting massage male boy man head face men salon spa
-💆🏻‍♂️	people	man getting massage: light skin tone
-💆🏼‍♂️	people	man getting massage: medium-light skin tone
-💆🏽‍♂️	people	man getting massage: medium skin tone
-💆🏾‍♂️	people	man getting massage: medium-dark skin tone
-💆🏿‍♂️	people	man getting massage: dark skin tone
-💆‍♀️	people	woman getting massage female girl woman head face salon spa women
-💆🏻‍♀️	people	woman getting massage: light skin tone
-💆🏼‍♀️	people	woman getting massage: medium-light skin tone
-💆🏽‍♀️	people	woman getting massage: medium skin tone
-💆🏾‍♀️	people	woman getting massage: medium-dark skin tone
-💆🏿‍♀️	people	woman getting massage: dark skin tone
-💇	people	person getting haircut hairstyle barber beauty cutting hair hairdresser parlor
-💇🏻	people	person getting haircut: light skin tone
-💇🏼	people	person getting haircut: medium-light skin tone
-💇🏽	people	person getting haircut: medium skin tone
-💇🏾	people	person getting haircut: medium-dark skin tone
-💇🏿	people	person getting haircut: dark skin tone
-💇‍♂️	people	man getting haircut male boy man barber beauty men parlor
-💇🏻‍♂️	people	man getting haircut: light skin tone
-💇🏼‍♂️	people	man getting haircut: medium-light skin tone
-💇🏽‍♂️	people	man getting haircut: medium skin tone
-💇🏾‍♂️	people	man getting haircut: medium-dark skin tone
-💇🏿‍♂️	people	man getting haircut: dark skin tone
-💇‍♀️	people	woman getting haircut female girl woman barber beauty parlor women
-💇🏻‍♀️	people	woman getting haircut: light skin tone
-💇🏼‍♀️	people	woman getting haircut: medium-light skin tone
-💇🏽‍♀️	people	woman getting haircut: medium skin tone
-💇🏾‍♀️	people	woman getting haircut: medium-dark skin tone
-💇🏿‍♀️	people	woman getting haircut: dark skin tone
-🚶	people	person walking move hike pedestrian walk walker
-🚶🏻	people	person walking: light skin tone
-🚶🏼	people	person walking: medium-light skin tone
-🚶🏽	people	person walking: medium skin tone
-🚶🏾	people	person walking: medium-dark skin tone
-🚶🏿	people	person walking: dark skin tone
-🚶‍♂️	people	man walking human feet steps hike male men pedestrian walk
-🚶🏻‍♂️	people	man walking: light skin tone
-🚶🏼‍♂️	people	man walking: medium-light skin tone
-🚶🏽‍♂️	people	man walking: medium skin tone
-🚶🏾‍♂️	people	man walking: medium-dark skin tone
-🚶🏿‍♂️	people	man walking: dark skin tone
-🚶‍♀️	people	woman walking human feet steps woman female hike pedestrian walk women
-🚶🏻‍♀️	people	woman walking: light skin tone
-🚶🏼‍♀️	people	woman walking: medium-light skin tone
-🚶🏽‍♀️	people	woman walking: medium skin tone
-🚶🏾‍♀️	people	woman walking: medium-dark skin tone
-🚶🏿‍♀️	people	woman walking: dark skin tone
-🚶‍➡️	people	person walking facing right peerson exercise
-🚶🏻‍➡️	people	person walking facing right: light skin tone
-🚶🏼‍➡️	people	person walking facing right: medium-light skin tone
-🚶🏽‍➡️	people	person walking facing right: medium skin tone
-🚶🏾‍➡️	people	person walking facing right: medium-dark skin tone
-🚶🏿‍➡️	people	person walking facing right: dark skin tone
-🚶‍♀️‍➡️	people	woman walking facing right person exercise
-🚶🏻‍♀️‍➡️	people	woman walking facing right: light skin tone
-🚶🏼‍♀️‍➡️	people	woman walking facing right: medium-light skin tone
-🚶🏽‍♀️‍➡️	people	woman walking facing right: medium skin tone
-🚶🏾‍♀️‍➡️	people	woman walking facing right: medium-dark skin tone
-🚶🏿‍♀️‍➡️	people	woman walking facing right: dark skin tone
-🚶‍♂️‍➡️	people	man walking facing right person exercise
-🚶🏻‍♂️‍➡️	people	man walking facing right: light skin tone
-🚶🏼‍♂️‍➡️	people	man walking facing right: medium-light skin tone
-🚶🏽‍♂️‍➡️	people	man walking facing right: medium skin tone
-🚶🏾‍♂️‍➡️	people	man walking facing right: medium-dark skin tone
-🚶🏿‍♂️‍➡️	people	man walking facing right: dark skin tone
-🧍	people	person standing still stand
-🧍🏻	people	person standing: light skin tone
-🧍🏼	people	person standing: medium-light skin tone
-🧍🏽	people	person standing: medium skin tone
-🧍🏾	people	person standing: medium-dark skin tone
-🧍🏿	people	person standing: dark skin tone
-🧍‍♂️	people	man standing still male men stand
-🧍🏻‍♂️	people	man standing: light skin tone
-🧍🏼‍♂️	people	man standing: medium-light skin tone
-🧍🏽‍♂️	people	man standing: medium skin tone
-🧍🏾‍♂️	people	man standing: medium-dark skin tone
-🧍🏿‍♂️	people	man standing: dark skin tone
-🧍‍♀️	people	woman standing still female stand women
-🧍🏻‍♀️	people	woman standing: light skin tone
-🧍🏼‍♀️	people	woman standing: medium-light skin tone
-🧍🏽‍♀️	people	woman standing: medium skin tone
-🧍🏾‍♀️	people	woman standing: medium-dark skin tone
-🧍🏿‍♀️	people	woman standing: dark skin tone
-🧎	people	person kneeling pray respectful kneel
-🧎🏻	people	person kneeling: light skin tone
-🧎🏼	people	person kneeling: medium-light skin tone
-🧎🏽	people	person kneeling: medium skin tone
-🧎🏾	people	person kneeling: medium-dark skin tone
-🧎🏿	people	person kneeling: dark skin tone
-🧎‍♂️	people	man kneeling pray respectful kneel male men
-🧎🏻‍♂️	people	man kneeling: light skin tone
-🧎🏼‍♂️	people	man kneeling: medium-light skin tone
-🧎🏽‍♂️	people	man kneeling: medium skin tone
-🧎🏾‍♂️	people	man kneeling: medium-dark skin tone
-🧎🏿‍♂️	people	man kneeling: dark skin tone
-🧎‍♀️	people	woman kneeling respectful pray female kneel women
-🧎🏻‍♀️	people	woman kneeling: light skin tone
-🧎🏼‍♀️	people	woman kneeling: medium-light skin tone
-🧎🏽‍♀️	people	woman kneeling: medium skin tone
-🧎🏾‍♀️	people	woman kneeling: medium-dark skin tone
-🧎🏿‍♀️	people	woman kneeling: dark skin tone
-🧎‍➡️	people	person kneeling facing right pray
-🧎🏻‍➡️	people	person kneeling facing right: light skin tone
-🧎🏼‍➡️	people	person kneeling facing right: medium-light skin tone
-🧎🏽‍➡️	people	person kneeling facing right: medium skin tone
-🧎🏾‍➡️	people	person kneeling facing right: medium-dark skin tone
-🧎🏿‍➡️	people	person kneeling facing right: dark skin tone
-🧎‍♀️‍➡️	people	woman kneeling facing right pray worship
-🧎🏻‍♀️‍➡️	people	woman kneeling facing right: light skin tone
-🧎🏼‍♀️‍➡️	people	woman kneeling facing right: medium-light skin tone
-🧎🏽‍♀️‍➡️	people	woman kneeling facing right: medium skin tone
-🧎🏾‍♀️‍➡️	people	woman kneeling facing right: medium-dark skin tone
-🧎🏿‍♀️‍➡️	people	woman kneeling facing right: dark skin tone
-🧎‍♂️‍➡️	people	man kneeling facing right pray worship
-🧎🏻‍♂️‍➡️	people	man kneeling facing right: light skin tone
-🧎🏼‍♂️‍➡️	people	man kneeling facing right: medium-light skin tone
-🧎🏽‍♂️‍➡️	people	man kneeling facing right: medium skin tone
-🧎🏾‍♂️‍➡️	people	man kneeling facing right: medium-dark skin tone
-🧎🏿‍♂️‍➡️	people	man kneeling facing right: dark skin tone
-🧑‍🦯	people	person with white cane person with probing cane blind accessibility white
-🧑🏻‍🦯	people	person with white cane: light skin tone
-🧑🏼‍🦯	people	person with white cane: medium-light skin tone
-🧑🏽‍🦯	people	person with white cane: medium skin tone
-🧑🏾‍🦯	people	person with white cane: medium-dark skin tone
-🧑🏿‍🦯	people	person with white cane: dark skin tone
-🧑‍🦯‍➡️	people	person with white cane facing right walk visually impaired blind
-🧑🏻‍🦯‍➡️	people	person with white cane facing right: light skin tone
-🧑🏼‍🦯‍➡️	people	person with white cane facing right: medium-light skin tone
-🧑🏽‍🦯‍➡️	people	person with white cane facing right: medium skin tone
-🧑🏾‍🦯‍➡️	people	person with white cane facing right: medium-dark skin tone
-🧑🏿‍🦯‍➡️	people	person with white cane facing right: dark skin tone
-👨‍🦯	people	man with white cane man with probing cane blind accessibility male men white
-👨🏻‍🦯	people	man with white cane: light skin tone
-👨🏼‍🦯	people	man with white cane: medium-light skin tone
-👨🏽‍🦯	people	man with white cane: medium skin tone
-👨🏾‍🦯	people	man with white cane: medium-dark skin tone
-👨🏿‍🦯	people	man with white cane: dark skin tone
-👨‍🦯‍➡️	people	man with white cane facing right visually impaired blind walk stick
-👨🏻‍🦯‍➡️	people	man with white cane facing right: light skin tone
-👨🏼‍🦯‍➡️	people	man with white cane facing right: medium-light skin tone
-👨🏽‍🦯‍➡️	people	man with white cane facing right: medium skin tone
-👨🏾‍🦯‍➡️	people	man with white cane facing right: medium-dark skin tone
-👨🏿‍🦯‍➡️	people	man with white cane facing right: dark skin tone
-👩‍🦯	people	woman with white cane woman with probing cane blind accessibility female white women
-👩🏻‍🦯	people	woman with white cane: light skin tone
-👩🏼‍🦯	people	woman with white cane: medium-light skin tone
-👩🏽‍🦯	people	woman with white cane: medium skin tone
-👩🏾‍🦯	people	woman with white cane: medium-dark skin tone
-👩🏿‍🦯	people	woman with white cane: dark skin tone
-👩‍🦯‍➡️	people	woman with white cane facing right stick visually impaired blind
-👩🏻‍🦯‍➡️	people	woman with white cane facing right: light skin tone
-👩🏼‍🦯‍➡️	people	woman with white cane facing right: medium-light skin tone
-👩🏽‍🦯‍➡️	people	woman with white cane facing right: medium skin tone
-👩🏾‍🦯‍➡️	people	woman with white cane facing right: medium-dark skin tone
-👩🏿‍🦯‍➡️	people	woman with white cane facing right: dark skin tone
-🧑‍🦼	people	person in motorized wheelchair disability accessibility
-🧑🏻‍🦼	people	person in motorized wheelchair: light skin tone
-🧑🏼‍🦼	people	person in motorized wheelchair: medium-light skin tone
-🧑🏽‍🦼	people	person in motorized wheelchair: medium skin tone
-🧑🏾‍🦼	people	person in motorized wheelchair: medium-dark skin tone
-🧑🏿‍🦼	people	person in motorized wheelchair: dark skin tone
-🧑‍🦼‍➡️	people	person in motorized wheelchair facing right accessibility disability
-🧑🏻‍🦼‍➡️	people	person in motorized wheelchair facing right: light skin tone
-🧑🏼‍🦼‍➡️	people	person in motorized wheelchair facing right: medium-light skin tone
-🧑🏽‍🦼‍➡️	people	person in motorized wheelchair facing right: medium skin tone
-🧑🏾‍🦼‍➡️	people	person in motorized wheelchair facing right: medium-dark skin tone
-🧑🏿‍🦼‍➡️	people	person in motorized wheelchair facing right: dark skin tone
-👨‍🦼	people	man in motorized wheelchair disability accessibility male men
-👨🏻‍🦼	people	man in motorized wheelchair: light skin tone
-👨🏼‍🦼	people	man in motorized wheelchair: medium-light skin tone
-👨🏽‍🦼	people	man in motorized wheelchair: medium skin tone
-👨🏾‍🦼	people	man in motorized wheelchair: medium-dark skin tone
-👨🏿‍🦼	people	man in motorized wheelchair: dark skin tone
-👨‍🦼‍➡️	people	man in motorized wheelchair facing right disability accessibility mobility
-👨🏻‍🦼‍➡️	people	man in motorized wheelchair facing right: light skin tone
-👨🏼‍🦼‍➡️	people	man in motorized wheelchair facing right: medium-light skin tone
-👨🏽‍🦼‍➡️	people	man in motorized wheelchair facing right: medium skin tone
-👨🏾‍🦼‍➡️	people	man in motorized wheelchair facing right: medium-dark skin tone
-👨🏿‍🦼‍➡️	people	man in motorized wheelchair facing right: dark skin tone
-👩‍🦼	people	woman in motorized wheelchair disability accessibility female women
-👩🏻‍🦼	people	woman in motorized wheelchair: light skin tone
-👩🏼‍🦼	people	woman in motorized wheelchair: medium-light skin tone
-👩🏽‍🦼	people	woman in motorized wheelchair: medium skin tone
-👩🏾‍🦼	people	woman in motorized wheelchair: medium-dark skin tone
-👩🏿‍🦼	people	woman in motorized wheelchair: dark skin tone
-👩‍🦼‍➡️	people	woman in motorized wheelchair facing right mobility accessibility disability
-👩🏻‍🦼‍➡️	people	woman in motorized wheelchair facing right: light skin tone
-👩🏼‍🦼‍➡️	people	woman in motorized wheelchair facing right: medium-light skin tone
-👩🏽‍🦼‍➡️	people	woman in motorized wheelchair facing right: medium skin tone
-👩🏾‍🦼‍➡️	people	woman in motorized wheelchair facing right: medium-dark skin tone
-👩🏿‍🦼‍➡️	people	woman in motorized wheelchair facing right: dark skin tone
-🧑‍🦽	people	person in manual wheelchair disability accessibility
-🧑🏻‍🦽	people	person in manual wheelchair: light skin tone
-🧑🏼‍🦽	people	person in manual wheelchair: medium-light skin tone
-🧑🏽‍🦽	people	person in manual wheelchair: medium skin tone
-🧑🏾‍🦽	people	person in manual wheelchair: medium-dark skin tone
-🧑🏿‍🦽	people	person in manual wheelchair: dark skin tone
-🧑‍🦽‍➡️	people	person in manual wheelchair facing right mobility accessibility disability
-🧑🏻‍🦽‍➡️	people	person in manual wheelchair facing right: light skin tone
-🧑🏼‍🦽‍➡️	people	person in manual wheelchair facing right: medium-light skin tone
-🧑🏽‍🦽‍➡️	people	person in manual wheelchair facing right: medium skin tone
-🧑🏾‍🦽‍➡️	people	person in manual wheelchair facing right: medium-dark skin tone
-🧑🏿‍🦽‍➡️	people	person in manual wheelchair facing right: dark skin tone
-👨‍🦽	people	man in manual wheelchair disability accessibility male men
-👨🏻‍🦽	people	man in manual wheelchair: light skin tone
-👨🏼‍🦽	people	man in manual wheelchair: medium-light skin tone
-👨🏽‍🦽	people	man in manual wheelchair: medium skin tone
-👨🏾‍🦽	people	man in manual wheelchair: medium-dark skin tone
-👨🏿‍🦽	people	man in manual wheelchair: dark skin tone
-👨‍🦽‍➡️	people	man in manual wheelchair facing right mobility accessibility disability
-👨🏻‍🦽‍➡️	people	man in manual wheelchair facing right: light skin tone
-👨🏼‍🦽‍➡️	people	man in manual wheelchair facing right: medium-light skin tone
-👨🏽‍🦽‍➡️	people	man in manual wheelchair facing right: medium skin tone
-👨🏾‍🦽‍➡️	people	man in manual wheelchair facing right: medium-dark skin tone
-👨🏿‍🦽‍➡️	people	man in manual wheelchair facing right: dark skin tone
-👩‍🦽	people	woman in manual wheelchair disability accessibility female women
-👩🏻‍🦽	people	woman in manual wheelchair: light skin tone
-👩🏼‍🦽	people	woman in manual wheelchair: medium-light skin tone
-👩🏽‍🦽	people	woman in manual wheelchair: medium skin tone
-👩🏾‍🦽	people	woman in manual wheelchair: medium-dark skin tone
-👩🏿‍🦽	people	woman in manual wheelchair: dark skin tone
-👩‍🦽‍➡️	people	woman in manual wheelchair facing right disability mobility accessibility
-👩🏻‍🦽‍➡️	people	woman in manual wheelchair facing right: light skin tone
-👩🏼‍🦽‍➡️	people	woman in manual wheelchair facing right: medium-light skin tone
-👩🏽‍🦽‍➡️	people	woman in manual wheelchair facing right: medium skin tone
-👩🏾‍🦽‍➡️	people	woman in manual wheelchair facing right: medium-dark skin tone
-👩🏿‍🦽‍➡️	people	woman in manual wheelchair facing right: dark skin tone
-🏃	people	person running move exercise jogging marathon run runner workout
-🏃🏻	people	person running: light skin tone
-🏃🏼	people	person running: medium-light skin tone
-🏃🏽	people	person running: medium skin tone
-🏃🏾	people	person running: medium-dark skin tone
-🏃🏿	people	person running: dark skin tone
-🏃‍♂️	people	man running man walking exercise race running male marathon men racing runner workout
-🏃🏻‍♂️	people	man running: light skin tone
-🏃🏼‍♂️	people	man running: medium-light skin tone
-🏃🏽‍♂️	people	man running: medium skin tone
-🏃🏾‍♂️	people	man running: medium-dark skin tone
-🏃🏿‍♂️	people	man running: dark skin tone
-🏃‍♀️	people	woman running woman walking exercise race running female boy marathon racing runner women workout
-🏃🏻‍♀️	people	woman running: light skin tone
-🏃🏼‍♀️	people	woman running: medium-light skin tone
-🏃🏽‍♀️	people	woman running: medium skin tone
-🏃🏾‍♀️	people	woman running: medium-dark skin tone
-🏃🏿‍♀️	people	woman running: dark skin tone
-🏃‍➡️	people	person running facing right exercise jog
-🏃🏻‍➡️	people	person running facing right: light skin tone
-🏃🏼‍➡️	people	person running facing right: medium-light skin tone
-🏃🏽‍➡️	people	person running facing right: medium skin tone
-🏃🏾‍➡️	people	person running facing right: medium-dark skin tone
-🏃🏿‍➡️	people	person running facing right: dark skin tone
-🏃‍♀️‍➡️	people	woman running facing right exercise jog
-🏃🏻‍♀️‍➡️	people	woman running facing right: light skin tone
-🏃🏼‍♀️‍➡️	people	woman running facing right: medium-light skin tone
-🏃🏽‍♀️‍➡️	people	woman running facing right: medium skin tone
-🏃🏾‍♀️‍➡️	people	woman running facing right: medium-dark skin tone
-🏃🏿‍♀️‍➡️	people	woman running facing right: dark skin tone
-🏃‍♂️‍➡️	people	man running facing right jog exercise
-🏃🏻‍♂️‍➡️	people	man running facing right: light skin tone
-🏃🏼‍♂️‍➡️	people	man running facing right: medium-light skin tone
-🏃🏽‍♂️‍➡️	people	man running facing right: medium skin tone
-🏃🏾‍♂️‍➡️	people	man running facing right: medium-dark skin tone
-🏃🏿‍♂️‍➡️	people	man running facing right: dark skin tone
-🧑‍🩰	people	ballet dancer
-🧑🏻‍🩰	people	ballet dancer: light skin tone
-🧑🏼‍🩰	people	ballet dancer: medium-light skin tone
-🧑🏽‍🩰	people	ballet dancer: medium skin tone
-🧑🏾‍🩰	people	ballet dancer: medium-dark skin tone
-🧑🏿‍🩰	people	ballet dancer: dark skin tone
-💃	people	woman dancing female girl woman fun dance dancer dress red salsa women
-💃🏻	people	woman dancing: light skin tone
-💃🏼	people	woman dancing: medium-light skin tone
-💃🏽	people	woman dancing: medium skin tone
-💃🏾	people	woman dancing: medium-dark skin tone
-💃🏿	people	woman dancing: dark skin tone
-🕺	people	man dancing male boy fun dancer dance disco men
-🕺🏻	people	man dancing: light skin tone
-🕺🏼	people	man dancing: medium-light skin tone
-🕺🏽	people	man dancing: medium skin tone
-🕺🏾	people	man dancing: medium-dark skin tone
-🕺🏿	people	man dancing: dark skin tone
-🕴️	people	person in suit levitating man in suit levitating suit business levitate hover jump boy hovering jabsco male men person rude walt
-🕴🏻	people	person in suit levitating: light skin tone
-🕴🏼	people	person in suit levitating: medium-light skin tone
-🕴🏽	people	person in suit levitating: medium skin tone
-🕴🏾	people	person in suit levitating: medium-dark skin tone
-🕴🏿	people	person in suit levitating: dark skin tone
-👯	people	people with bunny ears perform costume dancer dancing ear partying wearing women
-👯🏻	people	people with bunny ears: light skin tone
-👯🏼	people	people with bunny ears: medium-light skin tone
-👯🏽	people	people with bunny ears: medium skin tone
-👯🏾	people	people with bunny ears: medium-dark skin tone
-👯🏿	people	people with bunny ears: dark skin tone
-👯‍♂️	people	men with bunny ears male bunny men boys dancer dancing ear man partying wearing
-👯🏻‍♂️	people	men with bunny ears: light skin tone
-👯🏼‍♂️	people	men with bunny ears: medium-light skin tone
-👯🏽‍♂️	people	men with bunny ears: medium skin tone
-👯🏾‍♂️	people	men with bunny ears: medium-dark skin tone
-👯🏿‍♂️	people	men with bunny ears: dark skin tone
-👯‍♀️	people	women with bunny ears female bunny women girls dancer dancing ear partying people wearing
-👯🏻‍♀️	people	women with bunny ears: light skin tone
-👯🏼‍♀️	people	women with bunny ears: medium-light skin tone
-👯🏽‍♀️	people	women with bunny ears: medium skin tone
-👯🏾‍♀️	people	women with bunny ears: medium-dark skin tone
-👯🏿‍♀️	people	women with bunny ears: dark skin tone
-🧑🏻‍🐰‍🧑🏼	people	people with bunny ears: light skin tone, medium-light skin tone
-🧑🏻‍🐰‍🧑🏽	people	people with bunny ears: light skin tone, medium skin tone
-🧑🏻‍🐰‍🧑🏾	people	people with bunny ears: light skin tone, medium-dark skin tone
-🧑🏻‍🐰‍🧑🏿	people	people with bunny ears: light skin tone, dark skin tone
-🧑🏼‍🐰‍🧑🏻	people	people with bunny ears: medium-light skin tone, light skin tone
-🧑🏼‍🐰‍🧑🏽	people	people with bunny ears: medium-light skin tone, medium skin tone
-🧑🏼‍🐰‍🧑🏾	people	people with bunny ears: medium-light skin tone, medium-dark skin tone
-🧑🏼‍🐰‍🧑🏿	people	people with bunny ears: medium-light skin tone, dark skin tone
-🧑🏽‍🐰‍🧑🏻	people	people with bunny ears: medium skin tone, light skin tone
-🧑🏽‍🐰‍🧑🏼	people	people with bunny ears: medium skin tone, medium-light skin tone
-🧑🏽‍🐰‍🧑🏾	people	people with bunny ears: medium skin tone, medium-dark skin tone
-🧑🏽‍🐰‍🧑🏿	people	people with bunny ears: medium skin tone, dark skin tone
-🧑🏾‍🐰‍🧑🏻	people	people with bunny ears: medium-dark skin tone, light skin tone
-🧑🏾‍🐰‍🧑🏼	people	people with bunny ears: medium-dark skin tone, medium-light skin tone
-🧑🏾‍🐰‍🧑🏽	people	people with bunny ears: medium-dark skin tone, medium skin tone
-🧑🏾‍🐰‍🧑🏿	people	people with bunny ears: medium-dark skin tone, dark skin tone
-🧑🏿‍🐰‍🧑🏻	people	people with bunny ears: dark skin tone, light skin tone
-🧑🏿‍🐰‍🧑🏼	people	people with bunny ears: dark skin tone, medium-light skin tone
-🧑🏿‍🐰‍🧑🏽	people	people with bunny ears: dark skin tone, medium skin tone
-🧑🏿‍🐰‍🧑🏾	people	people with bunny ears: dark skin tone, medium-dark skin tone
-👨🏻‍🐰‍👨🏼	people	men with bunny ears: light skin tone, medium-light skin tone
-👨🏻‍🐰‍👨🏽	people	men with bunny ears: light skin tone, medium skin tone
-👨🏻‍🐰‍👨🏾	people	men with bunny ears: light skin tone, medium-dark skin tone
-👨🏻‍🐰‍👨🏿	people	men with bunny ears: light skin tone, dark skin tone
-👨🏼‍🐰‍👨🏻	people	men with bunny ears: medium-light skin tone, light skin tone
-👨🏼‍🐰‍👨🏽	people	men with bunny ears: medium-light skin tone, medium skin tone
-👨🏼‍🐰‍👨🏾	people	men with bunny ears: medium-light skin tone, medium-dark skin tone
-👨🏼‍🐰‍👨🏿	people	men with bunny ears: medium-light skin tone, dark skin tone
-👨🏽‍🐰‍👨🏻	people	men with bunny ears: medium skin tone, light skin tone
-👨🏽‍🐰‍👨🏼	people	men with bunny ears: medium skin tone, medium-light skin tone
-👨🏽‍🐰‍👨🏾	people	men with bunny ears: medium skin tone, medium-dark skin tone
-👨🏽‍🐰‍👨🏿	people	men with bunny ears: medium skin tone, dark skin tone
-👨🏾‍🐰‍👨🏻	people	men with bunny ears: medium-dark skin tone, light skin tone
-👨🏾‍🐰‍👨🏼	people	men with bunny ears: medium-dark skin tone, medium-light skin tone
-👨🏾‍🐰‍👨🏽	people	men with bunny ears: medium-dark skin tone, medium skin tone
-👨🏾‍🐰‍👨🏿	people	men with bunny ears: medium-dark skin tone, dark skin tone
-👨🏿‍🐰‍👨🏻	people	men with bunny ears: dark skin tone, light skin tone
-👨🏿‍🐰‍👨🏼	people	men with bunny ears: dark skin tone, medium-light skin tone
-👨🏿‍🐰‍👨🏽	people	men with bunny ears: dark skin tone, medium skin tone
-👨🏿‍🐰‍👨🏾	people	men with bunny ears: dark skin tone, medium-dark skin tone
-👩🏻‍🐰‍👩🏼	people	women with bunny ears: light skin tone, medium-light skin tone
-👩🏻‍🐰‍👩🏽	people	women with bunny ears: light skin tone, medium skin tone
-👩🏻‍🐰‍👩🏾	people	women with bunny ears: light skin tone, medium-dark skin tone
-👩🏻‍🐰‍👩🏿	people	women with bunny ears: light skin tone, dark skin tone
-👩🏼‍🐰‍👩🏻	people	women with bunny ears: medium-light skin tone, light skin tone
-👩🏼‍🐰‍👩🏽	people	women with bunny ears: medium-light skin tone, medium skin tone
-👩🏼‍🐰‍👩🏾	people	women with bunny ears: medium-light skin tone, medium-dark skin tone
-👩🏼‍🐰‍👩🏿	people	women with bunny ears: medium-light skin tone, dark skin tone
-👩🏽‍🐰‍👩🏻	people	women with bunny ears: medium skin tone, light skin tone
-👩🏽‍🐰‍👩🏼	people	women with bunny ears: medium skin tone, medium-light skin tone
-👩🏽‍🐰‍👩🏾	people	women with bunny ears: medium skin tone, medium-dark skin tone
-👩🏽‍🐰‍👩🏿	people	women with bunny ears: medium skin tone, dark skin tone
-👩🏾‍🐰‍👩🏻	people	women with bunny ears: medium-dark skin tone, light skin tone
-👩🏾‍🐰‍👩🏼	people	women with bunny ears: medium-dark skin tone, medium-light skin tone
-👩🏾‍🐰‍👩🏽	people	women with bunny ears: medium-dark skin tone, medium skin tone
-👩🏾‍🐰‍👩🏿	people	women with bunny ears: medium-dark skin tone, dark skin tone
-👩🏿‍🐰‍👩🏻	people	women with bunny ears: dark skin tone, light skin tone
-👩🏿‍🐰‍👩🏼	people	women with bunny ears: dark skin tone, medium-light skin tone
-👩🏿‍🐰‍👩🏽	people	women with bunny ears: dark skin tone, medium skin tone
-👩🏿‍🐰‍👩🏾	people	women with bunny ears: dark skin tone, medium-dark skin tone
-🧖	people	person in steamy room relax spa hamam sauna steam steambath
-🧖🏻	people	person in steamy room: light skin tone
-🧖🏼	people	person in steamy room: medium-light skin tone
-🧖🏽	people	person in steamy room: medium skin tone
-🧖🏾	people	person in steamy room: medium-dark skin tone
-🧖🏿	people	person in steamy room: dark skin tone
-🧖‍♂️	people	man in steamy room male man spa steamroom sauna hamam men steam steambath
-🧖🏻‍♂️	people	man in steamy room: light skin tone
-🧖🏼‍♂️	people	man in steamy room: medium-light skin tone
-🧖🏽‍♂️	people	man in steamy room: medium skin tone
-🧖🏾‍♂️	people	man in steamy room: medium-dark skin tone
-🧖🏿‍♂️	people	man in steamy room: dark skin tone
-🧖‍♀️	people	woman in steamy room female woman spa steamroom sauna hamam steam steambath women
-🧖🏻‍♀️	people	woman in steamy room: light skin tone
-🧖🏼‍♀️	people	woman in steamy room: medium-light skin tone
-🧖🏽‍♀️	people	woman in steamy room: medium skin tone
-🧖🏾‍♀️	people	woman in steamy room: medium-dark skin tone
-🧖🏿‍♀️	people	woman in steamy room: dark skin tone
-🧗	people	person climbing sport bouldering climber rock
-🧗🏻	people	person climbing: light skin tone
-🧗🏼	people	person climbing: medium-light skin tone
-🧗🏽	people	person climbing: medium skin tone
-🧗🏾	people	person climbing: medium-dark skin tone
-🧗🏿	people	person climbing: dark skin tone
-🧗‍♂️	people	man climbing sports hobby man male rock bouldering climber men
-🧗🏻‍♂️	people	man climbing: light skin tone
-🧗🏼‍♂️	people	man climbing: medium-light skin tone
-🧗🏽‍♂️	people	man climbing: medium skin tone
-🧗🏾‍♂️	people	man climbing: medium-dark skin tone
-🧗🏿‍♂️	people	man climbing: dark skin tone
-🧗‍♀️	people	woman climbing sports hobby woman female rock bouldering climber women
-🧗🏻‍♀️	people	woman climbing: light skin tone
-🧗🏼‍♀️	people	woman climbing: medium-light skin tone
-🧗🏽‍♀️	people	woman climbing: medium skin tone
-🧗🏾‍♀️	people	woman climbing: medium-dark skin tone
-🧗🏿‍♀️	people	woman climbing: dark skin tone
-🤺	people	person fencing sports fencing sword fencer
-🏇	people	horse racing animal betting competition gambling luck jockey race racehorse
-🏇🏻	people	horse racing: light skin tone
-🏇🏼	people	horse racing: medium-light skin tone
-🏇🏽	people	horse racing: medium skin tone
-🏇🏾	people	horse racing: medium-dark skin tone
-🏇🏿	people	horse racing: dark skin tone
-⛷️	people	skier sports winter snow ski
-🏂	people	snowboarder sports winter ski snow snowboard snowboarding
-🏂🏻	people	snowboarder: light skin tone
-🏂🏼	people	snowboarder: medium-light skin tone
-🏂🏽	people	snowboarder: medium skin tone
-🏂🏾	people	snowboarder: medium-dark skin tone
-🏂🏿	people	snowboarder: dark skin tone
-🏌️	people	person golfing sports business ball club golf golfer
-🏌🏻	people	person golfing: light skin tone
-🏌🏼	people	person golfing: medium-light skin tone
-🏌🏽	people	person golfing: medium skin tone
-🏌🏾	people	person golfing: medium-dark skin tone
-🏌🏿	people	person golfing: dark skin tone
-🏌️‍♂️	people	man golfing sport ball golf golfer male men
-🏌🏻‍♂️	people	man golfing: light skin tone
-🏌🏼‍♂️	people	man golfing: medium-light skin tone
-🏌🏽‍♂️	people	man golfing: medium skin tone
-🏌🏾‍♂️	people	man golfing: medium-dark skin tone
-🏌🏿‍♂️	people	man golfing: dark skin tone
-🏌️‍♀️	people	woman golfing sports business woman female ball golf golfer women
-🏌🏻‍♀️	people	woman golfing: light skin tone
-🏌🏼‍♀️	people	woman golfing: medium-light skin tone
-🏌🏽‍♀️	people	woman golfing: medium skin tone
-🏌🏾‍♀️	people	woman golfing: medium-dark skin tone
-🏌🏿‍♀️	people	woman golfing: dark skin tone
-🏄	people	person surfing sport sea surf surfer
-🏄🏻	people	person surfing: light skin tone
-🏄🏼	people	person surfing: medium-light skin tone
-🏄🏽	people	person surfing: medium skin tone
-🏄🏾	people	person surfing: medium-dark skin tone
-🏄🏿	people	person surfing: dark skin tone
-🏄‍♂️	people	man surfing sports ocean sea summer beach male men surfer
-🏄🏻‍♂️	people	man surfing: light skin tone
-🏄🏼‍♂️	people	man surfing: medium-light skin tone
-🏄🏽‍♂️	people	man surfing: medium skin tone
-🏄🏾‍♂️	people	man surfing: medium-dark skin tone
-🏄🏿‍♂️	people	man surfing: dark skin tone
-🏄‍♀️	people	woman surfing sports ocean sea summer beach woman female surfer women
-🏄🏻‍♀️	people	woman surfing: light skin tone
-🏄🏼‍♀️	people	woman surfing: medium-light skin tone
-🏄🏽‍♀️	people	woman surfing: medium skin tone
-🏄🏾‍♀️	people	woman surfing: medium-dark skin tone
-🏄🏿‍♀️	people	woman surfing: dark skin tone
-🚣	people	person rowing boat sport move paddles rowboat vehicle
-🚣🏻	people	person rowing boat: light skin tone
-🚣🏼	people	person rowing boat: medium-light skin tone
-🚣🏽	people	person rowing boat: medium skin tone
-🚣🏾	people	person rowing boat: medium-dark skin tone
-🚣🏿	people	person rowing boat: dark skin tone
-🚣‍♂️	people	man rowing boat sports hobby water ship male men rowboat vehicle
-🚣🏻‍♂️	people	man rowing boat: light skin tone
-🚣🏼‍♂️	people	man rowing boat: medium-light skin tone
-🚣🏽‍♂️	people	man rowing boat: medium skin tone
-🚣🏾‍♂️	people	man rowing boat: medium-dark skin tone
-🚣🏿‍♂️	people	man rowing boat: dark skin tone
-🚣‍♀️	people	woman rowing boat sports hobby water ship woman female rowboat vehicle women
-🚣🏻‍♀️	people	woman rowing boat: light skin tone
-🚣🏼‍♀️	people	woman rowing boat: medium-light skin tone
-🚣🏽‍♀️	people	woman rowing boat: medium skin tone
-🚣🏾‍♀️	people	woman rowing boat: medium-dark skin tone
-🚣🏿‍♀️	people	woman rowing boat: dark skin tone
-🏊	people	person swimming sport pool swim swimmer
-🏊🏻	people	person swimming: light skin tone
-🏊🏼	people	person swimming: medium-light skin tone
-🏊🏽	people	person swimming: medium skin tone
-🏊🏾	people	person swimming: medium-dark skin tone
-🏊🏿	people	person swimming: dark skin tone
-🏊‍♂️	people	man swimming sports exercise human athlete water summer male men swim swimmer
-🏊🏻‍♂️	people	man swimming: light skin tone
-🏊🏼‍♂️	people	man swimming: medium-light skin tone
-🏊🏽‍♂️	people	man swimming: medium skin tone
-🏊🏾‍♂️	people	man swimming: medium-dark skin tone
-🏊🏿‍♂️	people	man swimming: dark skin tone
-🏊‍♀️	people	woman swimming sports exercise human athlete water summer woman female swim swimmer women
-🏊🏻‍♀️	people	woman swimming: light skin tone
-🏊🏼‍♀️	people	woman swimming: medium-light skin tone
-🏊🏽‍♀️	people	woman swimming: medium skin tone
-🏊🏾‍♀️	people	woman swimming: medium-dark skin tone
-🏊🏿‍♀️	people	woman swimming: dark skin tone
-⛹️	people	person bouncing ball sports human basketball player
-⛹🏻	people	person bouncing ball: light skin tone
-⛹🏼	people	person bouncing ball: medium-light skin tone
-⛹🏽	people	person bouncing ball: medium skin tone
-⛹🏾	people	person bouncing ball: medium-dark skin tone
-⛹🏿	people	person bouncing ball: dark skin tone
-⛹️‍♂️	people	man bouncing ball sport basketball male men player
-⛹🏻‍♂️	people	man bouncing ball: light skin tone
-⛹🏼‍♂️	people	man bouncing ball: medium-light skin tone
-⛹🏽‍♂️	people	man bouncing ball: medium skin tone
-⛹🏾‍♂️	people	man bouncing ball: medium-dark skin tone
-⛹🏿‍♂️	people	man bouncing ball: dark skin tone
-⛹️‍♀️	people	woman bouncing ball sports human woman female basketball player women
-⛹🏻‍♀️	people	woman bouncing ball: light skin tone
-⛹🏼‍♀️	people	woman bouncing ball: medium-light skin tone
-⛹🏽‍♀️	people	woman bouncing ball: medium skin tone
-⛹🏾‍♀️	people	woman bouncing ball: medium-dark skin tone
-⛹🏿‍♀️	people	woman bouncing ball: dark skin tone
-🏋️	people	person lifting weights sports training exercise bodybuilder gym lifter weight weightlifter workout
-🏋🏻	people	person lifting weights: light skin tone
-🏋🏼	people	person lifting weights: medium-light skin tone
-🏋🏽	people	person lifting weights: medium skin tone
-🏋🏾	people	person lifting weights: medium-dark skin tone
-🏋🏿	people	person lifting weights: dark skin tone
-🏋️‍♂️	people	man lifting weights sport gym lifter male men weight weightlifter workout
-🏋🏻‍♂️	people	man lifting weights: light skin tone
-🏋🏼‍♂️	people	man lifting weights: medium-light skin tone
-🏋🏽‍♂️	people	man lifting weights: medium skin tone
-🏋🏾‍♂️	people	man lifting weights: medium-dark skin tone
-🏋🏿‍♂️	people	man lifting weights: dark skin tone
-🏋️‍♀️	people	woman lifting weights sports training exercise woman female gym lifter weight weightlifter women workout
-🏋🏻‍♀️	people	woman lifting weights: light skin tone
-🏋🏼‍♀️	people	woman lifting weights: medium-light skin tone
-🏋🏽‍♀️	people	woman lifting weights: medium skin tone
-🏋🏾‍♀️	people	woman lifting weights: medium-dark skin tone
-🏋🏿‍♀️	people	woman lifting weights: dark skin tone
-🚴	people	person biking bicycle bike cyclist sport move bicyclist
-🚴🏻	people	person biking: light skin tone
-🚴🏼	people	person biking: medium-light skin tone
-🚴🏽	people	person biking: medium skin tone
-🚴🏾	people	person biking: medium-dark skin tone
-🚴🏿	people	person biking: dark skin tone
-🚴‍♂️	people	man biking bicycle bike cyclist sports exercise hipster bicyclist male men
-🚴🏻‍♂️	people	man biking: light skin tone
-🚴🏼‍♂️	people	man biking: medium-light skin tone
-🚴🏽‍♂️	people	man biking: medium skin tone
-🚴🏾‍♂️	people	man biking: medium-dark skin tone
-🚴🏿‍♂️	people	man biking: dark skin tone
-🚴‍♀️	people	woman biking bicycle bike cyclist sports exercise hipster woman female bicyclist women
-🚴🏻‍♀️	people	woman biking: light skin tone
-🚴🏼‍♀️	people	woman biking: medium-light skin tone
-🚴🏽‍♀️	people	woman biking: medium skin tone
-🚴🏾‍♀️	people	woman biking: medium-dark skin tone
-🚴🏿‍♀️	people	woman biking: dark skin tone
-🚵	people	person mountain biking bicycle bike cyclist sport move bicyclist biker
-🚵🏻	people	person mountain biking: light skin tone
-🚵🏼	people	person mountain biking: medium-light skin tone
-🚵🏽	people	person mountain biking: medium skin tone
-🚵🏾	people	person mountain biking: medium-dark skin tone
-🚵🏿	people	person mountain biking: dark skin tone
-🚵‍♂️	people	man mountain biking bicycle bike cyclist transportation sports human race bicyclist biker male men
-🚵🏻‍♂️	people	man mountain biking: light skin tone
-🚵🏼‍♂️	people	man mountain biking: medium-light skin tone
-🚵🏽‍♂️	people	man mountain biking: medium skin tone
-🚵🏾‍♂️	people	man mountain biking: medium-dark skin tone
-🚵🏿‍♂️	people	man mountain biking: dark skin tone
-🚵‍♀️	people	woman mountain biking bicycle bike cyclist transportation sports human race woman female bicyclist biker women
-🚵🏻‍♀️	people	woman mountain biking: light skin tone
-🚵🏼‍♀️	people	woman mountain biking: medium-light skin tone
-🚵🏽‍♀️	people	woman mountain biking: medium skin tone
-🚵🏾‍♀️	people	woman mountain biking: medium-dark skin tone
-🚵🏿‍♀️	people	woman mountain biking: dark skin tone
-🤸	people	person cartwheeling sport gymnastic cartwheel doing gymnast gymnastics
-🤸🏻	people	person cartwheeling: light skin tone
-🤸🏼	people	person cartwheeling: medium-light skin tone
-🤸🏽	people	person cartwheeling: medium skin tone
-🤸🏾	people	person cartwheeling: medium-dark skin tone
-🤸🏿	people	person cartwheeling: dark skin tone
-🤸‍♂️	people	man cartwheeling gymnastics cartwheel doing male men
-🤸🏻‍♂️	people	man cartwheeling: light skin tone
-🤸🏼‍♂️	people	man cartwheeling: medium-light skin tone
-🤸🏽‍♂️	people	man cartwheeling: medium skin tone
-🤸🏾‍♂️	people	man cartwheeling: medium-dark skin tone
-🤸🏿‍♂️	people	man cartwheeling: dark skin tone
-🤸‍♀️	people	woman cartwheeling gymnastics cartwheel doing female women
-🤸🏻‍♀️	people	woman cartwheeling: light skin tone
-🤸🏼‍♀️	people	woman cartwheeling: medium-light skin tone
-🤸🏽‍♀️	people	woman cartwheeling: medium skin tone
-🤸🏾‍♀️	people	woman cartwheeling: medium-dark skin tone
-🤸🏿‍♀️	people	woman cartwheeling: dark skin tone
-🤼	people	people wrestling sport wrestle wrestler wrestlers
-🤼🏻	people	people wrestling: light skin tone
-🤼🏼	people	people wrestling: medium-light skin tone
-🤼🏽	people	people wrestling: medium skin tone
-🤼🏾	people	people wrestling: medium-dark skin tone
-🤼🏿	people	people wrestling: dark skin tone
-🤼‍♂️	people	men wrestling sports wrestlers male man wrestle wrestler
-🤼🏻‍♂️	people	men wrestling: light skin tone
-🤼🏼‍♂️	people	men wrestling: medium-light skin tone
-🤼🏽‍♂️	people	men wrestling: medium skin tone
-🤼🏾‍♂️	people	men wrestling: medium-dark skin tone
-🤼🏿‍♂️	people	men wrestling: dark skin tone
-🤼‍♀️	people	women wrestling sports wrestlers female woman wrestle wrestler
-🤼🏻‍♀️	people	women wrestling: light skin tone
-🤼🏼‍♀️	people	women wrestling: medium-light skin tone
-🤼🏽‍♀️	people	women wrestling: medium skin tone
-🤼🏾‍♀️	people	women wrestling: medium-dark skin tone
-🤼🏿‍♀️	people	women wrestling: dark skin tone
-🧑🏻‍🫯‍🧑🏼	people	people wrestling: light skin tone, medium-light skin tone
-🧑🏻‍🫯‍🧑🏽	people	people wrestling: light skin tone, medium skin tone
-🧑🏻‍🫯‍🧑🏾	people	people wrestling: light skin tone, medium-dark skin tone
-🧑🏻‍🫯‍🧑🏿	people	people wrestling: light skin tone, dark skin tone
-🧑🏼‍🫯‍🧑🏻	people	people wrestling: medium-light skin tone, light skin tone
-🧑🏼‍🫯‍🧑🏽	people	people wrestling: medium-light skin tone, medium skin tone
-🧑🏼‍🫯‍🧑🏾	people	people wrestling: medium-light skin tone, medium-dark skin tone
-🧑🏼‍🫯‍🧑🏿	people	people wrestling: medium-light skin tone, dark skin tone
-🧑🏽‍🫯‍🧑🏻	people	people wrestling: medium skin tone, light skin tone
-🧑🏽‍🫯‍🧑🏼	people	people wrestling: medium skin tone, medium-light skin tone
-🧑🏽‍🫯‍🧑🏾	people	people wrestling: medium skin tone, medium-dark skin tone
-🧑🏽‍🫯‍🧑🏿	people	people wrestling: medium skin tone, dark skin tone
-🧑🏾‍🫯‍🧑🏻	people	people wrestling: medium-dark skin tone, light skin tone
-🧑🏾‍🫯‍🧑🏼	people	people wrestling: medium-dark skin tone, medium-light skin tone
-🧑🏾‍🫯‍🧑🏽	people	people wrestling: medium-dark skin tone, medium skin tone
-🧑🏾‍🫯‍🧑🏿	people	people wrestling: medium-dark skin tone, dark skin tone
-🧑🏿‍🫯‍🧑🏻	people	people wrestling: dark skin tone, light skin tone
-🧑🏿‍🫯‍🧑🏼	people	people wrestling: dark skin tone, medium-light skin tone
-🧑🏿‍🫯‍🧑🏽	people	people wrestling: dark skin tone, medium skin tone
-🧑🏿‍🫯‍🧑🏾	people	people wrestling: dark skin tone, medium-dark skin tone
-👨🏻‍🫯‍👨🏼	people	men wrestling: light skin tone, medium-light skin tone
-👨🏻‍🫯‍👨🏽	people	men wrestling: light skin tone, medium skin tone
-👨🏻‍🫯‍👨🏾	people	men wrestling: light skin tone, medium-dark skin tone
-👨🏻‍🫯‍👨🏿	people	men wrestling: light skin tone, dark skin tone
-👨🏼‍🫯‍👨🏻	people	men wrestling: medium-light skin tone, light skin tone
-👨🏼‍🫯‍👨🏽	people	men wrestling: medium-light skin tone, medium skin tone
-👨🏼‍🫯‍👨🏾	people	men wrestling: medium-light skin tone, medium-dark skin tone
-👨🏼‍🫯‍👨🏿	people	men wrestling: medium-light skin tone, dark skin tone
-👨🏽‍🫯‍👨🏻	people	men wrestling: medium skin tone, light skin tone
-👨🏽‍🫯‍👨🏼	people	men wrestling: medium skin tone, medium-light skin tone
-👨🏽‍🫯‍👨🏾	people	men wrestling: medium skin tone, medium-dark skin tone
-👨🏽‍🫯‍👨🏿	people	men wrestling: medium skin tone, dark skin tone
-👨🏾‍🫯‍👨🏻	people	men wrestling: medium-dark skin tone, light skin tone
-👨🏾‍🫯‍👨🏼	people	men wrestling: medium-dark skin tone, medium-light skin tone
-👨🏾‍🫯‍👨🏽	people	men wrestling: medium-dark skin tone, medium skin tone
-👨🏾‍🫯‍👨🏿	people	men wrestling: medium-dark skin tone, dark skin tone
-👨🏿‍🫯‍👨🏻	people	men wrestling: dark skin tone, light skin tone
-👨🏿‍🫯‍👨🏼	people	men wrestling: dark skin tone, medium-light skin tone
-👨🏿‍🫯‍👨🏽	people	men wrestling: dark skin tone, medium skin tone
-👨🏿‍🫯‍👨🏾	people	men wrestling: dark skin tone, medium-dark skin tone
-👩🏻‍🫯‍👩🏼	people	women wrestling: light skin tone, medium-light skin tone
-👩🏻‍🫯‍👩🏽	people	women wrestling: light skin tone, medium skin tone
-👩🏻‍🫯‍👩🏾	people	women wrestling: light skin tone, medium-dark skin tone
-👩🏻‍🫯‍👩🏿	people	women wrestling: light skin tone, dark skin tone
-👩🏼‍🫯‍👩🏻	people	women wrestling: medium-light skin tone, light skin tone
-👩🏼‍🫯‍👩🏽	people	women wrestling: medium-light skin tone, medium skin tone
-👩🏼‍🫯‍👩🏾	people	women wrestling: medium-light skin tone, medium-dark skin tone
-👩🏼‍🫯‍👩🏿	people	women wrestling: medium-light skin tone, dark skin tone
-👩🏽‍🫯‍👩🏻	people	women wrestling: medium skin tone, light skin tone
-👩🏽‍🫯‍👩🏼	people	women wrestling: medium skin tone, medium-light skin tone
-👩🏽‍🫯‍👩🏾	people	women wrestling: medium skin tone, medium-dark skin tone
-👩🏽‍🫯‍👩🏿	people	women wrestling: medium skin tone, dark skin tone
-👩🏾‍🫯‍👩🏻	people	women wrestling: medium-dark skin tone, light skin tone
-👩🏾‍🫯‍👩🏼	people	women wrestling: medium-dark skin tone, medium-light skin tone
-👩🏾‍🫯‍👩🏽	people	women wrestling: medium-dark skin tone, medium skin tone
-👩🏾‍🫯‍👩🏿	people	women wrestling: medium-dark skin tone, dark skin tone
-👩🏿‍🫯‍👩🏻	people	women wrestling: dark skin tone, light skin tone
-👩🏿‍🫯‍👩🏼	people	women wrestling: dark skin tone, medium-light skin tone
-👩🏿‍🫯‍👩🏽	people	women wrestling: dark skin tone, medium skin tone
-👩🏿‍🫯‍👩🏾	people	women wrestling: dark skin tone, medium-dark skin tone
-🤽	people	person playing water polo sport
-🤽🏻	people	person playing water polo: light skin tone
-🤽🏼	people	person playing water polo: medium-light skin tone
-🤽🏽	people	person playing water polo: medium skin tone
-🤽🏾	people	person playing water polo: medium-dark skin tone
-🤽🏿	people	person playing water polo: dark skin tone
-🤽‍♂️	people	man playing water polo sports pool male men
-🤽🏻‍♂️	people	man playing water polo: light skin tone
-🤽🏼‍♂️	people	man playing water polo: medium-light skin tone
-🤽🏽‍♂️	people	man playing water polo: medium skin tone
-🤽🏾‍♂️	people	man playing water polo: medium-dark skin tone
-🤽🏿‍♂️	people	man playing water polo: dark skin tone
-🤽‍♀️	people	woman playing water polo sports pool female women
-🤽🏻‍♀️	people	woman playing water polo: light skin tone
-🤽🏼‍♀️	people	woman playing water polo: medium-light skin tone
-🤽🏽‍♀️	people	woman playing water polo: medium skin tone
-🤽🏾‍♀️	people	woman playing water polo: medium-dark skin tone
-🤽🏿‍♀️	people	woman playing water polo: dark skin tone
-🤾	people	person playing handball sport ball
-🤾🏻	people	person playing handball: light skin tone
-🤾🏼	people	person playing handball: medium-light skin tone
-🤾🏽	people	person playing handball: medium skin tone
-🤾🏾	people	person playing handball: medium-dark skin tone
-🤾🏿	people	person playing handball: dark skin tone
-🤾‍♂️	people	man playing handball sports ball male men
-🤾🏻‍♂️	people	man playing handball: light skin tone
-🤾🏼‍♂️	people	man playing handball: medium-light skin tone
-🤾🏽‍♂️	people	man playing handball: medium skin tone
-🤾🏾‍♂️	people	man playing handball: medium-dark skin tone
-🤾🏿‍♂️	people	man playing handball: dark skin tone
-🤾‍♀️	people	woman playing handball sports ball female women
-🤾🏻‍♀️	people	woman playing handball: light skin tone
-🤾🏼‍♀️	people	woman playing handball: medium-light skin tone
-🤾🏽‍♀️	people	woman playing handball: medium skin tone
-🤾🏾‍♀️	people	woman playing handball: medium-dark skin tone
-🤾🏿‍♀️	people	woman playing handball: dark skin tone
-🤹	people	person juggling performance balance juggle juggler multitask skill
-🤹🏻	people	person juggling: light skin tone
-🤹🏼	people	person juggling: medium-light skin tone
-🤹🏽	people	person juggling: medium skin tone
-🤹🏾	people	person juggling: medium-dark skin tone
-🤹🏿	people	person juggling: dark skin tone
-🤹‍♂️	people	man juggling juggle balance skill multitask juggler male men
-🤹🏻‍♂️	people	man juggling: light skin tone
-🤹🏼‍♂️	people	man juggling: medium-light skin tone
-🤹🏽‍♂️	people	man juggling: medium skin tone
-🤹🏾‍♂️	people	man juggling: medium-dark skin tone
-🤹🏿‍♂️	people	man juggling: dark skin tone
-🤹‍♀️	people	woman juggling juggle balance skill multitask female juggler women
-🤹🏻‍♀️	people	woman juggling: light skin tone
-🤹🏼‍♀️	people	woman juggling: medium-light skin tone
-🤹🏽‍♀️	people	woman juggling: medium skin tone
-🤹🏾‍♀️	people	woman juggling: medium-dark skin tone
-🤹🏿‍♀️	people	woman juggling: dark skin tone
-🧘	people	person in lotus position meditate meditation serenity yoga
-🧘🏻	people	person in lotus position: light skin tone
-🧘🏼	people	person in lotus position: medium-light skin tone
-🧘🏽	people	person in lotus position: medium skin tone
-🧘🏾	people	person in lotus position: medium-dark skin tone
-🧘🏿	people	person in lotus position: dark skin tone
-🧘‍♂️	people	man in lotus position man male meditation yoga serenity zen mindfulness men
-🧘🏻‍♂️	people	man in lotus position: light skin tone
-🧘🏼‍♂️	people	man in lotus position: medium-light skin tone
-🧘🏽‍♂️	people	man in lotus position: medium skin tone
-🧘🏾‍♂️	people	man in lotus position: medium-dark skin tone
-🧘🏿‍♂️	people	man in lotus position: dark skin tone
-🧘‍♀️	people	woman in lotus position woman female meditation yoga serenity zen mindfulness women
-🧘🏻‍♀️	people	woman in lotus position: light skin tone
-🧘🏼‍♀️	people	woman in lotus position: medium-light skin tone
-🧘🏽‍♀️	people	woman in lotus position: medium skin tone
-🧘🏾‍♀️	people	woman in lotus position: medium-dark skin tone
-🧘🏿‍♀️	people	woman in lotus position: dark skin tone
-🛀	people	person taking bath clean shower bathroom bathing bathtub hot
-🛀🏻	people	person taking bath: light skin tone
-🛀🏼	people	person taking bath: medium-light skin tone
-🛀🏽	people	person taking bath: medium skin tone
-🛀🏾	people	person taking bath: medium-dark skin tone
-🛀🏿	people	person taking bath: dark skin tone
-🛌	people	person in bed bed rest accommodation hotel sleep sleeping
-🛌🏻	people	person in bed: light skin tone
-🛌🏼	people	person in bed: medium-light skin tone
-🛌🏽	people	person in bed: medium skin tone
-🛌🏾	people	person in bed: medium-dark skin tone
-🛌🏿	people	person in bed: dark skin tone
-🧑‍🤝‍🧑	people	people holding hands friendship couple date gender hand hold inclusive neutral nonconforming
-🧑🏻‍🤝‍🧑🏻	people	people holding hands: light skin tone
-🧑🏻‍🤝‍🧑🏼	people	people holding hands: light skin tone, medium-light skin tone
-🧑🏻‍🤝‍🧑🏽	people	people holding hands: light skin tone, medium skin tone
-🧑🏻‍🤝‍🧑🏾	people	people holding hands: light skin tone, medium-dark skin tone
-🧑🏻‍🤝‍🧑🏿	people	people holding hands: light skin tone, dark skin tone
-🧑🏼‍🤝‍🧑🏻	people	people holding hands: medium-light skin tone, light skin tone
-🧑🏼‍🤝‍🧑🏼	people	people holding hands: medium-light skin tone
-🧑🏼‍🤝‍🧑🏽	people	people holding hands: medium-light skin tone, medium skin tone
-🧑🏼‍🤝‍🧑🏾	people	people holding hands: medium-light skin tone, medium-dark skin tone
-🧑🏼‍🤝‍🧑🏿	people	people holding hands: medium-light skin tone, dark skin tone
-🧑🏽‍🤝‍🧑🏻	people	people holding hands: medium skin tone, light skin tone
-🧑🏽‍🤝‍🧑🏼	people	people holding hands: medium skin tone, medium-light skin tone
-🧑🏽‍🤝‍🧑🏽	people	people holding hands: medium skin tone
-🧑🏽‍🤝‍🧑🏾	people	people holding hands: medium skin tone, medium-dark skin tone
-🧑🏽‍🤝‍🧑🏿	people	people holding hands: medium skin tone, dark skin tone
-🧑🏾‍🤝‍🧑🏻	people	people holding hands: medium-dark skin tone, light skin tone
-🧑🏾‍🤝‍🧑🏼	people	people holding hands: medium-dark skin tone, medium-light skin tone
-🧑🏾‍🤝‍🧑🏽	people	people holding hands: medium-dark skin tone, medium skin tone
-🧑🏾‍🤝‍🧑🏾	people	people holding hands: medium-dark skin tone
-🧑🏾‍🤝‍🧑🏿	people	people holding hands: medium-dark skin tone, dark skin tone
-🧑🏿‍🤝‍🧑🏻	people	people holding hands: dark skin tone, light skin tone
-🧑🏿‍🤝‍🧑🏼	people	people holding hands: dark skin tone, medium-light skin tone
-🧑🏿‍🤝‍🧑🏽	people	people holding hands: dark skin tone, medium skin tone
-🧑🏿‍🤝‍🧑🏾	people	people holding hands: dark skin tone, medium-dark skin tone
-🧑🏿‍🤝‍🧑🏿	people	people holding hands: dark skin tone
-👭	people	women holding hands pair friendship couple love like female people human date hand hold lesbian lgbt pride two woman
-👭🏻	people	women holding hands: light skin tone
-👩🏻‍🤝‍👩🏼	people	women holding hands: light skin tone, medium-light skin tone
-👩🏻‍🤝‍👩🏽	people	women holding hands: light skin tone, medium skin tone
-👩🏻‍🤝‍👩🏾	people	women holding hands: light skin tone, medium-dark skin tone
-👩🏻‍🤝‍👩🏿	people	women holding hands: light skin tone, dark skin tone
-👩🏼‍🤝‍👩🏻	people	women holding hands: medium-light skin tone, light skin tone
-👭🏼	people	women holding hands: medium-light skin tone
-👩🏼‍🤝‍👩🏽	people	women holding hands: medium-light skin tone, medium skin tone
-👩🏼‍🤝‍👩🏾	people	women holding hands: medium-light skin tone, medium-dark skin tone
-👩🏼‍🤝‍👩🏿	people	women holding hands: medium-light skin tone, dark skin tone
-👩🏽‍🤝‍👩🏻	people	women holding hands: medium skin tone, light skin tone
-👩🏽‍🤝‍👩🏼	people	women holding hands: medium skin tone, medium-light skin tone
-👭🏽	people	women holding hands: medium skin tone
-👩🏽‍🤝‍👩🏾	people	women holding hands: medium skin tone, medium-dark skin tone
-👩🏽‍🤝‍👩🏿	people	women holding hands: medium skin tone, dark skin tone
-👩🏾‍🤝‍👩🏻	people	women holding hands: medium-dark skin tone, light skin tone
-👩🏾‍🤝‍👩🏼	people	women holding hands: medium-dark skin tone, medium-light skin tone
-👩🏾‍🤝‍👩🏽	people	women holding hands: medium-dark skin tone, medium skin tone
-👭🏾	people	women holding hands: medium-dark skin tone
-👩🏾‍🤝‍👩🏿	people	women holding hands: medium-dark skin tone, dark skin tone
-👩🏿‍🤝‍👩🏻	people	women holding hands: dark skin tone, light skin tone
-👩🏿‍🤝‍👩🏼	people	women holding hands: dark skin tone, medium-light skin tone
-👩🏿‍🤝‍👩🏽	people	women holding hands: dark skin tone, medium skin tone
-👩🏿‍🤝‍👩🏾	people	women holding hands: dark skin tone, medium-dark skin tone
-👭🏿	people	women holding hands: dark skin tone
-👫	people	woman and man holding hands pair people human love date dating like affection valentines marriage couple female hand heterosexual hold male men straight women
-👫🏻	people	woman and man holding hands: light skin tone
-👩🏻‍🤝‍👨🏼	people	woman and man holding hands: light skin tone, medium-light skin tone
-👩🏻‍🤝‍👨🏽	people	woman and man holding hands: light skin tone, medium skin tone
-👩🏻‍🤝‍👨🏾	people	woman and man holding hands: light skin tone, medium-dark skin tone
-👩🏻‍🤝‍👨🏿	people	woman and man holding hands: light skin tone, dark skin tone
-👩🏼‍🤝‍👨🏻	people	woman and man holding hands: medium-light skin tone, light skin tone
-👫🏼	people	woman and man holding hands: medium-light skin tone
-👩🏼‍🤝‍👨🏽	people	woman and man holding hands: medium-light skin tone, medium skin tone
-👩🏼‍🤝‍👨🏾	people	woman and man holding hands: medium-light skin tone, medium-dark skin tone
-👩🏼‍🤝‍👨🏿	people	woman and man holding hands: medium-light skin tone, dark skin tone
-👩🏽‍🤝‍👨🏻	people	woman and man holding hands: medium skin tone, light skin tone
-👩🏽‍🤝‍👨🏼	people	woman and man holding hands: medium skin tone, medium-light skin tone
-👫🏽	people	woman and man holding hands: medium skin tone
-👩🏽‍🤝‍👨🏾	people	woman and man holding hands: medium skin tone, medium-dark skin tone
-👩🏽‍🤝‍👨🏿	people	woman and man holding hands: medium skin tone, dark skin tone
-👩🏾‍🤝‍👨🏻	people	woman and man holding hands: medium-dark skin tone, light skin tone
-👩🏾‍🤝‍👨🏼	people	woman and man holding hands: medium-dark skin tone, medium-light skin tone
-👩🏾‍🤝‍👨🏽	people	woman and man holding hands: medium-dark skin tone, medium skin tone
-👫🏾	people	woman and man holding hands: medium-dark skin tone
-👩🏾‍🤝‍👨🏿	people	woman and man holding hands: medium-dark skin tone, dark skin tone
-👩🏿‍🤝‍👨🏻	people	woman and man holding hands: dark skin tone, light skin tone
-👩🏿‍🤝‍👨🏼	people	woman and man holding hands: dark skin tone, medium-light skin tone
-👩🏿‍🤝‍👨🏽	people	woman and man holding hands: dark skin tone, medium skin tone
-👩🏿‍🤝‍👨🏾	people	woman and man holding hands: dark skin tone, medium-dark skin tone
-👫🏿	people	woman and man holding hands: dark skin tone
-👬	people	men holding hands pair couple love like bromance friendship people human date gay hand hold lgbt male man pride two
-👬🏻	people	men holding hands: light skin tone
-👨🏻‍🤝‍👨🏼	people	men holding hands: light skin tone, medium-light skin tone
-👨🏻‍🤝‍👨🏽	people	men holding hands: light skin tone, medium skin tone
-👨🏻‍🤝‍👨🏾	people	men holding hands: light skin tone, medium-dark skin tone
-👨🏻‍🤝‍👨🏿	people	men holding hands: light skin tone, dark skin tone
-👨🏼‍🤝‍👨🏻	people	men holding hands: medium-light skin tone, light skin tone
-👬🏼	people	men holding hands: medium-light skin tone
-👨🏼‍🤝‍👨🏽	people	men holding hands: medium-light skin tone, medium skin tone
-👨🏼‍🤝‍👨🏾	people	men holding hands: medium-light skin tone, medium-dark skin tone
-👨🏼‍🤝‍👨🏿	people	men holding hands: medium-light skin tone, dark skin tone
-👨🏽‍🤝‍👨🏻	people	men holding hands: medium skin tone, light skin tone
-👨🏽‍🤝‍👨🏼	people	men holding hands: medium skin tone, medium-light skin tone
-👬🏽	people	men holding hands: medium skin tone
-👨🏽‍🤝‍👨🏾	people	men holding hands: medium skin tone, medium-dark skin tone
-👨🏽‍🤝‍👨🏿	people	men holding hands: medium skin tone, dark skin tone
-👨🏾‍🤝‍👨🏻	people	men holding hands: medium-dark skin tone, light skin tone
-👨🏾‍🤝‍👨🏼	people	men holding hands: medium-dark skin tone, medium-light skin tone
-👨🏾‍🤝‍👨🏽	people	men holding hands: medium-dark skin tone, medium skin tone
-👬🏾	people	men holding hands: medium-dark skin tone
-👨🏾‍🤝‍👨🏿	people	men holding hands: medium-dark skin tone, dark skin tone
-👨🏿‍🤝‍👨🏻	people	men holding hands: dark skin tone, light skin tone
-👨🏿‍🤝‍👨🏼	people	men holding hands: dark skin tone, medium-light skin tone
-👨🏿‍🤝‍👨🏽	people	men holding hands: dark skin tone, medium skin tone
-👨🏿‍🤝‍👨🏾	people	men holding hands: dark skin tone, medium-dark skin tone
-👬🏿	people	men holding hands: dark skin tone
-💏	people	kiss pair valentines love like dating marriage couple couplekiss female gender heart kissing male man men neutral romance woman women
-💏🏻	people	kiss: light skin tone
-💏🏼	people	kiss: medium-light skin tone
-💏🏽	people	kiss: medium skin tone
-💏🏾	people	kiss: medium-dark skin tone
-💏🏿	people	kiss: dark skin tone
-🧑🏻‍❤️‍💋‍🧑🏼	people	kiss: person, person, light skin tone, medium-light skin tone
-🧑🏻‍❤️‍💋‍🧑🏽	people	kiss: person, person, light skin tone, medium skin tone
-🧑🏻‍❤️‍💋‍🧑🏾	people	kiss: person, person, light skin tone, medium-dark skin tone
-🧑🏻‍❤️‍💋‍🧑🏿	people	kiss: person, person, light skin tone, dark skin tone
-🧑🏼‍❤️‍💋‍🧑🏻	people	kiss: person, person, medium-light skin tone, light skin tone
-🧑🏼‍❤️‍💋‍🧑🏽	people	kiss: person, person, medium-light skin tone, medium skin tone
-🧑🏼‍❤️‍💋‍🧑🏾	people	kiss: person, person, medium-light skin tone, medium-dark skin tone
-🧑🏼‍❤️‍💋‍🧑🏿	people	kiss: person, person, medium-light skin tone, dark skin tone
-🧑🏽‍❤️‍💋‍🧑🏻	people	kiss: person, person, medium skin tone, light skin tone
-🧑🏽‍❤️‍💋‍🧑🏼	people	kiss: person, person, medium skin tone, medium-light skin tone
-🧑🏽‍❤️‍💋‍🧑🏾	people	kiss: person, person, medium skin tone, medium-dark skin tone
-🧑🏽‍❤️‍💋‍🧑🏿	people	kiss: person, person, medium skin tone, dark skin tone
-🧑🏾‍❤️‍💋‍🧑🏻	people	kiss: person, person, medium-dark skin tone, light skin tone
-🧑🏾‍❤️‍💋‍🧑🏼	people	kiss: person, person, medium-dark skin tone, medium-light skin tone
-🧑🏾‍❤️‍💋‍🧑🏽	people	kiss: person, person, medium-dark skin tone, medium skin tone
-🧑🏾‍❤️‍💋‍🧑🏿	people	kiss: person, person, medium-dark skin tone, dark skin tone
-🧑🏿‍❤️‍💋‍🧑🏻	people	kiss: person, person, dark skin tone, light skin tone
-🧑🏿‍❤️‍💋‍🧑🏼	people	kiss: person, person, dark skin tone, medium-light skin tone
-🧑🏿‍❤️‍💋‍🧑🏽	people	kiss: person, person, dark skin tone, medium skin tone
-🧑🏿‍❤️‍💋‍🧑🏾	people	kiss: person, person, dark skin tone, medium-dark skin tone
-👩‍❤️‍💋‍👨	people	kiss: woman, man kiss woman man love couple couplekiss female heart kissing male men romance women
-👩🏻‍❤️‍💋‍👨🏻	people	kiss: woman, man, light skin tone
-👩🏻‍❤️‍💋‍👨🏼	people	kiss: woman, man, light skin tone, medium-light skin tone
-👩🏻‍❤️‍💋‍👨🏽	people	kiss: woman, man, light skin tone, medium skin tone
-👩🏻‍❤️‍💋‍👨🏾	people	kiss: woman, man, light skin tone, medium-dark skin tone
-👩🏻‍❤️‍💋‍👨🏿	people	kiss: woman, man, light skin tone, dark skin tone
-👩🏼‍❤️‍💋‍👨🏻	people	kiss: woman, man, medium-light skin tone, light skin tone
-👩🏼‍❤️‍💋‍👨🏼	people	kiss: woman, man, medium-light skin tone
-👩🏼‍❤️‍💋‍👨🏽	people	kiss: woman, man, medium-light skin tone, medium skin tone
-👩🏼‍❤️‍💋‍👨🏾	people	kiss: woman, man, medium-light skin tone, medium-dark skin tone
-👩🏼‍❤️‍💋‍👨🏿	people	kiss: woman, man, medium-light skin tone, dark skin tone
-👩🏽‍❤️‍💋‍👨🏻	people	kiss: woman, man, medium skin tone, light skin tone
-👩🏽‍❤️‍💋‍👨🏼	people	kiss: woman, man, medium skin tone, medium-light skin tone
-👩🏽‍❤️‍💋‍👨🏽	people	kiss: woman, man, medium skin tone
-👩🏽‍❤️‍💋‍👨🏾	people	kiss: woman, man, medium skin tone, medium-dark skin tone
-👩🏽‍❤️‍💋‍👨🏿	people	kiss: woman, man, medium skin tone, dark skin tone
-👩🏾‍❤️‍💋‍👨🏻	people	kiss: woman, man, medium-dark skin tone, light skin tone
-👩🏾‍❤️‍💋‍👨🏼	people	kiss: woman, man, medium-dark skin tone, medium-light skin tone
-👩🏾‍❤️‍💋‍👨🏽	people	kiss: woman, man, medium-dark skin tone, medium skin tone
-👩🏾‍❤️‍💋‍👨🏾	people	kiss: woman, man, medium-dark skin tone
-👩🏾‍❤️‍💋‍👨🏿	people	kiss: woman, man, medium-dark skin tone, dark skin tone
-👩🏿‍❤️‍💋‍👨🏻	people	kiss: woman, man, dark skin tone, light skin tone
-👩🏿‍❤️‍💋‍👨🏼	people	kiss: woman, man, dark skin tone, medium-light skin tone
-👩🏿‍❤️‍💋‍👨🏽	people	kiss: woman, man, dark skin tone, medium skin tone
-👩🏿‍❤️‍💋‍👨🏾	people	kiss: woman, man, dark skin tone, medium-dark skin tone
-👩🏿‍❤️‍💋‍👨🏿	people	kiss: woman, man, dark skin tone
-👨‍❤️‍💋‍👨	people	kiss: man, man kiss man man pair valentines love like dating marriage couple couplekiss gay heart kissing lgbt male men pride romance two
-👨🏻‍❤️‍💋‍👨🏻	people	kiss: man, man, light skin tone
-👨🏻‍❤️‍💋‍👨🏼	people	kiss: man, man, light skin tone, medium-light skin tone
-👨🏻‍❤️‍💋‍👨🏽	people	kiss: man, man, light skin tone, medium skin tone
-👨🏻‍❤️‍💋‍👨🏾	people	kiss: man, man, light skin tone, medium-dark skin tone
-👨🏻‍❤️‍💋‍👨🏿	people	kiss: man, man, light skin tone, dark skin tone
-👨🏼‍❤️‍💋‍👨🏻	people	kiss: man, man, medium-light skin tone, light skin tone
-👨🏼‍❤️‍💋‍👨🏼	people	kiss: man, man, medium-light skin tone
-👨🏼‍❤️‍💋‍👨🏽	people	kiss: man, man, medium-light skin tone, medium skin tone
-👨🏼‍❤️‍💋‍👨🏾	people	kiss: man, man, medium-light skin tone, medium-dark skin tone
-👨🏼‍❤️‍💋‍👨🏿	people	kiss: man, man, medium-light skin tone, dark skin tone
-👨🏽‍❤️‍💋‍👨🏻	people	kiss: man, man, medium skin tone, light skin tone
-👨🏽‍❤️‍💋‍👨🏼	people	kiss: man, man, medium skin tone, medium-light skin tone
-👨🏽‍❤️‍💋‍👨🏽	people	kiss: man, man, medium skin tone
-👨🏽‍❤️‍💋‍👨🏾	people	kiss: man, man, medium skin tone, medium-dark skin tone
-👨🏽‍❤️‍💋‍👨🏿	people	kiss: man, man, medium skin tone, dark skin tone
-👨🏾‍❤️‍💋‍👨🏻	people	kiss: man, man, medium-dark skin tone, light skin tone
-👨🏾‍❤️‍💋‍👨🏼	people	kiss: man, man, medium-dark skin tone, medium-light skin tone
-👨🏾‍❤️‍💋‍👨🏽	people	kiss: man, man, medium-dark skin tone, medium skin tone
-👨🏾‍❤️‍💋‍👨🏾	people	kiss: man, man, medium-dark skin tone
-👨🏾‍❤️‍💋‍👨🏿	people	kiss: man, man, medium-dark skin tone, dark skin tone
-👨🏿‍❤️‍💋‍👨🏻	people	kiss: man, man, dark skin tone, light skin tone
-👨🏿‍❤️‍💋‍👨🏼	people	kiss: man, man, dark skin tone, medium-light skin tone
-👨🏿‍❤️‍💋‍👨🏽	people	kiss: man, man, dark skin tone, medium skin tone
-👨🏿‍❤️‍💋‍👨🏾	people	kiss: man, man, dark skin tone, medium-dark skin tone
-👨🏿‍❤️‍💋‍👨🏿	people	kiss: man, man, dark skin tone
-👩‍❤️‍💋‍👩	people	kiss: woman, woman kiss woman woman pair valentines love like dating marriage couple couplekiss female heart kissing lesbian lgbt pride romance two women
-👩🏻‍❤️‍💋‍👩🏻	people	kiss: woman, woman, light skin tone
-👩🏻‍❤️‍💋‍👩🏼	people	kiss: woman, woman, light skin tone, medium-light skin tone
-👩🏻‍❤️‍💋‍👩🏽	people	kiss: woman, woman, light skin tone, medium skin tone
-👩🏻‍❤️‍💋‍👩🏾	people	kiss: woman, woman, light skin tone, medium-dark skin tone
-👩🏻‍❤️‍💋‍👩🏿	people	kiss: woman, woman, light skin tone, dark skin tone
-👩🏼‍❤️‍💋‍👩🏻	people	kiss: woman, woman, medium-light skin tone, light skin tone
-👩🏼‍❤️‍💋‍👩🏼	people	kiss: woman, woman, medium-light skin tone
-👩🏼‍❤️‍💋‍👩🏽	people	kiss: woman, woman, medium-light skin tone, medium skin tone
-👩🏼‍❤️‍💋‍👩🏾	people	kiss: woman, woman, medium-light skin tone, medium-dark skin tone
-👩🏼‍❤️‍💋‍👩🏿	people	kiss: woman, woman, medium-light skin tone, dark skin tone
-👩🏽‍❤️‍💋‍👩🏻	people	kiss: woman, woman, medium skin tone, light skin tone
-👩🏽‍❤️‍💋‍👩🏼	people	kiss: woman, woman, medium skin tone, medium-light skin tone
-👩🏽‍❤️‍💋‍👩🏽	people	kiss: woman, woman, medium skin tone
-👩🏽‍❤️‍💋‍👩🏾	people	kiss: woman, woman, medium skin tone, medium-dark skin tone
-👩🏽‍❤️‍💋‍👩🏿	people	kiss: woman, woman, medium skin tone, dark skin tone
-👩🏾‍❤️‍💋‍👩🏻	people	kiss: woman, woman, medium-dark skin tone, light skin tone
-👩🏾‍❤️‍💋‍👩🏼	people	kiss: woman, woman, medium-dark skin tone, medium-light skin tone
-👩🏾‍❤️‍💋‍👩🏽	people	kiss: woman, woman, medium-dark skin tone, medium skin tone
-👩🏾‍❤️‍💋‍👩🏾	people	kiss: woman, woman, medium-dark skin tone
-👩🏾‍❤️‍💋‍👩🏿	people	kiss: woman, woman, medium-dark skin tone, dark skin tone
-👩🏿‍❤️‍💋‍👩🏻	people	kiss: woman, woman, dark skin tone, light skin tone
-👩🏿‍❤️‍💋‍👩🏼	people	kiss: woman, woman, dark skin tone, medium-light skin tone
-👩🏿‍❤️‍💋‍👩🏽	people	kiss: woman, woman, dark skin tone, medium skin tone
-👩🏿‍❤️‍💋‍👩🏾	people	kiss: woman, woman, dark skin tone, medium-dark skin tone
-👩🏿‍❤️‍💋‍👩🏿	people	kiss: woman, woman, dark skin tone
-💑	people	couple with heart pair love like affection human dating valentines marriage female gender loving male man men neutral romance woman women
-💑🏻	people	couple with heart: light skin tone
-💑🏼	people	couple with heart: medium-light skin tone
-💑🏽	people	couple with heart: medium skin tone
-💑🏾	people	couple with heart: medium-dark skin tone
-💑🏿	people	couple with heart: dark skin tone
-🧑🏻‍❤️‍🧑🏼	people	couple with heart: person, person, light skin tone, medium-light skin tone
-🧑🏻‍❤️‍🧑🏽	people	couple with heart: person, person, light skin tone, medium skin tone
-🧑🏻‍❤️‍🧑🏾	people	couple with heart: person, person, light skin tone, medium-dark skin tone
-🧑🏻‍❤️‍🧑🏿	people	couple with heart: person, person, light skin tone, dark skin tone
-🧑🏼‍❤️‍🧑🏻	people	couple with heart: person, person, medium-light skin tone, light skin tone
-🧑🏼‍❤️‍🧑🏽	people	couple with heart: person, person, medium-light skin tone, medium skin tone
-🧑🏼‍❤️‍🧑🏾	people	couple with heart: person, person, medium-light skin tone, medium-dark skin tone
-🧑🏼‍❤️‍🧑🏿	people	couple with heart: person, person, medium-light skin tone, dark skin tone
-🧑🏽‍❤️‍🧑🏻	people	couple with heart: person, person, medium skin tone, light skin tone
-🧑🏽‍❤️‍🧑🏼	people	couple with heart: person, person, medium skin tone, medium-light skin tone
-🧑🏽‍❤️‍🧑🏾	people	couple with heart: person, person, medium skin tone, medium-dark skin tone
-🧑🏽‍❤️‍🧑🏿	people	couple with heart: person, person, medium skin tone, dark skin tone
-🧑🏾‍❤️‍🧑🏻	people	couple with heart: person, person, medium-dark skin tone, light skin tone
-🧑🏾‍❤️‍🧑🏼	people	couple with heart: person, person, medium-dark skin tone, medium-light skin tone
-🧑🏾‍❤️‍🧑🏽	people	couple with heart: person, person, medium-dark skin tone, medium skin tone
-🧑🏾‍❤️‍🧑🏿	people	couple with heart: person, person, medium-dark skin tone, dark skin tone
-🧑🏿‍❤️‍🧑🏻	people	couple with heart: person, person, dark skin tone, light skin tone
-🧑🏿‍❤️‍🧑🏼	people	couple with heart: person, person, dark skin tone, medium-light skin tone
-🧑🏿‍❤️‍🧑🏽	people	couple with heart: person, person, dark skin tone, medium skin tone
-🧑🏿‍❤️‍🧑🏾	people	couple with heart: person, person, dark skin tone, medium-dark skin tone
-👩‍❤️‍👨	people	couple with heart: woman, man couple with heart woman man love female male men romance women
-👩🏻‍❤️‍👨🏻	people	couple with heart: woman, man, light skin tone
-👩🏻‍❤️‍👨🏼	people	couple with heart: woman, man, light skin tone, medium-light skin tone
-👩🏻‍❤️‍👨🏽	people	couple with heart: woman, man, light skin tone, medium skin tone
-👩🏻‍❤️‍👨🏾	people	couple with heart: woman, man, light skin tone, medium-dark skin tone
-👩🏻‍❤️‍👨🏿	people	couple with heart: woman, man, light skin tone, dark skin tone
-👩🏼‍❤️‍👨🏻	people	couple with heart: woman, man, medium-light skin tone, light skin tone
-👩🏼‍❤️‍👨🏼	people	couple with heart: woman, man, medium-light skin tone
-👩🏼‍❤️‍👨🏽	people	couple with heart: woman, man, medium-light skin tone, medium skin tone
-👩🏼‍❤️‍👨🏾	people	couple with heart: woman, man, medium-light skin tone, medium-dark skin tone
-👩🏼‍❤️‍👨🏿	people	couple with heart: woman, man, medium-light skin tone, dark skin tone
-👩🏽‍❤️‍👨🏻	people	couple with heart: woman, man, medium skin tone, light skin tone
-👩🏽‍❤️‍👨🏼	people	couple with heart: woman, man, medium skin tone, medium-light skin tone
-👩🏽‍❤️‍👨🏽	people	couple with heart: woman, man, medium skin tone
-👩🏽‍❤️‍👨🏾	people	couple with heart: woman, man, medium skin tone, medium-dark skin tone
-👩🏽‍❤️‍👨🏿	people	couple with heart: woman, man, medium skin tone, dark skin tone
-👩🏾‍❤️‍👨🏻	people	couple with heart: woman, man, medium-dark skin tone, light skin tone
-👩🏾‍❤️‍👨🏼	people	couple with heart: woman, man, medium-dark skin tone, medium-light skin tone
-👩🏾‍❤️‍👨🏽	people	couple with heart: woman, man, medium-dark skin tone, medium skin tone
-👩🏾‍❤️‍👨🏾	people	couple with heart: woman, man, medium-dark skin tone
-👩🏾‍❤️‍👨🏿	people	couple with heart: woman, man, medium-dark skin tone, dark skin tone
-👩🏿‍❤️‍👨🏻	people	couple with heart: woman, man, dark skin tone, light skin tone
-👩🏿‍❤️‍👨🏼	people	couple with heart: woman, man, dark skin tone, medium-light skin tone
-👩🏿‍❤️‍👨🏽	people	couple with heart: woman, man, dark skin tone, medium skin tone
-👩🏿‍❤️‍👨🏾	people	couple with heart: woman, man, dark skin tone, medium-dark skin tone
-👩🏿‍❤️‍👨🏿	people	couple with heart: woman, man, dark skin tone
-👨‍❤️‍👨	people	couple with heart: man, man couple with heart man man pair love like affection human dating valentines marriage gay lgbt male men pride romance two
-👨🏻‍❤️‍👨🏻	people	couple with heart: man, man, light skin tone
-👨🏻‍❤️‍👨🏼	people	couple with heart: man, man, light skin tone, medium-light skin tone
-👨🏻‍❤️‍👨🏽	people	couple with heart: man, man, light skin tone, medium skin tone
-👨🏻‍❤️‍👨🏾	people	couple with heart: man, man, light skin tone, medium-dark skin tone
-👨🏻‍❤️‍👨🏿	people	couple with heart: man, man, light skin tone, dark skin tone
-👨🏼‍❤️‍👨🏻	people	couple with heart: man, man, medium-light skin tone, light skin tone
-👨🏼‍❤️‍👨🏼	people	couple with heart: man, man, medium-light skin tone
-👨🏼‍❤️‍👨🏽	people	couple with heart: man, man, medium-light skin tone, medium skin tone
-👨🏼‍❤️‍👨🏾	people	couple with heart: man, man, medium-light skin tone, medium-dark skin tone
-👨🏼‍❤️‍👨🏿	people	couple with heart: man, man, medium-light skin tone, dark skin tone
-👨🏽‍❤️‍👨🏻	people	couple with heart: man, man, medium skin tone, light skin tone
-👨🏽‍❤️‍👨🏼	people	couple with heart: man, man, medium skin tone, medium-light skin tone
-👨🏽‍❤️‍👨🏽	people	couple with heart: man, man, medium skin tone
-👨🏽‍❤️‍👨🏾	people	couple with heart: man, man, medium skin tone, medium-dark skin tone
-👨🏽‍❤️‍👨🏿	people	couple with heart: man, man, medium skin tone, dark skin tone
-👨🏾‍❤️‍👨🏻	people	couple with heart: man, man, medium-dark skin tone, light skin tone
-👨🏾‍❤️‍👨🏼	people	couple with heart: man, man, medium-dark skin tone, medium-light skin tone
-👨🏾‍❤️‍👨🏽	people	couple with heart: man, man, medium-dark skin tone, medium skin tone
-👨🏾‍❤️‍👨🏾	people	couple with heart: man, man, medium-dark skin tone
-👨🏾‍❤️‍👨🏿	people	couple with heart: man, man, medium-dark skin tone, dark skin tone
-👨🏿‍❤️‍👨🏻	people	couple with heart: man, man, dark skin tone, light skin tone
-👨🏿‍❤️‍👨🏼	people	couple with heart: man, man, dark skin tone, medium-light skin tone
-👨🏿‍❤️‍👨🏽	people	couple with heart: man, man, dark skin tone, medium skin tone
-👨🏿‍❤️‍👨🏾	people	couple with heart: man, man, dark skin tone, medium-dark skin tone
-👨🏿‍❤️‍👨🏿	people	couple with heart: man, man, dark skin tone
-👩‍❤️‍👩	people	couple with heart: woman, woman couple with heart woman woman pair love like affection human dating valentines marriage female lesbian lgbt pride romance two women
-👩🏻‍❤️‍👩🏻	people	couple with heart: woman, woman, light skin tone
-👩🏻‍❤️‍👩🏼	people	couple with heart: woman, woman, light skin tone, medium-light skin tone
-👩🏻‍❤️‍👩🏽	people	couple with heart: woman, woman, light skin tone, medium skin tone
-👩🏻‍❤️‍👩🏾	people	couple with heart: woman, woman, light skin tone, medium-dark skin tone
-👩🏻‍❤️‍👩🏿	people	couple with heart: woman, woman, light skin tone, dark skin tone
-👩🏼‍❤️‍👩🏻	people	couple with heart: woman, woman, medium-light skin tone, light skin tone
-👩🏼‍❤️‍👩🏼	people	couple with heart: woman, woman, medium-light skin tone
-👩🏼‍❤️‍👩🏽	people	couple with heart: woman, woman, medium-light skin tone, medium skin tone
-👩🏼‍❤️‍👩🏾	people	couple with heart: woman, woman, medium-light skin tone, medium-dark skin tone
-👩🏼‍❤️‍👩🏿	people	couple with heart: woman, woman, medium-light skin tone, dark skin tone
-👩🏽‍❤️‍👩🏻	people	couple with heart: woman, woman, medium skin tone, light skin tone
-👩🏽‍❤️‍👩🏼	people	couple with heart: woman, woman, medium skin tone, medium-light skin tone
-👩🏽‍❤️‍👩🏽	people	couple with heart: woman, woman, medium skin tone
-👩🏽‍❤️‍👩🏾	people	couple with heart: woman, woman, medium skin tone, medium-dark skin tone
-👩🏽‍❤️‍👩🏿	people	couple with heart: woman, woman, medium skin tone, dark skin tone
-👩🏾‍❤️‍👩🏻	people	couple with heart: woman, woman, medium-dark skin tone, light skin tone
-👩🏾‍❤️‍👩🏼	people	couple with heart: woman, woman, medium-dark skin tone, medium-light skin tone
-👩🏾‍❤️‍👩🏽	people	couple with heart: woman, woman, medium-dark skin tone, medium skin tone
-👩🏾‍❤️‍👩🏾	people	couple with heart: woman, woman, medium-dark skin tone
-👩🏾‍❤️‍👩🏿	people	couple with heart: woman, woman, medium-dark skin tone, dark skin tone
-👩🏿‍❤️‍👩🏻	people	couple with heart: woman, woman, dark skin tone, light skin tone
-👩🏿‍❤️‍👩🏼	people	couple with heart: woman, woman, dark skin tone, medium-light skin tone
-👩🏿‍❤️‍👩🏽	people	couple with heart: woman, woman, dark skin tone, medium skin tone
-👩🏿‍❤️‍👩🏾	people	couple with heart: woman, woman, dark skin tone, medium-dark skin tone
-👩🏿‍❤️‍👩🏿	people	couple with heart: woman, woman, dark skin tone
-👨‍👩‍👦	people	family: man, woman, boy family man woman boy love father mother son
-👨‍👩‍👧	people	family: man, woman, girl family man woman girl home parents people human child daughter father female male men mother women
-👨‍👩‍👧‍👦	people	family: man, woman, girl, boy family man woman girl boy home parents people human children child daughter father female male men mother son women
-👨‍👩‍👦‍👦	people	family: man, woman, boy, boy family man woman boy boy home parents people human children child father female male men mother sons two women
-👨‍👩‍👧‍👧	people	family: man, woman, girl, girl family man woman girl girl home parents people human children child daughters father female male men mother two women
-👨‍👨‍👦	people	family: man, man, boy family man man boy home parents people human children child father fathers gay lgbt male men pride son two
-👨‍👨‍👧	people	family: man, man, girl family man man girl home parents people human children child daughter father fathers gay lgbt male men pride two
-👨‍👨‍👧‍👦	people	family: man, man, girl, boy family man man girl boy home parents people human children child daughter father fathers gay lgbt male men pride son two
-👨‍👨‍👦‍👦	people	family: man, man, boy, boy family man man boy boy home parents people human children child father fathers gay lgbt male men pride sons two
-👨‍👨‍👧‍👧	people	family: man, man, girl, girl family man man girl girl home parents people human children child daughters father fathers gay lgbt male men pride two
-👩‍👩‍👦	people	family: woman, woman, boy family woman woman boy home parents people human children child female lesbian lgbt mother mothers pride son two women
-👩‍👩‍👧	people	family: woman, woman, girl family woman woman girl home parents people human children child daughter female lesbian lgbt mother mothers pride two women
-👩‍👩‍👧‍👦	people	family: woman, woman, girl, boy family woman woman girl boy home parents people human children child daughter female lesbian lgbt mother mothers pride son two women
-👩‍👩‍👦‍👦	people	family: woman, woman, boy, boy family woman woman boy boy home parents people human children child female lesbian lgbt mother mothers pride sons two women
-👩‍👩‍👧‍👧	people	family: woman, woman, girl, girl family woman woman girl girl home parents people human children child daughters female lesbian lgbt mother mothers pride two women
-👨‍👦	people	family: man, boy family man boy home parent people human child father male men son
-👨‍👦‍👦	people	family: man, boy, boy family man boy boy home parent people human children child father male men sons two
-👨‍👧	people	family: man, girl family man girl home parent people human child daughter father female male
-👨‍👧‍👦	people	family: man, girl, boy family man girl boy home parent people human children child daughter father male men son
-👨‍👧‍👧	people	family: man, girl, girl family man girl girl home parent people human children child daughters father female male two
-👩‍👦	people	family: woman, boy family woman boy home parent people human child female mother son women
-👩‍👦‍👦	people	family: woman, boy, boy family woman boy boy home parent people human children child female mother sons two women
-👩‍👧	people	family: woman, girl family woman girl home parent people human child daughter female mother women
-👩‍👧‍👦	people	family: woman, girl, boy family woman girl boy home parent people human children child daughter female male mother son
-👩‍👧‍👧	people	family: woman, girl, girl family woman girl girl home parent people human children child daughters female mother two women
-🗣️	people	speaking head user person human sing say talk face mansplaining shout shouting silhouette speak
-👤	people	bust in silhouette user person human shadow
-👥	people	busts in silhouette user person human group team bust people shadows silhouettes two users contributors
-🫂	people	people hugging care goodbye hello hug thanks
-👪	people	family home parents child mom dad father mother people human boy female male man men woman women
-🧑‍🧑‍🧒	people	family: adult, adult, child family adult, adult, child kid parents
-🧑‍🧑‍🧒‍🧒	people	family: adult, adult, child, child family adult, adult, child, child children parents
-🧑‍🧒	people	family: adult, child family adult, child parent kid
-🧑‍🧒‍🧒	people	family: adult, child, child family adult, child, child parent children
-👣	people	footprints feet tracking walking beach body clothing footprint footsteps print tracks
-🫆	people	fingerprint
-🐵	animals	monkey face animal nature circus head
-🐒	animals	monkey animal nature banana circus cheeky
-🦍	animals	gorilla animal nature circus
-🦧	animals	orangutan animal ape
-🐶	animals	dog face animal friend nature woof puppy pet faithful
-🐕	animals	dog animal nature friend doge pet faithful dog2 doggo
-🦮	animals	guide dog animal blind accessibility eye seeing
-🐕‍🦺	animals	service dog blind animal accessibility assistance
-🐩	animals	poodle dog animal 101 nature pet miniature standard toy
-🐺	animals	wolf animal nature wild face
-🦊	animals	fox animal nature face
-🦝	animals	raccoon animal nature curious face sly
-🐱	animals	cat face animal meow nature pet kitten kitty
-🐈	animals	cat animal meow pet cats cat2 domestic feline housecat
-🐈‍⬛	animals	black cat superstition luck halloween pet unlucky
-🦁	animals	lion animal nature face leo zodiac
-🐯	animals	tiger face animal cat danger wild nature roar cute
-🐅	animals	tiger animal nature roar bengal tiger2
-🐆	animals	leopard animal nature african jaguar
-🐴	animals	horse face animal brown nature head
-🫎	animals	moose canada sweden sven cool
-🫏	animals	donkey eeyore mule
-🐎	animals	horse animal gamble luck equestrian galloping racehorse racing speed
-🦄	animals	unicorn animal nature mystical face
-🦓	animals	zebra animal nature stripes safari face stripe
-🦌	animals	deer animal nature horns venison buck reindeer stag
-🦬	animals	bison ox buffalo herd wisent
-🐮	animals	cow face beef ox animal nature moo milk happy
-🐂	animals	ox animal cow beef bull bullock oxen steer taurus zodiac
-🐃	animals	water buffalo animal nature ox cow domestic
-🐄	animals	cow beef ox animal nature moo milk cow2 dairy
-🐷	animals	pig face animal oink nature head
-🐖	animals	pig animal nature hog pig2 sow
-🐗	animals	boar animal nature pig warthog wild
-🐽	animals	pig nose animal oink face snout
-🐏	animals	ram animal sheep nature aries male zodiac
-🐑	animals	ewe animal nature wool shipit female lamb sheep
-🐐	animals	goat animal nature capricorn zodiac
-🐪	animals	camel animal hot desert hump arabian bump dromedary one
-🐫	animals	two-hump camel two hump camel animal nature hot desert hump asian bactrian bump
-🦙	animals	llama animal nature alpaca guanaco vicuña wool
-🦒	animals	giraffe animal nature spots safari face
-🐘	animals	elephant animal nature nose th circus
-🦣	animals	mammoth elephant tusks extinct extinction large tusk woolly
-🦏	animals	rhinoceros animal nature horn rhino
-🦛	animals	hippopotamus animal nature hippo
-🐭	animals	mouse face animal nature cheese wedge rodent
-🐁	animals	mouse animal nature rodent dormouse mice mouse2
-🐀	animals	rat animal mouse rodent
-🐹	animals	hamster animal nature face pet
-🐰	animals	rabbit face animal nature pet spring magic bunny easter
-🐇	animals	rabbit animal nature pet magic spring bunny rabbit2
-🐿️	animals	chipmunk animal nature rodent squirrel
-🦫	animals	beaver animal rodent dam
-🦔	animals	hedgehog animal nature spiny face
-🦇	animals	bat animal nature blind vampire batman
-🐻	animals	bear animal nature wild face teddy
-🐻‍❄️	animals	polar bear animal arctic face white
-🐨	animals	koala animal nature bear face marsupial
-🐼	animals	panda animal nature face
-🦥	animals	sloth animal lazy slow
+🧑🏻‍🚒	people	firefighter light skin tone fire firetruck
+🧑🏼‍🚒	people	firefighter medium light skin tone fire firetruck
+🧑🏽‍🚒	people	firefighter medium skin tone fire firetruck
+🧑🏾‍🚒	people	firefighter medium dark skin tone fire firetruck
+🧑🏿‍🚒	people	firefighter dark skin tone fire firetruck
+👨‍🚒	people	man firefighter fire firetruck
+👨🏻‍🚒	people	man firefighter light skin tone fire firetruck
+👨🏼‍🚒	people	man firefighter medium light skin tone fire firetruck
+👨🏽‍🚒	people	man firefighter medium skin tone fire firetruck
+👨🏾‍🚒	people	man firefighter medium dark skin tone fire firetruck
+👨🏿‍🚒	people	man firefighter dark skin tone fire firetruck
+👩‍🚒	people	woman firefighter fire firetruck
+👩🏻‍🚒	people	woman firefighter light skin tone fire firetruck
+👩🏼‍🚒	people	woman firefighter medium light skin tone fire firetruck
+👩🏽‍🚒	people	woman firefighter medium skin tone fire firetruck
+👩🏾‍🚒	people	woman firefighter medium dark skin tone fire firetruck
+👩🏿‍🚒	people	woman firefighter dark skin tone fire firetruck
+👮	people	police officer apprehend arrest citation cop law over pulled undercover
+👮🏻	people	police officer light skin tone apprehend arrest citation cop law over pulled undercover
+👮🏼	people	police officer medium light skin tone apprehend arrest citation cop law over pulled undercover
+👮🏽	people	police officer medium skin tone apprehend arrest citation cop law over pulled undercover
+👮🏾	people	police officer medium dark skin tone apprehend arrest citation cop law over pulled undercover
+👮🏿	people	police officer dark skin tone apprehend arrest citation cop law over pulled undercover
+👮‍♂️	people	man police officer apprehend arrest citation cop law over pulled undercover
+👮🏻‍♂️	people	man police officer light skin tone apprehend arrest citation cop law over pulled undercover
+👮🏼‍♂️	people	man police officer medium light skin tone apprehend arrest citation cop law over pulled undercover
+👮🏽‍♂️	people	man police officer medium skin tone apprehend arrest citation cop law over pulled undercover
+👮🏾‍♂️	people	man police officer medium dark skin tone apprehend arrest citation cop law over pulled undercover
+👮🏿‍♂️	people	man police officer dark skin tone apprehend arrest citation cop law over pulled undercover
+👮‍♀️	people	woman police officer apprehend arrest citation cop law over pulled undercover
+👮🏻‍♀️	people	woman police officer light skin tone apprehend arrest citation cop law over pulled undercover
+👮🏼‍♀️	people	woman police officer medium light skin tone apprehend arrest citation cop law over pulled undercover
+👮🏽‍♀️	people	woman police officer medium skin tone apprehend arrest citation cop law over pulled undercover
+👮🏾‍♀️	people	woman police officer medium dark skin tone apprehend arrest citation cop law over pulled undercover
+👮🏿‍♀️	people	woman police officer dark skin tone apprehend arrest citation cop law over pulled undercover
+🕵️	people	detective sleuth spy
+🕵🏻	people	detective light skin tone sleuth spy
+🕵🏼	people	detective medium light skin tone sleuth spy
+🕵🏽	people	detective medium skin tone sleuth spy
+🕵🏾	people	detective medium dark skin tone sleuth spy
+🕵🏿	people	detective dark skin tone sleuth spy
+🕵️‍♂️	people	man detective sleuth spy
+🕵🏻‍♂️	people	man detective light skin tone sleuth spy
+🕵🏼‍♂️	people	man detective medium light skin tone sleuth spy
+🕵🏽‍♂️	people	man detective medium skin tone sleuth spy
+🕵🏾‍♂️	people	man detective medium dark skin tone sleuth spy
+🕵🏿‍♂️	people	man detective dark skin tone sleuth spy
+🕵️‍♀️	people	woman detective sleuth spy
+🕵🏻‍♀️	people	woman detective light skin tone sleuth spy
+🕵🏼‍♀️	people	woman detective medium light skin tone sleuth spy
+🕵🏽‍♀️	people	woman detective medium skin tone sleuth spy
+🕵🏾‍♀️	people	woman detective medium dark skin tone sleuth spy
+🕵🏿‍♀️	people	woman detective dark skin tone sleuth spy
+💂	people	guard buckingham helmet london palace
+💂🏻	people	guard light skin tone buckingham helmet london palace
+💂🏼	people	guard medium light skin tone buckingham helmet london palace
+💂🏽	people	guard medium skin tone buckingham helmet london palace
+💂🏾	people	guard medium dark skin tone buckingham helmet london palace
+💂🏿	people	guard dark skin tone buckingham helmet london palace
+💂‍♂️	people	man guard buckingham helmet london palace
+💂🏻‍♂️	people	man guard light skin tone buckingham helmet london palace
+💂🏼‍♂️	people	man guard medium light skin tone buckingham helmet london palace
+💂🏽‍♂️	people	man guard medium skin tone buckingham helmet london palace
+💂🏾‍♂️	people	man guard medium dark skin tone buckingham helmet london palace
+💂🏿‍♂️	people	man guard dark skin tone buckingham helmet london palace
+💂‍♀️	people	woman guard buckingham helmet london palace
+💂🏻‍♀️	people	woman guard light skin tone buckingham helmet london palace
+💂🏼‍♀️	people	woman guard medium light skin tone buckingham helmet london palace
+💂🏽‍♀️	people	woman guard medium skin tone buckingham helmet london palace
+💂🏾‍♀️	people	woman guard medium dark skin tone buckingham helmet london palace
+💂🏿‍♀️	people	woman guard dark skin tone buckingham helmet london palace
+🥷	people	ninja assassin fight fighter hidden person secret skills sly soldier stealth war
+🥷🏻	people	ninja light skin tone assassin fight fighter hidden person secret skills sly soldier stealth war
+🥷🏼	people	ninja medium light skin tone assassin fight fighter hidden person secret skills sly soldier stealth war
+🥷🏽	people	ninja medium skin tone assassin fight fighter hidden person secret skills sly soldier stealth war
+🥷🏾	people	ninja medium dark skin tone assassin fight fighter hidden person secret skills sly soldier stealth war
+🥷🏿	people	ninja dark skin tone assassin fight fighter hidden person secret skills sly soldier stealth war
+👷	people	construction worker build fix hardhat hat man person rebuild remodel repair work
+👷🏻	people	construction worker light skin tone build fix hardhat hat man person rebuild remodel repair work
+👷🏼	people	construction worker medium light skin tone build fix hardhat hat man person rebuild remodel repair work
+👷🏽	people	construction worker medium skin tone build fix hardhat hat man person rebuild remodel repair work
+👷🏾	people	construction worker medium dark skin tone build fix hardhat hat man person rebuild remodel repair work
+👷🏿	people	construction worker dark skin tone build fix hardhat hat man person rebuild remodel repair work
+👷‍♂️	people	man construction worker build fix hardhat hat rebuild remodel repair work
+👷🏻‍♂️	people	man construction worker light skin tone build fix hardhat hat rebuild remodel repair work
+👷🏼‍♂️	people	man construction worker medium light skin tone build fix hardhat hat rebuild remodel repair work
+👷🏽‍♂️	people	man construction worker medium skin tone build fix hardhat hat rebuild remodel repair work
+👷🏾‍♂️	people	man construction worker medium dark skin tone build fix hardhat hat rebuild remodel repair work
+👷🏿‍♂️	people	man construction worker dark skin tone build fix hardhat hat rebuild remodel repair work
+👷‍♀️	people	woman construction worker build fix hardhat hat man rebuild remodel repair work
+👷🏻‍♀️	people	woman construction worker light skin tone build fix hardhat hat man rebuild remodel repair work
+👷🏼‍♀️	people	woman construction worker medium light skin tone build fix hardhat hat man rebuild remodel repair work
+👷🏽‍♀️	people	woman construction worker medium skin tone build fix hardhat hat man rebuild remodel repair work
+👷🏾‍♀️	people	woman construction worker medium dark skin tone build fix hardhat hat man rebuild remodel repair work
+👷🏿‍♀️	people	woman construction worker dark skin tone build fix hardhat hat man rebuild remodel repair work
+🫅	people	person with crown monarch noble regal royal royalty
+🫅🏻	people	person with crown light skin tone monarch noble regal royal royalty
+🫅🏼	people	person with crown medium light skin tone monarch noble regal royal royalty
+🫅🏽	people	person with crown medium skin tone monarch noble regal royal royalty
+🫅🏾	people	person with crown medium dark skin tone monarch noble regal royal royalty
+🫅🏿	people	person with crown dark skin tone monarch noble regal royal royalty
+🤴	people	prince crown fairy fairytale fantasy king royal royalty tale
+🤴🏻	people	prince light skin tone crown fairy fairytale fantasy king royal royalty tale
+🤴🏼	people	prince medium light skin tone crown fairy fairytale fantasy king royal royalty tale
+🤴🏽	people	prince medium skin tone crown fairy fairytale fantasy king royal royalty tale
+🤴🏾	people	prince medium dark skin tone crown fairy fairytale fantasy king royal royalty tale
+🤴🏿	people	prince dark skin tone crown fairy fairytale fantasy king royal royalty tale
+👸	people	princess crown fairy fairytale fantasy queen royal royalty tale
+👸🏻	people	princess light skin tone crown fairy fairytale fantasy queen royal royalty tale
+👸🏼	people	princess medium light skin tone crown fairy fairytale fantasy queen royal royalty tale
+👸🏽	people	princess medium skin tone crown fairy fairytale fantasy queen royal royalty tale
+👸🏾	people	princess medium dark skin tone crown fairy fairytale fantasy queen royal royalty tale
+👸🏿	people	princess dark skin tone crown fairy fairytale fantasy queen royal royalty tale
+👳	people	person wearing turban
+👳🏻	people	person wearing turban light skin tone
+👳🏼	people	person wearing turban medium light skin tone
+👳🏽	people	person wearing turban medium skin tone
+👳🏾	people	person wearing turban medium dark skin tone
+👳🏿	people	person wearing turban dark skin tone
+👳‍♂️	people	man wearing turban
+👳🏻‍♂️	people	man wearing turban light skin tone
+👳🏼‍♂️	people	man wearing turban medium light skin tone
+👳🏽‍♂️	people	man wearing turban medium skin tone
+👳🏾‍♂️	people	man wearing turban medium dark skin tone
+👳🏿‍♂️	people	man wearing turban dark skin tone
+👳‍♀️	people	woman wearing turban
+👳🏻‍♀️	people	woman wearing turban light skin tone
+👳🏼‍♀️	people	woman wearing turban medium light skin tone
+👳🏽‍♀️	people	woman wearing turban medium skin tone
+👳🏾‍♀️	people	woman wearing turban medium dark skin tone
+👳🏿‍♀️	people	woman wearing turban dark skin tone
+👲	people	person with skullcap cap chinese gua guapi hat mao pi
+👲🏻	people	person with skullcap light skin tone cap chinese gua guapi hat mao pi
+👲🏼	people	person with skullcap medium light skin tone cap chinese gua guapi hat mao pi
+👲🏽	people	person with skullcap medium skin tone cap chinese gua guapi hat mao pi
+👲🏾	people	person with skullcap medium dark skin tone cap chinese gua guapi hat mao pi
+👲🏿	people	person with skullcap dark skin tone cap chinese gua guapi hat mao pi
+🧕	people	woman with headscarf bandana head hijab kerchief mantilla tichel
+🧕🏻	people	woman with headscarf light skin tone bandana head hijab kerchief mantilla tichel
+🧕🏼	people	woman with headscarf medium light skin tone bandana head hijab kerchief mantilla tichel
+🧕🏽	people	woman with headscarf medium skin tone bandana head hijab kerchief mantilla tichel
+🧕🏾	people	woman with headscarf medium dark skin tone bandana head hijab kerchief mantilla tichel
+🧕🏿	people	woman with headscarf dark skin tone bandana head hijab kerchief mantilla tichel
+🤵	people	person in tuxedo formal wedding
+🤵🏻	people	person in tuxedo light skin tone formal wedding
+🤵🏼	people	person in tuxedo medium light skin tone formal wedding
+🤵🏽	people	person in tuxedo medium skin tone formal wedding
+🤵🏾	people	person in tuxedo medium dark skin tone formal wedding
+🤵🏿	people	person in tuxedo dark skin tone formal wedding
+🤵‍♂️	people	man in tuxedo formal groom wedding
+🤵🏻‍♂️	people	man in tuxedo light skin tone formal groom wedding
+🤵🏼‍♂️	people	man in tuxedo medium light skin tone formal groom wedding
+🤵🏽‍♂️	people	man in tuxedo medium skin tone formal groom wedding
+🤵🏾‍♂️	people	man in tuxedo medium dark skin tone formal groom wedding
+🤵🏿‍♂️	people	man in tuxedo dark skin tone formal groom wedding
+🤵‍♀️	people	woman in tuxedo formal wedding
+🤵🏻‍♀️	people	woman in tuxedo light skin tone formal wedding
+🤵🏼‍♀️	people	woman in tuxedo medium light skin tone formal wedding
+🤵🏽‍♀️	people	woman in tuxedo medium skin tone formal wedding
+🤵🏾‍♀️	people	woman in tuxedo medium dark skin tone formal wedding
+🤵🏿‍♀️	people	woman in tuxedo dark skin tone formal wedding
+👰	people	person with veil wedding
+👰🏻	people	person with veil light skin tone wedding
+👰🏼	people	person with veil medium light skin tone wedding
+👰🏽	people	person with veil medium skin tone wedding
+👰🏾	people	person with veil medium dark skin tone wedding
+👰🏿	people	person with veil dark skin tone wedding
+👰‍♂️	people	man with veil wedding
+👰🏻‍♂️	people	man with veil light skin tone wedding
+👰🏼‍♂️	people	man with veil medium light skin tone wedding
+👰🏽‍♂️	people	man with veil medium skin tone wedding
+👰🏾‍♂️	people	man with veil medium dark skin tone wedding
+👰🏿‍♂️	people	man with veil dark skin tone wedding
+👰‍♀️	people	woman with veil bride wedding
+👰🏻‍♀️	people	woman with veil light skin tone bride wedding
+👰🏼‍♀️	people	woman with veil medium light skin tone bride wedding
+👰🏽‍♀️	people	woman with veil medium skin tone bride wedding
+👰🏾‍♀️	people	woman with veil medium dark skin tone bride wedding
+👰🏿‍♀️	people	woman with veil dark skin tone bride wedding
+🤰	people	pregnant woman
+🤰🏻	people	pregnant woman light skin tone
+🤰🏼	people	pregnant woman medium light skin tone
+🤰🏽	people	pregnant woman medium skin tone
+🤰🏾	people	pregnant woman medium dark skin tone
+🤰🏿	people	pregnant woman dark skin tone
+🫃	people	pregnant man belly bloated full overeat
+🫃🏻	people	pregnant man light skin tone belly bloated full overeat
+🫃🏼	people	pregnant man medium light skin tone belly bloated full overeat
+🫃🏽	people	pregnant man medium skin tone belly bloated full overeat
+🫃🏾	people	pregnant man medium dark skin tone belly bloated full overeat
+🫃🏿	people	pregnant man dark skin tone belly bloated full overeat
+🫄	people	pregnant person belly bloated full overeat stuffed
+🫄🏻	people	pregnant person light skin tone belly bloated full overeat stuffed
+🫄🏼	people	pregnant person medium light skin tone belly bloated full overeat stuffed
+🫄🏽	people	pregnant person medium skin tone belly bloated full overeat stuffed
+🫄🏾	people	pregnant person medium dark skin tone belly bloated full overeat stuffed
+🫄🏿	people	pregnant person dark skin tone belly bloated full overeat stuffed
+🤱	people	breast feeding baby mom mother nursing woman
+🤱🏻	people	breast feeding light skin tone baby mom mother nursing woman
+🤱🏼	people	breast feeding medium light skin tone baby mom mother nursing woman
+🤱🏽	people	breast feeding medium skin tone baby mom mother nursing woman
+🤱🏾	people	breast feeding medium dark skin tone baby mom mother nursing woman
+🤱🏿	people	breast feeding dark skin tone baby mom mother nursing woman
+👩‍🍼	people	woman feeding baby feed mom mother nanny newborn nursing
+👩🏻‍🍼	people	woman feeding baby light skin tone feed mom mother nanny newborn nursing
+👩🏼‍🍼	people	woman feeding baby medium light skin tone feed mom mother nanny newborn nursing
+👩🏽‍🍼	people	woman feeding baby medium skin tone feed mom mother nanny newborn nursing
+👩🏾‍🍼	people	woman feeding baby medium dark skin tone feed mom mother nanny newborn nursing
+👩🏿‍🍼	people	woman feeding baby dark skin tone feed mom mother nanny newborn nursing
+👨‍🍼	people	man feeding baby dad father feed nanny newborn nursing
+👨🏻‍🍼	people	man feeding baby light skin tone dad father feed nanny newborn nursing
+👨🏼‍🍼	people	man feeding baby medium light skin tone dad father feed nanny newborn nursing
+👨🏽‍🍼	people	man feeding baby medium skin tone dad father feed nanny newborn nursing
+👨🏾‍🍼	people	man feeding baby medium dark skin tone dad father feed nanny newborn nursing
+👨🏿‍🍼	people	man feeding baby dark skin tone dad father feed nanny newborn nursing
+🧑‍🍼	people	person feeding baby feed nanny newborn nursing parent
+🧑🏻‍🍼	people	person feeding baby light skin tone feed nanny newborn nursing parent
+🧑🏼‍🍼	people	person feeding baby medium light skin tone feed nanny newborn nursing parent
+🧑🏽‍🍼	people	person feeding baby medium skin tone feed nanny newborn nursing parent
+🧑🏾‍🍼	people	person feeding baby medium dark skin tone feed nanny newborn nursing parent
+🧑🏿‍🍼	people	person feeding baby dark skin tone feed nanny newborn nursing parent
+👼	people	baby angel church face fairy fairytale fantasy tale
+👼🏻	people	baby angel light skin tone church face fairy fairytale fantasy tale
+👼🏼	people	baby angel medium light skin tone church face fairy fairytale fantasy tale
+👼🏽	people	baby angel medium skin tone church face fairy fairytale fantasy tale
+👼🏾	people	baby angel medium dark skin tone church face fairy fairytale fantasy tale
+👼🏿	people	baby angel dark skin tone church face fairy fairytale fantasy tale
+🎅	people	santa claus celebration christmas fairy fantasy father holiday merry tale xmas
+🎅🏻	people	santa claus light skin tone celebration christmas fairy fantasy father holiday merry tale xmas
+🎅🏼	people	santa claus medium light skin tone celebration christmas fairy fantasy father holiday merry tale xmas
+🎅🏽	people	santa claus medium skin tone celebration christmas fairy fantasy father holiday merry tale xmas
+🎅🏾	people	santa claus medium dark skin tone celebration christmas fairy fantasy father holiday merry tale xmas
+🎅🏿	people	santa claus dark skin tone celebration christmas fairy fantasy father holiday merry tale xmas
+🤶	people	mrs claus celebration christmas fairy fantasy holiday merry mother santa tale xmas
+🤶🏻	people	mrs claus light skin tone celebration christmas fairy fantasy holiday merry mother santa tale xmas
+🤶🏼	people	mrs claus medium light skin tone celebration christmas fairy fantasy holiday merry mother santa tale xmas
+🤶🏽	people	mrs claus medium skin tone celebration christmas fairy fantasy holiday merry mother santa tale xmas
+🤶🏾	people	mrs claus medium dark skin tone celebration christmas fairy fantasy holiday merry mother santa tale xmas
+🤶🏿	people	mrs claus dark skin tone celebration christmas fairy fantasy holiday merry mother santa tale xmas
+🧑‍🎄	people	mx claus celebration christmas fairy fantasy holiday merry santa tale xmas
+🧑🏻‍🎄	people	mx claus light skin tone celebration christmas fairy fantasy holiday merry santa tale xmas
+🧑🏼‍🎄	people	mx claus medium light skin tone celebration christmas fairy fantasy holiday merry santa tale xmas
+🧑🏽‍🎄	people	mx claus medium skin tone celebration christmas fairy fantasy holiday merry santa tale xmas
+🧑🏾‍🎄	people	mx claus medium dark skin tone celebration christmas fairy fantasy holiday merry santa tale xmas
+🧑🏿‍🎄	people	mx claus dark skin tone celebration christmas fairy fantasy holiday merry santa tale xmas
+🦸	people	superhero good hero superpower
+🦸🏻	people	superhero light skin tone good hero superpower
+🦸🏼	people	superhero medium light skin tone good hero superpower
+🦸🏽	people	superhero medium skin tone good hero superpower
+🦸🏾	people	superhero medium dark skin tone good hero superpower
+🦸🏿	people	superhero dark skin tone good hero superpower
+🦸‍♂️	people	man superhero good hero superpower
+🦸🏻‍♂️	people	man superhero light skin tone good hero superpower
+🦸🏼‍♂️	people	man superhero medium light skin tone good hero superpower
+🦸🏽‍♂️	people	man superhero medium skin tone good hero superpower
+🦸🏾‍♂️	people	man superhero medium dark skin tone good hero superpower
+🦸🏿‍♂️	people	man superhero dark skin tone good hero superpower
+🦸‍♀️	people	woman superhero good hero heroine superpower
+🦸🏻‍♀️	people	woman superhero light skin tone good hero heroine superpower
+🦸🏼‍♀️	people	woman superhero medium light skin tone good hero heroine superpower
+🦸🏽‍♀️	people	woman superhero medium skin tone good hero heroine superpower
+🦸🏾‍♀️	people	woman superhero medium dark skin tone good hero heroine superpower
+🦸🏿‍♀️	people	woman superhero dark skin tone good hero heroine superpower
+🦹	people	supervillain bad criminal evil superpower villain
+🦹🏻	people	supervillain light skin tone bad criminal evil superpower villain
+🦹🏼	people	supervillain medium light skin tone bad criminal evil superpower villain
+🦹🏽	people	supervillain medium skin tone bad criminal evil superpower villain
+🦹🏾	people	supervillain medium dark skin tone bad criminal evil superpower villain
+🦹🏿	people	supervillain dark skin tone bad criminal evil superpower villain
+🦹‍♂️	people	man supervillain bad criminal evil superpower villain
+🦹🏻‍♂️	people	man supervillain light skin tone bad criminal evil superpower villain
+🦹🏼‍♂️	people	man supervillain medium light skin tone bad criminal evil superpower villain
+🦹🏽‍♂️	people	man supervillain medium skin tone bad criminal evil superpower villain
+🦹🏾‍♂️	people	man supervillain medium dark skin tone bad criminal evil superpower villain
+🦹🏿‍♂️	people	man supervillain dark skin tone bad criminal evil superpower villain
+🦹‍♀️	people	woman supervillain bad criminal evil superpower villain
+🦹🏻‍♀️	people	woman supervillain light skin tone bad criminal evil superpower villain
+🦹🏼‍♀️	people	woman supervillain medium light skin tone bad criminal evil superpower villain
+🦹🏽‍♀️	people	woman supervillain medium skin tone bad criminal evil superpower villain
+🦹🏾‍♀️	people	woman supervillain medium dark skin tone bad criminal evil superpower villain
+🦹🏿‍♀️	people	woman supervillain dark skin tone bad criminal evil superpower villain
+🧙	people	mage fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙🏻	people	mage light skin tone fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙🏼	people	mage medium light skin tone fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙🏽	people	mage medium skin tone fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙🏾	people	mage medium dark skin tone fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙🏿	people	mage dark skin tone fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙‍♂️	people	man mage fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙🏻‍♂️	people	man mage light skin tone fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙🏼‍♂️	people	man mage medium light skin tone fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙🏽‍♂️	people	man mage medium skin tone fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙🏾‍♂️	people	man mage medium dark skin tone fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙🏿‍♂️	people	man mage dark skin tone fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙‍♀️	people	woman mage fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙🏻‍♀️	people	woman mage light skin tone fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙🏼‍♀️	people	woman mage medium light skin tone fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙🏽‍♀️	people	woman mage medium skin tone fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙🏾‍♀️	people	woman mage medium dark skin tone fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧙🏿‍♀️	people	woman mage dark skin tone fantasy magic play sorcerer sorceress sorcery spell summon witch wizard
+🧚	people	fairy fairytale fantasy myth person pixie tale wings
+🧚🏻	people	fairy light skin tone fairytale fantasy myth person pixie tale wings
+🧚🏼	people	fairy medium light skin tone fairytale fantasy myth person pixie tale wings
+🧚🏽	people	fairy medium skin tone fairytale fantasy myth person pixie tale wings
+🧚🏾	people	fairy medium dark skin tone fairytale fantasy myth person pixie tale wings
+🧚🏿	people	fairy dark skin tone fairytale fantasy myth person pixie tale wings
+🧚‍♂️	people	man fairy fairytale fantasy myth oberon person pixie puck tale wings
+🧚🏻‍♂️	people	man fairy light skin tone fairytale fantasy myth oberon person pixie puck tale wings
+🧚🏼‍♂️	people	man fairy medium light skin tone fairytale fantasy myth oberon person pixie puck tale wings
+🧚🏽‍♂️	people	man fairy medium skin tone fairytale fantasy myth oberon person pixie puck tale wings
+🧚🏾‍♂️	people	man fairy medium dark skin tone fairytale fantasy myth oberon person pixie puck tale wings
+🧚🏿‍♂️	people	man fairy dark skin tone fairytale fantasy myth oberon person pixie puck tale wings
+🧚‍♀️	people	woman fairy fairytale fantasy myth person pixie tale titania wings
+🧚🏻‍♀️	people	woman fairy light skin tone fairytale fantasy myth person pixie tale titania wings
+🧚🏼‍♀️	people	woman fairy medium light skin tone fairytale fantasy myth person pixie tale titania wings
+🧚🏽‍♀️	people	woman fairy medium skin tone fairytale fantasy myth person pixie tale titania wings
+🧚🏾‍♀️	people	woman fairy medium dark skin tone fairytale fantasy myth person pixie tale titania wings
+🧚🏿‍♀️	people	woman fairy dark skin tone fairytale fantasy myth person pixie tale titania wings
+🧛	people	vampire blood dracula fangs halloween scary supernatural teeth undead
+🧛🏻	people	vampire light skin tone blood dracula fangs halloween scary supernatural teeth undead
+🧛🏼	people	vampire medium light skin tone blood dracula fangs halloween scary supernatural teeth undead
+🧛🏽	people	vampire medium skin tone blood dracula fangs halloween scary supernatural teeth undead
+🧛🏾	people	vampire medium dark skin tone blood dracula fangs halloween scary supernatural teeth undead
+🧛🏿	people	vampire dark skin tone blood dracula fangs halloween scary supernatural teeth undead
+🧛‍♂️	people	man vampire blood fangs halloween scary supernatural teeth undead
+🧛🏻‍♂️	people	man vampire light skin tone blood fangs halloween scary supernatural teeth undead
+🧛🏼‍♂️	people	man vampire medium light skin tone blood fangs halloween scary supernatural teeth undead
+🧛🏽‍♂️	people	man vampire medium skin tone blood fangs halloween scary supernatural teeth undead
+🧛🏾‍♂️	people	man vampire medium dark skin tone blood fangs halloween scary supernatural teeth undead
+🧛🏿‍♂️	people	man vampire dark skin tone blood fangs halloween scary supernatural teeth undead
+🧛‍♀️	people	woman vampire blood fangs halloween scary supernatural teeth undead
+🧛🏻‍♀️	people	woman vampire light skin tone blood fangs halloween scary supernatural teeth undead
+🧛🏼‍♀️	people	woman vampire medium light skin tone blood fangs halloween scary supernatural teeth undead
+🧛🏽‍♀️	people	woman vampire medium skin tone blood fangs halloween scary supernatural teeth undead
+🧛🏾‍♀️	people	woman vampire medium dark skin tone blood fangs halloween scary supernatural teeth undead
+🧛🏿‍♀️	people	woman vampire dark skin tone blood fangs halloween scary supernatural teeth undead
+🧜	people	merperson creature fairytale folklore ocean sea siren trident
+🧜🏻	people	merperson light skin tone creature fairytale folklore ocean sea siren trident
+🧜🏼	people	merperson medium light skin tone creature fairytale folklore ocean sea siren trident
+🧜🏽	people	merperson medium skin tone creature fairytale folklore ocean sea siren trident
+🧜🏾	people	merperson medium dark skin tone creature fairytale folklore ocean sea siren trident
+🧜🏿	people	merperson dark skin tone creature fairytale folklore ocean sea siren trident
+🧜‍♂️	people	merman creature fairytale folklore neptune ocean poseidon sea siren trident triton
+🧜🏻‍♂️	people	merman light skin tone creature fairytale folklore neptune ocean poseidon sea siren trident triton
+🧜🏼‍♂️	people	merman medium light skin tone creature fairytale folklore neptune ocean poseidon sea siren trident triton
+🧜🏽‍♂️	people	merman medium skin tone creature fairytale folklore neptune ocean poseidon sea siren trident triton
+🧜🏾‍♂️	people	merman medium dark skin tone creature fairytale folklore neptune ocean poseidon sea siren trident triton
+🧜🏿‍♂️	people	merman dark skin tone creature fairytale folklore neptune ocean poseidon sea siren trident triton
+🧜‍♀️	people	mermaid creature fairytale folklore merwoman ocean sea siren trident
+🧜🏻‍♀️	people	mermaid light skin tone creature fairytale folklore merwoman ocean sea siren trident
+🧜🏼‍♀️	people	mermaid medium light skin tone creature fairytale folklore merwoman ocean sea siren trident
+🧜🏽‍♀️	people	mermaid medium skin tone creature fairytale folklore merwoman ocean sea siren trident
+🧜🏾‍♀️	people	mermaid medium dark skin tone creature fairytale folklore merwoman ocean sea siren trident
+🧜🏿‍♀️	people	mermaid dark skin tone creature fairytale folklore merwoman ocean sea siren trident
+🧝	people	elf elves enchantment fantasy folklore magic magical myth
+🧝🏻	people	elf light skin tone elves enchantment fantasy folklore magic magical myth
+🧝🏼	people	elf medium light skin tone elves enchantment fantasy folklore magic magical myth
+🧝🏽	people	elf medium skin tone elves enchantment fantasy folklore magic magical myth
+🧝🏾	people	elf medium dark skin tone elves enchantment fantasy folklore magic magical myth
+🧝🏿	people	elf dark skin tone elves enchantment fantasy folklore magic magical myth
+🧝‍♂️	people	man elf elves enchantment fantasy folklore magic magical myth
+🧝🏻‍♂️	people	man elf light skin tone elves enchantment fantasy folklore magic magical myth
+🧝🏼‍♂️	people	man elf medium light skin tone elves enchantment fantasy folklore magic magical myth
+🧝🏽‍♂️	people	man elf medium skin tone elves enchantment fantasy folklore magic magical myth
+🧝🏾‍♂️	people	man elf medium dark skin tone elves enchantment fantasy folklore magic magical myth
+🧝🏿‍♂️	people	man elf dark skin tone elves enchantment fantasy folklore magic magical myth
+🧝‍♀️	people	woman elf elves enchantment fantasy folklore magic magical myth
+🧝🏻‍♀️	people	woman elf light skin tone elves enchantment fantasy folklore magic magical myth
+🧝🏼‍♀️	people	woman elf medium light skin tone elves enchantment fantasy folklore magic magical myth
+🧝🏽‍♀️	people	woman elf medium skin tone elves enchantment fantasy folklore magic magical myth
+🧝🏾‍♀️	people	woman elf medium dark skin tone elves enchantment fantasy folklore magic magical myth
+🧝🏿‍♀️	people	woman elf dark skin tone elves enchantment fantasy folklore magic magical myth
+🧞	people	genie djinn fantasy jinn lamp myth rub wishes
+🧞‍♂️	people	man genie djinn fantasy jinn lamp myth rub wishes
+🧞‍♀️	people	woman genie djinn fantasy jinn lamp myth rub wishes
+🧟	people	zombie apocalypse dead halloween horror scary undead walking
+🧟‍♂️	people	man zombie apocalypse dead halloween horror scary undead walking
+🧟‍♀️	people	woman zombie apocalypse dead halloween horror scary undead walking
+🧌	people	troll fairy fantasy monster tale trolling
+💆	people	person getting massage face headache relax relaxing salon soothe spa tension therapy treatment
+💆🏻	people	person getting massage light skin tone face headache relax relaxing salon soothe spa tension therapy treatment
+💆🏼	people	person getting massage medium light skin tone face headache relax relaxing salon soothe spa tension therapy treatment
+💆🏽	people	person getting massage medium skin tone face headache relax relaxing salon soothe spa tension therapy treatment
+💆🏾	people	person getting massage medium dark skin tone face headache relax relaxing salon soothe spa tension therapy treatment
+💆🏿	people	person getting massage dark skin tone face headache relax relaxing salon soothe spa tension therapy treatment
+💆‍♂️	people	man getting massage face headache relax relaxing salon soothe spa tension therapy treatment
+💆🏻‍♂️	people	man getting massage light skin tone face headache relax relaxing salon soothe spa tension therapy treatment
+💆🏼‍♂️	people	man getting massage medium light skin tone face headache relax relaxing salon soothe spa tension therapy treatment
+💆🏽‍♂️	people	man getting massage medium skin tone face headache relax relaxing salon soothe spa tension therapy treatment
+💆🏾‍♂️	people	man getting massage medium dark skin tone face headache relax relaxing salon soothe spa tension therapy treatment
+💆🏿‍♂️	people	man getting massage dark skin tone face headache relax relaxing salon soothe spa tension therapy treatment
+💆‍♀️	people	woman getting massage face headache relax relaxing salon soothe spa tension therapy treatment
+💆🏻‍♀️	people	woman getting massage light skin tone face headache relax relaxing salon soothe spa tension therapy treatment
+💆🏼‍♀️	people	woman getting massage medium light skin tone face headache relax relaxing salon soothe spa tension therapy treatment
+💆🏽‍♀️	people	woman getting massage medium skin tone face headache relax relaxing salon soothe spa tension therapy treatment
+💆🏾‍♀️	people	woman getting massage medium dark skin tone face headache relax relaxing salon soothe spa tension therapy treatment
+💆🏿‍♀️	people	woman getting massage dark skin tone face headache relax relaxing salon soothe spa tension therapy treatment
+💇	people	person getting haircut barber beauty chop cosmetology cut groom hair parlor shears style
+💇🏻	people	person getting haircut light skin tone barber beauty chop cosmetology cut groom hair parlor shears style
+💇🏼	people	person getting haircut medium light skin tone barber beauty chop cosmetology cut groom hair parlor shears style
+💇🏽	people	person getting haircut medium skin tone barber beauty chop cosmetology cut groom hair parlor shears style
+💇🏾	people	person getting haircut medium dark skin tone barber beauty chop cosmetology cut groom hair parlor shears style
+💇🏿	people	person getting haircut dark skin tone barber beauty chop cosmetology cut groom hair parlor shears style
+💇‍♂️	people	man getting haircut barber beauty chop cosmetology cut groom hair parlor person shears style
+💇🏻‍♂️	people	man getting haircut light skin tone barber beauty chop cosmetology cut groom hair parlor person shears style
+💇🏼‍♂️	people	man getting haircut medium light skin tone barber beauty chop cosmetology cut groom hair parlor person shears style
+💇🏽‍♂️	people	man getting haircut medium skin tone barber beauty chop cosmetology cut groom hair parlor person shears style
+💇🏾‍♂️	people	man getting haircut medium dark skin tone barber beauty chop cosmetology cut groom hair parlor person shears style
+💇🏿‍♂️	people	man getting haircut dark skin tone barber beauty chop cosmetology cut groom hair parlor person shears style
+💇‍♀️	people	woman getting haircut barber beauty chop cosmetology cut groom hair parlor person shears style
+💇🏻‍♀️	people	woman getting haircut light skin tone barber beauty chop cosmetology cut groom hair parlor person shears style
+💇🏼‍♀️	people	woman getting haircut medium light skin tone barber beauty chop cosmetology cut groom hair parlor person shears style
+💇🏽‍♀️	people	woman getting haircut medium skin tone barber beauty chop cosmetology cut groom hair parlor person shears style
+💇🏾‍♀️	people	woman getting haircut medium dark skin tone barber beauty chop cosmetology cut groom hair parlor person shears style
+💇🏿‍♀️	people	woman getting haircut dark skin tone barber beauty chop cosmetology cut groom hair parlor person shears style
+🚶	people	person walking amble gait hike man pace pedestrian stride stroll walk
+🚶🏻	people	person walking light skin tone amble gait hike man pace pedestrian stride stroll walk
+🚶🏼	people	person walking medium light skin tone amble gait hike man pace pedestrian stride stroll walk
+🚶🏽	people	person walking medium skin tone amble gait hike man pace pedestrian stride stroll walk
+🚶🏾	people	person walking medium dark skin tone amble gait hike man pace pedestrian stride stroll walk
+🚶🏿	people	person walking dark skin tone amble gait hike man pace pedestrian stride stroll walk
+🚶‍♂️	people	man walking amble gait hike pace pedestrian stride stroll walk
+🚶🏻‍♂️	people	man walking light skin tone amble gait hike pace pedestrian stride stroll walk
+🚶🏼‍♂️	people	man walking medium light skin tone amble gait hike pace pedestrian stride stroll walk
+🚶🏽‍♂️	people	man walking medium skin tone amble gait hike pace pedestrian stride stroll walk
+🚶🏾‍♂️	people	man walking medium dark skin tone amble gait hike pace pedestrian stride stroll walk
+🚶🏿‍♂️	people	man walking dark skin tone amble gait hike pace pedestrian stride stroll walk
+🚶‍♀️	people	woman walking amble gait hike man pace pedestrian stride stroll walk
+🚶🏻‍♀️	people	woman walking light skin tone amble gait hike man pace pedestrian stride stroll walk
+🚶🏼‍♀️	people	woman walking medium light skin tone amble gait hike man pace pedestrian stride stroll walk
+🚶🏽‍♀️	people	woman walking medium skin tone amble gait hike man pace pedestrian stride stroll walk
+🚶🏾‍♀️	people	woman walking medium dark skin tone amble gait hike man pace pedestrian stride stroll walk
+🚶🏿‍♀️	people	woman walking dark skin tone amble gait hike man pace pedestrian stride stroll walk
+🚶‍➡️	people	person walking facing right amble gait hike man pace pedestrian stride stroll walk
+🚶🏻‍➡️	people	person walking light skin tone facing right amble gait hike man pace pedestrian stride stroll walk
+🚶🏼‍➡️	people	person walking medium light skin tone facing right amble gait hike man pace pedestrian stride stroll walk
+🚶🏽‍➡️	people	person walking medium skin tone facing right amble gait hike man pace pedestrian stride stroll walk
+🚶🏾‍➡️	people	person walking medium dark skin tone facing right amble gait hike man pace pedestrian stride stroll walk
+🚶🏿‍➡️	people	person walking dark skin tone facing right amble gait hike man pace pedestrian stride stroll walk
+🚶‍♀️‍➡️	people	woman walking facing right amble gait hike man pace pedestrian stride stroll walk
+🚶🏻‍♀️‍➡️	people	woman walking light skin tone facing right amble gait hike man pace pedestrian stride stroll walk
+🚶🏼‍♀️‍➡️	people	woman walking medium light skin tone facing right amble gait hike man pace pedestrian stride stroll walk
+🚶🏽‍♀️‍➡️	people	woman walking medium skin tone facing right amble gait hike man pace pedestrian stride stroll walk
+🚶🏾‍♀️‍➡️	people	woman walking medium dark skin tone facing right amble gait hike man pace pedestrian stride stroll walk
+🚶🏿‍♀️‍➡️	people	woman walking dark skin tone facing right amble gait hike man pace pedestrian stride stroll walk
+🚶‍♂️‍➡️	people	man walking facing right amble gait hike pace pedestrian stride stroll walk
+🚶🏻‍♂️‍➡️	people	man walking light skin tone facing right amble gait hike pace pedestrian stride stroll walk
+🚶🏼‍♂️‍➡️	people	man walking medium light skin tone facing right amble gait hike pace pedestrian stride stroll walk
+🚶🏽‍♂️‍➡️	people	man walking medium skin tone facing right amble gait hike pace pedestrian stride stroll walk
+🚶🏾‍♂️‍➡️	people	man walking medium dark skin tone facing right amble gait hike pace pedestrian stride stroll walk
+🚶🏿‍♂️‍➡️	people	man walking dark skin tone facing right amble gait hike pace pedestrian stride stroll walk
+🧍	people	person standing stand
+🧍🏻	people	person standing light skin tone stand
+🧍🏼	people	person standing medium light skin tone stand
+🧍🏽	people	person standing medium skin tone stand
+🧍🏾	people	person standing medium dark skin tone stand
+🧍🏿	people	person standing dark skin tone stand
+🧍‍♂️	people	man standing stand
+🧍🏻‍♂️	people	man standing light skin tone stand
+🧍🏼‍♂️	people	man standing medium light skin tone stand
+🧍🏽‍♂️	people	man standing medium skin tone stand
+🧍🏾‍♂️	people	man standing medium dark skin tone stand
+🧍🏿‍♂️	people	man standing dark skin tone stand
+🧍‍♀️	people	woman standing stand
+🧍🏻‍♀️	people	woman standing light skin tone stand
+🧍🏼‍♀️	people	woman standing medium light skin tone stand
+🧍🏽‍♀️	people	woman standing medium skin tone stand
+🧍🏾‍♀️	people	woman standing medium dark skin tone stand
+🧍🏿‍♀️	people	woman standing dark skin tone stand
+🧎	people	person kneeling kneel knees
+🧎🏻	people	person kneeling light skin tone kneel knees
+🧎🏼	people	person kneeling medium light skin tone kneel knees
+🧎🏽	people	person kneeling medium skin tone kneel knees
+🧎🏾	people	person kneeling medium dark skin tone kneel knees
+🧎🏿	people	person kneeling dark skin tone kneel knees
+🧎‍♂️	people	man kneeling kneel knees
+🧎🏻‍♂️	people	man kneeling light skin tone kneel knees
+🧎🏼‍♂️	people	man kneeling medium light skin tone kneel knees
+🧎🏽‍♂️	people	man kneeling medium skin tone kneel knees
+🧎🏾‍♂️	people	man kneeling medium dark skin tone kneel knees
+🧎🏿‍♂️	people	man kneeling dark skin tone kneel knees
+🧎‍♀️	people	woman kneeling kneel knees
+🧎🏻‍♀️	people	woman kneeling light skin tone kneel knees
+🧎🏼‍♀️	people	woman kneeling medium light skin tone kneel knees
+🧎🏽‍♀️	people	woman kneeling medium skin tone kneel knees
+🧎🏾‍♀️	people	woman kneeling medium dark skin tone kneel knees
+🧎🏿‍♀️	people	woman kneeling dark skin tone kneel knees
+🧎‍➡️	people	person kneeling facing right kneel knees
+🧎🏻‍➡️	people	person kneeling light skin tone facing right kneel knees
+🧎🏼‍➡️	people	person kneeling medium light skin tone facing right kneel knees
+🧎🏽‍➡️	people	person kneeling medium skin tone facing right kneel knees
+🧎🏾‍➡️	people	person kneeling medium dark skin tone facing right kneel knees
+🧎🏿‍➡️	people	person kneeling dark skin tone facing right kneel knees
+🧎‍♀️‍➡️	people	woman kneeling facing right kneel knees
+🧎🏻‍♀️‍➡️	people	woman kneeling light skin tone facing right kneel knees
+🧎🏼‍♀️‍➡️	people	woman kneeling medium light skin tone facing right kneel knees
+🧎🏽‍♀️‍➡️	people	woman kneeling medium skin tone facing right kneel knees
+🧎🏾‍♀️‍➡️	people	woman kneeling medium dark skin tone facing right kneel knees
+🧎🏿‍♀️‍➡️	people	woman kneeling dark skin tone facing right kneel knees
+🧎‍♂️‍➡️	people	man kneeling facing right kneel knees
+🧎🏻‍♂️‍➡️	people	man kneeling light skin tone facing right kneel knees
+🧎🏼‍♂️‍➡️	people	man kneeling medium light skin tone facing right kneel knees
+🧎🏽‍♂️‍➡️	people	man kneeling medium skin tone facing right kneel knees
+🧎🏾‍♂️‍➡️	people	man kneeling medium dark skin tone facing right kneel knees
+🧎🏿‍♂️‍➡️	people	man kneeling dark skin tone facing right kneel knees
+🧑‍🦯	people	person with white cane accessibility blind probing
+🧑🏻‍🦯	people	person with white cane light skin tone accessibility blind probing
+🧑🏼‍🦯	people	person with white cane medium light skin tone accessibility blind probing
+🧑🏽‍🦯	people	person with white cane medium skin tone accessibility blind probing
+🧑🏾‍🦯	people	person with white cane medium dark skin tone accessibility blind probing
+🧑🏿‍🦯	people	person with white cane dark skin tone accessibility blind probing
+🧑‍🦯‍➡️	people	person with white cane facing right accessibility blind probing
+🧑🏻‍🦯‍➡️	people	person with white cane light skin tone facing right accessibility blind probing
+🧑🏼‍🦯‍➡️	people	person with white cane medium light skin tone facing right accessibility blind probing
+🧑🏽‍🦯‍➡️	people	person with white cane medium skin tone facing right accessibility blind probing
+🧑🏾‍🦯‍➡️	people	person with white cane medium dark skin tone facing right accessibility blind probing
+🧑🏿‍🦯‍➡️	people	person with white cane dark skin tone facing right accessibility blind probing
+👨‍🦯	people	man with white cane accessibility blind probing
+👨🏻‍🦯	people	man with white cane light skin tone accessibility blind probing
+👨🏼‍🦯	people	man with white cane medium light skin tone accessibility blind probing
+👨🏽‍🦯	people	man with white cane medium skin tone accessibility blind probing
+👨🏾‍🦯	people	man with white cane medium dark skin tone accessibility blind probing
+👨🏿‍🦯	people	man with white cane dark skin tone accessibility blind probing
+👨‍🦯‍➡️	people	man with white cane facing right accessibility blind probing
+👨🏻‍🦯‍➡️	people	man with white cane light skin tone facing right accessibility blind probing
+👨🏼‍🦯‍➡️	people	man with white cane medium light skin tone facing right accessibility blind probing
+👨🏽‍🦯‍➡️	people	man with white cane medium skin tone facing right accessibility blind probing
+👨🏾‍🦯‍➡️	people	man with white cane medium dark skin tone facing right accessibility blind probing
+👨🏿‍🦯‍➡️	people	man with white cane dark skin tone facing right accessibility blind probing
+👩‍🦯	people	woman with white cane accessibility blind probing
+👩🏻‍🦯	people	woman with white cane light skin tone accessibility blind probing
+👩🏼‍🦯	people	woman with white cane medium light skin tone accessibility blind probing
+👩🏽‍🦯	people	woman with white cane medium skin tone accessibility blind probing
+👩🏾‍🦯	people	woman with white cane medium dark skin tone accessibility blind probing
+👩🏿‍🦯	people	woman with white cane dark skin tone accessibility blind probing
+👩‍🦯‍➡️	people	woman with white cane facing right accessibility blind probing
+👩🏻‍🦯‍➡️	people	woman with white cane light skin tone facing right accessibility blind probing
+👩🏼‍🦯‍➡️	people	woman with white cane medium light skin tone facing right accessibility blind probing
+👩🏽‍🦯‍➡️	people	woman with white cane medium skin tone facing right accessibility blind probing
+👩🏾‍🦯‍➡️	people	woman with white cane medium dark skin tone facing right accessibility blind probing
+👩🏿‍🦯‍➡️	people	woman with white cane dark skin tone facing right accessibility blind probing
+🧑‍🦼	people	person in motorized wheelchair accessibility
+🧑🏻‍🦼	people	person in motorized wheelchair light skin tone accessibility
+🧑🏼‍🦼	people	person in motorized wheelchair medium light skin tone accessibility
+🧑🏽‍🦼	people	person in motorized wheelchair medium skin tone accessibility
+🧑🏾‍🦼	people	person in motorized wheelchair medium dark skin tone accessibility
+🧑🏿‍🦼	people	person in motorized wheelchair dark skin tone accessibility
+🧑‍🦼‍➡️	people	person in motorized wheelchair facing right accessibility
+🧑🏻‍🦼‍➡️	people	person in motorized wheelchair light skin tone facing right accessibility
+🧑🏼‍🦼‍➡️	people	person in motorized wheelchair medium light skin tone facing right accessibility
+🧑🏽‍🦼‍➡️	people	person in motorized wheelchair medium skin tone facing right accessibility
+🧑🏾‍🦼‍➡️	people	person in motorized wheelchair medium dark skin tone facing right accessibility
+🧑🏿‍🦼‍➡️	people	person in motorized wheelchair dark skin tone facing right accessibility
+👨‍🦼	people	man in motorized wheelchair accessibility
+👨🏻‍🦼	people	man in motorized wheelchair light skin tone accessibility
+👨🏼‍🦼	people	man in motorized wheelchair medium light skin tone accessibility
+👨🏽‍🦼	people	man in motorized wheelchair medium skin tone accessibility
+👨🏾‍🦼	people	man in motorized wheelchair medium dark skin tone accessibility
+👨🏿‍🦼	people	man in motorized wheelchair dark skin tone accessibility
+👨‍🦼‍➡️	people	man in motorized wheelchair facing right accessibility
+👨🏻‍🦼‍➡️	people	man in motorized wheelchair light skin tone facing right accessibility
+👨🏼‍🦼‍➡️	people	man in motorized wheelchair medium light skin tone facing right accessibility
+👨🏽‍🦼‍➡️	people	man in motorized wheelchair medium skin tone facing right accessibility
+👨🏾‍🦼‍➡️	people	man in motorized wheelchair medium dark skin tone facing right accessibility
+👨🏿‍🦼‍➡️	people	man in motorized wheelchair dark skin tone facing right accessibility
+👩‍🦼	people	woman in motorized wheelchair accessibility
+👩🏻‍🦼	people	woman in motorized wheelchair light skin tone accessibility
+👩🏼‍🦼	people	woman in motorized wheelchair medium light skin tone accessibility
+👩🏽‍🦼	people	woman in motorized wheelchair medium skin tone accessibility
+👩🏾‍🦼	people	woman in motorized wheelchair medium dark skin tone accessibility
+👩🏿‍🦼	people	woman in motorized wheelchair dark skin tone accessibility
+👩‍🦼‍➡️	people	woman in motorized wheelchair facing right accessibility
+👩🏻‍🦼‍➡️	people	woman in motorized wheelchair light skin tone facing right accessibility
+👩🏼‍🦼‍➡️	people	woman in motorized wheelchair medium light skin tone facing right accessibility
+👩🏽‍🦼‍➡️	people	woman in motorized wheelchair medium skin tone facing right accessibility
+👩🏾‍🦼‍➡️	people	woman in motorized wheelchair medium dark skin tone facing right accessibility
+👩🏿‍🦼‍➡️	people	woman in motorized wheelchair dark skin tone facing right accessibility
+🧑‍🦽	people	person in manual wheelchair accessibility
+🧑🏻‍🦽	people	person in manual wheelchair light skin tone accessibility
+🧑🏼‍🦽	people	person in manual wheelchair medium light skin tone accessibility
+🧑🏽‍🦽	people	person in manual wheelchair medium skin tone accessibility
+🧑🏾‍🦽	people	person in manual wheelchair medium dark skin tone accessibility
+🧑🏿‍🦽	people	person in manual wheelchair dark skin tone accessibility
+🧑‍🦽‍➡️	people	person in manual wheelchair facing right accessibility
+🧑🏻‍🦽‍➡️	people	person in manual wheelchair light skin tone facing right accessibility
+🧑🏼‍🦽‍➡️	people	person in manual wheelchair medium light skin tone facing right accessibility
+🧑🏽‍🦽‍➡️	people	person in manual wheelchair medium skin tone facing right accessibility
+🧑🏾‍🦽‍➡️	people	person in manual wheelchair medium dark skin tone facing right accessibility
+🧑🏿‍🦽‍➡️	people	person in manual wheelchair dark skin tone facing right accessibility
+👨‍🦽	people	man in manual wheelchair accessibility
+👨🏻‍🦽	people	man in manual wheelchair light skin tone accessibility
+👨🏼‍🦽	people	man in manual wheelchair medium light skin tone accessibility
+👨🏽‍🦽	people	man in manual wheelchair medium skin tone accessibility
+👨🏾‍🦽	people	man in manual wheelchair medium dark skin tone accessibility
+👨🏿‍🦽	people	man in manual wheelchair dark skin tone accessibility
+👨‍🦽‍➡️	people	man in manual wheelchair facing right accessibility
+👨🏻‍🦽‍➡️	people	man in manual wheelchair light skin tone facing right accessibility
+👨🏼‍🦽‍➡️	people	man in manual wheelchair medium light skin tone facing right accessibility
+👨🏽‍🦽‍➡️	people	man in manual wheelchair medium skin tone facing right accessibility
+👨🏾‍🦽‍➡️	people	man in manual wheelchair medium dark skin tone facing right accessibility
+👨🏿‍🦽‍➡️	people	man in manual wheelchair dark skin tone facing right accessibility
+👩‍🦽	people	woman in manual wheelchair accessibility
+👩🏻‍🦽	people	woman in manual wheelchair light skin tone accessibility
+👩🏼‍🦽	people	woman in manual wheelchair medium light skin tone accessibility
+👩🏽‍🦽	people	woman in manual wheelchair medium skin tone accessibility
+👩🏾‍🦽	people	woman in manual wheelchair medium dark skin tone accessibility
+👩🏿‍🦽	people	woman in manual wheelchair dark skin tone accessibility
+👩‍🦽‍➡️	people	woman in manual wheelchair facing right accessibility
+👩🏻‍🦽‍➡️	people	woman in manual wheelchair light skin tone facing right accessibility
+👩🏼‍🦽‍➡️	people	woman in manual wheelchair medium light skin tone facing right accessibility
+👩🏽‍🦽‍➡️	people	woman in manual wheelchair medium skin tone facing right accessibility
+👩🏾‍🦽‍➡️	people	woman in manual wheelchair medium dark skin tone facing right accessibility
+👩🏿‍🦽‍➡️	people	woman in manual wheelchair dark skin tone facing right accessibility
+🏃	people	person running fast hurry marathon move quick race racing run rush speed
+🏃🏻	people	person running light skin tone fast hurry marathon move quick race racing run rush speed
+🏃🏼	people	person running medium light skin tone fast hurry marathon move quick race racing run rush speed
+🏃🏽	people	person running medium skin tone fast hurry marathon move quick race racing run rush speed
+🏃🏾	people	person running medium dark skin tone fast hurry marathon move quick race racing run rush speed
+🏃🏿	people	person running dark skin tone fast hurry marathon move quick race racing run rush speed
+🏃‍♂️	people	man running fast hurry marathon move quick race racing run rush speed
+🏃🏻‍♂️	people	man running light skin tone fast hurry marathon move quick race racing run rush speed
+🏃🏼‍♂️	people	man running medium light skin tone fast hurry marathon move quick race racing run rush speed
+🏃🏽‍♂️	people	man running medium skin tone fast hurry marathon move quick race racing run rush speed
+🏃🏾‍♂️	people	man running medium dark skin tone fast hurry marathon move quick race racing run rush speed
+🏃🏿‍♂️	people	man running dark skin tone fast hurry marathon move quick race racing run rush speed
+🏃‍♀️	people	woman running fast hurry marathon move quick race racing run rush speed
+🏃🏻‍♀️	people	woman running light skin tone fast hurry marathon move quick race racing run rush speed
+🏃🏼‍♀️	people	woman running medium light skin tone fast hurry marathon move quick race racing run rush speed
+🏃🏽‍♀️	people	woman running medium skin tone fast hurry marathon move quick race racing run rush speed
+🏃🏾‍♀️	people	woman running medium dark skin tone fast hurry marathon move quick race racing run rush speed
+🏃🏿‍♀️	people	woman running dark skin tone fast hurry marathon move quick race racing run rush speed
+🏃‍➡️	people	person running facing right fast hurry marathon move quick race racing run rush speed
+🏃🏻‍➡️	people	person running light skin tone facing right fast hurry marathon move quick race racing run rush speed
+🏃🏼‍➡️	people	person running medium light skin tone facing right fast hurry marathon move quick race racing run rush speed
+🏃🏽‍➡️	people	person running medium skin tone facing right fast hurry marathon move quick race racing run rush speed
+🏃🏾‍➡️	people	person running medium dark skin tone facing right fast hurry marathon move quick race racing run rush speed
+🏃🏿‍➡️	people	person running dark skin tone facing right fast hurry marathon move quick race racing run rush speed
+🏃‍♀️‍➡️	people	woman running facing right fast hurry marathon move quick race racing run rush speed
+🏃🏻‍♀️‍➡️	people	woman running light skin tone facing right fast hurry marathon move quick race racing run rush speed
+🏃🏼‍♀️‍➡️	people	woman running medium light skin tone facing right fast hurry marathon move quick race racing run rush speed
+🏃🏽‍♀️‍➡️	people	woman running medium skin tone facing right fast hurry marathon move quick race racing run rush speed
+🏃🏾‍♀️‍➡️	people	woman running medium dark skin tone facing right fast hurry marathon move quick race racing run rush speed
+🏃🏿‍♀️‍➡️	people	woman running dark skin tone facing right fast hurry marathon move quick race racing run rush speed
+🏃‍♂️‍➡️	people	man running facing right fast hurry marathon move quick race racing run rush speed
+🏃🏻‍♂️‍➡️	people	man running light skin tone facing right fast hurry marathon move quick race racing run rush speed
+🏃🏼‍♂️‍➡️	people	man running medium light skin tone facing right fast hurry marathon move quick race racing run rush speed
+🏃🏽‍♂️‍➡️	people	man running medium skin tone facing right fast hurry marathon move quick race racing run rush speed
+🏃🏾‍♂️‍➡️	people	man running medium dark skin tone facing right fast hurry marathon move quick race racing run rush speed
+🏃🏿‍♂️‍➡️	people	man running dark skin tone facing right fast hurry marathon move quick race racing run rush speed
+💃	people	woman dancing dance dancer elegant festive flair flamenco groove let s salsa tango
+💃🏻	people	woman dancing light skin tone dance dancer elegant festive flair flamenco groove let s salsa tango
+💃🏼	people	woman dancing medium light skin tone dance dancer elegant festive flair flamenco groove let s salsa tango
+💃🏽	people	woman dancing medium skin tone dance dancer elegant festive flair flamenco groove let s salsa tango
+💃🏾	people	woman dancing medium dark skin tone dance dancer elegant festive flair flamenco groove let s salsa tango
+💃🏿	people	woman dancing dark skin tone dance dancer elegant festive flair flamenco groove let s salsa tango
+🕺	people	man dancing dance dancer elegant festive flair flamenco groove let s salsa tango
+🕺🏻	people	man dancing light skin tone dance dancer elegant festive flair flamenco groove let s salsa tango
+🕺🏼	people	man dancing medium light skin tone dance dancer elegant festive flair flamenco groove let s salsa tango
+🕺🏽	people	man dancing medium skin tone dance dancer elegant festive flair flamenco groove let s salsa tango
+🕺🏾	people	man dancing medium dark skin tone dance dancer elegant festive flair flamenco groove let s salsa tango
+🕺🏿	people	man dancing dark skin tone dance dancer elegant festive flair flamenco groove let s salsa tango
+🕴️	people	person in suit levitating business
+🕴🏻	people	person in suit levitating light skin tone business
+🕴🏼	people	person in suit levitating medium light skin tone business
+🕴🏽	people	person in suit levitating medium skin tone business
+🕴🏾	people	person in suit levitating medium dark skin tone business
+🕴🏿	people	person in suit levitating dark skin tone business
+👯	people	people with bunny ears bestie bff counterpart dancer double ear identical pair party partying soulmate twin twinsies
+👯‍♂️	people	men with bunny ears bestie bff counterpart dancer double ear identical pair party partying people soulmate twin twinsies
+👯‍♀️	people	women with bunny ears bestie bff counterpart dancer double ear identical pair party partying people soulmate twin twinsies
+🧖	people	person in steamy room day luxurious pamper relax sauna spa steam steambath unwind
+🧖🏻	people	person in steamy room light skin tone day luxurious pamper relax sauna spa steam steambath unwind
+🧖🏼	people	person in steamy room medium light skin tone day luxurious pamper relax sauna spa steam steambath unwind
+🧖🏽	people	person in steamy room medium skin tone day luxurious pamper relax sauna spa steam steambath unwind
+🧖🏾	people	person in steamy room medium dark skin tone day luxurious pamper relax sauna spa steam steambath unwind
+🧖🏿	people	person in steamy room dark skin tone day luxurious pamper relax sauna spa steam steambath unwind
+🧖‍♂️	people	man in steamy room day luxurious pamper relax sauna spa steam steambath unwind
+🧖🏻‍♂️	people	man in steamy room light skin tone day luxurious pamper relax sauna spa steam steambath unwind
+🧖🏼‍♂️	people	man in steamy room medium light skin tone day luxurious pamper relax sauna spa steam steambath unwind
+🧖🏽‍♂️	people	man in steamy room medium skin tone day luxurious pamper relax sauna spa steam steambath unwind
+🧖🏾‍♂️	people	man in steamy room medium dark skin tone day luxurious pamper relax sauna spa steam steambath unwind
+🧖🏿‍♂️	people	man in steamy room dark skin tone day luxurious pamper relax sauna spa steam steambath unwind
+🧖‍♀️	people	woman in steamy room day luxurious pamper relax sauna spa steam steambath unwind
+🧖🏻‍♀️	people	woman in steamy room light skin tone day luxurious pamper relax sauna spa steam steambath unwind
+🧖🏼‍♀️	people	woman in steamy room medium light skin tone day luxurious pamper relax sauna spa steam steambath unwind
+🧖🏽‍♀️	people	woman in steamy room medium skin tone day luxurious pamper relax sauna spa steam steambath unwind
+🧖🏾‍♀️	people	woman in steamy room medium dark skin tone day luxurious pamper relax sauna spa steam steambath unwind
+🧖🏿‍♀️	people	woman in steamy room dark skin tone day luxurious pamper relax sauna spa steam steambath unwind
+🧗	people	person climbing climb climber mountain rock scale up
+🧗🏻	people	person climbing light skin tone climb climber mountain rock scale up
+🧗🏼	people	person climbing medium light skin tone climb climber mountain rock scale up
+🧗🏽	people	person climbing medium skin tone climb climber mountain rock scale up
+🧗🏾	people	person climbing medium dark skin tone climb climber mountain rock scale up
+🧗🏿	people	person climbing dark skin tone climb climber mountain rock scale up
+🧗‍♂️	people	man climbing climb climber mountain rock scale up
+🧗🏻‍♂️	people	man climbing light skin tone climb climber mountain rock scale up
+🧗🏼‍♂️	people	man climbing medium light skin tone climb climber mountain rock scale up
+🧗🏽‍♂️	people	man climbing medium skin tone climb climber mountain rock scale up
+🧗🏾‍♂️	people	man climbing medium dark skin tone climb climber mountain rock scale up
+🧗🏿‍♂️	people	man climbing dark skin tone climb climber mountain rock scale up
+🧗‍♀️	people	woman climbing climb climber mountain rock scale up
+🧗🏻‍♀️	people	woman climbing light skin tone climb climber mountain rock scale up
+🧗🏼‍♀️	people	woman climbing medium light skin tone climb climber mountain rock scale up
+🧗🏽‍♀️	people	woman climbing medium skin tone climb climber mountain rock scale up
+🧗🏾‍♀️	people	woman climbing medium dark skin tone climb climber mountain rock scale up
+🧗🏿‍♀️	people	woman climbing dark skin tone climb climber mountain rock scale up
+🤺	people	person fencing fencer sword
+🏇	people	horse racing jockey racehorse riding sport
+🏇🏻	people	horse racing light skin tone jockey racehorse riding sport
+🏇🏼	people	horse racing medium light skin tone jockey racehorse riding sport
+🏇🏽	people	horse racing medium skin tone jockey racehorse riding sport
+🏇🏾	people	horse racing medium dark skin tone jockey racehorse riding sport
+🏇🏿	people	horse racing dark skin tone jockey racehorse riding sport
+⛷️	people	skier ski snow
+🏂	people	snowboarder ski snow snowboard sport
+🏂🏻	people	snowboarder light skin tone ski snow snowboard sport
+🏂🏼	people	snowboarder medium light skin tone ski snow snowboard sport
+🏂🏽	people	snowboarder medium skin tone ski snow snowboard sport
+🏂🏾	people	snowboarder medium dark skin tone ski snow snowboard sport
+🏂🏿	people	snowboarder dark skin tone ski snow snowboard sport
+🏌️	people	person golfing ball birdie caddy driving golf green pga putt range tee
+🏌🏻	people	person golfing light skin tone ball birdie caddy driving golf green pga putt range tee
+🏌🏼	people	person golfing medium light skin tone ball birdie caddy driving golf green pga putt range tee
+🏌🏽	people	person golfing medium skin tone ball birdie caddy driving golf green pga putt range tee
+🏌🏾	people	person golfing medium dark skin tone ball birdie caddy driving golf green pga putt range tee
+🏌🏿	people	person golfing dark skin tone ball birdie caddy driving golf green pga putt range tee
+🏌️‍♂️	people	man golfing ball birdie caddy driving golf green pga putt range tee
+🏌🏻‍♂️	people	man golfing light skin tone ball birdie caddy driving golf green pga putt range tee
+🏌🏼‍♂️	people	man golfing medium light skin tone ball birdie caddy driving golf green pga putt range tee
+🏌🏽‍♂️	people	man golfing medium skin tone ball birdie caddy driving golf green pga putt range tee
+🏌🏾‍♂️	people	man golfing medium dark skin tone ball birdie caddy driving golf green pga putt range tee
+🏌🏿‍♂️	people	man golfing dark skin tone ball birdie caddy driving golf green pga putt range tee
+🏌️‍♀️	people	woman golfing ball birdie caddy driving golf green pga putt range tee
+🏌🏻‍♀️	people	woman golfing light skin tone ball birdie caddy driving golf green pga putt range tee
+🏌🏼‍♀️	people	woman golfing medium light skin tone ball birdie caddy driving golf green pga putt range tee
+🏌🏽‍♀️	people	woman golfing medium skin tone ball birdie caddy driving golf green pga putt range tee
+🏌🏾‍♀️	people	woman golfing medium dark skin tone ball birdie caddy driving golf green pga putt range tee
+🏌🏿‍♀️	people	woman golfing dark skin tone ball birdie caddy driving golf green pga putt range tee
+🏄	people	person surfing beach ocean sport surf surfer swell waves
+🏄🏻	people	person surfing light skin tone beach ocean sport surf surfer swell waves
+🏄🏼	people	person surfing medium light skin tone beach ocean sport surf surfer swell waves
+🏄🏽	people	person surfing medium skin tone beach ocean sport surf surfer swell waves
+🏄🏾	people	person surfing medium dark skin tone beach ocean sport surf surfer swell waves
+🏄🏿	people	person surfing dark skin tone beach ocean sport surf surfer swell waves
+🏄‍♂️	people	man surfing beach ocean sport surf surfer swell waves
+🏄🏻‍♂️	people	man surfing light skin tone beach ocean sport surf surfer swell waves
+🏄🏼‍♂️	people	man surfing medium light skin tone beach ocean sport surf surfer swell waves
+🏄🏽‍♂️	people	man surfing medium skin tone beach ocean sport surf surfer swell waves
+🏄🏾‍♂️	people	man surfing medium dark skin tone beach ocean sport surf surfer swell waves
+🏄🏿‍♂️	people	man surfing dark skin tone beach ocean sport surf surfer swell waves
+🏄‍♀️	people	woman surfing beach ocean person sport surf surfer swell waves
+🏄🏻‍♀️	people	woman surfing light skin tone beach ocean person sport surf surfer swell waves
+🏄🏼‍♀️	people	woman surfing medium light skin tone beach ocean person sport surf surfer swell waves
+🏄🏽‍♀️	people	woman surfing medium skin tone beach ocean person sport surf surfer swell waves
+🏄🏾‍♀️	people	woman surfing medium dark skin tone beach ocean person sport surf surfer swell waves
+🏄🏿‍♀️	people	woman surfing dark skin tone beach ocean person sport surf surfer swell waves
+🚣	people	person rowing boat canoe cruise fishing lake oar paddle raft river row rowboat
+🚣🏻	people	person rowing boat light skin tone canoe cruise fishing lake oar paddle raft river row rowboat
+🚣🏼	people	person rowing boat medium light skin tone canoe cruise fishing lake oar paddle raft river row rowboat
+🚣🏽	people	person rowing boat medium skin tone canoe cruise fishing lake oar paddle raft river row rowboat
+🚣🏾	people	person rowing boat medium dark skin tone canoe cruise fishing lake oar paddle raft river row rowboat
+🚣🏿	people	person rowing boat dark skin tone canoe cruise fishing lake oar paddle raft river row rowboat
+🚣‍♂️	people	man rowing boat canoe cruise fishing lake oar paddle raft river row rowboat
+🚣🏻‍♂️	people	man rowing boat light skin tone canoe cruise fishing lake oar paddle raft river row rowboat
+🚣🏼‍♂️	people	man rowing boat medium light skin tone canoe cruise fishing lake oar paddle raft river row rowboat
+🚣🏽‍♂️	people	man rowing boat medium skin tone canoe cruise fishing lake oar paddle raft river row rowboat
+🚣🏾‍♂️	people	man rowing boat medium dark skin tone canoe cruise fishing lake oar paddle raft river row rowboat
+🚣🏿‍♂️	people	man rowing boat dark skin tone canoe cruise fishing lake oar paddle raft river row rowboat
+🚣‍♀️	people	woman rowing boat canoe cruise fishing lake oar paddle raft river row rowboat
+🚣🏻‍♀️	people	woman rowing boat light skin tone canoe cruise fishing lake oar paddle raft river row rowboat
+🚣🏼‍♀️	people	woman rowing boat medium light skin tone canoe cruise fishing lake oar paddle raft river row rowboat
+🚣🏽‍♀️	people	woman rowing boat medium skin tone canoe cruise fishing lake oar paddle raft river row rowboat
+🚣🏾‍♀️	people	woman rowing boat medium dark skin tone canoe cruise fishing lake oar paddle raft river row rowboat
+🚣🏿‍♀️	people	woman rowing boat dark skin tone canoe cruise fishing lake oar paddle raft river row rowboat
+🏊	people	person swimming freestyle sport swim swimmer triathlon
+🏊🏻	people	person swimming light skin tone freestyle sport swim swimmer triathlon
+🏊🏼	people	person swimming medium light skin tone freestyle sport swim swimmer triathlon
+🏊🏽	people	person swimming medium skin tone freestyle sport swim swimmer triathlon
+🏊🏾	people	person swimming medium dark skin tone freestyle sport swim swimmer triathlon
+🏊🏿	people	person swimming dark skin tone freestyle sport swim swimmer triathlon
+🏊‍♂️	people	man swimming freestyle sport swim swimmer triathlon
+🏊🏻‍♂️	people	man swimming light skin tone freestyle sport swim swimmer triathlon
+🏊🏼‍♂️	people	man swimming medium light skin tone freestyle sport swim swimmer triathlon
+🏊🏽‍♂️	people	man swimming medium skin tone freestyle sport swim swimmer triathlon
+🏊🏾‍♂️	people	man swimming medium dark skin tone freestyle sport swim swimmer triathlon
+🏊🏿‍♂️	people	man swimming dark skin tone freestyle sport swim swimmer triathlon
+🏊‍♀️	people	woman swimming freestyle man sport swim swimmer triathlon
+🏊🏻‍♀️	people	woman swimming light skin tone freestyle man sport swim swimmer triathlon
+🏊🏼‍♀️	people	woman swimming medium light skin tone freestyle man sport swim swimmer triathlon
+🏊🏽‍♀️	people	woman swimming medium skin tone freestyle man sport swim swimmer triathlon
+🏊🏾‍♀️	people	woman swimming medium dark skin tone freestyle man sport swim swimmer triathlon
+🏊🏿‍♀️	people	woman swimming dark skin tone freestyle man sport swim swimmer triathlon
+⛹️	people	person bouncing ball athletic basketball championship dribble net player throw
+⛹🏻	people	person bouncing ball light skin tone athletic basketball championship dribble net player throw
+⛹🏼	people	person bouncing ball medium light skin tone athletic basketball championship dribble net player throw
+⛹🏽	people	person bouncing ball medium skin tone athletic basketball championship dribble net player throw
+⛹🏾	people	person bouncing ball medium dark skin tone athletic basketball championship dribble net player throw
+⛹🏿	people	person bouncing ball dark skin tone athletic basketball championship dribble net player throw
+⛹️‍♂️	people	man bouncing ball athletic basketball championship dribble net player throw
+⛹🏻‍♂️	people	man bouncing ball light skin tone athletic basketball championship dribble net player throw
+⛹🏼‍♂️	people	man bouncing ball medium light skin tone athletic basketball championship dribble net player throw
+⛹🏽‍♂️	people	man bouncing ball medium skin tone athletic basketball championship dribble net player throw
+⛹🏾‍♂️	people	man bouncing ball medium dark skin tone athletic basketball championship dribble net player throw
+⛹🏿‍♂️	people	man bouncing ball dark skin tone athletic basketball championship dribble net player throw
+⛹️‍♀️	people	woman bouncing ball athletic basketball championship dribble net player throw
+⛹🏻‍♀️	people	woman bouncing ball light skin tone athletic basketball championship dribble net player throw
+⛹🏼‍♀️	people	woman bouncing ball medium light skin tone athletic basketball championship dribble net player throw
+⛹🏽‍♀️	people	woman bouncing ball medium skin tone athletic basketball championship dribble net player throw
+⛹🏾‍♀️	people	woman bouncing ball medium dark skin tone athletic basketball championship dribble net player throw
+⛹🏿‍♀️	people	woman bouncing ball dark skin tone athletic basketball championship dribble net player throw
+🏋️	people	person lifting weights barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋🏻	people	person lifting weights light skin tone barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋🏼	people	person lifting weights medium light skin tone barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋🏽	people	person lifting weights medium skin tone barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋🏾	people	person lifting weights medium dark skin tone barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋🏿	people	person lifting weights dark skin tone barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋️‍♂️	people	man lifting weights barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋🏻‍♂️	people	man lifting weights light skin tone barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋🏼‍♂️	people	man lifting weights medium light skin tone barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋🏽‍♂️	people	man lifting weights medium skin tone barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋🏾‍♂️	people	man lifting weights medium dark skin tone barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋🏿‍♂️	people	man lifting weights dark skin tone barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋️‍♀️	people	woman lifting weights barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋🏻‍♀️	people	woman lifting weights light skin tone barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋🏼‍♀️	people	woman lifting weights medium light skin tone barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋🏽‍♀️	people	woman lifting weights medium skin tone barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋🏾‍♀️	people	woman lifting weights medium dark skin tone barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🏋🏿‍♀️	people	woman lifting weights dark skin tone barbell bodybuilder deadlift lifter powerlifting weight weightlifter workout
+🚴	people	person biking bicycle bicyclist bike cycle cyclist riding sport
+🚴🏻	people	person biking light skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚴🏼	people	person biking medium light skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚴🏽	people	person biking medium skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚴🏾	people	person biking medium dark skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚴🏿	people	person biking dark skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚴‍♂️	people	man biking bicycle bicyclist bike cycle cyclist riding sport
+🚴🏻‍♂️	people	man biking light skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚴🏼‍♂️	people	man biking medium light skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚴🏽‍♂️	people	man biking medium skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚴🏾‍♂️	people	man biking medium dark skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚴🏿‍♂️	people	man biking dark skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚴‍♀️	people	woman biking bicycle bicyclist bike cycle cyclist riding sport
+🚴🏻‍♀️	people	woman biking light skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚴🏼‍♀️	people	woman biking medium light skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚴🏽‍♀️	people	woman biking medium skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚴🏾‍♀️	people	woman biking medium dark skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚴🏿‍♀️	people	woman biking dark skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚵	people	person mountain biking bicycle bicyclist bike cycle cyclist riding sport
+🚵🏻	people	person mountain biking light skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚵🏼	people	person mountain biking medium light skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚵🏽	people	person mountain biking medium skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚵🏾	people	person mountain biking medium dark skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚵🏿	people	person mountain biking dark skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚵‍♂️	people	man mountain biking bicycle bicyclist bike cycle cyclist riding sport
+🚵🏻‍♂️	people	man mountain biking light skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚵🏼‍♂️	people	man mountain biking medium light skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚵🏽‍♂️	people	man mountain biking medium skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚵🏾‍♂️	people	man mountain biking medium dark skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚵🏿‍♂️	people	man mountain biking dark skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚵‍♀️	people	woman mountain biking bicycle bicyclist bike cycle cyclist riding sport
+🚵🏻‍♀️	people	woman mountain biking light skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚵🏼‍♀️	people	woman mountain biking medium light skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚵🏽‍♀️	people	woman mountain biking medium skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚵🏾‍♀️	people	woman mountain biking medium dark skin tone bicycle bicyclist bike cycle cyclist riding sport
+🚵🏿‍♀️	people	woman mountain biking dark skin tone bicycle bicyclist bike cycle cyclist riding sport
+🤸	people	person cartwheeling active cartwheel excited flip gymnastics happy somersault
+🤸🏻	people	person cartwheeling light skin tone active cartwheel excited flip gymnastics happy somersault
+🤸🏼	people	person cartwheeling medium light skin tone active cartwheel excited flip gymnastics happy somersault
+🤸🏽	people	person cartwheeling medium skin tone active cartwheel excited flip gymnastics happy somersault
+🤸🏾	people	person cartwheeling medium dark skin tone active cartwheel excited flip gymnastics happy somersault
+🤸🏿	people	person cartwheeling dark skin tone active cartwheel excited flip gymnastics happy somersault
+🤸‍♂️	people	man cartwheeling active cartwheel excited flip gymnastics happy somersault
+🤸🏻‍♂️	people	man cartwheeling light skin tone active cartwheel excited flip gymnastics happy somersault
+🤸🏼‍♂️	people	man cartwheeling medium light skin tone active cartwheel excited flip gymnastics happy somersault
+🤸🏽‍♂️	people	man cartwheeling medium skin tone active cartwheel excited flip gymnastics happy somersault
+🤸🏾‍♂️	people	man cartwheeling medium dark skin tone active cartwheel excited flip gymnastics happy somersault
+🤸🏿‍♂️	people	man cartwheeling dark skin tone active cartwheel excited flip gymnastics happy somersault
+🤸‍♀️	people	woman cartwheeling active cartwheel excited flip gymnastics happy somersault
+🤸🏻‍♀️	people	woman cartwheeling light skin tone active cartwheel excited flip gymnastics happy somersault
+🤸🏼‍♀️	people	woman cartwheeling medium light skin tone active cartwheel excited flip gymnastics happy somersault
+🤸🏽‍♀️	people	woman cartwheeling medium skin tone active cartwheel excited flip gymnastics happy somersault
+🤸🏾‍♀️	people	woman cartwheeling medium dark skin tone active cartwheel excited flip gymnastics happy somersault
+🤸🏿‍♀️	people	woman cartwheeling dark skin tone active cartwheel excited flip gymnastics happy somersault
+🤼	people	people wrestling combat duel grapple ring tournament wrestle
+🤼‍♂️	people	men wrestling combat duel grapple ring tournament wrestle
+🤼‍♀️	people	women wrestling combat duel grapple ring tournament wrestle
+🤽	people	person playing water polo sport swimming waterpolo
+🤽🏻	people	person playing water polo light skin tone sport swimming waterpolo
+🤽🏼	people	person playing water polo medium light skin tone sport swimming waterpolo
+🤽🏽	people	person playing water polo medium skin tone sport swimming waterpolo
+🤽🏾	people	person playing water polo medium dark skin tone sport swimming waterpolo
+🤽🏿	people	person playing water polo dark skin tone sport swimming waterpolo
+🤽‍♂️	people	man playing water polo sport swimming waterpolo
+🤽🏻‍♂️	people	man playing water polo light skin tone sport swimming waterpolo
+🤽🏼‍♂️	people	man playing water polo medium light skin tone sport swimming waterpolo
+🤽🏽‍♂️	people	man playing water polo medium skin tone sport swimming waterpolo
+🤽🏾‍♂️	people	man playing water polo medium dark skin tone sport swimming waterpolo
+🤽🏿‍♂️	people	man playing water polo dark skin tone sport swimming waterpolo
+🤽‍♀️	people	woman playing water polo sport swimming waterpolo
+🤽🏻‍♀️	people	woman playing water polo light skin tone sport swimming waterpolo
+🤽🏼‍♀️	people	woman playing water polo medium light skin tone sport swimming waterpolo
+🤽🏽‍♀️	people	woman playing water polo medium skin tone sport swimming waterpolo
+🤽🏾‍♀️	people	woman playing water polo medium dark skin tone sport swimming waterpolo
+🤽🏿‍♀️	people	woman playing water polo dark skin tone sport swimming waterpolo
+🤾	people	person playing handball athletics ball catch chuck hurl lob pitch sport throw toss
+🤾🏻	people	person playing handball light skin tone athletics ball catch chuck hurl lob pitch sport throw toss
+🤾🏼	people	person playing handball medium light skin tone athletics ball catch chuck hurl lob pitch sport throw toss
+🤾🏽	people	person playing handball medium skin tone athletics ball catch chuck hurl lob pitch sport throw toss
+🤾🏾	people	person playing handball medium dark skin tone athletics ball catch chuck hurl lob pitch sport throw toss
+🤾🏿	people	person playing handball dark skin tone athletics ball catch chuck hurl lob pitch sport throw toss
+🤾‍♂️	people	man playing handball athletics ball catch chuck hurl lob pitch sport throw toss
+🤾🏻‍♂️	people	man playing handball light skin tone athletics ball catch chuck hurl lob pitch sport throw toss
+🤾🏼‍♂️	people	man playing handball medium light skin tone athletics ball catch chuck hurl lob pitch sport throw toss
+🤾🏽‍♂️	people	man playing handball medium skin tone athletics ball catch chuck hurl lob pitch sport throw toss
+🤾🏾‍♂️	people	man playing handball medium dark skin tone athletics ball catch chuck hurl lob pitch sport throw toss
+🤾🏿‍♂️	people	man playing handball dark skin tone athletics ball catch chuck hurl lob pitch sport throw toss
+🤾‍♀️	people	woman playing handball athletics ball catch chuck hurl lob pitch sport throw toss
+🤾🏻‍♀️	people	woman playing handball light skin tone athletics ball catch chuck hurl lob pitch sport throw toss
+🤾🏼‍♀️	people	woman playing handball medium light skin tone athletics ball catch chuck hurl lob pitch sport throw toss
+🤾🏽‍♀️	people	woman playing handball medium skin tone athletics ball catch chuck hurl lob pitch sport throw toss
+🤾🏾‍♀️	people	woman playing handball medium dark skin tone athletics ball catch chuck hurl lob pitch sport throw toss
+🤾🏿‍♀️	people	woman playing handball dark skin tone athletics ball catch chuck hurl lob pitch sport throw toss
+🤹	people	person juggling act balance balancing handle juggle manage multitask skill
+🤹🏻	people	person juggling light skin tone act balance balancing handle juggle manage multitask skill
+🤹🏼	people	person juggling medium light skin tone act balance balancing handle juggle manage multitask skill
+🤹🏽	people	person juggling medium skin tone act balance balancing handle juggle manage multitask skill
+🤹🏾	people	person juggling medium dark skin tone act balance balancing handle juggle manage multitask skill
+🤹🏿	people	person juggling dark skin tone act balance balancing handle juggle manage multitask skill
+🤹‍♂️	people	man juggling act balance balancing handle juggle manage multitask skill
+🤹🏻‍♂️	people	man juggling light skin tone act balance balancing handle juggle manage multitask skill
+🤹🏼‍♂️	people	man juggling medium light skin tone act balance balancing handle juggle manage multitask skill
+🤹🏽‍♂️	people	man juggling medium skin tone act balance balancing handle juggle manage multitask skill
+🤹🏾‍♂️	people	man juggling medium dark skin tone act balance balancing handle juggle manage multitask skill
+🤹🏿‍♂️	people	man juggling dark skin tone act balance balancing handle juggle manage multitask skill
+🤹‍♀️	people	woman juggling act balance balancing handle juggle manage multitask skill
+🤹🏻‍♀️	people	woman juggling light skin tone act balance balancing handle juggle manage multitask skill
+🤹🏼‍♀️	people	woman juggling medium light skin tone act balance balancing handle juggle manage multitask skill
+🤹🏽‍♀️	people	woman juggling medium skin tone act balance balancing handle juggle manage multitask skill
+🤹🏾‍♀️	people	woman juggling medium dark skin tone act balance balancing handle juggle manage multitask skill
+🤹🏿‍♀️	people	woman juggling dark skin tone act balance balancing handle juggle manage multitask skill
+🧘	people	person in lotus position cross legged legs meditation peace relax serenity yoga yogi zen
+🧘🏻	people	person in lotus position light skin tone cross legged legs meditation peace relax serenity yoga yogi zen
+🧘🏼	people	person in lotus position medium light skin tone cross legged legs meditation peace relax serenity yoga yogi zen
+🧘🏽	people	person in lotus position medium skin tone cross legged legs meditation peace relax serenity yoga yogi zen
+🧘🏾	people	person in lotus position medium dark skin tone cross legged legs meditation peace relax serenity yoga yogi zen
+🧘🏿	people	person in lotus position dark skin tone cross legged legs meditation peace relax serenity yoga yogi zen
+🧘‍♂️	people	man in lotus position cross legged legs meditation peace relax serenity yoga yogi zen
+🧘🏻‍♂️	people	man in lotus position light skin tone cross legged legs meditation peace relax serenity yoga yogi zen
+🧘🏼‍♂️	people	man in lotus position medium light skin tone cross legged legs meditation peace relax serenity yoga yogi zen
+🧘🏽‍♂️	people	man in lotus position medium skin tone cross legged legs meditation peace relax serenity yoga yogi zen
+🧘🏾‍♂️	people	man in lotus position medium dark skin tone cross legged legs meditation peace relax serenity yoga yogi zen
+🧘🏿‍♂️	people	man in lotus position dark skin tone cross legged legs meditation peace relax serenity yoga yogi zen
+🧘‍♀️	people	woman in lotus position cross legged legs meditation peace relax serenity yoga yogi zen
+🧘🏻‍♀️	people	woman in lotus position light skin tone cross legged legs meditation peace relax serenity yoga yogi zen
+🧘🏼‍♀️	people	woman in lotus position medium light skin tone cross legged legs meditation peace relax serenity yoga yogi zen
+🧘🏽‍♀️	people	woman in lotus position medium skin tone cross legged legs meditation peace relax serenity yoga yogi zen
+🧘🏾‍♀️	people	woman in lotus position medium dark skin tone cross legged legs meditation peace relax serenity yoga yogi zen
+🧘🏿‍♀️	people	woman in lotus position dark skin tone cross legged legs meditation peace relax serenity yoga yogi zen
+🛀	people	person taking bath bathtub tub
+🛀🏻	people	person taking bath light skin tone bathtub tub
+🛀🏼	people	person taking bath medium light skin tone bathtub tub
+🛀🏽	people	person taking bath medium skin tone bathtub tub
+🛀🏾	people	person taking bath medium dark skin tone bathtub tub
+🛀🏿	people	person taking bath dark skin tone bathtub tub
+🛌	people	person in bed bedtime good goodnight hotel nap night sleep tired zzz
+🛌🏻	people	person in bed light skin tone bedtime good goodnight hotel nap night sleep tired zzz
+🛌🏼	people	person in bed medium light skin tone bedtime good goodnight hotel nap night sleep tired zzz
+🛌🏽	people	person in bed medium skin tone bedtime good goodnight hotel nap night sleep tired zzz
+🛌🏾	people	person in bed medium dark skin tone bedtime good goodnight hotel nap night sleep tired zzz
+🛌🏿	people	person in bed dark skin tone bedtime good goodnight hotel nap night sleep tired zzz
+🧑‍🤝‍🧑	people	people holding hands bae bestie bff couple dating flirt friends hand hold twins
+🧑🏻‍🤝‍🧑🏻	people	people holding hands light skin tone bae bestie bff couple dating flirt friends hand hold twins
+🧑🏻‍🤝‍🧑🏼	people	people holding hands light skin tone medium bae bestie bff couple dating flirt friends hand hold twins
+🧑🏻‍🤝‍🧑🏽	people	people holding hands light skin tone medium bae bestie bff couple dating flirt friends hand hold twins
+🧑🏻‍🤝‍🧑🏾	people	people holding hands light skin tone medium dark bae bestie bff couple dating flirt friends hand hold twins
+🧑🏻‍🤝‍🧑🏿	people	people holding hands light skin tone dark bae bestie bff couple dating flirt friends hand hold twins
+🧑🏼‍🤝‍🧑🏻	people	people holding hands medium light skin tone bae bestie bff couple dating flirt friends hand hold twins
+🧑🏼‍🤝‍🧑🏼	people	people holding hands medium light skin tone bae bestie bff couple dating flirt friends hand hold twins
+🧑🏼‍🤝‍🧑🏽	people	people holding hands medium light skin tone bae bestie bff couple dating flirt friends hand hold twins
+🧑🏼‍🤝‍🧑🏾	people	people holding hands medium light skin tone dark bae bestie bff couple dating flirt friends hand hold twins
+🧑🏼‍🤝‍🧑🏿	people	people holding hands medium light skin tone dark bae bestie bff couple dating flirt friends hand hold twins
+🧑🏽‍🤝‍🧑🏻	people	people holding hands medium skin tone light bae bestie bff couple dating flirt friends hand hold twins
+🧑🏽‍🤝‍🧑🏼	people	people holding hands medium skin tone light bae bestie bff couple dating flirt friends hand hold twins
+🧑🏽‍🤝‍🧑🏽	people	people holding hands medium skin tone bae bestie bff couple dating flirt friends hand hold twins
+🧑🏽‍🤝‍🧑🏾	people	people holding hands medium skin tone dark bae bestie bff couple dating flirt friends hand hold twins
+🧑🏽‍🤝‍🧑🏿	people	people holding hands medium skin tone dark bae bestie bff couple dating flirt friends hand hold twins
+🧑🏾‍🤝‍🧑🏻	people	people holding hands medium dark skin tone light bae bestie bff couple dating flirt friends hand hold twins
+🧑🏾‍🤝‍🧑🏼	people	people holding hands medium dark skin tone light bae bestie bff couple dating flirt friends hand hold twins
+🧑🏾‍🤝‍🧑🏽	people	people holding hands medium dark skin tone bae bestie bff couple dating flirt friends hand hold twins
+🧑🏾‍🤝‍🧑🏾	people	people holding hands medium dark skin tone bae bestie bff couple dating flirt friends hand hold twins
+🧑🏾‍🤝‍🧑🏿	people	people holding hands medium dark skin tone bae bestie bff couple dating flirt friends hand hold twins
+🧑🏿‍🤝‍🧑🏻	people	people holding hands dark skin tone light bae bestie bff couple dating flirt friends hand hold twins
+🧑🏿‍🤝‍🧑🏼	people	people holding hands dark skin tone medium light bae bestie bff couple dating flirt friends hand hold twins
+🧑🏿‍🤝‍🧑🏽	people	people holding hands dark skin tone medium bae bestie bff couple dating flirt friends hand hold twins
+🧑🏿‍🤝‍🧑🏾	people	people holding hands dark skin tone medium bae bestie bff couple dating flirt friends hand hold twins
+🧑🏿‍🤝‍🧑🏿	people	people holding hands dark skin tone bae bestie bff couple dating flirt friends hand hold twins
+👭	people	women holding hands bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👭🏻	people	women holding hands light skin tone bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏻‍🤝‍👩🏼	people	women holding hands light skin tone medium bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏻‍🤝‍👩🏽	people	women holding hands light skin tone medium bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏻‍🤝‍👩🏾	people	women holding hands light skin tone medium dark bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏻‍🤝‍👩🏿	people	women holding hands light skin tone dark bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏼‍🤝‍👩🏻	people	women holding hands medium light skin tone bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👭🏼	people	women holding hands medium light skin tone bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏼‍🤝‍👩🏽	people	women holding hands medium light skin tone bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏼‍🤝‍👩🏾	people	women holding hands medium light skin tone dark bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏼‍🤝‍👩🏿	people	women holding hands medium light skin tone dark bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏽‍🤝‍👩🏻	people	women holding hands medium skin tone light bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏽‍🤝‍👩🏼	people	women holding hands medium skin tone light bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👭🏽	people	women holding hands medium skin tone bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏽‍🤝‍👩🏾	people	women holding hands medium skin tone dark bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏽‍🤝‍👩🏿	people	women holding hands medium skin tone dark bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏾‍🤝‍👩🏻	people	women holding hands medium dark skin tone light bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏾‍🤝‍👩🏼	people	women holding hands medium dark skin tone light bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏾‍🤝‍👩🏽	people	women holding hands medium dark skin tone bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👭🏾	people	women holding hands medium dark skin tone bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏾‍🤝‍👩🏿	people	women holding hands medium dark skin tone bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏿‍🤝‍👩🏻	people	women holding hands dark skin tone light bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏿‍🤝‍👩🏼	people	women holding hands dark skin tone medium light bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏿‍🤝‍👩🏽	people	women holding hands dark skin tone medium bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👩🏿‍🤝‍👩🏾	people	women holding hands dark skin tone medium bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👭🏿	people	women holding hands dark skin tone bae bestie bff couple dating flirt friends girls hand hold sisters twins
+👫	people	woman and man holding hands bae bestie bff couple dating flirt friends hand hold twins
+👫🏻	people	woman and man holding hands light skin tone bae bestie bff couple dating flirt friends hand hold twins
+👩🏻‍🤝‍👨🏼	people	woman and man holding hands light skin tone medium bae bestie bff couple dating flirt friends hand hold twins
+👩🏻‍🤝‍👨🏽	people	woman and man holding hands light skin tone medium bae bestie bff couple dating flirt friends hand hold twins
+👩🏻‍🤝‍👨🏾	people	woman and man holding hands light skin tone medium dark bae bestie bff couple dating flirt friends hand hold twins
+👩🏻‍🤝‍👨🏿	people	woman and man holding hands light skin tone dark bae bestie bff couple dating flirt friends hand hold twins
+👩🏼‍🤝‍👨🏻	people	woman and man holding hands medium light skin tone bae bestie bff couple dating flirt friends hand hold twins
+👫🏼	people	woman and man holding hands medium light skin tone bae bestie bff couple dating flirt friends hand hold twins
+👩🏼‍🤝‍👨🏽	people	woman and man holding hands medium light skin tone bae bestie bff couple dating flirt friends hand hold twins
+👩🏼‍🤝‍👨🏾	people	woman and man holding hands medium light skin tone dark bae bestie bff couple dating flirt friends hand hold twins
+👩🏼‍🤝‍👨🏿	people	woman and man holding hands medium light skin tone dark bae bestie bff couple dating flirt friends hand hold twins
+👩🏽‍🤝‍👨🏻	people	woman and man holding hands medium skin tone light bae bestie bff couple dating flirt friends hand hold twins
+👩🏽‍🤝‍👨🏼	people	woman and man holding hands medium skin tone light bae bestie bff couple dating flirt friends hand hold twins
+👫🏽	people	woman and man holding hands medium skin tone bae bestie bff couple dating flirt friends hand hold twins
+👩🏽‍🤝‍👨🏾	people	woman and man holding hands medium skin tone dark bae bestie bff couple dating flirt friends hand hold twins
+👩🏽‍🤝‍👨🏿	people	woman and man holding hands medium skin tone dark bae bestie bff couple dating flirt friends hand hold twins
+👩🏾‍🤝‍👨🏻	people	woman and man holding hands medium dark skin tone light bae bestie bff couple dating flirt friends hand hold twins
+👩🏾‍🤝‍👨🏼	people	woman and man holding hands medium dark skin tone light bae bestie bff couple dating flirt friends hand hold twins
+👩🏾‍🤝‍👨🏽	people	woman and man holding hands medium dark skin tone bae bestie bff couple dating flirt friends hand hold twins
+👫🏾	people	woman and man holding hands medium dark skin tone bae bestie bff couple dating flirt friends hand hold twins
+👩🏾‍🤝‍👨🏿	people	woman and man holding hands medium dark skin tone bae bestie bff couple dating flirt friends hand hold twins
+👩🏿‍🤝‍👨🏻	people	woman and man holding hands dark skin tone light bae bestie bff couple dating flirt friends hand hold twins
+👩🏿‍🤝‍👨🏼	people	woman and man holding hands dark skin tone medium light bae bestie bff couple dating flirt friends hand hold twins
+👩🏿‍🤝‍👨🏽	people	woman and man holding hands dark skin tone medium bae bestie bff couple dating flirt friends hand hold twins
+👩🏿‍🤝‍👨🏾	people	woman and man holding hands dark skin tone medium bae bestie bff couple dating flirt friends hand hold twins
+👫🏿	people	woman and man holding hands dark skin tone bae bestie bff couple dating flirt friends hand hold twins
+👬	people	men holding hands bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👬🏻	people	men holding hands light skin tone bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏻‍🤝‍👨🏼	people	men holding hands light skin tone medium bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏻‍🤝‍👨🏽	people	men holding hands light skin tone medium bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏻‍🤝‍👨🏾	people	men holding hands light skin tone medium dark bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏻‍🤝‍👨🏿	people	men holding hands light skin tone dark bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏼‍🤝‍👨🏻	people	men holding hands medium light skin tone bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👬🏼	people	men holding hands medium light skin tone bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏼‍🤝‍👨🏽	people	men holding hands medium light skin tone bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏼‍🤝‍👨🏾	people	men holding hands medium light skin tone dark bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏼‍🤝‍👨🏿	people	men holding hands medium light skin tone dark bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏽‍🤝‍👨🏻	people	men holding hands medium skin tone light bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏽‍🤝‍👨🏼	people	men holding hands medium skin tone light bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👬🏽	people	men holding hands medium skin tone bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏽‍🤝‍👨🏾	people	men holding hands medium skin tone dark bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏽‍🤝‍👨🏿	people	men holding hands medium skin tone dark bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏾‍🤝‍👨🏻	people	men holding hands medium dark skin tone light bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏾‍🤝‍👨🏼	people	men holding hands medium dark skin tone light bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏾‍🤝‍👨🏽	people	men holding hands medium dark skin tone bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👬🏾	people	men holding hands medium dark skin tone bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏾‍🤝‍👨🏿	people	men holding hands medium dark skin tone bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏿‍🤝‍👨🏻	people	men holding hands dark skin tone light bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏿‍🤝‍👨🏼	people	men holding hands dark skin tone medium light bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏿‍🤝‍👨🏽	people	men holding hands dark skin tone medium bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👨🏿‍🤝‍👨🏾	people	men holding hands dark skin tone medium bae bestie bff boys brothers couple dating flirt friends hand hold twins
+👬🏿	people	men holding hands dark skin tone bae bestie bff boys brothers couple dating flirt friends hand hold twins
+💏	people	kiss anniversary babe bae couple date dating heart love mwah person romance together xoxo
+💏🏻	people	kiss light skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+💏🏼	people	kiss medium light skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+💏🏽	people	kiss medium skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+💏🏾	people	kiss medium dark skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+💏🏿	people	kiss dark skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+🧑🏻‍❤️‍💋‍🧑🏼	people	kiss person light skin tone medium anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏻‍❤️‍💋‍🧑🏽	people	kiss person light skin tone medium anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏻‍❤️‍💋‍🧑🏾	people	kiss person light skin tone medium dark anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏻‍❤️‍💋‍🧑🏿	people	kiss person light skin tone dark anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏼‍❤️‍💋‍🧑🏻	people	kiss person medium light skin tone anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏼‍❤️‍💋‍🧑🏽	people	kiss person medium light skin tone anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏼‍❤️‍💋‍🧑🏾	people	kiss person medium light skin tone dark anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏼‍❤️‍💋‍🧑🏿	people	kiss person medium light skin tone dark anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏽‍❤️‍💋‍🧑🏻	people	kiss person medium skin tone light anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏽‍❤️‍💋‍🧑🏼	people	kiss person medium skin tone light anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏽‍❤️‍💋‍🧑🏾	people	kiss person medium skin tone dark anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏽‍❤️‍💋‍🧑🏿	people	kiss person medium skin tone dark anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏾‍❤️‍💋‍🧑🏻	people	kiss person medium dark skin tone light anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏾‍❤️‍💋‍🧑🏼	people	kiss person medium dark skin tone light anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏾‍❤️‍💋‍🧑🏽	people	kiss person medium dark skin tone anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏾‍❤️‍💋‍🧑🏿	people	kiss person medium dark skin tone anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏿‍❤️‍💋‍🧑🏻	people	kiss person dark skin tone light anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏿‍❤️‍💋‍🧑🏼	people	kiss person dark skin tone medium light anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏿‍❤️‍💋‍🧑🏽	people	kiss person dark skin tone medium anniversary babe bae couple date dating heart love mwah romance together xoxo
+🧑🏿‍❤️‍💋‍🧑🏾	people	kiss person dark skin tone medium anniversary babe bae couple date dating heart love mwah romance together xoxo
+👩‍❤️‍💋‍👨	people	kiss woman man anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏻‍❤️‍💋‍👨🏻	people	kiss woman man light skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏻‍❤️‍💋‍👨🏼	people	kiss woman man light skin tone medium anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏻‍❤️‍💋‍👨🏽	people	kiss woman man light skin tone medium anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏻‍❤️‍💋‍👨🏾	people	kiss woman man light skin tone medium dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏻‍❤️‍💋‍👨🏿	people	kiss woman man light skin tone dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏼‍❤️‍💋‍👨🏻	people	kiss woman man medium light skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏼‍❤️‍💋‍👨🏼	people	kiss woman man medium light skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏼‍❤️‍💋‍👨🏽	people	kiss woman man medium light skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏼‍❤️‍💋‍👨🏾	people	kiss woman man medium light skin tone dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏼‍❤️‍💋‍👨🏿	people	kiss woman man medium light skin tone dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏽‍❤️‍💋‍👨🏻	people	kiss woman man medium skin tone light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏽‍❤️‍💋‍👨🏼	people	kiss woman man medium skin tone light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏽‍❤️‍💋‍👨🏽	people	kiss woman man medium skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏽‍❤️‍💋‍👨🏾	people	kiss woman man medium skin tone dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏽‍❤️‍💋‍👨🏿	people	kiss woman man medium skin tone dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏾‍❤️‍💋‍👨🏻	people	kiss woman man medium dark skin tone light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏾‍❤️‍💋‍👨🏼	people	kiss woman man medium dark skin tone light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏾‍❤️‍💋‍👨🏽	people	kiss woman man medium dark skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏾‍❤️‍💋‍👨🏾	people	kiss woman man medium dark skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏾‍❤️‍💋‍👨🏿	people	kiss woman man medium dark skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏿‍❤️‍💋‍👨🏻	people	kiss woman man dark skin tone light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏿‍❤️‍💋‍👨🏼	people	kiss woman man dark skin tone medium light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏿‍❤️‍💋‍👨🏽	people	kiss woman man dark skin tone medium anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏿‍❤️‍💋‍👨🏾	people	kiss woman man dark skin tone medium anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏿‍❤️‍💋‍👨🏿	people	kiss woman man dark skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨‍❤️‍💋‍👨	people	kiss man anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏻‍❤️‍💋‍👨🏻	people	kiss man light skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏻‍❤️‍💋‍👨🏼	people	kiss man light skin tone medium anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏻‍❤️‍💋‍👨🏽	people	kiss man light skin tone medium anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏻‍❤️‍💋‍👨🏾	people	kiss man light skin tone medium dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏻‍❤️‍💋‍👨🏿	people	kiss man light skin tone dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏼‍❤️‍💋‍👨🏻	people	kiss man medium light skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏼‍❤️‍💋‍👨🏼	people	kiss man medium light skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏼‍❤️‍💋‍👨🏽	people	kiss man medium light skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏼‍❤️‍💋‍👨🏾	people	kiss man medium light skin tone dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏼‍❤️‍💋‍👨🏿	people	kiss man medium light skin tone dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏽‍❤️‍💋‍👨🏻	people	kiss man medium skin tone light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏽‍❤️‍💋‍👨🏼	people	kiss man medium skin tone light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏽‍❤️‍💋‍👨🏽	people	kiss man medium skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏽‍❤️‍💋‍👨🏾	people	kiss man medium skin tone dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏽‍❤️‍💋‍👨🏿	people	kiss man medium skin tone dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏾‍❤️‍💋‍👨🏻	people	kiss man medium dark skin tone light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏾‍❤️‍💋‍👨🏼	people	kiss man medium dark skin tone light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏾‍❤️‍💋‍👨🏽	people	kiss man medium dark skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏾‍❤️‍💋‍👨🏾	people	kiss man medium dark skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏾‍❤️‍💋‍👨🏿	people	kiss man medium dark skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏿‍❤️‍💋‍👨🏻	people	kiss man dark skin tone light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏿‍❤️‍💋‍👨🏼	people	kiss man dark skin tone medium light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏿‍❤️‍💋‍👨🏽	people	kiss man dark skin tone medium anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏿‍❤️‍💋‍👨🏾	people	kiss man dark skin tone medium anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👨🏿‍❤️‍💋‍👨🏿	people	kiss man dark skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩‍❤️‍💋‍👩	people	kiss woman anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏻‍❤️‍💋‍👩🏻	people	kiss woman light skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏻‍❤️‍💋‍👩🏼	people	kiss woman light skin tone medium anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏻‍❤️‍💋‍👩🏽	people	kiss woman light skin tone medium anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏻‍❤️‍💋‍👩🏾	people	kiss woman light skin tone medium dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏻‍❤️‍💋‍👩🏿	people	kiss woman light skin tone dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏼‍❤️‍💋‍👩🏻	people	kiss woman medium light skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏼‍❤️‍💋‍👩🏼	people	kiss woman medium light skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏼‍❤️‍💋‍👩🏽	people	kiss woman medium light skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏼‍❤️‍💋‍👩🏾	people	kiss woman medium light skin tone dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏼‍❤️‍💋‍👩🏿	people	kiss woman medium light skin tone dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏽‍❤️‍💋‍👩🏻	people	kiss woman medium skin tone light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏽‍❤️‍💋‍👩🏼	people	kiss woman medium skin tone light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏽‍❤️‍💋‍👩🏽	people	kiss woman medium skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏽‍❤️‍💋‍👩🏾	people	kiss woman medium skin tone dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏽‍❤️‍💋‍👩🏿	people	kiss woman medium skin tone dark anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏾‍❤️‍💋‍👩🏻	people	kiss woman medium dark skin tone light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏾‍❤️‍💋‍👩🏼	people	kiss woman medium dark skin tone light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏾‍❤️‍💋‍👩🏽	people	kiss woman medium dark skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏾‍❤️‍💋‍👩🏾	people	kiss woman medium dark skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏾‍❤️‍💋‍👩🏿	people	kiss woman medium dark skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏿‍❤️‍💋‍👩🏻	people	kiss woman dark skin tone light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏿‍❤️‍💋‍👩🏼	people	kiss woman dark skin tone medium light anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏿‍❤️‍💋‍👩🏽	people	kiss woman dark skin tone medium anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏿‍❤️‍💋‍👩🏾	people	kiss woman dark skin tone medium anniversary babe bae couple date dating heart love mwah person romance together xoxo
+👩🏿‍❤️‍💋‍👩🏿	people	kiss woman dark skin tone anniversary babe bae couple date dating heart love mwah person romance together xoxo
+💑	people	couple with heart anniversary babe bae dating kiss love person relationship romance together you
+💑🏻	people	couple with heart light skin tone anniversary babe bae dating kiss love person relationship romance together you
+💑🏼	people	couple with heart medium light skin tone anniversary babe bae dating kiss love person relationship romance together you
+💑🏽	people	couple with heart medium skin tone anniversary babe bae dating kiss love person relationship romance together you
+💑🏾	people	couple with heart medium dark skin tone anniversary babe bae dating kiss love person relationship romance together you
+💑🏿	people	couple with heart dark skin tone anniversary babe bae dating kiss love person relationship romance together you
+🧑🏻‍❤️‍🧑🏼	people	couple with heart person light skin tone medium anniversary babe bae dating kiss love relationship romance together you
+🧑🏻‍❤️‍🧑🏽	people	couple with heart person light skin tone medium anniversary babe bae dating kiss love relationship romance together you
+🧑🏻‍❤️‍🧑🏾	people	couple with heart person light skin tone medium dark anniversary babe bae dating kiss love relationship romance together you
+🧑🏻‍❤️‍🧑🏿	people	couple with heart person light skin tone dark anniversary babe bae dating kiss love relationship romance together you
+🧑🏼‍❤️‍🧑🏻	people	couple with heart person medium light skin tone anniversary babe bae dating kiss love relationship romance together you
+🧑🏼‍❤️‍🧑🏽	people	couple with heart person medium light skin tone anniversary babe bae dating kiss love relationship romance together you
+🧑🏼‍❤️‍🧑🏾	people	couple with heart person medium light skin tone dark anniversary babe bae dating kiss love relationship romance together you
+🧑🏼‍❤️‍🧑🏿	people	couple with heart person medium light skin tone dark anniversary babe bae dating kiss love relationship romance together you
+🧑🏽‍❤️‍🧑🏻	people	couple with heart person medium skin tone light anniversary babe bae dating kiss love relationship romance together you
+🧑🏽‍❤️‍🧑🏼	people	couple with heart person medium skin tone light anniversary babe bae dating kiss love relationship romance together you
+🧑🏽‍❤️‍🧑🏾	people	couple with heart person medium skin tone dark anniversary babe bae dating kiss love relationship romance together you
+🧑🏽‍❤️‍🧑🏿	people	couple with heart person medium skin tone dark anniversary babe bae dating kiss love relationship romance together you
+🧑🏾‍❤️‍🧑🏻	people	couple with heart person medium dark skin tone light anniversary babe bae dating kiss love relationship romance together you
+🧑🏾‍❤️‍🧑🏼	people	couple with heart person medium dark skin tone light anniversary babe bae dating kiss love relationship romance together you
+🧑🏾‍❤️‍🧑🏽	people	couple with heart person medium dark skin tone anniversary babe bae dating kiss love relationship romance together you
+🧑🏾‍❤️‍🧑🏿	people	couple with heart person medium dark skin tone anniversary babe bae dating kiss love relationship romance together you
+🧑🏿‍❤️‍🧑🏻	people	couple with heart person dark skin tone light anniversary babe bae dating kiss love relationship romance together you
+🧑🏿‍❤️‍🧑🏼	people	couple with heart person dark skin tone medium light anniversary babe bae dating kiss love relationship romance together you
+🧑🏿‍❤️‍🧑🏽	people	couple with heart person dark skin tone medium anniversary babe bae dating kiss love relationship romance together you
+🧑🏿‍❤️‍🧑🏾	people	couple with heart person dark skin tone medium anniversary babe bae dating kiss love relationship romance together you
+👩‍❤️‍👨	people	couple with heart woman man anniversary babe bae dating kiss love person relationship romance together you
+👩🏻‍❤️‍👨🏻	people	couple with heart woman man light skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏻‍❤️‍👨🏼	people	couple with heart woman man light skin tone medium anniversary babe bae dating kiss love person relationship romance together you
+👩🏻‍❤️‍👨🏽	people	couple with heart woman man light skin tone medium anniversary babe bae dating kiss love person relationship romance together you
+👩🏻‍❤️‍👨🏾	people	couple with heart woman man light skin tone medium dark anniversary babe bae dating kiss love person relationship romance together you
+👩🏻‍❤️‍👨🏿	people	couple with heart woman man light skin tone dark anniversary babe bae dating kiss love person relationship romance together you
+👩🏼‍❤️‍👨🏻	people	couple with heart woman man medium light skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏼‍❤️‍👨🏼	people	couple with heart woman man medium light skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏼‍❤️‍👨🏽	people	couple with heart woman man medium light skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏼‍❤️‍👨🏾	people	couple with heart woman man medium light skin tone dark anniversary babe bae dating kiss love person relationship romance together you
+👩🏼‍❤️‍👨🏿	people	couple with heart woman man medium light skin tone dark anniversary babe bae dating kiss love person relationship romance together you
+👩🏽‍❤️‍👨🏻	people	couple with heart woman man medium skin tone light anniversary babe bae dating kiss love person relationship romance together you
+👩🏽‍❤️‍👨🏼	people	couple with heart woman man medium skin tone light anniversary babe bae dating kiss love person relationship romance together you
+👩🏽‍❤️‍👨🏽	people	couple with heart woman man medium skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏽‍❤️‍👨🏾	people	couple with heart woman man medium skin tone dark anniversary babe bae dating kiss love person relationship romance together you
+👩🏽‍❤️‍👨🏿	people	couple with heart woman man medium skin tone dark anniversary babe bae dating kiss love person relationship romance together you
+👩🏾‍❤️‍👨🏻	people	couple with heart woman man medium dark skin tone light anniversary babe bae dating kiss love person relationship romance together you
+👩🏾‍❤️‍👨🏼	people	couple with heart woman man medium dark skin tone light anniversary babe bae dating kiss love person relationship romance together you
+👩🏾‍❤️‍👨🏽	people	couple with heart woman man medium dark skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏾‍❤️‍👨🏾	people	couple with heart woman man medium dark skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏾‍❤️‍👨🏿	people	couple with heart woman man medium dark skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏿‍❤️‍👨🏻	people	couple with heart woman man dark skin tone light anniversary babe bae dating kiss love person relationship romance together you
+👩🏿‍❤️‍👨🏼	people	couple with heart woman man dark skin tone medium light anniversary babe bae dating kiss love person relationship romance together you
+👩🏿‍❤️‍👨🏽	people	couple with heart woman man dark skin tone medium anniversary babe bae dating kiss love person relationship romance together you
+👩🏿‍❤️‍👨🏾	people	couple with heart woman man dark skin tone medium anniversary babe bae dating kiss love person relationship romance together you
+👩🏿‍❤️‍👨🏿	people	couple with heart woman man dark skin tone anniversary babe bae dating kiss love person relationship romance together you
+👨‍❤️‍👨	people	couple with heart man anniversary babe bae dating kiss love person relationship romance together you
+👨🏻‍❤️‍👨🏻	people	couple with heart man light skin tone anniversary babe bae dating kiss love person relationship romance together you
+👨🏻‍❤️‍👨🏼	people	couple with heart man light skin tone medium anniversary babe bae dating kiss love person relationship romance together you
+👨🏻‍❤️‍👨🏽	people	couple with heart man light skin tone medium anniversary babe bae dating kiss love person relationship romance together you
+👨🏻‍❤️‍👨🏾	people	couple with heart man light skin tone medium dark anniversary babe bae dating kiss love person relationship romance together you
+👨🏻‍❤️‍👨🏿	people	couple with heart man light skin tone dark anniversary babe bae dating kiss love person relationship romance together you
+👨🏼‍❤️‍👨🏻	people	couple with heart man medium light skin tone anniversary babe bae dating kiss love person relationship romance together you
+👨🏼‍❤️‍👨🏼	people	couple with heart man medium light skin tone anniversary babe bae dating kiss love person relationship romance together you
+👨🏼‍❤️‍👨🏽	people	couple with heart man medium light skin tone anniversary babe bae dating kiss love person relationship romance together you
+👨🏼‍❤️‍👨🏾	people	couple with heart man medium light skin tone dark anniversary babe bae dating kiss love person relationship romance together you
+👨🏼‍❤️‍👨🏿	people	couple with heart man medium light skin tone dark anniversary babe bae dating kiss love person relationship romance together you
+👨🏽‍❤️‍👨🏻	people	couple with heart man medium skin tone light anniversary babe bae dating kiss love person relationship romance together you
+👨🏽‍❤️‍👨🏼	people	couple with heart man medium skin tone light anniversary babe bae dating kiss love person relationship romance together you
+👨🏽‍❤️‍👨🏽	people	couple with heart man medium skin tone anniversary babe bae dating kiss love person relationship romance together you
+👨🏽‍❤️‍👨🏾	people	couple with heart man medium skin tone dark anniversary babe bae dating kiss love person relationship romance together you
+👨🏽‍❤️‍👨🏿	people	couple with heart man medium skin tone dark anniversary babe bae dating kiss love person relationship romance together you
+👨🏾‍❤️‍👨🏻	people	couple with heart man medium dark skin tone light anniversary babe bae dating kiss love person relationship romance together you
+👨🏾‍❤️‍👨🏼	people	couple with heart man medium dark skin tone light anniversary babe bae dating kiss love person relationship romance together you
+👨🏾‍❤️‍👨🏽	people	couple with heart man medium dark skin tone anniversary babe bae dating kiss love person relationship romance together you
+👨🏾‍❤️‍👨🏾	people	couple with heart man medium dark skin tone anniversary babe bae dating kiss love person relationship romance together you
+👨🏾‍❤️‍👨🏿	people	couple with heart man medium dark skin tone anniversary babe bae dating kiss love person relationship romance together you
+👨🏿‍❤️‍👨🏻	people	couple with heart man dark skin tone light anniversary babe bae dating kiss love person relationship romance together you
+👨🏿‍❤️‍👨🏼	people	couple with heart man dark skin tone medium light anniversary babe bae dating kiss love person relationship romance together you
+👨🏿‍❤️‍👨🏽	people	couple with heart man dark skin tone medium anniversary babe bae dating kiss love person relationship romance together you
+👨🏿‍❤️‍👨🏾	people	couple with heart man dark skin tone medium anniversary babe bae dating kiss love person relationship romance together you
+👨🏿‍❤️‍👨🏿	people	couple with heart man dark skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩‍❤️‍👩	people	couple with heart woman anniversary babe bae dating kiss love person relationship romance together you
+👩🏻‍❤️‍👩🏻	people	couple with heart woman light skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏻‍❤️‍👩🏼	people	couple with heart woman light skin tone medium anniversary babe bae dating kiss love person relationship romance together you
+👩🏻‍❤️‍👩🏽	people	couple with heart woman light skin tone medium anniversary babe bae dating kiss love person relationship romance together you
+👩🏻‍❤️‍👩🏾	people	couple with heart woman light skin tone medium dark anniversary babe bae dating kiss love person relationship romance together you
+👩🏻‍❤️‍👩🏿	people	couple with heart woman light skin tone dark anniversary babe bae dating kiss love person relationship romance together you
+👩🏼‍❤️‍👩🏻	people	couple with heart woman medium light skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏼‍❤️‍👩🏼	people	couple with heart woman medium light skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏼‍❤️‍👩🏽	people	couple with heart woman medium light skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏼‍❤️‍👩🏾	people	couple with heart woman medium light skin tone dark anniversary babe bae dating kiss love person relationship romance together you
+👩🏼‍❤️‍👩🏿	people	couple with heart woman medium light skin tone dark anniversary babe bae dating kiss love person relationship romance together you
+👩🏽‍❤️‍👩🏻	people	couple with heart woman medium skin tone light anniversary babe bae dating kiss love person relationship romance together you
+👩🏽‍❤️‍👩🏼	people	couple with heart woman medium skin tone light anniversary babe bae dating kiss love person relationship romance together you
+👩🏽‍❤️‍👩🏽	people	couple with heart woman medium skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏽‍❤️‍👩🏾	people	couple with heart woman medium skin tone dark anniversary babe bae dating kiss love person relationship romance together you
+👩🏽‍❤️‍👩🏿	people	couple with heart woman medium skin tone dark anniversary babe bae dating kiss love person relationship romance together you
+👩🏾‍❤️‍👩🏻	people	couple with heart woman medium dark skin tone light anniversary babe bae dating kiss love person relationship romance together you
+👩🏾‍❤️‍👩🏼	people	couple with heart woman medium dark skin tone light anniversary babe bae dating kiss love person relationship romance together you
+👩🏾‍❤️‍👩🏽	people	couple with heart woman medium dark skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏾‍❤️‍👩🏾	people	couple with heart woman medium dark skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏾‍❤️‍👩🏿	people	couple with heart woman medium dark skin tone anniversary babe bae dating kiss love person relationship romance together you
+👩🏿‍❤️‍👩🏻	people	couple with heart woman dark skin tone light anniversary babe bae dating kiss love person relationship romance together you
+👩🏿‍❤️‍👩🏼	people	couple with heart woman dark skin tone medium light anniversary babe bae dating kiss love person relationship romance together you
+👩🏿‍❤️‍👩🏽	people	couple with heart woman dark skin tone medium anniversary babe bae dating kiss love person relationship romance together you
+👩🏿‍❤️‍👩🏾	people	couple with heart woman dark skin tone medium anniversary babe bae dating kiss love person relationship romance together you
+👩🏿‍❤️‍👩🏿	people	couple with heart woman dark skin tone anniversary babe bae dating kiss love person relationship romance together you
+👨‍👩‍👦	people	family man woman boy child
+👨‍👩‍👧	people	family man woman girl child
+👨‍👩‍👧‍👦	people	family man woman girl boy child
+👨‍👩‍👦‍👦	people	family man woman boy child
+👨‍👩‍👧‍👧	people	family man woman girl child
+👨‍👨‍👦	people	family man boy child
+👨‍👨‍👧	people	family man girl child
+👨‍👨‍👧‍👦	people	family man girl boy child
+👨‍👨‍👦‍👦	people	family man boy child
+👨‍👨‍👧‍👧	people	family man girl child
+👩‍👩‍👦	people	family woman boy child
+👩‍👩‍👧	people	family woman girl child
+👩‍👩‍👧‍👦	people	family woman girl boy child
+👩‍👩‍👦‍👦	people	family woman boy child
+👩‍👩‍👧‍👧	people	family woman girl child
+👨‍👦	people	family man boy child
+👨‍👦‍👦	people	family man boy child
+👨‍👧	people	family man girl child
+👨‍👧‍👦	people	family man girl boy child
+👨‍👧‍👧	people	family man girl child
+👩‍👦	people	family woman boy child
+👩‍👦‍👦	people	family woman boy child
+👩‍👧	people	family woman girl child
+👩‍👧‍👦	people	family woman girl boy child
+👩‍👧‍👧	people	family woman girl child
+🗣️	people	speaking head face silhouette speak
+👤	people	bust in silhouette mysterious shadow
+👥	people	busts in silhouette bff bust everyone friend friends people
+🫂	people	people hugging comfort embrace farewell friendship goodbye hello hug love thanks
+👪	people	family child
+🧑‍🧑‍🧒	people	family adult child
+🧑‍🧑‍🧒‍🧒	people	family adult child
+🧑‍🧒	people	family adult child
+🧑‍🧒‍🧒	people	family adult child
+👣	people	footprints barefoot clothing footprint omw print walk
+🫆	people	fingerprint clue crime detective forensics identity mystery print safety trace
+🐵	animals	monkey face animal banana
+🐒	animals	monkey animal banana
+🦍	animals	gorilla animal
+🦧	animals	orangutan animal ape monkey
+🐶	animals	dog face adorbs animal pet puppies puppy
+🐕	animals	dog animal animals dogs pet
+🦮	animals	guide dog accessibility animal blind
+🐕‍🦺	animals	service dog accessibility animal assistance
+🐩	animals	poodle animal dog fluffy
+🐺	animals	wolf animal face
+🦊	animals	fox animal face
+🦝	animals	raccoon animal curious sly
+🐱	animals	cat face animal kitten kitty pet
+🐈	animals	cat animal animals cats kitten pet
+🐈‍⬛	animals	black cat animal feline halloween meow unlucky
+🦁	animals	lion alpha animal face leo mane order rawr roar safari strong zodiac
+🐯	animals	tiger face animal big cat predator
+🐅	animals	tiger animal big cat predator zoo
+🐆	animals	leopard animal big cat predator zoo
+🐴	animals	horse face animal dressage equine farm horses
+🫎	animals	moose alces animal antlers elk mammal
+🫏	animals	donkey animal ass burro hinny mammal mule stubborn
+🐎	animals	horse animal equestrian farm racehorse racing
+🦄	animals	unicorn face
+🦓	animals	zebra animal stripe
+🦌	animals	deer animal
+🦬	animals	bison animal buffalo herd wisent
+🐮	animals	cow face animal farm milk moo
+🐂	animals	ox animal animals bull farm taurus zodiac
+🐃	animals	water buffalo animal zoo
+🐄	animals	cow animal animals farm milk moo
+🐷	animals	pig face animal bacon farm pork
+🐖	animals	pig animal bacon farm pork sow
+🐗	animals	boar animal pig
+🐽	animals	pig nose animal face farm smell snout
+🐏	animals	ram animal aries horns male sheep zodiac zoo
+🐑	animals	ewe animal baa farm female fluffy lamb sheep wool
+🐐	animals	goat animal capricorn farm milk zodiac
+🐪	animals	camel animal desert dromedary hump one
+🐫	animals	two hump camel animal bactrian desert
+🦙	animals	llama alpaca animal guanaco vicu a wool
+🦒	animals	giraffe animal spots
+🐘	animals	elephant animal
+🦣	animals	mammoth animal extinction large tusk wooly
+🦏	animals	rhinoceros animal
+🦛	animals	hippopotamus animal hippo
+🐭	animals	mouse face animal
+🐁	animals	mouse animal animals
+🐀	animals	rat animal
+🐹	animals	hamster animal face pet
+🐰	animals	rabbit face animal bunny pet
+🐇	animals	rabbit animal bunny pet
+🐿️	animals	chipmunk animal squirrel
+🦫	animals	beaver animal dam teeth
+🦔	animals	hedgehog animal spiny
+🦇	animals	bat animal vampire
+🐻	animals	bear animal face grizzly growl honey
+🐻‍❄️	animals	polar bear animal arctic white
+🐨	animals	koala animal australia bear down face marsupial under
+🐼	animals	panda animal bamboo face
+🦥	animals	sloth lazy slow
 🦦	animals	otter animal fishing playful
-🦨	animals	skunk animal smelly stink
-🦘	animals	kangaroo animal nature australia joey hop marsupial jump roo
-🦡	animals	badger animal nature honey pester
-🐾	animals	paw prints animal tracking footprints dog cat pet feet kitten print puppy
-🦃	animals	turkey animal bird thanksgiving wild
-🐔	animals	chicken animal cluck nature bird hen
-🐓	animals	rooster animal nature chicken bird cock cockerel
-🐣	animals	hatching chick animal chicken egg born baby bird
-🐤	animals	baby chick animal chicken bird yellow
-🐥	animals	front-facing baby chick front facing baby chick animal chicken baby bird hatched standing
-🐦	animals	bird animal nature fly tweet spring
-🐧	animals	penguin animal nature bird
-🕊️	animals	dove animal bird fly peace
-🦅	animals	eagle animal nature bird bald
-🦆	animals	duck animal nature bird mallard
-🦢	animals	swan animal nature bird cygnet duckling ugly
-🦉	animals	owl animal nature bird hoot wise
-🦤	animals	dodo animal bird extinct extinction large mauritius obsolete
-🪶	animals	feather bird fly flight light plumage
-🦩	animals	flamingo animal flamboyant tropical
-🦚	animals	peacock animal nature peahen bird ostentatious proud
-🦜	animals	parrot animal nature bird pirate talk
-🪽	animals	wing angel birds flying fly
-🐦‍⬛	animals	black bird crow
-🪿	animals	goose silly jemima goosebumps honk
-🐦‍🔥	animals	phoenix immortal bird mythtical reborn
-🐸	animals	frog animal nature croak toad face
-🐊	animals	crocodile animal nature reptile lizard alligator croc
-🐢	animals	turtle animal slow nature tortoise terrapin
-🦎	animals	lizard animal nature reptile gecko
-🐍	animals	snake animal evil nature hiss python bearer ophiuchus serpent zodiac
-🐲	animals	dragon face animal myth nature chinese green fairy head tale
-🐉	animals	dragon animal myth nature chinese green fairy tale
-🦕	animals	sauropod animal nature dinosaur brachiosaurus brontosaurus diplodocus extinct
-🦖	animals	t-rex t rex animal nature dinosaur tyrannosaurus extinct trex
-🐳	animals	spouting whale animal nature sea ocean cute face
-🐋	animals	whale animal nature sea ocean whale2
-🐬	animals	dolphin animal nature fish sea ocean flipper fins beach
-🫍	animals	orca ocean whale dolphin animal
-🦭	animals	seal animal creature sea lion
-🐟	animals	fish animal food nature freshwater pisces zodiac
-🐠	animals	tropical fish animal swim ocean beach nemo blue yellow
-🐡	animals	blowfish animal nature food sea ocean fish fugu pufferfish
-🦈	animals	shark animal nature fish sea ocean jaws fins beach great white
-🐙	animals	octopus animal creature ocean sea nature beach
-🐚	animals	spiral shell nature sea beach seashell
-🪸	animals	coral ocean sea reef
-🪼	animals	jellyfish sting tentacles
-🦀	animals	crab animal crustacean cancer zodiac
-🦞	animals	lobster animal nature bisque claws seafood
-🦐	animals	shrimp animal ocean nature seafood food prawn shellfish small
-🦑	animals	squid animal nature ocean sea food molusc
-🦪	animals	oyster food diving pearl
-🐌	animals	snail slow animal shell garden slug
-🦋	animals	butterfly animal insect nature caterpillar pretty
-🐛	animals	bug animal insect nature worm caterpillar
-🐜	animals	ant animal insect nature bug
-🐝	animals	honeybee animal insect nature bug spring honey bee bumblebee
-🪲	animals	beetle insect bug
-🐞	animals	lady beetle animal insect nature ladybug bug ladybird
-🦗	animals	cricket animal chirp grasshopper insect orthoptera
-🪳	animals	cockroach insect pests pest roach
-🕷️	animals	spider animal arachnid insect
-🕸️	animals	spider web animal insect arachnid silk cobweb spiderweb
-🦂	animals	scorpion animal arachnid scorpio scorpius zodiac
-🦟	animals	mosquito animal nature insect malaria disease fever pest virus
-🪰	animals	fly insect disease maggot pest rotting
+🦨	animals	skunk animal stink
+🦘	animals	kangaroo animal joey jump marsupial
+🦡	animals	badger animal honey pester
+🐾	animals	paw prints feet paws print
+🦃	animals	turkey bird gobble thanksgiving
+🐔	animals	chicken animal bird ornithology
+🐓	animals	rooster animal bird ornithology
+🐣	animals	hatching chick animal baby bird egg
+🐤	animals	baby chick animal bird ornithology
+🐥	animals	front facing baby chick animal bird newborn ornithology
+🐦	animals	bird animal ornithology
+🐧	animals	penguin animal antarctica bird ornithology
+🕊️	animals	dove bird fly ornithology peace
+🦅	animals	eagle animal bird ornithology
+🦆	animals	duck animal bird ornithology
+🦢	animals	swan animal bird cygnet duckling ornithology ugly
+🦉	animals	owl animal bird ornithology wise
+🦤	animals	dodo animal bird extinction large ornithology
+🪶	animals	feather bird flight light plumage
+🦩	animals	flamingo animal bird flamboyant ornithology tropical
+🦚	animals	peacock animal bird colorful ornithology ostentatious peahen pretty proud
+🦜	animals	parrot animal bird ornithology pirate talk
+🪽	animals	wing angelic ascend aviation bird fly flying heavenly mythology soar
+🐦‍⬛	animals	black bird animal beak caw corvid crow ornithology raven rook
+🪿	animals	goose animal bird duck flock fowl gaggle gander geese honk ornithology silly
+🐦‍🔥	animals	phoenix ascend ascension emerge fantasy firebird glory immortal rebirth reincarnation reinvent renewal revival revive rise transform
+🐸	animals	frog animal face
+🐊	animals	crocodile animal zoo
+🐢	animals	turtle animal terrapin tortoise
+🦎	animals	lizard animal reptile
+🐍	animals	snake animal bearer ophiuchus serpent zodiac
+🐲	animals	dragon face animal fairy fairytale tale
+🐉	animals	dragon animal fairy fairytale knights tale
+🦕	animals	sauropod brachiosaurus brontosaurus dinosaur diplodocus
+🦖	animals	t rex dinosaur tyrannosaurus
+🐳	animals	spouting whale animal beach face ocean
+🐋	animals	whale animal beach ocean
+🐬	animals	dolphin animal beach flipper ocean
+🦭	animals	seal animal lion ocean sea
+🐟	animals	fish animal dinner fishes fishing pisces zodiac
+🐠	animals	tropical fish animal fishes
+🐡	animals	blowfish animal fish
+🦈	animals	shark animal fish
+🐙	animals	octopus animal creature ocean
+🐚	animals	spiral shell animal beach conch sea
+🪸	animals	coral change climate ocean reef sea
+🪼	animals	jellyfish animal aquarium burn invertebrate jelly life marine ocean ouch plankton sea sting stinger tentacles
+🦀	animals	crab cancer zodiac
+🦞	animals	lobster animal bisque claws seafood
+🦐	animals	shrimp food shellfish small
+🦑	animals	squid animal food mollusk
+🦪	animals	oyster diving pearl
+🐌	animals	snail animal escargot garden nature slug
+🦋	animals	butterfly insect pretty
+🐛	animals	bug animal garden insect
+🐜	animals	ant animal garden insect
+🐝	animals	honeybee animal bee bumblebee honey insect nature spring
+🪲	animals	beetle animal bug insect
+🐞	animals	lady beetle animal garden insect ladybird ladybug nature
+🦗	animals	cricket animal bug grasshopper insect orthoptera
+🪳	animals	cockroach animal insect pest roach
+🕷️	animals	spider animal insect
+🕸️	animals	spider web
+🦂	animals	scorpion scorpio scorpius zodiac
+🦟	animals	mosquito bite disease fever insect malaria pest virus
+🪰	animals	fly animal disease insect maggot pest rotting
 🪱	animals	worm animal annelid earthworm parasite
-🦠	animals	microbe amoeba bacteria germs virus covid cell coronavirus germ microorganism
-💐	animals	bouquet flowers nature spring flower plant romance
-🌸	animals	cherry blossom nature plant spring flower pink sakura
-💮	animals	white flower japanese spring blossom cherry doily done paper stamp well
-🪷	animals	lotus flower calm meditation buddhism hinduism india purity vietnam
-🏵️	animals	rosette flower decoration military plant
-🌹	animals	rose flowers valentines love spring flower plant red
-🥀	animals	wilted flower plant nature flower rose dead drooping
-🌺	animals	hibiscus plant vegetable flowers beach flower
-🌻	animals	sunflower nature plant fall flower sun yellow
-🌼	animals	blossom nature flowers yellow blossoming flower daisy flower plant
-🌷	animals	tulip flowers plant nature summer spring flower
-🪻	animals	hyacinth flower lavender
-🌱	animals	seedling plant nature grass lawn spring sprout sprouting young seed
-🪴	animals	potted plant greenery house boring grow houseplant nurturing useless
-🌲	animals	evergreen tree plant nature fir pine wood
-🌳	animals	deciduous tree plant nature rounded shedding wood
-🌴	animals	palm tree plant vegetable nature summer beach mojito tropical coconut
-🌵	animals	cactus vegetable plant nature desert
-🌾	animals	sheaf of rice nature plant crop ear farming grain wheat
-🌿	animals	herb vegetable plant medicine weed grass lawn crop leaf
-☘️	animals	shamrock vegetable plant nature irish clover trefoil
-🍀	animals	four leaf clover vegetable plant nature lucky irish ireland luck
-🍁	animals	maple leaf nature plant vegetable ca fall canada canadian falling
-🍂	animals	fallen leaf nature plant vegetable leaves autumn brown fall falling
-🍃	animals	leaf fluttering in wind nature plant tree vegetable grass lawn spring blow flutter green leaves
-🪹	animals	empty nest bird nesting
-🪺	animals	nest with eggs bird nesting
-🍄	animals	mushroom plant vegetable fungus shroom toadstool
-🪾	animals	leafless tree
-🍇	food	grapes fruit food wine grape plant
-🍈	food	melon fruit nature food cantaloupe honeydew muskmelon plant
-🍉	food	watermelon fruit food picnic summer plant
-🍊	food	tangerine food fruit nature orange mandarin plant
-🍋	food	lemon fruit nature citrus lemonade plant
-🍋‍🟩	food	lime fruit acidic citric
-🍌	food	banana fruit food monkey plant plantain
-🍍	food	pineapple fruit nature food plant
-🥭	food	mango fruit food tropical
-🍎	food	red apple fruit mac school delicious plant
-🍏	food	green apple fruit nature delicious golden granny plant smith
-🍐	food	pear fruit nature food plant
-🍑	food	peach fruit nature food bottom butt plant
-🍒	food	cherries food fruit berries cherry plant red wild
-🍓	food	strawberry fruit food nature berry plant
-🫐	food	blueberries fruit berry bilberry blue blueberry
-🥝	food	kiwi fruit fruit food chinese gooseberry kiwifruit
-🍅	food	tomato fruit vegetable nature food plant
-🫒	food	olive fruit food olives
-🥥	food	coconut fruit nature food palm cocoanut colada piña
-🥑	food	avocado fruit food
-🍆	food	eggplant vegetable nature food aubergine phallic plant purple
-🥔	food	potato food tuber vegatable starch baked idaho vegetable
-🥕	food	carrot vegetable food orange
-🌽	food	ear of corn food vegetable plant cob maize maze
-🌶️	food	hot pepper food spicy chilli chili plant
-🫑	food	bell pepper fruit plant capsicum vegetable
-🥒	food	cucumber fruit food pickle gherkin vegetable
-🥬	food	leafy green food vegetable plant bok choy cabbage kale lettuce chinese cos greens romaine
-🥦	food	broccoli fruit food vegetable cabbage wild
-🧄	food	garlic food spice cook flavoring plant vegetable
-🧅	food	onion cook food spice flavoring plant vegetable
-🥜	food	peanuts food nut nuts peanut vegetable
-🫘	food	beans food kidney legume
-🌰	food	chestnut food squirrel acorn nut plant
-🫚	food	ginger root spice yellow cooking gingerbread
-🫛	food	pea pod cozy green
-🍄‍🟫	food	brown mushroom toadstool fungus
-🫜	food	root vegetable radish
-🍞	food	bread food wheat breakfast toast loaf
-🥐	food	croissant food bread french breakfast crescent roll
-🥖	food	baguette bread food bread french france bakery
-🫓	food	flatbread flour food bakery arepa bread flat lavash naan pita
-🥨	food	pretzel food bread twisted germany bakery soft twist
-🥯	food	bagel food bread bakery schmear jewish bakery breakfast cheese cream
-🥞	food	pancakes food breakfast flapjacks hotcakes brunch crêpe crêpes hotcake pancake
-🧇	food	waffle food breakfast brunch indecisive iron
-🧀	food	cheese wedge food chadder swiss
-🍖	food	meat on bone good food drumstick barbecue bbq manga
-🍗	food	poultry leg food meat drumstick bird chicken turkey bone
-🥩	food	cut of meat food cow meat cut chop lambchop porkchop steak
-🥓	food	bacon food breakfast pork pig meat brunch rashers
-🍔	food	hamburger meat fast food beef cheeseburger mcdonalds burger king
-🍟	food	french fries chips snack fast food potato mcdonald's
-🍕	food	pizza food party italy cheese pepperoni slice
-🌭	food	hot dog food frankfurter america hotdog redhot sausage wiener
-🥪	food	sandwich food lunch bread toast bakery cheese deli meat vegetables
-🌮	food	taco food mexican
-🌯	food	burrito food mexican wrap
-🫔	food	tamale food masa mexican tamal wrapped
-🥙	food	stuffed flatbread food flatbread stuffed gyro mediterranean doner falafel kebab pita sandwich shawarma
-🧆	food	falafel food mediterranean chickpea falfel meatball
-🥚	food	egg food chicken breakfast easter egg
-🍳	food	cooking food breakfast kitchen egg skillet fried frying pan
-🥘	food	shallow pan of food food cooking casserole paella skillet curry
-🍲	food	pot of food food meat soup hot pot bowl stew
-🫕	food	fondue cheese pot food chocolate melted swiss
-🥣	food	bowl with spoon food breakfast cereal oatmeal porridge congee tableware
-🥗	food	green salad food healthy lettuce vegetable
-🍿	food	popcorn food movie theater films snack drama corn popping
-🧈	food	butter food cook dairy
-🧂	food	salt condiment shaker
-🥫	food	canned food food soup tomatoes can preserve tin tinned
-🍱	food	bento box food japanese box lunch assets
-🍘	food	rice cracker food japanese snack senbei
-🍙	food	rice ball food japanese onigiri omusubi
-🍚	food	cooked rice food asian boiled bowl steamed
-🍛	food	curry rice food spicy hot indian
-🍜	food	steaming bowl food japanese noodle chopsticks ramen noodles soup
-🍝	food	spaghetti food italian pasta noodle
-🍠	food	roasted sweet potato food nature plant goguma yam
-🍢	food	oden skewer food japanese kebab seafood stick
-🍣	food	sushi food fish japanese rice sashimi seafood
-🍤	food	fried shrimp food animal appetizer summer prawn tempura
-🍥	food	fish cake with swirl food japan sea beach narutomaki pink swirl kamaboko surimi ramen design fishcake pastry
-🥮	food	moon cake food autumn dessert festival mooncake yuèbǐng
-🍡	food	dango food dessert sweet japanese barbecue meat balls green pink skewer stick white
-🥟	food	dumpling food empanada pierogi potsticker gyoza gyōza jiaozi
-🥠	food	fortune cookie food prophecy dessert
-🥡	food	takeout box food leftovers chinese container out oyster pail take
-🍦	food	soft ice cream food hot dessert summer icecream mr. serve sweet whippy
-🍧	food	shaved ice hot dessert summer cone snow sweet
-🍨	food	ice cream food hot dessert bowl sweet
-🍩	food	doughnut food dessert snack sweet donut breakfast
-🍪	food	cookie food snack oreo chocolate sweet dessert biscuit chip
-🎂	food	birthday cake food dessert cake candles celebration party pastry sweet
-🍰	food	shortcake food dessert cake pastry piece slice strawberry sweet
-🧁	food	cupcake food dessert bakery sweet cake fairy pastry
-🥧	food	pie food dessert pastry filling sweet
-🍫	food	chocolate bar food snack dessert sweet candy
-🍬	food	candy snack dessert sweet lolly
-🍭	food	lollipop food snack candy sweet dessert lollypop sucker
-🍮	food	custard dessert food pudding flan caramel creme sweet
-🍯	food	honey pot bees sweet kitchen honeypot
-🍼	food	baby bottle food container milk drink feeding
-🥛	food	glass of milk beverage drink cow
-☕	food	hot beverage beverage caffeine latte espresso coffee mug cafe chocolate drink steaming tea
-🫖	food	teapot drink hot kettle pot tea
-🍵	food	teacup without handle drink bowl breakfast green british beverage cup matcha tea
-🍶	food	sake wine drink drunk beverage japanese alcohol booze bar bottle cup rice
-🍾	food	bottle with popping cork drink wine bottle celebration bar bubbly champagne party sparkling
-🍷	food	wine glass drink beverage drunk alcohol booze bar red
-🍸	food	cocktail glass drink drunk alcohol beverage booze mojito bar martini
-🍹	food	tropical drink beverage cocktail summer beach alcohol booze mojito bar fruit punch tiki vacation
-🍺	food	beer mug relax beverage drink drunk party pub summer alcohol booze bar stein
-🍻	food	clinking beer mugs relax beverage drink drunk party pub summer alcohol booze bar beers cheers clink drinks mug
-🥂	food	clinking glasses beverage drink party alcohol celebrate cheers wine champagne toast celebration clink glass
-🥃	food	tumbler glass drink beverage drunk alcohol liquor booze bourbon scotch whisky glass shot rum whiskey
-🫗	food	pouring liquid cup water drink empty glass spill
-🥤	food	cup with straw drink soda go juice malt milkshake pop smoothie soft tableware water
-🧋	food	bubble tea taiwan boba milk tea straw momi pearl tapioca
-🧃	food	beverage box drink juice straw sweet
-🧉	food	mate drink tea beverage bombilla chimarrão cimarrón maté yerba
-🧊	food	ice water cold cube iceberg
-🥢	food	chopsticks food hashi jeotgarak kuaizi
-🍽️	food	fork and knife with plate food eat meal lunch dinner restaurant cooking cutlery dining tableware
-🍴	food	fork and knife cutlery kitchen cooking silverware tableware
-🥄	food	spoon cutlery kitchen tableware
-🔪	food	kitchen knife knife blade cutlery kitchen weapon butchers chop cooking cut hocho tool
-🫙	food	jar container sauce condiment empty store
-🏺	food	amphora vase jar aquarius cooking drink jug tool zodiac
-🌍	travel	globe showing europe-africa globe showing europe africa globe world earth international planet
-🌎	travel	globe showing americas globe world usa earth international planet
-🌏	travel	globe showing asia-australia globe showing asia australia globe world east earth international planet
-🌐	travel	globe with meridians earth international world internet interweb i18n global web wide www internationalization localization
-🗺️	travel	world map location direction travel
-🗾	travel	map of japan nation country japanese asia silhouette
-🧭	travel	compass magnetic navigation orienteering
-🏔️	travel	snow-capped mountain snow capped mountain photo nature environment winter cold
-⛰️	travel	mountain photo nature environment
-🛘	travel	landslide disaster accident
-🌋	travel	volcano photo nature disaster eruption mountain weather
-🗻	travel	mount fuji photo mountain nature japanese capped san snow
-🏕️	travel	camping photo outdoors tent campsite
-🏖️	travel	beach with umbrella weather summer sunny sand mojito
-🏜️	travel	desert photo warm saharah
-🏝️	travel	desert island photo tropical mojito
-🏞️	travel	national park photo environment nature
-🏟️	travel	stadium photo place sports concert venue grandstand sport
-🏛️	travel	classical building art culture history
-🏗️	travel	building construction wip working progress crane architectural
-🧱	travel	brick bricks clay construction mortar wall infrastructure
-🪨	travel	rock stone boulder construction heavy solid
-🪵	travel	wood nature timber trunk construction log lumber
-🛖	travel	hut house structure roundhouse yurt
-🏘️	travel	houses buildings photo building group house
-🏚️	travel	derelict house abandon evict broken building abandoned haunted old
-🏠	travel	house building home
-🏡	travel	house with garden home plant nature building tree
-🏢	travel	office building building bureau work city high rise
-🏣	travel	japanese post office building envelope communication japan mark postal
-🏤	travel	post office building email european
-🏥	travel	hospital building health surgery doctor cross emergency medical medicine red room
-🏦	travel	bank building money sales cash business enterprise bakkureru bk branch
-🏨	travel	hotel building accomodation checkin accommodation h
-🏩	travel	love hotel like affection dating building heart hospital
-🏪	travel	convenience store building shopping groceries corner e eleven® hour kwik mart shop
-🏫	travel	school building student education learn teach clock elementary high middle tower
-🏬	travel	department store building shopping mall center shops
-🏭	travel	factory building industry pollution smoke industrial smog
-🏯	travel	japanese castle photo building fortress
-🏰	travel	castle building royalty history european turrets
-💒	travel	wedding love like affection couple marriage bride groom activity chapel church heart romance
-🗼	travel	tokyo tower photo japanese eiffel red
-🗽	travel	statue of liberty american newyork new york
-⛪	travel	church building religion christ christian cross
-🕌	travel	mosque islam worship minaret domed muslim religion roof
-🛕	travel	hindu temple religion
-🕍	travel	synagogue judaism worship temple jewish jew religion synagog
-⛩️	travel	shinto shrine temple japan kyoto kami michi no religion
-🕋	travel	kaaba mecca mosque islam muslim religion
-⛲	travel	fountain photo summer water fresh feature park
-⛺	travel	tent photo camping outdoors
-🌁	travel	foggy photo mountain bridge city fog fog bridge karl under weather
-🌃	travel	night with stars evening city downtown star starry weather
-🏙️	travel	cityscape photo night life urban building city skyline
-🌄	travel	sunrise over mountains view vacation photo morning mountain sun weather
-🌅	travel	sunrise morning view vacation photo sun sunset weather
-🌆	travel	cityscape at dusk photo evening sky buildings building city landscape orange sun sunset weather
-🌇	travel	sunset photo good morning dawn building buildings city dusk over sun sunrise weather
-🌉	travel	bridge at night photo sanfrancisco gate golden weather
-♨️	travel	hot springs bath warm relax hotsprings onsen steam steaming
-🎠	travel	carousel horse photo carnival activity entertainment fairground go merry round
-🛝	travel	playground slide fun park amusement play
-🎡	travel	ferris wheel photo carnival londoneye activity amusement big entertainment fairground observation park
-🎢	travel	roller coaster carnival playground photo fun activity amusement entertainment park rollercoaster theme
-💈	travel	barber pole hair salon style barber's haircut hairdresser shop stripes
-🎪	travel	circus tent festival carnival party activity big entertainment top
-🚂	travel	locomotive transportation vehicle train engine railway steam
-🚃	travel	railway car transportation vehicle carriage electric railcar railroad train tram trolleybus wagon
-🚄	travel	high-speed train high speed train transportation vehicle bullettrain railway shinkansen side
-🚅	travel	bullet train transportation vehicle speed fast public travel bullettrain front high nose railway shinkansen
-🚆	travel	train transportation vehicle diesel electric passenger railway regular train2
-🚇	travel	metro transportation blue-square mrt underground tube subway train vehicle
-🚈	travel	light rail transportation vehicle railway
-🚉	travel	station transportation vehicle public platform railway train
-🚊	travel	tram transportation vehicle trolleybus
-🚝	travel	monorail transportation vehicle
-🚞	travel	mountain railway transportation vehicle car funicular train
-🚋	travel	tram car transportation vehicle carriage public travel train trolleybus
-🚌	travel	bus car vehicle transportation school
-🚍	travel	oncoming bus vehicle transportation front
-🚎	travel	trolleybus bart transportation vehicle bus electric bus tram trolley
-🚐	travel	minibus vehicle car transportation bus minivan mover people
-🚑	travel	ambulance health 911 hospital vehicle
-🚒	travel	fire engine transportation cars vehicle department truck
-🚓	travel	police car vehicle cars transportation law legal enforcement cop patrol side
-🚔	travel	oncoming police car vehicle law legal enforcement 911 front of 🚓 cop
-🚕	travel	taxi uber vehicle cars transportation new side taxicab york
-🚖	travel	oncoming taxi vehicle cars uber front taxicab
-🚗	travel	automobile red transportation vehicle car side
-🚘	travel	oncoming automobile car vehicle transportation front
-🚙	travel	sport utility vehicle transportation vehicle blue campervan car motorhome recreational rv
-🛻	travel	pickup truck car transportation vehicle
-🚚	travel	delivery truck cars transportation vehicle resources
-🚛	travel	articulated lorry vehicle cars transportation express green semi truck
-🚜	travel	tractor vehicle car farming agriculture farm
-🏎️	travel	racing car sports race fast formula f1 one
-🏍️	travel	motorcycle race sports fast motorbike racing
-🛵	travel	motor scooter vehicle vespa sasha bike cycle
+🦠	animals	microbe amoeba bacteria science virus
+💐	animals	bouquet anniversary birthday date flower love plant romance
+🌸	animals	cherry blossom flower plant spring springtime
+💮	animals	white flower
+🪷	animals	lotus beauty buddhism calm flower hinduism peace purity serenity
+🏵️	animals	rosette plant
+🌹	animals	rose beauty elegant flower love plant red valentine
+🥀	animals	wilted flower dying
+🌺	animals	hibiscus flower plant
+🌻	animals	sunflower flower outdoors plant sun
+🌼	animals	blossom buttercup dandelion flower plant
+🌷	animals	tulip blossom flower growth plant
+🪻	animals	hyacinth bloom bluebonnet flower indigo lavender lilac lupine plant purple shrub snapdragon spring violet
+🌱	animals	seedling plant sapling sprout young
+🪴	animals	potted plant decor grow house nurturing pot
+🌲	animals	evergreen tree christmas forest pine
+🌳	animals	deciduous tree forest green habitat shedding
+🌴	animals	palm tree beach plant tropical
+🌵	animals	cactus desert drought nature plant
+🌾	animals	sheaf of rice ear grain grains plant
+🌿	animals	herb leaf plant
+☘️	animals	shamrock irish plant
+🍀	animals	four leaf clover 4 irish lucky plant
+🍁	animals	maple leaf falling
+🍂	animals	fallen leaf autumn fall falling
+🍃	animals	leaf fluttering in wind blow flutter
+🪹	animals	empty nest branch home nesting
+🪺	animals	nest with eggs bird branch egg nesting
+🍄	animals	mushroom fungus toadstool
+🪾	animals	leafless tree bare barren branches dead drought trunk winter wood
+🍇	food	grapes dionysus fruit grape
+🍈	food	melon cantaloupe fruit
+🍉	food	watermelon fruit
+🍊	food	tangerine c citrus fruit nectarine orange vitamin
+🍋	food	lemon citrus fruit sour
+🍋‍🟩	food	lime acidity citrus cocktail fruit garnish key margarita mojito refreshing salsa sour tangy tequila tropical zest
+🍌	food	banana fruit potassium
+🍍	food	pineapple colada fruit pina tropical
+🥭	food	mango food fruit tropical
+🍎	food	red apple diet food fruit health ripe
+🍏	food	green apple fruit
+🍐	food	pear fruit
+🍑	food	peach fruit
+🍒	food	cherries berries cherry fruit red
+🍓	food	strawberry berry fruit
+🫐	food	blueberries berries berry bilberry blue blueberry food fruit
+🥝	food	kiwi fruit food
+🍅	food	tomato food fruit vegetable
+🫒	food	olive food
+🥥	food	coconut colada palm pi a
+🥑	food	avocado food fruit
+🍆	food	eggplant aubergine vegetable
+🥔	food	potato food vegetable
+🥕	food	carrot food vegetable
+🌽	food	ear of corn crops farm maize maze
+🌶️	food	hot pepper
+🫑	food	bell pepper capsicum food vegetable
+🥒	food	cucumber food pickle vegetable
+🥬	food	leafy green bok burgers cabbage choy kale lettuce salad
+🥦	food	broccoli cabbage wild
+🧄	food	garlic flavoring
+🧅	food	onion flavoring
+🥜	food	peanuts food nut peanut vegetable
+🫘	food	beans food kidney legume small
+🌰	food	chestnut almond plant
+🫚	food	ginger root beer health herb natural spice
+🫛	food	pea pod beans beanstalk edamame legume soybean vegetable veggie
+🍄‍🟫	food	brown mushroom food fungi fungus nature pizza portobello shiitake shroom spore sprout toppings truffle vegetable vegetarian veggie
+🫜	food	root vegetable beet food garden radish salad turnip vegetarian
+🍞	food	bread carbs food grain loaf restaurant toast wheat
+🥐	food	croissant bread breakfast crescent food french roll
+🥖	food	baguette bread food french
+🫓	food	flatbread arepa bread food gordita lavash naan pita
+🥨	food	pretzel convoluted twisted
+🥯	food	bagel bakery bread breakfast schmear
+🥞	food	pancakes breakfast cr pe food hotcake pancake
+🧇	food	waffle breakfast indecisive iron
+🧀	food	cheese wedge
+🍖	food	meat on bone
+🍗	food	poultry leg bone chicken drumstick hungry turkey
+🥩	food	cut of meat chop lambchop porkchop red steak
+🥓	food	bacon breakfast food meat
+🍔	food	hamburger burger eat fast food hungry
+🍟	food	french fries fast food
+🍕	food	pizza cheese food hungry pepperoni slice
+🌭	food	hot dog frankfurter hotdog sausage
+🥪	food	sandwich bread
+🌮	food	taco mexican
+🌯	food	burrito mexican wrap
+🫔	food	tamale food mexican pamonha wrapped
+🥙	food	stuffed flatbread falafel food gyro kebab
+🧆	food	falafel chickpea meatball
+🥚	food	egg breakfast food
+🍳	food	cooking breakfast easy egg fry frying over pan restaurant side sunny up
+🥘	food	shallow pan of food casserole paella
+🍲	food	pot of food soup stew
+🫕	food	fondue cheese chocolate food melted pot ski
+🥣	food	bowl with spoon breakfast cereal congee oatmeal porridge
+🥗	food	green salad food
+🍿	food	popcorn corn movie pop
+🧈	food	butter dairy
+🧂	food	salt condiment flavor mad salty shaker taste upset
+🥫	food	canned food can
+🍱	food	bento box food
+🍘	food	rice cracker food
+🍙	food	rice ball food japanese
+🍚	food	cooked rice food
+🍛	food	curry rice food
+🍜	food	steaming bowl chopsticks food noodle pho ramen soup
+🍝	food	spaghetti food meatballs pasta restaurant
+🍠	food	roasted sweet potato food
+🍢	food	oden food kebab restaurant seafood skewer stick
+🍣	food	sushi food
+🍤	food	fried shrimp prawn tempura
+🍥	food	fish cake with swirl food pastry restaurant
+🥮	food	moon cake autumn festival yu b ng
+🍡	food	dango dessert japanese skewer stick sweet
+🥟	food	dumpling empanada gy za jiaozi pierogi potsticker
+🥠	food	fortune cookie prophecy
+🥡	food	takeout box chopsticks delivery food oyster pail
+🍦	food	soft ice cream dessert food icecream restaurant serve sweet
+🍧	food	shaved ice dessert restaurant sweet
+🍨	food	ice cream dessert food restaurant sweet
+🍩	food	doughnut breakfast dessert donut food sweet
+🍪	food	cookie chip chocolate dessert sweet
+🎂	food	birthday cake bday celebration dessert happy pastry sweet
+🍰	food	shortcake cake dessert pastry slice sweet
+🧁	food	cupcake bakery dessert sprinkles sugar sweet treat
+🥧	food	pie apple filling fruit meat pastry pumpkin slice
+🍫	food	chocolate bar candy dessert halloween sweet tooth
+🍬	food	candy cavities dessert halloween restaurant sweet tooth wrapper
+🍭	food	lollipop candy dessert food restaurant sweet
+🍮	food	custard dessert pudding sweet
+🍯	food	honey pot barrel bear food honeypot jar sweet
+🍼	food	baby bottle babies birth born drink infant milk newborn
+🥛	food	glass of milk drink
+☕	food	hot beverage cafe caffeine chai coffee drink morning steaming tea
+🫖	food	teapot brew drink food pot tea
+🍵	food	teacup without handle beverage cup drink oolong tea
+🍶	food	sake bar beverage bottle cup drink restaurant
+🍾	food	bottle with popping cork bar drink
+🍷	food	wine glass alcohol bar beverage booze club drink drinking drinks restaurant
+🍸	food	cocktail glass alcohol bar booze club drink drinking drinks mad martini men
+🍹	food	tropical drink alcohol bar booze club cocktail drinking drinks drunk mai party tai tropics
+🍺	food	beer mug alcohol ale bar booze drink drinking drinks octoberfest oktoberfest pint stein summer
+🍻	food	clinking beer mugs alcohol bar booze bottoms cheers clink drinking drinks
+🥂	food	clinking glasses celebrate clink drink glass
+🥃	food	tumbler glass liquor scotch shot whiskey whisky
+🫗	food	pouring liquid accident drink empty glass oops pour spill water
+🥤	food	cup with straw drink juice malt soda soft water
+🧋	food	bubble tea boba food milk pearl
+🧃	food	beverage box juice straw sweet
+🧉	food	mate drink
+🧊	food	ice cold cube iceberg
+🥢	food	chopsticks hashi jeotgarak kuaizi
+🍽️	food	fork and knife with plate cooking dinner eat
+🍴	food	fork and knife breakfast breaky cooking cutlery delicious dinner eat feed food hungry lunch restaurant yum yummy
+🥄	food	spoon eat tableware
+🔪	food	kitchen knife chef cooking hocho tool weapon
+🫙	food	jar condiment container empty nothing sauce store
+🏺	food	amphora aquarius cooking drink jug tool weapon zodiac
+🌍	travel	globe showing europe africa earth world
+🌎	travel	globe showing americas earth world
+🌏	travel	globe showing asia australia earth world
+🌐	travel	globe with meridians earth internet web world worldwide
+🗺️	travel	world map
+🗾	travel	map of japan
+🧭	travel	compass direction magnetic navigation orienteering
+🏔️	travel	snow capped mountain cold
+⛰️	travel	mountain
+🌋	travel	volcano eruption mountain nature
+🗻	travel	mount fuji mountain nature
+🏕️	travel	camping
+🏖️	travel	beach with umbrella
+🏜️	travel	desert
+🏝️	travel	desert island
+🏞️	travel	national park
+🏟️	travel	stadium
+🏛️	travel	classical building
+🏗️	travel	building construction crane
+🧱	travel	brick bricks clay mortar wall
+🪨	travel	rock boulder heavy solid stone tough
+🪵	travel	wood log lumber timber
+🛖	travel	hut home house roundhouse shelter yurt
+🏘️	travel	houses house
+🏚️	travel	derelict house home
+🏠	travel	house building country heart home ranch settle simple suburban suburbia where
+🏡	travel	house with garden building country heart home ranch settle simple suburban suburbia where
+🏢	travel	office building city cubical job
+🏣	travel	japanese post office building
+🏤	travel	post office building european
+🏥	travel	hospital building doctor medicine
+🏦	travel	bank building
+🏨	travel	hotel building
+🏩	travel	love hotel building
+🏪	travel	convenience store 24 building hours
+🏫	travel	school building
+🏬	travel	department store building
+🏭	travel	factory building
+🏯	travel	japanese castle building
+🏰	travel	castle building european
+💒	travel	wedding chapel hitched nuptials romance
+🗼	travel	tokyo tower
+🗽	travel	statue of liberty new ny nyc york
+⛪	travel	church bless chapel christian cross religion
+🕌	travel	mosque islam masjid muslim religion
+🛕	travel	hindu temple
+🕍	travel	synagogue jew jewish judaism religion temple
+⛩️	travel	shinto shrine religion
+🕋	travel	kaaba hajj islam muslim religion umrah
+⛲	travel	fountain
+⛺	travel	tent camping
+🌁	travel	foggy fog
+🌃	travel	night with stars star
+🏙️	travel	cityscape city
+🌄	travel	sunrise over mountains morning sun
+🌅	travel	sunrise morning nature sun
+🌆	travel	cityscape at dusk building city evening landscape sun sunset
+🌇	travel	sunset building dusk sun
+🌉	travel	bridge at night
+♨️	travel	hot springs hotsprings steaming
+🎠	travel	carousel horse entertainment
+🛝	travel	playground slide amusement park play playing sliding theme
+🎡	travel	ferris wheel amusement park theme
+🎢	travel	roller coaster amusement park theme
+💈	travel	barber pole cut fresh haircut shave
+🎪	travel	circus tent
+🚂	travel	locomotive caboose engine railway steam train trains travel
+🚃	travel	railway car electric train tram travel trolleybus
+🚄	travel	high speed train railway shinkansen
+🚅	travel	bullet train high speed nose railway shinkansen travel
+🚆	travel	train arrived choo railway
+🚇	travel	metro subway travel
+🚈	travel	light rail arrived monorail railway
+🚉	travel	station railway train
+🚊	travel	tram trolleybus
+🚝	travel	monorail vehicle
+🚞	travel	mountain railway car trip
+🚋	travel	tram car bus trolley trolleybus
+🚌	travel	bus school vehicle
+🚍	travel	oncoming bus cars
+🚎	travel	trolleybus bus tram trolley
+🚐	travel	minibus bus drive van vehicle
+🚑	travel	ambulance emergency vehicle
+🚒	travel	fire engine truck
+🚓	travel	police car 5 0 cops patrol
+🚔	travel	oncoming police car
+🚕	travel	taxi cab cabbie car drive vehicle yellow
+🚖	travel	oncoming taxi cab cabbie cars drove hail yellow
+🚗	travel	automobile car driving vehicle
+🚘	travel	oncoming automobile car cars drove vehicle
+🚙	travel	sport utility vehicle car drive recreational sportutility
+🛻	travel	pickup truck automobile car flatbed pick up transportation
+🚚	travel	delivery truck car drive vehicle
+🚛	travel	articulated lorry car drive move semi truck vehicle
+🚜	travel	tractor vehicle
+🏎️	travel	racing car zoom
+🏍️	travel	motorcycle racing
+🛵	travel	motor scooter
 🦽	travel	manual wheelchair accessibility
 🦼	travel	motorized wheelchair accessibility
-🛺	travel	auto rickshaw move transportation tuk
-🚲	travel	bicycle bike sports exercise hipster push vehicle
-🛴	travel	kick scooter vehicle kick razor
-🛹	travel	skateboard board skate
-🛼	travel	roller skate footwear sports derby inline
-🚏	travel	bus stop transportation wait busstop
-🛣️	travel	motorway road cupertino interstate highway
-🛤️	travel	railway track train transportation
-🛢️	travel	oil drum barrell
-⛽	travel	fuel pump gas station petroleum diesel fuelpump petrol
-🛞	travel	wheel car transport circle tire turn
-🚨	travel	police car light police ambulance 911 emergency alert error pinged law legal beacon cars car’s emergency light flashing revolving rotating siren vehicle warning
-🚥	travel	horizontal traffic light transportation signal
-🚦	travel	vertical traffic light transportation driving semaphore signal
-🛑	travel	stop sign stop octagonal
-🚧	travel	construction wip progress caution warning barrier black roadwork sign striped yellow work in progress
-⚓	travel	anchor ship ferry sea boat admiralty fisherman pattern tool
-🛟	travel	ring buoy life saver life preserver float rescue safety
-⛵	travel	sailboat ship summer transportation water sailing boat dinghy resort sea vehicle yacht
-🛶	travel	canoe boat paddle water ship
-🚤	travel	speedboat ship transportation vehicle summer boat motorboat powerboat
-🛳️	travel	passenger ship yacht cruise ferry vehicle
-⛴️	travel	ferry boat ship yacht passenger
-🛥️	travel	motor boat ship motorboat vehicle
-🚢	travel	ship transportation titanic deploy boat cruise passenger vehicle
-✈️	travel	airplane vehicle transportation flight fly aeroplane plane
-🛩️	travel	small airplane flight transportation fly vehicle aeroplane plane
-🛫	travel	airplane departure airport flight landing aeroplane departures off plane taking vehicle
-🛬	travel	airplane arrival airport flight boarding aeroplane arrivals arriving landing plane vehicle
-🪂	travel	parachute fly glide hang parasail skydive
-💺	travel	seat sit airplane transport bus flight fly aeroplane chair train
-🚁	travel	helicopter transportation vehicle fly
-🚟	travel	suspension railway vehicle transportation
-🚠	travel	mountain cableway transportation vehicle ski cable gondola
-🚡	travel	aerial tramway transportation vehicle ski cable car gondola ropeway
-🛰️	travel	satellite communication gps orbit spaceflight nasa iss artificial space vehicle
-🚀	travel	rocket launch ship staffmode nasa outer space fly shuttle vehicle deploy
-🛸	travel	flying saucer transportation vehicle ufo alien extraterrestrial fantasy space
-🛎️	travel	bellhop bell service hotel
-🧳	travel	luggage packing travel suitcase
-⌛	travel	hourglass done time clock oldschool limit exam quiz test sand timer
-⏳	travel	hourglass not done oldschool time countdown flowing sand timer
-⌚	travel	watch time accessories apple clock timepiece wrist wristwatch
-⏰	travel	alarm clock time wake morning
-⏱️	travel	stopwatch time deadline clock
-⏲️	travel	timer clock alarm
+🛺	travel	auto rickshaw tuk
+🚲	travel	bicycle bike class cycle cycling cyclist gang ride spin spinning
+🛴	travel	kick scooter
+🛹	travel	skateboard board skate skater wheels
+🛼	travel	roller skate blades skates sport
+🚏	travel	bus stop busstop
+🛣️	travel	motorway highway road
+🛤️	travel	railway track train
+🛢️	travel	oil drum
+⛽	travel	fuel pump diesel fuelpump gas gasoline station
+🛞	travel	wheel car circle tire turn vehicle
+🚨	travel	police car light alarm alert beacon emergency revolving siren
+🚥	travel	horizontal traffic light intersection signal stop stoplight
+🚦	travel	vertical traffic light drove intersection signal stop stoplight
+🛑	travel	stop sign octagonal
+🚧	travel	construction barrier
+⚓	travel	anchor ship tool
+🛟	travel	ring buoy float life lifesaver preserver rescue safety save saver swim
+⛵	travel	sailboat boat resort sailing sea yacht
+🛶	travel	canoe boat
+🚤	travel	speedboat billionaire boat lake luxury millionaire summer travel
+🛳️	travel	passenger ship
+⛴️	travel	ferry boat passenger
+🛥️	travel	motor boat motorboat
+🚢	travel	ship boat passenger travel
+✈️	travel	airplane aeroplane fly flying jet plane travel
+🛩️	travel	small airplane aeroplane plane
+🛫	travel	airplane departure aeroplane check in departures plane
+🛬	travel	airplane arrival aeroplane arrivals arriving landing plane
+🪂	travel	parachute hang glide parasail skydive
+💺	travel	seat chair
+🚁	travel	helicopter copter roflcopter travel vehicle
+🚟	travel	suspension railway
+🚠	travel	mountain cableway cable gondola lift ski
+🚡	travel	aerial tramway cable car gondola ropeway
+🛰️	travel	satellite space
+🚀	travel	rocket launch rockets space travel
+🛸	travel	flying saucer aliens extra terrestrial ufo
+🛎️	travel	bellhop bell hotel
+🧳	travel	luggage bag packing roller suitcase travel
+⌛	travel	hourglass done sand time timer
+⏳	travel	hourglass not done flowing hours sand timer waiting yolo
+⌚	travel	watch clock time
+⏰	travel	alarm clock hours hrs late time waiting
+⏱️	travel	stopwatch clock time
+⏲️	travel	timer clock
 🕰️	travel	mantelpiece clock time
-🕛	travel	twelve o’clock twelve o clock 12 00:00 0000 12:00 1200 time noon midnight midday late early schedule clock12 face oclock o’clock
-🕧	travel	twelve-thirty twelve thirty 00:30 0030 12:30 1230 time late early schedule clock clock1230 face
-🕐	travel	one o’clock one o clock 1 1:00 100 13:00 1300 time late early schedule clock1 face oclock o’clock
-🕜	travel	one-thirty one thirty 1:30 130 13:30 1330 time late early schedule clock clock130 face
-🕑	travel	two o’clock two o clock 2 2:00 200 14:00 1400 time late early schedule clock2 face oclock o’clock
-🕝	travel	two-thirty two thirty 2:30 230 14:30 1430 time late early schedule clock clock230 face
-🕒	travel	three o’clock three o clock 3 3:00 300 15:00 1500 time late early schedule clock3 face oclock o’clock
-🕞	travel	three-thirty three thirty 3:30 330 15:30 1530 time late early schedule clock clock330 face
-🕓	travel	four o’clock four o clock 4 4:00 400 16:00 1600 time late early schedule clock4 face oclock o’clock
-🕟	travel	four-thirty four thirty 4:30 430 16:30 1630 time late early schedule clock clock430 face
-🕔	travel	five o’clock five o clock 5 5:00 500 17:00 1700 time late early schedule clock5 face oclock o’clock
-🕠	travel	five-thirty five thirty 5:30 530 17:30 1730 time late early schedule clock clock530 face
-🕕	travel	six o’clock six o clock 6 6:00 600 18:00 1800 time late early schedule dawn dusk clock6 face oclock o’clock
-🕡	travel	six-thirty six thirty 6:30 630 18:30 1830 time late early schedule clock clock630 face
-🕖	travel	seven o’clock seven o clock 7 7:00 700 19:00 1900 time late early schedule clock7 face oclock o’clock
-🕢	travel	seven-thirty seven thirty 7:30 730 19:30 1930 time late early schedule clock clock730 face
-🕗	travel	eight o’clock eight o clock 8 8:00 800 20:00 2000 time late early schedule clock8 face oclock o’clock
-🕣	travel	eight-thirty eight thirty 8:30 830 20:30 2030 time late early schedule clock clock830 face
-🕘	travel	nine o’clock nine o clock 9 9:00 900 21:00 2100 time late early schedule clock9 face oclock o’clock
-🕤	travel	nine-thirty nine thirty 9:30 930 21:30 2130 time late early schedule clock clock930 face
-🕙	travel	ten o’clock ten o clock 10 10:00 1000 22:00 2200 time late early schedule clock10 face oclock o’clock
-🕥	travel	ten-thirty ten thirty 10:30 1030 22:30 2230 time late early schedule clock clock1030 face
-🕚	travel	eleven o’clock eleven o clock 11 11:00 1100 23:00 2300 time late early schedule clock11 face oclock o’clock
-🕦	travel	eleven-thirty eleven thirty 11:30 1130 23:30 2330 time late early schedule clock clock1130 face
-🌑	travel	new moon nature twilight planet space night evening sleep dark eclipse shadow moon solar symbol weather
-🌒	travel	waxing crescent moon nature twilight planet space night evening sleep symbol weather
-🌓	travel	first quarter moon nature twilight planet space night evening sleep symbol weather
-🌔	travel	waxing gibbous moon nature night sky gray twilight planet space evening sleep symbol weather
-🌕	travel	full moon nature yellow twilight planet space night evening sleep symbol weather
-🌖	travel	waning gibbous moon nature twilight planet space night evening sleep waxing gibbous moon symbol weather
-🌗	travel	last quarter moon nature twilight planet space night evening sleep symbol weather
-🌘	travel	waning crescent moon nature twilight planet space night evening sleep symbol weather
-🌙	travel	crescent moon night sleep sky evening magic space weather
-🌚	travel	new moon face nature twilight planet space night evening sleep creepy dark molester weather
-🌛	travel	first quarter moon face nature twilight planet space night evening sleep weather
-🌜	travel	last quarter moon face nature twilight planet space night evening sleep weather
-🌡️	travel	thermometer weather temperature hot cold
-☀️	travel	sun weather nature brightness summer beach spring black bright rays space sunny sunshine
-🌝	travel	full moon face nature twilight planet space night evening sleep bright moonface smiley smiling weather
-🌞	travel	sun with face nature morning sky bright smiley smiling space summer sunface weather
-🪐	travel	ringed planet outerspace planets saturn saturnine space
-⭐	travel	star night yellow gold medium white
-🌟	travel	glowing star night sparkle awesome good magic glittery glow shining star2
-🌠	travel	shooting star night photo activity falling meteoroid space stars upon when wish you
-🌌	travel	milky way photo space stars galaxy night sky universe weather
-☁️	travel	cloud weather sky cloudy overcast
-⛅	travel	sun behind cloud weather nature cloudy morning fall spring partly sunny
-⛈️	travel	cloud with lightning and rain weather lightning thunder
-🌤️	travel	sun behind small cloud weather white
-🌥️	travel	sun behind large cloud weather white
-🌦️	travel	sun behind rain cloud weather white
+🕛	travel	twelve o clock 12 00 time
+🕧	travel	twelve thirty 12 30 clock time
+🕐	travel	one o clock 1 00 time
+🕜	travel	one thirty 1 30 clock time
+🕑	travel	two o clock 2 00 time
+🕝	travel	two thirty 2 30 clock time
+🕒	travel	three o clock 3 00 time
+🕞	travel	three thirty 3 30 clock time
+🕓	travel	four o clock 4 00 time
+🕟	travel	four thirty 30 4 clock time
+🕔	travel	five o clock 5 00 time
+🕠	travel	five thirty 30 5 clock time
+🕕	travel	six o clock 6 00 time
+🕡	travel	six thirty 30 6 clock
+🕖	travel	seven o clock 0 7 00
+🕢	travel	seven thirty 30 7 clock
+🕗	travel	eight o clock 8 00 time
+🕣	travel	eight thirty 30 8 clock time
+🕘	travel	nine o clock 9 00 time
+🕤	travel	nine thirty 30 9 clock time
+🕙	travel	ten o clock 0 10 00
+🕥	travel	ten thirty 10 30 clock time
+🕚	travel	eleven o clock 11 00 time
+🕦	travel	eleven thirty 11 30 clock time
+🌑	travel	new moon dark space
+🌒	travel	waxing crescent moon dreams space
+🌓	travel	first quarter moon space
+🌔	travel	waxing gibbous moon space
+🌕	travel	full moon space
+🌖	travel	waning gibbous moon space
+🌗	travel	last quarter moon space
+🌘	travel	waning crescent moon space
+🌙	travel	crescent moon ramadan space
+🌚	travel	new moon face space
+🌛	travel	first quarter moon face space
+🌜	travel	last quarter moon face dreams
+🌡️	travel	thermometer weather
+☀️	travel	sun bright rays space sunny weather
+🌝	travel	full moon face bright
+🌞	travel	sun with face beach bright day heat shine sunny sunshine weather
+🪐	travel	ringed planet saturn saturnine
+⭐	travel	star astronomy medium stars white
+🌟	travel	glowing star glittery glow night shining sparkle win
+🌠	travel	shooting star falling night space
+🌌	travel	milky way space
+☁️	travel	cloud weather
+⛅	travel	sun behind cloud cloudy weather
+⛈️	travel	cloud with lightning and rain thunder thunderstorm
+🌤️	travel	sun behind small cloud weather
+🌥️	travel	sun behind large cloud weather
+🌦️	travel	sun behind rain cloud weather
 🌧️	travel	cloud with rain weather
-🌨️	travel	cloud with snow weather cold
-🌩️	travel	cloud with lightning weather thunder
-🌪️	travel	tornado weather cyclone twister cloud whirlwind
-🌫️	travel	fog weather cloud
-🌬️	travel	wind face gust air blow blowing cloud mother nature weather
-🌀	travel	cyclone weather swirl blue cloud vortex spiral whirlpool spin tornado hurricane typhoon dizzy twister
-🌈	travel	rainbow nature happy unicorn face photo sky spring gay lgbt pride primary rain weather
-🌂	travel	closed umbrella weather rain drizzle clothing collapsed umbrella pink
-☂️	travel	umbrella weather spring clothing open rain
-☔	travel	umbrella with rain drops rainy weather spring clothing drop raining
-⛱️	travel	umbrella on ground weather summer beach parasol rain sun
-⚡	travel	high voltage thunder weather lightning bolt fast zap danger electric electricity sign thunderbolt speed
-❄️	travel	snowflake winter season cold weather christmas xmas snow snowing
-☃️	travel	snowman winter season cold weather christmas xmas frozen snow snowflakes snowing
-⛄	travel	snowman without snow winter season cold weather christmas xmas frozen without snow frosty olaf
+🌨️	travel	cloud with snow cold weather
+🌩️	travel	cloud with lightning weather
+🌪️	travel	tornado cloud weather whirlwind
+🌫️	travel	fog cloud weather
+🌬️	travel	wind face blow cloud
+🌀	travel	cyclone dizzy hurricane twister typhoon weather
+🌈	travel	rainbow gay genderqueer glbt glbtq lesbian lgbt lgbtq lgbtqia nature pride queer rain trans transgender weather
+🌂	travel	closed umbrella clothing rain
+☂️	travel	umbrella clothing rain
+☔	travel	umbrella with rain drops clothing drop weather
+⛱️	travel	umbrella on ground rain sun
+⚡	travel	high voltage danger electric electricity lightning nature thunder thunderbolt zap
+❄️	travel	snowflake cold snow weather
+☃️	travel	snowman cold man snow
+⛄	travel	snowman without snow cold man
 ☄️	travel	comet space
-🔥	travel	fire hot cook flame burn lit snapstreak tool remove
-💧	travel	droplet water drip faucet spring cold comic drop sweat weather
-🌊	travel	water wave sea water wave nature tsunami disaster beach ocean waves weather
-🎃	activities	jack-o-lantern jack o lantern halloween light pumpkin creepy fall activity celebration entertainment gourd
-🎄	activities	christmas tree festival vacation december xmas celebration activity entertainment xmas tree
-🎆	activities	fireworks photo festival carnival congratulations activity celebration entertainment explosion
-🎇	activities	sparkler stars night shine activity celebration entertainment firework fireworks hanabi senko sparkle
-🧨	activities	firecracker dynamite boom explode explosion explosive fireworks
-✨	activities	sparkles stars shine shiny cool awesome good magic entertainment glitter sparkle star
-🎈	activities	balloon party celebration birthday circus activity entertainment red
-🎉	activities	party popper party congratulations birthday magic circus celebration tada activity entertainment hat hooray
-🎊	activities	confetti ball festival party birthday circus activity celebration entertainment
-🎋	activities	tanabata tree plant nature branch summer bamboo wish star festival tanzaku activity banner celebration entertainment japanese
-🎍	activities	pine decoration japanese plant nature vegetable panda new years bamboo activity celebration kadomatsu year
-🎎	activities	japanese dolls japanese toy kimono activity celebration doll entertainment festival hinamatsuri imperial
-🎏	activities	carp streamer fish japanese koinobori carp banner activity celebration entertainment flag flags socks wind
-🎐	activities	wind chime nature ding spring bell activity celebration entertainment furin jellyfish
-🎑	activities	moon viewing ceremony photo japan asia tsukimi activity autumn celebration dumplings entertainment festival grass harvest mid rice scene
-🧧	activities	red envelope gift ang good hóngbāo lai luck money packet pao see
-🎀	activities	ribbon decoration pink girl bowtie bow celebration
-🎁	activities	wrapped gift present birthday christmas xmas box celebration entertainment
-🎗️	activities	reminder ribbon sports cause support awareness celebration
-🎟️	activities	admission tickets sports concert entrance entertainment ticket
-🎫	activities	ticket event concert pass activity admission entertainment stub tour world
-🎖️	activities	military medal award winning army celebration decoration medallion
-🏆	activities	trophy win award contest place ftw ceremony championship prize winner winners
-🏅	activities	sports medal award winning gold winner
-🥇	activities	1st place medal award winning first gold
-🥈	activities	2nd place medal award second silver
-🥉	activities	3rd place medal award third bronze
-⚽	activities	soccer ball sports football
-⚾	activities	baseball sports balls ball softball
-🥎	activities	softball sports balls ball game glove sport underarm
-🏀	activities	basketball sports balls nba ball hoop orange
-🏐	activities	volleyball sports balls ball game
-🏈	activities	american football sports balls nfl ball gridiron superbowl
-🏉	activities	rugby football sports team ball league union
-🎾	activities	tennis sports balls green ball racket racquet
-🥏	activities	flying disc sports frisbee ultimate game golf sport
-🎳	activities	bowling sports fun play ball game pin pins skittles ten
-🏏	activities	cricket game sports ball bat field
-🏑	activities	field hockey sports ball game stick
-🏒	activities	ice hockey sports game puck stick
-🥍	activities	lacrosse sports ball stick game goal sport
-🏓	activities	ping pong sports pingpong ball bat game paddle table tennis
-🏸	activities	badminton sports birdie game racquet shuttlecock
-🥊	activities	boxing glove sports fighting
+🔥	travel	fire af burn flame hot lit litaf tool
+💧	travel	droplet cold comic drop nature sad sweat tear water weather
+🌊	travel	water wave nature ocean surf surfer surfing
+🎃	activities	jack o lantern celebration halloween pumpkin
+🎄	activities	christmas tree celebration
+🎆	activities	fireworks boom celebration entertainment yolo
+🎇	activities	sparkler boom celebration fireworks sparkle
+🧨	activities	firecracker dynamite explosive fire fireworks light pop popping spark
+✨	activities	sparkles magic sparkle star
+🎈	activities	balloon birthday celebrate celebration
+🎉	activities	party popper awesome birthday celebrate celebration excited hooray tada woohoo
+🎊	activities	confetti ball celebrate celebration party woohoo
+🎋	activities	tanabata tree banner celebration japanese
+🎍	activities	pine decoration bamboo celebration japanese plant
+🎎	activities	japanese dolls celebration doll festival
+🎏	activities	carp streamer celebration
+🎐	activities	wind chime bell celebration
+🎑	activities	moon viewing ceremony celebration
+🧧	activities	red envelope gift good h ngb o lai luck money see
+🎀	activities	ribbon celebration
+🎁	activities	wrapped gift birthday bow box celebration christmas present surprise
+🎗️	activities	reminder ribbon celebration
+🎟️	activities	admission tickets ticket
+🎫	activities	ticket admission stub
+🎖️	activities	military medal award celebration
+🏆	activities	trophy champion champs prize slay sport victory win winning
+🏅	activities	sports medal award gold winner
+🥇	activities	1st place medal first gold
+🥈	activities	2nd place medal second silver
+🥉	activities	3rd place medal bronze third
+⚽	activities	soccer ball football futbol sport
+⚾	activities	baseball ball sport
+🥎	activities	softball ball glove sports underarm
+🏀	activities	basketball ball hoop sport
+🏐	activities	volleyball ball game
+🏈	activities	american football ball bowl sport super
+🏉	activities	rugby football ball sport
+🎾	activities	tennis ball racquet sport
+🥏	activities	flying disc ultimate
+🎳	activities	bowling ball game sport strike
+🏏	activities	cricket game ball bat
+🏑	activities	field hockey ball game stick
+🏒	activities	ice hockey game puck stick
+🥍	activities	lacrosse ball goal sports stick
+🏓	activities	ping pong ball bat game paddle pingpong table tennis
+🏸	activities	badminton birdie game racquet shuttlecock
+🥊	activities	boxing glove
 🥋	activities	martial arts uniform judo karate taekwondo
-🥅	activities	goal net sports catch
-⛳	activities	flag in hole sports business flag hole summer golf
-⛸️	activities	ice skate sports skating
-🎣	activities	fishing pole food hobby summer entertainment fish rod
-🤿	activities	diving mask sport ocean scuba snorkeling
-🎽	activities	running shirt play pageant athletics marathon sash singlet
-🎿	activities	skis sports winter cold snow boot ski skiing
-🛷	activities	sled sleigh luge toboggan sledge
-🥌	activities	curling stone sports game rock
-🎯	activities	direct hit game play bar target bullseye activity archery bull dart darts entertainment eye
-🪀	activities	yo-yo yo yo toy fluctuate yoyo
-🪁	activities	kite wind fly soar toy
-🔫	activities	water pistol pistol violence weapon revolver gun handgun shoot squirt tool water
-🎱	activities	pool 8 ball pool hobby game luck magic 8ball billiard billiards cue eight snooker
-🔮	activities	crystal ball disco party magic circus fortune teller clairvoyant fairy fantasy psychic purple tale tool
-🪄	activities	magic wand supernature power witch wizard
-🎮	activities	video game play console ps4 controller entertainment gamepad playstation u wii xbox
-🕹️	activities	joystick game play entertainment video
-🎰	activities	slot machine bet gamble vegas fruit machine luck casino activity gambling game poker
-🎲	activities	game die dice random tabletop play luck entertainment gambling
-🧩	activities	puzzle piece interlocking puzzle piece clue jigsaw
-🧸	activities	teddy bear plush stuffed plaything toy
-🪅	activities	pinata mexico candy celebration party piñata
-🪩	activities	mirror ball disco dance party glitter
-🪆	activities	nesting dolls matryoshka toy doll russia russian
-♠️	activities	spade suit poker cards suits magic black card game spades
-♥️	activities	heart suit poker cards magic suits black card game hearts
-♦️	activities	diamond suit poker cards magic suits black card diamonds game
-♣️	activities	club suit poker cards magic suits black card clubs game
-♟️	activities	chess pawn expendable black dupe game piece
-🃏	activities	joker poker cards game play magic black card entertainment playing wildcard
-🀄	activities	mahjong red dragon game play chinese kanji tile
-🎴	activities	flower playing cards game sunset red activity card deck entertainment hanafuda hwatu japanese of cards
-🎭	activities	performing arts acting theater drama activity art comedy entertainment greek logo mask masks theatre theatre masks tragedy
-🖼️	activities	framed picture photography art frame museum painting
-🎨	activities	artist palette design paint draw colors activity art entertainment museum painting improve
-🧵	activities	thread needle sewing spool string crafts
-🪡	activities	sewing needle stitches embroidery sutures tailoring
-🧶	activities	yarn ball crochet knit crafts
-🪢	activities	knot rope scout tangled tie twine twist
-👓	objects	glasses fashion accessories eyesight nerdy dork geek clothing eye eyeglasses eyewear
-🕶️	objects	sunglasses face cool accessories dark eye eyewear glasses
-🥽	objects	goggles eyes protection safety clothing eye swimming welding
-🥼	objects	lab coat doctor experiment scientist chemist clothing
-🦺	objects	safety vest protection emergency
-👔	objects	necktie shirt suitup formal fashion cloth business clothing tie
-👕	objects	t-shirt t shirt fashion cloth casual shirt tee clothing polo tshirt
-👖	objects	jeans fashion shopping clothing denim pants trousers
-🧣	objects	scarf neck winter clothes clothing
-🧤	objects	gloves hands winter clothes clothing hand
-🧥	objects	coat jacket clothing
-🧦	objects	socks stockings clothes clothing pair stocking
-👗	objects	dress clothes fashion shopping clothing gown skirt
-👘	objects	kimono dress fashion women female japanese clothing dressing gown
-🥻	objects	sari dress clothing saree shari
-🩱	objects	one-piece swimsuit one piece swimsuit fashion bathing clothing suit swim
-🩲	objects	briefs clothing bathing brief suit swim swimsuit underwear
-🩳	objects	shorts clothing bathing pants suit swim swimsuit underwear
-👙	objects	bikini swimming female woman girl fashion beach summer bathers clothing swim swimsuit
-👚	objects	woman’s clothes woman s clothes fashion shopping bags female blouse clothing pink shirt womans woman’s
-🪭	objects	folding hand fan flamenco hot sensu
-👛	objects	purse fashion accessories money sales shopping clothing coin wallet
-👜	objects	handbag fashion accessory accessories shopping bag clothing purse women’s
-👝	objects	clutch bag bag accessories shopping clothing pouch small
-🛍️	objects	shopping bags mall buy purchase bag hotel
-🎒	objects	backpack student education bag activity rucksack satchel school
-🩴	objects	thong sandal footwear summer beach flip flops jandals sandals thongs zōri
-👞	objects	man’s shoe man s shoe fashion male brown clothing dress mans man’s
-👟	objects	running shoe shoes sports sneakers athletic clothing runner sneaker sport tennis trainer
-🥾	objects	hiking boot backpacking camping hiking clothing
-🥿	objects	flat shoe ballet slip-on slipper clothing woman’s
-👠	objects	high-heeled shoe high heeled shoe fashion shoes female pumps stiletto clothing heel heels woman
-👡	objects	woman’s sandal woman s sandal shoes fashion flip flops clothing heeled sandals shoe womans woman’s
-🩰	objects	ballet shoes dance clothing pointe shoe
-👢	objects	woman’s boot woman s boot shoes fashion boots clothing cowgirl heeled high knee shoe womans woman’s
-🪮	objects	hair pick afro comb
-👑	objects	crown king kod leader royalty lord clothing queen royal
-👒	objects	woman’s hat woman s hat fashion accessories female lady spring bow clothing ladies womans woman’s
-🎩	objects	top hat magic gentleman classy circus activity clothing entertainment formal groom tophat wear
-🎓	objects	graduation cap school college degree university graduation cap hat legal learn education academic activity board celebration clothing graduate mortar square
-🧢	objects	billed cap cap baseball clothing hat
-🪖	objects	military helmet army protection soldier warrior
-⛑️	objects	rescue worker’s helmet rescue worker s helmet construction build aid cross face hat white worker’s
-📿	objects	prayer beads dhikr religious clothing necklace religion rosary
-💄	objects	lipstick female girl fashion woman cosmetics gloss lip makeup style
-💍	objects	ring wedding propose marriage valentines diamond fashion jewelry gem engagement engaged romance
-💎	objects	gem stone blue ruby diamond jewelry gemstone jewel romance
-🔇	objects	muted speaker sound volume silence quiet cancellation mute off silent stroke
-🔈	objects	speaker low volume sound volume silence broadcast soft
-🔉	objects	speaker medium volume volume speaker broadcast low one reduce sound wave
-🔊	objects	speaker high volume volume noise noisy speaker broadcast entertainment increase loud sound three waves
-📢	objects	loudspeaker volume sound address announcement bullhorn communication loud megaphone pa public system
-📣	objects	megaphone sound speaker volume bullhorn cheering communication mega
-📯	objects	postal horn instrument music bugle communication entertainment french post
-🔔	objects	bell sound notification christmas xmas chime liberty ringer wedding
-🔕	objects	bell with slash sound volume mute quiet silent cancellation disabled forbidden muted no not notifications off prohibited ringer stroke
-🎼	objects	musical score treble clef compose activity entertainment music sheet
-🎵	objects	musical note score tone sound activity beamed eighth entertainment music notes pair quavers
-🎶	objects	musical notes music score activity entertainment multiple note singing
-🎙️	objects	studio microphone sing recording artist talkshow mic music podcast
-🎚️	objects	level slider scale music
-🎛️	objects	control knobs dial music
-🎤	objects	microphone sound music pa sing talkshow activity entertainment karaoke mic singing
-🎧	objects	headphone music score gadgets activity earbud earphone earphones entertainment headphones ipod
-📻	objects	radio communication music podcast program digital entertainment video wireless
-🎷	objects	saxophone music instrument jazz blues activity entertainment sax
-🎺	objects	trumpet music brass activity entertainment horn instrument jazz
-🪊	objects	trombone music instrument
-🪗	objects	accordion music accordian box concertina squeeze
-🎸	objects	guitar music instrument acoustic guitar activity bass electric entertainment rock
-🎹	objects	musical keyboard piano instrument compose activity entertainment music
-🎻	objects	violin music instrument orchestra symphony activity entertainment quartet smallest string world’s
-🪕	objects	banjo music instructment activity entertainment instrument stringed
-🥁	objects	drum music instrument drumsticks snare
-🪘	objects	long drum music beat conga djembe rhythm
-🪇	objects	maracas music instrument percussion shaker
-🪈	objects	flute bamboo music instrument pied piper recorder
-🪉	objects	harp music instrument
-📱	objects	mobile phone technology apple gadgets dial cell communication iphone smartphone telephone responsive design
-📲	objects	mobile phone with arrow iphone incoming call calling cell communication left pointing receive rightwards telephone
-☎️	objects	telephone technology communication dial black phone rotary
-📞	objects	telephone receiver technology communication dial call handset phone
-📟	objects	pager bbcall oldschool 90s beeper bleeper communication
-📠	objects	fax machine communication technology facsimile
-🔋	objects	battery power energy sustain aa phone
-🪫	objects	low battery drained dead electronic energy no red
-🔌	objects	electric plug charger power ac adaptor cable electricity
-💻	objects	laptop technology screen display monitor computer desktop notebook pc personal
-🖥️	objects	desktop computer technology computing screen imac
-🖨️	objects	printer paper ink computer
-⌨️	objects	keyboard technology computer type input text
-🖱️	objects	computer mouse click button three
-🖲️	objects	trackball technology trackpad computer
-💽	objects	computer disk technology record data disk 90s entertainment minidisc minidisk optical
-💾	objects	floppy disk oldschool technology save 90s 80s computer
-💿	objects	optical disk technology dvd disk disc 90s cd compact computer rom
-📀	objects	dvd cd disk disc computer entertainment optical rom video
-🧮	objects	abacus calculation count counting frame math
-🎥	objects	movie camera film record activity cinema entertainment hollywood video
-🎞️	objects	film frames movie cinema entertainment strip
-📽️	objects	film projector video tape record movie cinema entertainment
-🎬	objects	clapper board movie film record activity clapboard director entertainment slate
-📺	objects	television technology program oldschool show entertainment tv video
-📷	objects	camera gadgets photography digital entertainment photo video
-📸	objects	camera with flash photography gadgets photo video snapshots
-📹	objects	video camera film record camcorder entertainment
-📼	objects	videocassette record video oldschool 90s 80s entertainment tape vcr vhs
-🔍	objects	magnifying glass tilted left search zoom find detective icon mag magnifier pointing tool
-🔎	objects	magnifying glass tilted right search zoom find detective icon mag magnifier pointing tool seo
-🕯️	objects	candle fire wax light
-💡	objects	light bulb light electricity idea comic electric
-🔦	objects	flashlight dark camping sight night electric light tool torch
-🏮	objects	red paper lantern light paper halloween spooky asian bar izakaya japanese
-🪔	objects	diya lamp lighting oil
-📔	objects	notebook with decorative cover classroom notes record paper study book decorated
-📕	objects	closed book read library knowledge textbook learn red
-📖	objects	open book book read library knowledge literature learn study novel
-📗	objects	green book read library knowledge study textbook
-📘	objects	blue book read library knowledge learn study textbook
-📙	objects	orange book read library knowledge textbook study
-📚	objects	books literature library study book pile stack
-📓	objects	notebook stationery record notes paper study black book composition white
-📒	objects	ledger notes paper binder book bound notebook spiral yellow
-📃	objects	page with curl documents office paper curled curly page document license
-📜	objects	scroll documents ancient history paper degree document parchment
-📄	objects	page facing up documents office paper information document printed
-📰	objects	newspaper press headline communication news paper
-🗞️	objects	rolled-up newspaper rolled up newspaper press headline delivery news paper roll
-📑	objects	bookmark tabs favorite save order tidy mark marker
-🔖	objects	bookmark favorite label save mark price tag
-🏷️	objects	label sale tag
-🪙	objects	coin money currency gold metal silver treasure
-💰	objects	money bag dollar payment coins sale cream moneybag moneybags rich
-🪎	objects	treasure chest gold haul mimic crate jewelry riches
-💴	objects	yen banknote money sales japanese dollar currency bank banknotes bill note sign
-💵	objects	dollar banknote money sales bill currency american bank banknotes note sign
-💶	objects	euro banknote money sales dollar currency bank banknotes bill note sign
-💷	objects	pound banknote british sterling money sales bills uk england currency bank banknotes bill note quid sign twenty
-💸	objects	money with wings dollar bills payment sale bank banknote bill fly flying losing note
-💳	objects	credit card money sales dollar bill payment shopping amex bank club diners mastercard subscription visa
-🧾	objects	receipt accounting expenses bookkeeping evidence proof
-💹	objects	chart increasing with yen green-square graph presentation stats bank currency exchange growth market money rate rise sign trend upward upwards
-✉️	objects	envelope letter postal inbox communication email ✉ letter
-📧	objects	e-mail e mail communication inbox email letter symbol
-📨	objects	incoming envelope email inbox communication fast letter lines mail receive
-📩	objects	envelope with arrow email communication above down downwards insert letter mail outgoing sent
-📤	objects	outbox tray inbox email box communication letter mail sent
-📥	objects	inbox tray email documents box communication letter mail receive
-📦	objects	package mail gift cardboard box moving communication parcel shipping container
-📫	objects	closed mailbox with raised flag email inbox communication mail postbox
-📪	objects	closed mailbox with lowered flag email communication inbox mail postbox
-📬	objects	open mailbox with raised flag email inbox communication mail postbox
-📭	objects	open mailbox with lowered flag email inbox communication mail no postbox
-📮	objects	postbox email letter envelope communication mail mailbox
-🗳️	objects	ballot box with ballot election vote voting
-✏️	objects	pencil stationery write paper writing school study lead pencil2 typos
-✒️	objects	black nib pen stationery writing write fountain ✒ fountain
-🖋️	objects	fountain pen stationery writing write communication left lower
-🖊️	objects	pen stationery writing write ballpoint communication left lower
-🖌️	objects	paintbrush drawing creativity art brush communication left lower painting
-🖍️	objects	crayon drawing creativity communication left lower
-📝	objects	memo write documents stationery pencil paper writing legal exam quiz test study compose communication document memorandum note documentation
-💼	objects	briefcase business documents work law legal job career suitcase
-📁	objects	file folder documents business office closed directory manilla
-📂	objects	open file folder documents load
-🗂️	objects	card index dividers organizing business stationery
-📅	objects	calendar schedule date day emoji july world
-📆	objects	tear-off calendar tear off calendar schedule date planning day desk
-🗒️	objects	spiral notepad memo stationery note pad
-🗓️	objects	spiral calendar date schedule planning pad
-📇	objects	card index business stationery rolodex system
-📈	objects	chart increasing graph presentation stats recovery business economics money sales good success growth metrics pointing positive chart trend up upward upwards analytics
-📉	objects	chart decreasing graph presentation stats recession business economics money sales bad failure down downwards down pointing metrics negative chart trend
-📊	objects	bar chart graph presentation stats metrics
-📋	objects	clipboard stationery documents
-📌	objects	pushpin stationery mark here location pin tack thumb
-📍	objects	round pushpin stationery location map here dropped pin red
-📎	objects	paperclip documents stationery clippy
-🖇️	objects	linked paperclips documents stationery communication link paperclip
-📏	objects	straight ruler stationery calculate length math school drawing architect sketch edge
-📐	objects	triangular ruler stationery math architect sketch set triangle
-✂️	objects	scissors stationery cut black cutting tool
-🗃️	objects	card file box business stationery database
-🗄️	objects	file cabinet filing organizing
-🗑️	objects	wastebasket bin trash rubbish garbage toss basket can litter wastepaper
-🔒	objects	locked security password padlock closed lock private privacy
-🔓	objects	unlocked privacy security lock open padlock unlock
-🔏	objects	locked with pen security secret fountain ink lock lock with nib privacy
-🔐	objects	locked with key security privacy closed lock secure secret
-🔑	objects	key lock door password gold
-🗝️	objects	old key lock door password clue
-🔨	objects	hammer tools build create claw handyman tool
-🪓	objects	axe tool chop cut hatchet split wood
-⛏️	objects	pick tools dig mining pickaxe tool
-⚒️	objects	hammer and pick tools build create tool
-🛠️	objects	hammer and wrench tools build create spanner tool
-🗡️	objects	dagger weapon knife
+🥅	activities	goal net
+⛳	activities	flag in hole golf sport
+⛸️	activities	ice skate skating
+🎣	activities	fishing pole entertainment fish sport
+🤿	activities	diving mask scuba snorkeling
+🎽	activities	running shirt athletics sash
+🎿	activities	skis ski snow sport
+🛷	activities	sled luge sledge sleigh snow toboggan
+🥌	activities	curling stone game rock
+🎯	activities	bullseye bull dart direct entertainment game hit target
+🪀	activities	yo fluctuate toy
+🪁	activities	kite fly soar
+🔫	activities	water pistol gun handgun revolver tool weapon
+🎱	activities	pool 8 ball 8ball billiard eight game
+🔮	activities	crystal ball fairy fairytale fantasy fortune future magic tale tool
+🪄	activities	magic wand magician witch wizard
+🎮	activities	video game controller entertainment
+🕹️	activities	joystick game video videogame
+🎰	activities	slot machine casino gamble gambling game slots
+🎲	activities	game die dice entertainment
+🧩	activities	puzzle piece clue interlocking jigsaw
+🧸	activities	teddy bear plaything plush stuffed toy
+🪅	activities	pi ata candy celebrate celebration cinco de festive mayo party pinada pinata
+🪩	activities	mirror ball dance disco glitter party
+🪆	activities	nesting dolls babooshka baboushka babushka doll matryoshka russia
+♠️	activities	spade suit card game
+♥️	activities	heart suit card emotion game hearts
+♦️	activities	diamond suit card game
+♣️	activities	club suit card clubs game
+♟️	activities	chess pawn dupe expendable
+🃏	activities	joker card game wildcard
+🀄	activities	mahjong red dragon game
+🎴	activities	flower playing cards card game japanese
+🎭	activities	performing arts actor actress art entertainment mask theater theatre thespian
+🖼️	activities	framed picture art frame museum painting
+🎨	activities	artist palette art artsy arty colorful creative entertainment museum painter painting
+🧵	activities	thread needle sewing spool string
+🪡	activities	sewing needle embroidery sew stitches sutures tailoring thread
+🧶	activities	yarn ball crochet knit
+🪢	activities	knot cord rope tangled tie twine twist
+👓	objects	glasses clothing eye eyeglasses eyewear
+🕶️	objects	sunglasses dark eye eyewear glasses
+🥽	objects	goggles dive eye protection scuba swimming welding
+🥼	objects	lab coat clothes doctor dr experiment jacket scientist white
+🦺	objects	safety vest emergency
+👔	objects	necktie clothing employed serious shirt tie
+👕	objects	t shirt blue casual clothes clothing collar dressed shopping tshirt weekend
+👖	objects	jeans blue casual clothes clothing denim dressed pants shopping trousers weekend
+🧣	objects	scarf bundle cold neck up
+🧤	objects	gloves hand
+🧥	objects	coat brr bundle cold jacket up
+🧦	objects	socks stocking
+👗	objects	dress clothes clothing dressed fancy shopping
+👘	objects	kimono clothing comfortable
+🥻	objects	sari clothing dress
+🩱	objects	one piece swimsuit bathing suit
+🩲	objects	briefs bathing one piece suit swimsuit underwear
+🩳	objects	shorts bathing pants suit swimsuit underwear
+👙	objects	bikini bathing beach clothing pool suit swim
+👚	objects	woman s clothes blouse clothing collar dress dressed lady shirt shopping
+🪭	objects	folding hand fan clack clap cool cooling dance flirt flutter hot shy
+👛	objects	purse clothes clothing coin dress fancy handbag shopping
+👜	objects	handbag bag clothes clothing dress lady purse shopping
+👝	objects	clutch bag clothes clothing dress handbag pouch purse
+🛍️	objects	shopping bags bag hotel
+🎒	objects	backpack backpacking bag bookbag education rucksack satchel school
+🩴	objects	thong sandal beach flip flop sandals shoe thongs z ri
+👞	objects	man s shoe brown clothes clothing feet foot kick shoes shopping
+👟	objects	running shoe athletic clothes clothing fast kick shoes shopping sneaker tennis
+🥾	objects	hiking boot backpacking brown camping outdoors shoe
+🥿	objects	flat shoe ballet comfy flats slip on slipper
+👠	objects	high heeled shoe clothes clothing dress fashion heel heels shoes shopping stiletto woman
+👡	objects	woman s sandal clothing shoe
+🩰	objects	ballet shoes dance
+👢	objects	woman s boot clothes clothing dress shoe shoes shopping
+🪮	objects	hair pick afro comb groom
+👑	objects	crown clothing family king medieval queen royal royalty win
+👒	objects	woman s hat clothes clothing garden hats party
+🎩	objects	top hat clothes clothing fancy formal magic tophat
+🎓	objects	graduation cap celebration clothing education hat scholar
+🧢	objects	billed cap baseball bent dad hat
+🪖	objects	military helmet army soldier war warrior
+⛑️	objects	rescue worker s helmet aid cross face hat
+📿	objects	prayer beads clothing necklace religion
+💄	objects	lipstick cosmetics date makeup
+💍	objects	ring diamond engaged engagement married romance shiny sparkling wedding
+💎	objects	gem stone diamond engagement jewel money romance wedding
+🔇	objects	muted speaker mute quiet silent sound
+🔈	objects	speaker low volume soft sound
+🔉	objects	speaker medium volume sound
+🔊	objects	speaker high volume loud music sound
+📢	objects	loudspeaker address communication loud public sound
+📣	objects	megaphone cheering sound
+📯	objects	postal horn post
+🔔	objects	bell break church sound
+🔕	objects	bell with slash forbidden mute no not prohibited quiet silent sound
+🎼	objects	musical score music note
+🎵	objects	musical note music sound
+🎶	objects	musical notes music note sound
+🎙️	objects	studio microphone mic music
+🎚️	objects	level slider music
+🎛️	objects	control knobs music
+🎤	objects	microphone karaoke mic music sing sound
+🎧	objects	headphone earbud sound
+📻	objects	radio entertainment tbt video
+🎷	objects	saxophone instrument music sax
+🪗	objects	accordion box concertina instrument music squeeze squeezebox
+🎸	objects	guitar instrument music strat
+🎹	objects	musical keyboard instrument music piano
+🎺	objects	trumpet instrument music
+🎻	objects	violin instrument music
+🪕	objects	banjo music stringed
+🥁	objects	drum drumsticks music
+🪘	objects	long drum beat conga instrument rhythm
+🪇	objects	maracas cha dance instrument music party percussion rattle shake shaker
+🪈	objects	flute band fife flautist instrument marching music orchestra piccolo pipe recorder woodwind
+🪉	objects	harp cupid instrument love music orchestra
+📱	objects	mobile phone cell communication telephone
+📲	objects	mobile phone with arrow build call cell communication receive telephone
+☎️	objects	telephone phone
+📞	objects	telephone receiver communication phone voip
+📟	objects	pager communication
+📠	objects	fax machine communication
+🔋	objects	battery
+🪫	objects	low battery drained electronic energy power
+🔌	objects	electric plug electricity
+💻	objects	laptop computer office pc personal
+🖥️	objects	desktop computer monitor
+🖨️	objects	printer computer
+⌨️	objects	keyboard computer
+🖱️	objects	computer mouse
+🖲️	objects	trackball computer
+💽	objects	computer disk minidisk optical
+💾	objects	floppy disk computer
+💿	objects	optical disk blu ray cd computer dvd
+📀	objects	dvd blu ray cd computer disk optical
+🧮	objects	abacus calculation calculator
+🎥	objects	movie camera bollywood cinema film hollywood record
+🎞️	objects	film frames cinema movie
+📽️	objects	film projector cinema movie video
+🎬	objects	clapper board action movie
+📺	objects	television tv video
+📷	objects	camera photo selfie snap tbt trip video
+📸	objects	camera with flash video
+📹	objects	video camera camcorder tbt
+📼	objects	videocassette old school tape vcr vhs video
+🔍	objects	magnifying glass tilted left lab pointing science search tool
+🔎	objects	magnifying glass tilted right contact lab pointing science search tool
+🕯️	objects	candle light
+💡	objects	light bulb comic electric idea
+🔦	objects	flashlight electric light tool torch
+🏮	objects	red paper lantern bar light restaurant
+🪔	objects	diya lamp light oil
+📔	objects	notebook with decorative cover book decorated education school writing
+📕	objects	closed book education
+📖	objects	open book education fantasy knowledge library novels reading
+📗	objects	green book education fantasy library reading
+📘	objects	blue book education fantasy library reading
+📙	objects	orange book education fantasy library reading
+📚	objects	books book education fantasy knowledge library novels reading school study
+📓	objects	notebook
+📒	objects	ledger notebook
+📃	objects	page with curl document paper
+📜	objects	scroll paper
+📄	objects	page facing up document paper
+📰	objects	newspaper communication news paper
+🗞️	objects	rolled up newspaper news paper
+📑	objects	bookmark tabs mark marker
+🔖	objects	bookmark mark
+🏷️	objects	label tag
+💰	objects	money bag bank bet billion cash cost dollar gold million moneybag paid paying pot rich win
+🪙	objects	coin dollar euro gold metal money rich silver treasure
+💴	objects	yen banknote bank bill currency money note
+💵	objects	dollar banknote bank bill currency money note
+💶	objects	euro banknote 100 bank bill currency money note rich
+💷	objects	pound banknote bank bill billion cash currency money note pounds
+💸	objects	money with wings bank banknote bill billion cash dollar fly million note pay
+💳	objects	credit card bank cash charge money pay
+🧾	objects	receipt accounting bookkeeping evidence invoice proof
+💹	objects	chart increasing with yen bank currency graph growth market money rise trend upward
+✉️	objects	envelope e mail email letter
+📧	objects	e mail email letter
+📨	objects	incoming envelope delivering e mail email letter receive sent
+📩	objects	envelope with arrow communication down e mail email letter outgoing send sent
+📤	objects	outbox tray box email letter mail sent
+📥	objects	inbox tray box email letter mail receive zero
+📦	objects	package box communication delivery parcel shipping
+📫	objects	closed mailbox with raised flag communication mail postbox
+📪	objects	closed mailbox with lowered flag mail postbox
+📬	objects	open mailbox with raised flag mail postbox
+📭	objects	open mailbox with lowered flag mail postbox
+📮	objects	postbox mail mailbox
+🗳️	objects	ballot box with
+✏️	objects	pencil
+✒️	objects	black nib pen
+🖋️	objects	fountain pen
+🖊️	objects	pen ballpoint
+🖌️	objects	paintbrush painting
+🖍️	objects	crayon
+📝	objects	memo communication media notes pencil
+💼	objects	briefcase office
+📁	objects	file folder
+📂	objects	open file folder
+🗂️	objects	card index dividers
+📅	objects	calendar date
+📆	objects	tear off calendar
+🗒️	objects	spiral notepad note pad
+🗓️	objects	spiral calendar pad
+📇	objects	card index old rolodex school
+📈	objects	chart increasing data graph growth right trend up upward
+📉	objects	chart decreasing data down downward graph negative trend
+📊	objects	bar chart data graph
+📋	objects	clipboard do list notes
+📌	objects	pushpin collage pin
+📍	objects	round pushpin location map pin
+📎	objects	paperclip
+🖇️	objects	linked paperclips link paperclip
+📏	objects	straight ruler angle edge math straightedge
+📐	objects	triangular ruler angle math rule set slide triangle
+✂️	objects	scissors cut cutting paper tool
+🗃️	objects	card file box
+🗄️	objects	file cabinet filing paper
+🗑️	objects	wastebasket can garbage trash waste
+🔒	objects	locked closed lock private
+🔓	objects	unlocked cracked lock open unlock
+🔏	objects	locked with pen ink lock nib privacy
+🔐	objects	locked with key bike closed lock secure
+🔑	objects	key keys lock major password unlock
+🗝️	objects	old key clue lock
+🔨	objects	hammer home improvement repairs tool
+🪓	objects	axe ax chop hatchet split wood
+⛏️	objects	pick hammer mining tool
+⚒️	objects	hammer and pick tool
+🛠️	objects	hammer and wrench spanner tool
+🗡️	objects	dagger knife weapon
 ⚔️	objects	crossed swords weapon
-💣	objects	bomb boom explode explosion terrorism comic
-🪃	objects	boomerang weapon australia rebound repercussion
-🏹	objects	bow and arrow sports archer archery sagittarius tool zodiac
-🛡️	objects	shield protection security weapon
-🪚	objects	carpentry saw cut chop carpenter hand lumber tool
-🔧	objects	wrench tools diy ikea fix maintainer spanner tool
-🪛	objects	screwdriver tools screw tool
-🔩	objects	nut and bolt handy tools fix screw tool
+💣	objects	bomb boom comic dangerous explosion hot
+🪃	objects	boomerang rebound repercussion weapon
+🏹	objects	bow and arrow archer archery sagittarius tool weapon zodiac
+🛡️	objects	shield weapon
+🪚	objects	carpentry saw carpenter cut lumber tool trim
+🔧	objects	wrench home improvement spanner tool
+🪛	objects	screwdriver flathead handy screw tool
+🔩	objects	nut and bolt home improvement tool
 ⚙️	objects	gear cog cogwheel tool
-🗜️	objects	clamp tool compress compression table vice winzip
-⚖️	objects	balance scale law fairness weight justice libra scales tool zodiac
-🦯	objects	white cane probing cane accessibility blind white
-🔗	objects	link rings url chain hyperlink linked symbol
-⛓️‍💥	objects	broken chain constraint break
-⛓️	objects	chains lock arrest chain
-🪝	objects	hook tools catch crook curve ensnare fishing point selling tool
-🧰	objects	toolbox tools diy fix maintainer mechanic chest tool
-🧲	objects	magnet attraction magnetic horseshoe
-🪜	objects	ladder tools climb rung step tool
-🪏	objects	shovel tool dig
-⚗️	objects	alembic distilling science experiment chemistry tool
-🧪	objects	test tube chemistry experiment lab science chemist test
-🧫	objects	petri dish bacteria biology culture lab biologist
-🧬	objects	dna biologist genetics life double evolution gene helix
-🔬	objects	microscope laboratory experiment zoomin science study investigate magnify tool
-🔭	objects	telescope stars space zoom science astronomy stargazing tool
-📡	objects	satellite antenna communication future radio space dish signal
-💉	objects	syringe health hospital drugs blood medicine needle doctor nurse shot sick tool vaccination vaccine
-🩸	objects	drop of blood period hurt harm wound bleed doctor donation injury medicine menstruation
-💊	objects	pill health medicine doctor pharmacy drug capsule drugs sick tablet
-🩹	objects	adhesive bandage heal aid band doctor medicine plaster
-🩼	objects	crutch accessibility assist aid cane disability hurt mobility stick
-🩺	objects	stethoscope health doctor heart medicine healthcheck
-🩻	objects	x-ray skeleton medicine bones doctor medical ray x
-🚪	objects	door house entry exit doorway front
-🛗	objects	elevator lift accessibility hoist
-🪞	objects	mirror reflection reflector speculum
-🪟	objects	window scenery air frame fresh glass opening transparent view
-🛏️	objects	bed sleep rest bedroom hotel
-🛋️	objects	couch and lamp read chill hotel lounge settee sofa
-🪑	objects	chair sit furniture seat
-🚽	objects	toilet restroom wc washroom bathroom potty loo
-🪠	objects	plunger toilet cup force plumber suction
-🚿	objects	shower clean water bathroom bath head
-🛁	objects	bathtub clean shower bathroom bath bubble
-🪤	objects	mouse trap cheese bait mousetrap rodent snare
-🪒	objects	razor cut sharp shave
-🧴	objects	lotion bottle moisturizer sunscreen shampoo
+🗜️	objects	clamp compress tool vice
+⚖️	objects	balance scale justice libra scales tool weight zodiac
+🦯	objects	white cane accessibility blind probing
+🔗	objects	link links
+⛓️‍💥	objects	broken chain break breaking cuffs freedom
+⛓️	objects	chains chain
+🪝	objects	hook catch crook curve ensnare point selling
+🧰	objects	toolbox box chest mechanic red tool
+🧲	objects	magnet attraction horseshoe magnetic negative positive shape u
+🪜	objects	ladder climb rung step
+🪏	objects	shovel bury dig garden hole plant scoop snow spade
+⚗️	objects	alembic chemistry tool
+🧪	objects	test tube chemist chemistry experiment lab science
+🧫	objects	petri dish bacteria biologist biology culture lab
+🧬	objects	dna biologist evolution gene genetics life
+🔬	objects	microscope experiment lab science tool
+🔭	objects	telescope contact extraterrestrial science tool
+📡	objects	satellite antenna aliens contact dish science
+💉	objects	syringe doctor flu medicine needle shot sick tool vaccination
+🩸	objects	drop of blood bleed donation injury medicine menstruation
+💊	objects	pill doctor drugs medicated medicine pills sick vitamin
+🩹	objects	adhesive bandage
+🩼	objects	crutch aid cane disability help hurt injured mobility stick
+🩺	objects	stethoscope doctor heart medicine
+🩻	objects	x ray bones doctor medical skeleton skull xray
+🚪	objects	door back closet front
+🛗	objects	elevator accessibility hoist lift
+🪞	objects	mirror makeup reflection reflector speculum
+🪟	objects	window air frame fresh opening transparent view
+🛏️	objects	bed hotel sleep
+🛋️	objects	couch and lamp hotel
+🪑	objects	chair seat sit
+🚽	objects	toilet bathroom
+🪠	objects	plunger cup force plumber poop suction toilet
+🚿	objects	shower water
+🛁	objects	bathtub bath
+🪤	objects	mouse trap bait cheese lure mousetrap snare
+🪒	objects	razor sharp shave
+🧴	objects	lotion bottle moisturizer shampoo sunscreen
 🧷	objects	safety pin diaper punk rock
-🧹	objects	broom cleaning sweeping witch brush sweep
-🧺	objects	basket laundry farming picnic
-🧻	objects	roll of paper roll toilet towels
-🪣	objects	bucket water container cask pail vat
-🧼	objects	soap bar bathing cleaning lather soapdish
-🫧	objects	bubbles soap fun carbonation sparkling burp clean underwater
-🪥	objects	toothbrush hygiene dental bathroom brush clean teeth
-🧽	objects	sponge absorbing cleaning porous
-🧯	objects	fire extinguisher quench extinguish
+🧹	objects	broom cleaning sweeping witch
+🧺	objects	basket farming laundry picnic
+🧻	objects	roll of paper toilet towels
+🪣	objects	bucket cask pail vat
+🧼	objects	soap bar bathing clean cleaning lather soapdish
+🫧	objects	bubbles bubble burp clean floating pearl soap underwater
+🪥	objects	toothbrush bathroom brush clean dental hygiene teeth toiletry
+🧽	objects	sponge absorbing cleaning porous soak
+🧯	objects	fire extinguisher extinguish quench
 🛒	objects	shopping cart trolley
-🚬	objects	cigarette kills tobacco joint smoke activity smoking symbol
-⚰️	objects	coffin vampire dead die death rip graveyard cemetery casket funeral box remove
-🪦	objects	headstone death rip grave cemetery graveyard halloween tombstone
-⚱️	objects	funeral urn dead die death rip ashes vase
-🧿	objects	nazar amulet bead charm boncuğu evil eye talisman
-🪬	objects	hamsa religion protection amulet fatima hand mary miriam
-🗿	objects	moai rock easter island carving face human moyai statue stone
-🪧	objects	placard announcement demonstration lawn picket post protest sign
-🪪	objects	identification card document credentials id license security
-🏧	symbols	atm sign money sales cash blue-square payment bank automated machine teller
-🚮	symbols	litter in bin sign blue-square sign human info its litterbox person place put symbol trash
-🚰	symbols	potable water blue-square liquid restroom cleaning faucet drink drinking symbol tap thirst thirsty
-♿	symbols	wheelchair symbol blue-square disabled accessibility access accessible bathroom
-🚹	symbols	men’s room men s room toilet restroom wc blue-square gender male lavatory man mens men’s symbol
-🚺	symbols	women’s room women s room purple-square woman female toilet loo restroom gender lavatory symbol wc womens womens toilet women’s
-🚻	symbols	restroom blue-square toilet refresh wc gender bathroom lavatory sign
-🚼	symbols	baby symbol orange-square child change changing nursery station
-🚾	symbols	water closet toilet restroom blue-square lavatory wc
-🛂	symbols	passport control custom blue-square border permissions authorization roles
-🛃	symbols	customs passport border blue-square
-🛄	symbols	baggage claim blue-square airport transport
-🛅	symbols	left luggage blue-square travel baggage bag with key locked locker suitcase
-⚠️	symbols	warning exclamation wip alert error problem issue sign symbol
-🚸	symbols	children crossing school warning danger sign driving yellow-diamond child kids pedestrian traffic experience usability
-⛔	symbols	no entry limit security privacy bad denied stop circle forbidden not prohibited traffic
-🚫	symbols	prohibited forbid stop limit denied disallow circle backslash banned block crossed entry forbidden no not red restricted sign
-🚳	symbols	no bicycles no bikes bicycle bike cyclist prohibited circle forbidden not sign vehicle
-🚭	symbols	no smoking cigarette blue-square smell smoke forbidden not prohibited sign symbol
-🚯	symbols	no littering trash bin garbage circle do forbidden litter not prohibited symbol
-🚱	symbols	non-potable water non potable water drink faucet tap circle drinking forbidden no not prohibited symbol
-🚷	symbols	no pedestrians rules crossing walking circle forbidden not pedestrian people prohibited
-📵	symbols	no mobile phones iphone mute circle cell communication forbidden not phone prohibited smartphones telephone
-🔞	symbols	no one under eighteen 18 drink pub night minor circle age forbidden not nsfw prohibited restriction symbol underage
-☢️	symbols	radioactive nuclear danger international radiation sign symbol
-☣️	symbols	biohazard danger sign
-⬆️	symbols	up arrow blue-square continue top direction black cardinal north pointing upwards upgrade
-↗️	symbols	up-right arrow up right arrow blue-square point direction diagonal northeast east intercardinal north upper
-➡️	symbols	right arrow blue-square next black cardinal direction east pointing rightwards right arrow
-↘️	symbols	down-right arrow down right arrow blue-square direction diagonal southeast east intercardinal lower right arrow south
-⬇️	symbols	down arrow blue-square direction bottom black cardinal downwards down arrow pointing south downgrade
-↙️	symbols	down-left arrow down left arrow blue-square direction diagonal southwest intercardinal left arrow lower south west
-⬅️	symbols	left arrow blue-square previous back black cardinal direction leftwards left arrow pointing west
-↖️	symbols	up-left arrow up left arrow blue-square point direction diagonal northwest intercardinal left arrow north upper west
-↕️	symbols	up-down arrow up down arrow blue-square direction way vertical arrows intercardinal northwest
-↔️	symbols	left-right arrow left right arrow shape direction horizontal sideways arrows horizontal arrows
-↩️	symbols	right arrow curving left back return blue-square undo enter curved email hook leftwards reply
-↪️	symbols	left arrow curving right blue-square return rotate direction email forward hook rightwards right curved
-⤴️	symbols	right arrow curving up blue-square direction top heading pointing rightwards then upwards
-⤵️	symbols	right arrow curving down blue-square direction bottom curved downwards heading pointing rightwards then
-🔃	symbols	clockwise vertical arrows sync cycle round repeat arrow circle downwards open reload upwards
-🔄	symbols	counterclockwise arrows button blue-square sync cycle anticlockwise arrow circle downwards open refresh rotate switch upwards withershins
-🔙	symbols	back arrow arrow words return above leftwards
-🔚	symbols	end arrow words arrow above leftwards
-🔛	symbols	on! arrow on arrow arrow words above exclamation left mark on! right
-🔜	symbols	soon arrow arrow words above rightwards
-🔝	symbols	top arrow words blue-square above up upwards
-🛐	symbols	place of worship religion church temple prayer building religious
-⚛️	symbols	atom symbol science physics chemistry atheist
-🕉️	symbols	om hinduism buddhism sikhism jainism aumkara hindu omkara pranava religion symbol
-✡️	symbols	star of david judaism jew jewish magen religion
-☸️	symbols	wheel of dharma hinduism buddhism sikhism jainism buddhist helm religion
-☯️	symbols	yin yang balance religion tao taoist
-✝️	symbols	latin cross christianity christian religion
-☦️	symbols	orthodox cross suppedaneum religion christian
-☪️	symbols	star and crescent islam muslim religion
-☮️	symbols	peace symbol hippie sign
-🕎	symbols	menorah hanukkah candles jewish branches candelabrum candlestick chanukiah nine religion
-🔯	symbols	dotted six-pointed star dotted six pointed star purple-square religion jewish hexagram dot fortune middle
-🪯	symbols	khanda sikhism religion
-♈	symbols	aries sign purple-square zodiac astrology ram
-♉	symbols	taurus purple-square sign zodiac astrology bull ox
-♊	symbols	gemini sign zodiac purple-square astrology twins
-♋	symbols	cancer sign zodiac purple-square astrology crab
-♌	symbols	leo sign purple-square zodiac astrology lion
-♍	symbols	virgo sign zodiac purple-square astrology maiden virgin
-♎	symbols	libra sign purple-square zodiac astrology balance justice scales
-♏	symbols	scorpio sign zodiac purple-square astrology scorpion scorpius
-♐	symbols	sagittarius sign zodiac purple-square astrology archer
-♑	symbols	capricorn sign zodiac purple-square astrology goat
-♒	symbols	aquarius sign purple-square zodiac astrology bearer water
-♓	symbols	pisces purple-square sign zodiac astrology fish
-⛎	symbols	ophiuchus sign purple-square constellation astrology bearer serpent snake zodiac
-🔀	symbols	shuffle tracks button blue-square shuffle music random arrow arrows crossed rightwards symbol twisted merge
-🔁	symbols	repeat button loop record arrow arrows circle clockwise leftwards open retweet rightwards symbol
-🔂	symbols	repeat single button blue-square loop arrow arrows circle circled clockwise leftwards number once one open overlay rightwards symbol track
-▶️	symbols	play button blue-square right direction play arrow black forward pointing right triangle triangle
-⏩	symbols	fast-forward button fast forward button blue-square play speed continue arrow black double pointing right symbol triangle
-⏭️	symbols	next track button forward next blue-square arrow bar black double pointing right scene skip symbol triangle vertical
-⏯️	symbols	play or pause button blue-square play pause arrow bar black double play/pause pointing right symbol triangle vertical
-◀️	symbols	reverse button blue-square left direction arrow backward black pointing triangle
-⏪	symbols	fast reverse button play blue-square arrow black double left pointing rewind symbol triangle revert
-⏮️	symbols	last track button backward arrow bar black double left pointing previous scene skip symbol triangle vertical
-🔼	symbols	upwards button blue-square triangle direction point forward top arrow pointing red small up
-⏫	symbols	fast up button blue-square direction top arrow black double pointing triangle
-🔽	symbols	downwards button blue-square direction bottom arrow down pointing red small triangle
-⏬	symbols	fast down button blue-square direction bottom arrow black double pointing triangle
-⏸️	symbols	pause button pause blue-square bar double symbol vertical
-⏹️	symbols	stop button blue-square black for square symbol
-⏺️	symbols	record button blue-square black circle for symbol
-⏏️	symbols	eject button blue-square symbol
-🎦	symbols	cinema blue-square record film movie curtain stage theater activity camera entertainment movies screen symbol
-🔅	symbols	dim button sun afternoon warm summer brightness decrease low symbol
-🔆	symbols	bright button sun light brightness high increase symbol
-📶	symbols	antenna bars blue-square reception phone internet connection wifi bluetooth bars bar cell cellular communication mobile signal stairs strength telephone
-🛜	symbols	wireless wifi internet contactless signal
-📳	symbols	vibration mode orange-square phone cell communication heart mobile silent telephone
-📴	symbols	mobile phone off mute orange-square silence quiet cell communication telephone
-♀️	symbols	female sign woman women lady girl symbol venus
-♂️	symbols	male sign man boy men mars symbol
-⚧️	symbols	transgender symbol transgender lgbtq female lgbt male pride sign stroke
-✖️	symbols	multiplication sign math calculation cancel heavy multiply symbol x
-➕	symbols	plus sign math calculation addition more increase heavy symbol add
-➖	symbols	minus sign math calculation subtract less heavy symbol remove
-➗	symbols	division sign divide math calculation heavy symbol
-🟰	symbols	heavy equals sign math equality
-♾️	symbols	infinity forever paper permanent sign unbounded universal
-‼️	symbols	double exclamation mark exclamation surprise bangbang punctuation red
-⁉️	symbols	exclamation question mark wat punctuation surprise interrobang red
-❓	symbols	red question mark question mark doubt confused black ornament punctuation red
-❔	symbols	white question mark doubts gray huh confused grey ornament outlined punctuation
-❕	symbols	white exclamation mark surprise punctuation gray wow warning grey ornament outlined
-❗	symbols	red exclamation mark exclamation mark heavy exclamation mark danger surprise punctuation wow warning bang red symbol
-〰️	symbols	wavy dash draw line moustache mustache squiggle scribble punctuation wave
-💱	symbols	currency exchange money sales dollar travel bank
-💲	symbols	heavy dollar sign money sales payment currency buck
-⚕️	symbols	medical symbol health hospital aesculapius asclepius asklepios care doctor medicine rod snake staff
-♻️	symbols	recycling symbol arrow environment garbage trash black green logo recycle universal reuse
-⚜️	symbols	fleur-de-lis fleur de lis decorative scout new orleans saints scouts
-🔱	symbols	trident emblem weapon spear anchor pitchfork ship tool
-📛	symbols	name badge fire forbid tag tofu
-🔰	symbols	japanese symbol for beginner badge shield chevron green leaf mark shoshinsha tool yellow
-⭕	symbols	hollow red circle circle round correct heavy large mark o
-✅	symbols	check mark button green-square ok agree vote election answer tick green heavy symbol white pass tests
-☑️	symbols	check box with check ok agree confirm black-square vote election yes tick ballot checkbox mark
-✔️	symbols	check mark ok nike answer yes tick heavy
-❌	symbols	cross mark no delete remove cancel red multiplication multiply x
-❎	symbols	cross mark button x green-square no deny negative square squared
-➰	symbols	curly loop scribble draw shape squiggle curl curling
-➿	symbols	double curly loop tape cassette curl curling voicemail
-〽️	symbols	part alternation mark graph presentation stats business economics bad m mcdonald’s
-✳️	symbols	eight-spoked asterisk eight spoked asterisk star sparkle green-square
-✴️	symbols	eight-pointed star eight pointed star orange-square shape polygon black orange
-❇️	symbols	sparkle stars green-square awesome good fireworks
-©️	symbols	copyright ip license circle law legal c sign
-®️	symbols	registered alphabet circle r sign
-™️	symbols	trade mark trademark brand law legal sign tm
-🫟	symbols	splatter
-#️⃣	symbols	keycap: # keycap symbol blue-square twitter hash hashtag key number octothorpe pound sign
-*️⃣	symbols	keycap: * keycap star asterisk
-0️⃣	symbols	keycap: 0 keycap 0 0 numbers blue-square null zero digit
-1️⃣	symbols	keycap: 1 keycap 1 blue-square numbers 1 one digit
-2️⃣	symbols	keycap: 2 keycap 2 numbers 2 prime blue-square two digit
-3️⃣	symbols	keycap: 3 keycap 3 3 numbers prime blue-square three digit
-4️⃣	symbols	keycap: 4 keycap 4 4 numbers blue-square four digit
-5️⃣	symbols	keycap: 5 keycap 5 5 numbers blue-square prime five digit
-6️⃣	symbols	keycap: 6 keycap 6 6 numbers blue-square six digit
-7️⃣	symbols	keycap: 7 keycap 7 7 numbers blue-square prime seven digit
-8️⃣	symbols	keycap: 8 keycap 8 8 blue-square numbers eight digit
-9️⃣	symbols	keycap: 9 keycap 9 blue-square numbers 9 nine digit
-🔟	symbols	keycap: 10 keycap 10 numbers 10 blue-square ten number
-🔠	symbols	input latin uppercase alphabet words letters uppercase blue-square abcd capital for symbol
-🔡	symbols	input latin lowercase blue-square letters lowercase alphabet abcd for small symbol
-🔢	symbols	input numbers numbers blue-square 1234 1 2 3 4 for numeric symbol
-🔣	symbols	input symbols blue-square music note ampersand percent glyphs characters for symbol symbol input
-🔤	symbols	input latin letters blue-square alphabet abc for symbol
-🅰️	symbols	a button (blood type) a button red-square alphabet letter blood capital latin negative squared type
-🆎	symbols	ab button (blood type) ab button red-square alphabet blood negative squared type
-🅱️	symbols	b button (blood type) b button red-square alphabet letter blood capital latin negative squared type
-🆑	symbols	cl button alphabet words red-square clear sign squared
-🆒	symbols	cool button words blue-square sign square squared
-🆓	symbols	free button blue-square words sign squared
-ℹ️	symbols	information blue-square alphabet letter i info lowercase source tourist
-🆔	symbols	id button purple-square words identification identity sign squared
-Ⓜ️	symbols	circled m alphabet blue-circle letter capital circle latin metro
-🆕	symbols	new button blue-square words start fresh sign squared
-🆖	symbols	ng button blue-square words shape icon blooper good no sign squared
-🅾️	symbols	o button (blood type) o button alphabet red-square letter blood capital latin negative o2 squared type
-🆗	symbols	ok button good agree yes blue-square okay sign square squared
-🅿️	symbols	p button cars blue-square alphabet letter capital latin negative parking sign squared
-🆘	symbols	sos button help red-square words emergency 911 distress sign signal squared
-🆙	symbols	up! button up button blue-square above high exclamation level mark sign squared up!
-🆚	symbols	vs button words orange-square squared versus
-🈁	symbols	japanese “here” button japanese here button blue-square here katakana japanese destination koko meaning sign squared word “here”
-🈂️	symbols	japanese “service charge” button japanese service charge button japanese blue-square katakana charge” meaning or sa sign squared “service “service”
-🈷️	symbols	japanese “monthly amount” button japanese monthly amount button chinese month moon japanese orange-square kanji amount” cjk ideograph meaning radical sign squared u6708 unified “monthly
-🈶	symbols	japanese “not free of charge” button japanese not free of charge button orange-square chinese have kanji charge” cjk exist ideograph meaning own sign squared u6709 unified “not
-🈯	symbols	japanese “reserved” button japanese reserved button chinese point green-square kanji cjk finger ideograph meaning sign squared u6307 unified “reserved”
-🉐	symbols	japanese “bargain” button japanese bargain button chinese kanji obtain get circle acquire advantage circled ideograph meaning sign “bargain”
-🈹	symbols	japanese “discount” button japanese discount button cut divide chinese kanji pink-square bargain cjk ideograph meaning sale sign squared u5272 unified “discount”
-🈚	symbols	japanese “free of charge” button japanese free of charge button nothing chinese kanji japanese orange-square charge” cjk ideograph lacking meaning negation sign squared u7121 unified “free
-🈲	symbols	japanese “prohibited” button japanese prohibited button kanji japanese chinese forbidden limit restricted red-square cjk forbid ideograph meaning prohibit sign squared u7981 unified “prohibited”
-🉑	symbols	japanese “acceptable” button japanese acceptable button ok good chinese kanji agree yes orange-circle accept circled ideograph meaning sign “acceptable”
-🈸	symbols	japanese “application” button japanese application button chinese japanese kanji orange-square apply cjk form ideograph meaning monkey request sign squared u7533 unified “application”
-🈴	symbols	japanese “passing grade” button japanese passing grade button japanese chinese join kanji red-square agreement cjk grade” ideograph meaning sign squared together u5408 unified “passing
-🈳	symbols	japanese “vacancy” button japanese vacancy button kanji japanese chinese empty sky blue-square 7a7a available cjk ideograph meaning sign squared u7a7a unified “vacancy”
-㊗️	symbols	japanese “congratulations” button japanese congratulations button chinese kanji japanese red-circle circled congratulate congratulation ideograph meaning sign “congratulations”
-㊙️	symbols	japanese “secret” button japanese secret button privacy chinese sshh kanji red-circle circled ideograph meaning sign “secret”
-🈺	symbols	japanese “open for business” button japanese open for business button japanese opening hours orange-square 55b6 business” chinese cjk ideograph meaning operating sign squared u55b6 unified work “open
-🈵	symbols	japanese “no vacancy” button japanese no vacancy button full chinese japanese red-square kanji 6e80 cjk fullness ideograph meaning sign squared u6e80 unified vacancy” “full; “no
-🔴	symbols	red circle shape error danger geometric large
-🟠	symbols	orange circle round geometric large
-🟡	symbols	yellow circle round geometric large
-🟢	symbols	green circle round geometric large
-🔵	symbols	blue circle shape icon button geometric large
-🟣	symbols	purple circle round geometric large
-🟤	symbols	brown circle round geometric large
-⚫	symbols	black circle shape button round geometric medium
-⚪	symbols	white circle shape round geometric medium
-🟥	symbols	red square card geometric large
-🟧	symbols	orange square geometric large
-🟨	symbols	yellow square card geometric large
-🟩	symbols	green square geometric large
-🟦	symbols	blue square geometric large
-🟪	symbols	purple square geometric large
-🟫	symbols	brown square geometric large
-⬛	symbols	black large square shape icon button geometric
-⬜	symbols	white large square shape icon stone button geometric
-◼️	symbols	black medium square shape button icon geometric
-◻️	symbols	white medium square shape stone icon geometric
-◾	symbols	black medium-small square black medium small square icon shape button geometric
-◽	symbols	white medium-small square white medium small square shape stone icon button geometric
-▪️	symbols	black small square shape icon geometric
-▫️	symbols	white small square shape icon geometric
-🔶	symbols	large orange diamond shape jewel gem geometric
-🔷	symbols	large blue diamond shape jewel gem geometric
-🔸	symbols	small orange diamond shape jewel gem geometric
-🔹	symbols	small blue diamond shape jewel gem geometric
-🔺	symbols	red triangle pointed up shape direction up top geometric pointing small
-🔻	symbols	red triangle pointed down shape direction bottom geometric pointing small
-💠	symbols	diamond with a dot jewel blue gem crystal fancy comic cuteness flower geometric inside kawaii shape
-🔘	symbols	radio button input old music circle geometric
-🔳	symbols	white square button shape input geometric outlined
-🔲	symbols	black square button shape input frame geometric
-🏁	flags	chequered flag contest finishline race gokart checkered finish girl grid milestone racing
-🚩	flags	triangular flag mark milestone place pole post red flag
-🎌	flags	crossed flags japanese nation country border activity celebration cross flag two
-🏴	flags	black flag pirate waving
-🏳️	flags	white flag losing loser lost surrender give up fail waving
-🏳️‍🌈	flags	rainbow flag flag rainbow pride gay lgbt queer homosexual lesbian bisexual
-🏳️‍⚧️	flags	transgender flag transgender flag pride lgbtq blue lgbt light pink trans white
-🏴‍☠️	flags	pirate flag skull crossbones flag banner jolly plunder roger treasure
-🇦🇨	flags	flag: ascension island flag ascension island
-🇦🇩	flags	flag: andorra flag andorra ad flag nation country banner andorra andorran
-🇦🇪	flags	flag: united arab emirates flag united arab emirates united arab emirates flag nation country banner united arab emirates emirati uae
-🇦🇫	flags	flag: afghanistan flag afghanistan af flag nation country banner afghanistan afghan
-🇦🇬	flags	flag: antigua & barbuda flag antigua barbuda antigua barbuda flag nation country banner antigua barbuda
-🇦🇮	flags	flag: anguilla flag anguilla ai flag nation country banner anguilla anguillan
-🇦🇱	flags	flag: albania flag albania al flag nation country banner albania albanian
-🇦🇲	flags	flag: armenia flag armenia am flag nation country banner armenia armenian
-🇦🇴	flags	flag: angola flag angola ao flag nation country banner angola angolan
-🇦🇶	flags	flag: antarctica flag antarctica aq flag nation country banner antarctica antarctic
-🇦🇷	flags	flag: argentina flag argentina ar flag nation country banner argentina argentinian
-🇦🇸	flags	flag: american samoa flag american samoa american ws flag nation country banner american samoa samoan
-🇦🇹	flags	flag: austria flag austria at flag nation country banner austria austrian
-🇦🇺	flags	flag: australia flag australia au flag nation country banner australia aussie australian heard mcdonald
-🇦🇼	flags	flag: aruba flag aruba aw flag nation country banner aruba aruban
-🇦🇽	flags	flag: åland islands flag aland islands åland islands flag nation country banner aland islands
-🇦🇿	flags	flag: azerbaijan flag azerbaijan az flag nation country banner azerbaijan azerbaijani
-🇧🇦	flags	flag: bosnia & herzegovina flag bosnia herzegovina bosnia herzegovina flag nation country banner bosnia herzegovina
-🇧🇧	flags	flag: barbados flag barbados bb flag nation country banner barbados bajan barbadian
-🇧🇩	flags	flag: bangladesh flag bangladesh bd flag nation country banner bangladesh bangladeshi
-🇧🇪	flags	flag: belgium flag belgium be flag nation country banner belgium belgian
-🇧🇫	flags	flag: burkina faso flag burkina faso burkina faso flag nation country banner burkina faso burkinabe
-🇧🇬	flags	flag: bulgaria flag bulgaria bg flag nation country banner bulgaria bulgarian
-🇧🇭	flags	flag: bahrain flag bahrain bh flag nation country banner bahrain bahrainian bahrani
-🇧🇮	flags	flag: burundi flag burundi bi flag nation country banner burundi burundian
-🇧🇯	flags	flag: benin flag benin bj flag nation country banner benin beninese
-🇧🇱	flags	flag: st. barthélemy flag st barthelemy saint barthélemy flag nation country banner st barthelemy st.
-🇧🇲	flags	flag: bermuda flag bermuda bm flag nation country banner bermuda bermudan flag
-🇧🇳	flags	flag: brunei flag brunei bn darussalam flag nation country banner brunei bruneian
-🇧🇴	flags	flag: bolivia flag bolivia bo flag nation country banner bolivia bolivian
-🇧🇶	flags	flag: caribbean netherlands flag caribbean netherlands bonaire flag nation country banner caribbean netherlands eustatius saba sint
-🇧🇷	flags	flag: brazil flag brazil br flag nation country banner brazil brasil brazilian for
-🇧🇸	flags	flag: bahamas flag bahamas bs flag nation country banner bahamas bahamian
-🇧🇹	flags	flag: bhutan flag bhutan bt flag nation country banner bhutan bhutanese
-🇧🇻	flags	flag: bouvet island flag bouvet island norway
-🇧🇼	flags	flag: botswana flag botswana bw flag nation country banner botswana batswana
-🇧🇾	flags	flag: belarus flag belarus by flag nation country banner belarus belarusian
-🇧🇿	flags	flag: belize flag belize bz flag nation country banner belize belizean
-🇨🇦	flags	flag: canada flag canada ca flag nation country banner canada canadian
-🇨🇨	flags	flag: cocos (keeling) islands flag cocos islands cocos keeling islands flag nation country banner cocos islands island
-🇨🇩	flags	flag: congo - kinshasa flag congo kinshasa congo democratic republic flag nation country banner congo kinshasa drc
-🇨🇫	flags	flag: central african republic flag central african republic central african republic flag nation country banner central african republic
-🇨🇬	flags	flag: congo - brazzaville flag congo brazzaville congo flag nation country banner congo brazzaville republic
-🇨🇭	flags	flag: switzerland flag switzerland ch flag nation country banner switzerland cross red swiss
-🇨🇮	flags	flag: côte d’ivoire flag cote d ivoire ivory coast flag nation country banner cote d ivoire côte divoire d’ivoire
-🇨🇰	flags	flag: cook islands flag cook islands cook islands flag nation country banner cook islands island islander
-🇨🇱	flags	flag: chile flag chile flag nation country banner chile chilean
-🇨🇲	flags	flag: cameroon flag cameroon cm flag nation country banner cameroon cameroonian
-🇨🇳	flags	flag: china flag china china chinese prc flag country nation banner cn indicator letters regional symbol
-🇨🇴	flags	flag: colombia flag colombia co flag nation country banner colombia colombian
-🇨🇵	flags	flag: clipperton island flag clipperton island
-🇨🇶	flags	flag: sark flag sark cq flag banner
-🇨🇷	flags	flag: costa rica flag costa rica costa rica flag nation country banner costa rica rican
-🇨🇺	flags	flag: cuba flag cuba cu flag nation country banner cuba cuban
-🇨🇻	flags	flag: cape verde flag cape verde cabo verde flag nation country banner cape verde verdian
-🇨🇼	flags	flag: curaçao flag curacao curaçao flag nation country banner curacao antilles curaçaoan
-🇨🇽	flags	flag: christmas island flag christmas island christmas island flag nation country banner christmas island
-🇨🇾	flags	flag: cyprus flag cyprus cy flag nation country banner cyprus cypriot
-🇨🇿	flags	flag: czechia flag czechia cz flag nation country banner czechia czech republic
-🇩🇪	flags	flag: germany flag germany german nation flag country banner germany de deutsch indicator letters regional symbol
-🇩🇬	flags	flag: diego garcia flag diego garcia
-🇩🇯	flags	flag: djibouti flag djibouti dj flag nation country banner djibouti djiboutian
-🇩🇰	flags	flag: denmark flag denmark dk flag nation country banner denmark danish
-🇩🇲	flags	flag: dominica flag dominica dm flag nation country banner dominica
-🇩🇴	flags	flag: dominican republic flag dominican republic dominican republic flag nation country banner dominican republic dom rep
-🇩🇿	flags	flag: algeria flag algeria dz flag nation country banner algeria algerian
-🇪🇦	flags	flag: ceuta & melilla flag ceuta melilla
-🇪🇨	flags	flag: ecuador flag ecuador ec flag nation country banner ecuador ecuadorian
-🇪🇪	flags	flag: estonia flag estonia ee flag nation country banner estonia estonian
-🇪🇬	flags	flag: egypt flag egypt eg flag nation country banner egypt egyptian
-🇪🇭	flags	flag: western sahara flag western sahara western sahara flag nation country banner western sahara saharan west
-🇪🇷	flags	flag: eritrea flag eritrea er flag nation country banner eritrea eritrean
-🇪🇸	flags	flag: spain flag spain spain flag nation country banner ceuta es indicator letters melilla regional spanish symbol
-🇪🇹	flags	flag: ethiopia flag ethiopia et flag nation country banner ethiopia ethiopian
-🇪🇺	flags	flag: european union flag european union european union flag banner eu
-🇫🇮	flags	flag: finland flag finland fi flag nation country banner finland finnish
-🇫🇯	flags	flag: fiji flag fiji fj flag nation country banner fiji fijian
-🇫🇰	flags	flag: falkland islands flag falkland islands falkland islands malvinas flag nation country banner falkland islands falklander falklands island islas
-🇫🇲	flags	flag: micronesia flag micronesia micronesia federated states flag nation country banner micronesian
-🇫🇴	flags	flag: faroe islands flag faroe islands faroe islands flag nation country banner faroe islands island islander
-🇫🇷	flags	flag: france flag france banner flag nation france french country clipperton fr indicator island letters martin regional saint st. symbol
-🇬🇦	flags	flag: gabon flag gabon ga flag nation country banner gabon gabonese
-🇬🇧	flags	flag: united kingdom flag united kingdom united kingdom great britain northern ireland flag nation country banner british uk english england union jack united kingdom cornwall gb scotland wales
-🇬🇩	flags	flag: grenada flag grenada gd flag nation country banner grenada grenadian
-🇬🇪	flags	flag: georgia flag georgia ge flag nation country banner georgia georgian
-🇬🇫	flags	flag: french guiana flag french guiana french guiana flag nation country banner french guiana guinean
-🇬🇬	flags	flag: guernsey flag guernsey gg flag nation country banner guernsey
-🇬🇭	flags	flag: ghana flag ghana gh flag nation country banner ghana ghanaian
-🇬🇮	flags	flag: gibraltar flag gibraltar gi flag nation country banner gibraltar gibraltarian
-🇬🇱	flags	flag: greenland flag greenland gl flag nation country banner greenland greenlandic
-🇬🇲	flags	flag: gambia flag gambia gm flag nation country banner gambia gambian flag
-🇬🇳	flags	flag: guinea flag guinea gn flag nation country banner guinea guinean
-🇬🇵	flags	flag: guadeloupe flag guadeloupe gp flag nation country banner guadeloupe guadeloupean
-🇬🇶	flags	flag: equatorial guinea flag equatorial guinea equatorial gn flag nation country banner equatorial guinea equatoguinean guinean
-🇬🇷	flags	flag: greece flag greece gr flag nation country banner greece greek
-🇬🇸	flags	flag: south georgia & south sandwich islands flag south georgia south sandwich islands south georgia sandwich islands flag nation country banner south georgia south sandwich islands island
-🇬🇹	flags	flag: guatemala flag guatemala gt flag nation country banner guatemala guatemalan
-🇬🇺	flags	flag: guam flag guam gu flag nation country banner guam chamorro guamanian
-🇬🇼	flags	flag: guinea-bissau flag guinea bissau gw bissau flag nation country banner guinea bissau
-🇬🇾	flags	flag: guyana flag guyana gy flag nation country banner guyana guyanese
-🇭🇰	flags	flag: hong kong sar china flag hong kong sar china hong kong flag nation country banner hong kong sar china
-🇭🇲	flags	flag: heard & mcdonald islands flag heard mcdonald islands
-🇭🇳	flags	flag: honduras flag honduras hn flag nation country banner honduras honduran
-🇭🇷	flags	flag: croatia flag croatia hr flag nation country banner croatia croatian
-🇭🇹	flags	flag: haiti flag haiti ht flag nation country banner haiti haitian
-🇭🇺	flags	flag: hungary flag hungary hu flag nation country banner hungary hungarian
-🇮🇨	flags	flag: canary islands flag canary islands canary islands flag nation country banner canary islands island
-🇮🇩	flags	flag: indonesia flag indonesia flag nation country banner indonesia indonesian
-🇮🇪	flags	flag: ireland flag ireland ie flag nation country banner ireland irish flag
-🇮🇱	flags	flag: israel flag israel il flag nation country banner israel israeli
-🇮🇲	flags	flag: isle of man flag isle of man isle man flag nation country banner isle of man manx
-🇮🇳	flags	flag: india flag india in flag nation country banner india indian
-🇮🇴	flags	flag: british indian ocean territory flag british indian ocean territory british indian ocean territory flag nation country banner british indian ocean territory chagos diego garcia island
-🇮🇶	flags	flag: iraq flag iraq iq flag nation country banner iraq iraqi
-🇮🇷	flags	flag: iran flag iran iran islamic republic flag nation country banner iranian flag
-🇮🇸	flags	flag: iceland flag iceland is flag nation country banner iceland icelandic
-🇮🇹	flags	flag: italy flag italy italy flag nation country banner indicator italian letters regional symbol
-🇯🇪	flags	flag: jersey flag jersey je flag nation country banner jersey
-🇯🇲	flags	flag: jamaica flag jamaica jm flag nation country banner jamaica jamaican flag
-🇯🇴	flags	flag: jordan flag jordan jo flag nation country banner jordan jordanian
-🇯🇵	flags	flag: japan flag japan japanese nation flag country banner japan jp ja indicator letters regional symbol
-🇰🇪	flags	flag: kenya flag kenya ke flag nation country banner kenya kenyan
-🇰🇬	flags	flag: kyrgyzstan flag kyrgyzstan kg flag nation country banner kyrgyzstan kyrgyzstani
-🇰🇭	flags	flag: cambodia flag cambodia kh flag nation country banner cambodia cambodian
-🇰🇮	flags	flag: kiribati flag kiribati ki flag nation country banner kiribati i
-🇰🇲	flags	flag: comoros flag comoros km flag nation country banner comoros comoran
-🇰🇳	flags	flag: st. kitts & nevis flag st kitts nevis saint kitts nevis flag nation country banner st kitts nevis st.
-🇰🇵	flags	flag: north korea flag north korea north korea nation flag country banner north korea korean
-🇰🇷	flags	flag: south korea flag south korea south korea nation flag country banner south korea indicator korean kr letters regional symbol
-🇰🇼	flags	flag: kuwait flag kuwait kw flag nation country banner kuwait kuwaiti
-🇰🇾	flags	flag: cayman islands flag cayman islands cayman islands flag nation country banner cayman islands caymanian island
-🇰🇿	flags	flag: kazakhstan flag kazakhstan kz flag nation country banner kazakhstan kazakh kazakhstani
-🇱🇦	flags	flag: laos flag laos lao democratic republic flag nation country banner laos laotian
-🇱🇧	flags	flag: lebanon flag lebanon lb flag nation country banner lebanon lebanese
-🇱🇨	flags	flag: st. lucia flag st lucia saint lucia flag nation country banner st lucia st.
-🇱🇮	flags	flag: liechtenstein flag liechtenstein li flag nation country banner liechtenstein liechtensteiner
-🇱🇰	flags	flag: sri lanka flag sri lanka sri lanka flag nation country banner sri lanka lankan
-🇱🇷	flags	flag: liberia flag liberia lr flag nation country banner liberia liberian
-🇱🇸	flags	flag: lesotho flag lesotho ls flag nation country banner lesotho basotho
-🇱🇹	flags	flag: lithuania flag lithuania lt flag nation country banner lithuania lithuanian
-🇱🇺	flags	flag: luxembourg flag luxembourg lu flag nation country banner luxembourg luxembourger
-🇱🇻	flags	flag: latvia flag latvia lv flag nation country banner latvia latvian
-🇱🇾	flags	flag: libya flag libya ly flag nation country banner libya libyan
-🇲🇦	flags	flag: morocco flag morocco ma flag nation country banner morocco moroccan
-🇲🇨	flags	flag: monaco flag monaco mc flag nation country banner monaco monégasque
-🇲🇩	flags	flag: moldova flag moldova moldova republic flag nation country banner moldovan
-🇲🇪	flags	flag: montenegro flag montenegro me flag nation country banner montenegro montenegrin
-🇲🇫	flags	flag: st. martin flag st martin st.
-🇲🇬	flags	flag: madagascar flag madagascar mg flag nation country banner madagascar madagascan
-🇲🇭	flags	flag: marshall islands flag marshall islands marshall islands flag nation country banner marshall islands island marshallese
-🇲🇰	flags	flag: north macedonia flag north macedonia macedonia flag nation country banner north macedonia macedonian
-🇲🇱	flags	flag: mali flag mali ml flag nation country banner mali malian
-🇲🇲	flags	flag: myanmar (burma) flag myanmar mm flag nation country banner myanmar burma burmese for myanmarese flag
-🇲🇳	flags	flag: mongolia flag mongolia mn flag nation country banner mongolia mongolian
-🇲🇴	flags	flag: macao sar china flag macao sar china macao flag nation country banner macao sar china macanese flag macau
-🇲🇵	flags	flag: northern mariana islands flag northern mariana islands northern mariana islands flag nation country banner northern mariana islands island micronesian north
-🇲🇶	flags	flag: martinique flag martinique mq flag nation country banner martinique martiniquais flag of martinique snake
-🇲🇷	flags	flag: mauritania flag mauritania mr flag nation country banner mauritania mauritanian
-🇲🇸	flags	flag: montserrat flag montserrat ms flag nation country banner montserrat montserratian
-🇲🇹	flags	flag: malta flag malta mt flag nation country banner malta maltese
-🇲🇺	flags	flag: mauritius flag mauritius mu flag nation country banner mauritius mauritian
-🇲🇻	flags	flag: maldives flag maldives mv flag nation country banner maldives maldivian
-🇲🇼	flags	flag: malawi flag malawi mw flag nation country banner malawi malawian flag
-🇲🇽	flags	flag: mexico flag mexico mx flag nation country banner mexico mexican
-🇲🇾	flags	flag: malaysia flag malaysia my flag nation country banner malaysia malaysian
-🇲🇿	flags	flag: mozambique flag mozambique mz flag nation country banner mozambique mozambican
-🇳🇦	flags	flag: namibia flag namibia na flag nation country banner namibia namibian
-🇳🇨	flags	flag: new caledonia flag new caledonia new caledonia flag nation country banner new caledonia caledonian
-🇳🇪	flags	flag: niger flag niger ne flag nation country banner niger nigerien flag
-🇳🇫	flags	flag: norfolk island flag norfolk island norfolk island flag nation country banner norfolk island
-🇳🇬	flags	flag: nigeria flag nigeria flag nation country banner nigeria nigerian
-🇳🇮	flags	flag: nicaragua flag nicaragua ni flag nation country banner nicaragua nicaraguan
-🇳🇱	flags	flag: netherlands flag netherlands nl flag nation country banner netherlands dutch
-🇳🇴	flags	flag: norway flag norway no flag nation country banner norway bouvet jan mayen norwegian svalbard
-🇳🇵	flags	flag: nepal flag nepal np flag nation country banner nepal nepalese
-🇳🇷	flags	flag: nauru flag nauru nr flag nation country banner nauru nauruan
-🇳🇺	flags	flag: niue flag niue nu flag nation country banner niue niuean
-🇳🇿	flags	flag: new zealand flag new zealand new zealand flag nation country banner new zealand kiwi
-🇴🇲	flags	flag: oman flag oman om symbol flag nation country banner oman omani
-🇵🇦	flags	flag: panama flag panama pa flag nation country banner panama panamanian
-🇵🇪	flags	flag: peru flag peru pe flag nation country banner peru peruvian
-🇵🇫	flags	flag: french polynesia flag french polynesia french polynesia flag nation country banner french polynesia polynesian
-🇵🇬	flags	flag: papua new guinea flag papua new guinea papua new guinea flag nation country banner papua new guinea guinean png
-🇵🇭	flags	flag: philippines flag philippines ph flag nation country banner philippines
-🇵🇰	flags	flag: pakistan flag pakistan pk flag nation country banner pakistan pakistani
-🇵🇱	flags	flag: poland flag poland pl flag nation country banner poland polish
-🇵🇲	flags	flag: st. pierre & miquelon flag st pierre miquelon saint pierre miquelon flag nation country banner st pierre miquelon st.
-🇵🇳	flags	flag: pitcairn islands flag pitcairn islands pitcairn flag nation country banner pitcairn islands island
-🇵🇷	flags	flag: puerto rico flag puerto rico puerto rico flag nation country banner puerto rico rican
-🇵🇸	flags	flag: palestinian territories flag palestinian territories palestine palestinian territories flag nation country banner palestinian territories
-🇵🇹	flags	flag: portugal flag portugal pt flag nation country banner portugal portugese
-🇵🇼	flags	flag: palau flag palau pw flag nation country banner palau palauan
-🇵🇾	flags	flag: paraguay flag paraguay py flag nation country banner paraguay paraguayan
-🇶🇦	flags	flag: qatar flag qatar qa flag nation country banner qatar qatari
-🇷🇪	flags	flag: réunion flag reunion réunion flag nation country banner reunion réunionnais
-🇷🇴	flags	flag: romania flag romania ro flag nation country banner romania romanian
-🇷🇸	flags	flag: serbia flag serbia rs flag nation country banner serbia serbian flag
-🇷🇺	flags	flag: russia flag russia russian federation flag nation country banner russia indicator letters regional ru symbol
-🇷🇼	flags	flag: rwanda flag rwanda rw flag nation country banner rwanda rwandan
-🇸🇦	flags	flag: saudi arabia flag saudi arabia flag nation country banner saudi arabia arabian flag
-🇸🇧	flags	flag: solomon islands flag solomon islands solomon islands flag nation country banner solomon islands island islander flag
-🇸🇨	flags	flag: seychelles flag seychelles sc flag nation country banner seychelles seychellois flag
-🇸🇩	flags	flag: sudan flag sudan sd flag nation country banner sudan sudanese
-🇸🇪	flags	flag: sweden flag sweden se flag nation country banner sweden swedish
-🇸🇬	flags	flag: singapore flag singapore sg flag nation country banner singapore singaporean
-🇸🇭	flags	flag: st. helena flag st helena saint helena ascension tristan cunha flag nation country banner st helena st.
-🇸🇮	flags	flag: slovenia flag slovenia si flag nation country banner slovenia slovenian
-🇸🇯	flags	flag: svalbard & jan mayen flag svalbard jan mayen
-🇸🇰	flags	flag: slovakia flag slovakia sk flag nation country banner slovakia slovakian slovak flag
-🇸🇱	flags	flag: sierra leone flag sierra leone sierra leone flag nation country banner sierra leone leonean
-🇸🇲	flags	flag: san marino flag san marino san marino flag nation country banner san marino sammarinese
-🇸🇳	flags	flag: senegal flag senegal sn flag nation country banner senegal sengalese
-🇸🇴	flags	flag: somalia flag somalia so flag nation country banner somalia somalian flag
-🇸🇷	flags	flag: suriname flag suriname sr flag nation country banner suriname surinamer
-🇸🇸	flags	flag: south sudan flag south sudan south sd flag nation country banner south sudan sudanese flag
-🇸🇹	flags	flag: são tomé & príncipe flag sao tome principe sao tome principe flag nation country banner sao tome principe príncipe são tomé
-🇸🇻	flags	flag: el salvador flag el salvador el salvador flag nation country banner el salvador salvadoran
-🇸🇽	flags	flag: sint maarten flag sint maarten sint maarten dutch flag nation country banner sint maarten
-🇸🇾	flags	flag: syria flag syria syrian arab republic flag nation country banner syria
-🇸🇿	flags	flag: eswatini flag eswatini sz flag nation country banner eswatini swaziland
-🇹🇦	flags	flag: tristan da cunha flag tristan da cunha
-🇹🇨	flags	flag: turks & caicos islands flag turks caicos islands turks caicos islands flag nation country banner turks caicos islands island
-🇹🇩	flags	flag: chad flag chad td flag nation country banner chad chadian
-🇹🇫	flags	flag: french southern territories flag french southern territories french southern territories flag nation country banner french southern territories antarctic lands
-🇹🇬	flags	flag: togo flag togo tg flag nation country banner togo togolese
-🇹🇭	flags	flag: thailand flag thailand th flag nation country banner thailand thai
-🇹🇯	flags	flag: tajikistan flag tajikistan tj flag nation country banner tajikistan tajik
-🇹🇰	flags	flag: tokelau flag tokelau tk flag nation country banner tokelau tokelauan
-🇹🇱	flags	flag: timor-leste flag timor leste timor leste flag nation country banner timor leste east leste flag timorese
-🇹🇲	flags	flag: turkmenistan flag turkmenistan flag nation country banner turkmenistan turkmen
-🇹🇳	flags	flag: tunisia flag tunisia tn flag nation country banner tunisia tunisian
-🇹🇴	flags	flag: tonga flag tonga to flag nation country banner tonga tongan flag
-🇹🇷	flags	flag: türkiye flag turkey turkey flag nation country banner tr turkish flag türkiye
-🇹🇹	flags	flag: trinidad & tobago flag trinidad tobago trinidad tobago flag nation country banner trinidad tobago
-🇹🇻	flags	flag: tuvalu flag tuvalu flag nation country banner tuvalu tuvaluan
-🇹🇼	flags	flag: taiwan flag taiwan tw flag nation country banner taiwan china taiwanese
-🇹🇿	flags	flag: tanzania flag tanzania tanzania united republic flag nation country banner tanzanian
-🇺🇦	flags	flag: ukraine flag ukraine ua flag nation country banner ukraine ukrainian
-🇺🇬	flags	flag: uganda flag uganda ug flag nation country banner uganda ugandan flag
-🇺🇲	flags	flag: u.s. outlying islands flag u s outlying islands u.s. us
-🇺🇳	flags	flag: united nations flag united nations un flag banner
-🇺🇸	flags	flag: united states flag united states united states america flag nation country banner united states american indicator islands letters outlying regional symbol us usa
-🇺🇾	flags	flag: uruguay flag uruguay uy flag nation country banner uruguay uruguayan
-🇺🇿	flags	flag: uzbekistan flag uzbekistan uz flag nation country banner uzbekistan uzbek uzbekistani
-🇻🇦	flags	flag: vatican city flag vatican city vatican city flag nation country banner vatican city vanticanien
-🇻🇨	flags	flag: st. vincent & grenadines flag st vincent grenadines saint vincent grenadines flag nation country banner st vincent grenadines st.
-🇻🇪	flags	flag: venezuela flag venezuela ve bolivarian republic flag nation country banner venezuela venezuelan
-🇻🇬	flags	flag: british virgin islands flag british virgin islands british virgin islands bvi flag nation country banner british virgin islands island islander
-🇻🇮	flags	flag: u.s. virgin islands flag u s virgin islands virgin islands us flag nation country banner u s virgin islands america island islander states u.s. united usa
-🇻🇳	flags	flag: vietnam flag vietnam viet nam flag nation country banner vietnam vietnamese
-🇻🇺	flags	flag: vanuatu flag vanuatu vu flag nation country banner vanuatu ni vanuatu flag
-🇼🇫	flags	flag: wallis & futuna flag wallis futuna wallis futuna flag nation country banner wallis futuna
-🇼🇸	flags	flag: samoa flag samoa ws flag nation country banner samoa samoan flag
-🇽🇰	flags	flag: kosovo flag kosovo xk flag nation country banner kosovo kosovar
-🇾🇪	flags	flag: yemen flag yemen ye flag nation country banner yemen yemeni flag
-🇾🇹	flags	flag: mayotte flag mayotte yt flag nation country banner mayotte
-🇿🇦	flags	flag: south africa flag south africa south africa flag nation country banner south africa african flag
-🇿🇲	flags	flag: zambia flag zambia zm flag nation country banner zambia zambian
-🇿🇼	flags	flag: zimbabwe flag zimbabwe zw flag nation country banner zimbabwe zim zimbabwean flag
-🏴󠁧󠁢󠁥󠁮󠁧󠁿	flags	flag: england flag england flag english cross george's st
-🏴󠁧󠁢󠁳󠁣󠁴󠁿	flags	flag: scotland flag scotland flag scottish andrew's cross saltire st
-🏴󠁧󠁢󠁷󠁬󠁳󠁿	flags	flag: wales flag wales flag welsh baner cymru ddraig dragon goch red y
+🚬	objects	cigarette smoking
+⚰️	objects	coffin dead death vampire
+🪦	objects	headstone cemetery dead grave graveyard memorial rip tomb tombstone
+⚱️	objects	funeral urn ashes death
+🧿	objects	nazar amulet bead blue charm evil eye talisman
+🪬	objects	hamsa amulet fatima fortune guide hand mary miriam palm protect protection
+🗿	objects	moai face moyai statue stoneface travel
+🪧	objects	placard card demonstration notice picket plaque protest sign
+🪪	objects	identification card credentials document id license security
+🏧	symbols	atm sign automated bank cash money teller
+🚮	symbols	litter in bin sign litterbin
+🚰	symbols	potable water drinking
+♿	symbols	wheelchair symbol access handicap
+🚹	symbols	men s room bathroom lavatory man restroom toilet wc
+🚺	symbols	women s room bathroom lavatory restroom toilet wc woman
+🚻	symbols	restroom bathroom lavatory toilet wc
+🚼	symbols	baby symbol changing
+🚾	symbols	water closet bathroom lavatory restroom toilet wc
+🛂	symbols	passport control
+🛃	symbols	customs packing
+🛄	symbols	baggage claim arrived bags case checked journey packing plane ready travel trip
+🛅	symbols	left luggage baggage case locker
+⚠️	symbols	warning caution
+🚸	symbols	children crossing child pedestrian traffic
+⛔	symbols	no entry do fail forbidden not pass prohibited traffic
+🚫	symbols	prohibited entry forbidden no not smoke
+🚳	symbols	no bicycles bicycle bike forbidden not prohibited
+🚭	symbols	no smoking forbidden not prohibited smoke
+🚯	symbols	no littering forbidden litter not prohibited
+🚱	symbols	non potable water dry drinking prohibited
+🚷	symbols	no pedestrians forbidden not pedestrian prohibited
+📵	symbols	no mobile phones cell forbidden not phone prohibited telephone
+🔞	symbols	no one under eighteen 18 age forbidden not prohibited restriction underage
+☢️	symbols	radioactive sign
+☣️	symbols	biohazard sign
+⬆️	symbols	up arrow cardinal direction north
+↗️	symbols	up right arrow direction intercardinal northeast
+➡️	symbols	right arrow cardinal direction east
+↘️	symbols	down right arrow direction intercardinal southeast
+⬇️	symbols	down arrow cardinal direction south
+↙️	symbols	down left arrow direction intercardinal southwest
+⬅️	symbols	left arrow cardinal direction west
+↖️	symbols	up left arrow direction intercardinal northwest
+↕️	symbols	up down arrow
+↔️	symbols	left right arrow
+↩️	symbols	right arrow curving left
+↪️	symbols	left arrow curving right
+⤴️	symbols	right arrow curving up
+⤵️	symbols	right arrow curving down
+🔃	symbols	clockwise vertical arrows arrow refresh reload
+🔄	symbols	counterclockwise arrows button again anticlockwise arrow deja refresh rewindershins vu
+🔙	symbols	back arrow
+🔚	symbols	end arrow
+🔛	symbols	on arrow mark
+🔜	symbols	soon arrow brb omw
+🔝	symbols	top arrow homie up
+🛐	symbols	place of worship pray religion
+⚛️	symbols	atom symbol atheist
+🕉️	symbols	om hindu religion
+✡️	symbols	star of david jew jewish judaism religion
+☸️	symbols	wheel of dharma buddhist religion
+☯️	symbols	yin yang difficult lives religion tao taoist total yinyang
+✝️	symbols	latin cross christ christian religion
+☦️	symbols	orthodox cross christian religion
+☪️	symbols	star and crescent islam muslim ramadan religion
+☮️	symbols	peace symbol healing peaceful
+🕎	symbols	menorah candelabrum candlestick hanukkah jewish judaism religion
+🔯	symbols	dotted six pointed star fortune jewish judaism
+🪯	symbols	khanda deg fateh khalsa religion sikh sikhism tegh
+♈	symbols	aries horoscope ram zodiac
+♉	symbols	taurus bull horoscope ox zodiac
+♊	symbols	gemini horoscope twins zodiac
+♋	symbols	cancer crab horoscope zodiac
+♌	symbols	leo horoscope lion zodiac
+♍	symbols	virgo horoscope zodiac
+♎	symbols	libra balance horoscope justice scales zodiac
+♏	symbols	scorpio horoscope scorpion scorpius zodiac
+♐	symbols	sagittarius archer horoscope zodiac
+♑	symbols	capricorn goat horoscope zodiac
+♒	symbols	aquarius bearer horoscope water zodiac
+♓	symbols	pisces fish horoscope zodiac
+⛎	symbols	ophiuchus bearer serpent snake zodiac
+🔀	symbols	shuffle tracks button arrow crossed
+🔁	symbols	repeat button arrow clockwise
+🔂	symbols	repeat single button arrow clockwise once
+▶️	symbols	play button arrow right triangle
+⏩	symbols	fast forward button arrow double
+⏭️	symbols	next track button arrow scene triangle
+⏯️	symbols	play or pause button arrow right triangle
+◀️	symbols	reverse button arrow left triangle
+⏪	symbols	fast reverse button arrow double rewind
+⏮️	symbols	last track button arrow previous scene triangle
+🔼	symbols	upwards button arrow red up
+⏫	symbols	fast up button arrow double
+🔽	symbols	downwards button arrow down red
+⏬	symbols	fast down button arrow double
+⏸️	symbols	pause button bar double vertical
+⏹️	symbols	stop button square
+⏺️	symbols	record button circle
+⏏️	symbols	eject button
+🎦	symbols	cinema camera film movie
+🔅	symbols	dim button brightness low
+🔆	symbols	bright button brightness light
+📶	symbols	antenna bars bar cell communication mobile phone signal telephone
+🛜	symbols	wireless broadband computer connectivity hotspot internet network router smartphone wi fi wifi wlan
+📳	symbols	vibration mode cell communication mobile phone telephone
+📴	symbols	mobile phone off cell telephone
+♀️	symbols	female sign woman
+♂️	symbols	male sign man
+⚧️	symbols	transgender symbol
+✖️	symbols	multiply cancel multiplication sign x
+➕	symbols	plus
+➖	symbols	minus heavy math sign
+➗	symbols	divide division heavy math sign
+🟰	symbols	heavy equals sign answer equal equality math
+♾️	symbols	infinity forever unbounded universal
+‼️	symbols	double exclamation mark bangbang punctuation
+⁉️	symbols	exclamation question mark interrobang punctuation
+❓	symbols	red question mark punctuation
+❔	symbols	white question mark outlined punctuation
+❕	symbols	white exclamation mark outlined punctuation
+❗	symbols	red exclamation mark punctuation
+〰️	symbols	wavy dash punctuation
+💱	symbols	currency exchange bank money
+💲	symbols	heavy dollar sign billion cash charge currency million money pay
+⚕️	symbols	medical symbol aesculapius medicine staff
+♻️	symbols	recycling symbol recycle
+⚜️	symbols	fleur de lis knights
+🔱	symbols	trident emblem anchor poseidon ship tool
+📛	symbols	name badge
+🔰	symbols	japanese symbol for beginner chevron green leaf tool yellow
+⭕	symbols	hollow red circle heavy large o
+✅	symbols	check mark button checked checkmark complete completed done fixed tick
+☑️	symbols	check box with ballot checked done off tick
+✔️	symbols	check mark checked checkmark done heavy tick
+❌	symbols	cross mark cancel multiplication multiply x
+❎	symbols	cross mark button multiplication multiply square x
+➰	symbols	curly loop curl
+➿	symbols	double curly loop curl
+〽️	symbols	part alternation mark
+✳️	symbols	eight spoked asterisk
+✴️	symbols	eight pointed star
+❇️	symbols	sparkle
+©️	symbols	copyright c
+®️	symbols	registered r
+™️	symbols	trade mark tm trademark
+🫟	symbols	splatter drip holi ink liquid mess paint spill stain
+#️⃣	symbols	keycap
+*️⃣	symbols	keycap
+0️⃣	symbols	keycap 0
+1️⃣	symbols	keycap 1
+2️⃣	symbols	keycap 2
+3️⃣	symbols	keycap 3
+4️⃣	symbols	keycap 4
+5️⃣	symbols	keycap 5
+6️⃣	symbols	keycap 6
+7️⃣	symbols	keycap 7
+8️⃣	symbols	keycap 8
+9️⃣	symbols	keycap 9
+🔟	symbols	keycap 10
+🔠	symbols	input latin uppercase abcd letters
+🔡	symbols	input latin lowercase abcd letters
+🔢	symbols	input numbers 1234
+🔣	symbols	input symbols
+🔤	symbols	input latin letters abc alphabet
+🅰️	symbols	a button blood type
+🆎	symbols	ab button blood type
+🅱️	symbols	b button blood type
+🆑	symbols	cl button
+🆒	symbols	cool button
+🆓	symbols	free button
+ℹ️	symbols	information i
+🆔	symbols	id button identity
+Ⓜ️	symbols	circled m circle
+🆕	symbols	new button
+🆖	symbols	ng button
+🅾️	symbols	o button blood type
+🆗	symbols	ok button okay
+🅿️	symbols	p button parking
+🆘	symbols	sos button help
+🆙	symbols	up button mark
+🆚	symbols	vs button versus
+🈁	symbols	japanese here button katakana
+🈂️	symbols	japanese service charge button katakana
+🈷️	symbols	japanese monthly amount button ideograph
+🈶	symbols	japanese not free of charge button ideograph
+🈯	symbols	japanese reserved button ideograph
+🉐	symbols	japanese bargain button ideograph
+🈹	symbols	japanese discount button ideograph
+🈚	symbols	japanese free of charge button ideograph
+🈲	symbols	japanese prohibited button ideograph
+🉑	symbols	japanese acceptable button ideograph
+🈸	symbols	japanese application button ideograph
+🈴	symbols	japanese passing grade button ideograph
+🈳	symbols	japanese vacancy button ideograph
+㊗️	symbols	japanese congratulations button ideograph
+㊙️	symbols	japanese secret button ideograph
+🈺	symbols	japanese open for business button ideograph
+🈵	symbols	japanese no vacancy button ideograph
+🔴	symbols	red circle geometric
+🟠	symbols	orange circle
+🟡	symbols	yellow circle
+🟢	symbols	green circle
+🔵	symbols	blue circle geometric
+🟣	symbols	purple circle
+🟤	symbols	brown circle
+⚫	symbols	black circle geometric
+⚪	symbols	white circle geometric
+🟥	symbols	red square card penalty
+🟧	symbols	orange square
+🟨	symbols	yellow square card penalty
+🟩	symbols	green square
+🟦	symbols	blue square
+🟪	symbols	purple square
+🟫	symbols	brown square
+⬛	symbols	black large square geometric
+⬜	symbols	white large square geometric
+◼️	symbols	black medium square geometric
+◻️	symbols	white medium square geometric
+◾	symbols	black medium small square geometric
+◽	symbols	white medium small square geometric
+▪️	symbols	black small square geometric
+▫️	symbols	white small square geometric
+🔶	symbols	large orange diamond geometric
+🔷	symbols	large blue diamond geometric
+🔸	symbols	small orange diamond geometric
+🔹	symbols	small blue diamond geometric
+🔺	symbols	red triangle pointed up geometric
+🔻	symbols	red triangle pointed down geometric
+💠	symbols	diamond with a dot comic geometric
+🔘	symbols	radio button geometric
+🔳	symbols	white square button geometric outlined
+🔲	symbols	black square button geometric
+🏁	flags	chequered flag checkered finish flags game race racing sport win country nation banner
+🚩	flags	triangular flag construction golf post country nation banner
+🎌	flags	crossed flags celebration cross japanese flag country nation banner
+🏴	flags	black flag waving country nation banner
+🏳️	flags	white flag waving country nation banner
+🏳️‍🌈	flags	rainbow flag bisexual gay genderqueer glbt glbtq lesbian lgbt lgbtq lgbtqia pride queer trans transgender country nation banner
+🏳️‍⚧️	flags	transgender flag blue light pink white country nation banner
+🏴‍☠️	flags	pirate flag jolly plunder roger treasure country nation banner
+🇦🇨	flags	flag ascension island country nation banner
+🇦🇩	flags	flag andorra country nation banner
+🇦🇪	flags	flag united arab emirates country nation banner
+🇦🇫	flags	flag afghanistan country nation banner
+🇦🇬	flags	flag antigua barbuda country nation banner
+🇦🇮	flags	flag anguilla country nation banner
+🇦🇱	flags	flag albania country nation banner
+🇦🇲	flags	flag armenia country nation banner
+🇦🇴	flags	flag angola country nation banner
+🇦🇶	flags	flag antarctica country nation banner
+🇦🇷	flags	flag argentina country nation banner
+🇦🇸	flags	flag american samoa country nation banner
+🇦🇹	flags	flag austria country nation banner
+🇦🇺	flags	flag australia country nation banner
+🇦🇼	flags	flag aruba country nation banner
+🇦🇽	flags	flag land islands country nation banner
+🇦🇿	flags	flag azerbaijan country nation banner
+🇧🇦	flags	flag bosnia herzegovina country nation banner
+🇧🇧	flags	flag barbados country nation banner
+🇧🇩	flags	flag bangladesh country nation banner
+🇧🇪	flags	flag belgium country nation banner
+🇧🇫	flags	flag burkina faso country nation banner
+🇧🇬	flags	flag bulgaria country nation banner
+🇧🇭	flags	flag bahrain country nation banner
+🇧🇮	flags	flag burundi country nation banner
+🇧🇯	flags	flag benin country nation banner
+🇧🇱	flags	flag st barth lemy country nation banner
+🇧🇲	flags	flag bermuda country nation banner
+🇧🇳	flags	flag brunei country nation banner
+🇧🇴	flags	flag bolivia country nation banner
+🇧🇶	flags	flag caribbean netherlands country nation banner
+🇧🇷	flags	flag brazil country nation banner
+🇧🇸	flags	flag bahamas country nation banner
+🇧🇹	flags	flag bhutan country nation banner
+🇧🇻	flags	flag bouvet island country nation banner
+🇧🇼	flags	flag botswana country nation banner
+🇧🇾	flags	flag belarus country nation banner
+🇧🇿	flags	flag belize country nation banner
+🇨🇦	flags	flag canada country nation banner
+🇨🇨	flags	flag cocos keeling islands country nation banner
+🇨🇩	flags	flag congo kinshasa country nation banner
+🇨🇫	flags	flag central african republic country nation banner
+🇨🇬	flags	flag congo brazzaville country nation banner
+🇨🇭	flags	flag switzerland country nation banner
+🇨🇮	flags	flag c te d ivoire country nation banner
+🇨🇰	flags	flag cook islands country nation banner
+🇨🇱	flags	flag chile country nation banner
+🇨🇲	flags	flag cameroon country nation banner
+🇨🇳	flags	flag china country nation banner
+🇨🇴	flags	flag colombia country nation banner
+🇨🇵	flags	flag clipperton island country nation banner
+🇨🇶	flags	flag sark country nation banner
+🇨🇷	flags	flag costa rica country nation banner
+🇨🇺	flags	flag cuba country nation banner
+🇨🇻	flags	flag cape verde country nation banner
+🇨🇼	flags	flag cura ao country nation banner
+🇨🇽	flags	flag christmas island country nation banner
+🇨🇾	flags	flag cyprus country nation banner
+🇨🇿	flags	flag czechia country nation banner
+🇩🇪	flags	flag germany country nation banner
+🇩🇬	flags	flag diego garcia country nation banner
+🇩🇯	flags	flag djibouti country nation banner
+🇩🇰	flags	flag denmark country nation banner
+🇩🇲	flags	flag dominica country nation banner
+🇩🇴	flags	flag dominican republic country nation banner
+🇩🇿	flags	flag algeria country nation banner
+🇪🇦	flags	flag ceuta melilla country nation banner
+🇪🇨	flags	flag ecuador country nation banner
+🇪🇪	flags	flag estonia country nation banner
+🇪🇬	flags	flag egypt country nation banner
+🇪🇭	flags	flag western sahara country nation banner
+🇪🇷	flags	flag eritrea country nation banner
+🇪🇸	flags	flag spain country nation banner
+🇪🇹	flags	flag ethiopia country nation banner
+🇪🇺	flags	flag european union country nation banner
+🇫🇮	flags	flag finland country nation banner
+🇫🇯	flags	flag fiji country nation banner
+🇫🇰	flags	flag falkland islands country nation banner
+🇫🇲	flags	flag micronesia country nation banner
+🇫🇴	flags	flag faroe islands country nation banner
+🇫🇷	flags	flag france country nation banner
+🇬🇦	flags	flag gabon country nation banner
+🇬🇧	flags	flag united kingdom country nation banner
+🇬🇩	flags	flag grenada country nation banner
+🇬🇪	flags	flag georgia country nation banner
+🇬🇫	flags	flag french guiana country nation banner
+🇬🇬	flags	flag guernsey country nation banner
+🇬🇭	flags	flag ghana country nation banner
+🇬🇮	flags	flag gibraltar country nation banner
+🇬🇱	flags	flag greenland country nation banner
+🇬🇲	flags	flag gambia country nation banner
+🇬🇳	flags	flag guinea country nation banner
+🇬🇵	flags	flag guadeloupe country nation banner
+🇬🇶	flags	flag equatorial guinea country nation banner
+🇬🇷	flags	flag greece country nation banner
+🇬🇸	flags	flag south georgia sandwich islands country nation banner
+🇬🇹	flags	flag guatemala country nation banner
+🇬🇺	flags	flag guam country nation banner
+🇬🇼	flags	flag guinea bissau country nation banner
+🇬🇾	flags	flag guyana country nation banner
+🇭🇰	flags	flag hong kong sar china country nation banner
+🇭🇲	flags	flag heard mcdonald islands country nation banner
+🇭🇳	flags	flag honduras country nation banner
+🇭🇷	flags	flag croatia country nation banner
+🇭🇹	flags	flag haiti country nation banner
+🇭🇺	flags	flag hungary country nation banner
+🇮🇨	flags	flag canary islands country nation banner
+🇮🇩	flags	flag indonesia country nation banner
+🇮🇪	flags	flag ireland country nation banner
+🇮🇱	flags	flag israel country nation banner
+🇮🇲	flags	flag isle of man country nation banner
+🇮🇳	flags	flag india country nation banner
+🇮🇴	flags	flag british indian ocean territory country nation banner
+🇮🇶	flags	flag iraq country nation banner
+🇮🇷	flags	flag iran country nation banner
+🇮🇸	flags	flag iceland country nation banner
+🇮🇹	flags	flag italy country nation banner
+🇯🇪	flags	flag jersey country nation banner
+🇯🇲	flags	flag jamaica country nation banner
+🇯🇴	flags	flag jordan country nation banner
+🇯🇵	flags	flag japan country nation banner
+🇰🇪	flags	flag kenya country nation banner
+🇰🇬	flags	flag kyrgyzstan country nation banner
+🇰🇭	flags	flag cambodia country nation banner
+🇰🇮	flags	flag kiribati country nation banner
+🇰🇲	flags	flag comoros country nation banner
+🇰🇳	flags	flag st kitts nevis country nation banner
+🇰🇵	flags	flag north korea country nation banner
+🇰🇷	flags	flag south korea country nation banner
+🇰🇼	flags	flag kuwait country nation banner
+🇰🇾	flags	flag cayman islands country nation banner
+🇰🇿	flags	flag kazakhstan country nation banner
+🇱🇦	flags	flag laos country nation banner
+🇱🇧	flags	flag lebanon country nation banner
+🇱🇨	flags	flag st lucia country nation banner
+🇱🇮	flags	flag liechtenstein country nation banner
+🇱🇰	flags	flag sri lanka country nation banner
+🇱🇷	flags	flag liberia country nation banner
+🇱🇸	flags	flag lesotho country nation banner
+🇱🇹	flags	flag lithuania country nation banner
+🇱🇺	flags	flag luxembourg country nation banner
+🇱🇻	flags	flag latvia country nation banner
+🇱🇾	flags	flag libya country nation banner
+🇲🇦	flags	flag morocco country nation banner
+🇲🇨	flags	flag monaco country nation banner
+🇲🇩	flags	flag moldova country nation banner
+🇲🇪	flags	flag montenegro country nation banner
+🇲🇫	flags	flag st martin country nation banner
+🇲🇬	flags	flag madagascar country nation banner
+🇲🇭	flags	flag marshall islands country nation banner
+🇲🇰	flags	flag north macedonia country nation banner
+🇲🇱	flags	flag mali country nation banner
+🇲🇲	flags	flag myanmar burma country nation banner
+🇲🇳	flags	flag mongolia country nation banner
+🇲🇴	flags	flag macao sar china country nation banner
+🇲🇵	flags	flag northern mariana islands country nation banner
+🇲🇶	flags	flag martinique country nation banner
+🇲🇷	flags	flag mauritania country nation banner
+🇲🇸	flags	flag montserrat country nation banner
+🇲🇹	flags	flag malta country nation banner
+🇲🇺	flags	flag mauritius country nation banner
+🇲🇻	flags	flag maldives country nation banner
+🇲🇼	flags	flag malawi country nation banner
+🇲🇽	flags	flag mexico country nation banner
+🇲🇾	flags	flag malaysia country nation banner
+🇲🇿	flags	flag mozambique country nation banner
+🇳🇦	flags	flag namibia country nation banner
+🇳🇨	flags	flag new caledonia country nation banner
+🇳🇪	flags	flag niger country nation banner
+🇳🇫	flags	flag norfolk island country nation banner
+🇳🇬	flags	flag nigeria country nation banner
+🇳🇮	flags	flag nicaragua country nation banner
+🇳🇱	flags	flag netherlands country nation banner
+🇳🇴	flags	flag norway country nation banner
+🇳🇵	flags	flag nepal country nation banner
+🇳🇷	flags	flag nauru country nation banner
+🇳🇺	flags	flag niue country nation banner
+🇳🇿	flags	flag new zealand country nation banner
+🇴🇲	flags	flag oman country nation banner
+🇵🇦	flags	flag panama country nation banner
+🇵🇪	flags	flag peru country nation banner
+🇵🇫	flags	flag french polynesia country nation banner
+🇵🇬	flags	flag papua new guinea country nation banner
+🇵🇭	flags	flag philippines country nation banner
+🇵🇰	flags	flag pakistan country nation banner
+🇵🇱	flags	flag poland country nation banner
+🇵🇲	flags	flag st pierre miquelon country nation banner
+🇵🇳	flags	flag pitcairn islands country nation banner
+🇵🇷	flags	flag puerto rico country nation banner
+🇵🇸	flags	flag palestinian territories country nation banner
+🇵🇹	flags	flag portugal country nation banner
+🇵🇼	flags	flag palau country nation banner
+🇵🇾	flags	flag paraguay country nation banner
+🇶🇦	flags	flag qatar country nation banner
+🇷🇪	flags	flag r union country nation banner
+🇷🇴	flags	flag romania country nation banner
+🇷🇸	flags	flag serbia country nation banner
+🇷🇺	flags	flag russia country nation banner
+🇷🇼	flags	flag rwanda country nation banner
+🇸🇦	flags	flag saudi arabia country nation banner
+🇸🇧	flags	flag solomon islands country nation banner
+🇸🇨	flags	flag seychelles country nation banner
+🇸🇩	flags	flag sudan country nation banner
+🇸🇪	flags	flag sweden country nation banner
+🇸🇬	flags	flag singapore country nation banner
+🇸🇭	flags	flag st helena country nation banner
+🇸🇮	flags	flag slovenia country nation banner
+🇸🇯	flags	flag svalbard jan mayen country nation banner
+🇸🇰	flags	flag slovakia country nation banner
+🇸🇱	flags	flag sierra leone country nation banner
+🇸🇲	flags	flag san marino country nation banner
+🇸🇳	flags	flag senegal country nation banner
+🇸🇴	flags	flag somalia country nation banner
+🇸🇷	flags	flag suriname country nation banner
+🇸🇸	flags	flag south sudan country nation banner
+🇸🇹	flags	flag s o tom pr ncipe country nation banner
+🇸🇻	flags	flag el salvador country nation banner
+🇸🇽	flags	flag sint maarten country nation banner
+🇸🇾	flags	flag syria country nation banner
+🇸🇿	flags	flag eswatini country nation banner
+🇹🇦	flags	flag tristan da cunha country nation banner
+🇹🇨	flags	flag turks caicos islands country nation banner
+🇹🇩	flags	flag chad country nation banner
+🇹🇫	flags	flag french southern territories country nation banner
+🇹🇬	flags	flag togo country nation banner
+🇹🇭	flags	flag thailand country nation banner
+🇹🇯	flags	flag tajikistan country nation banner
+🇹🇰	flags	flag tokelau country nation banner
+🇹🇱	flags	flag timor leste country nation banner
+🇹🇲	flags	flag turkmenistan country nation banner
+🇹🇳	flags	flag tunisia country nation banner
+🇹🇴	flags	flag tonga country nation banner
+🇹🇷	flags	flag t rkiye country nation banner
+🇹🇹	flags	flag trinidad tobago country nation banner
+🇹🇻	flags	flag tuvalu country nation banner
+🇹🇼	flags	flag taiwan country nation banner
+🇹🇿	flags	flag tanzania country nation banner
+🇺🇦	flags	flag ukraine country nation banner
+🇺🇬	flags	flag uganda country nation banner
+🇺🇲	flags	flag u s outlying islands country nation banner
+🇺🇳	flags	flag united nations country nation banner
+🇺🇸	flags	flag united states country nation banner
+🇺🇾	flags	flag uruguay country nation banner
+🇺🇿	flags	flag uzbekistan country nation banner
+🇻🇦	flags	flag vatican city country nation banner
+🇻🇨	flags	flag st vincent grenadines country nation banner
+🇻🇪	flags	flag venezuela country nation banner
+🇻🇬	flags	flag british virgin islands country nation banner
+🇻🇮	flags	flag u s virgin islands country nation banner
+🇻🇳	flags	flag vietnam country nation banner
+🇻🇺	flags	flag vanuatu country nation banner
+🇼🇫	flags	flag wallis futuna country nation banner
+🇼🇸	flags	flag samoa country nation banner
+🇽🇰	flags	flag kosovo country nation banner
+🇾🇪	flags	flag yemen country nation banner
+🇾🇹	flags	flag mayotte country nation banner
+🇿🇦	flags	flag south africa country nation banner
+🇿🇲	flags	flag zambia country nation banner
+🇿🇼	flags	flag zimbabwe country nation banner
+🏴󠁧󠁢󠁥󠁮󠁧󠁿	flags	flag england country nation banner
+🏴󠁧󠁢󠁳󠁣󠁴󠁿	flags	flag scotland country nation banner
+🏴󠁧󠁢󠁷󠁬󠁳󠁿	flags	flag wales country nation banner

--- a/tools/emoji-extras.tsv
+++ b/tools/emoji-extras.tsv
@@ -1,0 +1,12 @@
+# Search terms CLDR does not carry, merged in by generate-emoji-catalog.py.
+#
+# Keep this short. Everything here is a claim that upstream is missing
+# something people search for, and every line is one more thing to re-check
+# when CLDR moves. A key beginning with @ names a category and applies to
+# every emoji in it.
+#
+# Flags: CLDR annotates each flag with its country name and nothing else, so
+# without this the tab is unreachable by the words people actually type.
+# Measured against the hand-maintained catalog this replaces, dropping it lost
+# "country" (90 results to 2), "nation" (90 to 2) and "banner" (90 to 1).
+@flags	flag country nation banner

--- a/tools/generate-emoji-catalog.py
+++ b/tools/generate-emoji-catalog.py
@@ -120,6 +120,10 @@ def normalise(text: str) -> list[str]:
     tone" is findable by "light". Everything else that is not a letter or digit
     goes: the shipped file carries tokens like "flag:" and "tone," that only
     match today because both clients happen to compare by prefix.
+
+    ASCII-only, which is right for the English annotations and wrong for any
+    other locale — generating one would have to keep the letters of its script
+    rather than the a-z range.
     """
     lowered = unicodedata.normalize("NFKC", text).lower()
     return [token for token in re.split(r"[^a-z0-9]+", lowered) if token]
@@ -209,7 +213,18 @@ def build(keep_skin_tones: bool) -> tuple[list[str], dict[str, int]]:
 
     for line in read_source("emoji-test.txt").splitlines():
         if line.startswith("# group:"):
-            category = CATEGORIES.get(line.split(":", 1)[1].strip())
+            group = line.split(":", 1)[1].strip()
+            # A group Unicode adds later would otherwise be dropped in silence,
+            # taking every emoji in it with no tab to show they are missing.
+            # "Component" is the one that is meant to go: bare skin-tone and
+            # hair modifiers, which are not selectable on their own.
+            if group not in CATEGORIES and group != "Component":
+                raise SystemExit(
+                    f"emoji-test.txt has a group this generator does not know: "
+                    f"{group!r}. Add it to CATEGORIES, or to the line above if "
+                    f"it is deliberately not shown."
+                )
+            category = CATEGORIES.get(group)
             continue
         match = EMOJI_TEST_LINE.match(line)
         # Only fully-qualified sequences: the rest are the same emoji written
@@ -284,6 +299,7 @@ def main() -> int:
     print(
         f"Emoji {EMOJI_VERSION}, CLDR {CLDR_TAG}: {len(lines)} entries "
         f"({stats['skipped_tone']} toned sequences left out, "
+        f"{stats['skipped_component']} components, "
         f"{stats['no_annotation']} without a CLDR annotation)",
         file=sys.stderr,
     )

--- a/tools/generate-emoji-catalog.py
+++ b/tools/generate-emoji-catalog.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Regenerate assets/keyboard/emoji/catalog.tsv from Unicode and CLDR data.
+
+The catalog is one tab-separated line per emoji — glyph, category, keywords —
+read by both keyboards from the repository root. It was hand-maintained, with no
+record of where its keywords came from, which made two ordinary jobs awkward:
+taking a new Unicode release, and answering whether a missing search term was a
+deliberate omission or an oversight.
+
+Two upstream sources replace that:
+
+  * Unicode's `emoji-test.txt` is authoritative for which emoji exist, which
+    group each belongs to, and the order they should appear in. The order in the
+    file is the order the picker shows, and it is the one every other keyboard
+    uses, so the grid reads the way people expect.
+  * CLDR's annotations are the search keywords, maintained by the same people
+    who maintain the rest of the locale data, and available in about a hundred
+    languages if emoji search is ever offered in more than English.
+
+CLDR is deliberately literal, so a handful of useful search terms are not in it:
+nobody annotates a flag with "country". Those live in `extras.tsv` next to this
+script — a short, reviewable list, rather than a rule that quietly edits
+upstream data.
+
+Usage:
+    tools/generate-emoji-catalog.py --check     # fail if the catalog is stale
+    tools/generate-emoji-catalog.py --write     # rewrite it
+
+Sources are cached under .cache/ after the first download.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import unicodedata
+import urllib.request
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+
+# Pinned on purpose: an emoji the installed system font does not have renders as
+# a blank box, so moving to a newer Unicode release is a decision about the
+# devices in the field, not something a rebuild should do on its own.
+EMOJI_VERSION = "16.0"
+CLDR_TAG = "release-47"
+
+EMOJI_TEST_URL = f"https://unicode.org/Public/emoji/{EMOJI_VERSION}/emoji-test.txt"
+CLDR_BASE = f"https://raw.githubusercontent.com/unicode-org/cldr/{CLDR_TAG}/common"
+ANNOTATION_URLS = {
+    "annotations": f"{CLDR_BASE}/annotations/en.xml",
+    "annotationsDerived": f"{CLDR_BASE}/annotationsDerived/en.xml",
+}
+
+# Unicode's group names, mapped to the category ids the two keyboards use.
+# "Component" — the bare skin-tone and hair modifiers — has no group of its own
+# and is not selectable on its own, so it is dropped rather than mapped.
+CATEGORIES = {
+    "Smileys & Emotion": "smileys",
+    "People & Body": "people",
+    "Animals & Nature": "animals",
+    "Food & Drink": "food",
+    "Travel & Places": "travel",
+    "Activities": "activities",
+    "Objects": "objects",
+    "Symbols": "symbols",
+    "Flags": "flags",
+}
+
+SKIN_TONES = "\U0001F3FB\U0001F3FC\U0001F3FD\U0001F3FE\U0001F3FF"
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+CATALOG = REPOSITORY_ROOT / "assets" / "keyboard" / "emoji" / "catalog.tsv"
+EXTRAS = Path(__file__).resolve().parent / "emoji-extras.tsv"
+CACHE = Path(__file__).resolve().parent / ".cache"
+
+EMOJI_TEST_LINE = re.compile(
+    r"^(?P<codepoints>[0-9A-F ]+);\s*(?P<status>\S+)\s*#\s*(?P<glyph>\S+)\s+"
+    r"E(?P<version>\d+\.\d+)\s+(?P<name>.+)$"
+)
+
+
+def fetch(name: str, url: str) -> str:
+    CACHE.mkdir(exist_ok=True)
+    cached = CACHE / name
+    if not cached.exists():
+        print(f"  downloading {url}", file=sys.stderr)
+        with urllib.request.urlopen(url, timeout=120) as response:
+            cached.write_bytes(response.read())
+    return cached.read_text(encoding="utf-8")
+
+
+def normalise(text: str) -> list[str]:
+    """Search tokens from an annotation.
+
+    Hyphens and underscores split rather than survive, so "medium-light skin
+    tone" is findable by "light". Everything else that is not a letter or digit
+    goes: the shipped file carries tokens like "flag:" and "tone," that only
+    match today because both clients happen to compare by prefix.
+    """
+    lowered = unicodedata.normalize("NFKC", text).lower()
+    return [token for token in re.split(r"[^a-z0-9]+", lowered) if token]
+
+
+def load_annotations() -> dict[str, list[str]]:
+    """Glyph to its CLDR name followed by its keywords, in CLDR's own order."""
+    keywords: dict[str, list[str]] = {}
+    names: dict[str, str] = {}
+    for name, url in ANNOTATION_URLS.items():
+        root = ElementTree.fromstring(fetch(f"{name}-en.xml", url))
+        for annotation in root.iter("annotation"):
+            glyph = annotation.get("cp")
+            if glyph is None:
+                continue
+            text = annotation.text or ""
+            if annotation.get("type") == "tts":
+                names.setdefault(glyph, text)
+            else:
+                keywords.setdefault(glyph, []).extend(
+                    part.strip() for part in text.split("|") if part.strip()
+                )
+    return {
+        glyph: [names.get(glyph, "")] + keywords.get(glyph, [])
+        for glyph in set(names) | set(keywords)
+    }
+
+
+def load_extras() -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    """Search terms CLDR does not carry, by glyph and by category.
+
+    A key beginning with `@` names a category and applies to everything in it.
+    Flags are why: CLDR annotates each one with its country and nothing else, so
+    without a rule the whole tab becomes unfindable by the words people actually
+    reach for. Two hundred and seventy identical per-glyph lines would say the
+    same thing while hiding that it is one decision.
+    """
+    per_glyph: dict[str, list[str]] = {}
+    per_category: dict[str, list[str]] = {}
+    if not EXTRAS.exists():
+        return per_glyph, per_category
+    for line in EXTRAS.read_text(encoding="utf-8").splitlines():
+        if not line.strip() or line.startswith("#"):
+            continue
+        key, _, words = line.partition("\t")
+        if not words:
+            continue
+        if key.startswith("@"):
+            per_category[key[1:]] = words.split()
+        else:
+            per_glyph[key] = words.split()
+    return per_glyph, per_category
+
+
+def lookup(annotations: dict[str, list[str]], glyph: str) -> list[str] | None:
+    """The annotation for a glyph, allowing for how CLDR spells its keys.
+
+    Two mismatches with `emoji-test.txt`, and both are silent — a miss falls
+    back to the Unicode name, which reads fine and quietly halves that emoji's
+    search terms:
+
+      * CLDR omits U+FE0F from most keys, where emoji-test always writes the
+        fully-qualified form. This alone accounted for 365 of them.
+      * A toned sequence has no entry of its own, because CLDR annotates the
+        base and expects the client to compose the tone name.
+    """
+    variation_selector = "️"
+    untoned = "".join(c for c in glyph if c not in SKIN_TONES)
+    for candidate in (
+        glyph,
+        glyph.replace(variation_selector, ""),
+        untoned,
+        untoned.replace(variation_selector, ""),
+    ):
+        found = annotations.get(candidate)
+        if found is not None:
+            return found
+    return None
+
+
+def build(keep_skin_tones: bool) -> tuple[list[str], dict[str, int]]:
+    annotations = load_annotations()
+    extras, category_extras = load_extras()
+    lines: list[str] = []
+    stats = {"skipped_component": 0, "skipped_tone": 0, "no_annotation": 0}
+    category = None
+
+    for line in fetch("emoji-test.txt", EMOJI_TEST_URL).splitlines():
+        if line.startswith("# group:"):
+            category = CATEGORIES.get(line.split(":", 1)[1].strip())
+            continue
+        match = EMOJI_TEST_LINE.match(line)
+        # Only fully-qualified sequences: the rest are the same emoji written
+        # without its variation selector, which would show as a duplicate.
+        if not match or match["status"] != "fully-qualified":
+            continue
+        if category is None:
+            stats["skipped_component"] += 1
+            continue
+        glyph = match["glyph"]
+        if not keep_skin_tones and any(tone in glyph for tone in SKIN_TONES):
+            stats["skipped_tone"] += 1
+            continue
+
+        words: list[str] = []
+        seen: set[str] = set()
+        source = lookup(annotations, glyph)
+        if source is None:
+            stats["no_annotation"] += 1
+            source = [match["name"]]
+        tail = extras.get(glyph, []) + category_extras.get(category, [])
+        for chunk in list(source) + tail:
+            for token in normalise(chunk):
+                if token not in seen:
+                    seen.add(token)
+                    words.append(token)
+        lines.append(f"{glyph}\t{category}\t{' '.join(words)}")
+    return lines, stats
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--write", action="store_true", help="rewrite the catalog")
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="exit non-zero if the catalog differs from what this would generate",
+    )
+    parser.add_argument(
+        "--skin-tones",
+        choices=("inline", "base"),
+        default="inline",
+        help=(
+            "inline (default) lists all five toned forms of every emoji that "
+            "has them, matching the shipped catalog; base lists each emoji "
+            "once, which halves the file but needs a tone picker in the UI "
+            "before a toned emoji can be reached at all"
+        ),
+    )
+    arguments = parser.parse_args()
+
+    lines, stats = build(keep_skin_tones=arguments.skin_tones == "inline")
+    generated = "\n".join(lines) + "\n"
+
+    print(
+        f"Emoji {EMOJI_VERSION}, CLDR {CLDR_TAG}: {len(lines)} entries "
+        f"({stats['skipped_tone']} toned sequences left out, "
+        f"{stats['no_annotation']} without a CLDR annotation)",
+        file=sys.stderr,
+    )
+
+    if arguments.check:
+        current = CATALOG.read_text(encoding="utf-8") if CATALOG.exists() else ""
+        if current == generated:
+            print(f"{CATALOG.relative_to(REPOSITORY_ROOT)} is up to date")
+            return 0
+        print(
+            f"{CATALOG.relative_to(REPOSITORY_ROOT)} does not match the "
+            f"generator. Run tools/generate-emoji-catalog.py --write",
+            file=sys.stderr,
+        )
+        return 1
+
+    CATALOG.write_text(generated, encoding="utf-8")
+    print(f"wrote {CATALOG.relative_to(REPOSITORY_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/generate-emoji-catalog.py
+++ b/tools/generate-emoji-catalog.py
@@ -42,13 +42,15 @@ import re
 import sys
 import unicodedata
 import urllib.request
-# nosemgrep: python.lang.security.use-defused-xml.use-defused-xml
 # defusedxml would be a dependency for a script that has none, to parse two
-# files committed in this repository. What the rule is actually about is entity
-# expansion, and `parse_annotations` below refuses any document that declares
-# an entity or carries an internal DTD subset — which is where both an XXE and
-# a billion-laughs payload have to live. CLDR's own `<!DOCTYPE ldml SYSTEM ...>`
-# is external, and ElementTree has not fetched external DTDs since 3.7.1.
+# files committed in this repository. What the XXE rule is actually about is
+# entity expansion, and `parse_annotations` below refuses any document that
+# declares an entity or carries an internal DTD subset — which is where both an
+# XXE and a billion-laughs payload have to live. CLDR's own
+# `<!DOCTYPE ldml SYSTEM ...>` is external, and ElementTree has not fetched
+# external DTDs since 3.7.1. The marker has to sit on the line directly above
+# the import; anything between the two and Semgrep stops associating them.
+# nosemgrep: python.lang.security.use-defused-xml.use-defused-xml
 import xml.etree.ElementTree as ElementTree
 from pathlib import Path
 
@@ -126,6 +128,7 @@ def refresh() -> None:
         if not url.startswith("https://"):
             raise SystemExit(f"refusing to fetch {name} over {url!r}")
         print(f"  {url}", file=sys.stderr)
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
         with urllib.request.urlopen(url, timeout=120) as response:
             (SOURCES / name).write_bytes(response.read())
 

--- a/tools/generate-emoji-catalog.py
+++ b/tools/generate-emoji-catalog.py
@@ -18,15 +18,21 @@ Two upstream sources replace that:
     languages if emoji search is ever offered in more than English.
 
 CLDR is deliberately literal, so a handful of useful search terms are not in it:
-nobody annotates a flag with "country". Those live in `extras.tsv` next to this
-script — a short, reviewable list, rather than a rule that quietly edits
+nobody annotates a flag with "country". Those live in `emoji-extras.tsv` next
+to this script — a short, reviewable list, rather than a rule that quietly edits
 upstream data.
 
-Usage:
-    tools/generate-emoji-catalog.py --check     # fail if the catalog is stale
-    tools/generate-emoji-catalog.py --write     # rewrite it
+Both sources are vendored under tools/unicode/ rather than downloaded when
+this runs. The catalog they produce is shipped in the APK and the IPA, F-Droid
+rebuilds it from this tree and compares the result, and a check that reaches
+the network fails on someone else's outage and silently changes meaning when
+upstream edits a file in place. `--refresh` is the one command that goes out,
+and its diff is the record of what changed.
 
-Sources are cached under .cache/ after the first download.
+Usage:
+    tools/generate-emoji-catalog.py --check      # fail if the catalog is stale
+    tools/generate-emoji-catalog.py --write      # rewrite it
+    tools/generate-emoji-catalog.py --refresh    # re-download the vendored sources
 """
 
 from __future__ import annotations
@@ -45,12 +51,20 @@ from pathlib import Path
 EMOJI_VERSION = "16.0"
 CLDR_TAG = "release-47"
 
-EMOJI_TEST_URL = f"https://unicode.org/Public/emoji/{EMOJI_VERSION}/emoji-test.txt"
-CLDR_BASE = f"https://raw.githubusercontent.com/unicode-org/cldr/{CLDR_TAG}/common"
-ANNOTATION_URLS = {
-    "annotations": f"{CLDR_BASE}/annotations/en.xml",
-    "annotationsDerived": f"{CLDR_BASE}/annotationsDerived/en.xml",
+_CLDR_BASE = f"https://raw.githubusercontent.com/unicode-org/cldr/{CLDR_TAG}/common"
+
+# Vendored filename to where --refresh fetches it from.
+SOURCE_URLS = {
+    "emoji-test.txt": (
+        f"https://unicode.org/Public/emoji/{EMOJI_VERSION}/emoji-test.txt"
+    ),
+    "annotations-en.xml": f"{_CLDR_BASE}/annotations/en.xml",
+    "annotationsDerived-en.xml": f"{_CLDR_BASE}/annotationsDerived/en.xml",
 }
+
+# annotations holds the single code points, annotationsDerived the sequences —
+# flags, keycaps, and every ZWJ combination. Both are needed for full coverage.
+ANNOTATION_FILES = ("annotations-en.xml", "annotationsDerived-en.xml")
 
 # Unicode's group names, mapped to the category ids the two keyboards use.
 # "Component" — the bare skin-tone and hair modifiers — has no group of its own
@@ -72,7 +86,7 @@ SKIN_TONES = "\U0001F3FB\U0001F3FC\U0001F3FD\U0001F3FE\U0001F3FF"
 REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
 CATALOG = REPOSITORY_ROOT / "assets" / "keyboard" / "emoji" / "catalog.tsv"
 EXTRAS = Path(__file__).resolve().parent / "emoji-extras.tsv"
-CACHE = Path(__file__).resolve().parent / ".cache"
+SOURCES = Path(__file__).resolve().parent / "unicode"
 
 EMOJI_TEST_LINE = re.compile(
     r"^(?P<codepoints>[0-9A-F ]+);\s*(?P<status>\S+)\s*#\s*(?P<glyph>\S+)\s+"
@@ -80,14 +94,23 @@ EMOJI_TEST_LINE = re.compile(
 )
 
 
-def fetch(name: str, url: str) -> str:
-    CACHE.mkdir(exist_ok=True)
-    cached = CACHE / name
-    if not cached.exists():
-        print(f"  downloading {url}", file=sys.stderr)
+def read_source(name: str) -> str:
+    path = SOURCES / name
+    if not path.exists():
+        raise SystemExit(
+            f"{path.relative_to(REPOSITORY_ROOT)} is missing. "
+            "Run tools/generate-emoji-catalog.py --refresh"
+        )
+    return path.read_text(encoding="utf-8")
+
+
+def refresh() -> None:
+    """Re-download the vendored sources, so a version bump is one diff."""
+    SOURCES.mkdir(exist_ok=True)
+    for name, url in SOURCE_URLS.items():
+        print(f"  {url}", file=sys.stderr)
         with urllib.request.urlopen(url, timeout=120) as response:
-            cached.write_bytes(response.read())
-    return cached.read_text(encoding="utf-8")
+            (SOURCES / name).write_bytes(response.read())
 
 
 def normalise(text: str) -> list[str]:
@@ -106,8 +129,8 @@ def load_annotations() -> dict[str, list[str]]:
     """Glyph to its CLDR name followed by its keywords, in CLDR's own order."""
     keywords: dict[str, list[str]] = {}
     names: dict[str, str] = {}
-    for name, url in ANNOTATION_URLS.items():
-        root = ElementTree.fromstring(fetch(f"{name}-en.xml", url))
+    for name in ANNOTATION_FILES:
+        root = ElementTree.fromstring(read_source(name))
         for annotation in root.iter("annotation"):
             glyph = annotation.get("cp")
             if glyph is None:
@@ -184,7 +207,7 @@ def build(keep_skin_tones: bool) -> tuple[list[str], dict[str, int]]:
     stats = {"skipped_component": 0, "skipped_tone": 0, "no_annotation": 0}
     category = None
 
-    for line in fetch("emoji-test.txt", EMOJI_TEST_URL).splitlines():
+    for line in read_source("emoji-test.txt").splitlines():
         if line.startswith("# group:"):
             category = CATEGORIES.get(line.split(":", 1)[1].strip())
             continue
@@ -226,6 +249,14 @@ def main() -> int:
         action="store_true",
         help="exit non-zero if the catalog differs from what this would generate",
     )
+    mode.add_argument(
+        "--refresh",
+        action="store_true",
+        help=(
+            "re-download the vendored Unicode and CLDR sources; the only mode "
+            "that touches the network"
+        ),
+    )
     parser.add_argument(
         "--skin-tones",
         choices=("inline", "base"),
@@ -238,6 +269,14 @@ def main() -> int:
         ),
     )
     arguments = parser.parse_args()
+
+    if arguments.refresh:
+        refresh()
+        print(
+            f"refreshed tools/unicode/ from Emoji {EMOJI_VERSION} and CLDR "
+            f"{CLDR_TAG}. Review the diff, then --write."
+        )
+        return 0
 
     lines, stats = build(keep_skin_tones=arguments.skin_tones == "inline")
     generated = "\n".join(lines) + "\n"

--- a/tools/generate-emoji-catalog.py
+++ b/tools/generate-emoji-catalog.py
@@ -42,6 +42,13 @@ import re
 import sys
 import unicodedata
 import urllib.request
+# nosemgrep: python.lang.security.use-defused-xml.use-defused-xml
+# defusedxml would be a dependency for a script that has none, to parse two
+# files committed in this repository. What the rule is actually about is entity
+# expansion, and `parse_annotations` below refuses any document that declares
+# an entity or carries an internal DTD subset — which is where both an XXE and
+# a billion-laughs payload have to live. CLDR's own `<!DOCTYPE ldml SYSTEM ...>`
+# is external, and ElementTree has not fetched external DTDs since 3.7.1.
 import xml.etree.ElementTree as ElementTree
 from pathlib import Path
 
@@ -88,6 +95,11 @@ CATALOG = REPOSITORY_ROOT / "assets" / "keyboard" / "emoji" / "catalog.tsv"
 EXTRAS = Path(__file__).resolve().parent / "emoji-extras.tsv"
 SOURCES = Path(__file__).resolve().parent / "unicode"
 
+# An internal DTD subset: <!DOCTYPE name [ ... ]>, as opposed to the external
+# SYSTEM form CLDR ships. Entity declarations can only appear inside one.
+INTERNAL_DTD_SUBSET = re.compile(r"<!DOCTYPE[^>\[]*\[")
+ENTITY_DECLARATION = re.compile(r"<!ENTITY", re.IGNORECASE)
+
 EMOJI_TEST_LINE = re.compile(
     r"^(?P<codepoints>[0-9A-F ]+);\s*(?P<status>\S+)\s*#\s*(?P<glyph>\S+)\s+"
     r"E(?P<version>\d+\.\d+)\s+(?P<name>.+)$"
@@ -108,6 +120,11 @@ def refresh() -> None:
     """Re-download the vendored sources, so a version bump is one diff."""
     SOURCES.mkdir(exist_ok=True)
     for name, url in SOURCE_URLS.items():
+        # The URLs are built from the pinned constants above and nothing else,
+        # but urllib would honour a file:// or a plaintext one if that ever
+        # stopped being true, and this is the line that would have to notice.
+        if not url.startswith("https://"):
+            raise SystemExit(f"refusing to fetch {name} over {url!r}")
         print(f"  {url}", file=sys.stderr)
         with urllib.request.urlopen(url, timeout=120) as response:
             (SOURCES / name).write_bytes(response.read())
@@ -129,12 +146,29 @@ def normalise(text: str) -> list[str]:
     return [token for token in re.split(r"[^a-z0-9]+", lowered) if token]
 
 
+def parse_annotations(name: str) -> ElementTree.Element:
+    """A vendored CLDR annotation file, parsed once its DTD is known to be inert.
+
+    See the note on the ElementTree import. The check is cheap and exact: an
+    entity has to be declared to be referenced, and a declaration has to sit in
+    an internal DTD subset, so refusing both leaves nothing for an expansion
+    attack to stand on.
+    """
+    text = read_source(name)
+    if INTERNAL_DTD_SUBSET.search(text) or ENTITY_DECLARATION.search(text):
+        raise SystemExit(
+            f"{name} carries an internal DTD subset or an entity declaration. "
+            "CLDR does not ship either; refusing to parse it."
+        )
+    return ElementTree.fromstring(text)
+
+
 def load_annotations() -> dict[str, list[str]]:
     """Glyph to its CLDR name followed by its keywords, in CLDR's own order."""
     keywords: dict[str, list[str]] = {}
     names: dict[str, str] = {}
     for name in ANNOTATION_FILES:
-        root = ElementTree.fromstring(read_source(name))
+        root = parse_annotations(name)
         for annotation in root.iter("annotation"):
             glyph = annotation.get("cp")
             if glyph is None:

--- a/tools/unicode/annotations-en.xml
+++ b/tools/unicode/annotations-en.xml
@@ -1,0 +1,3920 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2024 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-3.0
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+
+the U.S. and other countries. CLDR data files are interpreted according to
+the LDML specification (http://unicode.org/reports/tr35/) Warnings: All cp
+values have U+FE0F characters removed. See /annotationsDerived/ for derived
+annotations.
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="en"/>
+	</identity>
+	<annotations>
+		<annotation cp="{">brace | bracket | curly | gullwing | open</annotation>
+		<annotation cp="{" type="tts">open curly bracket</annotation>
+		<annotation cp="🏻">1–2 | light | skin | tone | type</annotation>
+		<annotation cp="🏻" type="tts">light skin tone</annotation>
+		<annotation cp="🏼">3 | medium-light | skin | tone | type</annotation>
+		<annotation cp="🏼" type="tts">medium-light skin tone</annotation>
+		<annotation cp="🏽">4 | medium | skin | tone | type</annotation>
+		<annotation cp="🏽" type="tts">medium skin tone</annotation>
+		<annotation cp="🏾">5 | medium-dark | skin | tone | type</annotation>
+		<annotation cp="🏾" type="tts">medium-dark skin tone</annotation>
+		<annotation cp="🏿">6 | dark | skin | tone | type</annotation>
+		<annotation cp="🏿" type="tts">dark skin tone</annotation>
+		<annotation cp="‾">overline | overstrike | vinculum</annotation>
+		<annotation cp="‾" type="tts">overline</annotation>
+		<annotation cp="_">dash | line | low | underdash | underline</annotation>
+		<annotation cp="_" type="tts">low line</annotation>
+		<annotation cp="-">dash | hyphen | hyphen-minus | minus</annotation>
+		<annotation cp="-" type="tts">hyphen-minus</annotation>
+		<annotation cp="‐">dash | hyphen</annotation>
+		<annotation cp="‐" type="tts">hyphen</annotation>
+		<annotation cp="–">dash | en</annotation>
+		<annotation cp="–" type="tts">en dash</annotation>
+		<annotation cp="—">dash | em</annotation>
+		<annotation cp="—" type="tts">em dash</annotation>
+		<annotation cp="―">bar | dash | horizontal | line</annotation>
+		<annotation cp="―" type="tts">horizontal bar</annotation>
+		<annotation cp="・">dot | dots | interpunct | katakana | middle | middot</annotation>
+		<annotation cp="・" type="tts">katakana middle dot</annotation>
+		<!-- causes tool breakage
+			 <annotation cp="">whitespace</annotation>
+			 <annotation cp="" type="tts">space</annotation>
+		-->
+		<annotation cp=",">comma</annotation>
+		<annotation cp="," type="tts">comma</annotation>
+		<annotation cp="،">arabic | comma</annotation>
+		<annotation cp="،" type="tts">arabic comma</annotation>
+		<annotation cp="、">comma | ideographic</annotation>
+		<annotation cp="、" type="tts">ideographic comma</annotation>
+		<annotation cp=";">semi-colon | semicolon</annotation>
+		<annotation cp=";" type="tts">semicolon</annotation>
+		<annotation cp="؛">arabic | semi-colon | semicolon</annotation>
+		<annotation cp="؛" type="tts">arabic semicolon</annotation>
+		<annotation cp=":">colon</annotation>
+		<annotation cp=":" type="tts">colon</annotation>
+		<annotation cp="!">bang | exclamation | mark | point</annotation>
+		<annotation cp="!" type="tts">exclamation mark</annotation>
+		<annotation cp="¡">bang | exclamation | inverted | mark | point</annotation>
+		<annotation cp="¡" type="tts">inverted exclamation mark</annotation>
+		<annotation cp="?">mark | question</annotation>
+		<annotation cp="?" type="tts">question mark</annotation>
+		<annotation cp="¿">inverted | mark | question</annotation>
+		<annotation cp="¿" type="tts">inverted question mark</annotation>
+		<annotation cp="؟">arabic | mark | question</annotation>
+		<annotation cp="؟" type="tts">arabic question mark</annotation>
+		<annotation cp="‽">interabang | interrobang</annotation>
+		<annotation cp="‽" type="tts">interrobang</annotation>
+		<annotation cp=".">dot | full | period | stop</annotation>
+		<annotation cp="." type="tts">period</annotation>
+		<annotation cp="…">dots | ellipsis | omission</annotation>
+		<annotation cp="…" type="tts">ellipsis</annotation>
+		<annotation cp="。">full | ideographic | period | stop</annotation>
+		<annotation cp="。" type="tts">ideographic period</annotation>
+		<annotation cp="·">dot | interpunct | middle | middot</annotation>
+		<annotation cp="·" type="tts">middle dot</annotation>
+		<annotation cp="'">apostrophe | quote | single | typewriter</annotation>
+		<annotation cp="'" type="tts">typewriter apostrophe</annotation>
+		<annotation cp="‘">apostrophe | left | quote | single | smart</annotation>
+		<annotation cp="‘" type="tts">left apostrophe</annotation>
+		<annotation cp="’">apostrophe | quote | right | single | smart</annotation>
+		<annotation cp="’" type="tts">right apostrophe</annotation>
+		<annotation cp="‚">apostrophe | low | quote | right</annotation>
+		<annotation cp="‚" type="tts">low right apostrophe</annotation>
+		<annotation cp="“">double | left | mark | quotation | quote | smart</annotation>
+		<annotation cp="“" type="tts">left quotation mark</annotation>
+		<annotation cp="”">double | mark | quotation | quote | right | smart</annotation>
+		<annotation cp="”" type="tts">right quotation mark</annotation>
+		<annotation cp="„">double | low | mark | quotation | quote | right | smart</annotation>
+		<annotation cp="„" type="tts">low right quotation mark</annotation>
+		<annotation cp="«">angle | brackets | carets | chevron | guillemet | left | quote</annotation>
+		<annotation cp="«" type="tts">left guillemet</annotation>
+		<annotation cp="»">angle | brackets | carets | chevron | guillemet | quote | right</annotation>
+		<annotation cp="»" type="tts">right guillemet</annotation>
+		<annotation cp=")">bracket | close | paren | parens | parenthesis | round</annotation>
+		<annotation cp=")" type="tts">close parenthesis</annotation>
+		<annotation cp="[">bracket | crotchet | open | square</annotation>
+		<annotation cp="[" type="tts">open square bracket</annotation>
+		<annotation cp="]">bracket | close | crotchet | square</annotation>
+		<annotation cp="]" type="tts">close square bracket</annotation>
+		<annotation cp="}">brace | bracket | close | curly | gullwing</annotation>
+		<annotation cp="}" type="tts">close curly bracket</annotation>
+		<annotation cp="〈">angle | bracket | brackets | chevron | diamond | open | pointy | tuple</annotation>
+		<annotation cp="〈" type="tts">open angle bracket</annotation>
+		<annotation cp="〉">angle | bracket | brackets | chevron | close | diamond | pointy | tuple</annotation>
+		<annotation cp="〉" type="tts">close angle bracket</annotation>
+		<annotation cp="《">angle | bracket | double | open</annotation>
+		<annotation cp="《" type="tts">open double angle bracket</annotation>
+		<annotation cp="》">angle | bracket | close | double</annotation>
+		<annotation cp="》" type="tts">close double angle bracket</annotation>
+		<annotation cp="「">bracket | corner | open</annotation>
+		<annotation cp="「" type="tts">open corner bracket</annotation>
+		<annotation cp="」">bracket | close | corner</annotation>
+		<annotation cp="」" type="tts">close corner bracket</annotation>
+		<annotation cp="『">bracket | corner | hollow | open</annotation>
+		<annotation cp="『" type="tts">open hollow corner bracket</annotation>
+		<annotation cp="』">bracket | close | corner | hollow</annotation>
+		<annotation cp="』" type="tts">close hollow corner bracket</annotation>
+		<annotation cp="【">black | bracket | lens | lenticular | open</annotation>
+		<annotation cp="【" type="tts">open black lens bracket</annotation>
+		<annotation cp="】">black | bracket | close | lens | lenticular</annotation>
+		<annotation cp="】" type="tts">close black lens bracket</annotation>
+		<annotation cp="〔">bracket | open | shell | tortoise</annotation>
+		<annotation cp="〔" type="tts">open tortoise shell bracket</annotation>
+		<annotation cp="〕">bracket | close | shell | tortoise</annotation>
+		<annotation cp="〕" type="tts">close tortoise shell bracket</annotation>
+		<annotation cp="〖">bracket | hollow | lens | lenticular | open</annotation>
+		<annotation cp="〖" type="tts">open hollow lens bracket</annotation>
+		<annotation cp="〗">bracket | close | hollow | lens | lenticular</annotation>
+		<annotation cp="〗" type="tts">close hollow lens bracket</annotation>
+		<annotation cp="§">paragraph | part | section | silcrow</annotation>
+		<annotation cp="§" type="tts">section</annotation>
+		<annotation cp="¶">alinea | mark | paragraph | paraph | pilcrow</annotation>
+		<annotation cp="¶" type="tts">paragraph mark</annotation>
+		<annotation cp="@">ampersat | arobase | arroba | at | at-sign | commercial | mark | sign | strudel</annotation>
+		<annotation cp="@" type="tts">at-sign</annotation>
+		<annotation cp="*">asterisk | star | wildcard</annotation>
+		<annotation cp="*" type="tts">asterisk</annotation>
+		<annotation cp="/">oblique | slash | solidus | stroke | virgule | whack</annotation>
+		<annotation cp="/" type="tts">slash</annotation>
+		<annotation cp="\">backslash | reverse | solidus | whack</annotation>
+		<annotation cp="\" type="tts">backslash</annotation>
+		<annotation cp="&amp;">ampersand | and | et</annotation>
+		<annotation cp="&amp;" type="tts">ampersand</annotation>
+		<annotation cp="#">hash | hashtag | lb | number | pound | sign</annotation>
+		<annotation cp="#" type="tts">hash sign</annotation>
+		<annotation cp="%">cent | per | per-cent | percent</annotation>
+		<annotation cp="%" type="tts">percent</annotation>
+		<annotation cp="‰">mil | mille | per | permil | permille</annotation>
+		<annotation cp="‰" type="tts">per mille</annotation>
+		<annotation cp="†">dagger | obelisk | obelus | sign</annotation>
+		<annotation cp="†" type="tts">dagger sign</annotation>
+		<annotation cp="‡">dagger | double | obelisk | obelus | sign</annotation>
+		<annotation cp="‡" type="tts">double dagger sign</annotation>
+		<annotation cp="•">bullet | dot</annotation>
+		<annotation cp="•" type="tts">bullet</annotation>
+		<annotation cp="‧">dash | hyphen | hyphenation | point</annotation>
+		<annotation cp="‧" type="tts">hyphenation point</annotation>
+		<annotation cp="′">prime</annotation>
+		<annotation cp="′" type="tts">prime</annotation>
+		<annotation cp="″">double | prime</annotation>
+		<annotation cp="″" type="tts">double prime</annotation>
+		<annotation cp="‴">prime | triple</annotation>
+		<annotation cp="‴" type="tts">triple prime</annotation>
+		<annotation cp="‸">caret</annotation>
+		<annotation cp="‸" type="tts">caret</annotation>
+		<annotation cp="※">mark | reference</annotation>
+		<annotation cp="※" type="tts">reference mark</annotation>
+		<annotation cp="⁂">asterism | dinkus | stars</annotation>
+		<annotation cp="⁂" type="tts">asterism</annotation>
+		<annotation cp="`">accent | grave | tone</annotation>
+		<annotation cp="`" type="tts">grave accent</annotation>
+		<annotation cp="´">accent | acute | tone</annotation>
+		<annotation cp="´" type="tts">acute accent</annotation>
+		<annotation cp="^">accent | caret | chevron | circumflex | control | hat | pointer | power | sign | wedge | xor</annotation>
+		<annotation cp="^" type="tts">circumflex accent</annotation>
+		<annotation cp="¨">diaeresis | tréma | umlaut</annotation>
+		<annotation cp="¨" type="tts">diaeresis</annotation>
+		<annotation cp="°">degree | hour | proof</annotation>
+		<annotation cp="°" type="tts">degree</annotation>
+		<annotation cp="℗">copyright | recording | sound</annotation>
+		<annotation cp="℗" type="tts">sound recording copyright</annotation>
+		<annotation cp="←">arrow | left | left-pointing</annotation>
+		<annotation cp="←" type="tts">left-pointing arrow</annotation>
+		<annotation cp="↚">arrow | leftwards | stroke</annotation>
+		<annotation cp="↚" type="tts">leftwards arrow stroke</annotation>
+		<annotation cp="→">arrow | right | right-pointing</annotation>
+		<annotation cp="→" type="tts">right-pointing arrow</annotation>
+		<annotation cp="↛">arrow | rightwards | stroke</annotation>
+		<annotation cp="↛" type="tts">rightwards arrow stroke</annotation>
+		<annotation cp="↑">arrow | up | up-pointing</annotation>
+		<annotation cp="↑" type="tts">up-pointing arrow</annotation>
+		<annotation cp="↓">arrow | down | down-pointing</annotation>
+		<annotation cp="↓" type="tts">down-pointing arrow</annotation>
+		<annotation cp="↜">arrow | leftwards | wave</annotation>
+		<annotation cp="↜" type="tts">leftwards wave arrow</annotation>
+		<annotation cp="↝">arrow | rightwards | wave</annotation>
+		<annotation cp="↝" type="tts">rightwards wave arrow</annotation>
+		<annotation cp="↞">arrow | headed | leftwards | two</annotation>
+		<annotation cp="↞" type="tts">leftwards two headed arrow</annotation>
+		<annotation cp="↟">arrow | headed | two | upwards</annotation>
+		<annotation cp="↟" type="tts">upwards two headed arrow</annotation>
+		<annotation cp="↠">arrow | headed | rightwards | two</annotation>
+		<annotation cp="↠" type="tts">rightwards two headed arrow</annotation>
+		<annotation cp="↡">arrow | downwards | headed | two</annotation>
+		<annotation cp="↡" type="tts">downwards two headed arrow</annotation>
+		<annotation cp="↢">arrow | leftwards | tail</annotation>
+		<annotation cp="↢" type="tts">leftwards arrow tail</annotation>
+		<annotation cp="↣">arrow | rightwards | tail</annotation>
+		<annotation cp="↣" type="tts">rightwards arrow tail</annotation>
+		<annotation cp="↤">arrow | bar | from | leftwards</annotation>
+		<annotation cp="↤" type="tts">leftwards arrow from bar</annotation>
+		<annotation cp="↥">arrow | bar | from | upwards</annotation>
+		<annotation cp="↥" type="tts">upwards arrow from bar</annotation>
+		<annotation cp="↦">arrow | bar | from | rightwards</annotation>
+		<annotation cp="↦" type="tts">rightwards arrow from bar</annotation>
+		<annotation cp="↧">arrow | bar | downwards | from</annotation>
+		<annotation cp="↧" type="tts">downwards arrow from bar</annotation>
+		<annotation cp="↨">arrow | base | down | up | with</annotation>
+		<annotation cp="↨" type="tts">up down arrow with base</annotation>
+		<annotation cp="↫">arrow | leftwards | loop</annotation>
+		<annotation cp="↫" type="tts">leftwards arrow loop</annotation>
+		<annotation cp="↬">arrow | loop | rightwards</annotation>
+		<annotation cp="↬" type="tts">rightwards arrow loop</annotation>
+		<annotation cp="↭">arrow | left | right | wave</annotation>
+		<annotation cp="↭" type="tts">left right wave arrow</annotation>
+		<annotation cp="↯">arrow | downwards | zigzag</annotation>
+		<annotation cp="↯" type="tts">downwards zigzag arrow</annotation>
+		<annotation cp="↰">arrow | leftwards | tip | upwards</annotation>
+		<annotation cp="↰" type="tts">upwards arrow tip leftwards</annotation>
+		<annotation cp="↱">arrow | rightwards | tip | upwards</annotation>
+		<annotation cp="↱" type="tts">upwards arrow tip rightwards</annotation>
+		<annotation cp="↲">arrow | downwards | leftwards | tip</annotation>
+		<annotation cp="↲" type="tts">downwards arrow tip leftwards</annotation>
+		<annotation cp="↳">arrow | downwards | rightwards | tip</annotation>
+		<annotation cp="↳" type="tts">downwards arrow tip rightwards</annotation>
+		<annotation cp="↴">arrow | corner | downwards | rightwards</annotation>
+		<annotation cp="↴" type="tts">rightwards arrow corner downwards</annotation>
+		<annotation cp="↵">arrow | corner | downwards | leftwards</annotation>
+		<annotation cp="↵" type="tts">downwards arrow corner leftwards</annotation>
+		<annotation cp="↶">anticlockwise | arrow | semicircle | top</annotation>
+		<annotation cp="↶" type="tts">anticlockwise top semicircle arrow</annotation>
+		<annotation cp="↷">arrow | clockwise | semicircle | top</annotation>
+		<annotation cp="↷" type="tts">clockwise top semicircle arrow</annotation>
+		<annotation cp="↸">arrow | bar | long | north | west</annotation>
+		<annotation cp="↸" type="tts">north west arrow long bar</annotation>
+		<annotation cp="↹">arrow | bar | bars | leftwards | over | rightwards</annotation>
+		<annotation cp="↹" type="tts">leftwards over rightwards arrow bars</annotation>
+		<annotation cp="↺">anticlockwise | arrow | circle | open</annotation>
+		<annotation cp="↺" type="tts">anticlockwise open circle arrow</annotation>
+		<annotation cp="↻">arrow | circle | clockwise | open</annotation>
+		<annotation cp="↻" type="tts">clockwise open circle arrow</annotation>
+		<annotation cp="↼">barb | harpoon | leftwards | upwards</annotation>
+		<annotation cp="↼" type="tts">leftwards harpoon barb upwards</annotation>
+		<annotation cp="↽">barb | downwards | harpoon | leftwards</annotation>
+		<annotation cp="↽" type="tts">leftwards harpoon barb downwards</annotation>
+		<annotation cp="↾">barb | harpoon | rightwards | upwards</annotation>
+		<annotation cp="↾" type="tts">upwards harpoon barb rightwards</annotation>
+		<annotation cp="↿">barb | harpoon | leftwards | upwards</annotation>
+		<annotation cp="↿" type="tts">upwards harpoon barb leftwards</annotation>
+		<annotation cp="⇀">barb | harpoon | rightwards | upwards</annotation>
+		<annotation cp="⇀" type="tts">rightwards harpoon barb upwards</annotation>
+		<annotation cp="⇁">barb | downwards | harpoon | rightwards</annotation>
+		<annotation cp="⇁" type="tts">rightwards harpoon barb downwards</annotation>
+		<annotation cp="⇂">barb | downwards | harpoon | rightwards</annotation>
+		<annotation cp="⇂" type="tts">downwards harpoon barb rightwards</annotation>
+		<annotation cp="⇃">barb | downwards | harpoon | leftwards</annotation>
+		<annotation cp="⇃" type="tts">downwards harpoon barb leftwards</annotation>
+		<annotation cp="⇄">arrow | leftwards | over | rightwards</annotation>
+		<annotation cp="⇄" type="tts">rightwards arrow over leftwards arrow</annotation>
+		<annotation cp="⇅">and | arrow | arrows | down | down-pointing | up | up-pointing</annotation>
+		<annotation cp="⇅" type="tts">up-pointing and down-pointing arrows</annotation>
+		<annotation cp="⇆">arrow | arrows | left | left-pointing | over | right | right-pointing</annotation>
+		<annotation cp="⇆" type="tts">left-pointing over right-pointing arrows</annotation>
+		<annotation cp="⇇">arrows | leftwards | paired</annotation>
+		<annotation cp="⇇" type="tts">leftwards paired arrows</annotation>
+		<annotation cp="⇈">arrows | paired | upwards</annotation>
+		<annotation cp="⇈" type="tts">upwards paired arrows</annotation>
+		<annotation cp="⇉">arrows | paired | rightwards</annotation>
+		<annotation cp="⇉" type="tts">rightwards paired arrows</annotation>
+		<annotation cp="⇊">arrows | downwards | paired</annotation>
+		<annotation cp="⇊" type="tts">downwards paired arrows</annotation>
+		<annotation cp="⇋">harpoon | leftwards | over | rightwards</annotation>
+		<annotation cp="⇋" type="tts">leftwards harpoon over rightwards harpoon</annotation>
+		<annotation cp="⇌">harpoon | leftwards | over | rightwards</annotation>
+		<annotation cp="⇌" type="tts">rightwards harpoon over leftwards harpoon</annotation>
+		<annotation cp="⇐">arrow | double | leftwards</annotation>
+		<annotation cp="⇐" type="tts">leftwards double arrow</annotation>
+		<annotation cp="⇍">arrow | double | leftwards | stroke</annotation>
+		<annotation cp="⇍" type="tts">leftwards double arrow stroke</annotation>
+		<annotation cp="⇑">arrow | double | upwards</annotation>
+		<annotation cp="⇑" type="tts">upwards double arrow</annotation>
+		<annotation cp="⇒">arrow | double | rightwards</annotation>
+		<annotation cp="⇒" type="tts">rightwards double arrow</annotation>
+		<annotation cp="⇏">arrow | double | rightwards | stroke</annotation>
+		<annotation cp="⇏" type="tts">rightwards double arrow stroke</annotation>
+		<annotation cp="⇓">arrow | double | downwards</annotation>
+		<annotation cp="⇓" type="tts">downwards double arrow</annotation>
+		<annotation cp="⇔">arrow | double | left | right</annotation>
+		<annotation cp="⇔" type="tts">left right double arrow</annotation>
+		<annotation cp="⇎">arrow | double | left | right | stroke</annotation>
+		<annotation cp="⇎" type="tts">left right double arrow stroke</annotation>
+		<annotation cp="⇖">arrow | double | north | west</annotation>
+		<annotation cp="⇖" type="tts">north west double arrow</annotation>
+		<annotation cp="⇗">arrow | double | east | north</annotation>
+		<annotation cp="⇗" type="tts">north east double arrow</annotation>
+		<annotation cp="⇘">arrow | double | east | south</annotation>
+		<annotation cp="⇘" type="tts">south east double arrow</annotation>
+		<annotation cp="⇙">arrow | double | south | west</annotation>
+		<annotation cp="⇙" type="tts">south west double arrow</annotation>
+		<annotation cp="⇚">arrow | leftwards | triple</annotation>
+		<annotation cp="⇚" type="tts">leftwards triple arrow</annotation>
+		<annotation cp="⇛">arrow | rightwards | triple</annotation>
+		<annotation cp="⇛" type="tts">rightwards triple arrow</annotation>
+		<annotation cp="⇜">arrow | leftwards | squiggle</annotation>
+		<annotation cp="⇜" type="tts">leftwards squiggle arrow</annotation>
+		<annotation cp="⇝">arrow | rightwards | squiggle</annotation>
+		<annotation cp="⇝" type="tts">rightwards squiggle arrow</annotation>
+		<annotation cp="⇞">arrow | double | stroke | upwards</annotation>
+		<annotation cp="⇞" type="tts">upwards arrow double stroke</annotation>
+		<annotation cp="⇟">arrow | double | downwards | stroke</annotation>
+		<annotation cp="⇟" type="tts">downwards arrow double stroke</annotation>
+		<annotation cp="⇠">arrow | dashed | leftwards</annotation>
+		<annotation cp="⇠" type="tts">leftwards dashed arrow</annotation>
+		<annotation cp="⇡">arrow | dashed | upwards</annotation>
+		<annotation cp="⇡" type="tts">upwards dashed arrow</annotation>
+		<annotation cp="⇢">arrow | dashed | rightwards</annotation>
+		<annotation cp="⇢" type="tts">rightwards dashed arrow</annotation>
+		<annotation cp="⇣">arrow | dashed | downwards</annotation>
+		<annotation cp="⇣" type="tts">downwards dashed arrow</annotation>
+		<annotation cp="⇤">arrow | bar | leftwards</annotation>
+		<annotation cp="⇤" type="tts">leftwards arrow bar</annotation>
+		<annotation cp="⇥">arrow | bar | rightwards</annotation>
+		<annotation cp="⇥" type="tts">rightwards arrow bar</annotation>
+		<annotation cp="⇦">arrow | hollow | leftwards</annotation>
+		<annotation cp="⇦" type="tts">leftwards hollow arrow</annotation>
+		<annotation cp="⇧">arrow | hollow | upwards</annotation>
+		<annotation cp="⇧" type="tts">upwards hollow arrow</annotation>
+		<annotation cp="⇨">arrow | hollow | rightwards</annotation>
+		<annotation cp="⇨" type="tts">rightwards hollow arrow</annotation>
+		<annotation cp="⇩">arrow | downwards | hollow</annotation>
+		<annotation cp="⇩" type="tts">downwards hollow arrow</annotation>
+		<annotation cp="⇪">arrow | bar | from | hollow | upwards</annotation>
+		<annotation cp="⇪" type="tts">upwards hollow arrow from bar</annotation>
+		<annotation cp="⇵">arrow | downwards | leftwards | upwards</annotation>
+		<annotation cp="⇵" type="tts">downwards arrow leftwards upwards arrow</annotation>
+		<annotation cp="∀">all | any | for | given | universal</annotation>
+		<annotation cp="∀" type="tts">for all</annotation>
+		<annotation cp="∂">differential | partial</annotation>
+		<annotation cp="∂" type="tts">partial differential</annotation>
+		<annotation cp="∃">exists | there</annotation>
+		<annotation cp="∃" type="tts">there exists</annotation>
+		<annotation cp="∅">empty | mathematics | operator | set</annotation>
+		<annotation cp="∅" type="tts">empty set</annotation>
+		<annotation cp="∆">increment | triangle</annotation>
+		<annotation cp="∆" type="tts">increment</annotation>
+		<annotation cp="∇">nabla | triangle</annotation>
+		<annotation cp="∇" type="tts">nabla</annotation>
+		<annotation cp="∈">contains | element | membership | of | set</annotation>
+		<annotation cp="∈" type="tts">element of</annotation>
+		<annotation cp="∉">an | element | not</annotation>
+		<annotation cp="∉" type="tts">not an element</annotation>
+		<annotation cp="∋">as | contains | element | member</annotation>
+		<annotation cp="∋" type="tts">contains as member</annotation>
+		<annotation cp="∎">end | halmos | proof | q.e.d. | qed | tombstone</annotation>
+		<annotation cp="∎" type="tts">end proof</annotation>
+		<annotation cp="∏">logic | n-ary | product</annotation>
+		<annotation cp="∏" type="tts">n-ary product</annotation>
+		<annotation cp="∑">mathematics | n-ary | summation</annotation>
+		<annotation cp="∑" type="tts">n-ary summation</annotation>
+		<annotation cp="+">add | plus | sign</annotation>
+		<annotation cp="+" type="tts">plus sign</annotation>
+		<annotation cp="±">plus-minus</annotation>
+		<annotation cp="±" type="tts">plus-minus</annotation>
+		<annotation cp="÷">divide | division | obelus | sign</annotation>
+		<annotation cp="÷" type="tts">division sign</annotation>
+		<annotation cp="×">multiplication | multiply | sign | times</annotation>
+		<annotation cp="×" type="tts">multiplication sign</annotation>
+		<annotation cp="&lt;">less | less-than | open | tag | than</annotation>
+		<annotation cp="&lt;" type="tts">less-than</annotation>
+		<annotation cp="≮">inequality | less-than | mathematics | not</annotation>
+		<annotation cp="≮" type="tts">not less-than</annotation>
+		<annotation cp="=">equal | equals</annotation>
+		<annotation cp="=" type="tts">equal</annotation>
+		<annotation cp="≠">equal | inequality | inequation | not</annotation>
+		<annotation cp="≠" type="tts">not equal</annotation>
+		<annotation cp="&gt;">close | greater | greater-than | tag | than</annotation>
+		<annotation cp="&gt;" type="tts">greater-than</annotation>
+		<annotation cp="≯">greater-than | inequality | mathematics | not</annotation>
+		<annotation cp="≯" type="tts">not greater-than</annotation>
+		<annotation cp="¬">negation | not</annotation>
+		<annotation cp="¬" type="tts">negation</annotation>
+		<annotation cp="|">bar | line | pike | pipe | sheffer | stick | stroke | vbar | vertical</annotation>
+		<annotation cp="|" type="tts">vertical line</annotation>
+		<annotation cp="~">tilde</annotation>
+		<annotation cp="~" type="tts">tilde</annotation>
+		<annotation cp="−">minus | sign | subtract</annotation>
+		<annotation cp="−" type="tts">minus sign</annotation>
+		<annotation cp="⁻">minus | superscript</annotation>
+		<annotation cp="⁻" type="tts">superscript minus</annotation>
+		<annotation cp="∓">minus-or-plus | plus-minus</annotation>
+		<annotation cp="∓" type="tts">minus-or-plus</annotation>
+		<annotation cp="∕">division | slash | stroke | virgule</annotation>
+		<annotation cp="∕" type="tts">division slash</annotation>
+		<annotation cp="⁄">fraction | slash | stroke | virgule</annotation>
+		<annotation cp="⁄" type="tts">fraction slash</annotation>
+		<annotation cp="∗">asterisk | operator | star</annotation>
+		<annotation cp="∗" type="tts">asterisk operator</annotation>
+		<annotation cp="∘">composition | operator | ring</annotation>
+		<annotation cp="∘" type="tts">ring operator</annotation>
+		<annotation cp="∙">bullet | operator</annotation>
+		<annotation cp="∙" type="tts">bullet operator</annotation>
+		<annotation cp="√">radical | radix | root | square | surd</annotation>
+		<annotation cp="√" type="tts">square root</annotation>
+		<annotation cp="∝">proportional | proportionality</annotation>
+		<annotation cp="∝" type="tts">proportional</annotation>
+		<annotation cp="∞">infinity | sign</annotation>
+		<annotation cp="∞" type="tts">infinity sign</annotation>
+		<annotation cp="∟">angle | mathematics | right</annotation>
+		<annotation cp="∟" type="tts">right angle</annotation>
+		<annotation cp="∠">acute | angle</annotation>
+		<annotation cp="∠" type="tts">angle</annotation>
+		<annotation cp="∣">divides | divisor</annotation>
+		<annotation cp="∣" type="tts">divides</annotation>
+		<annotation cp="∥">parallel</annotation>
+		<annotation cp="∥" type="tts">parallel</annotation>
+		<annotation cp="∧">ac | and | atque | logical | wedge</annotation>
+		<annotation cp="∧" type="tts">logical and</annotation>
+		<annotation cp="∩">intersection | set</annotation>
+		<annotation cp="∩" type="tts">intersection</annotation>
+		<annotation cp="∪">collection | set | union</annotation>
+		<annotation cp="∪" type="tts">union</annotation>
+		<annotation cp="∫">calculus | integral</annotation>
+		<annotation cp="∫" type="tts">integral</annotation>
+		<annotation cp="∬">calculus | double | integral</annotation>
+		<annotation cp="∬" type="tts">double integral</annotation>
+		<annotation cp="∮">contour | integral</annotation>
+		<annotation cp="∮" type="tts">contour integral</annotation>
+		<annotation cp="∴">logic | therefore</annotation>
+		<annotation cp="∴" type="tts">therefore</annotation>
+		<annotation cp="∵">because | logic</annotation>
+		<annotation cp="∵" type="tts">because</annotation>
+		<annotation cp="∶">ratio</annotation>
+		<annotation cp="∶" type="tts">ratio</annotation>
+		<annotation cp="∷">proportion | proportionality</annotation>
+		<annotation cp="∷" type="tts">proportion</annotation>
+		<annotation cp="∼">operator | tilde</annotation>
+		<annotation cp="∼" type="tts">tilde operator</annotation>
+		<annotation cp="∽">reversed | tilde</annotation>
+		<annotation cp="∽" type="tts">reversed tilde</annotation>
+		<annotation cp="∾">inverted | lazy | s</annotation>
+		<annotation cp="∾" type="tts">inverted lazy s</annotation>
+		<annotation cp="≃">asymptote | asymptotically | equal | mathematics</annotation>
+		<annotation cp="≃" type="tts">asymptotically equal</annotation>
+		<annotation cp="≅">approximately | congruence | equal | equality | isomorphism | mathematics</annotation>
+		<annotation cp="≅" type="tts">approximately equal</annotation>
+		<annotation cp="≈">almost | approximate | approximation | equal</annotation>
+		<annotation cp="≈" type="tts">almost equal</annotation>
+		<annotation cp="≌">all | equal | equality | mathematics</annotation>
+		<annotation cp="≌" type="tts">all equal</annotation>
+		<annotation cp="≒">approximately | equal | image | the</annotation>
+		<annotation cp="≒" type="tts">approximately equal the image</annotation>
+		<annotation cp="≖">equal | equality | in | mathematics | ring</annotation>
+		<annotation cp="≖" type="tts">ring in equal</annotation>
+		<annotation cp="≡">exact | identical | to | triple</annotation>
+		<annotation cp="≡" type="tts">identical to</annotation>
+		<annotation cp="≣">equality | equivalent | mathematics | strictly</annotation>
+		<annotation cp="≣" type="tts">strictly equivalent</annotation>
+		<annotation cp="≤">equal | equals | inequality | less-than | or</annotation>
+		<annotation cp="≤" type="tts">less-than or equal</annotation>
+		<annotation cp="≥">equal | equals | greater-than | inequality | or</annotation>
+		<annotation cp="≥" type="tts">greater-than or equal</annotation>
+		<annotation cp="≦">equal | inequality | less-than | mathematics | over</annotation>
+		<annotation cp="≦" type="tts">less-than over equal</annotation>
+		<annotation cp="≧">equal | greater-than | inequality | mathematics | over</annotation>
+		<annotation cp="≧" type="tts">greater-than over equal</annotation>
+		<annotation cp="≪">inequality | less-than | mathematics | much</annotation>
+		<annotation cp="≪" type="tts">much less-than</annotation>
+		<annotation cp="≫">greater-than | inequality | mathematics | much</annotation>
+		<annotation cp="≫" type="tts">much greater-than</annotation>
+		<annotation cp="≬">between</annotation>
+		<annotation cp="≬" type="tts">between</annotation>
+		<annotation cp="≳">equivalent | greater-than | inequality | mathematics</annotation>
+		<annotation cp="≳" type="tts">greater-than equivalent</annotation>
+		<annotation cp="≺">mathematics | operator | precedes | set</annotation>
+		<annotation cp="≺" type="tts">precedes</annotation>
+		<annotation cp="≻">mathematics | operator | set | succeeds</annotation>
+		<annotation cp="≻" type="tts">succeeds</annotation>
+		<annotation cp="⊁">does | mathematics | not | operator | set | succeed</annotation>
+		<annotation cp="⊁" type="tts">does not succeed</annotation>
+		<annotation cp="⊂">of | set | subset</annotation>
+		<annotation cp="⊂" type="tts">subset of</annotation>
+		<annotation cp="⊃">mathematics | operator | set | superset</annotation>
+		<annotation cp="⊃" type="tts">superset</annotation>
+		<annotation cp="⊆">equal | subset</annotation>
+		<annotation cp="⊆" type="tts">subset equal</annotation>
+		<annotation cp="⊇">equal | equality | mathematics | superset</annotation>
+		<annotation cp="⊇" type="tts">superset equal</annotation>
+		<annotation cp="⊕">circled | plus</annotation>
+		<annotation cp="⊕" type="tts">circled plus</annotation>
+		<annotation cp="⊖">circled | difference | erosion | minus | symmetric</annotation>
+		<annotation cp="⊖" type="tts">circled minus</annotation>
+		<annotation cp="⊗">circled | product | tensor | times</annotation>
+		<annotation cp="⊗" type="tts">circled times</annotation>
+		<annotation cp="⊘">circled | division | division-like | mathematics | slash</annotation>
+		<annotation cp="⊘" type="tts">circled division slash</annotation>
+		<annotation cp="⊙">circled | dot | operator | XNOR</annotation>
+		<annotation cp="⊙" type="tts">circled dot operator</annotation>
+		<annotation cp="⊚">circled | operator | ring</annotation>
+		<annotation cp="⊚" type="tts">circled ring operator</annotation>
+		<annotation cp="⊛">asterisk | circled | operator</annotation>
+		<annotation cp="⊛" type="tts">circled asterisk operator</annotation>
+		<annotation cp="⊞">addition-like | mathematics | plus | squared</annotation>
+		<annotation cp="⊞" type="tts">squared plus</annotation>
+		<annotation cp="⊟">mathematics | minus | squared | subtraction-like</annotation>
+		<annotation cp="⊟" type="tts">squared minus</annotation>
+		<annotation cp="⊥">eet | falsum | tack | up</annotation>
+		<annotation cp="⊥" type="tts">up tack</annotation>
+		<annotation cp="⊮">does | force | not</annotation>
+		<annotation cp="⊮" type="tts">does not force</annotation>
+		<annotation cp="⊰">mathematics | operator | precedes | relation | set | under</annotation>
+		<annotation cp="⊰" type="tts">precedes under relation</annotation>
+		<annotation cp="⊱">mathematics | operator | relation | set | succeeds | under</annotation>
+		<annotation cp="⊱" type="tts">succeeds under relation</annotation>
+		<annotation cp="⋭">as | contain | does | equal | group | mathematics | normal | not | subgroup | theory</annotation>
+		<annotation cp="⋭" type="tts">does not contain as normal subgroup equal</annotation>
+		<annotation cp="⊶">original</annotation>
+		<annotation cp="⊶" type="tts">original</annotation>
+		<annotation cp="⊹">conjugate | hermitian | mathematics | matrix | self-adjoint | square</annotation>
+		<annotation cp="⊹" type="tts">hermitian conjugate matrix</annotation>
+		<annotation cp="⊿">mathematics | right | right-angled | triangle</annotation>
+		<annotation cp="⊿" type="tts">right triangle</annotation>
+		<annotation cp="⋁">disjunction | logic | logical | n-ary | or</annotation>
+		<annotation cp="⋁" type="tts">n-ary logical or</annotation>
+		<annotation cp="⋂">intersection | mathematics | n-ary | operator | set</annotation>
+		<annotation cp="⋂" type="tts">n-ary intersection</annotation>
+		<annotation cp="⋃">mathematics | n-ary | operator | set | union</annotation>
+		<annotation cp="⋃" type="tts">n-ary union</annotation>
+		<annotation cp="⋅">dot | operator</annotation>
+		<annotation cp="⋅" type="tts">dot operator</annotation>
+		<annotation cp="⋆">operator | star</annotation>
+		<annotation cp="⋆" type="tts">star operator</annotation>
+		<annotation cp="⋈">binary | bowtie | join | natural | operator</annotation>
+		<annotation cp="⋈" type="tts">natural join</annotation>
+		<annotation cp="⋒">double | intersection | mathematics | operator | set</annotation>
+		<annotation cp="⋒" type="tts">double intersection</annotation>
+		<annotation cp="⋘">inequality | less-than | mathematics | much | very</annotation>
+		<annotation cp="⋘" type="tts">very much less-than</annotation>
+		<annotation cp="⋙">greater-than | inequality | mathematics | much | very</annotation>
+		<annotation cp="⋙" type="tts">very much greater-than</annotation>
+		<annotation cp="⋮">ellipsis | mathematics | vertical</annotation>
+		<annotation cp="⋮" type="tts">vertical ellipsis</annotation>
+		<annotation cp="⋯">ellipsis | horizontal | midline</annotation>
+		<annotation cp="⋯" type="tts">midline horizontal ellipsis</annotation>
+		<annotation cp="⋰">diagonal | ellipsis | mathematics | right | up</annotation>
+		<annotation cp="⋰" type="tts">up right diagonal ellipsis</annotation>
+		<annotation cp="⋱">diagonal | down | ellipsis | mathematics | right</annotation>
+		<annotation cp="⋱" type="tts">down right diagonal ellipsis</annotation>
+		<annotation cp="■">filled | square</annotation>
+		<annotation cp="■" type="tts">filled square</annotation>
+		<annotation cp="□">hollow | square</annotation>
+		<annotation cp="□" type="tts">hollow square</annotation>
+		<annotation cp="▢">corners | hollow | rounded | square | with</annotation>
+		<annotation cp="▢" type="tts">hollow square with rounded corners</annotation>
+		<annotation cp="▣">containing | filled | hollow | square</annotation>
+		<annotation cp="▣" type="tts">hollow square containing filled square</annotation>
+		<annotation cp="▤">fill | horizontal | square | with</annotation>
+		<annotation cp="▤" type="tts">square with horizontal fill</annotation>
+		<annotation cp="▥">fill | square | vertical | with</annotation>
+		<annotation cp="▥" type="tts">square with vertical fill</annotation>
+		<annotation cp="▦">crosshatch | fill | orthogonal | square</annotation>
+		<annotation cp="▦" type="tts">square orthogonal crosshatch fill</annotation>
+		<annotation cp="▧">fill | left | lower | right | square | upper</annotation>
+		<annotation cp="▧" type="tts">square upper left lower right fill</annotation>
+		<annotation cp="▨">fill | left | lower | right | square | upper</annotation>
+		<annotation cp="▨" type="tts">square upper right lower left fill</annotation>
+		<annotation cp="▩">crosshatch | diagonal | fill | square</annotation>
+		<annotation cp="▩" type="tts">square diagonal crosshatch fill</annotation>
+		<annotation cp="▬">filled | rectangle</annotation>
+		<annotation cp="▬" type="tts">filled rectangle</annotation>
+		<annotation cp="▭">hollow | rectangle</annotation>
+		<annotation cp="▭" type="tts">hollow rectangle</annotation>
+		<annotation cp="▮">filled | rectangle | vertical</annotation>
+		<annotation cp="▮" type="tts">filled vertical rectangle</annotation>
+		<annotation cp="▰">filled | parallelogram</annotation>
+		<annotation cp="▰" type="tts">filled parallelogram</annotation>
+		<annotation cp="▲">arrow | filled | triangle | up | up-pointing</annotation>
+		<annotation cp="▲" type="tts">filled up-pointing triangle</annotation>
+		<annotation cp="△">hollow | triangle | up-pointing</annotation>
+		<annotation cp="△" type="tts">hollow up-pointing triangle</annotation>
+		<annotation cp="▴">filled | small | triangle | up-pointing</annotation>
+		<annotation cp="▴" type="tts">filled up-pointing small triangle</annotation>
+		<annotation cp="▵">hollow | small | triangle | up-pointing</annotation>
+		<annotation cp="▵" type="tts">hollow up-pointing small triangle</annotation>
+		<annotation cp="▷">hollow | right-pointing | triangle</annotation>
+		<annotation cp="▷" type="tts">hollow right-pointing triangle</annotation>
+		<annotation cp="▸">filled | right-pointing | small | triangle</annotation>
+		<annotation cp="▸" type="tts">filled right-pointing small triangle</annotation>
+		<annotation cp="▹">hollow | right-pointing | small | triangle</annotation>
+		<annotation cp="▹" type="tts">hollow right-pointing small triangle</annotation>
+		<annotation cp="►">filled | pointer | right-pointing</annotation>
+		<annotation cp="►" type="tts">filled right-pointing pointer</annotation>
+		<annotation cp="▻">hollow | pointer | right-pointing</annotation>
+		<annotation cp="▻" type="tts">hollow right-pointing pointer</annotation>
+		<annotation cp="▼">arrow | down | down-pointing | filled | triangle</annotation>
+		<annotation cp="▼" type="tts">filled down-pointing triangle</annotation>
+		<annotation cp="▽">down-pointing | hollow | triangle</annotation>
+		<annotation cp="▽" type="tts">hollow down-pointing triangle</annotation>
+		<annotation cp="▾">down-pointing | filled | small | triangle</annotation>
+		<annotation cp="▾" type="tts">filled down-pointing small triangle</annotation>
+		<annotation cp="▿">down-pointing | hollow | small | triangle</annotation>
+		<annotation cp="▿" type="tts">hollow down-pointing small triangle</annotation>
+		<annotation cp="◁">hollow | left-pointing | triangle</annotation>
+		<annotation cp="◁" type="tts">hollow left-pointing triangle</annotation>
+		<annotation cp="◂">filled | left-pointing | small | triangle</annotation>
+		<annotation cp="◂" type="tts">filled left-pointing small triangle</annotation>
+		<annotation cp="◃">hollow | left-pointing | small | triangle</annotation>
+		<annotation cp="◃" type="tts">hollow left-pointing small triangle</annotation>
+		<annotation cp="◄">filled | left-pointing | pointer</annotation>
+		<annotation cp="◄" type="tts">filled left-pointing pointer</annotation>
+		<annotation cp="◅">hollow | left-pointing | pointer</annotation>
+		<annotation cp="◅" type="tts">hollow left-pointing pointer</annotation>
+		<annotation cp="◆">diamond | filled</annotation>
+		<annotation cp="◆" type="tts">filled diamond</annotation>
+		<annotation cp="◇">diamond | hollow</annotation>
+		<annotation cp="◇" type="tts">hollow diamond</annotation>
+		<annotation cp="◈">containing | diamond | filled | hollow</annotation>
+		<annotation cp="◈" type="tts">hollow diamond containing filled diamond</annotation>
+		<annotation cp="◉">cicles | circle | circled | concentric | containing | dot | filled | fisheye | hollow | ward</annotation>
+		<annotation cp="◉" type="tts">hollow circle containing filled circle</annotation>
+		<annotation cp="◊">diamond | lozenge | rhombus</annotation>
+		<annotation cp="◊" type="tts">lozenge</annotation>
+		<annotation cp="○">circle | hollow | ring</annotation>
+		<annotation cp="○" type="tts">hollow circle</annotation>
+		<annotation cp="◌">circle | dotted</annotation>
+		<annotation cp="◌" type="tts">dotted circle</annotation>
+		<annotation cp="◍">circle | fill | vertical | with</annotation>
+		<annotation cp="◍" type="tts">circle with vertical fill</annotation>
+		<annotation cp="◎">circle | circles | concentric | double | target</annotation>
+		<annotation cp="◎" type="tts">concentric circles</annotation>
+		<annotation cp="●">circle | filled</annotation>
+		<annotation cp="●" type="tts">filled circle</annotation>
+		<annotation cp="◐">circle | filled | half | left</annotation>
+		<annotation cp="◐" type="tts">circle left half filled</annotation>
+		<annotation cp="◑">circle | filled | half | right</annotation>
+		<annotation cp="◑" type="tts">circle right half filled</annotation>
+		<annotation cp="◒">circle | filled | half | lower</annotation>
+		<annotation cp="◒" type="tts">circle lower half filled</annotation>
+		<annotation cp="◓">circle | filled | half | upper</annotation>
+		<annotation cp="◓" type="tts">circle upper half filled</annotation>
+		<annotation cp="◔">circle | filled | quadrant | right | upper</annotation>
+		<annotation cp="◔" type="tts">circle upper right quadrant filled</annotation>
+		<annotation cp="◕">all | but | circle | filled | left | quadrant | upper</annotation>
+		<annotation cp="◕" type="tts">circle all but upper left quadrant filled</annotation>
+		<annotation cp="◖">circle | filled | half | left</annotation>
+		<annotation cp="◖" type="tts">left half filled circle</annotation>
+		<annotation cp="◗">circle | filled | half | right</annotation>
+		<annotation cp="◗" type="tts">right half filled circle</annotation>
+		<annotation cp="◘">bullet | inverse</annotation>
+		<annotation cp="◘" type="tts">inverse bullet</annotation>
+		<annotation cp="◙">circle | containing | filled | hollow | inverse | square</annotation>
+		<annotation cp="◙" type="tts">filled square containing hollow circle</annotation>
+		<annotation cp="◜">arc | circular | left | quadrant | upper</annotation>
+		<annotation cp="◜" type="tts">upper left quadrant circular arc</annotation>
+		<annotation cp="◝">arc | circular | quadrant | right | upper</annotation>
+		<annotation cp="◝" type="tts">upper right quadrant circular arc</annotation>
+		<annotation cp="◞">arc | circular | lower | quadrant | right</annotation>
+		<annotation cp="◞" type="tts">lower right quadrant circular arc</annotation>
+		<annotation cp="◟">arc | circular | left | lower | quadrant</annotation>
+		<annotation cp="◟" type="tts">lower left quadrant circular arc</annotation>
+		<annotation cp="◠">circle | half | upper</annotation>
+		<annotation cp="◠" type="tts">upper half circle</annotation>
+		<annotation cp="◡">circle | half | lower</annotation>
+		<annotation cp="◡" type="tts">lower half circle</annotation>
+		<annotation cp="◢">filled | lower | right | triangle</annotation>
+		<annotation cp="◢" type="tts">filled lower right triangle</annotation>
+		<annotation cp="◣">filled | left | lower | triangle</annotation>
+		<annotation cp="◣" type="tts">filled lower left triangle</annotation>
+		<annotation cp="◤">filled | left | triangle | upper</annotation>
+		<annotation cp="◤" type="tts">filled upper left triangle</annotation>
+		<annotation cp="◥">filled | right | triangle | upper</annotation>
+		<annotation cp="◥" type="tts">filled upper right triangle</annotation>
+		<annotation cp="◦">bullet | hollow</annotation>
+		<annotation cp="◦" type="tts">hollow bullet</annotation>
+		<annotation cp="◯">circle | hollow | large | ring</annotation>
+		<annotation cp="◯" type="tts">large hollow circle</annotation>
+		<annotation cp="◳">hollow | quadrant | right | square | upper</annotation>
+		<annotation cp="◳" type="tts">hollow square upper right quadrant</annotation>
+		<annotation cp="◷">circle | hollow | quadrant | right | upper | with</annotation>
+		<annotation cp="◷" type="tts">hollow circle with upper right quadrant</annotation>
+		<annotation cp="◿">lower | right | triangle</annotation>
+		<annotation cp="◿" type="tts">lower right triangle</annotation>
+		<annotation cp="♪">eighth | music | note</annotation>
+		<annotation cp="♪" type="tts">eighth note</annotation>
+		<annotation cp="⨧">plus | subscript | two</annotation>
+		<annotation cp="⨧" type="tts">plus subscript two</annotation>
+		<annotation cp="⨯">cross | product | vector</annotation>
+		<annotation cp="⨯" type="tts">vector cross product</annotation>
+		<annotation cp="⨼">interior | product</annotation>
+		<annotation cp="⨼" type="tts">interior product</annotation>
+		<annotation cp="⩣">double | logical | or | underbar</annotation>
+		<annotation cp="⩣" type="tts">logical or double underbar</annotation>
+		<annotation cp="⩽">equal | less-than | slanted</annotation>
+		<annotation cp="⩽" type="tts">less-than slanted equal</annotation>
+		<annotation cp="⪍">above | equal | less-than | similar</annotation>
+		<annotation cp="⪍" type="tts">less-than above similar equal</annotation>
+		<annotation cp="⪚">double-line | equal | greater-than | inequality | mathematics</annotation>
+		<annotation cp="⪚" type="tts">double-line equal greater-than</annotation>
+		<annotation cp="⪺">above | almost | equal | not | succeeds</annotation>
+		<annotation cp="⪺" type="tts">succeeds above not almost equal</annotation>
+		<annotation cp="♭">bemolle | flat | music | note</annotation>
+		<annotation cp="♭" type="tts">flat</annotation>
+		<annotation cp="♯">dièse | diesis | music | note | sharp</annotation>
+		<annotation cp="♯" type="tts">sharp</annotation>
+		<annotation cp="😀">cheerful | cheery | face | grin | grinning | happy | laugh | nice | smile | smiling | teeth</annotation>
+		<annotation cp="😀" type="tts">grinning face</annotation>
+		<annotation cp="😃">awesome | big | eyes | face | grin | grinning | happy | mouth | open | smile | smiling | teeth | yay</annotation>
+		<annotation cp="😃" type="tts">grinning face with big eyes</annotation>
+		<annotation cp="😄">eye | eyes | face | grin | grinning | happy | laugh | lol | mouth | open | smile | smiling</annotation>
+		<annotation cp="😄" type="tts">grinning face with smiling eyes</annotation>
+		<annotation cp="😁">beaming | eye | eyes | face | grin | grinning | happy | nice | smile | smiling | teeth</annotation>
+		<annotation cp="😁" type="tts">beaming face with smiling eyes</annotation>
+		<annotation cp="😆">closed | eyes | face | grinning | haha | hahaha | happy | laugh | lol | mouth | open | rofl | smile | smiling | squinting</annotation>
+		<annotation cp="😆" type="tts">grinning squinting face</annotation>
+		<annotation cp="😅">cold | dejected | excited | face | grinning | mouth | nervous | open | smile | smiling | stress | stressed | sweat</annotation>
+		<annotation cp="😅" type="tts">grinning face with sweat</annotation>
+		<annotation cp="🤣">crying | face | floor | funny | haha | happy | hehe | hilarious | joy | laugh | lmao | lol | rofl | roflmao | rolling | tear</annotation>
+		<annotation cp="🤣" type="tts">rolling on the floor laughing</annotation>
+		<annotation cp="😂">crying | face | feels | funny | haha | happy | hehe | hilarious | joy | laugh | lmao | lol | rofl | roflmao | tear</annotation>
+		<annotation cp="😂" type="tts">face with tears of joy</annotation>
+		<annotation cp="🙂">face | happy | slightly | smile | smiling</annotation>
+		<annotation cp="🙂" type="tts">slightly smiling face</annotation>
+		<annotation cp="🙃">face | hehe | smile | upside-down</annotation>
+		<annotation cp="🙃" type="tts">upside-down face</annotation>
+		<annotation cp="🫠">disappear | dissolve | embarrassed | face | haha | heat | hot | liquid | lol | melt | melting | sarcasm | sarcastic</annotation> <!-- 1FAE0 -->
+		<annotation cp="🫠" type="tts">melting face</annotation>
+		<annotation cp="😉">face | flirt | heartbreaker | sexy | slide | tease | wink | winking | winks</annotation>
+		<annotation cp="😉" type="tts">winking face</annotation>
+		<annotation cp="😊">blush | eye | eyes | face | glad | satisfied | smile | smiling</annotation>
+		<annotation cp="😊" type="tts">smiling face with smiling eyes</annotation>
+		<annotation cp="😇">angel | angelic | angels | blessed | face | fairy | fairytale | fantasy | halo | happy | innocent | peaceful | smile | smiling | spirit | tale</annotation>
+		<annotation cp="😇" type="tts">smiling face with halo</annotation>
+		<annotation cp="🥰">3 | adore | crush | face | heart | hearts | ily | love | romance | smile | smiling | you</annotation>
+		<annotation cp="🥰" type="tts">smiling face with hearts</annotation>
+		<annotation cp="😍">143 | bae | eye | face | feels | heart-eyes | hearts | ily | kisses | love | romance | romantic | smile | xoxo</annotation>
+		<annotation cp="😍" type="tts">smiling face with heart-eyes</annotation>
+		<annotation cp="🤩">excited | eyes | face | grinning | smile | star | star-struck | starry-eyed | wow</annotation>
+		<annotation cp="🤩" type="tts">star-struck</annotation>
+		<annotation cp="😘">adorbs | bae | blowing | face | flirt | heart | ily | kiss | love | lover | miss | muah | romantic | smooch | xoxo | you</annotation>
+		<annotation cp="😘" type="tts">face blowing a kiss</annotation>
+		<annotation cp="😗">143 | date | dating | face | flirt | ily | kiss | love | smooch | smooches | xoxo | you</annotation>
+		<annotation cp="😗" type="tts">kissing face</annotation>
+		<annotation cp="☺">face | happy | outlined | relaxed | smile | smiling</annotation>
+		<annotation cp="☺" type="tts">smiling face</annotation>
+		<annotation cp="😚">143 | bae | blush | closed | date | dating | eye | eyes | face | flirt | ily | kisses | kissing | smooches | xoxo</annotation>
+		<annotation cp="😚" type="tts">kissing face with closed eyes</annotation>
+		<annotation cp="😙">143 | closed | date | dating | eye | eyes | face | flirt | ily | kiss | kisses | kissing | love | night | smile | smiling</annotation>
+		<annotation cp="😙" type="tts">kissing face with smiling eyes</annotation>
+		<annotation cp="🥲">face | glad | grateful | happy | joy | pain | proud | relieved | smile | smiley | smiling | tear | touched</annotation>
+		<annotation cp="🥲" type="tts">smiling face with tear</annotation>
+		<annotation cp="😋">delicious | eat | face | food | full | hungry | savor | smile | smiling | tasty | um | yum | yummy</annotation>
+		<annotation cp="😋" type="tts">face savoring food</annotation>
+		<annotation cp="😛">awesome | cool | face | nice | party | stuck-out | sweet | tongue</annotation>
+		<annotation cp="😛" type="tts">face with tongue</annotation>
+		<annotation cp="😜">crazy | epic | eye | face | funny | joke | loopy | nutty | party | stuck-out | tongue | wacky | weirdo | wink | winking | yolo</annotation>
+		<annotation cp="😜" type="tts">winking face with tongue</annotation>
+		<annotation cp="🤪">crazy | eye | eyes | face | goofy | large | small | zany</annotation>
+		<annotation cp="🤪" type="tts">zany face</annotation>
+		<annotation cp="😝">closed | eye | eyes | face | gross | horrible | omg | squinting | stuck-out | taste | tongue | whatever | yolo</annotation>
+		<annotation cp="😝" type="tts">squinting face with tongue</annotation>
+		<annotation cp="🤑">face | money | money-mouth | mouth | paid</annotation>
+		<annotation cp="🤑" type="tts">money-mouth face</annotation>
+		<annotation cp="🤗">face | hands | hug | hugging | open | smiling</annotation>
+		<annotation cp="🤗" type="tts">smiling face with open hands</annotation>
+		<annotation cp="🤭">face | giggle | giggling | hand | mouth | oops | realization | secret | shock | sudden | surprise | whoops</annotation>
+		<annotation cp="🤭" type="tts">face with hand over mouth</annotation>
+		<annotation cp="🫢">amazement | awe | disbelief | embarrass | eyes | face | gasp | hand | mouth | omg | open | over | quiet | scared | shock | surprise</annotation> <!-- 1FAE2 -->
+		<annotation cp="🫢" type="tts">face with open eyes and hand over mouth</annotation>
+		<annotation cp="🫣">captivated | embarrass | eye | face | hide | hiding | peek | peeking | peep | scared | shy | stare</annotation> <!-- 1FAE3 -->
+		<annotation cp="🫣" type="tts">face with peeking eye</annotation>
+		<annotation cp="🤫">face | quiet | shh | shush | shushing</annotation>
+		<annotation cp="🤫" type="tts">shushing face</annotation>
+		<annotation cp="🤔">chin | consider | face | hmm | ponder | pondering | thinking | wondering</annotation>
+		<annotation cp="🤔" type="tts">thinking face</annotation>
+		<annotation cp="🫡">face | good | luck | ma’am | OK | respect | salute | saluting | sir | troops | yes</annotation> <!-- 1FAE1 -->
+		<annotation cp="🫡" type="tts">saluting face</annotation>
+		<annotation cp="🤐">face | keep | mouth | quiet | secret | shut | zip | zipper | zipper-mouth</annotation>
+		<annotation cp="🤐" type="tts">zipper-mouth face</annotation>
+		<annotation cp="🤨">disapproval | disbelief | distrust | emoji | eyebrow | face | hmm | mild | raised | skeptic | skeptical | skepticism | surprise | what</annotation>
+		<annotation cp="🤨" type="tts">face with raised eyebrow</annotation>
+		<annotation cp="😐">awkward | blank | deadpan | expressionless | face | fine | jealous | meh | neutral | oh | shade | straight | unamused | unhappy | unimpressed | whatever</annotation>
+		<annotation cp="😐" type="tts">neutral face</annotation>
+		<annotation cp="😑">awkward | dead | expressionless | face | fine | inexpressive | jealous | meh | not | oh | omg | straight | uh | unhappy | unimpressed | whatever</annotation>
+		<annotation cp="😑" type="tts">expressionless face</annotation>
+		<annotation cp="😶">awkward | blank | expressionless | face | mouth | mouthless | mute | quiet | secret | silence | silent | speechless</annotation>
+		<annotation cp="😶" type="tts">face without mouth</annotation>
+		<annotation cp="🫥">depressed | disappear | dotted | face | hidden | hide | introvert | invisible | line | meh | whatever | wtv</annotation> <!-- 1FAE5 -->
+		<annotation cp="🫥" type="tts">dotted line face</annotation>
+		<annotation cp="😶‍🌫">absentminded | clouds | face | fog | head</annotation> <!-- 1F636 200D 1F32B FE0F: face in clouds -->
+		<annotation cp="😶‍🌫" type="tts">face in clouds</annotation>
+		<annotation cp="😏">boss | dapper | face | flirt | homie | kidding | leer | shade | slick | sly | smirk | smug | snicker | suave | suspicious | swag</annotation>
+		<annotation cp="😏" type="tts">smirking face</annotation>
+		<annotation cp="😒">... | bored | face | fine | jealous | jel | jelly | pissed | smh | ugh | uhh | unamused | unhappy | weird | whatever</annotation>
+		<annotation cp="😒" type="tts">unamused face</annotation>
+		<annotation cp="🙄">eyeroll | eyes | face | rolling | shade | ugh | whatever</annotation>
+		<annotation cp="🙄" type="tts">face with rolling eyes</annotation>
+		<annotation cp="😬">awk | awkward | dentist | face | grimace | grimacing | grinning | smile | smiling</annotation>
+		<annotation cp="😬" type="tts">grimacing face</annotation>
+		<annotation cp="😮‍💨">blow | blowing | exhale | exhaling | exhausted | face | gasp | groan | relief | sigh | smiley | smoke | whisper | whistle</annotation> <!-- 1F62E 200D 1F4A8 -->
+		<annotation cp="😮‍💨" type="tts">face exhaling</annotation>
+		<annotation cp="🤥">face | liar | lie | lying | pinocchio</annotation>
+		<annotation cp="🤥" type="tts">lying face</annotation>
+		<annotation cp="🫨">crazy | daze | earthquake | face | omg | panic | shaking | shock | surprise | vibrate | whoa | wow</annotation> <!-- 1FAE8 -->
+		<annotation cp="🫨" type="tts">shaking face</annotation>
+		<annotation cp="🙂‍↔">head | horizontally | no | shake | shaking</annotation> <!-- 1F642 200D 2194 -->
+		<annotation cp="🙂‍↔" type="tts">head shaking horizontally</annotation>
+		<annotation cp="🙂‍↕">head | nod | shaking | vertically | yes</annotation> <!-- 1F642 200D 2195 -->
+		<annotation cp="🙂‍↕" type="tts">head shaking vertically</annotation>
+		<annotation cp="😌">calm | face | peace | relief | relieved | zen</annotation>
+		<annotation cp="😌" type="tts">relieved face</annotation>
+		<annotation cp="😔">awful | bored | dejected | died | disappointed | face | losing | lost | pensive | sad | sucks</annotation>
+		<annotation cp="😔" type="tts">pensive face</annotation>
+		<annotation cp="😪">crying | face | good | night | sad | sleep | sleeping | sleepy | tired</annotation>
+		<annotation cp="😪" type="tts">sleepy face</annotation>
+		<annotation cp="🤤">drooling | face</annotation>
+		<annotation cp="🤤" type="tts">drooling face</annotation>
+		<annotation cp="😴">bed | bedtime | face | good | goodnight | nap | night | sleep | sleeping | tired | whatever | yawn | zzz</annotation>
+		<annotation cp="😴" type="tts">sleeping face</annotation>
+		<annotation cp="🫩">bags | bored | exhausted | eyes | face | fatigued | late | sleepy | tired | weary</annotation>
+		<annotation cp="🫩" type="tts">face with bags under eyes</annotation>
+		<annotation cp="😷">cold | dentist | dermatologist | doctor | dr | face | germs | mask | medical | medicine | sick</annotation>
+		<annotation cp="😷" type="tts">face with medical mask</annotation>
+		<annotation cp="🤒">face | ill | sick | thermometer</annotation>
+		<annotation cp="🤒" type="tts">face with thermometer</annotation>
+		<annotation cp="🤕">bandage | face | head-bandage | hurt | injury | ouch</annotation>
+		<annotation cp="🤕" type="tts">face with head-bandage</annotation>
+		<annotation cp="🤢">face | gross | nasty | nauseated | sick | vomit</annotation>
+		<annotation cp="🤢" type="tts">nauseated face</annotation>
+		<annotation cp="🤮">barf | ew | face | gross | puke | sick | spew | throw | up | vomit | vomiting</annotation>
+		<annotation cp="🤮" type="tts">face vomiting</annotation>
+		<annotation cp="🤧">face | fever | flu | gesundheit | sick | sneeze | sneezing</annotation>
+		<annotation cp="🤧" type="tts">sneezing face</annotation>
+		<annotation cp="🥵">dying | face | feverish | heat | hot | panting | red-faced | stroke | sweating | tongue</annotation>
+		<annotation cp="🥵" type="tts">hot face</annotation>
+		<annotation cp="🥶">blue | blue-faced | cold | face | freezing | frostbite | icicles | subzero | teeth</annotation>
+		<annotation cp="🥶" type="tts">cold face</annotation>
+		<annotation cp="🥴">dizzy | drunk | eyes | face | intoxicated | mouth | tipsy | uneven | wavy | woozy</annotation>
+		<annotation cp="🥴" type="tts">woozy face</annotation>
+		<annotation cp="😵">crossed-out | dead | dizzy | eyes | face | feels | knocked | out | sick | tired</annotation>
+		<annotation cp="😵" type="tts">face with crossed-out eyes</annotation>
+		<annotation cp="😵‍💫">confused | dizzy | eyes | face | hypnotized | omg | smiley | spiral | trouble | whoa | woah | woozy</annotation> <!-- 1F635 200D 1F4AB -->
+		<annotation cp="😵‍💫" type="tts">face with spiral eyes</annotation>
+		<annotation cp="🤯">blown | explode | exploding | head | mind | mindblown | no | shocked | way</annotation>
+		<annotation cp="🤯" type="tts">exploding head</annotation>
+		<annotation cp="🤠">cowboy | cowgirl | face | hat</annotation>
+		<annotation cp="🤠" type="tts">cowboy hat face</annotation>
+		<annotation cp="🥳">bday | birthday | celebrate | celebration | excited | face | happy | hat | hooray | horn | party | partying</annotation>
+		<annotation cp="🥳" type="tts">partying face</annotation>
+		<annotation cp="🥸">disguise | eyebrow | face | glasses | incognito | moustache | mustache | nose | person | spy | tache | tash</annotation>
+		<annotation cp="🥸" type="tts">disguised face</annotation>
+		<annotation cp="😎">awesome | beach | bright | bro | chilling | cool | face | rad | relaxed | shades | slay | smile | style | sunglasses | swag | win</annotation>
+		<annotation cp="😎" type="tts">smiling face with sunglasses</annotation>
+		<annotation cp="🤓">brainy | clever | expert | face | geek | gifted | glasses | intelligent | nerd | smart</annotation>
+		<annotation cp="🤓" type="tts">nerd face</annotation>
+		<annotation cp="🧐">classy | face | fancy | monocle | rich | stuffy | wealthy</annotation>
+		<annotation cp="🧐" type="tts">face with monocle</annotation>
+		<annotation cp="😕">befuddled | confused | confusing | dunno | face | frown | hm | meh | not | sad | sorry | sure</annotation>
+		<annotation cp="😕" type="tts">confused face</annotation>
+		<annotation cp="🫤">confused | confusion | diagonal | disappointed | doubt | doubtful | face | frustrated | frustration | meh | mouth | skeptical | unsure | whatever | wtv</annotation> <!-- 1FAE4 -->
+		<annotation cp="🫤" type="tts">face with diagonal mouth</annotation>
+		<annotation cp="😟">anxious | butterflies | face | nerves | nervous | sad | stress | stressed | surprised | worried | worry</annotation>
+		<annotation cp="😟" type="tts">worried face</annotation>
+		<annotation cp="🙁">face | frown | frowning | sad | slightly</annotation>
+		<annotation cp="🙁" type="tts">slightly frowning face</annotation>
+		<annotation cp="☹">face | frown | frowning | sad</annotation>
+		<annotation cp="☹" type="tts">frowning face</annotation>
+		<annotation cp="😮">believe | face | forgot | mouth | omg | open | shocked | surprised | sympathy | unbelievable | unreal | whoa | wow | you</annotation>
+		<annotation cp="😮" type="tts">face with open mouth</annotation>
+		<annotation cp="😯">epic | face | hushed | omg | stunned | surprised | whoa | woah</annotation>
+		<annotation cp="😯" type="tts">hushed face</annotation>
+		<annotation cp="😲">astonished | cost | face | no | omg | shocked | totally | way</annotation>
+		<annotation cp="😲" type="tts">astonished face</annotation>
+		<annotation cp="😳">amazed | awkward | crazy | dazed | dead | disbelief | embarrassed | face | flushed | geez | heat | hot | impressed | jeez | what | wow</annotation>
+		<annotation cp="😳" type="tts">flushed face</annotation>
+		<annotation cp="🥺">begging | big | eyes | face | mercy | not | pleading | please | pretty | puppy | sad | why</annotation>
+		<annotation cp="🥺" type="tts">pleading face</annotation>
+		<annotation cp="🥹">admiration | aww | back | cry | embarrassed | face | feelings | grateful | gratitude | holding | joy | please | proud | resist | sad | tears</annotation> <!-- 1F979 -->
+		<annotation cp="🥹" type="tts">face holding back tears</annotation>
+		<annotation cp="😦">caught | face | frown | frowning | guard | mouth | open | scared | scary | surprise | what | wow</annotation>
+		<annotation cp="😦" type="tts">frowning face with open mouth</annotation>
+		<annotation cp="😧">anguished | face | forgot | scared | scary | stressed | surprise | unhappy | what | wow</annotation>
+		<annotation cp="😧" type="tts">anguished face</annotation>
+		<annotation cp="😨">afraid | anxious | blame | face | fear | fearful | scared | worried</annotation>
+		<annotation cp="😨" type="tts">fearful face</annotation>
+		<annotation cp="😰">anxious | blue | cold | eek | face | mouth | nervous | open | rushed | scared | sweat | yikes</annotation>
+		<annotation cp="😰" type="tts">anxious face with sweat</annotation>
+		<annotation cp="😥">anxious | call | close | complicated | disappointed | face | not | relieved | sad | sweat | time | whew</annotation>
+		<annotation cp="😥" type="tts">sad but relieved face</annotation>
+		<annotation cp="😢">awful | cry | crying | face | feels | miss | sad | tear | triste | unhappy</annotation>
+		<annotation cp="😢" type="tts">crying face</annotation>
+		<annotation cp="😭">bawling | cry | crying | face | loudly | sad | sob | tear | tears | unhappy</annotation>
+		<annotation cp="😭" type="tts">loudly crying face</annotation>
+		<annotation cp="😱">epic | face | fear | fearful | munch | scared | scream | screamer | screaming | shocked | surprised | woah</annotation>
+		<annotation cp="😱" type="tts">face screaming in fear</annotation>
+		<annotation cp="😖">annoyed | confounded | confused | cringe | distraught | face | feels | frustrated | mad | sad</annotation>
+		<annotation cp="😖" type="tts">confounded face</annotation>
+		<annotation cp="😣">concentrate | concentration | face | focus | headache | persevere | persevering</annotation>
+		<annotation cp="😣" type="tts">persevering face</annotation>
+		<annotation cp="😞">awful | blame | dejected | disappointed | face | fail | losing | sad | unhappy</annotation>
+		<annotation cp="😞" type="tts">disappointed face</annotation>
+		<annotation cp="😓">close | cold | downcast | face | feels | headache | nervous | sad | scared | sweat | yikes</annotation>
+		<annotation cp="😓" type="tts">downcast face with sweat</annotation>
+		<annotation cp="😩">crying | face | fail | feels | hungry | mad | nooo | sad | sleepy | tired | unhappy | weary</annotation>
+		<annotation cp="😩" type="tts">weary face</annotation>
+		<annotation cp="😫">cost | face | feels | nap | sad | sneeze | tired</annotation>
+		<annotation cp="😫" type="tts">tired face</annotation>
+		<annotation cp="🥱">bedtime | bored | face | goodnight | nap | night | sleep | sleepy | tired | whatever | yawn | yawning | zzz</annotation>
+		<annotation cp="🥱" type="tts">yawning face</annotation>
+		<annotation cp="😤">anger | angry | face | feels | fume | fuming | furious | fury | mad | nose | steam | triumph | unhappy | won</annotation>
+		<annotation cp="😤" type="tts">face with steam from nose</annotation>
+		<annotation cp="😡">anger | angry | enraged | face | feels | mad | maddening | pouting | rage | red | shade | unhappy | upset</annotation>
+		<annotation cp="😡" type="tts">enraged face</annotation>
+		<annotation cp="😠">anger | angry | blame | face | feels | frustrated | mad | maddening | rage | shade | unhappy | upset</annotation>
+		<annotation cp="😠" type="tts">angry face</annotation>
+		<annotation cp="🤬">censor | cursing | cussing | face | mad | mouth | pissed | swearing | symbols</annotation>
+		<annotation cp="🤬" type="tts">face with symbols on mouth</annotation>
+		<annotation cp="😈">demon | devil | evil | face | fairy | fairytale | fantasy | horns | purple | shade | smile | smiling | tale</annotation>
+		<annotation cp="😈" type="tts">smiling face with horns</annotation>
+		<annotation cp="👿">angry | demon | devil | evil | face | fairy | fairytale | fantasy | horns | imp | mischievous | purple | shade | tale</annotation>
+		<annotation cp="👿" type="tts">angry face with horns</annotation>
+		<annotation cp="💀">body | dead | death | face | fairy | fairytale | i’m | lmao | monster | skull | tale | yolo</annotation>
+		<annotation cp="💀" type="tts">skull</annotation>
+		<annotation cp="☠">bone | crossbones | dead | death | face | monster | skull</annotation>
+		<annotation cp="☠" type="tts">skull and crossbones</annotation>
+		<annotation cp="💩">bs | comic | doo | dung | face | fml | monster | pile | poo | poop | smelly | smh | stink | stinks | stinky | turd</annotation>
+		<annotation cp="💩" type="tts">pile of poo</annotation>
+		<annotation cp="🤡">clown | face</annotation>
+		<annotation cp="🤡" type="tts">clown face</annotation>
+		<annotation cp="👹">creature | devil | face | fairy | fairytale | fantasy | mask | monster | ogre | scary | tale</annotation>
+		<annotation cp="👹" type="tts">ogre</annotation>
+		<annotation cp="👺">angry | creature | face | fairy | fairytale | fantasy | goblin | mask | mean | monster | tale</annotation>
+		<annotation cp="👺" type="tts">goblin</annotation>
+		<annotation cp="👻">boo | creature | excited | face | fairy | fairytale | fantasy | ghost | halloween | haunting | monster | scary | silly | tale</annotation>
+		<annotation cp="👻" type="tts">ghost</annotation>
+		<annotation cp="👽">alien | creature | extraterrestrial | face | fairy | fairytale | fantasy | monster | space | tale | ufo</annotation>
+		<annotation cp="👽" type="tts">alien</annotation>
+		<annotation cp="👾">alien | creature | extraterrestrial | face | fairy | fairytale | fantasy | game | gamer | games | monster | pixelated | space | tale | ufo</annotation>
+		<annotation cp="👾" type="tts">alien monster</annotation>
+		<annotation cp="🤖">face | monster | robot</annotation>
+		<annotation cp="🤖" type="tts">robot</annotation>
+		<annotation cp="😺">animal | cat | face | grinning | mouth | open | smile | smiling</annotation>
+		<annotation cp="😺" type="tts">grinning cat</annotation>
+		<annotation cp="😸">animal | cat | eye | eyes | face | grin | grinning | smile | smiling</annotation>
+		<annotation cp="😸" type="tts">grinning cat with smiling eyes</annotation>
+		<annotation cp="😹">animal | cat | face | joy | laugh | laughing | lol | tear | tears</annotation>
+		<annotation cp="😹" type="tts">cat with tears of joy</annotation>
+		<annotation cp="😻">animal | cat | eye | face | heart | heart-eyes | love | smile | smiling</annotation>
+		<annotation cp="😻" type="tts">smiling cat with heart-eyes</annotation>
+		<annotation cp="😼">animal | cat | face | ironic | smile | wry</annotation>
+		<annotation cp="😼" type="tts">cat with wry smile</annotation>
+		<annotation cp="😽">animal | cat | closed | eye | eyes | face | kiss | kissing</annotation>
+		<annotation cp="😽" type="tts">kissing cat</annotation>
+		<annotation cp="🙀">animal | cat | face | oh | surprised | weary</annotation>
+		<annotation cp="🙀" type="tts">weary cat</annotation>
+		<annotation cp="😿">animal | cat | cry | crying | face | sad | tear</annotation>
+		<annotation cp="😿" type="tts">crying cat</annotation>
+		<annotation cp="😾">animal | cat | face | pouting</annotation>
+		<annotation cp="😾" type="tts">pouting cat</annotation>
+		<annotation cp="🙈">embarrassed | evil | face | forbidden | forgot | gesture | hide | monkey | no | omg | prohibited | scared | secret | smh | watch</annotation>
+		<annotation cp="🙈" type="tts">see-no-evil monkey</annotation>
+		<annotation cp="🙉">animal | ears | evil | face | forbidden | gesture | hear | listen | monkey | no | not | prohibited | secret | shh | tmi</annotation>
+		<annotation cp="🙉" type="tts">hear-no-evil monkey</annotation>
+		<annotation cp="🙊">animal | evil | face | forbidden | gesture | monkey | no | not | oops | prohibited | quiet | secret | speak | stealth</annotation>
+		<annotation cp="🙊" type="tts">speak-no-evil monkey</annotation>
+		<annotation cp="💌">heart | letter | love | mail | romance | valentine</annotation>
+		<annotation cp="💌" type="tts">love letter</annotation>
+		<annotation cp="💘">143 | adorbs | arrow | cupid | date | emotion | heart | ily | love | romance | valentine</annotation>
+		<annotation cp="💘" type="tts">heart with arrow</annotation>
+		<annotation cp="💝">143 | anniversary | emotion | heart | ily | kisses | ribbon | valentine | xoxo</annotation>
+		<annotation cp="💝" type="tts">heart with ribbon</annotation>
+		<annotation cp="💖">143 | emotion | excited | good | heart | ily | kisses | morning | night | sparkle | sparkling | xoxo</annotation>
+		<annotation cp="💖" type="tts">sparkling heart</annotation>
+		<annotation cp="💗">143 | emotion | excited | growing | heart | heartpulse | ily | kisses | muah | nervous | pulse | xoxo</annotation>
+		<annotation cp="💗" type="tts">growing heart</annotation>
+		<annotation cp="💓">143 | beating | cardio | emotion | heart | heartbeat | ily | love | pulsating | pulse</annotation>
+		<annotation cp="💓" type="tts">beating heart</annotation>
+		<annotation cp="💞">143 | adorbs | anniversary | emotion | heart | hearts | revolving</annotation>
+		<annotation cp="💞" type="tts">revolving hearts</annotation>
+		<annotation cp="💕">143 | anniversary | date | dating | emotion | heart | hearts | ily | kisses | love | loving | two | xoxo</annotation>
+		<annotation cp="💕" type="tts">two hearts</annotation>
+		<annotation cp="💟">143 | decoration | emotion | heart | hearth | purple | white</annotation>
+		<annotation cp="💟" type="tts">heart decoration</annotation>
+		<annotation cp="❣">exclamation | heart | heavy | mark | punctuation</annotation>
+		<annotation cp="❣" type="tts">heart exclamation</annotation>
+		<annotation cp="💔">break | broken | crushed | emotion | heart | heartbroken | lonely | sad</annotation>
+		<annotation cp="💔" type="tts">broken heart</annotation>
+		<annotation cp="❤‍🔥">burn | fire | heart | love | lust | sacred</annotation> <!-- 2764 200D 1F525 -->
+		<annotation cp="❤‍🔥" type="tts">heart on fire</annotation>
+		<annotation cp="❤‍🩹">healthier | heart | improving | mending | recovering | recuperating | well</annotation> <!-- 2764 200D 1FA79 -->
+		<annotation cp="❤‍🩹" type="tts">mending heart</annotation>
+		<annotation cp="❤">emotion | heart | love | red</annotation>
+		<annotation cp="❤" type="tts">red heart</annotation>
+		<annotation cp="🩷">143 | adorable | cute | emotion | heart | ily | like | love | pink | special | sweet</annotation> <!-- 1FA77 -->
+		<annotation cp="🩷" type="tts">pink heart</annotation>
+		<annotation cp="🧡">143 | heart | orange</annotation>
+		<annotation cp="🧡" type="tts">orange heart</annotation>
+		<annotation cp="💛">143 | cardiac | emotion | heart | ily | love | yellow</annotation>
+		<annotation cp="💛" type="tts">yellow heart</annotation>
+		<annotation cp="💚">143 | emotion | green | heart | ily | love | romantic</annotation>
+		<annotation cp="💚" type="tts">green heart</annotation>
+		<annotation cp="💙">143 | blue | emotion | heart | ily | love | romance</annotation>
+		<annotation cp="💙" type="tts">blue heart</annotation>
+		<annotation cp="🩵">143 | blue | cute | cyan | emotion | heart | ily | light | like | love | sky | special | teal</annotation> <!-- 1FA75 -->
+		<annotation cp="🩵" type="tts">light blue heart</annotation>
+		<annotation cp="💜">143 | bestest | emotion | heart | ily | love | purple</annotation>
+		<annotation cp="💜" type="tts">purple heart</annotation>
+		<annotation cp="🤎">143 | brown | heart</annotation>
+		<annotation cp="🤎" type="tts">brown heart</annotation>
+		<annotation cp="🖤">black | evil | heart | wicked</annotation>
+		<annotation cp="🖤" type="tts">black heart</annotation>
+		<annotation cp="🩶">143 | emotion | gray | grey | heart | ily | love | silver | slate | special</annotation> <!-- 1FA76 -->
+		<annotation cp="🩶" type="tts">grey heart</annotation>
+		<annotation cp="🤍">143 | heart | white</annotation>
+		<annotation cp="🤍" type="tts">white heart</annotation>
+		<annotation cp="💋">dating | emotion | heart | kiss | kissing | lips | mark | romance | sexy</annotation>
+		<annotation cp="💋" type="tts">kiss mark</annotation>
+		<annotation cp="💯">100 | a+ | agree | clearly | definitely | faithful | fleek | full | hundred | keep | perfect | point | score | TRUE | truth | yup</annotation>
+		<annotation cp="💯" type="tts">hundred points</annotation>
+		<annotation cp="💢">anger | angry | comic | mad | symbol | upset</annotation>
+		<annotation cp="💢" type="tts">anger symbol</annotation>
+		<annotation cp="💥">bomb | boom | collide | collision | comic | explode</annotation>
+		<annotation cp="💥" type="tts">collision</annotation>
+		<annotation cp="💫">comic | dizzy | shining | shooting | star | stars</annotation>
+		<annotation cp="💫" type="tts">dizzy</annotation>
+		<annotation cp="💦">comic | drip | droplet | droplets | drops | splashing | squirt | sweat | water | wet | work | workout</annotation>
+		<annotation cp="💦" type="tts">sweat droplets</annotation>
+		<annotation cp="💨">away | cloud | comic | dash | dashing | fart | fast | go | gone | gotta | running | smoke</annotation>
+		<annotation cp="💨" type="tts">dashing away</annotation>
+		<annotation cp="🕳">hole</annotation>
+		<annotation cp="🕳" type="tts">hole</annotation>
+		<annotation cp="💬">balloon | bubble | comic | dialog | message | sms | speech | talk | text | typing</annotation>
+		<annotation cp="💬" type="tts">speech balloon</annotation>
+		<annotation cp="👁‍🗨">balloon | bubble | eye | speech | witness</annotation>
+		<annotation cp="👁‍🗨" type="tts">eye in speech bubble</annotation>
+		<annotation cp="🗨">balloon | bubble | dialog | left | speech</annotation>
+		<annotation cp="🗨" type="tts">left speech bubble</annotation>
+		<annotation cp="🗯">anger | angry | balloon | bubble | mad | right</annotation>
+		<annotation cp="🗯" type="tts">right anger bubble</annotation>
+		<annotation cp="💭">balloon | bubble | cartoon | cloud | comic | daydream | decisions | dream | idea | invent | invention | realize | think | thoughts | wonder</annotation>
+		<annotation cp="💭" type="tts">thought balloon</annotation>
+		<annotation cp="💤">comic | good | goodnight | night | sleep | sleeping | sleepy | tired | zzz</annotation>
+		<annotation cp="💤" type="tts">ZZZ</annotation>
+		<annotation cp="👋">bye | cya | g2g | greetings | gtg | hand | hello | hey | hi | later | outtie | ttfn | ttyl | wave | yo | you</annotation>
+		<annotation cp="👋" type="tts">waving hand</annotation>
+		<annotation cp="🤚">back | backhand | hand | raised</annotation>
+		<annotation cp="🤚" type="tts">raised back of hand</annotation>
+		<annotation cp="🖐">finger | fingers | hand | raised | splayed | stop</annotation>
+		<annotation cp="🖐" type="tts">hand with fingers splayed</annotation>
+		<annotation cp="✋">5 | five | hand | high | raised | stop</annotation>
+		<annotation cp="✋" type="tts">raised hand</annotation>
+		<annotation cp="🖖">finger | hand | hands | salute | Vulcan</annotation>
+		<annotation cp="🖖" type="tts">vulcan salute</annotation>
+		<annotation cp="🫱">hand | handshake | hold | reach | right | rightward | rightwards | shake</annotation> <!-- 1FAF1 -->
+		<annotation cp="🫱" type="tts">rightwards hand</annotation>
+		<annotation cp="🫲">hand | handshake | hold | left | leftward | leftwards | reach | shake</annotation> <!-- 1FAF2 -->
+		<annotation cp="🫲" type="tts">leftwards hand</annotation>
+		<annotation cp="🫳">dismiss | down | drop | dropped | hand | palm | pick | shoo | up</annotation> <!-- 1FAF3 -->
+		<annotation cp="🫳" type="tts">palm down hand</annotation>
+		<annotation cp="🫴">beckon | catch | come | hand | hold | know | lift | me | offer | palm | tell</annotation> <!-- 1FAF4 -->
+		<annotation cp="🫴" type="tts">palm up hand</annotation>
+		<annotation cp="🫷">block | five | halt | hand | high | hold | leftward | leftwards | pause | push | pushing | refuse | slap | stop | wait</annotation> <!-- 1FAF7 -->
+		<annotation cp="🫷" type="tts">leftwards pushing hand</annotation>
+		<annotation cp="🫸">block | five | halt | hand | high | hold | pause | push | pushing | refuse | rightward | rightwards | slap | stop | wait</annotation> <!-- 1FAF8 -->
+		<annotation cp="🫸" type="tts">rightwards pushing hand</annotation>
+		<annotation cp="👌">awesome | bet | dope | fleek | fosho | got | gotcha | hand | legit | OK | okay | pinch | rad | sure | sweet | three</annotation>
+		<annotation cp="👌" type="tts">OK hand</annotation>
+		<annotation cp="🤌">fingers | gesture | hand | hold | huh | interrogation | patience | pinched | relax | sarcastic | ugh | what | zip</annotation>
+		<annotation cp="🤌" type="tts">pinched fingers</annotation>
+		<annotation cp="🤏">amount | bit | fingers | hand | little | pinching | small | sort</annotation>
+		<annotation cp="🤏" type="tts">pinching hand</annotation>
+		<annotation cp="✌">hand | peace | v | victory</annotation>
+		<annotation cp="✌" type="tts">victory hand</annotation>
+		<annotation cp="🤞">cross | crossed | finger | fingers | hand | luck</annotation>
+		<annotation cp="🤞" type="tts">crossed fingers</annotation>
+		<annotation cp="🫰">&lt;3 | crossed | expensive | finger | hand | heart | index | love | money | snap | thumb</annotation> <!-- 1FAF0 -->
+		<annotation cp="🫰" type="tts">hand with index finger and thumb crossed</annotation>
+		<annotation cp="🤟">fingers | gesture | hand | ILY | love | love-you | three | you</annotation>
+		<annotation cp="🤟" type="tts">love-you gesture</annotation>
+		<annotation cp="🤘">finger | hand | horns | rock-on | sign</annotation>
+		<annotation cp="🤘" type="tts">sign of the horns</annotation>
+		<annotation cp="🤙">call | hand | hang | loose | me | Shaka</annotation>
+		<annotation cp="🤙" type="tts">call me hand</annotation>
+		<annotation cp="👈">backhand | finger | hand | index | left | point | pointing</annotation>
+		<annotation cp="👈" type="tts">backhand index pointing left</annotation>
+		<annotation cp="👉">backhand | finger | hand | index | point | pointing | right</annotation>
+		<annotation cp="👉" type="tts">backhand index pointing right</annotation>
+		<annotation cp="👆">backhand | finger | hand | index | point | pointing | up</annotation>
+		<annotation cp="👆" type="tts">backhand index pointing up</annotation>
+		<annotation cp="🖕">finger | hand | middle</annotation>
+		<annotation cp="🖕" type="tts">middle finger</annotation>
+		<annotation cp="👇">backhand | down | finger | hand | index | point | pointing</annotation>
+		<annotation cp="👇" type="tts">backhand index pointing down</annotation>
+		<annotation cp="☝">finger | hand | index | point | pointing | this | up</annotation>
+		<annotation cp="☝" type="tts">index pointing up</annotation>
+		<annotation cp="🫵">at | finger | hand | index | pointing | poke | viewer | you</annotation> <!-- 1FAF5 -->
+		<annotation cp="🫵" type="tts">index pointing at the viewer</annotation>
+		<annotation cp="👍">+1 | good | hand | like | thumb | up | yes</annotation>
+		<annotation cp="👍" type="tts">thumbs up</annotation>
+		<annotation cp="👎">-1 | bad | dislike | down | good | hand | no | nope | thumb | thumbs</annotation>
+		<annotation cp="👎" type="tts">thumbs down</annotation>
+		<annotation cp="✊">clenched | fist | hand | punch | raised | solidarity</annotation>
+		<annotation cp="✊" type="tts">raised fist</annotation>
+		<annotation cp="👊">absolutely | agree | boom | bro | bruh | bump | clenched | correct | fist | hand | knuckle | oncoming | pound | punch | rock | ttyl</annotation>
+		<annotation cp="👊" type="tts">oncoming fist</annotation>
+		<annotation cp="🤛">fist | left-facing | leftwards</annotation>
+		<annotation cp="🤛" type="tts">left-facing fist</annotation>
+		<annotation cp="🤜">fist | right-facing | rightwards</annotation>
+		<annotation cp="🤜" type="tts">right-facing fist</annotation>
+		<annotation cp="👏">applause | approval | awesome | clap | congrats | congratulations | excited | good | great | hand | homie | job | nice | prayed | well | yay</annotation>
+		<annotation cp="👏" type="tts">clapping hands</annotation>
+		<annotation cp="🙌">celebration | gesture | hand | hands | hooray | praise | raised | raising</annotation>
+		<annotation cp="🙌" type="tts">raising hands</annotation>
+		<annotation cp="🫶">&lt;3 | hands | heart | love | you</annotation> <!-- 1FAF6 -->
+		<annotation cp="🫶" type="tts">heart hands</annotation>
+		<annotation cp="👐">hand | hands | hug | jazz | open | swerve</annotation>
+		<annotation cp="👐" type="tts">open hands</annotation>
+		<annotation cp="🤲">cupped | dua | hands | palms | pray | prayer | together | up | wish</annotation>
+		<annotation cp="🤲" type="tts">palms up together</annotation>
+		<annotation cp="🤝">agreement | deal | hand | handshake | meeting | shake</annotation>
+		<annotation cp="🤝" type="tts">handshake</annotation>
+		<annotation cp="🙏">appreciate | ask | beg | blessed | bow | cmon | five | folded | gesture | hand | high | please | pray | thanks | thx</annotation>
+		<annotation cp="🙏" type="tts">folded hands</annotation>
+		<annotation cp="✍">hand | write | writing</annotation>
+		<annotation cp="✍" type="tts">writing hand</annotation>
+		<annotation cp="💅">bored | care | cosmetics | done | makeup | manicure | nail | polish | whatever</annotation>
+		<annotation cp="💅" type="tts">nail polish</annotation>
+		<annotation cp="🤳">camera | phone | selfie</annotation>
+		<annotation cp="🤳" type="tts">selfie</annotation>
+		<annotation cp="💪">arm | beast | bench | biceps | bodybuilder | bro | curls | flex | gains | gym | jacked | muscle | press | ripped | strong | weightlift</annotation>
+		<annotation cp="💪" type="tts">flexed biceps</annotation>
+		<annotation cp="🦾">accessibility | arm | mechanical | prosthetic</annotation>
+		<annotation cp="🦾" type="tts">mechanical arm</annotation>
+		<annotation cp="🦿">accessibility | leg | mechanical | prosthetic</annotation>
+		<annotation cp="🦿" type="tts">mechanical leg</annotation>
+		<annotation cp="🦵">bent | foot | kick | knee | leg | limb</annotation>
+		<annotation cp="🦵" type="tts">leg</annotation>
+		<annotation cp="🦶">ankle | feet | foot | kick | stomp</annotation>
+		<annotation cp="🦶" type="tts">foot</annotation>
+		<annotation cp="👂">body | ear | ears | hear | hearing | listen | listening | sound</annotation>
+		<annotation cp="👂" type="tts">ear</annotation>
+		<annotation cp="🦻">accessibility | aid | ear | hard | hearing</annotation>
+		<annotation cp="🦻" type="tts">ear with hearing aid</annotation>
+		<annotation cp="👃">body | nose | noses | nosey | odor | smell | smells</annotation>
+		<annotation cp="👃" type="tts">nose</annotation>
+		<annotation cp="🧠">brain | intelligent | smart</annotation>
+		<annotation cp="🧠" type="tts">brain</annotation>
+		<annotation cp="🫀">anatomical | beat | cardiology | heart | heartbeat | organ | pulse | real | red</annotation>
+		<annotation cp="🫀" type="tts">anatomical heart</annotation>
+		<annotation cp="🫁">breath | breathe | exhalation | inhalation | lung | lungs | organ | respiration</annotation>
+		<annotation cp="🫁" type="tts">lungs</annotation>
+		<annotation cp="🦷">dentist | pearly | teeth | tooth | white</annotation>
+		<annotation cp="🦷" type="tts">tooth</annotation>
+		<annotation cp="🦴">bone | bones | dog | skeleton | wishbone</annotation>
+		<annotation cp="🦴" type="tts">bone</annotation>
+		<annotation cp="👀">body | eye | eyes | face | googly | look | looking | omg | peep | see | seeing</annotation>
+		<annotation cp="👀" type="tts">eyes</annotation>
+		<annotation cp="👁">1 | body | eye | one</annotation>
+		<annotation cp="👁" type="tts">eye</annotation>
+		<annotation cp="👅">body | lick | slurp | tongue</annotation>
+		<annotation cp="👅" type="tts">tongue</annotation>
+		<annotation cp="👄">beauty | body | kiss | kissing | lips | lipstick | mouth</annotation>
+		<annotation cp="👄" type="tts">mouth</annotation>
+		<annotation cp="🫦">anxious | bite | biting | fear | flirt | flirting | kiss | lip | lipstick | nervous | sexy | uncomfortable | worried | worry</annotation> <!-- 1FAE6 -->
+		<annotation cp="🫦" type="tts">biting lip</annotation>
+		<annotation cp="👶">babies | baby | children | goo | infant | newborn | pregnant | young</annotation>
+		<annotation cp="👶" type="tts">baby</annotation>
+		<annotation cp="🧒">bright-eyed | child | grandchild | kid | young | younger</annotation>
+		<annotation cp="🧒" type="tts">child</annotation>
+		<annotation cp="👦">boy | bright-eyed | child | grandson | kid | son | young | younger</annotation>
+		<annotation cp="👦" type="tts">boy</annotation>
+		<annotation cp="👧">bright-eyed | child | daughter | girl | granddaughter | kid | Virgo | young | younger | zodiac</annotation>
+		<annotation cp="👧" type="tts">girl</annotation>
+		<annotation cp="🧑">adult | person</annotation>
+		<annotation cp="🧑" type="tts">person</annotation>
+		<annotation cp="👱">blond | blond-haired | human | person</annotation>
+		<annotation cp="👱" type="tts">person: blond hair</annotation>
+		<annotation cp="👨">adult | bro | man</annotation>
+		<annotation cp="👨" type="tts">man</annotation>
+		<annotation cp="🧔">beard | bearded | person | whiskers</annotation>
+		<annotation cp="🧔" type="tts">person: beard</annotation>
+		<annotation cp="🧔‍♂">beard | bearded | man | whiskers</annotation>
+		<annotation cp="🧔‍♂" type="tts">man: beard</annotation>
+		<annotation cp="👱‍♂">blond | blond-haired | hair | man</annotation>
+		<annotation cp="👱‍♂" type="tts">man: blond hair</annotation>
+		<annotation cp="👩">adult | lady | woman</annotation>
+		<annotation cp="👩" type="tts">woman</annotation>
+		<annotation cp="🧔‍♀">beard | bearded | whiskers | woman</annotation>
+		<annotation cp="🧔‍♀" type="tts">woman: beard</annotation>
+		<annotation cp="👱‍♀">blond | blond-haired | blonde | hair | woman</annotation>
+		<annotation cp="👱‍♀" type="tts">woman: blond hair</annotation>
+		<annotation cp="🧓">adult | elderly | grandparent | old | person | wise</annotation>
+		<annotation cp="🧓" type="tts">older person</annotation>
+		<annotation cp="👴">adult | bald | elderly | gramps | grandfather | grandpa | man | old | wise</annotation>
+		<annotation cp="👴" type="tts">old man</annotation>
+		<annotation cp="👵">adult | elderly | grandma | grandmother | granny | lady | old | wise | woman</annotation>
+		<annotation cp="👵" type="tts">old woman</annotation>
+		<annotation cp="🙍">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | person | upset</annotation>
+		<annotation cp="🙍" type="tts">person frowning</annotation>
+		<annotation cp="🙍‍♂">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | man | upset</annotation>
+		<annotation cp="🙍‍♂" type="tts">man frowning</annotation>
+		<annotation cp="🙍‍♀">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | upset | woman</annotation>
+		<annotation cp="🙍‍♀" type="tts">woman frowning</annotation>
+		<annotation cp="🙎">disappointed | downtrodden | frown | grimace | person | pouting | scowl | sulk | upset | whine</annotation>
+		<annotation cp="🙎" type="tts">person pouting</annotation>
+		<annotation cp="🙎‍♂">disappointed | downtrodden | frown | grimace | man | pouting | scowl | sulk | upset | whine</annotation>
+		<annotation cp="🙎‍♂" type="tts">man pouting</annotation>
+		<annotation cp="🙎‍♀">disappointed | downtrodden | frown | grimace | pouting | scowl | sulk | upset | whine | woman</annotation>
+		<annotation cp="🙎‍♀" type="tts">woman pouting</annotation>
+		<annotation cp="🙅">forbidden | gesture | hand | NO | not | person | prohibit</annotation>
+		<annotation cp="🙅" type="tts">person gesturing NO</annotation>
+		<annotation cp="🙅‍♂">forbidden | gesture | hand | man | NO | not | prohibit</annotation>
+		<annotation cp="🙅‍♂" type="tts">man gesturing NO</annotation>
+		<annotation cp="🙅‍♀">forbidden | gesture | hand | NO | not | prohibit | woman</annotation>
+		<annotation cp="🙅‍♀" type="tts">woman gesturing NO</annotation>
+		<annotation cp="🙆">exercise | gesture | gesturing | hand | OK | omg | person</annotation>
+		<annotation cp="🙆" type="tts">person gesturing OK</annotation>
+		<annotation cp="🙆‍♂">exercise | gesture | gesturing | hand | man | OK | omg</annotation>
+		<annotation cp="🙆‍♂" type="tts">man gesturing OK</annotation>
+		<annotation cp="🙆‍♀">exercise | gesture | gesturing | hand | OK | omg | woman</annotation>
+		<annotation cp="🙆‍♀" type="tts">woman gesturing OK</annotation>
+		<annotation cp="💁">fetch | flick | flip | gossip | hand | person | sarcasm | sarcastic | sassy | seriously | tipping | whatever</annotation>
+		<annotation cp="💁" type="tts">person tipping hand</annotation>
+		<annotation cp="💁‍♂">fetch | flick | flip | gossip | hand | man | sarcasm | sarcastic | sassy | seriously | tipping | whatever</annotation>
+		<annotation cp="💁‍♂" type="tts">man tipping hand</annotation>
+		<annotation cp="💁‍♀">fetch | flick | flip | gossip | hand | sarcasm | sarcastic | sassy | seriously | tipping | whatever | woman</annotation>
+		<annotation cp="💁‍♀" type="tts">woman tipping hand</annotation>
+		<annotation cp="🙋">gesture | hand | here | know | me | person | pick | question | raise | raising</annotation>
+		<annotation cp="🙋" type="tts">person raising hand</annotation>
+		<annotation cp="🙋‍♂">gesture | hand | here | know | man | me | pick | question | raise | raising</annotation>
+		<annotation cp="🙋‍♂" type="tts">man raising hand</annotation>
+		<annotation cp="🙋‍♀">gesture | hand | here | know | me | pick | question | raise | raising | woman</annotation>
+		<annotation cp="🙋‍♀" type="tts">woman raising hand</annotation>
+		<annotation cp="🧏">accessibility | deaf | ear | gesture | hear | person</annotation>
+		<annotation cp="🧏" type="tts">deaf person</annotation>
+		<annotation cp="🧏‍♂">accessibility | deaf | ear | gesture | hear | man</annotation>
+		<annotation cp="🧏‍♂" type="tts">deaf man</annotation>
+		<annotation cp="🧏‍♀">accessibility | deaf | ear | gesture | hear | woman</annotation>
+		<annotation cp="🧏‍♀" type="tts">deaf woman</annotation>
+		<annotation cp="🙇">apology | ask | beg | bow | bowing | favor | forgive | gesture | meditate | meditation | person | pity | regret | sorry</annotation>
+		<annotation cp="🙇" type="tts">person bowing</annotation>
+		<annotation cp="🙇‍♂">apology | ask | beg | bow | bowing | favor | forgive | gesture | man | meditate | meditation | pity | regret | sorry</annotation>
+		<annotation cp="🙇‍♂" type="tts">man bowing</annotation>
+		<annotation cp="🙇‍♀">apology | ask | beg | bow | bowing | favor | forgive | gesture | meditate | meditation | pity | regret | sorry | woman</annotation>
+		<annotation cp="🙇‍♀" type="tts">woman bowing</annotation>
+		<annotation cp="🤦">again | bewilder | disbelief | exasperation | facepalm | no | not | oh | omg | person | shock | smh</annotation>
+		<annotation cp="🤦" type="tts">person facepalming</annotation>
+		<annotation cp="🤦‍♂">again | bewilder | disbelief | exasperation | facepalm | man | no | not | oh | omg | shock | smh</annotation>
+		<annotation cp="🤦‍♂" type="tts">man facepalming</annotation>
+		<annotation cp="🤦‍♀">again | bewilder | disbelief | exasperation | facepalm | no | not | oh | omg | shock | smh | woman</annotation>
+		<annotation cp="🤦‍♀" type="tts">woman facepalming</annotation>
+		<annotation cp="🤷">doubt | dunno | guess | idk | ignorance | indifference | knows | maybe | person | shrug | shrugging | whatever | who</annotation>
+		<annotation cp="🤷" type="tts">person shrugging</annotation>
+		<annotation cp="🤷‍♂">doubt | dunno | guess | idk | ignorance | indifference | knows | man | maybe | shrug | shrugging | whatever | who</annotation>
+		<annotation cp="🤷‍♂" type="tts">man shrugging</annotation>
+		<annotation cp="🤷‍♀">doubt | dunno | guess | idk | ignorance | indifference | knows | maybe | shrug | shrugging | whatever | who | woman</annotation>
+		<annotation cp="🤷‍♀" type="tts">woman shrugging</annotation>
+		<annotation cp="🧑‍⚕">doctor | health | healthcare | nurse | therapist | worker</annotation>
+		<annotation cp="🧑‍⚕" type="tts">health worker</annotation>
+		<annotation cp="👨‍⚕">doctor | health | healthcare | man | nurse | therapist | worker</annotation>
+		<annotation cp="👨‍⚕" type="tts">man health worker</annotation>
+		<annotation cp="👩‍⚕">doctor | health | healthcare | nurse | therapist | woman | worker</annotation>
+		<annotation cp="👩‍⚕" type="tts">woman health worker</annotation>
+		<annotation cp="🧑‍🎓">graduate | student</annotation>
+		<annotation cp="🧑‍🎓" type="tts">student</annotation>
+		<annotation cp="👨‍🎓">graduate | man | student</annotation>
+		<annotation cp="👨‍🎓" type="tts">man student</annotation>
+		<annotation cp="👩‍🎓">graduate | student | woman</annotation>
+		<annotation cp="👩‍🎓" type="tts">woman student</annotation>
+		<annotation cp="🧑‍🏫">instructor | lecturer | professor | teacher</annotation>
+		<annotation cp="🧑‍🏫" type="tts">teacher</annotation>
+		<annotation cp="👨‍🏫">instructor | lecturer | man | professor | teacher</annotation>
+		<annotation cp="👨‍🏫" type="tts">man teacher</annotation>
+		<annotation cp="👩‍🏫">instructor | lecturer | professor | teacher | woman</annotation>
+		<annotation cp="👩‍🏫" type="tts">woman teacher</annotation>
+		<annotation cp="🧑‍⚖">judge | justice | law | scales</annotation>
+		<annotation cp="🧑‍⚖" type="tts">judge</annotation>
+		<annotation cp="👨‍⚖">judge | justice | law | man | scales</annotation>
+		<annotation cp="👨‍⚖" type="tts">man judge</annotation>
+		<annotation cp="👩‍⚖">judge | justice | law | scales | woman</annotation>
+		<annotation cp="👩‍⚖" type="tts">woman judge</annotation>
+		<annotation cp="🧑‍🌾">farmer | gardener | rancher</annotation>
+		<annotation cp="🧑‍🌾" type="tts">farmer</annotation>
+		<annotation cp="👨‍🌾">farmer | gardener | man | rancher</annotation>
+		<annotation cp="👨‍🌾" type="tts">man farmer</annotation>
+		<annotation cp="👩‍🌾">farmer | gardener | rancher | woman</annotation>
+		<annotation cp="👩‍🌾" type="tts">woman farmer</annotation>
+		<annotation cp="🧑‍🍳">chef | cook</annotation>
+		<annotation cp="🧑‍🍳" type="tts">cook</annotation>
+		<annotation cp="👨‍🍳">chef | cook | man</annotation>
+		<annotation cp="👨‍🍳" type="tts">man cook</annotation>
+		<annotation cp="👩‍🍳">chef | cook | woman</annotation>
+		<annotation cp="👩‍🍳" type="tts">woman cook</annotation>
+		<annotation cp="🧑‍🔧">electrician | mechanic | plumber | tradesperson</annotation>
+		<annotation cp="🧑‍🔧" type="tts">mechanic</annotation>
+		<annotation cp="👨‍🔧">electrician | man | mechanic | plumber | tradesperson</annotation>
+		<annotation cp="👨‍🔧" type="tts">man mechanic</annotation>
+		<annotation cp="👩‍🔧">electrician | mechanic | plumber | tradesperson | woman</annotation>
+		<annotation cp="👩‍🔧" type="tts">woman mechanic</annotation>
+		<annotation cp="🧑‍🏭">assembly | factory | industrial | worker</annotation>
+		<annotation cp="🧑‍🏭" type="tts">factory worker</annotation>
+		<annotation cp="👨‍🏭">assembly | factory | industrial | man | worker</annotation>
+		<annotation cp="👨‍🏭" type="tts">man factory worker</annotation>
+		<annotation cp="👩‍🏭">assembly | factory | industrial | woman | worker</annotation>
+		<annotation cp="👩‍🏭" type="tts">woman factory worker</annotation>
+		<annotation cp="🧑‍💼">architect | business | manager | office | white-collar | worker</annotation>
+		<annotation cp="🧑‍💼" type="tts">office worker</annotation>
+		<annotation cp="👨‍💼">architect | business | man | manager | office | white-collar | worker</annotation>
+		<annotation cp="👨‍💼" type="tts">man office worker</annotation>
+		<annotation cp="👩‍💼">architect | business | manager | office | white-collar | woman | worker</annotation>
+		<annotation cp="👩‍💼" type="tts">woman office worker</annotation>
+		<annotation cp="🧑‍🔬">biologist | chemist | engineer | mathematician | physicist | scientist</annotation>
+		<annotation cp="🧑‍🔬" type="tts">scientist</annotation>
+		<annotation cp="👨‍🔬">biologist | chemist | engineer | man | mathematician | physicist | scientist</annotation>
+		<annotation cp="👨‍🔬" type="tts">man scientist</annotation>
+		<annotation cp="👩‍🔬">biologist | chemist | engineer | mathematician | physicist | scientist | woman</annotation>
+		<annotation cp="👩‍🔬" type="tts">woman scientist</annotation>
+		<annotation cp="🧑‍💻">coder | computer | developer | inventor | software | technologist</annotation>
+		<annotation cp="🧑‍💻" type="tts">technologist</annotation>
+		<annotation cp="👨‍💻">coder | computer | developer | inventor | man | software | technologist</annotation>
+		<annotation cp="👨‍💻" type="tts">man technologist</annotation>
+		<annotation cp="👩‍💻">coder | computer | developer | inventor | software | technologist | woman</annotation>
+		<annotation cp="👩‍💻" type="tts">woman technologist</annotation>
+		<annotation cp="🧑‍🎤">actor | entertainer | rock | rockstar | singer | star</annotation>
+		<annotation cp="🧑‍🎤" type="tts">singer</annotation>
+		<annotation cp="👨‍🎤">actor | entertainer | man | rock | rockstar | singer | star</annotation>
+		<annotation cp="👨‍🎤" type="tts">man singer</annotation>
+		<annotation cp="👩‍🎤">actor | entertainer | rock | rockstar | singer | star | woman</annotation>
+		<annotation cp="👩‍🎤" type="tts">woman singer</annotation>
+		<annotation cp="🧑‍🎨">artist | palette</annotation>
+		<annotation cp="🧑‍🎨" type="tts">artist</annotation>
+		<annotation cp="👨‍🎨">artist | man | palette</annotation>
+		<annotation cp="👨‍🎨" type="tts">man artist</annotation>
+		<annotation cp="👩‍🎨">artist | palette | woman</annotation>
+		<annotation cp="👩‍🎨" type="tts">woman artist</annotation>
+		<annotation cp="🧑‍✈">pilot | plane</annotation>
+		<annotation cp="🧑‍✈" type="tts">pilot</annotation>
+		<annotation cp="👨‍✈">man | pilot | plane</annotation>
+		<annotation cp="👨‍✈" type="tts">man pilot</annotation>
+		<annotation cp="👩‍✈">pilot | plane | woman</annotation>
+		<annotation cp="👩‍✈" type="tts">woman pilot</annotation>
+		<annotation cp="🧑‍🚀">astronaut | rocket | space</annotation>
+		<annotation cp="🧑‍🚀" type="tts">astronaut</annotation>
+		<annotation cp="👨‍🚀">astronaut | man | rocket | space</annotation>
+		<annotation cp="👨‍🚀" type="tts">man astronaut</annotation>
+		<annotation cp="👩‍🚀">astronaut | rocket | space | woman</annotation>
+		<annotation cp="👩‍🚀" type="tts">woman astronaut</annotation>
+		<annotation cp="🧑‍🚒">fire | firefighter | firetruck</annotation>
+		<annotation cp="🧑‍🚒" type="tts">firefighter</annotation>
+		<annotation cp="👨‍🚒">fire | firefighter | firetruck | man</annotation>
+		<annotation cp="👨‍🚒" type="tts">man firefighter</annotation>
+		<annotation cp="👩‍🚒">fire | firefighter | firetruck | woman</annotation>
+		<annotation cp="👩‍🚒" type="tts">woman firefighter</annotation>
+		<annotation cp="👮">apprehend | arrest | citation | cop | law | officer | over | police | pulled | undercover</annotation>
+		<annotation cp="👮" type="tts">police officer</annotation>
+		<annotation cp="👮‍♂">apprehend | arrest | citation | cop | law | man | officer | over | police | pulled | undercover</annotation>
+		<annotation cp="👮‍♂" type="tts">man police officer</annotation>
+		<annotation cp="👮‍♀">apprehend | arrest | citation | cop | law | officer | over | police | pulled | undercover | woman</annotation>
+		<annotation cp="👮‍♀" type="tts">woman police officer</annotation>
+		<annotation cp="🕵">detective | sleuth | spy</annotation>
+		<annotation cp="🕵" type="tts">detective</annotation>
+		<annotation cp="🕵‍♂">detective | man | sleuth | spy</annotation>
+		<annotation cp="🕵‍♂" type="tts">man detective</annotation>
+		<annotation cp="🕵‍♀">detective | sleuth | spy | woman</annotation>
+		<annotation cp="🕵‍♀" type="tts">woman detective</annotation>
+		<annotation cp="💂">buckingham | guard | helmet | london | palace</annotation>
+		<annotation cp="💂" type="tts">guard</annotation>
+		<annotation cp="💂‍♂">buckingham | guard | helmet | london | man | palace</annotation>
+		<annotation cp="💂‍♂" type="tts">man guard</annotation>
+		<annotation cp="💂‍♀">buckingham | guard | helmet | london | palace | woman</annotation>
+		<annotation cp="💂‍♀" type="tts">woman guard</annotation>
+		<annotation cp="🥷">assassin | fight | fighter | hidden | ninja | person | secret | skills | sly | soldier | stealth | war</annotation>
+		<annotation cp="🥷" type="tts">ninja</annotation>
+		<annotation cp="👷">build | construction | fix | hardhat | hat | man | person | rebuild | remodel | repair | work | worker</annotation>
+		<annotation cp="👷" type="tts">construction worker</annotation>
+		<annotation cp="👷‍♂">build | construction | fix | hardhat | hat | man | rebuild | remodel | repair | work | worker</annotation>
+		<annotation cp="👷‍♂" type="tts">man construction worker</annotation>
+		<annotation cp="👷‍♀">build | construction | fix | hardhat | hat | man | rebuild | remodel | repair | woman | work | worker</annotation>
+		<annotation cp="👷‍♀" type="tts">woman construction worker</annotation>
+		<annotation cp="🫅">crown | monarch | noble | person | regal | royal | royalty</annotation> <!-- 1FAC5 -->
+		<annotation cp="🫅" type="tts">person with crown</annotation>
+		<annotation cp="🤴">crown | fairy | fairytale | fantasy | king | prince | royal | royalty | tale</annotation>
+		<annotation cp="🤴" type="tts">prince</annotation>
+		<annotation cp="👸">crown | fairy | fairytale | fantasy | princess | queen | royal | royalty | tale</annotation>
+		<annotation cp="👸" type="tts">princess</annotation>
+		<annotation cp="👳">person | turban | wearing</annotation>
+		<annotation cp="👳" type="tts">person wearing turban</annotation>
+		<annotation cp="👳‍♂">man | turban | wearing</annotation>
+		<annotation cp="👳‍♂" type="tts">man wearing turban</annotation>
+		<annotation cp="👳‍♀">turban | wearing | woman</annotation>
+		<annotation cp="👳‍♀" type="tts">woman wearing turban</annotation>
+		<annotation cp="👲">cap | Chinese | gua | guapi | hat | mao | person | pi | skullcap</annotation>
+		<annotation cp="👲" type="tts">person with skullcap</annotation>
+		<annotation cp="🧕">bandana | head | headscarf | hijab | kerchief | mantilla | tichel | woman</annotation>
+		<annotation cp="🧕" type="tts">woman with headscarf</annotation>
+		<annotation cp="🤵">formal | person | tuxedo | wedding</annotation>
+		<annotation cp="🤵" type="tts">person in tuxedo</annotation>
+		<annotation cp="🤵‍♂">formal | groom | man | tuxedo | wedding</annotation> <!-- 1F935 200D 2642 -->
+		<annotation cp="🤵‍♂" type="tts">man in tuxedo</annotation>
+		<annotation cp="🤵‍♀">formal | tuxedo | wedding | woman</annotation> <!-- 1F935 200D 2640 -->
+		<annotation cp="🤵‍♀" type="tts">woman in tuxedo</annotation>
+		<annotation cp="👰">person | veil | wedding</annotation>
+		<annotation cp="👰" type="tts">person with veil</annotation>
+		<annotation cp="👰‍♂">man | veil | wedding</annotation> <!-- 1F470 200D 2642 -->
+		<annotation cp="👰‍♂" type="tts">man with veil</annotation>
+		<annotation cp="👰‍♀">bride | veil | wedding | woman</annotation> <!-- 1F470 200D 2640 -->
+		<annotation cp="👰‍♀" type="tts">woman with veil</annotation>
+		<annotation cp="🤰">pregnant | woman</annotation>
+		<annotation cp="🤰" type="tts">pregnant woman</annotation>
+		<annotation cp="🫃">belly | bloated | full | man | overeat | pregnant</annotation> <!-- 1FAC3 -->
+		<annotation cp="🫃" type="tts">pregnant man</annotation>
+		<annotation cp="🫄">belly | bloated | full | overeat | person | pregnant | stuffed</annotation> <!-- 1FAC4 -->
+		<annotation cp="🫄" type="tts">pregnant person</annotation>
+		<annotation cp="🤱">baby | breast | breast-feeding | feeding | mom | mother | nursing | woman</annotation>
+		<annotation cp="🤱" type="tts">breast-feeding</annotation>
+		<annotation cp="👩‍🍼">baby | feed | feeding | mom | mother | nanny | newborn | nursing | woman</annotation> <!-- 1F469 200D 1F37C -->
+		<annotation cp="👩‍🍼" type="tts">woman feeding baby</annotation>
+		<annotation cp="👨‍🍼">baby | dad | father | feed | feeding | man | nanny | newborn | nursing</annotation> <!-- 1F468 200D 1F37C -->
+		<annotation cp="👨‍🍼" type="tts">man feeding baby</annotation>
+		<annotation cp="🧑‍🍼">baby | feed | feeding | nanny | newborn | nursing | parent</annotation> <!-- 1F9D1 200D 1F37C -->
+		<annotation cp="🧑‍🍼" type="tts">person feeding baby</annotation>
+		<annotation cp="👼">angel | baby | church | face | fairy | fairytale | fantasy | tale</annotation>
+		<annotation cp="👼" type="tts">baby angel</annotation>
+		<annotation cp="🎅">celebration | Christmas | claus | fairy | fantasy | father | holiday | merry | santa | tale | xmas</annotation>
+		<annotation cp="🎅" type="tts">Santa Claus</annotation>
+		<annotation cp="🤶">celebration | Christmas | claus | fairy | fantasy | holiday | merry | mother | Mrs | santa | tale | xmas</annotation>
+		<annotation cp="🤶" type="tts">Mrs. Claus</annotation>
+		<annotation cp="🧑‍🎄">celebration | Christmas | claus | fairy | fantasy | holiday | merry | Mx | santa | tale | xmas</annotation> <!-- 1F9D1 200D 1F384 -->
+		<annotation cp="🧑‍🎄" type="tts">Mx Claus</annotation>
+		<annotation cp="🦸">good | hero | superhero | superpower</annotation>
+		<annotation cp="🦸" type="tts">superhero</annotation>
+		<annotation cp="🦸‍♂">good | hero | man | superhero | superpower</annotation>
+		<annotation cp="🦸‍♂" type="tts">man superhero</annotation>
+		<annotation cp="🦸‍♀">good | hero | heroine | superhero | superpower | woman</annotation>
+		<annotation cp="🦸‍♀" type="tts">woman superhero</annotation>
+		<annotation cp="🦹">bad | criminal | evil | superpower | supervillain | villain</annotation>
+		<annotation cp="🦹" type="tts">supervillain</annotation>
+		<annotation cp="🦹‍♂">bad | criminal | evil | man | superpower | supervillain | villain</annotation>
+		<annotation cp="🦹‍♂" type="tts">man supervillain</annotation>
+		<annotation cp="🦹‍♀">bad | criminal | evil | superpower | supervillain | villain | woman</annotation>
+		<annotation cp="🦹‍♀" type="tts">woman supervillain</annotation>
+		<annotation cp="🧙">fantasy | mage | magic | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard</annotation>
+		<annotation cp="🧙" type="tts">mage</annotation>
+		<annotation cp="🧙‍♂">fantasy | mage | magic | man | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard</annotation>
+		<annotation cp="🧙‍♂" type="tts">man mage</annotation>
+		<annotation cp="🧙‍♀">fantasy | mage | magic | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard | woman</annotation>
+		<annotation cp="🧙‍♀" type="tts">woman mage</annotation>
+		<annotation cp="🧚">fairy | fairytale | fantasy | myth | person | pixie | tale | wings</annotation>
+		<annotation cp="🧚" type="tts">fairy</annotation>
+		<annotation cp="🧚‍♂">fairy | fairytale | fantasy | man | myth | Oberon | person | pixie | Puck | tale | wings</annotation>
+		<annotation cp="🧚‍♂" type="tts">man fairy</annotation>
+		<annotation cp="🧚‍♀">fairy | fairytale | fantasy | myth | person | pixie | tale | Titania | wings | woman</annotation>
+		<annotation cp="🧚‍♀" type="tts">woman fairy</annotation>
+		<annotation cp="🧛">blood | Dracula | fangs | halloween | scary | supernatural | teeth | undead | vampire</annotation>
+		<annotation cp="🧛" type="tts">vampire</annotation>
+		<annotation cp="🧛‍♂">blood | fangs | halloween | man | scary | supernatural | teeth | undead | vampire</annotation>
+		<annotation cp="🧛‍♂" type="tts">man vampire</annotation>
+		<annotation cp="🧛‍♀">blood | fangs | halloween | scary | supernatural | teeth | undead | vampire | woman</annotation>
+		<annotation cp="🧛‍♀" type="tts">woman vampire</annotation>
+		<annotation cp="🧜">creature | fairytale | folklore | merperson | ocean | sea | siren | trident</annotation>
+		<annotation cp="🧜" type="tts">merperson</annotation>
+		<annotation cp="🧜‍♂">creature | fairytale | folklore | merman | Neptune | ocean | Poseidon | sea | siren | trident | Triton</annotation>
+		<annotation cp="🧜‍♂" type="tts">merman</annotation>
+		<annotation cp="🧜‍♀">creature | fairytale | folklore | mermaid | merwoman | ocean | sea | siren | trident</annotation>
+		<annotation cp="🧜‍♀" type="tts">mermaid</annotation>
+		<annotation cp="🧝">elf | elves | enchantment | fantasy | folklore | magic | magical | myth</annotation>
+		<annotation cp="🧝" type="tts">elf</annotation>
+		<annotation cp="🧝‍♂">elf | elves | enchantment | fantasy | folklore | magic | magical | man | myth</annotation>
+		<annotation cp="🧝‍♂" type="tts">man elf</annotation>
+		<annotation cp="🧝‍♀">elf | elves | enchantment | fantasy | folklore | magic | magical | myth | woman</annotation>
+		<annotation cp="🧝‍♀" type="tts">woman elf</annotation>
+		<annotation cp="🧞">djinn | fantasy | genie | jinn | lamp | myth | rub | wishes</annotation>
+		<annotation cp="🧞" type="tts">genie</annotation>
+		<annotation cp="🧞‍♂">djinn | fantasy | genie | jinn | lamp | man | myth | rub | wishes</annotation>
+		<annotation cp="🧞‍♂" type="tts">man genie</annotation>
+		<annotation cp="🧞‍♀">djinn | fantasy | genie | jinn | lamp | myth | rub | wishes | woman</annotation>
+		<annotation cp="🧞‍♀" type="tts">woman genie</annotation>
+		<annotation cp="🧟">apocalypse | dead | halloween | horror | scary | undead | walking | zombie</annotation>
+		<annotation cp="🧟" type="tts">zombie</annotation>
+		<annotation cp="🧟‍♂">apocalypse | dead | halloween | horror | man | scary | undead | walking | zombie</annotation>
+		<annotation cp="🧟‍♂" type="tts">man zombie</annotation>
+		<annotation cp="🧟‍♀">apocalypse | dead | halloween | horror | scary | undead | walking | woman | zombie</annotation>
+		<annotation cp="🧟‍♀" type="tts">woman zombie</annotation>
+		<annotation cp="🧌">fairy | fantasy | monster | tale | troll | trolling</annotation> <!-- 1F9CC -->
+		<annotation cp="🧌" type="tts">troll</annotation>
+		<annotation cp="💆">face | getting | headache | massage | person | relax | relaxing | salon | soothe | spa | tension | therapy | treatment</annotation>
+		<annotation cp="💆" type="tts">person getting massage</annotation>
+		<annotation cp="💆‍♂">face | getting | headache | man | massage | relax | relaxing | salon | soothe | spa | tension | therapy | treatment</annotation>
+		<annotation cp="💆‍♂" type="tts">man getting massage</annotation>
+		<annotation cp="💆‍♀">face | getting | headache | massage | relax | relaxing | salon | soothe | spa | tension | therapy | treatment | woman</annotation>
+		<annotation cp="💆‍♀" type="tts">woman getting massage</annotation>
+		<annotation cp="💇">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | parlor | person | shears | style</annotation>
+		<annotation cp="💇" type="tts">person getting haircut</annotation>
+		<annotation cp="💇‍♂">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | man | parlor | person | shears | style</annotation>
+		<annotation cp="💇‍♂" type="tts">man getting haircut</annotation>
+		<annotation cp="💇‍♀">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | parlor | person | shears | style | woman</annotation>
+		<annotation cp="💇‍♀" type="tts">woman getting haircut</annotation>
+		<annotation cp="🚶">amble | gait | hike | man | pace | pedestrian | person | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶" type="tts">person walking</annotation>
+		<annotation cp="🚶‍♂">amble | gait | hike | man | pace | pedestrian | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶‍♂" type="tts">man walking</annotation>
+		<annotation cp="🚶‍♀">amble | gait | hike | man | pace | pedestrian | stride | stroll | walk | walking | woman</annotation>
+		<annotation cp="🚶‍♀" type="tts">woman walking</annotation>
+		<annotation cp="🧍">person | stand | standing</annotation>
+		<annotation cp="🧍" type="tts">person standing</annotation>
+		<annotation cp="🧍‍♂">man | stand | standing</annotation>
+		<annotation cp="🧍‍♂" type="tts">man standing</annotation>
+		<annotation cp="🧍‍♀">stand | standing | woman</annotation>
+		<annotation cp="🧍‍♀" type="tts">woman standing</annotation>
+		<annotation cp="🧎">kneel | kneeling | knees | person</annotation>
+		<annotation cp="🧎" type="tts">person kneeling</annotation>
+		<annotation cp="🧎‍♂">kneel | kneeling | knees | man</annotation>
+		<annotation cp="🧎‍♂" type="tts">man kneeling</annotation>
+		<annotation cp="🧎‍♀">kneel | kneeling | knees | woman</annotation>
+		<annotation cp="🧎‍♀" type="tts">woman kneeling</annotation>
+		<annotation cp="🧑‍🦯">accessibility | blind | cane | person | probing | white</annotation>
+		<annotation cp="🧑‍🦯" type="tts">person with white cane</annotation>
+		<annotation cp="👨‍🦯">accessibility | blind | cane | man | probing | white</annotation>
+		<annotation cp="👨‍🦯" type="tts">man with white cane</annotation>
+		<annotation cp="👩‍🦯">accessibility | blind | cane | probing | white | woman</annotation>
+		<annotation cp="👩‍🦯" type="tts">woman with white cane</annotation>
+		<annotation cp="🧑‍🦼">accessibility | motorized | person | wheelchair</annotation>
+		<annotation cp="🧑‍🦼" type="tts">person in motorized wheelchair</annotation>
+		<annotation cp="👨‍🦼">accessibility | man | motorized | wheelchair</annotation>
+		<annotation cp="👨‍🦼" type="tts">man in motorized wheelchair</annotation>
+		<annotation cp="👩‍🦼">accessibility | motorized | wheelchair | woman</annotation>
+		<annotation cp="👩‍🦼" type="tts">woman in motorized wheelchair</annotation>
+		<annotation cp="🧑‍🦽">accessibility | manual | person | wheelchair</annotation>
+		<annotation cp="🧑‍🦽" type="tts">person in manual wheelchair</annotation>
+		<annotation cp="👨‍🦽">accessibility | man | manual | wheelchair</annotation>
+		<annotation cp="👨‍🦽" type="tts">man in manual wheelchair</annotation>
+		<annotation cp="👩‍🦽">accessibility | manual | wheelchair | woman</annotation>
+		<annotation cp="👩‍🦽" type="tts">woman in manual wheelchair</annotation>
+		<annotation cp="🏃">fast | hurry | marathon | move | person | quick | race | racing | run | rush | speed</annotation>
+		<annotation cp="🏃" type="tts">person running</annotation>
+		<annotation cp="🏃‍♂">fast | hurry | man | marathon | move | quick | race | racing | run | rush | speed</annotation>
+		<annotation cp="🏃‍♂" type="tts">man running</annotation>
+		<annotation cp="🏃‍♀">fast | hurry | marathon | move | quick | race | racing | run | rush | speed | woman</annotation>
+		<annotation cp="🏃‍♀" type="tts">woman running</annotation>
+		<annotation cp="💃">dance | dancer | dancing | elegant | festive | flair | flamenco | groove | let’s | salsa | tango | woman</annotation>
+		<annotation cp="💃" type="tts">woman dancing</annotation>
+		<annotation cp="🕺">dance | dancer | dancing | elegant | festive | flair | flamenco | groove | let’s | man | salsa | tango</annotation>
+		<annotation cp="🕺" type="tts">man dancing</annotation>
+		<annotation cp="🕴">business | levitating | person | suit</annotation>
+		<annotation cp="🕴" type="tts">person in suit levitating</annotation>
+		<annotation cp="👯">bestie | bff | bunny | counterpart | dancer | double | ear | identical | pair | party | partying | people | soulmate | twin | twinsies</annotation>
+		<annotation cp="👯" type="tts">people with bunny ears</annotation>
+		<annotation cp="👯‍♂">bestie | bff | bunny | counterpart | dancer | double | ear | identical | men | pair | party | partying | people | soulmate | twin | twinsies</annotation>
+		<annotation cp="👯‍♂" type="tts">men with bunny ears</annotation>
+		<annotation cp="👯‍♀">bestie | bff | bunny | counterpart | dancer | double | ear | identical | pair | party | partying | people | soulmate | twin | twinsies | women</annotation>
+		<annotation cp="👯‍♀" type="tts">women with bunny ears</annotation>
+		<annotation cp="🧖">day | luxurious | pamper | person | relax | room | sauna | spa | steam | steambath | unwind</annotation>
+		<annotation cp="🧖" type="tts">person in steamy room</annotation>
+		<annotation cp="🧖‍♂">day | luxurious | man | pamper | relax | room | sauna | spa | steam | steambath | unwind</annotation>
+		<annotation cp="🧖‍♂" type="tts">man in steamy room</annotation>
+		<annotation cp="🧖‍♀">day | luxurious | pamper | relax | room | sauna | spa | steam | steambath | unwind | woman</annotation>
+		<annotation cp="🧖‍♀" type="tts">woman in steamy room</annotation>
+		<annotation cp="🧗">climb | climber | climbing | mountain | person | rock | scale | up</annotation>
+		<annotation cp="🧗" type="tts">person climbing</annotation>
+		<annotation cp="🧗‍♂">climb | climber | climbing | man | mountain | rock | scale | up</annotation>
+		<annotation cp="🧗‍♂" type="tts">man climbing</annotation>
+		<annotation cp="🧗‍♀">climb | climber | climbing | mountain | rock | scale | up | woman</annotation>
+		<annotation cp="🧗‍♀" type="tts">woman climbing</annotation>
+		<annotation cp="🤺">fencer | fencing | person | sword</annotation>
+		<annotation cp="🤺" type="tts">person fencing</annotation>
+		<annotation cp="🏇">horse | jockey | racehorse | racing | riding | sport</annotation>
+		<annotation cp="🏇" type="tts">horse racing</annotation>
+		<annotation cp="⛷">ski | skier | snow</annotation>
+		<annotation cp="⛷" type="tts">skier</annotation>
+		<annotation cp="🏂">ski | snow | snowboard | snowboarder | sport</annotation>
+		<annotation cp="🏂" type="tts">snowboarder</annotation>
+		<annotation cp="🏌">ball | birdie | caddy | driving | golf | golfing | green | person | pga | putt | range | tee</annotation>
+		<annotation cp="🏌" type="tts">person golfing</annotation>
+		<annotation cp="🏌‍♂">ball | birdie | caddy | driving | golf | golfing | green | man | pga | putt | range | tee</annotation>
+		<annotation cp="🏌‍♂" type="tts">man golfing</annotation>
+		<annotation cp="🏌‍♀">ball | birdie | caddy | driving | golf | golfing | green | pga | putt | range | tee | woman</annotation>
+		<annotation cp="🏌‍♀" type="tts">woman golfing</annotation>
+		<annotation cp="🏄">beach | ocean | person | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄" type="tts">person surfing</annotation>
+		<annotation cp="🏄‍♂">beach | man | ocean | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄‍♂" type="tts">man surfing</annotation>
+		<annotation cp="🏄‍♀">beach | ocean | person | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄‍♀" type="tts">woman surfing</annotation>
+		<annotation cp="🚣">boat | canoe | cruise | fishing | lake | oar | paddle | person | raft | river | row | rowboat | rowing</annotation>
+		<annotation cp="🚣" type="tts">person rowing boat</annotation>
+		<annotation cp="🚣‍♂">boat | canoe | cruise | fishing | lake | man | oar | paddle | raft | river | row | rowboat | rowing</annotation>
+		<annotation cp="🚣‍♂" type="tts">man rowing boat</annotation>
+		<annotation cp="🚣‍♀">boat | canoe | cruise | fishing | lake | oar | paddle | raft | river | row | rowboat | rowing | woman</annotation>
+		<annotation cp="🚣‍♀" type="tts">woman rowing boat</annotation>
+		<annotation cp="🏊">freestyle | person | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊" type="tts">person swimming</annotation>
+		<annotation cp="🏊‍♂">freestyle | man | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊‍♂" type="tts">man swimming</annotation>
+		<annotation cp="🏊‍♀">freestyle | man | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊‍♀" type="tts">woman swimming</annotation>
+		<annotation cp="⛹">athletic | ball | basketball | bouncing | championship | dribble | net | person | player | throw</annotation>
+		<annotation cp="⛹" type="tts">person bouncing ball</annotation>
+		<annotation cp="⛹‍♂">athletic | ball | basketball | bouncing | championship | dribble | man | net | player | throw</annotation>
+		<annotation cp="⛹‍♂" type="tts">man bouncing ball</annotation>
+		<annotation cp="⛹‍♀">athletic | ball | basketball | bouncing | championship | dribble | net | player | throw | woman</annotation>
+		<annotation cp="⛹‍♀" type="tts">woman bouncing ball</annotation>
+		<annotation cp="🏋">barbell | bodybuilder | deadlift | lifter | lifting | person | powerlifting | weight | weightlifter | weights | workout</annotation>
+		<annotation cp="🏋" type="tts">person lifting weights</annotation>
+		<annotation cp="🏋‍♂">barbell | bodybuilder | deadlift | lifter | lifting | man | powerlifting | weight | weightlifter | weights | workout</annotation>
+		<annotation cp="🏋‍♂" type="tts">man lifting weights</annotation>
+		<annotation cp="🏋‍♀">barbell | bodybuilder | deadlift | lifter | lifting | powerlifting | weight | weightlifter | weights | woman | workout</annotation>
+		<annotation cp="🏋‍♀" type="tts">woman lifting weights</annotation>
+		<annotation cp="🚴">bicycle | bicyclist | bike | biking | cycle | cyclist | person | riding | sport</annotation>
+		<annotation cp="🚴" type="tts">person biking</annotation>
+		<annotation cp="🚴‍♂">bicycle | bicyclist | bike | biking | cycle | cyclist | man | riding | sport</annotation>
+		<annotation cp="🚴‍♂" type="tts">man biking</annotation>
+		<annotation cp="🚴‍♀">bicycle | bicyclist | bike | biking | cycle | cyclist | riding | sport | woman</annotation>
+		<annotation cp="🚴‍♀" type="tts">woman biking</annotation>
+		<annotation cp="🚵">bicycle | bicyclist | bike | biking | cycle | cyclist | mountain | person | riding | sport</annotation>
+		<annotation cp="🚵" type="tts">person mountain biking</annotation>
+		<annotation cp="🚵‍♂">bicycle | bicyclist | bike | biking | cycle | cyclist | man | mountain | riding | sport</annotation>
+		<annotation cp="🚵‍♂" type="tts">man mountain biking</annotation>
+		<annotation cp="🚵‍♀">bicycle | bicyclist | bike | biking | cycle | cyclist | mountain | riding | sport | woman</annotation>
+		<annotation cp="🚵‍♀" type="tts">woman mountain biking</annotation>
+		<annotation cp="🤸">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | person | somersault</annotation>
+		<annotation cp="🤸" type="tts">person cartwheeling</annotation>
+		<annotation cp="🤸‍♂">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | man | somersault</annotation>
+		<annotation cp="🤸‍♂" type="tts">man cartwheeling</annotation>
+		<annotation cp="🤸‍♀">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | somersault | woman</annotation>
+		<annotation cp="🤸‍♀" type="tts">woman cartwheeling</annotation>
+		<annotation cp="🤼">combat | duel | grapple | people | ring | tournament | wrestle | wrestling</annotation>
+		<annotation cp="🤼" type="tts">people wrestling</annotation>
+		<annotation cp="🤼‍♂">combat | duel | grapple | men | ring | tournament | wrestle | wrestling</annotation>
+		<annotation cp="🤼‍♂" type="tts">men wrestling</annotation>
+		<annotation cp="🤼‍♀">combat | duel | grapple | ring | tournament | women | wrestle | wrestling</annotation>
+		<annotation cp="🤼‍♀" type="tts">women wrestling</annotation>
+		<annotation cp="🤽">person | playing | polo | sport | swimming | water | waterpolo</annotation>
+		<annotation cp="🤽" type="tts">person playing water polo</annotation>
+		<annotation cp="🤽‍♂">man | playing | polo | sport | swimming | water | waterpolo</annotation>
+		<annotation cp="🤽‍♂" type="tts">man playing water polo</annotation>
+		<annotation cp="🤽‍♀">playing | polo | sport | swimming | water | waterpolo | woman</annotation>
+		<annotation cp="🤽‍♀" type="tts">woman playing water polo</annotation>
+		<annotation cp="🤾">athletics | ball | catch | chuck | handball | hurl | lob | person | pitch | playing | sport | throw | toss</annotation>
+		<annotation cp="🤾" type="tts">person playing handball</annotation>
+		<annotation cp="🤾‍♂">athletics | ball | catch | chuck | handball | hurl | lob | man | pitch | playing | sport | throw | toss</annotation>
+		<annotation cp="🤾‍♂" type="tts">man playing handball</annotation>
+		<annotation cp="🤾‍♀">athletics | ball | catch | chuck | handball | hurl | lob | pitch | playing | sport | throw | toss | woman</annotation>
+		<annotation cp="🤾‍♀" type="tts">woman playing handball</annotation>
+		<annotation cp="🤹">act | balance | balancing | handle | juggle | juggling | manage | multitask | person | skill</annotation>
+		<annotation cp="🤹" type="tts">person juggling</annotation>
+		<annotation cp="🤹‍♂">act | balance | balancing | handle | juggle | juggling | man | manage | multitask | skill</annotation>
+		<annotation cp="🤹‍♂" type="tts">man juggling</annotation>
+		<annotation cp="🤹‍♀">act | balance | balancing | handle | juggle | juggling | manage | multitask | skill | woman</annotation>
+		<annotation cp="🤹‍♀" type="tts">woman juggling</annotation>
+		<annotation cp="🧘">cross | legged | legs | lotus | meditation | peace | person | position | relax | serenity | yoga | yogi | zen</annotation>
+		<annotation cp="🧘" type="tts">person in lotus position</annotation>
+		<annotation cp="🧘‍♂">cross | legged | legs | lotus | man | meditation | peace | position | relax | serenity | yoga | yogi | zen</annotation>
+		<annotation cp="🧘‍♂" type="tts">man in lotus position</annotation>
+		<annotation cp="🧘‍♀">cross | legged | legs | lotus | meditation | peace | position | relax | serenity | woman | yoga | yogi | zen</annotation>
+		<annotation cp="🧘‍♀" type="tts">woman in lotus position</annotation>
+		<annotation cp="🛀">bath | bathtub | person | taking | tub</annotation>
+		<annotation cp="🛀" type="tts">person taking bath</annotation>
+		<annotation cp="🛌">bed | bedtime | good | goodnight | hotel | nap | night | person | sleep | tired | zzz</annotation>
+		<annotation cp="🛌" type="tts">person in bed</annotation>
+		<annotation cp="🧑‍🤝‍🧑">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | people | twins</annotation>
+		<annotation cp="🧑‍🤝‍🧑" type="tts">people holding hands</annotation>
+		<annotation cp="👭">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | sisters | twins | women</annotation>
+		<annotation cp="👭" type="tts">women holding hands</annotation>
+		<annotation cp="👫">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | man | twins | woman</annotation>
+		<annotation cp="👫" type="tts">woman and man holding hands</annotation>
+		<annotation cp="👬">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | men | twins</annotation>
+		<annotation cp="👬" type="tts">men holding hands</annotation>
+		<annotation cp="💏">anniversary | babe | bae | couple | date | dating | heart | kiss | love | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="💏" type="tts">kiss</annotation>
+		<annotation cp="💑">anniversary | babe | bae | couple | dating | heart | kiss | love | person | relationship | romance | together | you</annotation>
+		<annotation cp="💑" type="tts">couple with heart</annotation>
+		<annotation cp="🗣">face | head | silhouette | speak | speaking</annotation>
+		<annotation cp="🗣" type="tts">speaking head</annotation>
+		<annotation cp="👤">bust | mysterious | shadow | silhouette</annotation>
+		<annotation cp="👤" type="tts">bust in silhouette</annotation>
+		<annotation cp="👥">bff | bust | busts | everyone | friend | friends | people | silhouette</annotation>
+		<annotation cp="👥" type="tts">busts in silhouette</annotation>
+		<annotation cp="🫂">comfort | embrace | farewell | friendship | goodbye | hello | hug | hugging | love | people | thanks</annotation>
+		<annotation cp="🫂" type="tts">people hugging</annotation>
+		<annotation cp="👪">child | family</annotation>
+		<annotation cp="👪" type="tts">family</annotation>
+		<annotation cp="🧑‍🧑‍🧒">adult | child | family</annotation> <!-- 1F9D1 200D 1F9D1 200D 1F9D2 -->
+		<annotation cp="🧑‍🧑‍🧒" type="tts">family: adult, adult, child</annotation>
+		<annotation cp="🧑‍🧑‍🧒‍🧒">adult | child | family</annotation> <!-- 1F9D1 200D 1F9D1 200D 1F9D2 200D 1F9D2 -->
+		<annotation cp="🧑‍🧑‍🧒‍🧒" type="tts">family: adult, adult, child, child</annotation>
+		<annotation cp="🧑‍🧒">adult | child | family</annotation> <!-- 1F9D1 200D 1F9D2 -->
+		<annotation cp="🧑‍🧒" type="tts">family: adult, child</annotation>
+		<annotation cp="🧑‍🧒‍🧒">adult | child | family</annotation> <!-- 1F9D1 200D 1F9D2 200D 1F9D2 -->
+		<annotation cp="🧑‍🧒‍🧒" type="tts">family: adult, child, child</annotation>
+		<annotation cp="👣">barefoot | clothing | footprint | footprints | omw | print | walk</annotation>
+		<annotation cp="👣" type="tts">footprints</annotation>
+		<annotation cp="🫆">clue | crime | detective | fingerprint | forensics | identity | mystery | print | safety | trace</annotation>
+		<annotation cp="🫆" type="tts">fingerprint</annotation>
+		<annotation cp="🦰">ginger | hair | red | redhead</annotation>
+		<annotation cp="🦰" type="tts">red hair</annotation>
+		<annotation cp="🦱">afro | curly | hair | ringlets</annotation>
+		<annotation cp="🦱" type="tts">curly hair</annotation>
+		<annotation cp="🦳">gray | hair | old | white</annotation>
+		<annotation cp="🦳" type="tts">white hair</annotation>
+		<annotation cp="🦲">bald | chemotherapy | hair | hairless | no | shaven</annotation>
+		<annotation cp="🦲" type="tts">bald</annotation>
+		<annotation cp="🐵">animal | banana | face | monkey</annotation>
+		<annotation cp="🐵" type="tts">monkey face</annotation>
+		<annotation cp="🐒">animal | banana | monkey</annotation>
+		<annotation cp="🐒" type="tts">monkey</annotation>
+		<annotation cp="🦍">animal | gorilla</annotation>
+		<annotation cp="🦍" type="tts">gorilla</annotation>
+		<annotation cp="🦧">animal | ape | monkey | orangutan</annotation>
+		<annotation cp="🦧" type="tts">orangutan</annotation>
+		<annotation cp="🐶">adorbs | animal | dog | face | pet | puppies | puppy</annotation>
+		<annotation cp="🐶" type="tts">dog face</annotation>
+		<annotation cp="🐕">animal | animals | dog | dogs | pet</annotation>
+		<annotation cp="🐕" type="tts">dog</annotation>
+		<annotation cp="🦮">accessibility | animal | blind | dog | guide</annotation>
+		<annotation cp="🦮" type="tts">guide dog</annotation>
+		<annotation cp="🐕‍🦺">accessibility | animal | assistance | dog | service</annotation>
+		<annotation cp="🐕‍🦺" type="tts">service dog</annotation>
+		<annotation cp="🐩">animal | dog | fluffy | poodle</annotation>
+		<annotation cp="🐩" type="tts">poodle</annotation>
+		<annotation cp="🐺">animal | face | wolf</annotation>
+		<annotation cp="🐺" type="tts">wolf</annotation>
+		<annotation cp="🦊">animal | face | fox</annotation>
+		<annotation cp="🦊" type="tts">fox</annotation>
+		<annotation cp="🦝">animal | curious | raccoon | sly</annotation>
+		<annotation cp="🦝" type="tts">raccoon</annotation>
+		<annotation cp="🐱">animal | cat | face | kitten | kitty | pet</annotation>
+		<annotation cp="🐱" type="tts">cat face</annotation>
+		<annotation cp="🐈">animal | animals | cat | cats | kitten | pet</annotation>
+		<annotation cp="🐈" type="tts">cat</annotation>
+		<annotation cp="🐈‍⬛">animal | black | cat | feline | halloween | meow | unlucky</annotation> <!-- 1F408 200D 2B1B -->
+		<annotation cp="🐈‍⬛" type="tts">black cat</annotation>
+		<annotation cp="🦁">alpha | animal | face | Leo | lion | mane | order | rawr | roar | safari | strong | zodiac</annotation>
+		<annotation cp="🦁" type="tts">lion</annotation>
+		<annotation cp="🐯">animal | big | cat | face | predator | tiger</annotation>
+		<annotation cp="🐯" type="tts">tiger face</annotation>
+		<annotation cp="🐅">animal | big | cat | predator | tiger | zoo</annotation>
+		<annotation cp="🐅" type="tts">tiger</annotation>
+		<annotation cp="🐆">animal | big | cat | leopard | predator | zoo</annotation>
+		<annotation cp="🐆" type="tts">leopard</annotation>
+		<annotation cp="🐴">animal | dressage | equine | face | farm | horse | horses</annotation>
+		<annotation cp="🐴" type="tts">horse face</annotation>
+		<annotation cp="🫎">alces | animal | antlers | elk | mammal | moose</annotation> <!-- 1FACE -->
+		<annotation cp="🫎" type="tts">moose</annotation>
+		<annotation cp="🫏">animal | ass | burro | donkey | hinny | mammal | mule | stubborn</annotation> <!-- 1FACF -->
+		<annotation cp="🫏" type="tts">donkey</annotation>
+		<annotation cp="🐎">animal | equestrian | farm | horse | racehorse | racing</annotation>
+		<annotation cp="🐎" type="tts">horse</annotation>
+		<annotation cp="🦄">face | unicorn</annotation>
+		<annotation cp="🦄" type="tts">unicorn</annotation>
+		<annotation cp="🦓">animal | stripe | zebra</annotation>
+		<annotation cp="🦓" type="tts">zebra</annotation>
+		<annotation cp="🦌">animal | deer</annotation>
+		<annotation cp="🦌" type="tts">deer</annotation>
+		<annotation cp="🦬">animal | bison | buffalo | herd | wisent</annotation>
+		<annotation cp="🦬" type="tts">bison</annotation>
+		<annotation cp="🐮">animal | cow | face | farm | milk | moo</annotation>
+		<annotation cp="🐮" type="tts">cow face</annotation>
+		<annotation cp="🐂">animal | animals | bull | farm | ox | Taurus | zodiac</annotation>
+		<annotation cp="🐂" type="tts">ox</annotation>
+		<annotation cp="🐃">animal | buffalo | water | zoo</annotation>
+		<annotation cp="🐃" type="tts">water buffalo</annotation>
+		<annotation cp="🐄">animal | animals | cow | farm | milk | moo</annotation>
+		<annotation cp="🐄" type="tts">cow</annotation>
+		<annotation cp="🐷">animal | bacon | face | farm | pig | pork</annotation>
+		<annotation cp="🐷" type="tts">pig face</annotation>
+		<annotation cp="🐖">animal | bacon | farm | pig | pork | sow</annotation>
+		<annotation cp="🐖" type="tts">pig</annotation>
+		<annotation cp="🐗">animal | boar | pig</annotation>
+		<annotation cp="🐗" type="tts">boar</annotation>
+		<annotation cp="🐽">animal | face | farm | nose | pig | smell | snout</annotation>
+		<annotation cp="🐽" type="tts">pig nose</annotation>
+		<annotation cp="🐏">animal | Aries | horns | male | ram | sheep | zodiac | zoo</annotation>
+		<annotation cp="🐏" type="tts">ram</annotation>
+		<annotation cp="🐑">animal | baa | ewe | farm | female | fluffy | lamb | sheep | wool</annotation>
+		<annotation cp="🐑" type="tts">ewe</annotation>
+		<annotation cp="🐐">animal | Capricorn | farm | goat | milk | zodiac</annotation>
+		<annotation cp="🐐" type="tts">goat</annotation>
+		<annotation cp="🐪">animal | camel | desert | dromedary | hump | one</annotation>
+		<annotation cp="🐪" type="tts">camel</annotation>
+		<annotation cp="🐫">animal | bactrian | camel | desert | hump | two | two-hump</annotation>
+		<annotation cp="🐫" type="tts">two-hump camel</annotation>
+		<annotation cp="🦙">alpaca | animal | guanaco | llama | vicuña | wool</annotation>
+		<annotation cp="🦙" type="tts">llama</annotation>
+		<annotation cp="🦒">animal | giraffe | spots</annotation>
+		<annotation cp="🦒" type="tts">giraffe</annotation>
+		<annotation cp="🐘">animal | elephant</annotation>
+		<annotation cp="🐘" type="tts">elephant</annotation>
+		<annotation cp="🦣">animal | extinction | large | mammoth | tusk | wooly</annotation>
+		<annotation cp="🦣" type="tts">mammoth</annotation>
+		<annotation cp="🦏">animal | rhinoceros</annotation>
+		<annotation cp="🦏" type="tts">rhinoceros</annotation>
+		<annotation cp="🦛">animal | hippo | hippopotamus</annotation>
+		<annotation cp="🦛" type="tts">hippopotamus</annotation>
+		<annotation cp="🐭">animal | face | mouse</annotation>
+		<annotation cp="🐭" type="tts">mouse face</annotation>
+		<annotation cp="🐁">animal | animals | mouse</annotation>
+		<annotation cp="🐁" type="tts">mouse</annotation>
+		<annotation cp="🐀">animal | rat</annotation>
+		<annotation cp="🐀" type="tts">rat</annotation>
+		<annotation cp="🐹">animal | face | hamster | pet</annotation>
+		<annotation cp="🐹" type="tts">hamster</annotation>
+		<annotation cp="🐰">animal | bunny | face | pet | rabbit</annotation>
+		<annotation cp="🐰" type="tts">rabbit face</annotation>
+		<annotation cp="🐇">animal | bunny | pet | rabbit</annotation>
+		<annotation cp="🐇" type="tts">rabbit</annotation>
+		<annotation cp="🐿">animal | chipmunk | squirrel</annotation>
+		<annotation cp="🐿" type="tts">chipmunk</annotation>
+		<annotation cp="🦫">animal | beaver | dam | teeth</annotation>
+		<annotation cp="🦫" type="tts">beaver</annotation>
+		<annotation cp="🦔">animal | hedgehog | spiny</annotation>
+		<annotation cp="🦔" type="tts">hedgehog</annotation>
+		<annotation cp="🦇">animal | bat | vampire</annotation>
+		<annotation cp="🦇" type="tts">bat</annotation>
+		<annotation cp="🐻">animal | bear | face | grizzly | growl | honey</annotation>
+		<annotation cp="🐻" type="tts">bear</annotation>
+		<annotation cp="🐻‍❄">animal | arctic | bear | polar | white</annotation> <!-- 1F43B 200D 2744 -->
+		<annotation cp="🐻‍❄" type="tts">polar bear</annotation>
+		<annotation cp="🐨">animal | australia | bear | down | face | koala | marsupial | under</annotation>
+		<annotation cp="🐨" type="tts">koala</annotation>
+		<annotation cp="🐼">animal | bamboo | face | panda</annotation>
+		<annotation cp="🐼" type="tts">panda</annotation>
+		<annotation cp="🦥">lazy | sloth | slow</annotation>
+		<annotation cp="🦥" type="tts">sloth</annotation>
+		<annotation cp="🦦">animal | fishing | otter | playful</annotation>
+		<annotation cp="🦦" type="tts">otter</annotation>
+		<annotation cp="🦨">animal | skunk | stink</annotation>
+		<annotation cp="🦨" type="tts">skunk</annotation>
+		<annotation cp="🦘">animal | joey | jump | kangaroo | marsupial</annotation>
+		<annotation cp="🦘" type="tts">kangaroo</annotation>
+		<annotation cp="🦡">animal | badger | honey | pester</annotation>
+		<annotation cp="🦡" type="tts">badger</annotation>
+		<annotation cp="🐾">feet | paw | paws | print | prints</annotation>
+		<annotation cp="🐾" type="tts">paw prints</annotation>
+		<annotation cp="🦃">bird | gobble | thanksgiving | turkey</annotation>
+		<annotation cp="🦃" type="tts">turkey</annotation>
+		<annotation cp="🐔">animal | bird | chicken | ornithology</annotation>
+		<annotation cp="🐔" type="tts">chicken</annotation>
+		<annotation cp="🐓">animal | bird | ornithology | rooster</annotation>
+		<annotation cp="🐓" type="tts">rooster</annotation>
+		<annotation cp="🐣">animal | baby | bird | chick | egg | hatching</annotation>
+		<annotation cp="🐣" type="tts">hatching chick</annotation>
+		<annotation cp="🐤">animal | baby | bird | chick | ornithology</annotation>
+		<annotation cp="🐤" type="tts">baby chick</annotation>
+		<annotation cp="🐥">animal | baby | bird | chick | front-facing | newborn | ornithology</annotation>
+		<annotation cp="🐥" type="tts">front-facing baby chick</annotation>
+		<annotation cp="🐦">animal | bird | ornithology</annotation>
+		<annotation cp="🐦" type="tts">bird</annotation>
+		<annotation cp="🐧">animal | antarctica | bird | ornithology | penguin</annotation>
+		<annotation cp="🐧" type="tts">penguin</annotation>
+		<annotation cp="🕊">bird | dove | fly | ornithology | peace</annotation>
+		<annotation cp="🕊" type="tts">dove</annotation>
+		<annotation cp="🦅">animal | bird | eagle | ornithology</annotation>
+		<annotation cp="🦅" type="tts">eagle</annotation>
+		<annotation cp="🦆">animal | bird | duck | ornithology</annotation>
+		<annotation cp="🦆" type="tts">duck</annotation>
+		<annotation cp="🦢">animal | bird | cygnet | duckling | ornithology | swan | ugly</annotation>
+		<annotation cp="🦢" type="tts">swan</annotation>
+		<annotation cp="🦉">animal | bird | ornithology | owl | wise</annotation>
+		<annotation cp="🦉" type="tts">owl</annotation>
+		<annotation cp="🦤">animal | bird | dodo | extinction | large | ornithology</annotation>
+		<annotation cp="🦤" type="tts">dodo</annotation>
+		<annotation cp="🪶">bird | feather | flight | light | plumage</annotation>
+		<annotation cp="🪶" type="tts">feather</annotation>
+		<annotation cp="🦩">animal | bird | flamboyant | flamingo | ornithology | tropical</annotation>
+		<annotation cp="🦩" type="tts">flamingo</annotation>
+		<annotation cp="🦚">animal | bird | colorful | ornithology | ostentatious | peacock | peahen | pretty | proud</annotation>
+		<annotation cp="🦚" type="tts">peacock</annotation>
+		<annotation cp="🦜">animal | bird | ornithology | parrot | pirate | talk</annotation>
+		<annotation cp="🦜" type="tts">parrot</annotation>
+		<annotation cp="🪽">angelic | ascend | aviation | bird | fly | flying | heavenly | mythology | soar | wing</annotation> <!-- 1FABD -->
+		<annotation cp="🪽" type="tts">wing</annotation>
+		<annotation cp="🐦‍⬛">animal | beak | bird | black | caw | corvid | crow | ornithology | raven | rook</annotation> <!-- 1F426 200D 2B1B -->
+		<annotation cp="🐦‍⬛" type="tts">black bird</annotation>
+		<annotation cp="🪿">animal | bird | duck | flock | fowl | gaggle | gander | geese | goose | honk | ornithology | silly</annotation> <!-- 1FABF -->
+		<annotation cp="🪿" type="tts">goose</annotation>
+		<annotation cp="🐦‍🔥">ascend | ascension | emerge | fantasy | firebird | glory | immortal | phoenix | rebirth | reincarnation | reinvent | renewal | revival | revive | rise | transform</annotation> <!-- 1F426 200D 1F525 -->
+		<annotation cp="🐦‍🔥" type="tts">phoenix</annotation>
+		<annotation cp="🐸">animal | face | frog</annotation>
+		<annotation cp="🐸" type="tts">frog</annotation>
+		<annotation cp="🐊">animal | crocodile | zoo</annotation>
+		<annotation cp="🐊" type="tts">crocodile</annotation>
+		<annotation cp="🐢">animal | terrapin | tortoise | turtle</annotation>
+		<annotation cp="🐢" type="tts">turtle</annotation>
+		<annotation cp="🦎">animal | lizard | reptile</annotation>
+		<annotation cp="🦎" type="tts">lizard</annotation>
+		<annotation cp="🐍">animal | bearer | Ophiuchus | serpent | snake | zodiac</annotation>
+		<annotation cp="🐍" type="tts">snake</annotation>
+		<annotation cp="🐲">animal | dragon | face | fairy | fairytale | tale</annotation>
+		<annotation cp="🐲" type="tts">dragon face</annotation>
+		<annotation cp="🐉">animal | dragon | fairy | fairytale | knights | tale</annotation>
+		<annotation cp="🐉" type="tts">dragon</annotation>
+		<annotation cp="🦕">brachiosaurus | brontosaurus | dinosaur | diplodocus | sauropod</annotation>
+		<annotation cp="🦕" type="tts">sauropod</annotation>
+		<annotation cp="🦖">dinosaur | Rex | T | T-Rex | Tyrannosaurus</annotation>
+		<annotation cp="🦖" type="tts">T-Rex</annotation>
+		<annotation cp="🐳">animal | beach | face | ocean | spouting | whale</annotation>
+		<annotation cp="🐳" type="tts">spouting whale</annotation>
+		<annotation cp="🐋">animal | beach | ocean | whale</annotation>
+		<annotation cp="🐋" type="tts">whale</annotation>
+		<annotation cp="🐬">animal | beach | dolphin | flipper | ocean</annotation>
+		<annotation cp="🐬" type="tts">dolphin</annotation>
+		<annotation cp="🦭">animal | lion | ocean | sea | seal</annotation>
+		<annotation cp="🦭" type="tts">seal</annotation>
+		<annotation cp="🐟">animal | dinner | fish | fishes | fishing | Pisces | zodiac</annotation>
+		<annotation cp="🐟" type="tts">fish</annotation>
+		<annotation cp="🐠">animal | fish | fishes | tropical</annotation>
+		<annotation cp="🐠" type="tts">tropical fish</annotation>
+		<annotation cp="🐡">animal | blowfish | fish</annotation>
+		<annotation cp="🐡" type="tts">blowfish</annotation>
+		<annotation cp="🦈">animal | fish | shark</annotation>
+		<annotation cp="🦈" type="tts">shark</annotation>
+		<annotation cp="🐙">animal | creature | ocean | octopus</annotation>
+		<annotation cp="🐙" type="tts">octopus</annotation>
+		<annotation cp="🐚">animal | beach | conch | sea | shell | spiral</annotation>
+		<annotation cp="🐚" type="tts">spiral shell</annotation>
+		<annotation cp="🪸">change | climate | coral | ocean | reef | sea</annotation> <!-- 1FAB8 -->
+		<annotation cp="🪸" type="tts">coral</annotation>
+		<annotation cp="🪼">animal | aquarium | burn | invertebrate | jelly | jellyfish | life | marine | ocean | ouch | plankton | sea | sting | stinger | tentacles</annotation> <!-- 1FABC -->
+		<annotation cp="🪼" type="tts">jellyfish</annotation>
+		<annotation cp="🦀">Cancer | crab | zodiac</annotation>
+		<annotation cp="🦀" type="tts">crab</annotation>
+		<annotation cp="🦞">animal | bisque | claws | lobster | seafood</annotation>
+		<annotation cp="🦞" type="tts">lobster</annotation>
+		<annotation cp="🦐">food | shellfish | shrimp | small</annotation>
+		<annotation cp="🦐" type="tts">shrimp</annotation>
+		<annotation cp="🦑">animal | food | mollusk | squid</annotation>
+		<annotation cp="🦑" type="tts">squid</annotation>
+		<annotation cp="🦪">diving | oyster | pearl</annotation>
+		<annotation cp="🦪" type="tts">oyster</annotation>
+		<annotation cp="🐌">animal | escargot | garden | nature | slug | snail</annotation>
+		<annotation cp="🐌" type="tts">snail</annotation>
+		<annotation cp="🦋">butterfly | insect | pretty</annotation>
+		<annotation cp="🦋" type="tts">butterfly</annotation>
+		<annotation cp="🐛">animal | bug | garden | insect</annotation>
+		<annotation cp="🐛" type="tts">bug</annotation>
+		<annotation cp="🐜">animal | ant | garden | insect</annotation>
+		<annotation cp="🐜" type="tts">ant</annotation>
+		<annotation cp="🐝">animal | bee | bumblebee | honey | honeybee | insect | nature | spring</annotation>
+		<annotation cp="🐝" type="tts">honeybee</annotation>
+		<annotation cp="🪲">animal | beetle | bug | insect</annotation>
+		<annotation cp="🪲" type="tts">beetle</annotation>
+		<annotation cp="🐞">animal | beetle | garden | insect | lady | ladybird | ladybug | nature</annotation>
+		<annotation cp="🐞" type="tts">lady beetle</annotation>
+		<annotation cp="🦗">animal | bug | cricket | grasshopper | insect | Orthoptera</annotation>
+		<annotation cp="🦗" type="tts">cricket</annotation>
+		<annotation cp="🪳">animal | cockroach | insect | pest | roach</annotation>
+		<annotation cp="🪳" type="tts">cockroach</annotation>
+		<annotation cp="🕷">animal | insect | spider</annotation>
+		<annotation cp="🕷" type="tts">spider</annotation>
+		<annotation cp="🕸">spider | web</annotation>
+		<annotation cp="🕸" type="tts">spider web</annotation>
+		<annotation cp="🦂">Scorpio | scorpion | Scorpius | zodiac</annotation>
+		<annotation cp="🦂" type="tts">scorpion</annotation>
+		<annotation cp="🦟">bite | disease | fever | insect | malaria | mosquito | pest | virus</annotation>
+		<annotation cp="🦟" type="tts">mosquito</annotation>
+		<annotation cp="🪰">animal | disease | fly | insect | maggot | pest | rotting</annotation>
+		<annotation cp="🪰" type="tts">fly</annotation>
+		<annotation cp="🪱">animal | annelid | earthworm | parasite | worm</annotation>
+		<annotation cp="🪱" type="tts">worm</annotation>
+		<annotation cp="🦠">amoeba | bacteria | microbe | science | virus</annotation>
+		<annotation cp="🦠" type="tts">microbe</annotation>
+		<annotation cp="💐">anniversary | birthday | bouquet | date | flower | love | plant | romance</annotation>
+		<annotation cp="💐" type="tts">bouquet</annotation>
+		<annotation cp="🌸">blossom | cherry | flower | plant | spring | springtime</annotation>
+		<annotation cp="🌸" type="tts">cherry blossom</annotation>
+		<annotation cp="💮">flower | white</annotation>
+		<annotation cp="💮" type="tts">white flower</annotation>
+		<annotation cp="🪷">beauty | Buddhism | calm | flower | Hinduism | lotus | peace | purity | serenity</annotation> <!-- 1FAB7 -->
+		<annotation cp="🪷" type="tts">lotus</annotation>
+		<annotation cp="🏵">plant | rosette</annotation>
+		<annotation cp="🏵" type="tts">rosette</annotation>
+		<annotation cp="🌹">beauty | elegant | flower | love | plant | red | rose | valentine</annotation>
+		<annotation cp="🌹" type="tts">rose</annotation>
+		<annotation cp="🥀">dying | flower | wilted</annotation>
+		<annotation cp="🥀" type="tts">wilted flower</annotation>
+		<annotation cp="🌺">flower | hibiscus | plant</annotation>
+		<annotation cp="🌺" type="tts">hibiscus</annotation>
+		<annotation cp="🌻">flower | outdoors | plant | sun | sunflower</annotation>
+		<annotation cp="🌻" type="tts">sunflower</annotation>
+		<annotation cp="🌼">blossom | buttercup | dandelion | flower | plant</annotation>
+		<annotation cp="🌼" type="tts">blossom</annotation>
+		<annotation cp="🌷">blossom | flower | growth | plant | tulip</annotation>
+		<annotation cp="🌷" type="tts">tulip</annotation>
+		<annotation cp="🪻">bloom | bluebonnet | flower | hyacinth | indigo | lavender | lilac | lupine | plant | purple | shrub | snapdragon | spring | violet</annotation> <!-- 1FABB -->
+		<annotation cp="🪻" type="tts">hyacinth</annotation>
+		<annotation cp="🌱">plant | sapling | seedling | sprout | young</annotation>
+		<annotation cp="🌱" type="tts">seedling</annotation>
+		<annotation cp="🪴">decor | grow | house | nurturing | plant | pot | potted</annotation>
+		<annotation cp="🪴" type="tts">potted plant</annotation>
+		<annotation cp="🌲">christmas | evergreen | forest | pine | tree</annotation>
+		<annotation cp="🌲" type="tts">evergreen tree</annotation>
+		<annotation cp="🌳">deciduous | forest | green | habitat | shedding | tree</annotation>
+		<annotation cp="🌳" type="tts">deciduous tree</annotation>
+		<annotation cp="🌴">beach | palm | plant | tree | tropical</annotation>
+		<annotation cp="🌴" type="tts">palm tree</annotation>
+		<annotation cp="🌵">cactus | desert | drought | nature | plant</annotation>
+		<annotation cp="🌵" type="tts">cactus</annotation>
+		<annotation cp="🌾">ear | grain | grains | plant | rice | sheaf</annotation>
+		<annotation cp="🌾" type="tts">sheaf of rice</annotation>
+		<annotation cp="🌿">herb | leaf | plant</annotation>
+		<annotation cp="🌿" type="tts">herb</annotation>
+		<annotation cp="☘">irish | plant | shamrock</annotation>
+		<annotation cp="☘" type="tts">shamrock</annotation>
+		<annotation cp="🍀">4 | clover | four | four-leaf | irish | leaf | lucky | plant</annotation>
+		<annotation cp="🍀" type="tts">four leaf clover</annotation>
+		<annotation cp="🍁">falling | leaf | maple</annotation>
+		<annotation cp="🍁" type="tts">maple leaf</annotation>
+		<annotation cp="🍂">autumn | fall | fallen | falling | leaf</annotation>
+		<annotation cp="🍂" type="tts">fallen leaf</annotation>
+		<annotation cp="🍃">blow | flutter | fluttering | leaf | wind</annotation>
+		<annotation cp="🍃" type="tts">leaf fluttering in wind</annotation>
+		<annotation cp="🪹">branch | empty | home | nest | nesting</annotation> <!-- 1FAB9 -->
+		<annotation cp="🪹" type="tts">empty nest</annotation>
+		<annotation cp="🪺">bird | branch | egg | eggs | nest | nesting</annotation> <!-- 1FABA -->
+		<annotation cp="🪺" type="tts">nest with eggs</annotation>
+		<annotation cp="🍄">fungus | mushroom | toadstool</annotation>
+		<annotation cp="🍄" type="tts">mushroom</annotation>
+		<annotation cp="🪾">bare | barren | branches | dead | drought | leafless | tree | trunk | winter | wood</annotation>
+		<annotation cp="🪾" type="tts">leafless tree</annotation>
+		<annotation cp="🍇">Dionysus | fruit | grape | grapes</annotation>
+		<annotation cp="🍇" type="tts">grapes</annotation>
+		<annotation cp="🍈">cantaloupe | fruit | melon</annotation>
+		<annotation cp="🍈" type="tts">melon</annotation>
+		<annotation cp="🍉">fruit | watermelon</annotation>
+		<annotation cp="🍉" type="tts">watermelon</annotation>
+		<annotation cp="🍊">c | citrus | fruit | nectarine | orange | tangerine | vitamin</annotation>
+		<annotation cp="🍊" type="tts">tangerine</annotation>
+		<annotation cp="🍋">citrus | fruit | lemon | sour</annotation>
+		<annotation cp="🍋" type="tts">lemon</annotation>
+		<annotation cp="🍋‍🟩">acidity | citrus | cocktail | fruit | garnish | key | lime | margarita | mojito | refreshing | salsa | sour | tangy | tequila | tropical | zest</annotation> <!-- 1F34B 200D 1F7E9 -->
+		<annotation cp="🍋‍🟩" type="tts">lime</annotation>
+		<annotation cp="🍌">banana | fruit | potassium</annotation>
+		<annotation cp="🍌" type="tts">banana</annotation>
+		<annotation cp="🍍">colada | fruit | pina | pineapple | tropical</annotation>
+		<annotation cp="🍍" type="tts">pineapple</annotation>
+		<annotation cp="🥭">food | fruit | mango | tropical</annotation>
+		<annotation cp="🥭" type="tts">mango</annotation>
+		<annotation cp="🍎">apple | diet | food | fruit | health | red | ripe</annotation>
+		<annotation cp="🍎" type="tts">red apple</annotation>
+		<annotation cp="🍏">apple | fruit | green</annotation>
+		<annotation cp="🍏" type="tts">green apple</annotation>
+		<annotation cp="🍐">fruit | pear</annotation>
+		<annotation cp="🍐" type="tts">pear</annotation>
+		<annotation cp="🍑">fruit | peach</annotation>
+		<annotation cp="🍑" type="tts">peach</annotation>
+		<annotation cp="🍒">berries | cherries | cherry | fruit | red</annotation>
+		<annotation cp="🍒" type="tts">cherries</annotation>
+		<annotation cp="🍓">berry | fruit | strawberry</annotation>
+		<annotation cp="🍓" type="tts">strawberry</annotation>
+		<annotation cp="🫐">berries | berry | bilberry | blue | blueberries | blueberry | food | fruit</annotation>
+		<annotation cp="🫐" type="tts">blueberries</annotation>
+		<annotation cp="🥝">food | fruit | kiwi</annotation>
+		<annotation cp="🥝" type="tts">kiwi fruit</annotation>
+		<annotation cp="🍅">food | fruit | tomato | vegetable</annotation>
+		<annotation cp="🍅" type="tts">tomato</annotation>
+		<annotation cp="🫒">food | olive</annotation>
+		<annotation cp="🫒" type="tts">olive</annotation>
+		<annotation cp="🥥">coconut | colada | palm | piña</annotation>
+		<annotation cp="🥥" type="tts">coconut</annotation>
+		<annotation cp="🥑">avocado | food | fruit</annotation>
+		<annotation cp="🥑" type="tts">avocado</annotation>
+		<annotation cp="🍆">aubergine | eggplant | vegetable</annotation>
+		<annotation cp="🍆" type="tts">eggplant</annotation>
+		<annotation cp="🥔">food | potato | vegetable</annotation>
+		<annotation cp="🥔" type="tts">potato</annotation>
+		<annotation cp="🥕">carrot | food | vegetable</annotation>
+		<annotation cp="🥕" type="tts">carrot</annotation>
+		<annotation cp="🌽">corn | crops | ear | farm | maize | maze</annotation>
+		<annotation cp="🌽" type="tts">ear of corn</annotation>
+		<annotation cp="🌶">hot | pepper</annotation>
+		<annotation cp="🌶" type="tts">hot pepper</annotation>
+		<annotation cp="🫑">bell | capsicum | food | pepper | vegetable</annotation>
+		<annotation cp="🫑" type="tts">bell pepper</annotation>
+		<annotation cp="🥒">cucumber | food | pickle | vegetable</annotation>
+		<annotation cp="🥒" type="tts">cucumber</annotation>
+		<annotation cp="🥬">bok | burgers | cabbage | choy | green | kale | leafy | lettuce | salad</annotation>
+		<annotation cp="🥬" type="tts">leafy green</annotation>
+		<annotation cp="🥦">broccoli | cabbage | wild</annotation>
+		<annotation cp="🥦" type="tts">broccoli</annotation>
+		<annotation cp="🧄">flavoring | garlic</annotation>
+		<annotation cp="🧄" type="tts">garlic</annotation>
+		<annotation cp="🧅">flavoring | onion</annotation>
+		<annotation cp="🧅" type="tts">onion</annotation>
+		<annotation cp="🥜">food | nut | peanut | peanuts | vegetable</annotation>
+		<annotation cp="🥜" type="tts">peanuts</annotation>
+		<annotation cp="🫘">beans | food | kidney | legume | small</annotation> <!-- 1FAD8 -->
+		<annotation cp="🫘" type="tts">beans</annotation>
+		<annotation cp="🌰">almond | chestnut | plant</annotation>
+		<annotation cp="🌰" type="tts">chestnut</annotation>
+		<annotation cp="🫚">beer | ginger | health | herb | natural | root | spice</annotation> <!-- 1FADA -->
+		<annotation cp="🫚" type="tts">ginger root</annotation>
+		<annotation cp="🫛">beans | beanstalk | edamame | legume | pea | pod | soybean | vegetable | veggie</annotation> <!-- 1FADB -->
+		<annotation cp="🫛" type="tts">pea pod</annotation>
+		<annotation cp="🍄‍🟫">food | fungi | fungus | mushroom | nature | pizza | portobello | shiitake | shroom | spore | sprout | toppings | truffle | vegetable | vegetarian | veggie</annotation> <!-- 1F344 200D 1F7EB -->
+		<annotation cp="🍄‍🟫" type="tts">brown mushroom</annotation>
+		<annotation cp="🫜">beet | food | garden | radish | root | salad | turnip | vegetable | vegetarian</annotation>
+		<annotation cp="🫜" type="tts">root vegetable</annotation>
+		<annotation cp="🍞">bread | carbs | food | grain | loaf | restaurant | toast | wheat</annotation>
+		<annotation cp="🍞" type="tts">bread</annotation>
+		<annotation cp="🥐">bread | breakfast | crescent | croissant | food | french | roll</annotation>
+		<annotation cp="🥐" type="tts">croissant</annotation>
+		<annotation cp="🥖">baguette | bread | food | french</annotation>
+		<annotation cp="🥖" type="tts">baguette bread</annotation>
+		<annotation cp="🫓">arepa | bread | flatbread | food | gordita | lavash | naan | pita</annotation>
+		<annotation cp="🫓" type="tts">flatbread</annotation>
+		<annotation cp="🥨">convoluted | pretzel | twisted</annotation>
+		<annotation cp="🥨" type="tts">pretzel</annotation>
+		<annotation cp="🥯">bagel | bakery | bread | breakfast | schmear</annotation>
+		<annotation cp="🥯" type="tts">bagel</annotation>
+		<annotation cp="🥞">breakfast | crêpe | food | hotcake | pancake | pancakes</annotation>
+		<annotation cp="🥞" type="tts">pancakes</annotation>
+		<annotation cp="🧇">breakfast | indecisive | iron | waffle</annotation>
+		<annotation cp="🧇" type="tts">waffle</annotation>
+		<annotation cp="🧀">cheese | wedge</annotation>
+		<annotation cp="🧀" type="tts">cheese wedge</annotation>
+		<annotation cp="🍖">bone | meat</annotation>
+		<annotation cp="🍖" type="tts">meat on bone</annotation>
+		<annotation cp="🍗">bone | chicken | drumstick | hungry | leg | poultry | turkey</annotation>
+		<annotation cp="🍗" type="tts">poultry leg</annotation>
+		<annotation cp="🥩">chop | cut | lambchop | meat | porkchop | red | steak</annotation>
+		<annotation cp="🥩" type="tts">cut of meat</annotation>
+		<annotation cp="🥓">bacon | breakfast | food | meat</annotation>
+		<annotation cp="🥓" type="tts">bacon</annotation>
+		<annotation cp="🍔">burger | eat | fast | food | hamburger | hungry</annotation>
+		<annotation cp="🍔" type="tts">hamburger</annotation>
+		<annotation cp="🍟">fast | food | french | fries</annotation>
+		<annotation cp="🍟" type="tts">french fries</annotation>
+		<annotation cp="🍕">cheese | food | hungry | pepperoni | pizza | slice</annotation>
+		<annotation cp="🍕" type="tts">pizza</annotation>
+		<annotation cp="🌭">dog | frankfurter | hot | hotdog | sausage</annotation>
+		<annotation cp="🌭" type="tts">hot dog</annotation>
+		<annotation cp="🥪">bread | sandwich</annotation>
+		<annotation cp="🥪" type="tts">sandwich</annotation>
+		<annotation cp="🌮">mexican | taco</annotation>
+		<annotation cp="🌮" type="tts">taco</annotation>
+		<annotation cp="🌯">burrito | mexican | wrap</annotation>
+		<annotation cp="🌯" type="tts">burrito</annotation>
+		<annotation cp="🫔">food | mexican | pamonha | tamale | wrapped</annotation>
+		<annotation cp="🫔" type="tts">tamale</annotation>
+		<annotation cp="🥙">falafel | flatbread | food | gyro | kebab | stuffed</annotation>
+		<annotation cp="🥙" type="tts">stuffed flatbread</annotation>
+		<annotation cp="🧆">chickpea | falafel | meatball</annotation>
+		<annotation cp="🧆" type="tts">falafel</annotation>
+		<annotation cp="🥚">breakfast | egg | food</annotation>
+		<annotation cp="🥚" type="tts">egg</annotation>
+		<annotation cp="🍳">breakfast | cooking | easy | egg | fry | frying | over | pan | restaurant | side | sunny | up</annotation>
+		<annotation cp="🍳" type="tts">cooking</annotation>
+		<annotation cp="🥘">casserole | food | paella | pan | shallow</annotation>
+		<annotation cp="🥘" type="tts">shallow pan of food</annotation>
+		<annotation cp="🍲">food | pot | soup | stew</annotation>
+		<annotation cp="🍲" type="tts">pot of food</annotation>
+		<annotation cp="🫕">cheese | chocolate | fondue | food | melted | pot | ski</annotation>
+		<annotation cp="🫕" type="tts">fondue</annotation>
+		<annotation cp="🥣">bowl | breakfast | cereal | congee | oatmeal | porridge | spoon</annotation>
+		<annotation cp="🥣" type="tts">bowl with spoon</annotation>
+		<annotation cp="🥗">food | green | salad</annotation>
+		<annotation cp="🥗" type="tts">green salad</annotation>
+		<annotation cp="🍿">corn | movie | pop | popcorn</annotation>
+		<annotation cp="🍿" type="tts">popcorn</annotation>
+		<annotation cp="🧈">butter | dairy</annotation>
+		<annotation cp="🧈" type="tts">butter</annotation>
+		<annotation cp="🧂">condiment | flavor | mad | salt | salty | shaker | taste | upset</annotation>
+		<annotation cp="🧂" type="tts">salt</annotation>
+		<annotation cp="🥫">can | canned | food</annotation>
+		<annotation cp="🥫" type="tts">canned food</annotation>
+		<annotation cp="🍱">bento | box | food</annotation>
+		<annotation cp="🍱" type="tts">bento box</annotation>
+		<annotation cp="🍘">cracker | food | rice</annotation>
+		<annotation cp="🍘" type="tts">rice cracker</annotation>
+		<annotation cp="🍙">ball | food | Japanese | rice</annotation>
+		<annotation cp="🍙" type="tts">rice ball</annotation>
+		<annotation cp="🍚">cooked | food | rice</annotation>
+		<annotation cp="🍚" type="tts">cooked rice</annotation>
+		<annotation cp="🍛">curry | food | rice</annotation>
+		<annotation cp="🍛" type="tts">curry rice</annotation>
+		<annotation cp="🍜">bowl | chopsticks | food | noodle | pho | ramen | soup | steaming</annotation>
+		<annotation cp="🍜" type="tts">steaming bowl</annotation>
+		<annotation cp="🍝">food | meatballs | pasta | restaurant | spaghetti</annotation>
+		<annotation cp="🍝" type="tts">spaghetti</annotation>
+		<annotation cp="🍠">food | potato | roasted | sweet</annotation>
+		<annotation cp="🍠" type="tts">roasted sweet potato</annotation>
+		<annotation cp="🍢">food | kebab | oden | restaurant | seafood | skewer | stick</annotation>
+		<annotation cp="🍢" type="tts">oden</annotation>
+		<annotation cp="🍣">food | sushi</annotation>
+		<annotation cp="🍣" type="tts">sushi</annotation>
+		<annotation cp="🍤">fried | prawn | shrimp | tempura</annotation>
+		<annotation cp="🍤" type="tts">fried shrimp</annotation>
+		<annotation cp="🍥">cake | fish | food | pastry | restaurant | swirl</annotation>
+		<annotation cp="🍥" type="tts">fish cake with swirl</annotation>
+		<annotation cp="🥮">autumn | cake | festival | moon | yuèbǐng</annotation>
+		<annotation cp="🥮" type="tts">moon cake</annotation>
+		<annotation cp="🍡">dango | dessert | Japanese | skewer | stick | sweet</annotation>
+		<annotation cp="🍡" type="tts">dango</annotation>
+		<annotation cp="🥟">dumpling | empanada | gyōza | jiaozi | pierogi | potsticker</annotation>
+		<annotation cp="🥟" type="tts">dumpling</annotation>
+		<annotation cp="🥠">cookie | fortune | prophecy</annotation>
+		<annotation cp="🥠" type="tts">fortune cookie</annotation>
+		<annotation cp="🥡">box | chopsticks | delivery | food | oyster | pail | takeout</annotation>
+		<annotation cp="🥡" type="tts">takeout box</annotation>
+		<annotation cp="🍦">cream | dessert | food | ice | icecream | restaurant | serve | soft | sweet</annotation>
+		<annotation cp="🍦" type="tts">soft ice cream</annotation>
+		<annotation cp="🍧">dessert | ice | restaurant | shaved | sweet</annotation>
+		<annotation cp="🍧" type="tts">shaved ice</annotation>
+		<annotation cp="🍨">cream | dessert | food | ice | restaurant | sweet</annotation>
+		<annotation cp="🍨" type="tts">ice cream</annotation>
+		<annotation cp="🍩">breakfast | dessert | donut | doughnut | food | sweet</annotation>
+		<annotation cp="🍩" type="tts">doughnut</annotation>
+		<annotation cp="🍪">chip | chocolate | cookie | dessert | sweet</annotation>
+		<annotation cp="🍪" type="tts">cookie</annotation>
+		<annotation cp="🎂">bday | birthday | cake | celebration | dessert | happy | pastry | sweet</annotation>
+		<annotation cp="🎂" type="tts">birthday cake</annotation>
+		<annotation cp="🍰">cake | dessert | pastry | shortcake | slice | sweet</annotation>
+		<annotation cp="🍰" type="tts">shortcake</annotation>
+		<annotation cp="🧁">bakery | cupcake | dessert | sprinkles | sugar | sweet | treat</annotation>
+		<annotation cp="🧁" type="tts">cupcake</annotation>
+		<annotation cp="🥧">apple | filling | fruit | meat | pastry | pie | pumpkin | slice</annotation>
+		<annotation cp="🥧" type="tts">pie</annotation>
+		<annotation cp="🍫">bar | candy | chocolate | dessert | halloween | sweet | tooth</annotation>
+		<annotation cp="🍫" type="tts">chocolate bar</annotation>
+		<annotation cp="🍬">candy | cavities | dessert | halloween | restaurant | sweet | tooth | wrapper</annotation>
+		<annotation cp="🍬" type="tts">candy</annotation>
+		<annotation cp="🍭">candy | dessert | food | lollipop | restaurant | sweet</annotation>
+		<annotation cp="🍭" type="tts">lollipop</annotation>
+		<annotation cp="🍮">custard | dessert | pudding | sweet</annotation>
+		<annotation cp="🍮" type="tts">custard</annotation>
+		<annotation cp="🍯">barrel | bear | food | honey | honeypot | jar | pot | sweet</annotation>
+		<annotation cp="🍯" type="tts">honey pot</annotation>
+		<annotation cp="🍼">babies | baby | birth | born | bottle | drink | infant | milk | newborn</annotation>
+		<annotation cp="🍼" type="tts">baby bottle</annotation>
+		<annotation cp="🥛">drink | glass | milk</annotation>
+		<annotation cp="🥛" type="tts">glass of milk</annotation>
+		<annotation cp="☕">beverage | cafe | caffeine | chai | coffee | drink | hot | morning | steaming | tea</annotation>
+		<annotation cp="☕" type="tts">hot beverage</annotation>
+		<annotation cp="🫖">brew | drink | food | pot | tea | teapot</annotation>
+		<annotation cp="🫖" type="tts">teapot</annotation>
+		<annotation cp="🍵">beverage | cup | drink | handle | oolong | tea | teacup</annotation>
+		<annotation cp="🍵" type="tts">teacup without handle</annotation>
+		<annotation cp="🍶">bar | beverage | bottle | cup | drink | restaurant | sake</annotation>
+		<annotation cp="🍶" type="tts">sake</annotation>
+		<annotation cp="🍾">bar | bottle | cork | drink | popping</annotation>
+		<annotation cp="🍾" type="tts">bottle with popping cork</annotation>
+		<annotation cp="🍷">alcohol | bar | beverage | booze | club | drink | drinking | drinks | glass | restaurant | wine</annotation>
+		<annotation cp="🍷" type="tts">wine glass</annotation>
+		<annotation cp="🍸">alcohol | bar | booze | club | cocktail | drink | drinking | drinks | glass | mad | martini | men</annotation>
+		<annotation cp="🍸" type="tts">cocktail glass</annotation>
+		<annotation cp="🍹">alcohol | bar | booze | club | cocktail | drink | drinking | drinks | drunk | mai | party | tai | tropical | tropics</annotation>
+		<annotation cp="🍹" type="tts">tropical drink</annotation>
+		<annotation cp="🍺">alcohol | ale | bar | beer | booze | drink | drinking | drinks | mug | octoberfest | oktoberfest | pint | stein | summer</annotation>
+		<annotation cp="🍺" type="tts">beer mug</annotation>
+		<annotation cp="🍻">alcohol | bar | beer | booze | bottoms | cheers | clink | clinking | drinking | drinks | mugs</annotation>
+		<annotation cp="🍻" type="tts">clinking beer mugs</annotation>
+		<annotation cp="🥂">celebrate | clink | clinking | drink | glass | glasses</annotation>
+		<annotation cp="🥂" type="tts">clinking glasses</annotation>
+		<annotation cp="🥃">glass | liquor | scotch | shot | tumbler | whiskey | whisky</annotation>
+		<annotation cp="🥃" type="tts">tumbler glass</annotation>
+		<annotation cp="🫗">accident | drink | empty | glass | liquid | oops | pour | pouring | spill | water</annotation> <!-- 1FAD7 -->
+		<annotation cp="🫗" type="tts">pouring liquid</annotation>
+		<annotation cp="🥤">cup | drink | juice | malt | soda | soft | straw | water</annotation>
+		<annotation cp="🥤" type="tts">cup with straw</annotation>
+		<annotation cp="🧋">boba | bubble | food | milk | pearl | tea</annotation>
+		<annotation cp="🧋" type="tts">bubble tea</annotation>
+		<annotation cp="🧃">beverage | box | juice | straw | sweet</annotation>
+		<annotation cp="🧃" type="tts">beverage box</annotation>
+		<annotation cp="🧉">drink | mate</annotation>
+		<annotation cp="🧉" type="tts">mate</annotation>
+		<annotation cp="🧊">cold | cube | ice | iceberg</annotation>
+		<annotation cp="🧊" type="tts">ice</annotation>
+		<annotation cp="🥢">chopsticks | hashi | jeotgarak | kuaizi</annotation>
+		<annotation cp="🥢" type="tts">chopsticks</annotation>
+		<annotation cp="🍽">cooking | dinner | eat | fork | knife | plate</annotation>
+		<annotation cp="🍽" type="tts">fork and knife with plate</annotation>
+		<annotation cp="🍴">breakfast | breaky | cooking | cutlery | delicious | dinner | eat | feed | food | fork | hungry | knife | lunch | restaurant | yum | yummy</annotation>
+		<annotation cp="🍴" type="tts">fork and knife</annotation>
+		<annotation cp="🥄">eat | spoon | tableware</annotation>
+		<annotation cp="🥄" type="tts">spoon</annotation>
+		<annotation cp="🔪">chef | cooking | hocho | kitchen | knife | tool | weapon</annotation>
+		<annotation cp="🔪" type="tts">kitchen knife</annotation>
+		<annotation cp="🫙">condiment | container | empty | jar | nothing | sauce | store</annotation> <!-- 1FAD9 -->
+		<annotation cp="🫙" type="tts">jar</annotation>
+		<annotation cp="🏺">amphora | Aquarius | cooking | drink | jug | tool | weapon | zodiac</annotation>
+		<annotation cp="🏺" type="tts">amphora</annotation>
+		<annotation cp="🌍">Africa | earth | Europe | Europe-Africa | globe | showing | world</annotation>
+		<annotation cp="🌍" type="tts">globe showing Europe-Africa</annotation>
+		<annotation cp="🌎">Americas | earth | globe | showing | world</annotation>
+		<annotation cp="🌎" type="tts">globe showing Americas</annotation>
+		<annotation cp="🌏">Asia | Asia-Australia | Australia | earth | globe | showing | world</annotation>
+		<annotation cp="🌏" type="tts">globe showing Asia-Australia</annotation>
+		<annotation cp="🌐">earth | globe | internet | meridians | web | world | worldwide</annotation>
+		<annotation cp="🌐" type="tts">globe with meridians</annotation>
+		<annotation cp="🗺">map | world</annotation>
+		<annotation cp="🗺" type="tts">world map</annotation>
+		<annotation cp="🗾">Japan | map</annotation>
+		<annotation cp="🗾" type="tts">map of Japan</annotation>
+		<annotation cp="🧭">compass | direction | magnetic | navigation | orienteering</annotation>
+		<annotation cp="🧭" type="tts">compass</annotation>
+		<annotation cp="🏔">cold | mountain | snow | snow-capped</annotation>
+		<annotation cp="🏔" type="tts">snow-capped mountain</annotation>
+		<annotation cp="⛰">mountain</annotation>
+		<annotation cp="⛰" type="tts">mountain</annotation>
+		<annotation cp="🌋">eruption | mountain | nature | volcano</annotation>
+		<annotation cp="🌋" type="tts">volcano</annotation>
+		<annotation cp="🗻">fuji | mount | mountain | nature</annotation>
+		<annotation cp="🗻" type="tts">mount fuji</annotation>
+		<annotation cp="🏕">camping</annotation>
+		<annotation cp="🏕" type="tts">camping</annotation>
+		<annotation cp="🏖">beach | umbrella</annotation>
+		<annotation cp="🏖" type="tts">beach with umbrella</annotation>
+		<annotation cp="🏜">desert</annotation>
+		<annotation cp="🏜" type="tts">desert</annotation>
+		<annotation cp="🏝">desert | island</annotation>
+		<annotation cp="🏝" type="tts">desert island</annotation>
+		<annotation cp="🏞">national | park</annotation>
+		<annotation cp="🏞" type="tts">national park</annotation>
+		<annotation cp="🏟">stadium</annotation>
+		<annotation cp="🏟" type="tts">stadium</annotation>
+		<annotation cp="🏛">building | classical</annotation>
+		<annotation cp="🏛" type="tts">classical building</annotation>
+		<annotation cp="🏗">building | construction | crane</annotation>
+		<annotation cp="🏗" type="tts">building construction</annotation>
+		<annotation cp="🧱">brick | bricks | clay | mortar | wall</annotation>
+		<annotation cp="🧱" type="tts">brick</annotation>
+		<annotation cp="🪨">boulder | heavy | rock | solid | stone | tough</annotation>
+		<annotation cp="🪨" type="tts">rock</annotation>
+		<annotation cp="🪵">log | lumber | timber | wood</annotation>
+		<annotation cp="🪵" type="tts">wood</annotation>
+		<annotation cp="🛖">home | house | hut | roundhouse | shelter | yurt</annotation>
+		<annotation cp="🛖" type="tts">hut</annotation>
+		<annotation cp="🏘">house | houses</annotation>
+		<annotation cp="🏘" type="tts">houses</annotation>
+		<annotation cp="🏚">derelict | home | house</annotation>
+		<annotation cp="🏚" type="tts">derelict house</annotation>
+		<annotation cp="🏠">building | country | heart | home | house | ranch | settle | simple | suburban | suburbia | where</annotation>
+		<annotation cp="🏠" type="tts">house</annotation>
+		<annotation cp="🏡">building | country | garden | heart | home | house | ranch | settle | simple | suburban | suburbia | where</annotation>
+		<annotation cp="🏡" type="tts">house with garden</annotation>
+		<annotation cp="🏢">building | city | cubical | job | office</annotation>
+		<annotation cp="🏢" type="tts">office building</annotation>
+		<annotation cp="🏣">building | Japanese | office | post</annotation>
+		<annotation cp="🏣" type="tts">Japanese post office</annotation>
+		<annotation cp="🏤">building | European | office | post</annotation>
+		<annotation cp="🏤" type="tts">post office</annotation>
+		<annotation cp="🏥">building | doctor | hospital | medicine</annotation>
+		<annotation cp="🏥" type="tts">hospital</annotation>
+		<annotation cp="🏦">bank | building</annotation>
+		<annotation cp="🏦" type="tts">bank</annotation>
+		<annotation cp="🏨">building | hotel</annotation>
+		<annotation cp="🏨" type="tts">hotel</annotation>
+		<annotation cp="🏩">building | hotel | love</annotation>
+		<annotation cp="🏩" type="tts">love hotel</annotation>
+		<annotation cp="🏪">24 | building | convenience | hours | store</annotation>
+		<annotation cp="🏪" type="tts">convenience store</annotation>
+		<annotation cp="🏫">building | school</annotation>
+		<annotation cp="🏫" type="tts">school</annotation>
+		<annotation cp="🏬">building | department | store</annotation>
+		<annotation cp="🏬" type="tts">department store</annotation>
+		<annotation cp="🏭">building | factory</annotation>
+		<annotation cp="🏭" type="tts">factory</annotation>
+		<annotation cp="🏯">building | castle | Japanese</annotation>
+		<annotation cp="🏯" type="tts">Japanese castle</annotation>
+		<annotation cp="🏰">building | castle | European</annotation>
+		<annotation cp="🏰" type="tts">castle</annotation>
+		<annotation cp="💒">chapel | hitched | nuptials | romance | wedding</annotation>
+		<annotation cp="💒" type="tts">wedding</annotation>
+		<annotation cp="🗼">Tokyo | tower</annotation>
+		<annotation cp="🗼" type="tts">Tokyo tower</annotation>
+		<annotation cp="🗽">liberty | Liberty | new | ny | nyc | statue | Statue | york</annotation>
+		<annotation cp="🗽" type="tts">Statue of Liberty</annotation>
+		<annotation cp="⛪">bless | chapel | Christian | church | cross | religion</annotation>
+		<annotation cp="⛪" type="tts">church</annotation>
+		<annotation cp="🕌">islam | masjid | mosque | Muslim | religion</annotation>
+		<annotation cp="🕌" type="tts">mosque</annotation>
+		<annotation cp="🛕">hindu | temple</annotation>
+		<annotation cp="🛕" type="tts">hindu temple</annotation>
+		<annotation cp="🕍">Jew | Jewish | judaism | religion | synagogue | temple</annotation>
+		<annotation cp="🕍" type="tts">synagogue</annotation>
+		<annotation cp="⛩">religion | shinto | shrine</annotation>
+		<annotation cp="⛩" type="tts">shinto shrine</annotation>
+		<annotation cp="🕋">hajj | islam | kaaba | Muslim | religion | umrah</annotation>
+		<annotation cp="🕋" type="tts">kaaba</annotation>
+		<annotation cp="⛲">fountain</annotation>
+		<annotation cp="⛲" type="tts">fountain</annotation>
+		<annotation cp="⛺">camping | tent</annotation>
+		<annotation cp="⛺" type="tts">tent</annotation>
+		<annotation cp="🌁">fog | foggy</annotation>
+		<annotation cp="🌁" type="tts">foggy</annotation>
+		<annotation cp="🌃">night | star | stars</annotation>
+		<annotation cp="🌃" type="tts">night with stars</annotation>
+		<annotation cp="🏙">city | cityscape</annotation>
+		<annotation cp="🏙" type="tts">cityscape</annotation>
+		<annotation cp="🌄">morning | mountains | over | sun | sunrise</annotation>
+		<annotation cp="🌄" type="tts">sunrise over mountains</annotation>
+		<annotation cp="🌅">morning | nature | sun | sunrise</annotation>
+		<annotation cp="🌅" type="tts">sunrise</annotation>
+		<annotation cp="🌆">at | building | city | cityscape | dusk | evening | landscape | sun | sunset</annotation>
+		<annotation cp="🌆" type="tts">cityscape at dusk</annotation>
+		<annotation cp="🌇">building | dusk | sun | sunset</annotation>
+		<annotation cp="🌇" type="tts">sunset</annotation>
+		<annotation cp="🌉">at | bridge | night</annotation>
+		<annotation cp="🌉" type="tts">bridge at night</annotation>
+		<annotation cp="♨">hot | hotsprings | springs | steaming</annotation>
+		<annotation cp="♨" type="tts">hot springs</annotation>
+		<annotation cp="🎠">carousel | entertainment | horse</annotation>
+		<annotation cp="🎠" type="tts">carousel horse</annotation>
+		<annotation cp="🛝">amusement | park | play | playground | playing | slide | sliding | theme</annotation> <!-- 1F6DD -->
+		<annotation cp="🛝" type="tts">playground slide</annotation>
+		<annotation cp="🎡">amusement | ferris | park | theme | wheel</annotation>
+		<annotation cp="🎡" type="tts">ferris wheel</annotation>
+		<annotation cp="🎢">amusement | coaster | park | roller | theme</annotation>
+		<annotation cp="🎢" type="tts">roller coaster</annotation>
+		<annotation cp="💈">barber | cut | fresh | haircut | pole | shave</annotation>
+		<annotation cp="💈" type="tts">barber pole</annotation>
+		<annotation cp="🎪">circus | tent</annotation>
+		<annotation cp="🎪" type="tts">circus tent</annotation>
+		<annotation cp="🚂">caboose | engine | locomotive | railway | steam | train | trains | travel</annotation>
+		<annotation cp="🚂" type="tts">locomotive</annotation>
+		<annotation cp="🚃">car | electric | railway | train | tram | travel | trolleybus</annotation>
+		<annotation cp="🚃" type="tts">railway car</annotation>
+		<annotation cp="🚄">high-speed | railway | shinkansen | speed | train</annotation>
+		<annotation cp="🚄" type="tts">high-speed train</annotation>
+		<annotation cp="🚅">bullet | high-speed | nose | railway | shinkansen | speed | train | travel</annotation>
+		<annotation cp="🚅" type="tts">bullet train</annotation>
+		<annotation cp="🚆">arrived | choo | railway | train</annotation>
+		<annotation cp="🚆" type="tts">train</annotation>
+		<annotation cp="🚇">metro | subway | travel</annotation>
+		<annotation cp="🚇" type="tts">metro</annotation>
+		<annotation cp="🚈">arrived | light | monorail | rail | railway</annotation>
+		<annotation cp="🚈" type="tts">light rail</annotation>
+		<annotation cp="🚉">railway | station | train</annotation>
+		<annotation cp="🚉" type="tts">station</annotation>
+		<annotation cp="🚊">tram | trolleybus</annotation>
+		<annotation cp="🚊" type="tts">tram</annotation>
+		<annotation cp="🚝">monorail | vehicle</annotation>
+		<annotation cp="🚝" type="tts">monorail</annotation>
+		<annotation cp="🚞">car | mountain | railway | trip</annotation>
+		<annotation cp="🚞" type="tts">mountain railway</annotation>
+		<annotation cp="🚋">bus | car | tram | trolley | trolleybus</annotation>
+		<annotation cp="🚋" type="tts">tram car</annotation>
+		<annotation cp="🚌">bus | school | vehicle</annotation>
+		<annotation cp="🚌" type="tts">bus</annotation>
+		<annotation cp="🚍">bus | cars | oncoming</annotation>
+		<annotation cp="🚍" type="tts">oncoming bus</annotation>
+		<annotation cp="🚎">bus | tram | trolley | trolleybus</annotation>
+		<annotation cp="🚎" type="tts">trolleybus</annotation>
+		<annotation cp="🚐">bus | drive | minibus | van | vehicle</annotation>
+		<annotation cp="🚐" type="tts">minibus</annotation>
+		<annotation cp="🚑">ambulance | emergency | vehicle</annotation>
+		<annotation cp="🚑" type="tts">ambulance</annotation>
+		<annotation cp="🚒">engine | fire | truck</annotation>
+		<annotation cp="🚒" type="tts">fire engine</annotation>
+		<annotation cp="🚓">5–0 | car | cops | patrol | police</annotation>
+		<annotation cp="🚓" type="tts">police car</annotation>
+		<annotation cp="🚔">car | oncoming | police</annotation>
+		<annotation cp="🚔" type="tts">oncoming police car</annotation>
+		<annotation cp="🚕">cab | cabbie | car | drive | taxi | vehicle | yellow</annotation>
+		<annotation cp="🚕" type="tts">taxi</annotation>
+		<annotation cp="🚖">cab | cabbie | cars | drove | hail | oncoming | taxi | yellow</annotation>
+		<annotation cp="🚖" type="tts">oncoming taxi</annotation>
+		<annotation cp="🚗">automobile | car | driving | vehicle</annotation>
+		<annotation cp="🚗" type="tts">automobile</annotation>
+		<annotation cp="🚘">automobile | car | cars | drove | oncoming | vehicle</annotation>
+		<annotation cp="🚘" type="tts">oncoming automobile</annotation>
+		<annotation cp="🚙">car | drive | recreational | sport | sportutility | utility | vehicle</annotation>
+		<annotation cp="🚙" type="tts">sport utility vehicle</annotation>
+		<annotation cp="🛻">automobile | car | flatbed | pick-up | pickup | transportation | truck</annotation>
+		<annotation cp="🛻" type="tts">pickup truck</annotation>
+		<annotation cp="🚚">car | delivery | drive | truck | vehicle</annotation>
+		<annotation cp="🚚" type="tts">delivery truck</annotation>
+		<annotation cp="🚛">articulated | car | drive | lorry | move | semi | truck | vehicle</annotation>
+		<annotation cp="🚛" type="tts">articulated lorry</annotation>
+		<annotation cp="🚜">tractor | vehicle</annotation>
+		<annotation cp="🚜" type="tts">tractor</annotation>
+		<annotation cp="🏎">car | racing | zoom</annotation>
+		<annotation cp="🏎" type="tts">racing car</annotation>
+		<annotation cp="🏍">motorcycle | racing</annotation>
+		<annotation cp="🏍" type="tts">motorcycle</annotation>
+		<annotation cp="🛵">motor | scooter</annotation>
+		<annotation cp="🛵" type="tts">motor scooter</annotation>
+		<annotation cp="🦽">accessibility | manual | wheelchair</annotation>
+		<annotation cp="🦽" type="tts">manual wheelchair</annotation>
+		<annotation cp="🦼">accessibility | motorized | wheelchair</annotation>
+		<annotation cp="🦼" type="tts">motorized wheelchair</annotation>
+		<annotation cp="🛺">auto | rickshaw | tuk</annotation>
+		<annotation cp="🛺" type="tts">auto rickshaw</annotation>
+		<annotation cp="🚲">bicycle | bike | class | cycle | cycling | cyclist | gang | ride | spin | spinning</annotation>
+		<annotation cp="🚲" type="tts">bicycle</annotation>
+		<annotation cp="🛴">kick | scooter</annotation>
+		<annotation cp="🛴" type="tts">kick scooter</annotation>
+		<annotation cp="🛹">board | skate | skateboard | skater | wheels</annotation>
+		<annotation cp="🛹" type="tts">skateboard</annotation>
+		<annotation cp="🛼">blades | roller | skate | skates | sport</annotation>
+		<annotation cp="🛼" type="tts">roller skate</annotation>
+		<annotation cp="🚏">bus | busstop | stop</annotation>
+		<annotation cp="🚏" type="tts">bus stop</annotation>
+		<annotation cp="🛣">highway | motorway | road</annotation>
+		<annotation cp="🛣" type="tts">motorway</annotation>
+		<annotation cp="🛤">railway | track | train</annotation>
+		<annotation cp="🛤" type="tts">railway track</annotation>
+		<annotation cp="🛢">drum | oil</annotation>
+		<annotation cp="🛢" type="tts">oil drum</annotation>
+		<annotation cp="⛽">diesel | fuel | fuelpump | gas | gasoline | pump | station</annotation>
+		<annotation cp="⛽" type="tts">fuel pump</annotation>
+		<annotation cp="🛞">car | circle | tire | turn | vehicle | wheel</annotation> <!-- 1F6DE -->
+		<annotation cp="🛞" type="tts">wheel</annotation>
+		<annotation cp="🚨">alarm | alert | beacon | car | emergency | light | police | revolving | siren</annotation>
+		<annotation cp="🚨" type="tts">police car light</annotation>
+		<annotation cp="🚥">horizontal | intersection | light | signal | stop | stoplight | traffic</annotation>
+		<annotation cp="🚥" type="tts">horizontal traffic light</annotation>
+		<annotation cp="🚦">drove | intersection | light | signal | stop | stoplight | traffic | vertical</annotation>
+		<annotation cp="🚦" type="tts">vertical traffic light</annotation>
+		<annotation cp="🛑">octagonal | sign | stop</annotation>
+		<annotation cp="🛑" type="tts">stop sign</annotation>
+		<annotation cp="🚧">barrier | construction</annotation>
+		<annotation cp="🚧" type="tts">construction</annotation>
+		<annotation cp="⚓">anchor | ship | tool</annotation>
+		<annotation cp="⚓" type="tts">anchor</annotation>
+		<annotation cp="🛟">buoy | float | life | lifesaver | preserver | rescue | ring | safety | save | saver | swim</annotation> <!-- 1F6DF -->
+		<annotation cp="🛟" type="tts">ring buoy</annotation>
+		<annotation cp="⛵">boat | resort | sailboat | sailing | sea | yacht</annotation>
+		<annotation cp="⛵" type="tts">sailboat</annotation>
+		<annotation cp="🛶">boat | canoe</annotation>
+		<annotation cp="🛶" type="tts">canoe</annotation>
+		<annotation cp="🚤">billionaire | boat | lake | luxury | millionaire | speedboat | summer | travel</annotation>
+		<annotation cp="🚤" type="tts">speedboat</annotation>
+		<annotation cp="🛳">passenger | ship</annotation>
+		<annotation cp="🛳" type="tts">passenger ship</annotation>
+		<annotation cp="⛴">boat | ferry | passenger</annotation>
+		<annotation cp="⛴" type="tts">ferry</annotation>
+		<annotation cp="🛥">boat | motor | motorboat</annotation>
+		<annotation cp="🛥" type="tts">motor boat</annotation>
+		<annotation cp="🚢">boat | passenger | ship | travel</annotation>
+		<annotation cp="🚢" type="tts">ship</annotation>
+		<annotation cp="✈">aeroplane | airplane | fly | flying | jet | plane | travel</annotation>
+		<annotation cp="✈" type="tts">airplane</annotation>
+		<annotation cp="🛩">aeroplane | airplane | plane | small</annotation>
+		<annotation cp="🛩" type="tts">small airplane</annotation>
+		<annotation cp="🛫">aeroplane | airplane | check-in | departure | departures | plane</annotation>
+		<annotation cp="🛫" type="tts">airplane departure</annotation>
+		<annotation cp="🛬">aeroplane | airplane | arrival | arrivals | arriving | landing | plane</annotation>
+		<annotation cp="🛬" type="tts">airplane arrival</annotation>
+		<annotation cp="🪂">hang-glide | parachute | parasail | skydive</annotation>
+		<annotation cp="🪂" type="tts">parachute</annotation>
+		<annotation cp="💺">chair | seat</annotation>
+		<annotation cp="💺" type="tts">seat</annotation>
+		<annotation cp="🚁">copter | helicopter | roflcopter | travel | vehicle</annotation>
+		<annotation cp="🚁" type="tts">helicopter</annotation>
+		<annotation cp="🚟">railway | suspension</annotation>
+		<annotation cp="🚟" type="tts">suspension railway</annotation>
+		<annotation cp="🚠">cable | cableway | gondola | lift | mountain | ski</annotation>
+		<annotation cp="🚠" type="tts">mountain cableway</annotation>
+		<annotation cp="🚡">aerial | cable | car | gondola | ropeway | tramway</annotation>
+		<annotation cp="🚡" type="tts">aerial tramway</annotation>
+		<annotation cp="🛰">satellite | space</annotation>
+		<annotation cp="🛰" type="tts">satellite</annotation>
+		<annotation cp="🚀">launch | rocket | rockets | space | travel</annotation>
+		<annotation cp="🚀" type="tts">rocket</annotation>
+		<annotation cp="🛸">aliens | extra | flying | saucer | terrestrial | UFO</annotation>
+		<annotation cp="🛸" type="tts">flying saucer</annotation>
+		<annotation cp="🛎">bell | bellhop | hotel</annotation>
+		<annotation cp="🛎" type="tts">bellhop bell</annotation>
+		<annotation cp="🧳">bag | luggage | packing | roller | suitcase | travel</annotation>
+		<annotation cp="🧳" type="tts">luggage</annotation>
+		<annotation cp="⌛">done | hourglass | sand | time | timer</annotation>
+		<annotation cp="⌛" type="tts">hourglass done</annotation>
+		<annotation cp="⏳">done | flowing | hourglass | hours | not | sand | timer | waiting | yolo</annotation>
+		<annotation cp="⏳" type="tts">hourglass not done</annotation>
+		<annotation cp="⌚">clock | time | watch</annotation>
+		<annotation cp="⌚" type="tts">watch</annotation>
+		<annotation cp="⏰">alarm | clock | hours | hrs | late | time | waiting</annotation>
+		<annotation cp="⏰" type="tts">alarm clock</annotation>
+		<annotation cp="⏱">clock | stopwatch | time</annotation>
+		<annotation cp="⏱" type="tts">stopwatch</annotation>
+		<annotation cp="⏲">clock | timer</annotation>
+		<annotation cp="⏲" type="tts">timer clock</annotation>
+		<annotation cp="🕰">clock | mantelpiece | time</annotation>
+		<annotation cp="🕰" type="tts">mantelpiece clock</annotation>
+		<annotation cp="🕛">12 | 12:00 | clock | o’clock | time | twelve</annotation>
+		<annotation cp="🕛" type="tts">twelve o’clock</annotation>
+		<annotation cp="🕧">12 | 12:30 | 30 | clock | thirty | time | twelve | twelve-thirty</annotation>
+		<annotation cp="🕧" type="tts">twelve-thirty</annotation>
+		<annotation cp="🕐">1 | 1:00 | clock | o’clock | one | time</annotation>
+		<annotation cp="🕐" type="tts">one o’clock</annotation>
+		<annotation cp="🕜">1 | 1:30 | 30 | clock | one | one-thirty | thirty | time</annotation>
+		<annotation cp="🕜" type="tts">one-thirty</annotation>
+		<annotation cp="🕑">2 | 2:00 | clock | o’clock | time | two</annotation>
+		<annotation cp="🕑" type="tts">two o’clock</annotation>
+		<annotation cp="🕝">2 | 2:30 | 30 | clock | thirty | time | two | two-thirty</annotation>
+		<annotation cp="🕝" type="tts">two-thirty</annotation>
+		<annotation cp="🕒">3 | 3:00 | clock | o’clock | three | time</annotation>
+		<annotation cp="🕒" type="tts">three o’clock</annotation>
+		<annotation cp="🕞">3 | 3:30 | 30 | clock | thirty | three | three-thirty | time</annotation>
+		<annotation cp="🕞" type="tts">three-thirty</annotation>
+		<annotation cp="🕓">4 | 4:00 | clock | four | o’clock | time</annotation>
+		<annotation cp="🕓" type="tts">four o’clock</annotation>
+		<annotation cp="🕟">30 | 4 | 4:30 | clock | four | four-thirty | thirty | time</annotation>
+		<annotation cp="🕟" type="tts">four-thirty</annotation>
+		<annotation cp="🕔">5 | 5:00 | clock | five | o’clock | time</annotation>
+		<annotation cp="🕔" type="tts">five o’clock</annotation>
+		<annotation cp="🕠">30 | 5 | 5:30 | clock | five | five-thirty | thirty | time</annotation>
+		<annotation cp="🕠" type="tts">five-thirty</annotation>
+		<annotation cp="🕕">6 | 6:00 | clock | o’clock | six | time</annotation>
+		<annotation cp="🕕" type="tts">six o’clock</annotation>
+		<annotation cp="🕡">30 | 6 | 6:30 | clock | six | six-thirty | thirty</annotation>
+		<annotation cp="🕡" type="tts">six-thirty</annotation>
+		<annotation cp="🕖">0 | 7 | 7:00 | clock | o’clock | seven</annotation>
+		<annotation cp="🕖" type="tts">seven o’clock</annotation>
+		<annotation cp="🕢">30 | 7 | 7:30 | clock | seven | seven-thirty | thirty</annotation>
+		<annotation cp="🕢" type="tts">seven-thirty</annotation>
+		<annotation cp="🕗">8 | 8:00 | clock | eight | o’clock | time</annotation>
+		<annotation cp="🕗" type="tts">eight o’clock</annotation>
+		<annotation cp="🕣">30 | 8 | 8:30 | clock | eight | eight-thirty | thirty | time</annotation>
+		<annotation cp="🕣" type="tts">eight-thirty</annotation>
+		<annotation cp="🕘">9 | 9:00 | clock | nine | o’clock | time</annotation>
+		<annotation cp="🕘" type="tts">nine o’clock</annotation>
+		<annotation cp="🕤">30 | 9 | 9:30 | clock | nine | nine-thirty | thirty | time</annotation>
+		<annotation cp="🕤" type="tts">nine-thirty</annotation>
+		<annotation cp="🕙">0 | 10 | 10:00 | clock | o’clock | ten</annotation>
+		<annotation cp="🕙" type="tts">ten o’clock</annotation>
+		<annotation cp="🕥">10 | 10:30 | 30 | clock | ten | ten-thirty | thirty | time</annotation>
+		<annotation cp="🕥" type="tts">ten-thirty</annotation>
+		<annotation cp="🕚">11 | 11:00 | clock | eleven | o’clock | time</annotation>
+		<annotation cp="🕚" type="tts">eleven o’clock</annotation>
+		<annotation cp="🕦">11 | 11:30 | 30 | clock | eleven | eleven-thirty | thirty | time</annotation>
+		<annotation cp="🕦" type="tts">eleven-thirty</annotation>
+		<annotation cp="🌑">dark | moon | new | space</annotation>
+		<annotation cp="🌑" type="tts">new moon</annotation>
+		<annotation cp="🌒">crescent | dreams | moon | space | waxing</annotation>
+		<annotation cp="🌒" type="tts">waxing crescent moon</annotation>
+		<annotation cp="🌓">first | moon | quarter | space</annotation>
+		<annotation cp="🌓" type="tts">first quarter moon</annotation>
+		<annotation cp="🌔">gibbous | moon | space | waxing</annotation>
+		<annotation cp="🌔" type="tts">waxing gibbous moon</annotation>
+		<annotation cp="🌕">full | moon | space</annotation>
+		<annotation cp="🌕" type="tts">full moon</annotation>
+		<annotation cp="🌖">gibbous | moon | space | waning</annotation>
+		<annotation cp="🌖" type="tts">waning gibbous moon</annotation>
+		<annotation cp="🌗">last | moon | quarter | space</annotation>
+		<annotation cp="🌗" type="tts">last quarter moon</annotation>
+		<annotation cp="🌘">crescent | moon | space | waning</annotation>
+		<annotation cp="🌘" type="tts">waning crescent moon</annotation>
+		<annotation cp="🌙">crescent | moon | ramadan | space</annotation>
+		<annotation cp="🌙" type="tts">crescent moon</annotation>
+		<annotation cp="🌚">face | moon | new | space</annotation>
+		<annotation cp="🌚" type="tts">new moon face</annotation>
+		<annotation cp="🌛">face | first | moon | quarter | space</annotation>
+		<annotation cp="🌛" type="tts">first quarter moon face</annotation>
+		<annotation cp="🌜">dreams | face | last | moon | quarter</annotation>
+		<annotation cp="🌜" type="tts">last quarter moon face</annotation>
+		<annotation cp="🌡">thermometer | weather</annotation>
+		<annotation cp="🌡" type="tts">thermometer</annotation>
+		<annotation cp="☀">bright | rays | space | sun | sunny | weather</annotation>
+		<annotation cp="☀" type="tts">sun</annotation>
+		<annotation cp="🌝">bright | face | full | moon</annotation>
+		<annotation cp="🌝" type="tts">full moon face</annotation>
+		<annotation cp="🌞">beach | bright | day | face | heat | shine | sun | sunny | sunshine | weather</annotation>
+		<annotation cp="🌞" type="tts">sun with face</annotation>
+		<annotation cp="🪐">planet | ringed | saturn | saturnine</annotation>
+		<annotation cp="🪐" type="tts">ringed planet</annotation>
+		<annotation cp="⭐">astronomy | medium | star | stars | white</annotation>
+		<annotation cp="⭐" type="tts">star</annotation>
+		<annotation cp="🌟">glittery | glow | glowing | night | shining | sparkle | star | win</annotation>
+		<annotation cp="🌟" type="tts">glowing star</annotation>
+		<annotation cp="🌠">falling | night | shooting | space | star</annotation>
+		<annotation cp="🌠" type="tts">shooting star</annotation>
+		<annotation cp="🌌">milky | space | way</annotation>
+		<annotation cp="🌌" type="tts">milky way</annotation>
+		<annotation cp="☁">cloud | weather</annotation>
+		<annotation cp="☁" type="tts">cloud</annotation>
+		<annotation cp="⛅">behind | cloud | cloudy | sun | weather</annotation>
+		<annotation cp="⛅" type="tts">sun behind cloud</annotation>
+		<annotation cp="⛈">cloud | lightning | rain | thunder | thunderstorm</annotation>
+		<annotation cp="⛈" type="tts">cloud with lightning and rain</annotation>
+		<annotation cp="🌤">behind | cloud | sun | weather</annotation>
+		<annotation cp="🌤" type="tts">sun behind small cloud</annotation>
+		<annotation cp="🌥">behind | cloud | sun | weather</annotation>
+		<annotation cp="🌥" type="tts">sun behind large cloud</annotation>
+		<annotation cp="🌦">behind | cloud | rain | sun | weather</annotation>
+		<annotation cp="🌦" type="tts">sun behind rain cloud</annotation>
+		<annotation cp="🌧">cloud | rain | weather</annotation>
+		<annotation cp="🌧" type="tts">cloud with rain</annotation>
+		<annotation cp="🌨">cloud | cold | snow | weather</annotation>
+		<annotation cp="🌨" type="tts">cloud with snow</annotation>
+		<annotation cp="🌩">cloud | lightning | weather</annotation>
+		<annotation cp="🌩" type="tts">cloud with lightning</annotation>
+		<annotation cp="🌪">cloud | tornado | weather | whirlwind</annotation>
+		<annotation cp="🌪" type="tts">tornado</annotation>
+		<annotation cp="🌫">cloud | fog | weather</annotation>
+		<annotation cp="🌫" type="tts">fog</annotation>
+		<annotation cp="🌬">blow | cloud | face | wind</annotation>
+		<annotation cp="🌬" type="tts">wind face</annotation>
+		<annotation cp="🌀">cyclone | dizzy | hurricane | twister | typhoon | weather</annotation>
+		<annotation cp="🌀" type="tts">cyclone</annotation>
+		<annotation cp="🌈">gay | genderqueer | glbt | glbtq | lesbian | lgbt | lgbtq | lgbtqia | nature | pride | queer | rain | rainbow | trans | transgender | weather</annotation>
+		<annotation cp="🌈" type="tts">rainbow</annotation>
+		<annotation cp="🌂">closed | clothing | rain | umbrella</annotation>
+		<annotation cp="🌂" type="tts">closed umbrella</annotation>
+		<annotation cp="☂">clothing | rain | umbrella</annotation>
+		<annotation cp="☂" type="tts">umbrella</annotation>
+		<annotation cp="☔">clothing | drop | drops | rain | umbrella | weather</annotation>
+		<annotation cp="☔" type="tts">umbrella with rain drops</annotation>
+		<annotation cp="⛱">ground | rain | sun | umbrella</annotation>
+		<annotation cp="⛱" type="tts">umbrella on ground</annotation>
+		<annotation cp="⚡">danger | electric | electricity | high | lightning | nature | thunder | thunderbolt | voltage | zap</annotation>
+		<annotation cp="⚡" type="tts">high voltage</annotation>
+		<annotation cp="❄">cold | snow | snowflake | weather</annotation>
+		<annotation cp="❄" type="tts">snowflake</annotation>
+		<annotation cp="☃">cold | man | snow | snowman</annotation>
+		<annotation cp="☃" type="tts">snowman</annotation>
+		<annotation cp="⛄">cold | man | snow | snowman</annotation>
+		<annotation cp="⛄" type="tts">snowman without snow</annotation>
+		<annotation cp="☄">comet | space</annotation>
+		<annotation cp="☄" type="tts">comet</annotation>
+		<annotation cp="🔥">af | burn | fire | flame | hot | lit | litaf | tool</annotation>
+		<annotation cp="🔥" type="tts">fire</annotation>
+		<annotation cp="💧">cold | comic | drop | droplet | nature | sad | sweat | tear | water | weather</annotation>
+		<annotation cp="💧" type="tts">droplet</annotation>
+		<annotation cp="🌊">nature | ocean | surf | surfer | surfing | water | wave</annotation>
+		<annotation cp="🌊" type="tts">water wave</annotation>
+		<annotation cp="🎃">celebration | halloween | jack | jack-o-lantern | lantern | pumpkin</annotation>
+		<annotation cp="🎃" type="tts">jack-o-lantern</annotation>
+		<annotation cp="🎄">celebration | Christmas | tree</annotation>
+		<annotation cp="🎄" type="tts">Christmas tree</annotation>
+		<annotation cp="🎆">boom | celebration | entertainment | fireworks | yolo</annotation>
+		<annotation cp="🎆" type="tts">fireworks</annotation>
+		<annotation cp="🎇">boom | celebration | fireworks | sparkle | sparkler</annotation>
+		<annotation cp="🎇" type="tts">sparkler</annotation>
+		<annotation cp="🧨">dynamite | explosive | fire | firecracker | fireworks | light | pop | popping | spark</annotation>
+		<annotation cp="🧨" type="tts">firecracker</annotation>
+		<annotation cp="✨">* | magic | sparkle | sparkles | star</annotation>
+		<annotation cp="✨" type="tts">sparkles</annotation>
+		<annotation cp="🎈">balloon | birthday | celebrate | celebration</annotation>
+		<annotation cp="🎈" type="tts">balloon</annotation>
+		<annotation cp="🎉">awesome | birthday | celebrate | celebration | excited | hooray | party | popper | tada | woohoo</annotation>
+		<annotation cp="🎉" type="tts">party popper</annotation>
+		<annotation cp="🎊">ball | celebrate | celebration | confetti | party | woohoo</annotation>
+		<annotation cp="🎊" type="tts">confetti ball</annotation>
+		<annotation cp="🎋">banner | celebration | Japanese | tanabata | tree</annotation>
+		<annotation cp="🎋" type="tts">tanabata tree</annotation>
+		<annotation cp="🎍">bamboo | celebration | decoration | Japanese | pine | plant</annotation>
+		<annotation cp="🎍" type="tts">pine decoration</annotation>
+		<annotation cp="🎎">celebration | doll | dolls | festival | Japanese</annotation>
+		<annotation cp="🎎" type="tts">Japanese dolls</annotation>
+		<annotation cp="🎏">carp | celebration | streamer</annotation>
+		<annotation cp="🎏" type="tts">carp streamer</annotation>
+		<annotation cp="🎐">bell | celebration | chime | wind</annotation>
+		<annotation cp="🎐" type="tts">wind chime</annotation>
+		<annotation cp="🎑">celebration | ceremony | moon | viewing</annotation>
+		<annotation cp="🎑" type="tts">moon viewing ceremony</annotation>
+		<annotation cp="🧧">envelope | gift | good | hóngbāo | lai | luck | money | red | see</annotation>
+		<annotation cp="🧧" type="tts">red envelope</annotation>
+		<annotation cp="🎀">celebration | ribbon</annotation>
+		<annotation cp="🎀" type="tts">ribbon</annotation>
+		<annotation cp="🎁">birthday | bow | box | celebration | christmas | gift | present | surprise | wrapped</annotation>
+		<annotation cp="🎁" type="tts">wrapped gift</annotation>
+		<annotation cp="🎗">celebration | reminder | ribbon</annotation>
+		<annotation cp="🎗" type="tts">reminder ribbon</annotation>
+		<annotation cp="🎟">admission | ticket | tickets</annotation>
+		<annotation cp="🎟" type="tts">admission tickets</annotation>
+		<annotation cp="🎫">admission | stub | ticket</annotation>
+		<annotation cp="🎫" type="tts">ticket</annotation>
+		<annotation cp="🎖">award | celebration | medal | military</annotation>
+		<annotation cp="🎖" type="tts">military medal</annotation>
+		<annotation cp="🏆">champion | champs | prize | slay | sport | trophy | victory | win | winning</annotation>
+		<annotation cp="🏆" type="tts">trophy</annotation>
+		<annotation cp="🏅">award | gold | medal | sports | winner</annotation>
+		<annotation cp="🏅" type="tts">sports medal</annotation>
+		<annotation cp="🥇">1st | first | gold | medal | place</annotation>
+		<annotation cp="🥇" type="tts">1st place medal</annotation>
+		<annotation cp="🥈">2nd | medal | place | second | silver</annotation>
+		<annotation cp="🥈" type="tts">2nd place medal</annotation>
+		<annotation cp="🥉">3rd | bronze | medal | place | third</annotation>
+		<annotation cp="🥉" type="tts">3rd place medal</annotation>
+		<annotation cp="⚽">ball | football | futbol | soccer | sport</annotation>
+		<annotation cp="⚽" type="tts">soccer ball</annotation>
+		<annotation cp="⚾">ball | baseball | sport</annotation>
+		<annotation cp="⚾" type="tts">baseball</annotation>
+		<annotation cp="🥎">ball | glove | softball | sports | underarm</annotation>
+		<annotation cp="🥎" type="tts">softball</annotation>
+		<annotation cp="🏀">ball | basketball | hoop | sport</annotation>
+		<annotation cp="🏀" type="tts">basketball</annotation>
+		<annotation cp="🏐">ball | game | volleyball</annotation>
+		<annotation cp="🏐" type="tts">volleyball</annotation>
+		<annotation cp="🏈">american | ball | bowl | football | sport | super</annotation>
+		<annotation cp="🏈" type="tts">american football</annotation>
+		<annotation cp="🏉">ball | football | rugby | sport</annotation>
+		<annotation cp="🏉" type="tts">rugby football</annotation>
+		<annotation cp="🎾">ball | racquet | sport | tennis</annotation>
+		<annotation cp="🎾" type="tts">tennis</annotation>
+		<annotation cp="🥏">disc | flying | ultimate</annotation>
+		<annotation cp="🥏" type="tts">flying disc</annotation>
+		<annotation cp="🎳">ball | bowling | game | sport | strike</annotation>
+		<annotation cp="🎳" type="tts">bowling</annotation>
+		<annotation cp="🏏">ball | bat | cricket | game</annotation>
+		<annotation cp="🏏" type="tts">cricket game</annotation>
+		<annotation cp="🏑">ball | field | game | hockey | stick</annotation>
+		<annotation cp="🏑" type="tts">field hockey</annotation>
+		<annotation cp="🏒">game | hockey | ice | puck | stick</annotation>
+		<annotation cp="🏒" type="tts">ice hockey</annotation>
+		<annotation cp="🥍">ball | goal | lacrosse | sports | stick</annotation>
+		<annotation cp="🥍" type="tts">lacrosse</annotation>
+		<annotation cp="🏓">ball | bat | game | paddle | ping | pingpong | pong | table | tennis</annotation>
+		<annotation cp="🏓" type="tts">ping pong</annotation>
+		<annotation cp="🏸">badminton | birdie | game | racquet | shuttlecock</annotation>
+		<annotation cp="🏸" type="tts">badminton</annotation>
+		<annotation cp="🥊">boxing | glove</annotation>
+		<annotation cp="🥊" type="tts">boxing glove</annotation>
+		<annotation cp="🥋">arts | judo | karate | martial | taekwondo | uniform</annotation>
+		<annotation cp="🥋" type="tts">martial arts uniform</annotation>
+		<annotation cp="🥅">goal | net</annotation>
+		<annotation cp="🥅" type="tts">goal net</annotation>
+		<annotation cp="⛳">flag | golf | hole | sport</annotation>
+		<annotation cp="⛳" type="tts">flag in hole</annotation>
+		<annotation cp="⛸">ice | skate | skating</annotation>
+		<annotation cp="⛸" type="tts">ice skate</annotation>
+		<annotation cp="🎣">entertainment | fish | fishing | pole | sport</annotation>
+		<annotation cp="🎣" type="tts">fishing pole</annotation>
+		<annotation cp="🤿">diving | mask | scuba | snorkeling</annotation>
+		<annotation cp="🤿" type="tts">diving mask</annotation>
+		<annotation cp="🎽">athletics | running | sash | shirt</annotation>
+		<annotation cp="🎽" type="tts">running shirt</annotation>
+		<annotation cp="🎿">ski | skis | snow | sport</annotation>
+		<annotation cp="🎿" type="tts">skis</annotation>
+		<annotation cp="🛷">luge | sled | sledge | sleigh | snow | toboggan</annotation>
+		<annotation cp="🛷" type="tts">sled</annotation>
+		<annotation cp="🥌">curling | game | rock | stone</annotation>
+		<annotation cp="🥌" type="tts">curling stone</annotation>
+		<annotation cp="🎯">bull | bullseye | dart | direct | entertainment | game | hit | target</annotation>
+		<annotation cp="🎯" type="tts">bullseye</annotation>
+		<annotation cp="🪀">fluctuate | toy | yo-yo</annotation>
+		<annotation cp="🪀" type="tts">yo-yo</annotation>
+		<annotation cp="🪁">fly | kite | soar</annotation>
+		<annotation cp="🪁" type="tts">kite</annotation>
+		<annotation cp="🔫">gun | handgun | pistol | revolver | tool | water | weapon</annotation>
+		<annotation cp="🔫" type="tts">water pistol</annotation>
+		<annotation cp="🎱">8 | 8ball | ball | billiard | eight | game | pool</annotation>
+		<annotation cp="🎱" type="tts">pool 8 ball</annotation>
+		<annotation cp="🔮">ball | crystal | fairy | fairytale | fantasy | fortune | future | magic | tale | tool</annotation>
+		<annotation cp="🔮" type="tts">crystal ball</annotation>
+		<annotation cp="🪄">magic | magician | wand | witch | wizard</annotation>
+		<annotation cp="🪄" type="tts">magic wand</annotation>
+		<annotation cp="🎮">controller | entertainment | game | video</annotation>
+		<annotation cp="🎮" type="tts">video game</annotation>
+		<annotation cp="🕹">game | joystick | video | videogame</annotation>
+		<annotation cp="🕹" type="tts">joystick</annotation>
+		<annotation cp="🎰">casino | gamble | gambling | game | machine | slot | slots</annotation>
+		<annotation cp="🎰" type="tts">slot machine</annotation>
+		<annotation cp="🎲">dice | die | entertainment | game</annotation>
+		<annotation cp="🎲" type="tts">game die</annotation>
+		<annotation cp="🧩">clue | interlocking | jigsaw | piece | puzzle</annotation>
+		<annotation cp="🧩" type="tts">puzzle piece</annotation>
+		<annotation cp="🧸">bear | plaything | plush | stuffed | teddy | toy</annotation>
+		<annotation cp="🧸" type="tts">teddy bear</annotation>
+		<annotation cp="🪅">candy | celebrate | celebration | cinco | de | festive | mayo | party | pinada | pinata | piñata</annotation>
+		<annotation cp="🪅" type="tts">piñata</annotation>
+		<annotation cp="🪩">ball | dance | disco | glitter | mirror | party</annotation> <!-- 1FAA9 -->
+		<annotation cp="🪩" type="tts">mirror ball</annotation>
+		<annotation cp="🪆">babooshka | baboushka | babushka | doll | dolls | matryoshka | nesting | russia</annotation>
+		<annotation cp="🪆" type="tts">nesting dolls</annotation>
+		<annotation cp="♠">card | game | spade | suit</annotation>
+		<annotation cp="♠" type="tts">spade suit</annotation>
+		<annotation cp="♥">card | emotion | game | heart | hearts | suit</annotation>
+		<annotation cp="♥" type="tts">heart suit</annotation>
+		<annotation cp="♦">card | diamond | game | suit</annotation>
+		<annotation cp="♦" type="tts">diamond suit</annotation>
+		<annotation cp="♣">card | club | clubs | game | suit</annotation>
+		<annotation cp="♣" type="tts">club suit</annotation>
+		<annotation cp="♟">chess | dupe | expendable | pawn</annotation>
+		<annotation cp="♟" type="tts">chess pawn</annotation>
+		<annotation cp="🃏">card | game | joker | wildcard</annotation>
+		<annotation cp="🃏" type="tts">joker</annotation>
+		<annotation cp="🀄">dragon | game | mahjong | red</annotation>
+		<annotation cp="🀄" type="tts">mahjong red dragon</annotation>
+		<annotation cp="🎴">card | cards | flower | game | Japanese | playing</annotation>
+		<annotation cp="🎴" type="tts">flower playing cards</annotation>
+		<annotation cp="🎭">actor | actress | art | arts | entertainment | mask | performing | theater | theatre | thespian</annotation>
+		<annotation cp="🎭" type="tts">performing arts</annotation>
+		<annotation cp="🖼">art | frame | framed | museum | painting | picture</annotation>
+		<annotation cp="🖼" type="tts">framed picture</annotation>
+		<annotation cp="🎨">art | artist | artsy | arty | colorful | creative | entertainment | museum | painter | painting | palette</annotation>
+		<annotation cp="🎨" type="tts">artist palette</annotation>
+		<annotation cp="🧵">needle | sewing | spool | string | thread</annotation>
+		<annotation cp="🧵" type="tts">thread</annotation>
+		<annotation cp="🪡">embroidery | needle | sew | sewing | stitches | sutures | tailoring | thread</annotation>
+		<annotation cp="🪡" type="tts">sewing needle</annotation>
+		<annotation cp="🧶">ball | crochet | knit | yarn</annotation>
+		<annotation cp="🧶" type="tts">yarn</annotation>
+		<annotation cp="🪢">cord | knot | rope | tangled | tie | twine | twist</annotation>
+		<annotation cp="🪢" type="tts">knot</annotation>
+		<annotation cp="👓">clothing | eye | eyeglasses | eyewear | glasses</annotation>
+		<annotation cp="👓" type="tts">glasses</annotation>
+		<annotation cp="🕶">dark | eye | eyewear | glasses | sunglasses</annotation>
+		<annotation cp="🕶" type="tts">sunglasses</annotation>
+		<annotation cp="🥽">dive | eye | goggles | protection | scuba | swimming | welding</annotation>
+		<annotation cp="🥽" type="tts">goggles</annotation>
+		<annotation cp="🥼">clothes | coat | doctor | dr | experiment | jacket | lab | scientist | white</annotation>
+		<annotation cp="🥼" type="tts">lab coat</annotation>
+		<annotation cp="🦺">emergency | safety | vest</annotation>
+		<annotation cp="🦺" type="tts">safety vest</annotation>
+		<annotation cp="👔">clothing | employed | necktie | serious | shirt | tie</annotation>
+		<annotation cp="👔" type="tts">necktie</annotation>
+		<annotation cp="👕">blue | casual | clothes | clothing | collar | dressed | shirt | shopping | t-shirt | tshirt | weekend</annotation>
+		<annotation cp="👕" type="tts">t-shirt</annotation>
+		<annotation cp="👖">blue | casual | clothes | clothing | denim | dressed | jeans | pants | shopping | trousers | weekend</annotation>
+		<annotation cp="👖" type="tts">jeans</annotation>
+		<annotation cp="🧣">bundle | cold | neck | scarf | up</annotation>
+		<annotation cp="🧣" type="tts">scarf</annotation>
+		<annotation cp="🧤">gloves | hand</annotation>
+		<annotation cp="🧤" type="tts">gloves</annotation>
+		<annotation cp="🧥">brr | bundle | coat | cold | jacket | up</annotation>
+		<annotation cp="🧥" type="tts">coat</annotation>
+		<annotation cp="🧦">socks | stocking</annotation>
+		<annotation cp="🧦" type="tts">socks</annotation>
+		<annotation cp="👗">clothes | clothing | dress | dressed | fancy | shopping</annotation>
+		<annotation cp="👗" type="tts">dress</annotation>
+		<annotation cp="👘">clothing | comfortable | kimono</annotation>
+		<annotation cp="👘" type="tts">kimono</annotation>
+		<annotation cp="🥻">clothing | dress | sari</annotation>
+		<annotation cp="🥻" type="tts">sari</annotation>
+		<annotation cp="🩱">bathing | one-piece | suit | swimsuit</annotation>
+		<annotation cp="🩱" type="tts">one-piece swimsuit</annotation>
+		<annotation cp="🩲">bathing | briefs | one-piece | suit | swimsuit | underwear</annotation>
+		<annotation cp="🩲" type="tts">briefs</annotation>
+		<annotation cp="🩳">bathing | pants | shorts | suit | swimsuit | underwear</annotation>
+		<annotation cp="🩳" type="tts">shorts</annotation>
+		<annotation cp="👙">bathing | beach | bikini | clothing | pool | suit | swim</annotation>
+		<annotation cp="👙" type="tts">bikini</annotation>
+		<annotation cp="👚">blouse | clothes | clothing | collar | dress | dressed | lady | shirt | shopping | woman | woman’s</annotation>
+		<annotation cp="👚" type="tts">woman’s clothes</annotation>
+		<annotation cp="🪭">clack | clap | cool | cooling | dance | fan | flirt | flutter | folding | hand | hot | shy</annotation> <!-- 1FAAD -->
+		<annotation cp="🪭" type="tts">folding hand fan</annotation>
+		<annotation cp="👛">clothes | clothing | coin | dress | fancy | handbag | purse | shopping</annotation>
+		<annotation cp="👛" type="tts">purse</annotation>
+		<annotation cp="👜">bag | clothes | clothing | dress | handbag | lady | purse | shopping</annotation>
+		<annotation cp="👜" type="tts">handbag</annotation>
+		<annotation cp="👝">bag | clothes | clothing | clutch | dress | handbag | pouch | purse</annotation>
+		<annotation cp="👝" type="tts">clutch bag</annotation>
+		<annotation cp="🛍">bag | bags | hotel | shopping</annotation>
+		<annotation cp="🛍" type="tts">shopping bags</annotation>
+		<annotation cp="🎒">backpack | backpacking | bag | bookbag | education | rucksack | satchel | school</annotation>
+		<annotation cp="🎒" type="tts">backpack</annotation>
+		<annotation cp="🩴">beach | flip | flop | sandal | sandals | shoe | thong | thongs | zōri</annotation>
+		<annotation cp="🩴" type="tts">thong sandal</annotation>
+		<annotation cp="👞">brown | clothes | clothing | feet | foot | kick | man | man’s | shoe | shoes | shopping</annotation>
+		<annotation cp="👞" type="tts">man’s shoe</annotation>
+		<annotation cp="👟">athletic | clothes | clothing | fast | kick | running | shoe | shoes | shopping | sneaker | tennis</annotation>
+		<annotation cp="👟" type="tts">running shoe</annotation>
+		<annotation cp="🥾">backpacking | boot | brown | camping | hiking | outdoors | shoe</annotation>
+		<annotation cp="🥾" type="tts">hiking boot</annotation>
+		<annotation cp="🥿">ballet | comfy | flat | flats | shoe | slip-on | slipper</annotation>
+		<annotation cp="🥿" type="tts">flat shoe</annotation>
+		<annotation cp="👠">clothes | clothing | dress | fashion | heel | heels | high-heeled | shoe | shoes | shopping | stiletto | woman</annotation>
+		<annotation cp="👠" type="tts">high-heeled shoe</annotation>
+		<annotation cp="👡">clothing | sandal | shoe | woman | woman’s</annotation>
+		<annotation cp="👡" type="tts">woman’s sandal</annotation>
+		<annotation cp="🩰">ballet | dance | shoes</annotation>
+		<annotation cp="🩰" type="tts">ballet shoes</annotation>
+		<annotation cp="👢">boot | clothes | clothing | dress | shoe | shoes | shopping | woman | woman’s</annotation>
+		<annotation cp="👢" type="tts">woman’s boot</annotation>
+		<annotation cp="🪮">Afro | comb | groom | hair | pick</annotation> <!-- 1FAAE -->
+		<annotation cp="🪮" type="tts">hair pick</annotation>
+		<annotation cp="👑">clothing | crown | family | king | medieval | queen | royal | royalty | win</annotation>
+		<annotation cp="👑" type="tts">crown</annotation>
+		<annotation cp="👒">clothes | clothing | garden | hat | hats | party | woman | woman’s</annotation>
+		<annotation cp="👒" type="tts">woman’s hat</annotation>
+		<annotation cp="🎩">clothes | clothing | fancy | formal | hat | magic | top | tophat</annotation>
+		<annotation cp="🎩" type="tts">top hat</annotation>
+		<annotation cp="🎓">cap | celebration | clothing | education | graduation | hat | scholar</annotation>
+		<annotation cp="🎓" type="tts">graduation cap</annotation>
+		<annotation cp="🧢">baseball | bent | billed | cap | dad | hat</annotation>
+		<annotation cp="🧢" type="tts">billed cap</annotation>
+		<annotation cp="🪖">army | helmet | military | soldier | war | warrior</annotation>
+		<annotation cp="🪖" type="tts">military helmet</annotation>
+		<annotation cp="⛑">aid | cross | face | hat | helmet | rescue | worker’s</annotation>
+		<annotation cp="⛑" type="tts">rescue worker’s helmet</annotation>
+		<annotation cp="📿">beads | clothing | necklace | prayer | religion</annotation>
+		<annotation cp="📿" type="tts">prayer beads</annotation>
+		<annotation cp="💄">cosmetics | date | lipstick | makeup</annotation>
+		<annotation cp="💄" type="tts">lipstick</annotation>
+		<annotation cp="💍">diamond | engaged | engagement | married | ring | romance | shiny | sparkling | wedding</annotation>
+		<annotation cp="💍" type="tts">ring</annotation>
+		<annotation cp="💎">diamond | engagement | gem | jewel | money | romance | stone | wedding</annotation>
+		<annotation cp="💎" type="tts">gem stone</annotation>
+		<annotation cp="🔇">mute | muted | quiet | silent | sound | speaker</annotation>
+		<annotation cp="🔇" type="tts">muted speaker</annotation>
+		<annotation cp="🔈">low | soft | sound | speaker | volume</annotation>
+		<annotation cp="🔈" type="tts">speaker low volume</annotation>
+		<annotation cp="🔉">medium | sound | speaker | volume</annotation>
+		<annotation cp="🔉" type="tts">speaker medium volume</annotation>
+		<annotation cp="🔊">high | loud | music | sound | speaker | volume</annotation>
+		<annotation cp="🔊" type="tts">speaker high volume</annotation>
+		<annotation cp="📢">address | communication | loud | loudspeaker | public | sound</annotation>
+		<annotation cp="📢" type="tts">loudspeaker</annotation>
+		<annotation cp="📣">cheering | megaphone | sound</annotation>
+		<annotation cp="📣" type="tts">megaphone</annotation>
+		<annotation cp="📯">horn | post | postal</annotation>
+		<annotation cp="📯" type="tts">postal horn</annotation>
+		<annotation cp="🔔">bell | break | church | sound</annotation>
+		<annotation cp="🔔" type="tts">bell</annotation>
+		<annotation cp="🔕">bell | forbidden | mute | no | not | prohibited | quiet | silent | slash | sound</annotation>
+		<annotation cp="🔕" type="tts">bell with slash</annotation>
+		<annotation cp="🎼">music | musical | note | score</annotation>
+		<annotation cp="🎼" type="tts">musical score</annotation>
+		<annotation cp="🎵">music | musical | note | sound</annotation>
+		<annotation cp="🎵" type="tts">musical note</annotation>
+		<annotation cp="🎶">music | musical | note | notes | sound</annotation>
+		<annotation cp="🎶" type="tts">musical notes</annotation>
+		<annotation cp="🎙">mic | microphone | music | studio</annotation>
+		<annotation cp="🎙" type="tts">studio microphone</annotation>
+		<annotation cp="🎚">level | music | slider</annotation>
+		<annotation cp="🎚" type="tts">level slider</annotation>
+		<annotation cp="🎛">control | knobs | music</annotation>
+		<annotation cp="🎛" type="tts">control knobs</annotation>
+		<annotation cp="🎤">karaoke | mic | microphone | music | sing | sound</annotation>
+		<annotation cp="🎤" type="tts">microphone</annotation>
+		<annotation cp="🎧">earbud | headphone | sound</annotation>
+		<annotation cp="🎧" type="tts">headphone</annotation>
+		<annotation cp="📻">entertainment | radio | tbt | video</annotation>
+		<annotation cp="📻" type="tts">radio</annotation>
+		<annotation cp="🎷">instrument | music | sax | saxophone</annotation>
+		<annotation cp="🎷" type="tts">saxophone</annotation>
+		<annotation cp="🪗">accordion | box | concertina | instrument | music | squeeze | squeezebox</annotation>
+		<annotation cp="🪗" type="tts">accordion</annotation>
+		<annotation cp="🎸">guitar | instrument | music | strat</annotation>
+		<annotation cp="🎸" type="tts">guitar</annotation>
+		<annotation cp="🎹">instrument | keyboard | music | musical | piano</annotation>
+		<annotation cp="🎹" type="tts">musical keyboard</annotation>
+		<annotation cp="🎺">instrument | music | trumpet</annotation>
+		<annotation cp="🎺" type="tts">trumpet</annotation>
+		<annotation cp="🎻">instrument | music | violin</annotation>
+		<annotation cp="🎻" type="tts">violin</annotation>
+		<annotation cp="🪕">banjo | music | stringed</annotation>
+		<annotation cp="🪕" type="tts">banjo</annotation>
+		<annotation cp="🥁">drum | drumsticks | music</annotation>
+		<annotation cp="🥁" type="tts">drum</annotation>
+		<annotation cp="🪘">beat | conga | drum | instrument | long | rhythm</annotation>
+		<annotation cp="🪘" type="tts">long drum</annotation>
+		<annotation cp="🪇">cha | dance | instrument | maracas | music | party | percussion | rattle | shake | shaker</annotation> <!-- 1FA87 -->
+		<annotation cp="🪇" type="tts">maracas</annotation>
+		<annotation cp="🪈">band | fife | flautist | flute | instrument | marching | music | orchestra | piccolo | pipe | recorder | woodwind</annotation> <!-- 1FA88 -->
+		<annotation cp="🪈" type="tts">flute</annotation>
+		<annotation cp="🪉">cupid | harp | instrument | love | music | orchestra</annotation>
+		<annotation cp="🪉" type="tts">harp</annotation>
+		<annotation cp="📱">cell | communication | mobile | phone | telephone</annotation>
+		<annotation cp="📱" type="tts">mobile phone</annotation>
+		<annotation cp="📲">arrow | build | call | cell | communication | mobile | phone | receive | telephone</annotation>
+		<annotation cp="📲" type="tts">mobile phone with arrow</annotation>
+		<annotation cp="☎">phone | telephone</annotation>
+		<annotation cp="☎" type="tts">telephone</annotation>
+		<annotation cp="📞">communication | phone | receiver | telephone | voip</annotation>
+		<annotation cp="📞" type="tts">telephone receiver</annotation>
+		<annotation cp="📟">communication | pager</annotation>
+		<annotation cp="📟" type="tts">pager</annotation>
+		<annotation cp="📠">communication | fax | machine</annotation>
+		<annotation cp="📠" type="tts">fax machine</annotation>
+		<annotation cp="🔋">battery</annotation>
+		<annotation cp="🔋" type="tts">battery</annotation>
+		<annotation cp="🪫">battery | drained | electronic | energy | low | power</annotation> <!-- 1FAAB -->
+		<annotation cp="🪫" type="tts">low battery</annotation>
+		<annotation cp="🔌">electric | electricity | plug</annotation>
+		<annotation cp="🔌" type="tts">electric plug</annotation>
+		<annotation cp="💻">computer | laptop | office | pc | personal</annotation>
+		<annotation cp="💻" type="tts">laptop</annotation>
+		<annotation cp="🖥">computer | desktop | monitor</annotation>
+		<annotation cp="🖥" type="tts">desktop computer</annotation>
+		<annotation cp="🖨">computer | printer</annotation>
+		<annotation cp="🖨" type="tts">printer</annotation>
+		<annotation cp="⌨">computer | keyboard</annotation>
+		<annotation cp="⌨" type="tts">keyboard</annotation>
+		<annotation cp="🖱">computer | mouse</annotation>
+		<annotation cp="🖱" type="tts">computer mouse</annotation>
+		<annotation cp="🖲">computer | trackball</annotation>
+		<annotation cp="🖲" type="tts">trackball</annotation>
+		<annotation cp="💽">computer | disk | minidisk | optical</annotation>
+		<annotation cp="💽" type="tts">computer disk</annotation>
+		<annotation cp="💾">computer | disk | floppy</annotation>
+		<annotation cp="💾" type="tts">floppy disk</annotation>
+		<annotation cp="💿">blu-ray | CD | computer | disk | dvd | optical</annotation>
+		<annotation cp="💿" type="tts">optical disk</annotation>
+		<annotation cp="📀">Blu-ray | cd | computer | disk | DVD | optical</annotation>
+		<annotation cp="📀" type="tts">dvd</annotation>
+		<annotation cp="🧮">abacus | calculation | calculator</annotation>
+		<annotation cp="🧮" type="tts">abacus</annotation>
+		<annotation cp="🎥">bollywood | camera | cinema | film | hollywood | movie | record</annotation>
+		<annotation cp="🎥" type="tts">movie camera</annotation>
+		<annotation cp="🎞">cinema | film | frames | movie</annotation>
+		<annotation cp="🎞" type="tts">film frames</annotation>
+		<annotation cp="📽">cinema | film | movie | projector | video</annotation>
+		<annotation cp="📽" type="tts">film projector</annotation>
+		<annotation cp="🎬">action | board | clapper | movie</annotation>
+		<annotation cp="🎬" type="tts">clapper board</annotation>
+		<annotation cp="📺">television | tv | video</annotation>
+		<annotation cp="📺" type="tts">television</annotation>
+		<annotation cp="📷">camera | photo | selfie | snap | tbt | trip | video</annotation>
+		<annotation cp="📷" type="tts">camera</annotation>
+		<annotation cp="📸">camera | flash | video</annotation>
+		<annotation cp="📸" type="tts">camera with flash</annotation>
+		<annotation cp="📹">camcorder | camera | tbt | video</annotation>
+		<annotation cp="📹" type="tts">video camera</annotation>
+		<annotation cp="📼">old | school | tape | vcr | vhs | video | videocassette</annotation>
+		<annotation cp="📼" type="tts">videocassette</annotation>
+		<annotation cp="🔍">glass | lab | left | left-pointing | magnifying | science | search | tilted | tool</annotation>
+		<annotation cp="🔍" type="tts">magnifying glass tilted left</annotation>
+		<annotation cp="🔎">contact | glass | lab | magnifying | right | right-pointing | science | search | tilted | tool</annotation>
+		<annotation cp="🔎" type="tts">magnifying glass tilted right</annotation>
+		<annotation cp="🕯">candle | light</annotation>
+		<annotation cp="🕯" type="tts">candle</annotation>
+		<annotation cp="💡">bulb | comic | electric | idea | light</annotation>
+		<annotation cp="💡" type="tts">light bulb</annotation>
+		<annotation cp="🔦">electric | flashlight | light | tool | torch</annotation>
+		<annotation cp="🔦" type="tts">flashlight</annotation>
+		<annotation cp="🏮">bar | lantern | light | paper | red | restaurant</annotation>
+		<annotation cp="🏮" type="tts">red paper lantern</annotation>
+		<annotation cp="🪔">diya | lamp | light | oil</annotation>
+		<annotation cp="🪔" type="tts">diya lamp</annotation>
+		<annotation cp="📔">book | cover | decorated | decorative | education | notebook | school | writing</annotation>
+		<annotation cp="📔" type="tts">notebook with decorative cover</annotation>
+		<annotation cp="📕">book | closed | education</annotation>
+		<annotation cp="📕" type="tts">closed book</annotation>
+		<annotation cp="📖">book | education | fantasy | knowledge | library | novels | open | reading</annotation>
+		<annotation cp="📖" type="tts">open book</annotation>
+		<annotation cp="📗">book | education | fantasy | green | library | reading</annotation>
+		<annotation cp="📗" type="tts">green book</annotation>
+		<annotation cp="📘">blue | book | education | fantasy | library | reading</annotation>
+		<annotation cp="📘" type="tts">blue book</annotation>
+		<annotation cp="📙">book | education | fantasy | library | orange | reading</annotation>
+		<annotation cp="📙" type="tts">orange book</annotation>
+		<annotation cp="📚">book | books | education | fantasy | knowledge | library | novels | reading | school | study</annotation>
+		<annotation cp="📚" type="tts">books</annotation>
+		<annotation cp="📓">notebook</annotation>
+		<annotation cp="📓" type="tts">notebook</annotation>
+		<annotation cp="📒">ledger | notebook</annotation>
+		<annotation cp="📒" type="tts">ledger</annotation>
+		<annotation cp="📃">curl | document | page | paper</annotation>
+		<annotation cp="📃" type="tts">page with curl</annotation>
+		<annotation cp="📜">paper | scroll</annotation>
+		<annotation cp="📜" type="tts">scroll</annotation>
+		<annotation cp="📄">document | facing | page | paper | up</annotation>
+		<annotation cp="📄" type="tts">page facing up</annotation>
+		<annotation cp="📰">communication | news | newspaper | paper</annotation>
+		<annotation cp="📰" type="tts">newspaper</annotation>
+		<annotation cp="🗞">news | newspaper | paper | rolled | rolled-up</annotation>
+		<annotation cp="🗞" type="tts">rolled-up newspaper</annotation>
+		<annotation cp="📑">bookmark | mark | marker | tabs</annotation>
+		<annotation cp="📑" type="tts">bookmark tabs</annotation>
+		<annotation cp="🔖">bookmark | mark</annotation>
+		<annotation cp="🔖" type="tts">bookmark</annotation>
+		<annotation cp="🏷">label | tag</annotation>
+		<annotation cp="🏷" type="tts">label</annotation>
+		<annotation cp="💰">bag | bank | bet | billion | cash | cost | dollar | gold | million | money | moneybag | paid | paying | pot | rich | win</annotation>
+		<annotation cp="💰" type="tts">money bag</annotation>
+		<annotation cp="🪙">coin | dollar | euro | gold | metal | money | rich | silver | treasure</annotation>
+		<annotation cp="🪙" type="tts">coin</annotation>
+		<annotation cp="💴">bank | banknote | bill | currency | money | note | yen</annotation>
+		<annotation cp="💴" type="tts">yen banknote</annotation>
+		<annotation cp="💵">bank | banknote | bill | currency | dollar | money | note</annotation>
+		<annotation cp="💵" type="tts">dollar banknote</annotation>
+		<annotation cp="💶">100 | bank | banknote | bill | currency | euro | money | note | rich</annotation>
+		<annotation cp="💶" type="tts">euro banknote</annotation>
+		<annotation cp="💷">bank | banknote | bill | billion | cash | currency | money | note | pound | pounds</annotation>
+		<annotation cp="💷" type="tts">pound banknote</annotation>
+		<annotation cp="💸">bank | banknote | bill | billion | cash | dollar | fly | million | money | note | pay | wings</annotation>
+		<annotation cp="💸" type="tts">money with wings</annotation>
+		<annotation cp="💳">bank | card | cash | charge | credit | money | pay</annotation>
+		<annotation cp="💳" type="tts">credit card</annotation>
+		<annotation cp="🧾">accounting | bookkeeping | evidence | invoice | proof | receipt</annotation>
+		<annotation cp="🧾" type="tts">receipt</annotation>
+		<annotation cp="💹">bank | chart | currency | graph | growth | increasing | market | money | rise | trend | upward | yen</annotation>
+		<annotation cp="💹" type="tts">chart increasing with yen</annotation>
+		<annotation cp="✉">e-mail | email | envelope | letter</annotation>
+		<annotation cp="✉" type="tts">envelope</annotation>
+		<annotation cp="📧">e-mail | email | letter | mail</annotation>
+		<annotation cp="📧" type="tts">e-mail</annotation>
+		<annotation cp="📨">delivering | e-mail | email | envelope | incoming | letter | mail | receive | sent</annotation>
+		<annotation cp="📨" type="tts">incoming envelope</annotation>
+		<annotation cp="📩">arrow | communication | down | e-mail | email | envelope | letter | mail | outgoing | send | sent</annotation>
+		<annotation cp="📩" type="tts">envelope with arrow</annotation>
+		<annotation cp="📤">box | email | letter | mail | outbox | sent | tray</annotation>
+		<annotation cp="📤" type="tts">outbox tray</annotation>
+		<annotation cp="📥">box | email | inbox | letter | mail | receive | tray | zero</annotation>
+		<annotation cp="📥" type="tts">inbox tray</annotation>
+		<annotation cp="📦">box | communication | delivery | package | parcel | shipping</annotation>
+		<annotation cp="📦" type="tts">package</annotation>
+		<annotation cp="📫">closed | communication | flag | mail | mailbox | postbox | raised</annotation>
+		<annotation cp="📫" type="tts">closed mailbox with raised flag</annotation>
+		<annotation cp="📪">closed | flag | lowered | mail | mailbox | postbox</annotation>
+		<annotation cp="📪" type="tts">closed mailbox with lowered flag</annotation>
+		<annotation cp="📬">flag | mail | mailbox | open | postbox | raised</annotation>
+		<annotation cp="📬" type="tts">open mailbox with raised flag</annotation>
+		<annotation cp="📭">flag | lowered | mail | mailbox | open | postbox</annotation>
+		<annotation cp="📭" type="tts">open mailbox with lowered flag</annotation>
+		<annotation cp="📮">mail | mailbox | postbox</annotation>
+		<annotation cp="📮" type="tts">postbox</annotation>
+		<annotation cp="🗳">ballot | box</annotation>
+		<annotation cp="🗳" type="tts">ballot box with ballot</annotation>
+		<annotation cp="✏">pencil</annotation>
+		<annotation cp="✏" type="tts">pencil</annotation>
+		<annotation cp="✒">black | nib | pen</annotation>
+		<annotation cp="✒" type="tts">black nib</annotation>
+		<annotation cp="🖋">fountain | pen</annotation>
+		<annotation cp="🖋" type="tts">fountain pen</annotation>
+		<annotation cp="🖊">ballpoint | pen</annotation>
+		<annotation cp="🖊" type="tts">pen</annotation>
+		<annotation cp="🖌">paintbrush | painting</annotation>
+		<annotation cp="🖌" type="tts">paintbrush</annotation>
+		<annotation cp="🖍">crayon</annotation>
+		<annotation cp="🖍" type="tts">crayon</annotation>
+		<annotation cp="📝">communication | media | memo | notes | pencil</annotation>
+		<annotation cp="📝" type="tts">memo</annotation>
+		<annotation cp="💼">briefcase | office</annotation>
+		<annotation cp="💼" type="tts">briefcase</annotation>
+		<annotation cp="📁">file | folder</annotation>
+		<annotation cp="📁" type="tts">file folder</annotation>
+		<annotation cp="📂">file | folder | open</annotation>
+		<annotation cp="📂" type="tts">open file folder</annotation>
+		<annotation cp="🗂">card | dividers | index</annotation>
+		<annotation cp="🗂" type="tts">card index dividers</annotation>
+		<annotation cp="📅">calendar | date</annotation>
+		<annotation cp="📅" type="tts">calendar</annotation>
+		<annotation cp="📆">calendar | tear-off</annotation>
+		<annotation cp="📆" type="tts">tear-off calendar</annotation>
+		<annotation cp="🗒">note | notepad | pad | spiral</annotation>
+		<annotation cp="🗒" type="tts">spiral notepad</annotation>
+		<annotation cp="🗓">calendar | pad | spiral</annotation>
+		<annotation cp="🗓" type="tts">spiral calendar</annotation>
+		<annotation cp="📇">card | index | old | rolodex | school</annotation>
+		<annotation cp="📇" type="tts">card index</annotation>
+		<annotation cp="📈">chart | data | graph | growth | increasing | right | trend | up | upward</annotation>
+		<annotation cp="📈" type="tts">chart increasing</annotation>
+		<annotation cp="📉">chart | data | decreasing | down | downward | graph | negative | trend</annotation>
+		<annotation cp="📉" type="tts">chart decreasing</annotation>
+		<annotation cp="📊">bar | chart | data | graph</annotation>
+		<annotation cp="📊" type="tts">bar chart</annotation>
+		<annotation cp="📋">clipboard | do | list | notes</annotation>
+		<annotation cp="📋" type="tts">clipboard</annotation>
+		<annotation cp="📌">collage | pin | pushpin</annotation>
+		<annotation cp="📌" type="tts">pushpin</annotation>
+		<annotation cp="📍">location | map | pin | pushpin | round</annotation>
+		<annotation cp="📍" type="tts">round pushpin</annotation>
+		<annotation cp="📎">paperclip</annotation>
+		<annotation cp="📎" type="tts">paperclip</annotation>
+		<annotation cp="🖇">link | linked | paperclip | paperclips</annotation>
+		<annotation cp="🖇" type="tts">linked paperclips</annotation>
+		<annotation cp="📏">angle | edge | math | ruler | straight | straightedge</annotation>
+		<annotation cp="📏" type="tts">straight ruler</annotation>
+		<annotation cp="📐">angle | math | rule | ruler | set | slide | triangle | triangular</annotation>
+		<annotation cp="📐" type="tts">triangular ruler</annotation>
+		<annotation cp="✂">cut | cutting | paper | scissors | tool</annotation>
+		<annotation cp="✂" type="tts">scissors</annotation>
+		<annotation cp="🗃">box | card | file</annotation>
+		<annotation cp="🗃" type="tts">card file box</annotation>
+		<annotation cp="🗄">cabinet | file | filing | paper</annotation>
+		<annotation cp="🗄" type="tts">file cabinet</annotation>
+		<annotation cp="🗑">can | garbage | trash | waste | wastebasket</annotation>
+		<annotation cp="🗑" type="tts">wastebasket</annotation>
+		<annotation cp="🔒">closed | lock | locked | private</annotation>
+		<annotation cp="🔒" type="tts">locked</annotation>
+		<annotation cp="🔓">cracked | lock | open | unlock | unlocked</annotation>
+		<annotation cp="🔓" type="tts">unlocked</annotation>
+		<annotation cp="🔏">ink | lock | locked | nib | pen | privacy</annotation>
+		<annotation cp="🔏" type="tts">locked with pen</annotation>
+		<annotation cp="🔐">bike | closed | key | lock | locked | secure</annotation>
+		<annotation cp="🔐" type="tts">locked with key</annotation>
+		<annotation cp="🔑">key | keys | lock | major | password | unlock</annotation>
+		<annotation cp="🔑" type="tts">key</annotation>
+		<annotation cp="🗝">clue | key | lock | old</annotation>
+		<annotation cp="🗝" type="tts">old key</annotation>
+		<annotation cp="🔨">hammer | home | improvement | repairs | tool</annotation>
+		<annotation cp="🔨" type="tts">hammer</annotation>
+		<annotation cp="🪓">ax | axe | chop | hatchet | split | wood</annotation>
+		<annotation cp="🪓" type="tts">axe</annotation>
+		<annotation cp="⛏">hammer | mining | pick | tool</annotation>
+		<annotation cp="⛏" type="tts">pick</annotation>
+		<annotation cp="⚒">hammer | pick | tool</annotation>
+		<annotation cp="⚒" type="tts">hammer and pick</annotation>
+		<annotation cp="🛠">hammer | spanner | tool | wrench</annotation>
+		<annotation cp="🛠" type="tts">hammer and wrench</annotation>
+		<annotation cp="🗡">dagger | knife | weapon</annotation>
+		<annotation cp="🗡" type="tts">dagger</annotation>
+		<annotation cp="⚔">crossed | swords | weapon</annotation>
+		<annotation cp="⚔" type="tts">crossed swords</annotation>
+		<annotation cp="💣">bomb | boom | comic | dangerous | explosion | hot</annotation>
+		<annotation cp="💣" type="tts">bomb</annotation>
+		<annotation cp="🪃">boomerang | rebound | repercussion | weapon</annotation>
+		<annotation cp="🪃" type="tts">boomerang</annotation>
+		<annotation cp="🏹">archer | archery | arrow | bow | Sagittarius | tool | weapon | zodiac</annotation>
+		<annotation cp="🏹" type="tts">bow and arrow</annotation>
+		<annotation cp="🛡">shield | weapon</annotation>
+		<annotation cp="🛡" type="tts">shield</annotation>
+		<annotation cp="🪚">carpenter | carpentry | cut | lumber | saw | tool | trim</annotation>
+		<annotation cp="🪚" type="tts">carpentry saw</annotation>
+		<annotation cp="🔧">home | improvement | spanner | tool | wrench</annotation>
+		<annotation cp="🔧" type="tts">wrench</annotation>
+		<annotation cp="🪛">flathead | handy | screw | screwdriver | tool</annotation>
+		<annotation cp="🪛" type="tts">screwdriver</annotation>
+		<annotation cp="🔩">bolt | home | improvement | nut | tool</annotation>
+		<annotation cp="🔩" type="tts">nut and bolt</annotation>
+		<annotation cp="⚙">cog | cogwheel | gear | tool</annotation>
+		<annotation cp="⚙" type="tts">gear</annotation>
+		<annotation cp="🗜">clamp | compress | tool | vice</annotation>
+		<annotation cp="🗜" type="tts">clamp</annotation>
+		<annotation cp="⚖">balance | justice | Libra | scale | scales | tool | weight | zodiac</annotation>
+		<annotation cp="⚖" type="tts">balance scale</annotation>
+		<annotation cp="🦯">accessibility | blind | cane | probing | white</annotation>
+		<annotation cp="🦯" type="tts">white cane</annotation>
+		<annotation cp="🔗">link | links</annotation>
+		<annotation cp="🔗" type="tts">link</annotation>
+		<annotation cp="⛓‍💥">break | breaking | broken | chain | cuffs | freedom</annotation> <!-- 26D3 200D 1F4A5 -->
+		<annotation cp="⛓‍💥" type="tts">broken chain</annotation>
+		<annotation cp="⛓">chain | chains</annotation>
+		<annotation cp="⛓" type="tts">chains</annotation>
+		<annotation cp="🪝">catch | crook | curve | ensnare | hook | point | selling</annotation>
+		<annotation cp="🪝" type="tts">hook</annotation>
+		<annotation cp="🧰">box | chest | mechanic | red | tool | toolbox</annotation>
+		<annotation cp="🧰" type="tts">toolbox</annotation>
+		<annotation cp="🧲">attraction | horseshoe | magnet | magnetic | negative | positive | shape | u</annotation>
+		<annotation cp="🧲" type="tts">magnet</annotation>
+		<annotation cp="🪜">climb | ladder | rung | step</annotation>
+		<annotation cp="🪜" type="tts">ladder</annotation>
+		<annotation cp="🪏">bury | dig | garden | hole | plant | scoop | shovel | snow | spade</annotation>
+		<annotation cp="🪏" type="tts">shovel</annotation>
+		<annotation cp="⚗">alembic | chemistry | tool</annotation>
+		<annotation cp="⚗" type="tts">alembic</annotation>
+		<annotation cp="🧪">chemist | chemistry | experiment | lab | science | test | tube</annotation>
+		<annotation cp="🧪" type="tts">test tube</annotation>
+		<annotation cp="🧫">bacteria | biologist | biology | culture | dish | lab | petri</annotation>
+		<annotation cp="🧫" type="tts">petri dish</annotation>
+		<annotation cp="🧬">biologist | dna | evolution | gene | genetics | life</annotation>
+		<annotation cp="🧬" type="tts">dna</annotation>
+		<annotation cp="🔬">experiment | lab | microscope | science | tool</annotation>
+		<annotation cp="🔬" type="tts">microscope</annotation>
+		<annotation cp="🔭">contact | extraterrestrial | science | telescope | tool</annotation>
+		<annotation cp="🔭" type="tts">telescope</annotation>
+		<annotation cp="📡">aliens | antenna | contact | dish | satellite | science</annotation>
+		<annotation cp="📡" type="tts">satellite antenna</annotation>
+		<annotation cp="💉">doctor | flu | medicine | needle | shot | sick | syringe | tool | vaccination</annotation>
+		<annotation cp="💉" type="tts">syringe</annotation>
+		<annotation cp="🩸">bleed | blood | donation | drop | injury | medicine | menstruation</annotation>
+		<annotation cp="🩸" type="tts">drop of blood</annotation>
+		<annotation cp="💊">doctor | drugs | medicated | medicine | pill | pills | sick | vitamin</annotation>
+		<annotation cp="💊" type="tts">pill</annotation>
+		<annotation cp="🩹">adhesive | bandage</annotation>
+		<annotation cp="🩹" type="tts">adhesive bandage</annotation>
+		<annotation cp="🩼">aid | cane | crutch | disability | help | hurt | injured | mobility | stick</annotation> <!-- 1FA7C -->
+		<annotation cp="🩼" type="tts">crutch</annotation>
+		<annotation cp="🩺">doctor | heart | medicine | stethoscope</annotation>
+		<annotation cp="🩺" type="tts">stethoscope</annotation>
+		<annotation cp="🩻">bones | doctor | medical | skeleton | skull | x-ray | xray</annotation> <!-- 1FA7B -->
+		<annotation cp="🩻" type="tts">x-ray</annotation>
+		<annotation cp="🚪">back | closet | door | front</annotation>
+		<annotation cp="🚪" type="tts">door</annotation>
+		<annotation cp="🛗">accessibility | elevator | hoist | lift</annotation>
+		<annotation cp="🛗" type="tts">elevator</annotation>
+		<annotation cp="🪞">makeup | mirror | reflection | reflector | speculum</annotation>
+		<annotation cp="🪞" type="tts">mirror</annotation>
+		<annotation cp="🪟">air | frame | fresh | opening | transparent | view | window</annotation>
+		<annotation cp="🪟" type="tts">window</annotation>
+		<annotation cp="🛏">bed | hotel | sleep</annotation>
+		<annotation cp="🛏" type="tts">bed</annotation>
+		<annotation cp="🛋">couch | hotel | lamp</annotation>
+		<annotation cp="🛋" type="tts">couch and lamp</annotation>
+		<annotation cp="🪑">chair | seat | sit</annotation>
+		<annotation cp="🪑" type="tts">chair</annotation>
+		<annotation cp="🚽">bathroom | toilet</annotation>
+		<annotation cp="🚽" type="tts">toilet</annotation>
+		<annotation cp="🪠">cup | force | plumber | plunger | poop | suction | toilet</annotation>
+		<annotation cp="🪠" type="tts">plunger</annotation>
+		<annotation cp="🚿">shower | water</annotation>
+		<annotation cp="🚿" type="tts">shower</annotation>
+		<annotation cp="🛁">bath | bathtub</annotation>
+		<annotation cp="🛁" type="tts">bathtub</annotation>
+		<annotation cp="🪤">bait | cheese | lure | mouse | mousetrap | snare | trap</annotation>
+		<annotation cp="🪤" type="tts">mouse trap</annotation>
+		<annotation cp="🪒">razor | sharp | shave</annotation>
+		<annotation cp="🪒" type="tts">razor</annotation>
+		<annotation cp="🧴">bottle | lotion | moisturizer | shampoo | sunscreen</annotation>
+		<annotation cp="🧴" type="tts">lotion bottle</annotation>
+		<annotation cp="🧷">diaper | pin | punk | rock | safety</annotation>
+		<annotation cp="🧷" type="tts">safety pin</annotation>
+		<annotation cp="🧹">broom | cleaning | sweeping | witch</annotation>
+		<annotation cp="🧹" type="tts">broom</annotation>
+		<annotation cp="🧺">basket | farming | laundry | picnic</annotation>
+		<annotation cp="🧺" type="tts">basket</annotation>
+		<annotation cp="🧻">paper | roll | toilet | towels</annotation>
+		<annotation cp="🧻" type="tts">roll of paper</annotation>
+		<annotation cp="🪣">bucket | cask | pail | vat</annotation>
+		<annotation cp="🪣" type="tts">bucket</annotation>
+		<annotation cp="🧼">bar | bathing | clean | cleaning | lather | soap | soapdish</annotation>
+		<annotation cp="🧼" type="tts">soap</annotation>
+		<annotation cp="🫧">bubble | bubbles | burp | clean | floating | pearl | soap | underwater</annotation> <!-- 1FAE7 -->
+		<annotation cp="🫧" type="tts">bubbles</annotation>
+		<annotation cp="🪥">bathroom | brush | clean | dental | hygiene | teeth | toiletry | toothbrush</annotation>
+		<annotation cp="🪥" type="tts">toothbrush</annotation>
+		<annotation cp="🧽">absorbing | cleaning | porous | soak | sponge</annotation>
+		<annotation cp="🧽" type="tts">sponge</annotation>
+		<annotation cp="🧯">extinguish | extinguisher | fire | quench</annotation>
+		<annotation cp="🧯" type="tts">fire extinguisher</annotation>
+		<annotation cp="🛒">cart | shopping | trolley</annotation>
+		<annotation cp="🛒" type="tts">shopping cart</annotation>
+		<annotation cp="🚬">cigarette | smoking</annotation>
+		<annotation cp="🚬" type="tts">cigarette</annotation>
+		<annotation cp="⚰">coffin | dead | death | vampire</annotation>
+		<annotation cp="⚰" type="tts">coffin</annotation>
+		<annotation cp="🪦">cemetery | dead | grave | graveyard | headstone | memorial | rip | tomb | tombstone</annotation>
+		<annotation cp="🪦" type="tts">headstone</annotation>
+		<annotation cp="⚱">ashes | death | funeral | urn</annotation>
+		<annotation cp="⚱" type="tts">funeral urn</annotation>
+		<annotation cp="🧿">amulet | bead | blue | charm | evil-eye | nazar | talisman</annotation>
+		<annotation cp="🧿" type="tts">nazar amulet</annotation>
+		<annotation cp="🪬">amulet | Fatima | fortune | guide | hamsa | hand | Mary | Miriam | palm | protect | protection</annotation> <!-- 1FAAC -->
+		<annotation cp="🪬" type="tts">hamsa</annotation>
+		<annotation cp="🗿">face | moai | moyai | statue | stoneface | travel</annotation>
+		<annotation cp="🗿" type="tts">moai</annotation>
+		<annotation cp="🪧">card | demonstration | notice | picket | placard | plaque | protest | sign</annotation>
+		<annotation cp="🪧" type="tts">placard</annotation>
+		<annotation cp="🪪">card | credentials | document | ID | identification | license | security</annotation> <!-- 1FAAA -->
+		<annotation cp="🪪" type="tts">identification card</annotation>
+		<annotation cp="🏧">ATM | automated | bank | cash | money | sign | teller</annotation>
+		<annotation cp="🏧" type="tts">ATM sign</annotation>
+		<annotation cp="🚮">bin | litter | litterbin | sign</annotation>
+		<annotation cp="🚮" type="tts">litter in bin sign</annotation>
+		<annotation cp="🚰">drinking | potable | water</annotation>
+		<annotation cp="🚰" type="tts">potable water</annotation>
+		<annotation cp="♿">access | handicap | symbol | wheelchair</annotation>
+		<annotation cp="♿" type="tts">wheelchair symbol</annotation>
+		<annotation cp="🚹">bathroom | lavatory | man | men’s | restroom | room | toilet | WC</annotation>
+		<annotation cp="🚹" type="tts">men’s room</annotation>
+		<annotation cp="🚺">bathroom | lavatory | restroom | room | toilet | WC | woman | women’s</annotation>
+		<annotation cp="🚺" type="tts">women’s room</annotation>
+		<annotation cp="🚻">bathroom | lavatory | restroom | toilet | WC</annotation>
+		<annotation cp="🚻" type="tts">restroom</annotation>
+		<annotation cp="🚼">baby | changing | symbol</annotation>
+		<annotation cp="🚼" type="tts">baby symbol</annotation>
+		<annotation cp="🚾">bathroom | closet | lavatory | restroom | toilet | water | WC</annotation>
+		<annotation cp="🚾" type="tts">water closet</annotation>
+		<annotation cp="🛂">control | passport</annotation>
+		<annotation cp="🛂" type="tts">passport control</annotation>
+		<annotation cp="🛃">customs | packing</annotation>
+		<annotation cp="🛃" type="tts">customs</annotation>
+		<annotation cp="🛄">arrived | baggage | bags | case | checked | claim | journey | packing | plane | ready | travel | trip</annotation>
+		<annotation cp="🛄" type="tts">baggage claim</annotation>
+		<annotation cp="🛅">baggage | case | left | locker | luggage</annotation>
+		<annotation cp="🛅" type="tts">left luggage</annotation>
+		<annotation cp="⚠">caution | warning</annotation>
+		<annotation cp="⚠" type="tts">warning</annotation>
+		<annotation cp="🚸">child | children | crossing | pedestrian | traffic</annotation>
+		<annotation cp="🚸" type="tts">children crossing</annotation>
+		<annotation cp="⛔">do | entry | fail | forbidden | no | not | pass | prohibited | traffic</annotation>
+		<annotation cp="⛔" type="tts">no entry</annotation>
+		<annotation cp="🚫">entry | forbidden | no | not | prohibited | smoke</annotation>
+		<annotation cp="🚫" type="tts">prohibited</annotation>
+		<annotation cp="🚳">bicycle | bicycles | bike | forbidden | no | not | prohibited</annotation>
+		<annotation cp="🚳" type="tts">no bicycles</annotation>
+		<annotation cp="🚭">forbidden | no | not | prohibited | smoke | smoking</annotation>
+		<annotation cp="🚭" type="tts">no smoking</annotation>
+		<annotation cp="🚯">forbidden | litter | littering | no | not | prohibited</annotation>
+		<annotation cp="🚯" type="tts">no littering</annotation>
+		<annotation cp="🚱">dry | non-drinking | non-potable | prohibited | water</annotation>
+		<annotation cp="🚱" type="tts">non-potable water</annotation>
+		<annotation cp="🚷">forbidden | no | not | pedestrian | pedestrians | prohibited</annotation>
+		<annotation cp="🚷" type="tts">no pedestrians</annotation>
+		<annotation cp="📵">cell | forbidden | mobile | no | not | phone | phones | prohibited | telephone</annotation>
+		<annotation cp="📵" type="tts">no mobile phones</annotation>
+		<annotation cp="🔞">18 | age | eighteen | forbidden | no | not | one | prohibited | restriction | underage</annotation>
+		<annotation cp="🔞" type="tts">no one under eighteen</annotation>
+		<annotation cp="☢">radioactive | sign</annotation>
+		<annotation cp="☢" type="tts">radioactive</annotation>
+		<annotation cp="☣">biohazard | sign</annotation>
+		<annotation cp="☣" type="tts">biohazard</annotation>
+		<annotation cp="⬆">arrow | cardinal | direction | north | up</annotation>
+		<annotation cp="⬆" type="tts">up arrow</annotation>
+		<annotation cp="↗">arrow | direction | intercardinal | northeast | up-right</annotation>
+		<annotation cp="↗" type="tts">up-right arrow</annotation>
+		<annotation cp="➡">arrow | cardinal | direction | east | right</annotation>
+		<annotation cp="➡" type="tts">right arrow</annotation>
+		<annotation cp="↘">arrow | direction | down-right | intercardinal | southeast</annotation>
+		<annotation cp="↘" type="tts">down-right arrow</annotation>
+		<annotation cp="⬇">arrow | cardinal | direction | down | south</annotation>
+		<annotation cp="⬇" type="tts">down arrow</annotation>
+		<annotation cp="↙">arrow | direction | down-left | intercardinal | southwest</annotation>
+		<annotation cp="↙" type="tts">down-left arrow</annotation>
+		<annotation cp="⬅">arrow | cardinal | direction | left | west</annotation>
+		<annotation cp="⬅" type="tts">left arrow</annotation>
+		<annotation cp="↖">arrow | direction | intercardinal | northwest | up-left</annotation>
+		<annotation cp="↖" type="tts">up-left arrow</annotation>
+		<annotation cp="↕">arrow | up-down</annotation>
+		<annotation cp="↕" type="tts">up-down arrow</annotation>
+		<annotation cp="↔">arrow | left-right</annotation>
+		<annotation cp="↔" type="tts">left-right arrow</annotation>
+		<annotation cp="↮">arrow | left | right | stroke</annotation>
+		<annotation cp="↮" type="tts">left right arrow stroke</annotation>
+		<annotation cp="↩">arrow | curving | left | right</annotation>
+		<annotation cp="↩" type="tts">right arrow curving left</annotation>
+		<annotation cp="↪">arrow | curving | left | right</annotation>
+		<annotation cp="↪" type="tts">left arrow curving right</annotation>
+		<annotation cp="⤴">arrow | curving | right | up</annotation>
+		<annotation cp="⤴" type="tts">right arrow curving up</annotation>
+		<annotation cp="⤵">arrow | curving | down | right</annotation>
+		<annotation cp="⤵" type="tts">right arrow curving down</annotation>
+		<annotation cp="🔃">arrow | arrows | clockwise | refresh | reload | vertical</annotation>
+		<annotation cp="🔃" type="tts">clockwise vertical arrows</annotation>
+		<annotation cp="🔄">again | anticlockwise | arrow | arrows | button | counterclockwise | deja | refresh | rewindershins | vu</annotation>
+		<annotation cp="🔄" type="tts">counterclockwise arrows button</annotation>
+		<annotation cp="🔙">arrow | BACK</annotation>
+		<annotation cp="🔙" type="tts">BACK arrow</annotation>
+		<annotation cp="🔚">arrow | END</annotation>
+		<annotation cp="🔚" type="tts">END arrow</annotation>
+		<annotation cp="🔛">arrow | mark | ON!</annotation>
+		<annotation cp="🔛" type="tts">ON! arrow</annotation>
+		<annotation cp="🔜">arrow | brb | omw | SOON</annotation>
+		<annotation cp="🔜" type="tts">SOON arrow</annotation>
+		<annotation cp="🔝">arrow | homie | TOP | up</annotation>
+		<annotation cp="🔝" type="tts">TOP arrow</annotation>
+		<annotation cp="🛐">place | pray | religion | worship</annotation>
+		<annotation cp="🛐" type="tts">place of worship</annotation>
+		<annotation cp="⚛">atheist | atom | symbol</annotation>
+		<annotation cp="⚛" type="tts">atom symbol</annotation>
+		<annotation cp="🕉">Hindu | om | religion</annotation>
+		<annotation cp="🕉" type="tts">om</annotation>
+		<annotation cp="✡">David | Jew | Jewish | judaism | religion | star</annotation>
+		<annotation cp="✡" type="tts">star of David</annotation>
+		<annotation cp="☸">Buddhist | dharma | religion | wheel</annotation>
+		<annotation cp="☸" type="tts">wheel of dharma</annotation>
+		<annotation cp="☯">difficult | lives | religion | tao | taoist | total | yang | yin | yinyang</annotation>
+		<annotation cp="☯" type="tts">yin yang</annotation>
+		<annotation cp="✝">christ | Christian | cross | latin | religion</annotation>
+		<annotation cp="✝" type="tts">latin cross</annotation>
+		<annotation cp="☦">Christian | cross | orthodox | religion</annotation>
+		<annotation cp="☦" type="tts">orthodox cross</annotation>
+		<annotation cp="☪">crescent | islam | Muslim | ramadan | religion | star</annotation>
+		<annotation cp="☪" type="tts">star and crescent</annotation>
+		<annotation cp="☮">healing | peace | peaceful | symbol</annotation>
+		<annotation cp="☮" type="tts">peace symbol</annotation>
+		<annotation cp="🕎">candelabrum | candlestick | hanukkah | jewish | judaism | menorah | religion</annotation>
+		<annotation cp="🕎" type="tts">menorah</annotation>
+		<annotation cp="🔯">dotted | fortune | jewish | judaism | six-pointed | star</annotation>
+		<annotation cp="🔯" type="tts">dotted six-pointed star</annotation>
+		<annotation cp="🪯">Deg | Fateh | Khalsa | Khanda | religion | Sikh | Sikhism | Tegh</annotation> <!-- 1FAAF -->
+		<annotation cp="🪯" type="tts">khanda</annotation>
+		<annotation cp="♈">Aries | horoscope | ram | zodiac</annotation>
+		<annotation cp="♈" type="tts">Aries</annotation>
+		<annotation cp="♉">bull | horoscope | ox | Taurus | zodiac</annotation>
+		<annotation cp="♉" type="tts">Taurus</annotation>
+		<annotation cp="♊">Gemini | horoscope | twins | zodiac</annotation>
+		<annotation cp="♊" type="tts">Gemini</annotation>
+		<annotation cp="♋">Cancer | crab | horoscope | zodiac</annotation>
+		<annotation cp="♋" type="tts">Cancer</annotation>
+		<annotation cp="♌">horoscope | Leo | lion | zodiac</annotation>
+		<annotation cp="♌" type="tts">Leo</annotation>
+		<annotation cp="♍">horoscope | Virgo | zodiac</annotation>
+		<annotation cp="♍" type="tts">Virgo</annotation>
+		<annotation cp="♎">balance | horoscope | justice | Libra | scales | zodiac</annotation>
+		<annotation cp="♎" type="tts">Libra</annotation>
+		<annotation cp="♏">horoscope | Scorpio | scorpion | Scorpius | zodiac</annotation>
+		<annotation cp="♏" type="tts">Scorpio</annotation>
+		<annotation cp="♐">archer | horoscope | Sagittarius | zodiac</annotation>
+		<annotation cp="♐" type="tts">Sagittarius</annotation>
+		<annotation cp="♑">Capricorn | goat | horoscope | zodiac</annotation>
+		<annotation cp="♑" type="tts">Capricorn</annotation>
+		<annotation cp="♒">Aquarius | bearer | horoscope | water | zodiac</annotation>
+		<annotation cp="♒" type="tts">Aquarius</annotation>
+		<annotation cp="♓">fish | horoscope | Pisces | zodiac</annotation>
+		<annotation cp="♓" type="tts">Pisces</annotation>
+		<annotation cp="⛎">bearer | Ophiuchus | serpent | snake | zodiac</annotation>
+		<annotation cp="⛎" type="tts">Ophiuchus</annotation>
+		<annotation cp="🔀">arrow | button | crossed | shuffle | tracks</annotation>
+		<annotation cp="🔀" type="tts">shuffle tracks button</annotation>
+		<annotation cp="🔁">arrow | button | clockwise | repeat</annotation>
+		<annotation cp="🔁" type="tts">repeat button</annotation>
+		<annotation cp="🔂">arrow | button | clockwise | once | repeat | single</annotation>
+		<annotation cp="🔂" type="tts">repeat single button</annotation>
+		<annotation cp="▶">arrow | button | play | right | triangle</annotation>
+		<annotation cp="▶" type="tts">play button</annotation>
+		<annotation cp="⏩">arrow | button | double | fast | fast-forward | forward</annotation>
+		<annotation cp="⏩" type="tts">fast-forward button</annotation>
+		<annotation cp="⏭">arrow | button | next | scene | track | triangle</annotation>
+		<annotation cp="⏭" type="tts">next track button</annotation>
+		<annotation cp="⏯">arrow | button | pause | play | right | triangle</annotation>
+		<annotation cp="⏯" type="tts">play or pause button</annotation>
+		<annotation cp="◀">arrow | button | left | reverse | triangle</annotation>
+		<annotation cp="◀" type="tts">reverse button</annotation>
+		<annotation cp="⏪">arrow | button | double | fast | reverse | rewind</annotation>
+		<annotation cp="⏪" type="tts">fast reverse button</annotation>
+		<annotation cp="⏮">arrow | button | last | previous | scene | track | triangle</annotation>
+		<annotation cp="⏮" type="tts">last track button</annotation>
+		<annotation cp="🔼">arrow | button | red | up | upwards</annotation>
+		<annotation cp="🔼" type="tts">upwards button</annotation>
+		<annotation cp="⏫">arrow | button | double | fast | up</annotation>
+		<annotation cp="⏫" type="tts">fast up button</annotation>
+		<annotation cp="🔽">arrow | button | down | downwards | red</annotation>
+		<annotation cp="🔽" type="tts">downwards button</annotation>
+		<annotation cp="⏬">arrow | button | double | down | fast</annotation>
+		<annotation cp="⏬" type="tts">fast down button</annotation>
+		<annotation cp="⏸">bar | button | double | pause | vertical</annotation>
+		<annotation cp="⏸" type="tts">pause button</annotation>
+		<annotation cp="⏹">button | square | stop</annotation>
+		<annotation cp="⏹" type="tts">stop button</annotation>
+		<annotation cp="⏺">button | circle | record</annotation>
+		<annotation cp="⏺" type="tts">record button</annotation>
+		<annotation cp="⏏">button | eject</annotation>
+		<annotation cp="⏏" type="tts">eject button</annotation>
+		<annotation cp="🎦">camera | cinema | film | movie</annotation>
+		<annotation cp="🎦" type="tts">cinema</annotation>
+		<annotation cp="🔅">brightness | button | dim | low</annotation>
+		<annotation cp="🔅" type="tts">dim button</annotation>
+		<annotation cp="🔆">bright | brightness | button | light</annotation>
+		<annotation cp="🔆" type="tts">bright button</annotation>
+		<annotation cp="📶">antenna | bar | bars | cell | communication | mobile | phone | signal | telephone</annotation>
+		<annotation cp="📶" type="tts">antenna bars</annotation>
+		<annotation cp="🛜">broadband | computer | connectivity | hotspot | internet | network | router | smartphone | wi-fi | wifi | wireless | wlan</annotation> <!-- 1F6DC -->
+		<annotation cp="🛜" type="tts">wireless</annotation>
+		<annotation cp="📳">cell | communication | mobile | mode | phone | telephone | vibration</annotation>
+		<annotation cp="📳" type="tts">vibration mode</annotation>
+		<annotation cp="📴">cell | mobile | off | phone | telephone</annotation>
+		<annotation cp="📴" type="tts">mobile phone off</annotation>
+		<annotation cp="♀">female | sign | woman</annotation>
+		<annotation cp="♀" type="tts">female sign</annotation>
+		<annotation cp="♂">male | man | sign</annotation>
+		<annotation cp="♂" type="tts">male sign</annotation>
+		<annotation cp="⚧">symbol | transgender</annotation>
+		<annotation cp="⚧" type="tts">transgender symbol</annotation>
+		<annotation cp="✖">× | cancel | multiplication | multiply | sign | x</annotation>
+		<annotation cp="✖" type="tts">multiply</annotation>
+		<annotation cp="➕">+ | plus</annotation>
+		<annotation cp="➕" type="tts">plus</annotation>
+		<annotation cp="➖">- | − | heavy | math | minus | sign</annotation>
+		<annotation cp="➖" type="tts">minus</annotation>
+		<annotation cp="➗">÷ | divide | division | heavy | math | sign</annotation>
+		<annotation cp="➗" type="tts">divide</annotation>
+		<annotation cp="🟰">answer | equal | equality | equals | heavy | math | sign</annotation> <!-- 1F7F0 -->
+		<annotation cp="🟰" type="tts">heavy equals sign</annotation>
+		<annotation cp="♾">forever | infinity | unbounded | universal</annotation>
+		<annotation cp="♾" type="tts">infinity</annotation>
+		<annotation cp="‼">! | !! | bangbang | double | exclamation | mark | punctuation</annotation>
+		<annotation cp="‼" type="tts">double exclamation mark</annotation>
+		<annotation cp="⁉">! | !? | ? | exclamation | interrobang | mark | punctuation | question</annotation>
+		<annotation cp="⁉" type="tts">exclamation question mark</annotation>
+		<annotation cp="❓">? | mark | punctuation | question | red</annotation>
+		<annotation cp="❓" type="tts">red question mark</annotation>
+		<annotation cp="❔">? | mark | outlined | punctuation | question | white</annotation>
+		<annotation cp="❔" type="tts">white question mark</annotation>
+		<annotation cp="❕">! | exclamation | mark | outlined | punctuation | white</annotation>
+		<annotation cp="❕" type="tts">white exclamation mark</annotation>
+		<annotation cp="❗">! | exclamation | mark | punctuation | red</annotation>
+		<annotation cp="❗" type="tts">red exclamation mark</annotation>
+		<annotation cp="〰">dash | punctuation | wavy</annotation>
+		<annotation cp="〰" type="tts">wavy dash</annotation>
+		<annotation cp="💱">bank | currency | exchange | money</annotation>
+		<annotation cp="💱" type="tts">currency exchange</annotation>
+		<annotation cp="💲">billion | cash | charge | currency | dollar | heavy | million | money | pay | sign</annotation>
+		<annotation cp="💲" type="tts">heavy dollar sign</annotation>
+		<annotation cp="⚕">aesculapius | medical | medicine | staff | symbol</annotation>
+		<annotation cp="⚕" type="tts">medical symbol</annotation>
+		<annotation cp="♻">recycle | recycling | symbol</annotation>
+		<annotation cp="♻" type="tts">recycling symbol</annotation>
+		<annotation cp="⚜">fleur-de-lis | knights</annotation>
+		<annotation cp="⚜" type="tts">fleur-de-lis</annotation>
+		<annotation cp="🔱">anchor | emblem | poseidon | ship | tool | trident</annotation>
+		<annotation cp="🔱" type="tts">trident emblem</annotation>
+		<annotation cp="📛">badge | name</annotation>
+		<annotation cp="📛" type="tts">name badge</annotation>
+		<annotation cp="🔰">beginner | chevron | green | Japanese | leaf | symbol | tool | yellow</annotation>
+		<annotation cp="🔰" type="tts">Japanese symbol for beginner</annotation>
+		<annotation cp="⭕">circle | heavy | hollow | large | o | red</annotation>
+		<annotation cp="⭕" type="tts">hollow red circle</annotation>
+		<annotation cp="✅">✓ | button | check | checked | checkmark | complete | completed | done | fixed | mark | tick</annotation>
+		<annotation cp="✅" type="tts">check mark button</annotation>
+		<annotation cp="☑">✓ | ballot | box | check | checked | done | off | tick</annotation>
+		<annotation cp="☑" type="tts">check box with check</annotation>
+		<annotation cp="✔">✓ | check | checked | checkmark | done | heavy | mark | tick</annotation>
+		<annotation cp="✔" type="tts">check mark</annotation>
+		<annotation cp="❌">× | cancel | cross | mark | multiplication | multiply | x</annotation>
+		<annotation cp="❌" type="tts">cross mark</annotation>
+		<annotation cp="❎">× | button | cross | mark | multiplication | multiply | square | x</annotation>
+		<annotation cp="❎" type="tts">cross mark button</annotation>
+		<annotation cp="➰">curl | curly | loop</annotation>
+		<annotation cp="➰" type="tts">curly loop</annotation>
+		<annotation cp="➿">curl | curly | double | loop</annotation>
+		<annotation cp="➿" type="tts">double curly loop</annotation>
+		<annotation cp="〽">alternation | mark | part</annotation>
+		<annotation cp="〽" type="tts">part alternation mark</annotation>
+		<annotation cp="✳">* | asterisk | eight-spoked</annotation>
+		<annotation cp="✳" type="tts">eight-spoked asterisk</annotation>
+		<annotation cp="✴">* | eight-pointed | star</annotation>
+		<annotation cp="✴" type="tts">eight-pointed star</annotation>
+		<annotation cp="❇">* | sparkle</annotation>
+		<annotation cp="❇" type="tts">sparkle</annotation>
+		<annotation cp="©">C | copyright</annotation>
+		<annotation cp="©" type="tts">copyright</annotation>
+		<annotation cp="®">R | registered</annotation>
+		<annotation cp="®" type="tts">registered</annotation>
+		<annotation cp="™">mark | TM | trade | trademark</annotation>
+		<annotation cp="™" type="tts">trade mark</annotation>
+		<annotation cp="🫟">drip | holi | ink | liquid | mess | paint | spill | splatter | stain</annotation>
+		<annotation cp="🫟" type="tts">splatter</annotation>
+		<annotation cp="🔠">ABCD | input | latin | letters | uppercase</annotation>
+		<annotation cp="🔠" type="tts">input latin uppercase</annotation>
+		<annotation cp="🔡">abcd | input | latin | letters | lowercase</annotation>
+		<annotation cp="🔡" type="tts">input latin lowercase</annotation>
+		<annotation cp="🔢">1234 | input | numbers</annotation>
+		<annotation cp="🔢" type="tts">input numbers</annotation>
+		<annotation cp="🔣">&amp; | % | ♪ | 〒 | input | symbols</annotation>
+		<annotation cp="🔣" type="tts">input symbols</annotation>
+		<annotation cp="🔤">abc | alphabet | input | latin | letters</annotation>
+		<annotation cp="🔤" type="tts">input latin letters</annotation>
+		<annotation cp="🅰">blood | button | type</annotation>
+		<annotation cp="🅰" type="tts">A button (blood type)</annotation>
+		<annotation cp="🆎">AB | blood | button | type</annotation>
+		<annotation cp="🆎" type="tts">AB button (blood type)</annotation>
+		<annotation cp="🅱">B | blood | button | type</annotation>
+		<annotation cp="🅱" type="tts">B button (blood type)</annotation>
+		<annotation cp="🆑">button | CL</annotation>
+		<annotation cp="🆑" type="tts">CL button</annotation>
+		<annotation cp="🆒">button | COOL</annotation>
+		<annotation cp="🆒" type="tts">COOL button</annotation>
+		<annotation cp="🆓">button | FREE</annotation>
+		<annotation cp="🆓" type="tts">FREE button</annotation>
+		<annotation cp="ℹ">I | information</annotation>
+		<annotation cp="ℹ" type="tts">information</annotation>
+		<annotation cp="🆔">button | ID | identity</annotation>
+		<annotation cp="🆔" type="tts">ID button</annotation>
+		<annotation cp="Ⓜ">circle | circled | M</annotation>
+		<annotation cp="Ⓜ" type="tts">circled M</annotation>
+		<annotation cp="🆕">button | NEW</annotation>
+		<annotation cp="🆕" type="tts">NEW button</annotation>
+		<annotation cp="🆖">button | NG</annotation>
+		<annotation cp="🆖" type="tts">NG button</annotation>
+		<annotation cp="🅾">blood | button | O | type</annotation>
+		<annotation cp="🅾" type="tts">O button (blood type)</annotation>
+		<annotation cp="🆗">button | OK | okay</annotation>
+		<annotation cp="🆗" type="tts">OK button</annotation>
+		<annotation cp="🅿">button | P | parking</annotation>
+		<annotation cp="🅿" type="tts">P button</annotation>
+		<annotation cp="🆘">button | help | SOS</annotation>
+		<annotation cp="🆘" type="tts">SOS button</annotation>
+		<annotation cp="🆙">button | mark | UP | UP!</annotation>
+		<annotation cp="🆙" type="tts">UP! button</annotation>
+		<annotation cp="🆚">button | versus | VS</annotation>
+		<annotation cp="🆚" type="tts">VS button</annotation>
+		<annotation cp="🈁">button | here | Japanese | katakana</annotation>
+		<annotation cp="🈁" type="tts">Japanese “here” button</annotation>
+		<annotation cp="🈂">button | charge | Japanese | katakana | service</annotation>
+		<annotation cp="🈂" type="tts">Japanese “service charge” button</annotation>
+		<annotation cp="🈷">amount | button | ideograph | Japanese | monthly</annotation>
+		<annotation cp="🈷" type="tts">Japanese “monthly amount” button</annotation>
+		<annotation cp="🈶">button | charge | free | ideograph | Japanese | not</annotation>
+		<annotation cp="🈶" type="tts">Japanese “not free of charge” button</annotation>
+		<annotation cp="🈯">button | ideograph | Japanese | reserved</annotation>
+		<annotation cp="🈯" type="tts">Japanese “reserved” button</annotation>
+		<annotation cp="🉐">bargain | button | ideograph | Japanese</annotation>
+		<annotation cp="🉐" type="tts">Japanese “bargain” button</annotation>
+		<annotation cp="🈹">button | discount | ideograph | Japanese</annotation>
+		<annotation cp="🈹" type="tts">Japanese “discount” button</annotation>
+		<annotation cp="🈚">button | charge | free | ideograph | Japanese</annotation>
+		<annotation cp="🈚" type="tts">Japanese “free of charge” button</annotation>
+		<annotation cp="🈲">button | ideograph | Japanese | prohibited</annotation>
+		<annotation cp="🈲" type="tts">Japanese “prohibited” button</annotation>
+		<annotation cp="🉑">acceptable | button | ideograph | Japanese</annotation>
+		<annotation cp="🉑" type="tts">Japanese “acceptable” button</annotation>
+		<annotation cp="🈸">application | button | ideograph | Japanese</annotation>
+		<annotation cp="🈸" type="tts">Japanese “application” button</annotation>
+		<annotation cp="🈴">button | grade | ideograph | Japanese | passing</annotation>
+		<annotation cp="🈴" type="tts">Japanese “passing grade” button</annotation>
+		<annotation cp="🈳">button | ideograph | Japanese | vacancy</annotation>
+		<annotation cp="🈳" type="tts">Japanese “vacancy” button</annotation>
+		<annotation cp="㊗">button | congratulations | ideograph | Japanese</annotation>
+		<annotation cp="㊗" type="tts">Japanese “congratulations” button</annotation>
+		<annotation cp="㊙">button | ideograph | Japanese | secret</annotation>
+		<annotation cp="㊙" type="tts">Japanese “secret” button</annotation>
+		<annotation cp="🈺">business | button | ideograph | Japanese | open</annotation>
+		<annotation cp="🈺" type="tts">Japanese “open for business” button</annotation>
+		<annotation cp="🈵">button | ideograph | Japanese | no | vacancy</annotation>
+		<annotation cp="🈵" type="tts">Japanese “no vacancy” button</annotation>
+		<annotation cp="🔴">circle | geometric | red</annotation>
+		<annotation cp="🔴" type="tts">red circle</annotation>
+		<annotation cp="🟠">circle | orange</annotation>
+		<annotation cp="🟠" type="tts">orange circle</annotation>
+		<annotation cp="🟡">circle | yellow</annotation>
+		<annotation cp="🟡" type="tts">yellow circle</annotation>
+		<annotation cp="🟢">circle | green</annotation>
+		<annotation cp="🟢" type="tts">green circle</annotation>
+		<annotation cp="🔵">blue | circle | geometric</annotation>
+		<annotation cp="🔵" type="tts">blue circle</annotation>
+		<annotation cp="🟣">circle | purple</annotation>
+		<annotation cp="🟣" type="tts">purple circle</annotation>
+		<annotation cp="🟤">brown | circle</annotation>
+		<annotation cp="🟤" type="tts">brown circle</annotation>
+		<annotation cp="⚫">black | circle | geometric</annotation>
+		<annotation cp="⚫" type="tts">black circle</annotation>
+		<annotation cp="⚪">circle | geometric | white</annotation>
+		<annotation cp="⚪" type="tts">white circle</annotation>
+		<annotation cp="🟥">card | penalty | red | square</annotation>
+		<annotation cp="🟥" type="tts">red square</annotation>
+		<annotation cp="🟧">orange | square</annotation>
+		<annotation cp="🟧" type="tts">orange square</annotation>
+		<annotation cp="🟨">card | penalty | square | yellow</annotation>
+		<annotation cp="🟨" type="tts">yellow square</annotation>
+		<annotation cp="🟩">green | square</annotation>
+		<annotation cp="🟩" type="tts">green square</annotation>
+		<annotation cp="🟦">blue | square</annotation>
+		<annotation cp="🟦" type="tts">blue square</annotation>
+		<annotation cp="🟪">purple | square</annotation>
+		<annotation cp="🟪" type="tts">purple square</annotation>
+		<annotation cp="🟫">brown | square</annotation>
+		<annotation cp="🟫" type="tts">brown square</annotation>
+		<annotation cp="⬛">black | geometric | large | square</annotation>
+		<annotation cp="⬛" type="tts">black large square</annotation>
+		<annotation cp="⬜">geometric | large | square | white</annotation>
+		<annotation cp="⬜" type="tts">white large square</annotation>
+		<annotation cp="◼">black | geometric | medium | square</annotation>
+		<annotation cp="◼" type="tts">black medium square</annotation>
+		<annotation cp="◻">geometric | medium | square | white</annotation>
+		<annotation cp="◻" type="tts">white medium square</annotation>
+		<annotation cp="◾">black | geometric | medium-small | square</annotation>
+		<annotation cp="◾" type="tts">black medium-small square</annotation>
+		<annotation cp="◽">geometric | medium-small | square | white</annotation>
+		<annotation cp="◽" type="tts">white medium-small square</annotation>
+		<annotation cp="▪">black | geometric | small | square</annotation>
+		<annotation cp="▪" type="tts">black small square</annotation>
+		<annotation cp="▫">geometric | small | square | white</annotation>
+		<annotation cp="▫" type="tts">white small square</annotation>
+		<annotation cp="🔶">diamond | geometric | large | orange</annotation>
+		<annotation cp="🔶" type="tts">large orange diamond</annotation>
+		<annotation cp="🔷">blue | diamond | geometric | large</annotation>
+		<annotation cp="🔷" type="tts">large blue diamond</annotation>
+		<annotation cp="🔸">diamond | geometric | orange | small</annotation>
+		<annotation cp="🔸" type="tts">small orange diamond</annotation>
+		<annotation cp="🔹">blue | diamond | geometric | small</annotation>
+		<annotation cp="🔹" type="tts">small blue diamond</annotation>
+		<annotation cp="🔺">geometric | pointed | red | triangle | up</annotation>
+		<annotation cp="🔺" type="tts">red triangle pointed up</annotation>
+		<annotation cp="🔻">down | geometric | pointed | red | triangle</annotation>
+		<annotation cp="🔻" type="tts">red triangle pointed down</annotation>
+		<annotation cp="💠">comic | diamond | dot | geometric</annotation>
+		<annotation cp="💠" type="tts">diamond with a dot</annotation>
+		<annotation cp="🔘">button | geometric | radio</annotation>
+		<annotation cp="🔘" type="tts">radio button</annotation>
+		<annotation cp="🔳">button | geometric | outlined | square | white</annotation>
+		<annotation cp="🔳" type="tts">white square button</annotation>
+		<annotation cp="🔲">black | button | geometric | square</annotation>
+		<annotation cp="🔲" type="tts">black square button</annotation>
+		<annotation cp="🏁">checkered | chequered | finish | flag | flags | game | race | racing | sport | win</annotation>
+		<annotation cp="🏁" type="tts">chequered flag</annotation>
+		<annotation cp="🚩">construction | flag | golf | post | triangular</annotation>
+		<annotation cp="🚩" type="tts">triangular flag</annotation>
+		<annotation cp="🎌">celebration | cross | crossed | flags | Japanese</annotation>
+		<annotation cp="🎌" type="tts">crossed flags</annotation>
+		<annotation cp="🏴">black | flag | waving</annotation>
+		<annotation cp="🏴" type="tts">black flag</annotation>
+		<annotation cp="🏳">flag | waving | white</annotation>
+		<annotation cp="🏳" type="tts">white flag</annotation>
+		<annotation cp="🏳‍🌈">bisexual | flag | gay | genderqueer | glbt | glbtq | lesbian | lgbt | lgbtq | lgbtqia | pride | queer | rainbow | trans | transgender</annotation>
+		<annotation cp="🏳‍🌈" type="tts">rainbow flag</annotation>
+		<annotation cp="🏳‍⚧">blue | flag | light | pink | transgender | white</annotation>
+		<annotation cp="🏳‍⚧" type="tts">transgender flag</annotation>
+		<annotation cp="🏴‍☠">flag | Jolly | pirate | plunder | Roger | treasure</annotation>
+		<annotation cp="🏴‍☠" type="tts">pirate flag</annotation>
+		<annotation cp="¢">cent</annotation>
+		<annotation cp="¢" type="tts">cent</annotation>
+		<annotation cp="$">dollar | money | peso | USD</annotation>
+		<annotation cp="$" type="tts">dollar</annotation>
+		<annotation cp="£">currency | EGP | GBP | pound</annotation>
+		<annotation cp="£" type="tts">pound</annotation>
+		<annotation cp="¥">CNY | currency | JPY | yen | yuan</annotation>
+		<annotation cp="¥" type="tts">yen</annotation>
+		<annotation cp="₢">BRB | cruzeiro | currency</annotation>
+		<annotation cp="₢" type="tts">cruzeiro</annotation>
+		<annotation cp="₣">currency | franc | french</annotation>
+		<annotation cp="₣" type="tts">french franc</annotation>
+		<annotation cp="₤">currency | lira</annotation>
+		<annotation cp="₤" type="tts">lira</annotation>
+		<annotation cp="₥">mil | mill</annotation>
+		<annotation cp="₥" type="tts">mill</annotation>
+		<annotation cp="₩">KPW | KRW | won</annotation>
+		<annotation cp="₩" type="tts">won</annotation>
+		<annotation cp="€">currency | EUR | euro</annotation>
+		<annotation cp="€" type="tts">euro</annotation>
+		<annotation cp="₰">currency | german | penny | pfennig</annotation>
+		<annotation cp="₰" type="tts">german penny</annotation>
+		<annotation cp="₱">peso</annotation>
+		<annotation cp="₱" type="tts">peso</annotation>
+		<annotation cp="₳">ARA | austral | currency</annotation>
+		<annotation cp="₳" type="tts">austral</annotation>
+		<annotation cp="₶">currency | livre | tournois</annotation>
+		<annotation cp="₶" type="tts">livre tournois</annotation>
+		<annotation cp="₷">currency | spesmilo</annotation>
+		<annotation cp="₷" type="tts">spesmilo</annotation>
+		<annotation cp="₹">currency | indian | rupee</annotation>
+		<annotation cp="₹" type="tts">indian rupee</annotation>
+		<annotation cp="₽">currency | ruble</annotation>
+		<annotation cp="₽" type="tts">ruble</annotation>
+		<annotation cp="₿">bitcoin | BTC</annotation>
+		<annotation cp="₿" type="tts">bitcoin</annotation>
+		<annotation cp="¹">one | superscript</annotation>
+		<annotation cp="¹" type="tts">superscript one</annotation>
+		<annotation cp="²">squared | superscript | two</annotation>
+		<annotation cp="²" type="tts">superscript two</annotation>
+		<annotation cp="³">cubed | superscript | three</annotation>
+		<annotation cp="³" type="tts">superscript three</annotation>
+		<annotation cp="₨">currency | rupee</annotation>
+		<annotation cp="₨" type="tts">rupee</annotation>
+		<annotation cp="µ">measure | micro | sign</annotation>
+		<annotation cp="µ" type="tts">micro sign</annotation>
+		<annotation cp="﷼">currency | rial</annotation>
+		<annotation cp="﷼" type="tts">rial</annotation>
+	</annotations>
+</ldml>

--- a/tools/unicode/annotationsDerived-en.xml
+++ b/tools/unicode/annotationsDerived-en.xml
@@ -1,0 +1,4459 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2024 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-3.0
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+
+Derived short names and annotations, using GenerateDerivedAnnotations.java. See warnings in /annotations/ file.
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="en"/>
+	</identity>
+	<annotations>
+		<annotation cp="👋🏻">bye | cya | g2g | greetings | gtg | hand | hello | hey | hi | later | light skin tone | outtie | ttfn | ttyl | wave | yo | you</annotation>
+		<annotation cp="👋🏻" type="tts">waving hand: light skin tone</annotation>
+		<annotation cp="👋🏼">bye | cya | g2g | greetings | gtg | hand | hello | hey | hi | later | medium-light skin tone | outtie | ttfn | ttyl | wave | yo | you</annotation>
+		<annotation cp="👋🏼" type="tts">waving hand: medium-light skin tone</annotation>
+		<annotation cp="👋🏽">bye | cya | g2g | greetings | gtg | hand | hello | hey | hi | later | medium skin tone | outtie | ttfn | ttyl | wave | yo | you</annotation>
+		<annotation cp="👋🏽" type="tts">waving hand: medium skin tone</annotation>
+		<annotation cp="👋🏾">bye | cya | g2g | greetings | gtg | hand | hello | hey | hi | later | medium-dark skin tone | outtie | ttfn | ttyl | wave | yo | you</annotation>
+		<annotation cp="👋🏾" type="tts">waving hand: medium-dark skin tone</annotation>
+		<annotation cp="👋🏿">bye | cya | dark skin tone | g2g | greetings | gtg | hand | hello | hey | hi | later | outtie | ttfn | ttyl | wave | yo | you</annotation>
+		<annotation cp="👋🏿" type="tts">waving hand: dark skin tone</annotation>
+		<annotation cp="🤚🏻">back | backhand | hand | light skin tone | raised</annotation>
+		<annotation cp="🤚🏻" type="tts">raised back of hand: light skin tone</annotation>
+		<annotation cp="🤚🏼">back | backhand | hand | medium-light skin tone | raised</annotation>
+		<annotation cp="🤚🏼" type="tts">raised back of hand: medium-light skin tone</annotation>
+		<annotation cp="🤚🏽">back | backhand | hand | medium skin tone | raised</annotation>
+		<annotation cp="🤚🏽" type="tts">raised back of hand: medium skin tone</annotation>
+		<annotation cp="🤚🏾">back | backhand | hand | medium-dark skin tone | raised</annotation>
+		<annotation cp="🤚🏾" type="tts">raised back of hand: medium-dark skin tone</annotation>
+		<annotation cp="🤚🏿">back | backhand | dark skin tone | hand | raised</annotation>
+		<annotation cp="🤚🏿" type="tts">raised back of hand: dark skin tone</annotation>
+		<annotation cp="🖐🏻">finger | fingers | hand | light skin tone | raised | splayed | stop</annotation>
+		<annotation cp="🖐🏻" type="tts">hand with fingers splayed: light skin tone</annotation>
+		<annotation cp="🖐🏼">finger | fingers | hand | medium-light skin tone | raised | splayed | stop</annotation>
+		<annotation cp="🖐🏼" type="tts">hand with fingers splayed: medium-light skin tone</annotation>
+		<annotation cp="🖐🏽">finger | fingers | hand | medium skin tone | raised | splayed | stop</annotation>
+		<annotation cp="🖐🏽" type="tts">hand with fingers splayed: medium skin tone</annotation>
+		<annotation cp="🖐🏾">finger | fingers | hand | medium-dark skin tone | raised | splayed | stop</annotation>
+		<annotation cp="🖐🏾" type="tts">hand with fingers splayed: medium-dark skin tone</annotation>
+		<annotation cp="🖐🏿">dark skin tone | finger | fingers | hand | raised | splayed | stop</annotation>
+		<annotation cp="🖐🏿" type="tts">hand with fingers splayed: dark skin tone</annotation>
+		<annotation cp="✋🏻">5 | five | hand | high | light skin tone | raised | stop</annotation>
+		<annotation cp="✋🏻" type="tts">raised hand: light skin tone</annotation>
+		<annotation cp="✋🏼">5 | five | hand | high | medium-light skin tone | raised | stop</annotation>
+		<annotation cp="✋🏼" type="tts">raised hand: medium-light skin tone</annotation>
+		<annotation cp="✋🏽">5 | five | hand | high | medium skin tone | raised | stop</annotation>
+		<annotation cp="✋🏽" type="tts">raised hand: medium skin tone</annotation>
+		<annotation cp="✋🏾">5 | five | hand | high | medium-dark skin tone | raised | stop</annotation>
+		<annotation cp="✋🏾" type="tts">raised hand: medium-dark skin tone</annotation>
+		<annotation cp="✋🏿">5 | dark skin tone | five | hand | high | raised | stop</annotation>
+		<annotation cp="✋🏿" type="tts">raised hand: dark skin tone</annotation>
+		<annotation cp="🖖🏻">finger | hand | hands | light skin tone | salute | Vulcan</annotation>
+		<annotation cp="🖖🏻" type="tts">vulcan salute: light skin tone</annotation>
+		<annotation cp="🖖🏼">finger | hand | hands | medium-light skin tone | salute | Vulcan</annotation>
+		<annotation cp="🖖🏼" type="tts">vulcan salute: medium-light skin tone</annotation>
+		<annotation cp="🖖🏽">finger | hand | hands | medium skin tone | salute | Vulcan</annotation>
+		<annotation cp="🖖🏽" type="tts">vulcan salute: medium skin tone</annotation>
+		<annotation cp="🖖🏾">finger | hand | hands | medium-dark skin tone | salute | Vulcan</annotation>
+		<annotation cp="🖖🏾" type="tts">vulcan salute: medium-dark skin tone</annotation>
+		<annotation cp="🖖🏿">dark skin tone | finger | hand | hands | salute | Vulcan</annotation>
+		<annotation cp="🖖🏿" type="tts">vulcan salute: dark skin tone</annotation>
+		<annotation cp="🫱🏻">hand | handshake | hold | light skin tone | reach | right | rightward | rightwards | shake</annotation>
+		<annotation cp="🫱🏻" type="tts">rightwards hand: light skin tone</annotation>
+		<annotation cp="🫱🏼">hand | handshake | hold | medium-light skin tone | reach | right | rightward | rightwards | shake</annotation>
+		<annotation cp="🫱🏼" type="tts">rightwards hand: medium-light skin tone</annotation>
+		<annotation cp="🫱🏽">hand | handshake | hold | medium skin tone | reach | right | rightward | rightwards | shake</annotation>
+		<annotation cp="🫱🏽" type="tts">rightwards hand: medium skin tone</annotation>
+		<annotation cp="🫱🏾">hand | handshake | hold | medium-dark skin tone | reach | right | rightward | rightwards | shake</annotation>
+		<annotation cp="🫱🏾" type="tts">rightwards hand: medium-dark skin tone</annotation>
+		<annotation cp="🫱🏿">dark skin tone | hand | handshake | hold | reach | right | rightward | rightwards | shake</annotation>
+		<annotation cp="🫱🏿" type="tts">rightwards hand: dark skin tone</annotation>
+		<annotation cp="🫱🏻‍🫲🏼">agreement | deal | hand | handshake | light skin tone | medium-light skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏻‍🫲🏼" type="tts">handshake: light skin tone, medium-light skin tone</annotation>
+		<annotation cp="🫱🏻‍🫲🏽">agreement | deal | hand | handshake | light skin tone | medium skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏻‍🫲🏽" type="tts">handshake: light skin tone, medium skin tone</annotation>
+		<annotation cp="🫱🏻‍🫲🏾">agreement | deal | hand | handshake | light skin tone | medium-dark skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏻‍🫲🏾" type="tts">handshake: light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🫱🏻‍🫲🏿">agreement | dark skin tone | deal | hand | handshake | light skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏻‍🫲🏿" type="tts">handshake: light skin tone, dark skin tone</annotation>
+		<annotation cp="🫱🏼‍🫲🏻">agreement | deal | hand | handshake | light skin tone | medium-light skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏼‍🫲🏻" type="tts">handshake: medium-light skin tone, light skin tone</annotation>
+		<annotation cp="🫱🏼‍🫲🏽">agreement | deal | hand | handshake | medium skin tone | medium-light skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏼‍🫲🏽" type="tts">handshake: medium-light skin tone, medium skin tone</annotation>
+		<annotation cp="🫱🏼‍🫲🏾">agreement | deal | hand | handshake | medium-dark skin tone | medium-light skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏼‍🫲🏾" type="tts">handshake: medium-light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🫱🏼‍🫲🏿">agreement | dark skin tone | deal | hand | handshake | medium-light skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏼‍🫲🏿" type="tts">handshake: medium-light skin tone, dark skin tone</annotation>
+		<annotation cp="🫱🏽‍🫲🏻">agreement | deal | hand | handshake | light skin tone | medium skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏽‍🫲🏻" type="tts">handshake: medium skin tone, light skin tone</annotation>
+		<annotation cp="🫱🏽‍🫲🏼">agreement | deal | hand | handshake | medium skin tone | medium-light skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏽‍🫲🏼" type="tts">handshake: medium skin tone, medium-light skin tone</annotation>
+		<annotation cp="🫱🏽‍🫲🏾">agreement | deal | hand | handshake | medium skin tone | medium-dark skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏽‍🫲🏾" type="tts">handshake: medium skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🫱🏽‍🫲🏿">agreement | dark skin tone | deal | hand | handshake | medium skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏽‍🫲🏿" type="tts">handshake: medium skin tone, dark skin tone</annotation>
+		<annotation cp="🫱🏾‍🫲🏻">agreement | deal | hand | handshake | light skin tone | medium-dark skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏾‍🫲🏻" type="tts">handshake: medium-dark skin tone, light skin tone</annotation>
+		<annotation cp="🫱🏾‍🫲🏼">agreement | deal | hand | handshake | medium-dark skin tone | medium-light skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏾‍🫲🏼" type="tts">handshake: medium-dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="🫱🏾‍🫲🏽">agreement | deal | hand | handshake | medium skin tone | medium-dark skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏾‍🫲🏽" type="tts">handshake: medium-dark skin tone, medium skin tone</annotation>
+		<annotation cp="🫱🏾‍🫲🏿">agreement | dark skin tone | deal | hand | handshake | medium-dark skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏾‍🫲🏿" type="tts">handshake: medium-dark skin tone, dark skin tone</annotation>
+		<annotation cp="🫱🏿‍🫲🏻">agreement | dark skin tone | deal | hand | handshake | light skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏿‍🫲🏻" type="tts">handshake: dark skin tone, light skin tone</annotation>
+		<annotation cp="🫱🏿‍🫲🏼">agreement | dark skin tone | deal | hand | handshake | medium-light skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏿‍🫲🏼" type="tts">handshake: dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="🫱🏿‍🫲🏽">agreement | dark skin tone | deal | hand | handshake | medium skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏿‍🫲🏽" type="tts">handshake: dark skin tone, medium skin tone</annotation>
+		<annotation cp="🫱🏿‍🫲🏾">agreement | dark skin tone | deal | hand | handshake | medium-dark skin tone | meeting | shake</annotation>
+		<annotation cp="🫱🏿‍🫲🏾" type="tts">handshake: dark skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🫲🏻">hand | handshake | hold | left | leftward | leftwards | light skin tone | reach | shake</annotation>
+		<annotation cp="🫲🏻" type="tts">leftwards hand: light skin tone</annotation>
+		<annotation cp="🫲🏼">hand | handshake | hold | left | leftward | leftwards | medium-light skin tone | reach | shake</annotation>
+		<annotation cp="🫲🏼" type="tts">leftwards hand: medium-light skin tone</annotation>
+		<annotation cp="🫲🏽">hand | handshake | hold | left | leftward | leftwards | medium skin tone | reach | shake</annotation>
+		<annotation cp="🫲🏽" type="tts">leftwards hand: medium skin tone</annotation>
+		<annotation cp="🫲🏾">hand | handshake | hold | left | leftward | leftwards | medium-dark skin tone | reach | shake</annotation>
+		<annotation cp="🫲🏾" type="tts">leftwards hand: medium-dark skin tone</annotation>
+		<annotation cp="🫲🏿">dark skin tone | hand | handshake | hold | left | leftward | leftwards | reach | shake</annotation>
+		<annotation cp="🫲🏿" type="tts">leftwards hand: dark skin tone</annotation>
+		<annotation cp="🫳🏻">dismiss | down | drop | dropped | hand | light skin tone | palm | pick | shoo | up</annotation>
+		<annotation cp="🫳🏻" type="tts">palm down hand: light skin tone</annotation>
+		<annotation cp="🫳🏼">dismiss | down | drop | dropped | hand | medium-light skin tone | palm | pick | shoo | up</annotation>
+		<annotation cp="🫳🏼" type="tts">palm down hand: medium-light skin tone</annotation>
+		<annotation cp="🫳🏽">dismiss | down | drop | dropped | hand | medium skin tone | palm | pick | shoo | up</annotation>
+		<annotation cp="🫳🏽" type="tts">palm down hand: medium skin tone</annotation>
+		<annotation cp="🫳🏾">dismiss | down | drop | dropped | hand | medium-dark skin tone | palm | pick | shoo | up</annotation>
+		<annotation cp="🫳🏾" type="tts">palm down hand: medium-dark skin tone</annotation>
+		<annotation cp="🫳🏿">dark skin tone | dismiss | down | drop | dropped | hand | palm | pick | shoo | up</annotation>
+		<annotation cp="🫳🏿" type="tts">palm down hand: dark skin tone</annotation>
+		<annotation cp="🫴🏻">beckon | catch | come | hand | hold | know | lift | light skin tone | me | offer | palm | tell</annotation>
+		<annotation cp="🫴🏻" type="tts">palm up hand: light skin tone</annotation>
+		<annotation cp="🫴🏼">beckon | catch | come | hand | hold | know | lift | me | medium-light skin tone | offer | palm | tell</annotation>
+		<annotation cp="🫴🏼" type="tts">palm up hand: medium-light skin tone</annotation>
+		<annotation cp="🫴🏽">beckon | catch | come | hand | hold | know | lift | me | medium skin tone | offer | palm | tell</annotation>
+		<annotation cp="🫴🏽" type="tts">palm up hand: medium skin tone</annotation>
+		<annotation cp="🫴🏾">beckon | catch | come | hand | hold | know | lift | me | medium-dark skin tone | offer | palm | tell</annotation>
+		<annotation cp="🫴🏾" type="tts">palm up hand: medium-dark skin tone</annotation>
+		<annotation cp="🫴🏿">beckon | catch | come | dark skin tone | hand | hold | know | lift | me | offer | palm | tell</annotation>
+		<annotation cp="🫴🏿" type="tts">palm up hand: dark skin tone</annotation>
+		<annotation cp="🫷🏻">block | five | halt | hand | high | hold | leftward | leftwards | light skin tone | pause | push | pushing | refuse | slap | stop | wait</annotation>
+		<annotation cp="🫷🏻" type="tts">leftwards pushing hand: light skin tone</annotation>
+		<annotation cp="🫷🏼">block | five | halt | hand | high | hold | leftward | leftwards | medium-light skin tone | pause | push | pushing | refuse | slap | stop | wait</annotation>
+		<annotation cp="🫷🏼" type="tts">leftwards pushing hand: medium-light skin tone</annotation>
+		<annotation cp="🫷🏽">block | five | halt | hand | high | hold | leftward | leftwards | medium skin tone | pause | push | pushing | refuse | slap | stop | wait</annotation>
+		<annotation cp="🫷🏽" type="tts">leftwards pushing hand: medium skin tone</annotation>
+		<annotation cp="🫷🏾">block | five | halt | hand | high | hold | leftward | leftwards | medium-dark skin tone | pause | push | pushing | refuse | slap | stop | wait</annotation>
+		<annotation cp="🫷🏾" type="tts">leftwards pushing hand: medium-dark skin tone</annotation>
+		<annotation cp="🫷🏿">block | dark skin tone | five | halt | hand | high | hold | leftward | leftwards | pause | push | pushing | refuse | slap | stop | wait</annotation>
+		<annotation cp="🫷🏿" type="tts">leftwards pushing hand: dark skin tone</annotation>
+		<annotation cp="🫸🏻">block | five | halt | hand | high | hold | light skin tone | pause | push | pushing | refuse | rightward | rightwards | slap | stop | wait</annotation>
+		<annotation cp="🫸🏻" type="tts">rightwards pushing hand: light skin tone</annotation>
+		<annotation cp="🫸🏼">block | five | halt | hand | high | hold | medium-light skin tone | pause | push | pushing | refuse | rightward | rightwards | slap | stop | wait</annotation>
+		<annotation cp="🫸🏼" type="tts">rightwards pushing hand: medium-light skin tone</annotation>
+		<annotation cp="🫸🏽">block | five | halt | hand | high | hold | medium skin tone | pause | push | pushing | refuse | rightward | rightwards | slap | stop | wait</annotation>
+		<annotation cp="🫸🏽" type="tts">rightwards pushing hand: medium skin tone</annotation>
+		<annotation cp="🫸🏾">block | five | halt | hand | high | hold | medium-dark skin tone | pause | push | pushing | refuse | rightward | rightwards | slap | stop | wait</annotation>
+		<annotation cp="🫸🏾" type="tts">rightwards pushing hand: medium-dark skin tone</annotation>
+		<annotation cp="🫸🏿">block | dark skin tone | five | halt | hand | high | hold | pause | push | pushing | refuse | rightward | rightwards | slap | stop | wait</annotation>
+		<annotation cp="🫸🏿" type="tts">rightwards pushing hand: dark skin tone</annotation>
+		<annotation cp="👌🏻">awesome | bet | dope | fleek | fosho | got | gotcha | hand | legit | light skin tone | OK | okay | pinch | rad | sure | sweet | three</annotation>
+		<annotation cp="👌🏻" type="tts">OK hand: light skin tone</annotation>
+		<annotation cp="👌🏼">awesome | bet | dope | fleek | fosho | got | gotcha | hand | legit | medium-light skin tone | OK | okay | pinch | rad | sure | sweet | three</annotation>
+		<annotation cp="👌🏼" type="tts">OK hand: medium-light skin tone</annotation>
+		<annotation cp="👌🏽">awesome | bet | dope | fleek | fosho | got | gotcha | hand | legit | medium skin tone | OK | okay | pinch | rad | sure | sweet | three</annotation>
+		<annotation cp="👌🏽" type="tts">OK hand: medium skin tone</annotation>
+		<annotation cp="👌🏾">awesome | bet | dope | fleek | fosho | got | gotcha | hand | legit | medium-dark skin tone | OK | okay | pinch | rad | sure | sweet | three</annotation>
+		<annotation cp="👌🏾" type="tts">OK hand: medium-dark skin tone</annotation>
+		<annotation cp="👌🏿">awesome | bet | dark skin tone | dope | fleek | fosho | got | gotcha | hand | legit | OK | okay | pinch | rad | sure | sweet | three</annotation>
+		<annotation cp="👌🏿" type="tts">OK hand: dark skin tone</annotation>
+		<annotation cp="🤌🏻">fingers | gesture | hand | hold | huh | interrogation | light skin tone | patience | pinched | relax | sarcastic | ugh | what | zip</annotation>
+		<annotation cp="🤌🏻" type="tts">pinched fingers: light skin tone</annotation>
+		<annotation cp="🤌🏼">fingers | gesture | hand | hold | huh | interrogation | medium-light skin tone | patience | pinched | relax | sarcastic | ugh | what | zip</annotation>
+		<annotation cp="🤌🏼" type="tts">pinched fingers: medium-light skin tone</annotation>
+		<annotation cp="🤌🏽">fingers | gesture | hand | hold | huh | interrogation | medium skin tone | patience | pinched | relax | sarcastic | ugh | what | zip</annotation>
+		<annotation cp="🤌🏽" type="tts">pinched fingers: medium skin tone</annotation>
+		<annotation cp="🤌🏾">fingers | gesture | hand | hold | huh | interrogation | medium-dark skin tone | patience | pinched | relax | sarcastic | ugh | what | zip</annotation>
+		<annotation cp="🤌🏾" type="tts">pinched fingers: medium-dark skin tone</annotation>
+		<annotation cp="🤌🏿">dark skin tone | fingers | gesture | hand | hold | huh | interrogation | patience | pinched | relax | sarcastic | ugh | what | zip</annotation>
+		<annotation cp="🤌🏿" type="tts">pinched fingers: dark skin tone</annotation>
+		<annotation cp="🤏🏻">amount | bit | fingers | hand | light skin tone | little | pinching | small | sort</annotation>
+		<annotation cp="🤏🏻" type="tts">pinching hand: light skin tone</annotation>
+		<annotation cp="🤏🏼">amount | bit | fingers | hand | little | medium-light skin tone | pinching | small | sort</annotation>
+		<annotation cp="🤏🏼" type="tts">pinching hand: medium-light skin tone</annotation>
+		<annotation cp="🤏🏽">amount | bit | fingers | hand | little | medium skin tone | pinching | small | sort</annotation>
+		<annotation cp="🤏🏽" type="tts">pinching hand: medium skin tone</annotation>
+		<annotation cp="🤏🏾">amount | bit | fingers | hand | little | medium-dark skin tone | pinching | small | sort</annotation>
+		<annotation cp="🤏🏾" type="tts">pinching hand: medium-dark skin tone</annotation>
+		<annotation cp="🤏🏿">amount | bit | dark skin tone | fingers | hand | little | pinching | small | sort</annotation>
+		<annotation cp="🤏🏿" type="tts">pinching hand: dark skin tone</annotation>
+		<annotation cp="✌🏻">hand | light skin tone | peace | v | victory</annotation>
+		<annotation cp="✌🏻" type="tts">victory hand: light skin tone</annotation>
+		<annotation cp="✌🏼">hand | medium-light skin tone | peace | v | victory</annotation>
+		<annotation cp="✌🏼" type="tts">victory hand: medium-light skin tone</annotation>
+		<annotation cp="✌🏽">hand | medium skin tone | peace | v | victory</annotation>
+		<annotation cp="✌🏽" type="tts">victory hand: medium skin tone</annotation>
+		<annotation cp="✌🏾">hand | medium-dark skin tone | peace | v | victory</annotation>
+		<annotation cp="✌🏾" type="tts">victory hand: medium-dark skin tone</annotation>
+		<annotation cp="✌🏿">dark skin tone | hand | peace | v | victory</annotation>
+		<annotation cp="✌🏿" type="tts">victory hand: dark skin tone</annotation>
+		<annotation cp="🤞🏻">cross | crossed | finger | fingers | hand | light skin tone | luck</annotation>
+		<annotation cp="🤞🏻" type="tts">crossed fingers: light skin tone</annotation>
+		<annotation cp="🤞🏼">cross | crossed | finger | fingers | hand | luck | medium-light skin tone</annotation>
+		<annotation cp="🤞🏼" type="tts">crossed fingers: medium-light skin tone</annotation>
+		<annotation cp="🤞🏽">cross | crossed | finger | fingers | hand | luck | medium skin tone</annotation>
+		<annotation cp="🤞🏽" type="tts">crossed fingers: medium skin tone</annotation>
+		<annotation cp="🤞🏾">cross | crossed | finger | fingers | hand | luck | medium-dark skin tone</annotation>
+		<annotation cp="🤞🏾" type="tts">crossed fingers: medium-dark skin tone</annotation>
+		<annotation cp="🤞🏿">cross | crossed | dark skin tone | finger | fingers | hand | luck</annotation>
+		<annotation cp="🤞🏿" type="tts">crossed fingers: dark skin tone</annotation>
+		<annotation cp="🫰🏻">&lt;3 | crossed | expensive | finger | hand | heart | index | light skin tone | love | money | snap | thumb</annotation>
+		<annotation cp="🫰🏻" type="tts">hand with index finger and thumb crossed: light skin tone</annotation>
+		<annotation cp="🫰🏼">&lt;3 | crossed | expensive | finger | hand | heart | index | love | medium-light skin tone | money | snap | thumb</annotation>
+		<annotation cp="🫰🏼" type="tts">hand with index finger and thumb crossed: medium-light skin tone</annotation>
+		<annotation cp="🫰🏽">&lt;3 | crossed | expensive | finger | hand | heart | index | love | medium skin tone | money | snap | thumb</annotation>
+		<annotation cp="🫰🏽" type="tts">hand with index finger and thumb crossed: medium skin tone</annotation>
+		<annotation cp="🫰🏾">&lt;3 | crossed | expensive | finger | hand | heart | index | love | medium-dark skin tone | money | snap | thumb</annotation>
+		<annotation cp="🫰🏾" type="tts">hand with index finger and thumb crossed: medium-dark skin tone</annotation>
+		<annotation cp="🫰🏿">&lt;3 | crossed | dark skin tone | expensive | finger | hand | heart | index | love | money | snap | thumb</annotation>
+		<annotation cp="🫰🏿" type="tts">hand with index finger and thumb crossed: dark skin tone</annotation>
+		<annotation cp="🤟🏻">fingers | gesture | hand | ILY | light skin tone | love | love-you | three | you</annotation>
+		<annotation cp="🤟🏻" type="tts">love-you gesture: light skin tone</annotation>
+		<annotation cp="🤟🏼">fingers | gesture | hand | ILY | love | love-you | medium-light skin tone | three | you</annotation>
+		<annotation cp="🤟🏼" type="tts">love-you gesture: medium-light skin tone</annotation>
+		<annotation cp="🤟🏽">fingers | gesture | hand | ILY | love | love-you | medium skin tone | three | you</annotation>
+		<annotation cp="🤟🏽" type="tts">love-you gesture: medium skin tone</annotation>
+		<annotation cp="🤟🏾">fingers | gesture | hand | ILY | love | love-you | medium-dark skin tone | three | you</annotation>
+		<annotation cp="🤟🏾" type="tts">love-you gesture: medium-dark skin tone</annotation>
+		<annotation cp="🤟🏿">dark skin tone | fingers | gesture | hand | ILY | love | love-you | three | you</annotation>
+		<annotation cp="🤟🏿" type="tts">love-you gesture: dark skin tone</annotation>
+		<annotation cp="🤘🏻">finger | hand | horns | light skin tone | rock-on | sign</annotation>
+		<annotation cp="🤘🏻" type="tts">sign of the horns: light skin tone</annotation>
+		<annotation cp="🤘🏼">finger | hand | horns | medium-light skin tone | rock-on | sign</annotation>
+		<annotation cp="🤘🏼" type="tts">sign of the horns: medium-light skin tone</annotation>
+		<annotation cp="🤘🏽">finger | hand | horns | medium skin tone | rock-on | sign</annotation>
+		<annotation cp="🤘🏽" type="tts">sign of the horns: medium skin tone</annotation>
+		<annotation cp="🤘🏾">finger | hand | horns | medium-dark skin tone | rock-on | sign</annotation>
+		<annotation cp="🤘🏾" type="tts">sign of the horns: medium-dark skin tone</annotation>
+		<annotation cp="🤘🏿">dark skin tone | finger | hand | horns | rock-on | sign</annotation>
+		<annotation cp="🤘🏿" type="tts">sign of the horns: dark skin tone</annotation>
+		<annotation cp="🤙🏻">call | hand | hang | light skin tone | loose | me | Shaka</annotation>
+		<annotation cp="🤙🏻" type="tts">call me hand: light skin tone</annotation>
+		<annotation cp="🤙🏼">call | hand | hang | loose | me | medium-light skin tone | Shaka</annotation>
+		<annotation cp="🤙🏼" type="tts">call me hand: medium-light skin tone</annotation>
+		<annotation cp="🤙🏽">call | hand | hang | loose | me | medium skin tone | Shaka</annotation>
+		<annotation cp="🤙🏽" type="tts">call me hand: medium skin tone</annotation>
+		<annotation cp="🤙🏾">call | hand | hang | loose | me | medium-dark skin tone | Shaka</annotation>
+		<annotation cp="🤙🏾" type="tts">call me hand: medium-dark skin tone</annotation>
+		<annotation cp="🤙🏿">call | dark skin tone | hand | hang | loose | me | Shaka</annotation>
+		<annotation cp="🤙🏿" type="tts">call me hand: dark skin tone</annotation>
+		<annotation cp="👈🏻">backhand | finger | hand | index | left | light skin tone | point | pointing</annotation>
+		<annotation cp="👈🏻" type="tts">backhand index pointing left: light skin tone</annotation>
+		<annotation cp="👈🏼">backhand | finger | hand | index | left | medium-light skin tone | point | pointing</annotation>
+		<annotation cp="👈🏼" type="tts">backhand index pointing left: medium-light skin tone</annotation>
+		<annotation cp="👈🏽">backhand | finger | hand | index | left | medium skin tone | point | pointing</annotation>
+		<annotation cp="👈🏽" type="tts">backhand index pointing left: medium skin tone</annotation>
+		<annotation cp="👈🏾">backhand | finger | hand | index | left | medium-dark skin tone | point | pointing</annotation>
+		<annotation cp="👈🏾" type="tts">backhand index pointing left: medium-dark skin tone</annotation>
+		<annotation cp="👈🏿">backhand | dark skin tone | finger | hand | index | left | point | pointing</annotation>
+		<annotation cp="👈🏿" type="tts">backhand index pointing left: dark skin tone</annotation>
+		<annotation cp="👉🏻">backhand | finger | hand | index | light skin tone | point | pointing | right</annotation>
+		<annotation cp="👉🏻" type="tts">backhand index pointing right: light skin tone</annotation>
+		<annotation cp="👉🏼">backhand | finger | hand | index | medium-light skin tone | point | pointing | right</annotation>
+		<annotation cp="👉🏼" type="tts">backhand index pointing right: medium-light skin tone</annotation>
+		<annotation cp="👉🏽">backhand | finger | hand | index | medium skin tone | point | pointing | right</annotation>
+		<annotation cp="👉🏽" type="tts">backhand index pointing right: medium skin tone</annotation>
+		<annotation cp="👉🏾">backhand | finger | hand | index | medium-dark skin tone | point | pointing | right</annotation>
+		<annotation cp="👉🏾" type="tts">backhand index pointing right: medium-dark skin tone</annotation>
+		<annotation cp="👉🏿">backhand | dark skin tone | finger | hand | index | point | pointing | right</annotation>
+		<annotation cp="👉🏿" type="tts">backhand index pointing right: dark skin tone</annotation>
+		<annotation cp="👆🏻">backhand | finger | hand | index | light skin tone | point | pointing | up</annotation>
+		<annotation cp="👆🏻" type="tts">backhand index pointing up: light skin tone</annotation>
+		<annotation cp="👆🏼">backhand | finger | hand | index | medium-light skin tone | point | pointing | up</annotation>
+		<annotation cp="👆🏼" type="tts">backhand index pointing up: medium-light skin tone</annotation>
+		<annotation cp="👆🏽">backhand | finger | hand | index | medium skin tone | point | pointing | up</annotation>
+		<annotation cp="👆🏽" type="tts">backhand index pointing up: medium skin tone</annotation>
+		<annotation cp="👆🏾">backhand | finger | hand | index | medium-dark skin tone | point | pointing | up</annotation>
+		<annotation cp="👆🏾" type="tts">backhand index pointing up: medium-dark skin tone</annotation>
+		<annotation cp="👆🏿">backhand | dark skin tone | finger | hand | index | point | pointing | up</annotation>
+		<annotation cp="👆🏿" type="tts">backhand index pointing up: dark skin tone</annotation>
+		<annotation cp="🖕🏻">finger | hand | light skin tone | middle</annotation>
+		<annotation cp="🖕🏻" type="tts">middle finger: light skin tone</annotation>
+		<annotation cp="🖕🏼">finger | hand | medium-light skin tone | middle</annotation>
+		<annotation cp="🖕🏼" type="tts">middle finger: medium-light skin tone</annotation>
+		<annotation cp="🖕🏽">finger | hand | medium skin tone | middle</annotation>
+		<annotation cp="🖕🏽" type="tts">middle finger: medium skin tone</annotation>
+		<annotation cp="🖕🏾">finger | hand | medium-dark skin tone | middle</annotation>
+		<annotation cp="🖕🏾" type="tts">middle finger: medium-dark skin tone</annotation>
+		<annotation cp="🖕🏿">dark skin tone | finger | hand | middle</annotation>
+		<annotation cp="🖕🏿" type="tts">middle finger: dark skin tone</annotation>
+		<annotation cp="👇🏻">backhand | down | finger | hand | index | light skin tone | point | pointing</annotation>
+		<annotation cp="👇🏻" type="tts">backhand index pointing down: light skin tone</annotation>
+		<annotation cp="👇🏼">backhand | down | finger | hand | index | medium-light skin tone | point | pointing</annotation>
+		<annotation cp="👇🏼" type="tts">backhand index pointing down: medium-light skin tone</annotation>
+		<annotation cp="👇🏽">backhand | down | finger | hand | index | medium skin tone | point | pointing</annotation>
+		<annotation cp="👇🏽" type="tts">backhand index pointing down: medium skin tone</annotation>
+		<annotation cp="👇🏾">backhand | down | finger | hand | index | medium-dark skin tone | point | pointing</annotation>
+		<annotation cp="👇🏾" type="tts">backhand index pointing down: medium-dark skin tone</annotation>
+		<annotation cp="👇🏿">backhand | dark skin tone | down | finger | hand | index | point | pointing</annotation>
+		<annotation cp="👇🏿" type="tts">backhand index pointing down: dark skin tone</annotation>
+		<annotation cp="☝🏻">finger | hand | index | light skin tone | point | pointing | this | up</annotation>
+		<annotation cp="☝🏻" type="tts">index pointing up: light skin tone</annotation>
+		<annotation cp="☝🏼">finger | hand | index | medium-light skin tone | point | pointing | this | up</annotation>
+		<annotation cp="☝🏼" type="tts">index pointing up: medium-light skin tone</annotation>
+		<annotation cp="☝🏽">finger | hand | index | medium skin tone | point | pointing | this | up</annotation>
+		<annotation cp="☝🏽" type="tts">index pointing up: medium skin tone</annotation>
+		<annotation cp="☝🏾">finger | hand | index | medium-dark skin tone | point | pointing | this | up</annotation>
+		<annotation cp="☝🏾" type="tts">index pointing up: medium-dark skin tone</annotation>
+		<annotation cp="☝🏿">dark skin tone | finger | hand | index | point | pointing | this | up</annotation>
+		<annotation cp="☝🏿" type="tts">index pointing up: dark skin tone</annotation>
+		<annotation cp="🫵🏻">at | finger | hand | index | light skin tone | pointing | poke | viewer | you</annotation>
+		<annotation cp="🫵🏻" type="tts">index pointing at the viewer: light skin tone</annotation>
+		<annotation cp="🫵🏼">at | finger | hand | index | medium-light skin tone | pointing | poke | viewer | you</annotation>
+		<annotation cp="🫵🏼" type="tts">index pointing at the viewer: medium-light skin tone</annotation>
+		<annotation cp="🫵🏽">at | finger | hand | index | medium skin tone | pointing | poke | viewer | you</annotation>
+		<annotation cp="🫵🏽" type="tts">index pointing at the viewer: medium skin tone</annotation>
+		<annotation cp="🫵🏾">at | finger | hand | index | medium-dark skin tone | pointing | poke | viewer | you</annotation>
+		<annotation cp="🫵🏾" type="tts">index pointing at the viewer: medium-dark skin tone</annotation>
+		<annotation cp="🫵🏿">at | dark skin tone | finger | hand | index | pointing | poke | viewer | you</annotation>
+		<annotation cp="🫵🏿" type="tts">index pointing at the viewer: dark skin tone</annotation>
+		<annotation cp="👍🏻">+1 | good | hand | light skin tone | like | thumb | up | yes</annotation>
+		<annotation cp="👍🏻" type="tts">thumbs up: light skin tone</annotation>
+		<annotation cp="👍🏼">+1 | good | hand | like | medium-light skin tone | thumb | up | yes</annotation>
+		<annotation cp="👍🏼" type="tts">thumbs up: medium-light skin tone</annotation>
+		<annotation cp="👍🏽">+1 | good | hand | like | medium skin tone | thumb | up | yes</annotation>
+		<annotation cp="👍🏽" type="tts">thumbs up: medium skin tone</annotation>
+		<annotation cp="👍🏾">+1 | good | hand | like | medium-dark skin tone | thumb | up | yes</annotation>
+		<annotation cp="👍🏾" type="tts">thumbs up: medium-dark skin tone</annotation>
+		<annotation cp="👍🏿">+1 | dark skin tone | good | hand | like | thumb | up | yes</annotation>
+		<annotation cp="👍🏿" type="tts">thumbs up: dark skin tone</annotation>
+		<annotation cp="👎🏻">-1 | bad | dislike | down | good | hand | light skin tone | no | nope | thumb | thumbs</annotation>
+		<annotation cp="👎🏻" type="tts">thumbs down: light skin tone</annotation>
+		<annotation cp="👎🏼">-1 | bad | dislike | down | good | hand | medium-light skin tone | no | nope | thumb | thumbs</annotation>
+		<annotation cp="👎🏼" type="tts">thumbs down: medium-light skin tone</annotation>
+		<annotation cp="👎🏽">-1 | bad | dislike | down | good | hand | medium skin tone | no | nope | thumb | thumbs</annotation>
+		<annotation cp="👎🏽" type="tts">thumbs down: medium skin tone</annotation>
+		<annotation cp="👎🏾">-1 | bad | dislike | down | good | hand | medium-dark skin tone | no | nope | thumb | thumbs</annotation>
+		<annotation cp="👎🏾" type="tts">thumbs down: medium-dark skin tone</annotation>
+		<annotation cp="👎🏿">-1 | bad | dark skin tone | dislike | down | good | hand | no | nope | thumb | thumbs</annotation>
+		<annotation cp="👎🏿" type="tts">thumbs down: dark skin tone</annotation>
+		<annotation cp="✊🏻">clenched | fist | hand | light skin tone | punch | raised | solidarity</annotation>
+		<annotation cp="✊🏻" type="tts">raised fist: light skin tone</annotation>
+		<annotation cp="✊🏼">clenched | fist | hand | medium-light skin tone | punch | raised | solidarity</annotation>
+		<annotation cp="✊🏼" type="tts">raised fist: medium-light skin tone</annotation>
+		<annotation cp="✊🏽">clenched | fist | hand | medium skin tone | punch | raised | solidarity</annotation>
+		<annotation cp="✊🏽" type="tts">raised fist: medium skin tone</annotation>
+		<annotation cp="✊🏾">clenched | fist | hand | medium-dark skin tone | punch | raised | solidarity</annotation>
+		<annotation cp="✊🏾" type="tts">raised fist: medium-dark skin tone</annotation>
+		<annotation cp="✊🏿">clenched | dark skin tone | fist | hand | punch | raised | solidarity</annotation>
+		<annotation cp="✊🏿" type="tts">raised fist: dark skin tone</annotation>
+		<annotation cp="👊🏻">absolutely | agree | boom | bro | bruh | bump | clenched | correct | fist | hand | knuckle | light skin tone | oncoming | pound | punch | rock | ttyl</annotation>
+		<annotation cp="👊🏻" type="tts">oncoming fist: light skin tone</annotation>
+		<annotation cp="👊🏼">absolutely | agree | boom | bro | bruh | bump | clenched | correct | fist | hand | knuckle | medium-light skin tone | oncoming | pound | punch | rock | ttyl</annotation>
+		<annotation cp="👊🏼" type="tts">oncoming fist: medium-light skin tone</annotation>
+		<annotation cp="👊🏽">absolutely | agree | boom | bro | bruh | bump | clenched | correct | fist | hand | knuckle | medium skin tone | oncoming | pound | punch | rock | ttyl</annotation>
+		<annotation cp="👊🏽" type="tts">oncoming fist: medium skin tone</annotation>
+		<annotation cp="👊🏾">absolutely | agree | boom | bro | bruh | bump | clenched | correct | fist | hand | knuckle | medium-dark skin tone | oncoming | pound | punch | rock | ttyl</annotation>
+		<annotation cp="👊🏾" type="tts">oncoming fist: medium-dark skin tone</annotation>
+		<annotation cp="👊🏿">absolutely | agree | boom | bro | bruh | bump | clenched | correct | dark skin tone | fist | hand | knuckle | oncoming | pound | punch | rock | ttyl</annotation>
+		<annotation cp="👊🏿" type="tts">oncoming fist: dark skin tone</annotation>
+		<annotation cp="🤛🏻">fist | left-facing | leftwards | light skin tone</annotation>
+		<annotation cp="🤛🏻" type="tts">left-facing fist: light skin tone</annotation>
+		<annotation cp="🤛🏼">fist | left-facing | leftwards | medium-light skin tone</annotation>
+		<annotation cp="🤛🏼" type="tts">left-facing fist: medium-light skin tone</annotation>
+		<annotation cp="🤛🏽">fist | left-facing | leftwards | medium skin tone</annotation>
+		<annotation cp="🤛🏽" type="tts">left-facing fist: medium skin tone</annotation>
+		<annotation cp="🤛🏾">fist | left-facing | leftwards | medium-dark skin tone</annotation>
+		<annotation cp="🤛🏾" type="tts">left-facing fist: medium-dark skin tone</annotation>
+		<annotation cp="🤛🏿">dark skin tone | fist | left-facing | leftwards</annotation>
+		<annotation cp="🤛🏿" type="tts">left-facing fist: dark skin tone</annotation>
+		<annotation cp="🤜🏻">fist | light skin tone | right-facing | rightwards</annotation>
+		<annotation cp="🤜🏻" type="tts">right-facing fist: light skin tone</annotation>
+		<annotation cp="🤜🏼">fist | medium-light skin tone | right-facing | rightwards</annotation>
+		<annotation cp="🤜🏼" type="tts">right-facing fist: medium-light skin tone</annotation>
+		<annotation cp="🤜🏽">fist | medium skin tone | right-facing | rightwards</annotation>
+		<annotation cp="🤜🏽" type="tts">right-facing fist: medium skin tone</annotation>
+		<annotation cp="🤜🏾">fist | medium-dark skin tone | right-facing | rightwards</annotation>
+		<annotation cp="🤜🏾" type="tts">right-facing fist: medium-dark skin tone</annotation>
+		<annotation cp="🤜🏿">dark skin tone | fist | right-facing | rightwards</annotation>
+		<annotation cp="🤜🏿" type="tts">right-facing fist: dark skin tone</annotation>
+		<annotation cp="👏🏻">applause | approval | awesome | clap | congrats | congratulations | excited | good | great | hand | homie | job | light skin tone | nice | prayed | well | yay</annotation>
+		<annotation cp="👏🏻" type="tts">clapping hands: light skin tone</annotation>
+		<annotation cp="👏🏼">applause | approval | awesome | clap | congrats | congratulations | excited | good | great | hand | homie | job | medium-light skin tone | nice | prayed | well | yay</annotation>
+		<annotation cp="👏🏼" type="tts">clapping hands: medium-light skin tone</annotation>
+		<annotation cp="👏🏽">applause | approval | awesome | clap | congrats | congratulations | excited | good | great | hand | homie | job | medium skin tone | nice | prayed | well | yay</annotation>
+		<annotation cp="👏🏽" type="tts">clapping hands: medium skin tone</annotation>
+		<annotation cp="👏🏾">applause | approval | awesome | clap | congrats | congratulations | excited | good | great | hand | homie | job | medium-dark skin tone | nice | prayed | well | yay</annotation>
+		<annotation cp="👏🏾" type="tts">clapping hands: medium-dark skin tone</annotation>
+		<annotation cp="👏🏿">applause | approval | awesome | clap | congrats | congratulations | dark skin tone | excited | good | great | hand | homie | job | nice | prayed | well | yay</annotation>
+		<annotation cp="👏🏿" type="tts">clapping hands: dark skin tone</annotation>
+		<annotation cp="🙌🏻">celebration | gesture | hand | hands | hooray | light skin tone | praise | raised | raising</annotation>
+		<annotation cp="🙌🏻" type="tts">raising hands: light skin tone</annotation>
+		<annotation cp="🙌🏼">celebration | gesture | hand | hands | hooray | medium-light skin tone | praise | raised | raising</annotation>
+		<annotation cp="🙌🏼" type="tts">raising hands: medium-light skin tone</annotation>
+		<annotation cp="🙌🏽">celebration | gesture | hand | hands | hooray | medium skin tone | praise | raised | raising</annotation>
+		<annotation cp="🙌🏽" type="tts">raising hands: medium skin tone</annotation>
+		<annotation cp="🙌🏾">celebration | gesture | hand | hands | hooray | medium-dark skin tone | praise | raised | raising</annotation>
+		<annotation cp="🙌🏾" type="tts">raising hands: medium-dark skin tone</annotation>
+		<annotation cp="🙌🏿">celebration | dark skin tone | gesture | hand | hands | hooray | praise | raised | raising</annotation>
+		<annotation cp="🙌🏿" type="tts">raising hands: dark skin tone</annotation>
+		<annotation cp="🫶🏻">&lt;3 | hands | heart | light skin tone | love | you</annotation>
+		<annotation cp="🫶🏻" type="tts">heart hands: light skin tone</annotation>
+		<annotation cp="🫶🏼">&lt;3 | hands | heart | love | medium-light skin tone | you</annotation>
+		<annotation cp="🫶🏼" type="tts">heart hands: medium-light skin tone</annotation>
+		<annotation cp="🫶🏽">&lt;3 | hands | heart | love | medium skin tone | you</annotation>
+		<annotation cp="🫶🏽" type="tts">heart hands: medium skin tone</annotation>
+		<annotation cp="🫶🏾">&lt;3 | hands | heart | love | medium-dark skin tone | you</annotation>
+		<annotation cp="🫶🏾" type="tts">heart hands: medium-dark skin tone</annotation>
+		<annotation cp="🫶🏿">&lt;3 | dark skin tone | hands | heart | love | you</annotation>
+		<annotation cp="🫶🏿" type="tts">heart hands: dark skin tone</annotation>
+		<annotation cp="👐🏻">hand | hands | hug | jazz | light skin tone | open | swerve</annotation>
+		<annotation cp="👐🏻" type="tts">open hands: light skin tone</annotation>
+		<annotation cp="👐🏼">hand | hands | hug | jazz | medium-light skin tone | open | swerve</annotation>
+		<annotation cp="👐🏼" type="tts">open hands: medium-light skin tone</annotation>
+		<annotation cp="👐🏽">hand | hands | hug | jazz | medium skin tone | open | swerve</annotation>
+		<annotation cp="👐🏽" type="tts">open hands: medium skin tone</annotation>
+		<annotation cp="👐🏾">hand | hands | hug | jazz | medium-dark skin tone | open | swerve</annotation>
+		<annotation cp="👐🏾" type="tts">open hands: medium-dark skin tone</annotation>
+		<annotation cp="👐🏿">dark skin tone | hand | hands | hug | jazz | open | swerve</annotation>
+		<annotation cp="👐🏿" type="tts">open hands: dark skin tone</annotation>
+		<annotation cp="🤲🏻">cupped | dua | hands | light skin tone | palms | pray | prayer | together | up | wish</annotation>
+		<annotation cp="🤲🏻" type="tts">palms up together: light skin tone</annotation>
+		<annotation cp="🤲🏼">cupped | dua | hands | medium-light skin tone | palms | pray | prayer | together | up | wish</annotation>
+		<annotation cp="🤲🏼" type="tts">palms up together: medium-light skin tone</annotation>
+		<annotation cp="🤲🏽">cupped | dua | hands | medium skin tone | palms | pray | prayer | together | up | wish</annotation>
+		<annotation cp="🤲🏽" type="tts">palms up together: medium skin tone</annotation>
+		<annotation cp="🤲🏾">cupped | dua | hands | medium-dark skin tone | palms | pray | prayer | together | up | wish</annotation>
+		<annotation cp="🤲🏾" type="tts">palms up together: medium-dark skin tone</annotation>
+		<annotation cp="🤲🏿">cupped | dark skin tone | dua | hands | palms | pray | prayer | together | up | wish</annotation>
+		<annotation cp="🤲🏿" type="tts">palms up together: dark skin tone</annotation>
+		<annotation cp="🤝🏻">agreement | deal | hand | handshake | light skin tone | meeting | shake</annotation>
+		<annotation cp="🤝🏻" type="tts">handshake: light skin tone</annotation>
+		<annotation cp="🤝🏼">agreement | deal | hand | handshake | medium-light skin tone | meeting | shake</annotation>
+		<annotation cp="🤝🏼" type="tts">handshake: medium-light skin tone</annotation>
+		<annotation cp="🤝🏽">agreement | deal | hand | handshake | medium skin tone | meeting | shake</annotation>
+		<annotation cp="🤝🏽" type="tts">handshake: medium skin tone</annotation>
+		<annotation cp="🤝🏾">agreement | deal | hand | handshake | medium-dark skin tone | meeting | shake</annotation>
+		<annotation cp="🤝🏾" type="tts">handshake: medium-dark skin tone</annotation>
+		<annotation cp="🤝🏿">agreement | dark skin tone | deal | hand | handshake | meeting | shake</annotation>
+		<annotation cp="🤝🏿" type="tts">handshake: dark skin tone</annotation>
+		<annotation cp="🙏🏻">appreciate | ask | beg | blessed | bow | cmon | five | folded | gesture | hand | high | light skin tone | please | pray | thanks | thx</annotation>
+		<annotation cp="🙏🏻" type="tts">folded hands: light skin tone</annotation>
+		<annotation cp="🙏🏼">appreciate | ask | beg | blessed | bow | cmon | five | folded | gesture | hand | high | medium-light skin tone | please | pray | thanks | thx</annotation>
+		<annotation cp="🙏🏼" type="tts">folded hands: medium-light skin tone</annotation>
+		<annotation cp="🙏🏽">appreciate | ask | beg | blessed | bow | cmon | five | folded | gesture | hand | high | medium skin tone | please | pray | thanks | thx</annotation>
+		<annotation cp="🙏🏽" type="tts">folded hands: medium skin tone</annotation>
+		<annotation cp="🙏🏾">appreciate | ask | beg | blessed | bow | cmon | five | folded | gesture | hand | high | medium-dark skin tone | please | pray | thanks | thx</annotation>
+		<annotation cp="🙏🏾" type="tts">folded hands: medium-dark skin tone</annotation>
+		<annotation cp="🙏🏿">appreciate | ask | beg | blessed | bow | cmon | dark skin tone | five | folded | gesture | hand | high | please | pray | thanks | thx</annotation>
+		<annotation cp="🙏🏿" type="tts">folded hands: dark skin tone</annotation>
+		<annotation cp="✍🏻">hand | light skin tone | write | writing</annotation>
+		<annotation cp="✍🏻" type="tts">writing hand: light skin tone</annotation>
+		<annotation cp="✍🏼">hand | medium-light skin tone | write | writing</annotation>
+		<annotation cp="✍🏼" type="tts">writing hand: medium-light skin tone</annotation>
+		<annotation cp="✍🏽">hand | medium skin tone | write | writing</annotation>
+		<annotation cp="✍🏽" type="tts">writing hand: medium skin tone</annotation>
+		<annotation cp="✍🏾">hand | medium-dark skin tone | write | writing</annotation>
+		<annotation cp="✍🏾" type="tts">writing hand: medium-dark skin tone</annotation>
+		<annotation cp="✍🏿">dark skin tone | hand | write | writing</annotation>
+		<annotation cp="✍🏿" type="tts">writing hand: dark skin tone</annotation>
+		<annotation cp="💅🏻">bored | care | cosmetics | done | light skin tone | makeup | manicure | nail | polish | whatever</annotation>
+		<annotation cp="💅🏻" type="tts">nail polish: light skin tone</annotation>
+		<annotation cp="💅🏼">bored | care | cosmetics | done | makeup | manicure | medium-light skin tone | nail | polish | whatever</annotation>
+		<annotation cp="💅🏼" type="tts">nail polish: medium-light skin tone</annotation>
+		<annotation cp="💅🏽">bored | care | cosmetics | done | makeup | manicure | medium skin tone | nail | polish | whatever</annotation>
+		<annotation cp="💅🏽" type="tts">nail polish: medium skin tone</annotation>
+		<annotation cp="💅🏾">bored | care | cosmetics | done | makeup | manicure | medium-dark skin tone | nail | polish | whatever</annotation>
+		<annotation cp="💅🏾" type="tts">nail polish: medium-dark skin tone</annotation>
+		<annotation cp="💅🏿">bored | care | cosmetics | dark skin tone | done | makeup | manicure | nail | polish | whatever</annotation>
+		<annotation cp="💅🏿" type="tts">nail polish: dark skin tone</annotation>
+		<annotation cp="🤳🏻">camera | light skin tone | phone | selfie</annotation>
+		<annotation cp="🤳🏻" type="tts">selfie: light skin tone</annotation>
+		<annotation cp="🤳🏼">camera | medium-light skin tone | phone | selfie</annotation>
+		<annotation cp="🤳🏼" type="tts">selfie: medium-light skin tone</annotation>
+		<annotation cp="🤳🏽">camera | medium skin tone | phone | selfie</annotation>
+		<annotation cp="🤳🏽" type="tts">selfie: medium skin tone</annotation>
+		<annotation cp="🤳🏾">camera | medium-dark skin tone | phone | selfie</annotation>
+		<annotation cp="🤳🏾" type="tts">selfie: medium-dark skin tone</annotation>
+		<annotation cp="🤳🏿">camera | dark skin tone | phone | selfie</annotation>
+		<annotation cp="🤳🏿" type="tts">selfie: dark skin tone</annotation>
+		<annotation cp="💪🏻">arm | beast | bench | biceps | bodybuilder | bro | curls | flex | gains | gym | jacked | light skin tone | muscle | press | ripped | strong | weightlift</annotation>
+		<annotation cp="💪🏻" type="tts">flexed biceps: light skin tone</annotation>
+		<annotation cp="💪🏼">arm | beast | bench | biceps | bodybuilder | bro | curls | flex | gains | gym | jacked | medium-light skin tone | muscle | press | ripped | strong | weightlift</annotation>
+		<annotation cp="💪🏼" type="tts">flexed biceps: medium-light skin tone</annotation>
+		<annotation cp="💪🏽">arm | beast | bench | biceps | bodybuilder | bro | curls | flex | gains | gym | jacked | medium skin tone | muscle | press | ripped | strong | weightlift</annotation>
+		<annotation cp="💪🏽" type="tts">flexed biceps: medium skin tone</annotation>
+		<annotation cp="💪🏾">arm | beast | bench | biceps | bodybuilder | bro | curls | flex | gains | gym | jacked | medium-dark skin tone | muscle | press | ripped | strong | weightlift</annotation>
+		<annotation cp="💪🏾" type="tts">flexed biceps: medium-dark skin tone</annotation>
+		<annotation cp="💪🏿">arm | beast | bench | biceps | bodybuilder | bro | curls | dark skin tone | flex | gains | gym | jacked | muscle | press | ripped | strong | weightlift</annotation>
+		<annotation cp="💪🏿" type="tts">flexed biceps: dark skin tone</annotation>
+		<annotation cp="🦵🏻">bent | foot | kick | knee | leg | light skin tone | limb</annotation>
+		<annotation cp="🦵🏻" type="tts">leg: light skin tone</annotation>
+		<annotation cp="🦵🏼">bent | foot | kick | knee | leg | limb | medium-light skin tone</annotation>
+		<annotation cp="🦵🏼" type="tts">leg: medium-light skin tone</annotation>
+		<annotation cp="🦵🏽">bent | foot | kick | knee | leg | limb | medium skin tone</annotation>
+		<annotation cp="🦵🏽" type="tts">leg: medium skin tone</annotation>
+		<annotation cp="🦵🏾">bent | foot | kick | knee | leg | limb | medium-dark skin tone</annotation>
+		<annotation cp="🦵🏾" type="tts">leg: medium-dark skin tone</annotation>
+		<annotation cp="🦵🏿">bent | dark skin tone | foot | kick | knee | leg | limb</annotation>
+		<annotation cp="🦵🏿" type="tts">leg: dark skin tone</annotation>
+		<annotation cp="🦶🏻">ankle | feet | foot | kick | light skin tone | stomp</annotation>
+		<annotation cp="🦶🏻" type="tts">foot: light skin tone</annotation>
+		<annotation cp="🦶🏼">ankle | feet | foot | kick | medium-light skin tone | stomp</annotation>
+		<annotation cp="🦶🏼" type="tts">foot: medium-light skin tone</annotation>
+		<annotation cp="🦶🏽">ankle | feet | foot | kick | medium skin tone | stomp</annotation>
+		<annotation cp="🦶🏽" type="tts">foot: medium skin tone</annotation>
+		<annotation cp="🦶🏾">ankle | feet | foot | kick | medium-dark skin tone | stomp</annotation>
+		<annotation cp="🦶🏾" type="tts">foot: medium-dark skin tone</annotation>
+		<annotation cp="🦶🏿">ankle | dark skin tone | feet | foot | kick | stomp</annotation>
+		<annotation cp="🦶🏿" type="tts">foot: dark skin tone</annotation>
+		<annotation cp="👂🏻">body | ear | ears | hear | hearing | light skin tone | listen | listening | sound</annotation>
+		<annotation cp="👂🏻" type="tts">ear: light skin tone</annotation>
+		<annotation cp="👂🏼">body | ear | ears | hear | hearing | listen | listening | medium-light skin tone | sound</annotation>
+		<annotation cp="👂🏼" type="tts">ear: medium-light skin tone</annotation>
+		<annotation cp="👂🏽">body | ear | ears | hear | hearing | listen | listening | medium skin tone | sound</annotation>
+		<annotation cp="👂🏽" type="tts">ear: medium skin tone</annotation>
+		<annotation cp="👂🏾">body | ear | ears | hear | hearing | listen | listening | medium-dark skin tone | sound</annotation>
+		<annotation cp="👂🏾" type="tts">ear: medium-dark skin tone</annotation>
+		<annotation cp="👂🏿">body | dark skin tone | ear | ears | hear | hearing | listen | listening | sound</annotation>
+		<annotation cp="👂🏿" type="tts">ear: dark skin tone</annotation>
+		<annotation cp="🦻🏻">accessibility | aid | ear | hard | hearing | light skin tone</annotation>
+		<annotation cp="🦻🏻" type="tts">ear with hearing aid: light skin tone</annotation>
+		<annotation cp="🦻🏼">accessibility | aid | ear | hard | hearing | medium-light skin tone</annotation>
+		<annotation cp="🦻🏼" type="tts">ear with hearing aid: medium-light skin tone</annotation>
+		<annotation cp="🦻🏽">accessibility | aid | ear | hard | hearing | medium skin tone</annotation>
+		<annotation cp="🦻🏽" type="tts">ear with hearing aid: medium skin tone</annotation>
+		<annotation cp="🦻🏾">accessibility | aid | ear | hard | hearing | medium-dark skin tone</annotation>
+		<annotation cp="🦻🏾" type="tts">ear with hearing aid: medium-dark skin tone</annotation>
+		<annotation cp="🦻🏿">accessibility | aid | dark skin tone | ear | hard | hearing</annotation>
+		<annotation cp="🦻🏿" type="tts">ear with hearing aid: dark skin tone</annotation>
+		<annotation cp="👃🏻">body | light skin tone | nose | noses | nosey | odor | smell | smells</annotation>
+		<annotation cp="👃🏻" type="tts">nose: light skin tone</annotation>
+		<annotation cp="👃🏼">body | medium-light skin tone | nose | noses | nosey | odor | smell | smells</annotation>
+		<annotation cp="👃🏼" type="tts">nose: medium-light skin tone</annotation>
+		<annotation cp="👃🏽">body | medium skin tone | nose | noses | nosey | odor | smell | smells</annotation>
+		<annotation cp="👃🏽" type="tts">nose: medium skin tone</annotation>
+		<annotation cp="👃🏾">body | medium-dark skin tone | nose | noses | nosey | odor | smell | smells</annotation>
+		<annotation cp="👃🏾" type="tts">nose: medium-dark skin tone</annotation>
+		<annotation cp="👃🏿">body | dark skin tone | nose | noses | nosey | odor | smell | smells</annotation>
+		<annotation cp="👃🏿" type="tts">nose: dark skin tone</annotation>
+		<annotation cp="👶🏻">babies | baby | children | goo | infant | light skin tone | newborn | pregnant | young</annotation>
+		<annotation cp="👶🏻" type="tts">baby: light skin tone</annotation>
+		<annotation cp="👶🏼">babies | baby | children | goo | infant | medium-light skin tone | newborn | pregnant | young</annotation>
+		<annotation cp="👶🏼" type="tts">baby: medium-light skin tone</annotation>
+		<annotation cp="👶🏽">babies | baby | children | goo | infant | medium skin tone | newborn | pregnant | young</annotation>
+		<annotation cp="👶🏽" type="tts">baby: medium skin tone</annotation>
+		<annotation cp="👶🏾">babies | baby | children | goo | infant | medium-dark skin tone | newborn | pregnant | young</annotation>
+		<annotation cp="👶🏾" type="tts">baby: medium-dark skin tone</annotation>
+		<annotation cp="👶🏿">babies | baby | children | dark skin tone | goo | infant | newborn | pregnant | young</annotation>
+		<annotation cp="👶🏿" type="tts">baby: dark skin tone</annotation>
+		<annotation cp="🧒🏻">bright-eyed | child | grandchild | kid | light skin tone | young | younger</annotation>
+		<annotation cp="🧒🏻" type="tts">child: light skin tone</annotation>
+		<annotation cp="🧒🏼">bright-eyed | child | grandchild | kid | medium-light skin tone | young | younger</annotation>
+		<annotation cp="🧒🏼" type="tts">child: medium-light skin tone</annotation>
+		<annotation cp="🧒🏽">bright-eyed | child | grandchild | kid | medium skin tone | young | younger</annotation>
+		<annotation cp="🧒🏽" type="tts">child: medium skin tone</annotation>
+		<annotation cp="🧒🏾">bright-eyed | child | grandchild | kid | medium-dark skin tone | young | younger</annotation>
+		<annotation cp="🧒🏾" type="tts">child: medium-dark skin tone</annotation>
+		<annotation cp="🧒🏿">bright-eyed | child | dark skin tone | grandchild | kid | young | younger</annotation>
+		<annotation cp="🧒🏿" type="tts">child: dark skin tone</annotation>
+		<annotation cp="👦🏻">boy | bright-eyed | child | grandson | kid | light skin tone | son | young | younger</annotation>
+		<annotation cp="👦🏻" type="tts">boy: light skin tone</annotation>
+		<annotation cp="👦🏼">boy | bright-eyed | child | grandson | kid | medium-light skin tone | son | young | younger</annotation>
+		<annotation cp="👦🏼" type="tts">boy: medium-light skin tone</annotation>
+		<annotation cp="👦🏽">boy | bright-eyed | child | grandson | kid | medium skin tone | son | young | younger</annotation>
+		<annotation cp="👦🏽" type="tts">boy: medium skin tone</annotation>
+		<annotation cp="👦🏾">boy | bright-eyed | child | grandson | kid | medium-dark skin tone | son | young | younger</annotation>
+		<annotation cp="👦🏾" type="tts">boy: medium-dark skin tone</annotation>
+		<annotation cp="👦🏿">boy | bright-eyed | child | dark skin tone | grandson | kid | son | young | younger</annotation>
+		<annotation cp="👦🏿" type="tts">boy: dark skin tone</annotation>
+		<annotation cp="👧🏻">bright-eyed | child | daughter | girl | granddaughter | kid | light skin tone | Virgo | young | younger | zodiac</annotation>
+		<annotation cp="👧🏻" type="tts">girl: light skin tone</annotation>
+		<annotation cp="👧🏼">bright-eyed | child | daughter | girl | granddaughter | kid | medium-light skin tone | Virgo | young | younger | zodiac</annotation>
+		<annotation cp="👧🏼" type="tts">girl: medium-light skin tone</annotation>
+		<annotation cp="👧🏽">bright-eyed | child | daughter | girl | granddaughter | kid | medium skin tone | Virgo | young | younger | zodiac</annotation>
+		<annotation cp="👧🏽" type="tts">girl: medium skin tone</annotation>
+		<annotation cp="👧🏾">bright-eyed | child | daughter | girl | granddaughter | kid | medium-dark skin tone | Virgo | young | younger | zodiac</annotation>
+		<annotation cp="👧🏾" type="tts">girl: medium-dark skin tone</annotation>
+		<annotation cp="👧🏿">bright-eyed | child | dark skin tone | daughter | girl | granddaughter | kid | Virgo | young | younger | zodiac</annotation>
+		<annotation cp="👧🏿" type="tts">girl: dark skin tone</annotation>
+		<annotation cp="🧑🏻">adult | light skin tone | person</annotation>
+		<annotation cp="🧑🏻" type="tts">person: light skin tone</annotation>
+		<annotation cp="🧑🏼">adult | medium-light skin tone | person</annotation>
+		<annotation cp="🧑🏼" type="tts">person: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽">adult | medium skin tone | person</annotation>
+		<annotation cp="🧑🏽" type="tts">person: medium skin tone</annotation>
+		<annotation cp="🧑🏾">adult | medium-dark skin tone | person</annotation>
+		<annotation cp="🧑🏾" type="tts">person: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿">adult | dark skin tone | person</annotation>
+		<annotation cp="🧑🏿" type="tts">person: dark skin tone</annotation>
+		<annotation cp="👱🏻">blond | blond hair | blond-haired | human | light skin tone | person</annotation>
+		<annotation cp="👱🏻" type="tts">person: light skin tone, blond hair</annotation>
+		<annotation cp="👱🏼">blond | blond hair | blond-haired | human | medium-light skin tone | person</annotation>
+		<annotation cp="👱🏼" type="tts">person: medium-light skin tone, blond hair</annotation>
+		<annotation cp="👱🏽">blond | blond hair | blond-haired | human | medium skin tone | person</annotation>
+		<annotation cp="👱🏽" type="tts">person: medium skin tone, blond hair</annotation>
+		<annotation cp="👱🏾">blond | blond hair | blond-haired | human | medium-dark skin tone | person</annotation>
+		<annotation cp="👱🏾" type="tts">person: medium-dark skin tone, blond hair</annotation>
+		<annotation cp="👱🏿">blond | blond hair | blond-haired | dark skin tone | human | person</annotation>
+		<annotation cp="👱🏿" type="tts">person: dark skin tone, blond hair</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏼" type="tts">kiss: person, person, light skin tone, medium-light skin tone</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | medium skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏽" type="tts">kiss: person, person, light skin tone, medium skin tone</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | medium-dark skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏾" type="tts">kiss: person, person, light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | light skin tone | love | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏿" type="tts">kiss: person, person, light skin tone, dark skin tone</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏻" type="tts">kiss: person, person, medium-light skin tone, light skin tone</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium skin tone | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏽" type="tts">kiss: person, person, medium-light skin tone, medium skin tone</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium-dark skin tone | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏾" type="tts">kiss: person, person, medium-light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏿" type="tts">kiss: person, person, medium-light skin tone, dark skin tone</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | medium skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏻" type="tts">kiss: person, person, medium skin tone, light skin tone</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium skin tone | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏼" type="tts">kiss: person, person, medium skin tone, medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium skin tone | medium-dark skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏾" type="tts">kiss: person, person, medium skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | medium skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏿" type="tts">kiss: person, person, medium skin tone, dark skin tone</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | medium-dark skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏻" type="tts">kiss: person, person, medium-dark skin tone, light skin tone</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium-dark skin tone | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏼" type="tts">kiss: person, person, medium-dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium skin tone | medium-dark skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏽" type="tts">kiss: person, person, medium-dark skin tone, medium skin tone</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | medium-dark skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏿" type="tts">kiss: person, person, medium-dark skin tone, dark skin tone</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏻">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | light skin tone | love | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏻" type="tts">kiss: person, person, dark skin tone, light skin tone</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏼">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏼" type="tts">kiss: person, person, dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏽">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | medium skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏽" type="tts">kiss: person, person, dark skin tone, medium skin tone</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏾">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | medium-dark skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏾" type="tts">kiss: person, person, dark skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏼">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏼" type="tts">couple with heart: person, person, light skin tone, medium-light skin tone</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏽">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | medium skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏽" type="tts">couple with heart: person, person, light skin tone, medium skin tone</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏾">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | medium-dark skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏾" type="tts">couple with heart: person, person, light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | light skin tone | love | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏿" type="tts">couple with heart: person, person, light skin tone, dark skin tone</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏻" type="tts">couple with heart: person, person, medium-light skin tone, light skin tone</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏽">anniversary | babe | bae | couple | dating | heart | kiss | love | medium skin tone | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏽" type="tts">couple with heart: person, person, medium-light skin tone, medium skin tone</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏾">anniversary | babe | bae | couple | dating | heart | kiss | love | medium-dark skin tone | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏾" type="tts">couple with heart: person, person, medium-light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏿" type="tts">couple with heart: person, person, medium-light skin tone, dark skin tone</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | medium skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏻" type="tts">couple with heart: person, person, medium skin tone, light skin tone</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏼">anniversary | babe | bae | couple | dating | heart | kiss | love | medium skin tone | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏼" type="tts">couple with heart: person, person, medium skin tone, medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏾">anniversary | babe | bae | couple | dating | heart | kiss | love | medium skin tone | medium-dark skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏾" type="tts">couple with heart: person, person, medium skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | medium skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏿" type="tts">couple with heart: person, person, medium skin tone, dark skin tone</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | medium-dark skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏻" type="tts">couple with heart: person, person, medium-dark skin tone, light skin tone</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏼">anniversary | babe | bae | couple | dating | heart | kiss | love | medium-dark skin tone | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏼" type="tts">couple with heart: person, person, medium-dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏽">anniversary | babe | bae | couple | dating | heart | kiss | love | medium skin tone | medium-dark skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏽" type="tts">couple with heart: person, person, medium-dark skin tone, medium skin tone</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | medium-dark skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏿" type="tts">couple with heart: person, person, medium-dark skin tone, dark skin tone</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏻">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | light skin tone | love | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏻" type="tts">couple with heart: person, person, dark skin tone, light skin tone</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏼">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏼" type="tts">couple with heart: person, person, dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏽">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | medium skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏽" type="tts">couple with heart: person, person, dark skin tone, medium skin tone</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏾">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | medium-dark skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏾" type="tts">couple with heart: person, person, dark skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🧑‍🦰">adult | person | red hair</annotation>
+		<annotation cp="🧑‍🦰" type="tts">person: red hair</annotation>
+		<annotation cp="🧑🏻‍🦰">adult | light skin tone | person | red hair</annotation>
+		<annotation cp="🧑🏻‍🦰" type="tts">person: light skin tone, red hair</annotation>
+		<annotation cp="🧑🏼‍🦰">adult | medium-light skin tone | person | red hair</annotation>
+		<annotation cp="🧑🏼‍🦰" type="tts">person: medium-light skin tone, red hair</annotation>
+		<annotation cp="🧑🏽‍🦰">adult | medium skin tone | person | red hair</annotation>
+		<annotation cp="🧑🏽‍🦰" type="tts">person: medium skin tone, red hair</annotation>
+		<annotation cp="🧑🏾‍🦰">adult | medium-dark skin tone | person | red hair</annotation>
+		<annotation cp="🧑🏾‍🦰" type="tts">person: medium-dark skin tone, red hair</annotation>
+		<annotation cp="🧑🏿‍🦰">adult | dark skin tone | person | red hair</annotation>
+		<annotation cp="🧑🏿‍🦰" type="tts">person: dark skin tone, red hair</annotation>
+		<annotation cp="🧑‍🦱">adult | curly hair | person</annotation>
+		<annotation cp="🧑‍🦱" type="tts">person: curly hair</annotation>
+		<annotation cp="🧑🏻‍🦱">adult | curly hair | light skin tone | person</annotation>
+		<annotation cp="🧑🏻‍🦱" type="tts">person: light skin tone, curly hair</annotation>
+		<annotation cp="🧑🏼‍🦱">adult | curly hair | medium-light skin tone | person</annotation>
+		<annotation cp="🧑🏼‍🦱" type="tts">person: medium-light skin tone, curly hair</annotation>
+		<annotation cp="🧑🏽‍🦱">adult | curly hair | medium skin tone | person</annotation>
+		<annotation cp="🧑🏽‍🦱" type="tts">person: medium skin tone, curly hair</annotation>
+		<annotation cp="🧑🏾‍🦱">adult | curly hair | medium-dark skin tone | person</annotation>
+		<annotation cp="🧑🏾‍🦱" type="tts">person: medium-dark skin tone, curly hair</annotation>
+		<annotation cp="🧑🏿‍🦱">adult | curly hair | dark skin tone | person</annotation>
+		<annotation cp="🧑🏿‍🦱" type="tts">person: dark skin tone, curly hair</annotation>
+		<annotation cp="🧑‍🦳">adult | person | white hair</annotation>
+		<annotation cp="🧑‍🦳" type="tts">person: white hair</annotation>
+		<annotation cp="🧑🏻‍🦳">adult | light skin tone | person | white hair</annotation>
+		<annotation cp="🧑🏻‍🦳" type="tts">person: light skin tone, white hair</annotation>
+		<annotation cp="🧑🏼‍🦳">adult | medium-light skin tone | person | white hair</annotation>
+		<annotation cp="🧑🏼‍🦳" type="tts">person: medium-light skin tone, white hair</annotation>
+		<annotation cp="🧑🏽‍🦳">adult | medium skin tone | person | white hair</annotation>
+		<annotation cp="🧑🏽‍🦳" type="tts">person: medium skin tone, white hair</annotation>
+		<annotation cp="🧑🏾‍🦳">adult | medium-dark skin tone | person | white hair</annotation>
+		<annotation cp="🧑🏾‍🦳" type="tts">person: medium-dark skin tone, white hair</annotation>
+		<annotation cp="🧑🏿‍🦳">adult | dark skin tone | person | white hair</annotation>
+		<annotation cp="🧑🏿‍🦳" type="tts">person: dark skin tone, white hair</annotation>
+		<annotation cp="🧑‍🦲">adult | bald | person</annotation>
+		<annotation cp="🧑‍🦲" type="tts">person: bald</annotation>
+		<annotation cp="🧑🏻‍🦲">adult | bald | light skin tone | person</annotation>
+		<annotation cp="🧑🏻‍🦲" type="tts">person: light skin tone, bald</annotation>
+		<annotation cp="🧑🏼‍🦲">adult | bald | medium-light skin tone | person</annotation>
+		<annotation cp="🧑🏼‍🦲" type="tts">person: medium-light skin tone, bald</annotation>
+		<annotation cp="🧑🏽‍🦲">adult | bald | medium skin tone | person</annotation>
+		<annotation cp="🧑🏽‍🦲" type="tts">person: medium skin tone, bald</annotation>
+		<annotation cp="🧑🏾‍🦲">adult | bald | medium-dark skin tone | person</annotation>
+		<annotation cp="🧑🏾‍🦲" type="tts">person: medium-dark skin tone, bald</annotation>
+		<annotation cp="🧑🏿‍🦲">adult | bald | dark skin tone | person</annotation>
+		<annotation cp="🧑🏿‍🦲" type="tts">person: dark skin tone, bald</annotation>
+		<annotation cp="👨🏻">adult | bro | light skin tone | man</annotation>
+		<annotation cp="👨🏻" type="tts">man: light skin tone</annotation>
+		<annotation cp="👨🏼">adult | bro | man | medium-light skin tone</annotation>
+		<annotation cp="👨🏼" type="tts">man: medium-light skin tone</annotation>
+		<annotation cp="👨🏽">adult | bro | man | medium skin tone</annotation>
+		<annotation cp="👨🏽" type="tts">man: medium skin tone</annotation>
+		<annotation cp="👨🏾">adult | bro | man | medium-dark skin tone</annotation>
+		<annotation cp="👨🏾" type="tts">man: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿">adult | bro | dark skin tone | man</annotation>
+		<annotation cp="👨🏿" type="tts">man: dark skin tone</annotation>
+		<annotation cp="🧔🏻">beard | bearded | light skin tone | person | whiskers</annotation>
+		<annotation cp="🧔🏻" type="tts">person: light skin tone, beard</annotation>
+		<annotation cp="🧔🏼">beard | bearded | medium-light skin tone | person | whiskers</annotation>
+		<annotation cp="🧔🏼" type="tts">person: medium-light skin tone, beard</annotation>
+		<annotation cp="🧔🏽">beard | bearded | medium skin tone | person | whiskers</annotation>
+		<annotation cp="🧔🏽" type="tts">person: medium skin tone, beard</annotation>
+		<annotation cp="🧔🏾">beard | bearded | medium-dark skin tone | person | whiskers</annotation>
+		<annotation cp="🧔🏾" type="tts">person: medium-dark skin tone, beard</annotation>
+		<annotation cp="🧔🏿">beard | bearded | dark skin tone | person | whiskers</annotation>
+		<annotation cp="🧔🏿" type="tts">person: dark skin tone, beard</annotation>
+		<annotation cp="🧔🏻‍♂">beard | bearded | light skin tone | man | whiskers</annotation>
+		<annotation cp="🧔🏻‍♂" type="tts">man: light skin tone, beard</annotation>
+		<annotation cp="🧔🏼‍♂">beard | bearded | man | medium-light skin tone | whiskers</annotation>
+		<annotation cp="🧔🏼‍♂" type="tts">man: medium-light skin tone, beard</annotation>
+		<annotation cp="🧔🏽‍♂">beard | bearded | man | medium skin tone | whiskers</annotation>
+		<annotation cp="🧔🏽‍♂" type="tts">man: medium skin tone, beard</annotation>
+		<annotation cp="🧔🏾‍♂">beard | bearded | man | medium-dark skin tone | whiskers</annotation>
+		<annotation cp="🧔🏾‍♂" type="tts">man: medium-dark skin tone, beard</annotation>
+		<annotation cp="🧔🏿‍♂">beard | bearded | dark skin tone | man | whiskers</annotation>
+		<annotation cp="🧔🏿‍♂" type="tts">man: dark skin tone, beard</annotation>
+		<annotation cp="👱🏻‍♂">blond | blond-haired | hair | light skin tone | man</annotation>
+		<annotation cp="👱🏻‍♂" type="tts">man: light skin tone, blond hair</annotation>
+		<annotation cp="👱🏼‍♂">blond | blond-haired | hair | man | medium-light skin tone</annotation>
+		<annotation cp="👱🏼‍♂" type="tts">man: medium-light skin tone, blond hair</annotation>
+		<annotation cp="👱🏽‍♂">blond | blond-haired | hair | man | medium skin tone</annotation>
+		<annotation cp="👱🏽‍♂" type="tts">man: medium skin tone, blond hair</annotation>
+		<annotation cp="👱🏾‍♂">blond | blond-haired | hair | man | medium-dark skin tone</annotation>
+		<annotation cp="👱🏾‍♂" type="tts">man: medium-dark skin tone, blond hair</annotation>
+		<annotation cp="👱🏿‍♂">blond | blond-haired | dark skin tone | hair | man</annotation>
+		<annotation cp="👱🏿‍♂" type="tts">man: dark skin tone, blond hair</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | man | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏻" type="tts">kiss: man, man, light skin tone</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | man | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏼" type="tts">kiss: man, man, light skin tone, medium-light skin tone</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | man | medium skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏽" type="tts">kiss: man, man, light skin tone, medium skin tone</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | man | medium-dark skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏾" type="tts">kiss: man, man, light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | light skin tone | love | man | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏿" type="tts">kiss: man, man, light skin tone, dark skin tone</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | man | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏻" type="tts">kiss: man, man, medium-light skin tone, light skin tone</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏼" type="tts">kiss: man, man, medium-light skin tone</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium skin tone | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏽" type="tts">kiss: man, man, medium-light skin tone, medium skin tone</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium-dark skin tone | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏾" type="tts">kiss: man, man, medium-light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | man | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏿" type="tts">kiss: man, man, medium-light skin tone, dark skin tone</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | man | medium skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏻" type="tts">kiss: man, man, medium skin tone, light skin tone</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium skin tone | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏼" type="tts">kiss: man, man, medium skin tone, medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏽" type="tts">kiss: man, man, medium skin tone</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium skin tone | medium-dark skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏾" type="tts">kiss: man, man, medium skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | man | medium skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏿" type="tts">kiss: man, man, medium skin tone, dark skin tone</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | man | medium-dark skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏻" type="tts">kiss: man, man, medium-dark skin tone, light skin tone</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium-dark skin tone | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏼" type="tts">kiss: man, man, medium-dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium skin tone | medium-dark skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏽" type="tts">kiss: man, man, medium-dark skin tone, medium skin tone</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium-dark skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏾" type="tts">kiss: man, man, medium-dark skin tone</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | man | medium-dark skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏿" type="tts">kiss: man, man, medium-dark skin tone, dark skin tone</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏻">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | light skin tone | love | man | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏻" type="tts">kiss: man, man, dark skin tone, light skin tone</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏼">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | man | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏼" type="tts">kiss: man, man, dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏽">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | man | medium skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏽" type="tts">kiss: man, man, dark skin tone, medium skin tone</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏾">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | man | medium-dark skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏾" type="tts">kiss: man, man, dark skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | man | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏿" type="tts">kiss: man, man, dark skin tone</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | man | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏻" type="tts">couple with heart: man, man, light skin tone</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏼">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | man | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏼" type="tts">couple with heart: man, man, light skin tone, medium-light skin tone</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏽">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | man | medium skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏽" type="tts">couple with heart: man, man, light skin tone, medium skin tone</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏾">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | man | medium-dark skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏾" type="tts">couple with heart: man, man, light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | light skin tone | love | man | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏿" type="tts">couple with heart: man, man, light skin tone, dark skin tone</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | man | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏻" type="tts">couple with heart: man, man, medium-light skin tone, light skin tone</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏼">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏼" type="tts">couple with heart: man, man, medium-light skin tone</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏽">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium skin tone | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏽" type="tts">couple with heart: man, man, medium-light skin tone, medium skin tone</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏾">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium-dark skin tone | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏾" type="tts">couple with heart: man, man, medium-light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | man | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏿" type="tts">couple with heart: man, man, medium-light skin tone, dark skin tone</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | man | medium skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏻" type="tts">couple with heart: man, man, medium skin tone, light skin tone</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏼">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium skin tone | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏼" type="tts">couple with heart: man, man, medium skin tone, medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏽">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏽" type="tts">couple with heart: man, man, medium skin tone</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏾">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium skin tone | medium-dark skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏾" type="tts">couple with heart: man, man, medium skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | man | medium skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏿" type="tts">couple with heart: man, man, medium skin tone, dark skin tone</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | man | medium-dark skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏻" type="tts">couple with heart: man, man, medium-dark skin tone, light skin tone</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏼">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium-dark skin tone | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏼" type="tts">couple with heart: man, man, medium-dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏽">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium skin tone | medium-dark skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏽" type="tts">couple with heart: man, man, medium-dark skin tone, medium skin tone</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏾">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium-dark skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏾" type="tts">couple with heart: man, man, medium-dark skin tone</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | man | medium-dark skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏿" type="tts">couple with heart: man, man, medium-dark skin tone, dark skin tone</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏻">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | light skin tone | love | man | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏻" type="tts">couple with heart: man, man, dark skin tone, light skin tone</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏼">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | man | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏼" type="tts">couple with heart: man, man, dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏽">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | man | medium skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏽" type="tts">couple with heart: man, man, dark skin tone, medium skin tone</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏾">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | man | medium-dark skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏾" type="tts">couple with heart: man, man, dark skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | man | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏿" type="tts">couple with heart: man, man, dark skin tone</annotation>
+		<annotation cp="👨‍🦰">adult | bro | man | red hair</annotation>
+		<annotation cp="👨‍🦰" type="tts">man: red hair</annotation>
+		<annotation cp="👨🏻‍🦰">adult | bro | light skin tone | man | red hair</annotation>
+		<annotation cp="👨🏻‍🦰" type="tts">man: light skin tone, red hair</annotation>
+		<annotation cp="👨🏼‍🦰">adult | bro | man | medium-light skin tone | red hair</annotation>
+		<annotation cp="👨🏼‍🦰" type="tts">man: medium-light skin tone, red hair</annotation>
+		<annotation cp="👨🏽‍🦰">adult | bro | man | medium skin tone | red hair</annotation>
+		<annotation cp="👨🏽‍🦰" type="tts">man: medium skin tone, red hair</annotation>
+		<annotation cp="👨🏾‍🦰">adult | bro | man | medium-dark skin tone | red hair</annotation>
+		<annotation cp="👨🏾‍🦰" type="tts">man: medium-dark skin tone, red hair</annotation>
+		<annotation cp="👨🏿‍🦰">adult | bro | dark skin tone | man | red hair</annotation>
+		<annotation cp="👨🏿‍🦰" type="tts">man: dark skin tone, red hair</annotation>
+		<annotation cp="👨‍🦱">adult | bro | curly hair | man</annotation>
+		<annotation cp="👨‍🦱" type="tts">man: curly hair</annotation>
+		<annotation cp="👨🏻‍🦱">adult | bro | curly hair | light skin tone | man</annotation>
+		<annotation cp="👨🏻‍🦱" type="tts">man: light skin tone, curly hair</annotation>
+		<annotation cp="👨🏼‍🦱">adult | bro | curly hair | man | medium-light skin tone</annotation>
+		<annotation cp="👨🏼‍🦱" type="tts">man: medium-light skin tone, curly hair</annotation>
+		<annotation cp="👨🏽‍🦱">adult | bro | curly hair | man | medium skin tone</annotation>
+		<annotation cp="👨🏽‍🦱" type="tts">man: medium skin tone, curly hair</annotation>
+		<annotation cp="👨🏾‍🦱">adult | bro | curly hair | man | medium-dark skin tone</annotation>
+		<annotation cp="👨🏾‍🦱" type="tts">man: medium-dark skin tone, curly hair</annotation>
+		<annotation cp="👨🏿‍🦱">adult | bro | curly hair | dark skin tone | man</annotation>
+		<annotation cp="👨🏿‍🦱" type="tts">man: dark skin tone, curly hair</annotation>
+		<annotation cp="👨‍🦳">adult | bro | man | white hair</annotation>
+		<annotation cp="👨‍🦳" type="tts">man: white hair</annotation>
+		<annotation cp="👨🏻‍🦳">adult | bro | light skin tone | man | white hair</annotation>
+		<annotation cp="👨🏻‍🦳" type="tts">man: light skin tone, white hair</annotation>
+		<annotation cp="👨🏼‍🦳">adult | bro | man | medium-light skin tone | white hair</annotation>
+		<annotation cp="👨🏼‍🦳" type="tts">man: medium-light skin tone, white hair</annotation>
+		<annotation cp="👨🏽‍🦳">adult | bro | man | medium skin tone | white hair</annotation>
+		<annotation cp="👨🏽‍🦳" type="tts">man: medium skin tone, white hair</annotation>
+		<annotation cp="👨🏾‍🦳">adult | bro | man | medium-dark skin tone | white hair</annotation>
+		<annotation cp="👨🏾‍🦳" type="tts">man: medium-dark skin tone, white hair</annotation>
+		<annotation cp="👨🏿‍🦳">adult | bro | dark skin tone | man | white hair</annotation>
+		<annotation cp="👨🏿‍🦳" type="tts">man: dark skin tone, white hair</annotation>
+		<annotation cp="👨‍🦲">adult | bald | bro | man</annotation>
+		<annotation cp="👨‍🦲" type="tts">man: bald</annotation>
+		<annotation cp="👨🏻‍🦲">adult | bald | bro | light skin tone | man</annotation>
+		<annotation cp="👨🏻‍🦲" type="tts">man: light skin tone, bald</annotation>
+		<annotation cp="👨🏼‍🦲">adult | bald | bro | man | medium-light skin tone</annotation>
+		<annotation cp="👨🏼‍🦲" type="tts">man: medium-light skin tone, bald</annotation>
+		<annotation cp="👨🏽‍🦲">adult | bald | bro | man | medium skin tone</annotation>
+		<annotation cp="👨🏽‍🦲" type="tts">man: medium skin tone, bald</annotation>
+		<annotation cp="👨🏾‍🦲">adult | bald | bro | man | medium-dark skin tone</annotation>
+		<annotation cp="👨🏾‍🦲" type="tts">man: medium-dark skin tone, bald</annotation>
+		<annotation cp="👨🏿‍🦲">adult | bald | bro | dark skin tone | man</annotation>
+		<annotation cp="👨🏿‍🦲" type="tts">man: dark skin tone, bald</annotation>
+		<annotation cp="👩🏻">adult | lady | light skin tone | woman</annotation>
+		<annotation cp="👩🏻" type="tts">woman: light skin tone</annotation>
+		<annotation cp="👩🏼">adult | lady | medium-light skin tone | woman</annotation>
+		<annotation cp="👩🏼" type="tts">woman: medium-light skin tone</annotation>
+		<annotation cp="👩🏽">adult | lady | medium skin tone | woman</annotation>
+		<annotation cp="👩🏽" type="tts">woman: medium skin tone</annotation>
+		<annotation cp="👩🏾">adult | lady | medium-dark skin tone | woman</annotation>
+		<annotation cp="👩🏾" type="tts">woman: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿">adult | dark skin tone | lady | woman</annotation>
+		<annotation cp="👩🏿" type="tts">woman: dark skin tone</annotation>
+		<annotation cp="🧔🏻‍♀">beard | bearded | light skin tone | whiskers | woman</annotation>
+		<annotation cp="🧔🏻‍♀" type="tts">woman: light skin tone, beard</annotation>
+		<annotation cp="🧔🏼‍♀">beard | bearded | medium-light skin tone | whiskers | woman</annotation>
+		<annotation cp="🧔🏼‍♀" type="tts">woman: medium-light skin tone, beard</annotation>
+		<annotation cp="🧔🏽‍♀">beard | bearded | medium skin tone | whiskers | woman</annotation>
+		<annotation cp="🧔🏽‍♀" type="tts">woman: medium skin tone, beard</annotation>
+		<annotation cp="🧔🏾‍♀">beard | bearded | medium-dark skin tone | whiskers | woman</annotation>
+		<annotation cp="🧔🏾‍♀" type="tts">woman: medium-dark skin tone, beard</annotation>
+		<annotation cp="🧔🏿‍♀">beard | bearded | dark skin tone | whiskers | woman</annotation>
+		<annotation cp="🧔🏿‍♀" type="tts">woman: dark skin tone, beard</annotation>
+		<annotation cp="👱🏻‍♀">blond | blond-haired | blonde | hair | light skin tone | woman</annotation>
+		<annotation cp="👱🏻‍♀" type="tts">woman: light skin tone, blond hair</annotation>
+		<annotation cp="👱🏼‍♀">blond | blond-haired | blonde | hair | medium-light skin tone | woman</annotation>
+		<annotation cp="👱🏼‍♀" type="tts">woman: medium-light skin tone, blond hair</annotation>
+		<annotation cp="👱🏽‍♀">blond | blond-haired | blonde | hair | medium skin tone | woman</annotation>
+		<annotation cp="👱🏽‍♀" type="tts">woman: medium skin tone, blond hair</annotation>
+		<annotation cp="👱🏾‍♀">blond | blond-haired | blonde | hair | medium-dark skin tone | woman</annotation>
+		<annotation cp="👱🏾‍♀" type="tts">woman: medium-dark skin tone, blond hair</annotation>
+		<annotation cp="👱🏿‍♀">blond | blond-haired | blonde | dark skin tone | hair | woman</annotation>
+		<annotation cp="👱🏿‍♀" type="tts">woman: dark skin tone, blond hair</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | man | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏻" type="tts">kiss: woman, man, light skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | man | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏼" type="tts">kiss: woman, man, light skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | man | medium skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏽" type="tts">kiss: woman, man, light skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | man | medium-dark skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏾" type="tts">kiss: woman, man, light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | light skin tone | love | man | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏿" type="tts">kiss: woman, man, light skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | man | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏻" type="tts">kiss: woman, man, medium-light skin tone, light skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏼" type="tts">kiss: woman, man, medium-light skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium skin tone | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏽" type="tts">kiss: woman, man, medium-light skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium-dark skin tone | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏾" type="tts">kiss: woman, man, medium-light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | man | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏿" type="tts">kiss: woman, man, medium-light skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | man | medium skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏻" type="tts">kiss: woman, man, medium skin tone, light skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium skin tone | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏼" type="tts">kiss: woman, man, medium skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏽" type="tts">kiss: woman, man, medium skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium skin tone | medium-dark skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏾" type="tts">kiss: woman, man, medium skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | man | medium skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏿" type="tts">kiss: woman, man, medium skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | man | medium-dark skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏻" type="tts">kiss: woman, man, medium-dark skin tone, light skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium-dark skin tone | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏼" type="tts">kiss: woman, man, medium-dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium skin tone | medium-dark skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏽" type="tts">kiss: woman, man, medium-dark skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | medium-dark skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏾" type="tts">kiss: woman, man, medium-dark skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | man | medium-dark skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏿" type="tts">kiss: woman, man, medium-dark skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏻">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | light skin tone | love | man | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏻" type="tts">kiss: woman, man, dark skin tone, light skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏼">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | man | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏼" type="tts">kiss: woman, man, dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏽">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | man | medium skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏽" type="tts">kiss: woman, man, dark skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏾">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | man | medium-dark skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏾" type="tts">kiss: woman, man, dark skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | man | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏿" type="tts">kiss: woman, man, dark skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏻" type="tts">kiss: woman, woman, light skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏼" type="tts">kiss: woman, woman, light skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | medium skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏽" type="tts">kiss: woman, woman, light skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | medium-dark skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏾" type="tts">kiss: woman, woman, light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | light skin tone | love | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏿" type="tts">kiss: woman, woman, light skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏻" type="tts">kiss: woman, woman, medium-light skin tone, light skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏼" type="tts">kiss: woman, woman, medium-light skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium skin tone | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏽" type="tts">kiss: woman, woman, medium-light skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium-dark skin tone | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏾" type="tts">kiss: woman, woman, medium-light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏿" type="tts">kiss: woman, woman, medium-light skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | medium skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏻" type="tts">kiss: woman, woman, medium skin tone, light skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium skin tone | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏼" type="tts">kiss: woman, woman, medium skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏽" type="tts">kiss: woman, woman, medium skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium skin tone | medium-dark skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏾" type="tts">kiss: woman, woman, medium skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | medium skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏿" type="tts">kiss: woman, woman, medium skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | medium-dark skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏻" type="tts">kiss: woman, woman, medium-dark skin tone, light skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium-dark skin tone | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏼" type="tts">kiss: woman, woman, medium-dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium skin tone | medium-dark skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏽" type="tts">kiss: woman, woman, medium-dark skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium-dark skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏾" type="tts">kiss: woman, woman, medium-dark skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | medium-dark skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏿" type="tts">kiss: woman, woman, medium-dark skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏻">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | light skin tone | love | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏻" type="tts">kiss: woman, woman, dark skin tone, light skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏼">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | medium-light skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏼" type="tts">kiss: woman, woman, dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏽">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | medium skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏽" type="tts">kiss: woman, woman, dark skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏾">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | medium-dark skin tone | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏾" type="tts">kiss: woman, woman, dark skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏿" type="tts">kiss: woman, woman, dark skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | man | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏻" type="tts">couple with heart: woman, man, light skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏼">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | man | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏼" type="tts">couple with heart: woman, man, light skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏽">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | man | medium skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏽" type="tts">couple with heart: woman, man, light skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏾">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | man | medium-dark skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏾" type="tts">couple with heart: woman, man, light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | light skin tone | love | man | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏿" type="tts">couple with heart: woman, man, light skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | man | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏻" type="tts">couple with heart: woman, man, medium-light skin tone, light skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏼">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏼" type="tts">couple with heart: woman, man, medium-light skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏽">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium skin tone | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏽" type="tts">couple with heart: woman, man, medium-light skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏾">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium-dark skin tone | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏾" type="tts">couple with heart: woman, man, medium-light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | man | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏿" type="tts">couple with heart: woman, man, medium-light skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | man | medium skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏻" type="tts">couple with heart: woman, man, medium skin tone, light skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏼">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium skin tone | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏼" type="tts">couple with heart: woman, man, medium skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏽">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏽" type="tts">couple with heart: woman, man, medium skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏾">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium skin tone | medium-dark skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏾" type="tts">couple with heart: woman, man, medium skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | man | medium skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏿" type="tts">couple with heart: woman, man, medium skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | man | medium-dark skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏻" type="tts">couple with heart: woman, man, medium-dark skin tone, light skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏼">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium-dark skin tone | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏼" type="tts">couple with heart: woman, man, medium-dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏽">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium skin tone | medium-dark skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏽" type="tts">couple with heart: woman, man, medium-dark skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏾">anniversary | babe | bae | couple | dating | heart | kiss | love | man | medium-dark skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏾" type="tts">couple with heart: woman, man, medium-dark skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | man | medium-dark skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏿" type="tts">couple with heart: woman, man, medium-dark skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏻">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | light skin tone | love | man | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏻" type="tts">couple with heart: woman, man, dark skin tone, light skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏼">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | man | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏼" type="tts">couple with heart: woman, man, dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏽">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | man | medium skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏽" type="tts">couple with heart: woman, man, dark skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏾">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | man | medium-dark skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏾" type="tts">couple with heart: woman, man, dark skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | man | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏿" type="tts">couple with heart: woman, man, dark skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏻" type="tts">couple with heart: woman, woman, light skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏼">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏼" type="tts">couple with heart: woman, woman, light skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏽">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | medium skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏽" type="tts">couple with heart: woman, woman, light skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏾">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | medium-dark skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏾" type="tts">couple with heart: woman, woman, light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | light skin tone | love | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏿" type="tts">couple with heart: woman, woman, light skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏻" type="tts">couple with heart: woman, woman, medium-light skin tone, light skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏼">anniversary | babe | bae | couple | dating | heart | kiss | love | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏼" type="tts">couple with heart: woman, woman, medium-light skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏽">anniversary | babe | bae | couple | dating | heart | kiss | love | medium skin tone | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏽" type="tts">couple with heart: woman, woman, medium-light skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏾">anniversary | babe | bae | couple | dating | heart | kiss | love | medium-dark skin tone | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏾" type="tts">couple with heart: woman, woman, medium-light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏿" type="tts">couple with heart: woman, woman, medium-light skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | medium skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏻" type="tts">couple with heart: woman, woman, medium skin tone, light skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏼">anniversary | babe | bae | couple | dating | heart | kiss | love | medium skin tone | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏼" type="tts">couple with heart: woman, woman, medium skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏽">anniversary | babe | bae | couple | dating | heart | kiss | love | medium skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏽" type="tts">couple with heart: woman, woman, medium skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏾">anniversary | babe | bae | couple | dating | heart | kiss | love | medium skin tone | medium-dark skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏾" type="tts">couple with heart: woman, woman, medium skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | medium skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏿" type="tts">couple with heart: woman, woman, medium skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | medium-dark skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏻" type="tts">couple with heart: woman, woman, medium-dark skin tone, light skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏼">anniversary | babe | bae | couple | dating | heart | kiss | love | medium-dark skin tone | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏼" type="tts">couple with heart: woman, woman, medium-dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏽">anniversary | babe | bae | couple | dating | heart | kiss | love | medium skin tone | medium-dark skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏽" type="tts">couple with heart: woman, woman, medium-dark skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏾">anniversary | babe | bae | couple | dating | heart | kiss | love | medium-dark skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏾" type="tts">couple with heart: woman, woman, medium-dark skin tone</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | medium-dark skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏿" type="tts">couple with heart: woman, woman, medium-dark skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏻">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | light skin tone | love | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏻" type="tts">couple with heart: woman, woman, dark skin tone, light skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏼">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | medium-light skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏼" type="tts">couple with heart: woman, woman, dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏽">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | medium skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏽" type="tts">couple with heart: woman, woman, dark skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏾">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | medium-dark skin tone | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏾" type="tts">couple with heart: woman, woman, dark skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏿" type="tts">couple with heart: woman, woman, dark skin tone</annotation>
+		<annotation cp="👩‍🦰">adult | lady | red hair | woman</annotation>
+		<annotation cp="👩‍🦰" type="tts">woman: red hair</annotation>
+		<annotation cp="👩🏻‍🦰">adult | lady | light skin tone | red hair | woman</annotation>
+		<annotation cp="👩🏻‍🦰" type="tts">woman: light skin tone, red hair</annotation>
+		<annotation cp="👩🏼‍🦰">adult | lady | medium-light skin tone | red hair | woman</annotation>
+		<annotation cp="👩🏼‍🦰" type="tts">woman: medium-light skin tone, red hair</annotation>
+		<annotation cp="👩🏽‍🦰">adult | lady | medium skin tone | red hair | woman</annotation>
+		<annotation cp="👩🏽‍🦰" type="tts">woman: medium skin tone, red hair</annotation>
+		<annotation cp="👩🏾‍🦰">adult | lady | medium-dark skin tone | red hair | woman</annotation>
+		<annotation cp="👩🏾‍🦰" type="tts">woman: medium-dark skin tone, red hair</annotation>
+		<annotation cp="👩🏿‍🦰">adult | dark skin tone | lady | red hair | woman</annotation>
+		<annotation cp="👩🏿‍🦰" type="tts">woman: dark skin tone, red hair</annotation>
+		<annotation cp="👩‍🦱">adult | curly hair | lady | woman</annotation>
+		<annotation cp="👩‍🦱" type="tts">woman: curly hair</annotation>
+		<annotation cp="👩🏻‍🦱">adult | curly hair | lady | light skin tone | woman</annotation>
+		<annotation cp="👩🏻‍🦱" type="tts">woman: light skin tone, curly hair</annotation>
+		<annotation cp="👩🏼‍🦱">adult | curly hair | lady | medium-light skin tone | woman</annotation>
+		<annotation cp="👩🏼‍🦱" type="tts">woman: medium-light skin tone, curly hair</annotation>
+		<annotation cp="👩🏽‍🦱">adult | curly hair | lady | medium skin tone | woman</annotation>
+		<annotation cp="👩🏽‍🦱" type="tts">woman: medium skin tone, curly hair</annotation>
+		<annotation cp="👩🏾‍🦱">adult | curly hair | lady | medium-dark skin tone | woman</annotation>
+		<annotation cp="👩🏾‍🦱" type="tts">woman: medium-dark skin tone, curly hair</annotation>
+		<annotation cp="👩🏿‍🦱">adult | curly hair | dark skin tone | lady | woman</annotation>
+		<annotation cp="👩🏿‍🦱" type="tts">woman: dark skin tone, curly hair</annotation>
+		<annotation cp="👩‍🦳">adult | lady | white hair | woman</annotation>
+		<annotation cp="👩‍🦳" type="tts">woman: white hair</annotation>
+		<annotation cp="👩🏻‍🦳">adult | lady | light skin tone | white hair | woman</annotation>
+		<annotation cp="👩🏻‍🦳" type="tts">woman: light skin tone, white hair</annotation>
+		<annotation cp="👩🏼‍🦳">adult | lady | medium-light skin tone | white hair | woman</annotation>
+		<annotation cp="👩🏼‍🦳" type="tts">woman: medium-light skin tone, white hair</annotation>
+		<annotation cp="👩🏽‍🦳">adult | lady | medium skin tone | white hair | woman</annotation>
+		<annotation cp="👩🏽‍🦳" type="tts">woman: medium skin tone, white hair</annotation>
+		<annotation cp="👩🏾‍🦳">adult | lady | medium-dark skin tone | white hair | woman</annotation>
+		<annotation cp="👩🏾‍🦳" type="tts">woman: medium-dark skin tone, white hair</annotation>
+		<annotation cp="👩🏿‍🦳">adult | dark skin tone | lady | white hair | woman</annotation>
+		<annotation cp="👩🏿‍🦳" type="tts">woman: dark skin tone, white hair</annotation>
+		<annotation cp="👩‍🦲">adult | bald | lady | woman</annotation>
+		<annotation cp="👩‍🦲" type="tts">woman: bald</annotation>
+		<annotation cp="👩🏻‍🦲">adult | bald | lady | light skin tone | woman</annotation>
+		<annotation cp="👩🏻‍🦲" type="tts">woman: light skin tone, bald</annotation>
+		<annotation cp="👩🏼‍🦲">adult | bald | lady | medium-light skin tone | woman</annotation>
+		<annotation cp="👩🏼‍🦲" type="tts">woman: medium-light skin tone, bald</annotation>
+		<annotation cp="👩🏽‍🦲">adult | bald | lady | medium skin tone | woman</annotation>
+		<annotation cp="👩🏽‍🦲" type="tts">woman: medium skin tone, bald</annotation>
+		<annotation cp="👩🏾‍🦲">adult | bald | lady | medium-dark skin tone | woman</annotation>
+		<annotation cp="👩🏾‍🦲" type="tts">woman: medium-dark skin tone, bald</annotation>
+		<annotation cp="👩🏿‍🦲">adult | bald | dark skin tone | lady | woman</annotation>
+		<annotation cp="👩🏿‍🦲" type="tts">woman: dark skin tone, bald</annotation>
+		<annotation cp="🧓🏻">adult | elderly | grandparent | light skin tone | old | person | wise</annotation>
+		<annotation cp="🧓🏻" type="tts">older person: light skin tone</annotation>
+		<annotation cp="🧓🏼">adult | elderly | grandparent | medium-light skin tone | old | person | wise</annotation>
+		<annotation cp="🧓🏼" type="tts">older person: medium-light skin tone</annotation>
+		<annotation cp="🧓🏽">adult | elderly | grandparent | medium skin tone | old | person | wise</annotation>
+		<annotation cp="🧓🏽" type="tts">older person: medium skin tone</annotation>
+		<annotation cp="🧓🏾">adult | elderly | grandparent | medium-dark skin tone | old | person | wise</annotation>
+		<annotation cp="🧓🏾" type="tts">older person: medium-dark skin tone</annotation>
+		<annotation cp="🧓🏿">adult | dark skin tone | elderly | grandparent | old | person | wise</annotation>
+		<annotation cp="🧓🏿" type="tts">older person: dark skin tone</annotation>
+		<annotation cp="👴🏻">adult | bald | elderly | gramps | grandfather | grandpa | light skin tone | man | old | wise</annotation>
+		<annotation cp="👴🏻" type="tts">old man: light skin tone</annotation>
+		<annotation cp="👴🏼">adult | bald | elderly | gramps | grandfather | grandpa | man | medium-light skin tone | old | wise</annotation>
+		<annotation cp="👴🏼" type="tts">old man: medium-light skin tone</annotation>
+		<annotation cp="👴🏽">adult | bald | elderly | gramps | grandfather | grandpa | man | medium skin tone | old | wise</annotation>
+		<annotation cp="👴🏽" type="tts">old man: medium skin tone</annotation>
+		<annotation cp="👴🏾">adult | bald | elderly | gramps | grandfather | grandpa | man | medium-dark skin tone | old | wise</annotation>
+		<annotation cp="👴🏾" type="tts">old man: medium-dark skin tone</annotation>
+		<annotation cp="👴🏿">adult | bald | dark skin tone | elderly | gramps | grandfather | grandpa | man | old | wise</annotation>
+		<annotation cp="👴🏿" type="tts">old man: dark skin tone</annotation>
+		<annotation cp="👵🏻">adult | elderly | grandma | grandmother | granny | lady | light skin tone | old | wise | woman</annotation>
+		<annotation cp="👵🏻" type="tts">old woman: light skin tone</annotation>
+		<annotation cp="👵🏼">adult | elderly | grandma | grandmother | granny | lady | medium-light skin tone | old | wise | woman</annotation>
+		<annotation cp="👵🏼" type="tts">old woman: medium-light skin tone</annotation>
+		<annotation cp="👵🏽">adult | elderly | grandma | grandmother | granny | lady | medium skin tone | old | wise | woman</annotation>
+		<annotation cp="👵🏽" type="tts">old woman: medium skin tone</annotation>
+		<annotation cp="👵🏾">adult | elderly | grandma | grandmother | granny | lady | medium-dark skin tone | old | wise | woman</annotation>
+		<annotation cp="👵🏾" type="tts">old woman: medium-dark skin tone</annotation>
+		<annotation cp="👵🏿">adult | dark skin tone | elderly | grandma | grandmother | granny | lady | old | wise | woman</annotation>
+		<annotation cp="👵🏿" type="tts">old woman: dark skin tone</annotation>
+		<annotation cp="🙍🏻">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | light skin tone | person | upset</annotation>
+		<annotation cp="🙍🏻" type="tts">person frowning: light skin tone</annotation>
+		<annotation cp="🙍🏼">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | medium-light skin tone | person | upset</annotation>
+		<annotation cp="🙍🏼" type="tts">person frowning: medium-light skin tone</annotation>
+		<annotation cp="🙍🏽">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | medium skin tone | person | upset</annotation>
+		<annotation cp="🙍🏽" type="tts">person frowning: medium skin tone</annotation>
+		<annotation cp="🙍🏾">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | medium-dark skin tone | person | upset</annotation>
+		<annotation cp="🙍🏾" type="tts">person frowning: medium-dark skin tone</annotation>
+		<annotation cp="🙍🏿">annoyed | dark skin tone | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | person | upset</annotation>
+		<annotation cp="🙍🏿" type="tts">person frowning: dark skin tone</annotation>
+		<annotation cp="🙍🏻‍♂">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | light skin tone | man | upset</annotation>
+		<annotation cp="🙍🏻‍♂" type="tts">man frowning: light skin tone</annotation>
+		<annotation cp="🙍🏼‍♂">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | man | medium-light skin tone | upset</annotation>
+		<annotation cp="🙍🏼‍♂" type="tts">man frowning: medium-light skin tone</annotation>
+		<annotation cp="🙍🏽‍♂">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | man | medium skin tone | upset</annotation>
+		<annotation cp="🙍🏽‍♂" type="tts">man frowning: medium skin tone</annotation>
+		<annotation cp="🙍🏾‍♂">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | man | medium-dark skin tone | upset</annotation>
+		<annotation cp="🙍🏾‍♂" type="tts">man frowning: medium-dark skin tone</annotation>
+		<annotation cp="🙍🏿‍♂">annoyed | dark skin tone | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | man | upset</annotation>
+		<annotation cp="🙍🏿‍♂" type="tts">man frowning: dark skin tone</annotation>
+		<annotation cp="🙍🏻‍♀">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | light skin tone | upset | woman</annotation>
+		<annotation cp="🙍🏻‍♀" type="tts">woman frowning: light skin tone</annotation>
+		<annotation cp="🙍🏼‍♀">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | medium-light skin tone | upset | woman</annotation>
+		<annotation cp="🙍🏼‍♀" type="tts">woman frowning: medium-light skin tone</annotation>
+		<annotation cp="🙍🏽‍♀">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | medium skin tone | upset | woman</annotation>
+		<annotation cp="🙍🏽‍♀" type="tts">woman frowning: medium skin tone</annotation>
+		<annotation cp="🙍🏾‍♀">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | medium-dark skin tone | upset | woman</annotation>
+		<annotation cp="🙍🏾‍♀" type="tts">woman frowning: medium-dark skin tone</annotation>
+		<annotation cp="🙍🏿‍♀">annoyed | dark skin tone | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | upset | woman</annotation>
+		<annotation cp="🙍🏿‍♀" type="tts">woman frowning: dark skin tone</annotation>
+		<annotation cp="🙎🏻">disappointed | downtrodden | frown | grimace | light skin tone | person | pouting | scowl | sulk | upset | whine</annotation>
+		<annotation cp="🙎🏻" type="tts">person pouting: light skin tone</annotation>
+		<annotation cp="🙎🏼">disappointed | downtrodden | frown | grimace | medium-light skin tone | person | pouting | scowl | sulk | upset | whine</annotation>
+		<annotation cp="🙎🏼" type="tts">person pouting: medium-light skin tone</annotation>
+		<annotation cp="🙎🏽">disappointed | downtrodden | frown | grimace | medium skin tone | person | pouting | scowl | sulk | upset | whine</annotation>
+		<annotation cp="🙎🏽" type="tts">person pouting: medium skin tone</annotation>
+		<annotation cp="🙎🏾">disappointed | downtrodden | frown | grimace | medium-dark skin tone | person | pouting | scowl | sulk | upset | whine</annotation>
+		<annotation cp="🙎🏾" type="tts">person pouting: medium-dark skin tone</annotation>
+		<annotation cp="🙎🏿">dark skin tone | disappointed | downtrodden | frown | grimace | person | pouting | scowl | sulk | upset | whine</annotation>
+		<annotation cp="🙎🏿" type="tts">person pouting: dark skin tone</annotation>
+		<annotation cp="🙎🏻‍♂">disappointed | downtrodden | frown | grimace | light skin tone | man | pouting | scowl | sulk | upset | whine</annotation>
+		<annotation cp="🙎🏻‍♂" type="tts">man pouting: light skin tone</annotation>
+		<annotation cp="🙎🏼‍♂">disappointed | downtrodden | frown | grimace | man | medium-light skin tone | pouting | scowl | sulk | upset | whine</annotation>
+		<annotation cp="🙎🏼‍♂" type="tts">man pouting: medium-light skin tone</annotation>
+		<annotation cp="🙎🏽‍♂">disappointed | downtrodden | frown | grimace | man | medium skin tone | pouting | scowl | sulk | upset | whine</annotation>
+		<annotation cp="🙎🏽‍♂" type="tts">man pouting: medium skin tone</annotation>
+		<annotation cp="🙎🏾‍♂">disappointed | downtrodden | frown | grimace | man | medium-dark skin tone | pouting | scowl | sulk | upset | whine</annotation>
+		<annotation cp="🙎🏾‍♂" type="tts">man pouting: medium-dark skin tone</annotation>
+		<annotation cp="🙎🏿‍♂">dark skin tone | disappointed | downtrodden | frown | grimace | man | pouting | scowl | sulk | upset | whine</annotation>
+		<annotation cp="🙎🏿‍♂" type="tts">man pouting: dark skin tone</annotation>
+		<annotation cp="🙎🏻‍♀">disappointed | downtrodden | frown | grimace | light skin tone | pouting | scowl | sulk | upset | whine | woman</annotation>
+		<annotation cp="🙎🏻‍♀" type="tts">woman pouting: light skin tone</annotation>
+		<annotation cp="🙎🏼‍♀">disappointed | downtrodden | frown | grimace | medium-light skin tone | pouting | scowl | sulk | upset | whine | woman</annotation>
+		<annotation cp="🙎🏼‍♀" type="tts">woman pouting: medium-light skin tone</annotation>
+		<annotation cp="🙎🏽‍♀">disappointed | downtrodden | frown | grimace | medium skin tone | pouting | scowl | sulk | upset | whine | woman</annotation>
+		<annotation cp="🙎🏽‍♀" type="tts">woman pouting: medium skin tone</annotation>
+		<annotation cp="🙎🏾‍♀">disappointed | downtrodden | frown | grimace | medium-dark skin tone | pouting | scowl | sulk | upset | whine | woman</annotation>
+		<annotation cp="🙎🏾‍♀" type="tts">woman pouting: medium-dark skin tone</annotation>
+		<annotation cp="🙎🏿‍♀">dark skin tone | disappointed | downtrodden | frown | grimace | pouting | scowl | sulk | upset | whine | woman</annotation>
+		<annotation cp="🙎🏿‍♀" type="tts">woman pouting: dark skin tone</annotation>
+		<annotation cp="🙅🏻">forbidden | gesture | hand | light skin tone | NO | not | person | prohibit</annotation>
+		<annotation cp="🙅🏻" type="tts">person gesturing NO: light skin tone</annotation>
+		<annotation cp="🙅🏼">forbidden | gesture | hand | medium-light skin tone | NO | not | person | prohibit</annotation>
+		<annotation cp="🙅🏼" type="tts">person gesturing NO: medium-light skin tone</annotation>
+		<annotation cp="🙅🏽">forbidden | gesture | hand | medium skin tone | NO | not | person | prohibit</annotation>
+		<annotation cp="🙅🏽" type="tts">person gesturing NO: medium skin tone</annotation>
+		<annotation cp="🙅🏾">forbidden | gesture | hand | medium-dark skin tone | NO | not | person | prohibit</annotation>
+		<annotation cp="🙅🏾" type="tts">person gesturing NO: medium-dark skin tone</annotation>
+		<annotation cp="🙅🏿">dark skin tone | forbidden | gesture | hand | NO | not | person | prohibit</annotation>
+		<annotation cp="🙅🏿" type="tts">person gesturing NO: dark skin tone</annotation>
+		<annotation cp="🙅🏻‍♂">forbidden | gesture | hand | light skin tone | man | NO | not | prohibit</annotation>
+		<annotation cp="🙅🏻‍♂" type="tts">man gesturing NO: light skin tone</annotation>
+		<annotation cp="🙅🏼‍♂">forbidden | gesture | hand | man | medium-light skin tone | NO | not | prohibit</annotation>
+		<annotation cp="🙅🏼‍♂" type="tts">man gesturing NO: medium-light skin tone</annotation>
+		<annotation cp="🙅🏽‍♂">forbidden | gesture | hand | man | medium skin tone | NO | not | prohibit</annotation>
+		<annotation cp="🙅🏽‍♂" type="tts">man gesturing NO: medium skin tone</annotation>
+		<annotation cp="🙅🏾‍♂">forbidden | gesture | hand | man | medium-dark skin tone | NO | not | prohibit</annotation>
+		<annotation cp="🙅🏾‍♂" type="tts">man gesturing NO: medium-dark skin tone</annotation>
+		<annotation cp="🙅🏿‍♂">dark skin tone | forbidden | gesture | hand | man | NO | not | prohibit</annotation>
+		<annotation cp="🙅🏿‍♂" type="tts">man gesturing NO: dark skin tone</annotation>
+		<annotation cp="🙅🏻‍♀">forbidden | gesture | hand | light skin tone | NO | not | prohibit | woman</annotation>
+		<annotation cp="🙅🏻‍♀" type="tts">woman gesturing NO: light skin tone</annotation>
+		<annotation cp="🙅🏼‍♀">forbidden | gesture | hand | medium-light skin tone | NO | not | prohibit | woman</annotation>
+		<annotation cp="🙅🏼‍♀" type="tts">woman gesturing NO: medium-light skin tone</annotation>
+		<annotation cp="🙅🏽‍♀">forbidden | gesture | hand | medium skin tone | NO | not | prohibit | woman</annotation>
+		<annotation cp="🙅🏽‍♀" type="tts">woman gesturing NO: medium skin tone</annotation>
+		<annotation cp="🙅🏾‍♀">forbidden | gesture | hand | medium-dark skin tone | NO | not | prohibit | woman</annotation>
+		<annotation cp="🙅🏾‍♀" type="tts">woman gesturing NO: medium-dark skin tone</annotation>
+		<annotation cp="🙅🏿‍♀">dark skin tone | forbidden | gesture | hand | NO | not | prohibit | woman</annotation>
+		<annotation cp="🙅🏿‍♀" type="tts">woman gesturing NO: dark skin tone</annotation>
+		<annotation cp="🙆🏻">exercise | gesture | gesturing | hand | light skin tone | OK | omg | person</annotation>
+		<annotation cp="🙆🏻" type="tts">person gesturing OK: light skin tone</annotation>
+		<annotation cp="🙆🏼">exercise | gesture | gesturing | hand | medium-light skin tone | OK | omg | person</annotation>
+		<annotation cp="🙆🏼" type="tts">person gesturing OK: medium-light skin tone</annotation>
+		<annotation cp="🙆🏽">exercise | gesture | gesturing | hand | medium skin tone | OK | omg | person</annotation>
+		<annotation cp="🙆🏽" type="tts">person gesturing OK: medium skin tone</annotation>
+		<annotation cp="🙆🏾">exercise | gesture | gesturing | hand | medium-dark skin tone | OK | omg | person</annotation>
+		<annotation cp="🙆🏾" type="tts">person gesturing OK: medium-dark skin tone</annotation>
+		<annotation cp="🙆🏿">dark skin tone | exercise | gesture | gesturing | hand | OK | omg | person</annotation>
+		<annotation cp="🙆🏿" type="tts">person gesturing OK: dark skin tone</annotation>
+		<annotation cp="🙆🏻‍♂">exercise | gesture | gesturing | hand | light skin tone | man | OK | omg</annotation>
+		<annotation cp="🙆🏻‍♂" type="tts">man gesturing OK: light skin tone</annotation>
+		<annotation cp="🙆🏼‍♂">exercise | gesture | gesturing | hand | man | medium-light skin tone | OK | omg</annotation>
+		<annotation cp="🙆🏼‍♂" type="tts">man gesturing OK: medium-light skin tone</annotation>
+		<annotation cp="🙆🏽‍♂">exercise | gesture | gesturing | hand | man | medium skin tone | OK | omg</annotation>
+		<annotation cp="🙆🏽‍♂" type="tts">man gesturing OK: medium skin tone</annotation>
+		<annotation cp="🙆🏾‍♂">exercise | gesture | gesturing | hand | man | medium-dark skin tone | OK | omg</annotation>
+		<annotation cp="🙆🏾‍♂" type="tts">man gesturing OK: medium-dark skin tone</annotation>
+		<annotation cp="🙆🏿‍♂">dark skin tone | exercise | gesture | gesturing | hand | man | OK | omg</annotation>
+		<annotation cp="🙆🏿‍♂" type="tts">man gesturing OK: dark skin tone</annotation>
+		<annotation cp="🙆🏻‍♀">exercise | gesture | gesturing | hand | light skin tone | OK | omg | woman</annotation>
+		<annotation cp="🙆🏻‍♀" type="tts">woman gesturing OK: light skin tone</annotation>
+		<annotation cp="🙆🏼‍♀">exercise | gesture | gesturing | hand | medium-light skin tone | OK | omg | woman</annotation>
+		<annotation cp="🙆🏼‍♀" type="tts">woman gesturing OK: medium-light skin tone</annotation>
+		<annotation cp="🙆🏽‍♀">exercise | gesture | gesturing | hand | medium skin tone | OK | omg | woman</annotation>
+		<annotation cp="🙆🏽‍♀" type="tts">woman gesturing OK: medium skin tone</annotation>
+		<annotation cp="🙆🏾‍♀">exercise | gesture | gesturing | hand | medium-dark skin tone | OK | omg | woman</annotation>
+		<annotation cp="🙆🏾‍♀" type="tts">woman gesturing OK: medium-dark skin tone</annotation>
+		<annotation cp="🙆🏿‍♀">dark skin tone | exercise | gesture | gesturing | hand | OK | omg | woman</annotation>
+		<annotation cp="🙆🏿‍♀" type="tts">woman gesturing OK: dark skin tone</annotation>
+		<annotation cp="💁🏻">fetch | flick | flip | gossip | hand | light skin tone | person | sarcasm | sarcastic | sassy | seriously | tipping | whatever</annotation>
+		<annotation cp="💁🏻" type="tts">person tipping hand: light skin tone</annotation>
+		<annotation cp="💁🏼">fetch | flick | flip | gossip | hand | medium-light skin tone | person | sarcasm | sarcastic | sassy | seriously | tipping | whatever</annotation>
+		<annotation cp="💁🏼" type="tts">person tipping hand: medium-light skin tone</annotation>
+		<annotation cp="💁🏽">fetch | flick | flip | gossip | hand | medium skin tone | person | sarcasm | sarcastic | sassy | seriously | tipping | whatever</annotation>
+		<annotation cp="💁🏽" type="tts">person tipping hand: medium skin tone</annotation>
+		<annotation cp="💁🏾">fetch | flick | flip | gossip | hand | medium-dark skin tone | person | sarcasm | sarcastic | sassy | seriously | tipping | whatever</annotation>
+		<annotation cp="💁🏾" type="tts">person tipping hand: medium-dark skin tone</annotation>
+		<annotation cp="💁🏿">dark skin tone | fetch | flick | flip | gossip | hand | person | sarcasm | sarcastic | sassy | seriously | tipping | whatever</annotation>
+		<annotation cp="💁🏿" type="tts">person tipping hand: dark skin tone</annotation>
+		<annotation cp="💁🏻‍♂">fetch | flick | flip | gossip | hand | light skin tone | man | sarcasm | sarcastic | sassy | seriously | tipping | whatever</annotation>
+		<annotation cp="💁🏻‍♂" type="tts">man tipping hand: light skin tone</annotation>
+		<annotation cp="💁🏼‍♂">fetch | flick | flip | gossip | hand | man | medium-light skin tone | sarcasm | sarcastic | sassy | seriously | tipping | whatever</annotation>
+		<annotation cp="💁🏼‍♂" type="tts">man tipping hand: medium-light skin tone</annotation>
+		<annotation cp="💁🏽‍♂">fetch | flick | flip | gossip | hand | man | medium skin tone | sarcasm | sarcastic | sassy | seriously | tipping | whatever</annotation>
+		<annotation cp="💁🏽‍♂" type="tts">man tipping hand: medium skin tone</annotation>
+		<annotation cp="💁🏾‍♂">fetch | flick | flip | gossip | hand | man | medium-dark skin tone | sarcasm | sarcastic | sassy | seriously | tipping | whatever</annotation>
+		<annotation cp="💁🏾‍♂" type="tts">man tipping hand: medium-dark skin tone</annotation>
+		<annotation cp="💁🏿‍♂">dark skin tone | fetch | flick | flip | gossip | hand | man | sarcasm | sarcastic | sassy | seriously | tipping | whatever</annotation>
+		<annotation cp="💁🏿‍♂" type="tts">man tipping hand: dark skin tone</annotation>
+		<annotation cp="💁🏻‍♀">fetch | flick | flip | gossip | hand | light skin tone | sarcasm | sarcastic | sassy | seriously | tipping | whatever | woman</annotation>
+		<annotation cp="💁🏻‍♀" type="tts">woman tipping hand: light skin tone</annotation>
+		<annotation cp="💁🏼‍♀">fetch | flick | flip | gossip | hand | medium-light skin tone | sarcasm | sarcastic | sassy | seriously | tipping | whatever | woman</annotation>
+		<annotation cp="💁🏼‍♀" type="tts">woman tipping hand: medium-light skin tone</annotation>
+		<annotation cp="💁🏽‍♀">fetch | flick | flip | gossip | hand | medium skin tone | sarcasm | sarcastic | sassy | seriously | tipping | whatever | woman</annotation>
+		<annotation cp="💁🏽‍♀" type="tts">woman tipping hand: medium skin tone</annotation>
+		<annotation cp="💁🏾‍♀">fetch | flick | flip | gossip | hand | medium-dark skin tone | sarcasm | sarcastic | sassy | seriously | tipping | whatever | woman</annotation>
+		<annotation cp="💁🏾‍♀" type="tts">woman tipping hand: medium-dark skin tone</annotation>
+		<annotation cp="💁🏿‍♀">dark skin tone | fetch | flick | flip | gossip | hand | sarcasm | sarcastic | sassy | seriously | tipping | whatever | woman</annotation>
+		<annotation cp="💁🏿‍♀" type="tts">woman tipping hand: dark skin tone</annotation>
+		<annotation cp="🙋🏻">gesture | hand | here | know | light skin tone | me | person | pick | question | raise | raising</annotation>
+		<annotation cp="🙋🏻" type="tts">person raising hand: light skin tone</annotation>
+		<annotation cp="🙋🏼">gesture | hand | here | know | me | medium-light skin tone | person | pick | question | raise | raising</annotation>
+		<annotation cp="🙋🏼" type="tts">person raising hand: medium-light skin tone</annotation>
+		<annotation cp="🙋🏽">gesture | hand | here | know | me | medium skin tone | person | pick | question | raise | raising</annotation>
+		<annotation cp="🙋🏽" type="tts">person raising hand: medium skin tone</annotation>
+		<annotation cp="🙋🏾">gesture | hand | here | know | me | medium-dark skin tone | person | pick | question | raise | raising</annotation>
+		<annotation cp="🙋🏾" type="tts">person raising hand: medium-dark skin tone</annotation>
+		<annotation cp="🙋🏿">dark skin tone | gesture | hand | here | know | me | person | pick | question | raise | raising</annotation>
+		<annotation cp="🙋🏿" type="tts">person raising hand: dark skin tone</annotation>
+		<annotation cp="🙋🏻‍♂">gesture | hand | here | know | light skin tone | man | me | pick | question | raise | raising</annotation>
+		<annotation cp="🙋🏻‍♂" type="tts">man raising hand: light skin tone</annotation>
+		<annotation cp="🙋🏼‍♂">gesture | hand | here | know | man | me | medium-light skin tone | pick | question | raise | raising</annotation>
+		<annotation cp="🙋🏼‍♂" type="tts">man raising hand: medium-light skin tone</annotation>
+		<annotation cp="🙋🏽‍♂">gesture | hand | here | know | man | me | medium skin tone | pick | question | raise | raising</annotation>
+		<annotation cp="🙋🏽‍♂" type="tts">man raising hand: medium skin tone</annotation>
+		<annotation cp="🙋🏾‍♂">gesture | hand | here | know | man | me | medium-dark skin tone | pick | question | raise | raising</annotation>
+		<annotation cp="🙋🏾‍♂" type="tts">man raising hand: medium-dark skin tone</annotation>
+		<annotation cp="🙋🏿‍♂">dark skin tone | gesture | hand | here | know | man | me | pick | question | raise | raising</annotation>
+		<annotation cp="🙋🏿‍♂" type="tts">man raising hand: dark skin tone</annotation>
+		<annotation cp="🙋🏻‍♀">gesture | hand | here | know | light skin tone | me | pick | question | raise | raising | woman</annotation>
+		<annotation cp="🙋🏻‍♀" type="tts">woman raising hand: light skin tone</annotation>
+		<annotation cp="🙋🏼‍♀">gesture | hand | here | know | me | medium-light skin tone | pick | question | raise | raising | woman</annotation>
+		<annotation cp="🙋🏼‍♀" type="tts">woman raising hand: medium-light skin tone</annotation>
+		<annotation cp="🙋🏽‍♀">gesture | hand | here | know | me | medium skin tone | pick | question | raise | raising | woman</annotation>
+		<annotation cp="🙋🏽‍♀" type="tts">woman raising hand: medium skin tone</annotation>
+		<annotation cp="🙋🏾‍♀">gesture | hand | here | know | me | medium-dark skin tone | pick | question | raise | raising | woman</annotation>
+		<annotation cp="🙋🏾‍♀" type="tts">woman raising hand: medium-dark skin tone</annotation>
+		<annotation cp="🙋🏿‍♀">dark skin tone | gesture | hand | here | know | me | pick | question | raise | raising | woman</annotation>
+		<annotation cp="🙋🏿‍♀" type="tts">woman raising hand: dark skin tone</annotation>
+		<annotation cp="🧏🏻">accessibility | deaf | ear | gesture | hear | light skin tone | person</annotation>
+		<annotation cp="🧏🏻" type="tts">deaf person: light skin tone</annotation>
+		<annotation cp="🧏🏼">accessibility | deaf | ear | gesture | hear | medium-light skin tone | person</annotation>
+		<annotation cp="🧏🏼" type="tts">deaf person: medium-light skin tone</annotation>
+		<annotation cp="🧏🏽">accessibility | deaf | ear | gesture | hear | medium skin tone | person</annotation>
+		<annotation cp="🧏🏽" type="tts">deaf person: medium skin tone</annotation>
+		<annotation cp="🧏🏾">accessibility | deaf | ear | gesture | hear | medium-dark skin tone | person</annotation>
+		<annotation cp="🧏🏾" type="tts">deaf person: medium-dark skin tone</annotation>
+		<annotation cp="🧏🏿">accessibility | dark skin tone | deaf | ear | gesture | hear | person</annotation>
+		<annotation cp="🧏🏿" type="tts">deaf person: dark skin tone</annotation>
+		<annotation cp="🧏🏻‍♂">accessibility | deaf | ear | gesture | hear | light skin tone | man</annotation>
+		<annotation cp="🧏🏻‍♂" type="tts">deaf man: light skin tone</annotation>
+		<annotation cp="🧏🏼‍♂">accessibility | deaf | ear | gesture | hear | man | medium-light skin tone</annotation>
+		<annotation cp="🧏🏼‍♂" type="tts">deaf man: medium-light skin tone</annotation>
+		<annotation cp="🧏🏽‍♂">accessibility | deaf | ear | gesture | hear | man | medium skin tone</annotation>
+		<annotation cp="🧏🏽‍♂" type="tts">deaf man: medium skin tone</annotation>
+		<annotation cp="🧏🏾‍♂">accessibility | deaf | ear | gesture | hear | man | medium-dark skin tone</annotation>
+		<annotation cp="🧏🏾‍♂" type="tts">deaf man: medium-dark skin tone</annotation>
+		<annotation cp="🧏🏿‍♂">accessibility | dark skin tone | deaf | ear | gesture | hear | man</annotation>
+		<annotation cp="🧏🏿‍♂" type="tts">deaf man: dark skin tone</annotation>
+		<annotation cp="🧏🏻‍♀">accessibility | deaf | ear | gesture | hear | light skin tone | woman</annotation>
+		<annotation cp="🧏🏻‍♀" type="tts">deaf woman: light skin tone</annotation>
+		<annotation cp="🧏🏼‍♀">accessibility | deaf | ear | gesture | hear | medium-light skin tone | woman</annotation>
+		<annotation cp="🧏🏼‍♀" type="tts">deaf woman: medium-light skin tone</annotation>
+		<annotation cp="🧏🏽‍♀">accessibility | deaf | ear | gesture | hear | medium skin tone | woman</annotation>
+		<annotation cp="🧏🏽‍♀" type="tts">deaf woman: medium skin tone</annotation>
+		<annotation cp="🧏🏾‍♀">accessibility | deaf | ear | gesture | hear | medium-dark skin tone | woman</annotation>
+		<annotation cp="🧏🏾‍♀" type="tts">deaf woman: medium-dark skin tone</annotation>
+		<annotation cp="🧏🏿‍♀">accessibility | dark skin tone | deaf | ear | gesture | hear | woman</annotation>
+		<annotation cp="🧏🏿‍♀" type="tts">deaf woman: dark skin tone</annotation>
+		<annotation cp="🙇🏻">apology | ask | beg | bow | bowing | favor | forgive | gesture | light skin tone | meditate | meditation | person | pity | regret | sorry</annotation>
+		<annotation cp="🙇🏻" type="tts">person bowing: light skin tone</annotation>
+		<annotation cp="🙇🏼">apology | ask | beg | bow | bowing | favor | forgive | gesture | meditate | meditation | medium-light skin tone | person | pity | regret | sorry</annotation>
+		<annotation cp="🙇🏼" type="tts">person bowing: medium-light skin tone</annotation>
+		<annotation cp="🙇🏽">apology | ask | beg | bow | bowing | favor | forgive | gesture | meditate | meditation | medium skin tone | person | pity | regret | sorry</annotation>
+		<annotation cp="🙇🏽" type="tts">person bowing: medium skin tone</annotation>
+		<annotation cp="🙇🏾">apology | ask | beg | bow | bowing | favor | forgive | gesture | meditate | meditation | medium-dark skin tone | person | pity | regret | sorry</annotation>
+		<annotation cp="🙇🏾" type="tts">person bowing: medium-dark skin tone</annotation>
+		<annotation cp="🙇🏿">apology | ask | beg | bow | bowing | dark skin tone | favor | forgive | gesture | meditate | meditation | person | pity | regret | sorry</annotation>
+		<annotation cp="🙇🏿" type="tts">person bowing: dark skin tone</annotation>
+		<annotation cp="🙇🏻‍♂">apology | ask | beg | bow | bowing | favor | forgive | gesture | light skin tone | man | meditate | meditation | pity | regret | sorry</annotation>
+		<annotation cp="🙇🏻‍♂" type="tts">man bowing: light skin tone</annotation>
+		<annotation cp="🙇🏼‍♂">apology | ask | beg | bow | bowing | favor | forgive | gesture | man | meditate | meditation | medium-light skin tone | pity | regret | sorry</annotation>
+		<annotation cp="🙇🏼‍♂" type="tts">man bowing: medium-light skin tone</annotation>
+		<annotation cp="🙇🏽‍♂">apology | ask | beg | bow | bowing | favor | forgive | gesture | man | meditate | meditation | medium skin tone | pity | regret | sorry</annotation>
+		<annotation cp="🙇🏽‍♂" type="tts">man bowing: medium skin tone</annotation>
+		<annotation cp="🙇🏾‍♂">apology | ask | beg | bow | bowing | favor | forgive | gesture | man | meditate | meditation | medium-dark skin tone | pity | regret | sorry</annotation>
+		<annotation cp="🙇🏾‍♂" type="tts">man bowing: medium-dark skin tone</annotation>
+		<annotation cp="🙇🏿‍♂">apology | ask | beg | bow | bowing | dark skin tone | favor | forgive | gesture | man | meditate | meditation | pity | regret | sorry</annotation>
+		<annotation cp="🙇🏿‍♂" type="tts">man bowing: dark skin tone</annotation>
+		<annotation cp="🙇🏻‍♀">apology | ask | beg | bow | bowing | favor | forgive | gesture | light skin tone | meditate | meditation | pity | regret | sorry | woman</annotation>
+		<annotation cp="🙇🏻‍♀" type="tts">woman bowing: light skin tone</annotation>
+		<annotation cp="🙇🏼‍♀">apology | ask | beg | bow | bowing | favor | forgive | gesture | meditate | meditation | medium-light skin tone | pity | regret | sorry | woman</annotation>
+		<annotation cp="🙇🏼‍♀" type="tts">woman bowing: medium-light skin tone</annotation>
+		<annotation cp="🙇🏽‍♀">apology | ask | beg | bow | bowing | favor | forgive | gesture | meditate | meditation | medium skin tone | pity | regret | sorry | woman</annotation>
+		<annotation cp="🙇🏽‍♀" type="tts">woman bowing: medium skin tone</annotation>
+		<annotation cp="🙇🏾‍♀">apology | ask | beg | bow | bowing | favor | forgive | gesture | meditate | meditation | medium-dark skin tone | pity | regret | sorry | woman</annotation>
+		<annotation cp="🙇🏾‍♀" type="tts">woman bowing: medium-dark skin tone</annotation>
+		<annotation cp="🙇🏿‍♀">apology | ask | beg | bow | bowing | dark skin tone | favor | forgive | gesture | meditate | meditation | pity | regret | sorry | woman</annotation>
+		<annotation cp="🙇🏿‍♀" type="tts">woman bowing: dark skin tone</annotation>
+		<annotation cp="🤦🏻">again | bewilder | disbelief | exasperation | facepalm | light skin tone | no | not | oh | omg | person | shock | smh</annotation>
+		<annotation cp="🤦🏻" type="tts">person facepalming: light skin tone</annotation>
+		<annotation cp="🤦🏼">again | bewilder | disbelief | exasperation | facepalm | medium-light skin tone | no | not | oh | omg | person | shock | smh</annotation>
+		<annotation cp="🤦🏼" type="tts">person facepalming: medium-light skin tone</annotation>
+		<annotation cp="🤦🏽">again | bewilder | disbelief | exasperation | facepalm | medium skin tone | no | not | oh | omg | person | shock | smh</annotation>
+		<annotation cp="🤦🏽" type="tts">person facepalming: medium skin tone</annotation>
+		<annotation cp="🤦🏾">again | bewilder | disbelief | exasperation | facepalm | medium-dark skin tone | no | not | oh | omg | person | shock | smh</annotation>
+		<annotation cp="🤦🏾" type="tts">person facepalming: medium-dark skin tone</annotation>
+		<annotation cp="🤦🏿">again | bewilder | dark skin tone | disbelief | exasperation | facepalm | no | not | oh | omg | person | shock | smh</annotation>
+		<annotation cp="🤦🏿" type="tts">person facepalming: dark skin tone</annotation>
+		<annotation cp="🤦🏻‍♂">again | bewilder | disbelief | exasperation | facepalm | light skin tone | man | no | not | oh | omg | shock | smh</annotation>
+		<annotation cp="🤦🏻‍♂" type="tts">man facepalming: light skin tone</annotation>
+		<annotation cp="🤦🏼‍♂">again | bewilder | disbelief | exasperation | facepalm | man | medium-light skin tone | no | not | oh | omg | shock | smh</annotation>
+		<annotation cp="🤦🏼‍♂" type="tts">man facepalming: medium-light skin tone</annotation>
+		<annotation cp="🤦🏽‍♂">again | bewilder | disbelief | exasperation | facepalm | man | medium skin tone | no | not | oh | omg | shock | smh</annotation>
+		<annotation cp="🤦🏽‍♂" type="tts">man facepalming: medium skin tone</annotation>
+		<annotation cp="🤦🏾‍♂">again | bewilder | disbelief | exasperation | facepalm | man | medium-dark skin tone | no | not | oh | omg | shock | smh</annotation>
+		<annotation cp="🤦🏾‍♂" type="tts">man facepalming: medium-dark skin tone</annotation>
+		<annotation cp="🤦🏿‍♂">again | bewilder | dark skin tone | disbelief | exasperation | facepalm | man | no | not | oh | omg | shock | smh</annotation>
+		<annotation cp="🤦🏿‍♂" type="tts">man facepalming: dark skin tone</annotation>
+		<annotation cp="🤦🏻‍♀">again | bewilder | disbelief | exasperation | facepalm | light skin tone | no | not | oh | omg | shock | smh | woman</annotation>
+		<annotation cp="🤦🏻‍♀" type="tts">woman facepalming: light skin tone</annotation>
+		<annotation cp="🤦🏼‍♀">again | bewilder | disbelief | exasperation | facepalm | medium-light skin tone | no | not | oh | omg | shock | smh | woman</annotation>
+		<annotation cp="🤦🏼‍♀" type="tts">woman facepalming: medium-light skin tone</annotation>
+		<annotation cp="🤦🏽‍♀">again | bewilder | disbelief | exasperation | facepalm | medium skin tone | no | not | oh | omg | shock | smh | woman</annotation>
+		<annotation cp="🤦🏽‍♀" type="tts">woman facepalming: medium skin tone</annotation>
+		<annotation cp="🤦🏾‍♀">again | bewilder | disbelief | exasperation | facepalm | medium-dark skin tone | no | not | oh | omg | shock | smh | woman</annotation>
+		<annotation cp="🤦🏾‍♀" type="tts">woman facepalming: medium-dark skin tone</annotation>
+		<annotation cp="🤦🏿‍♀">again | bewilder | dark skin tone | disbelief | exasperation | facepalm | no | not | oh | omg | shock | smh | woman</annotation>
+		<annotation cp="🤦🏿‍♀" type="tts">woman facepalming: dark skin tone</annotation>
+		<annotation cp="🤷🏻">doubt | dunno | guess | idk | ignorance | indifference | knows | light skin tone | maybe | person | shrug | shrugging | whatever | who</annotation>
+		<annotation cp="🤷🏻" type="tts">person shrugging: light skin tone</annotation>
+		<annotation cp="🤷🏼">doubt | dunno | guess | idk | ignorance | indifference | knows | maybe | medium-light skin tone | person | shrug | shrugging | whatever | who</annotation>
+		<annotation cp="🤷🏼" type="tts">person shrugging: medium-light skin tone</annotation>
+		<annotation cp="🤷🏽">doubt | dunno | guess | idk | ignorance | indifference | knows | maybe | medium skin tone | person | shrug | shrugging | whatever | who</annotation>
+		<annotation cp="🤷🏽" type="tts">person shrugging: medium skin tone</annotation>
+		<annotation cp="🤷🏾">doubt | dunno | guess | idk | ignorance | indifference | knows | maybe | medium-dark skin tone | person | shrug | shrugging | whatever | who</annotation>
+		<annotation cp="🤷🏾" type="tts">person shrugging: medium-dark skin tone</annotation>
+		<annotation cp="🤷🏿">dark skin tone | doubt | dunno | guess | idk | ignorance | indifference | knows | maybe | person | shrug | shrugging | whatever | who</annotation>
+		<annotation cp="🤷🏿" type="tts">person shrugging: dark skin tone</annotation>
+		<annotation cp="🤷🏻‍♂">doubt | dunno | guess | idk | ignorance | indifference | knows | light skin tone | man | maybe | shrug | shrugging | whatever | who</annotation>
+		<annotation cp="🤷🏻‍♂" type="tts">man shrugging: light skin tone</annotation>
+		<annotation cp="🤷🏼‍♂">doubt | dunno | guess | idk | ignorance | indifference | knows | man | maybe | medium-light skin tone | shrug | shrugging | whatever | who</annotation>
+		<annotation cp="🤷🏼‍♂" type="tts">man shrugging: medium-light skin tone</annotation>
+		<annotation cp="🤷🏽‍♂">doubt | dunno | guess | idk | ignorance | indifference | knows | man | maybe | medium skin tone | shrug | shrugging | whatever | who</annotation>
+		<annotation cp="🤷🏽‍♂" type="tts">man shrugging: medium skin tone</annotation>
+		<annotation cp="🤷🏾‍♂">doubt | dunno | guess | idk | ignorance | indifference | knows | man | maybe | medium-dark skin tone | shrug | shrugging | whatever | who</annotation>
+		<annotation cp="🤷🏾‍♂" type="tts">man shrugging: medium-dark skin tone</annotation>
+		<annotation cp="🤷🏿‍♂">dark skin tone | doubt | dunno | guess | idk | ignorance | indifference | knows | man | maybe | shrug | shrugging | whatever | who</annotation>
+		<annotation cp="🤷🏿‍♂" type="tts">man shrugging: dark skin tone</annotation>
+		<annotation cp="🤷🏻‍♀">doubt | dunno | guess | idk | ignorance | indifference | knows | light skin tone | maybe | shrug | shrugging | whatever | who | woman</annotation>
+		<annotation cp="🤷🏻‍♀" type="tts">woman shrugging: light skin tone</annotation>
+		<annotation cp="🤷🏼‍♀">doubt | dunno | guess | idk | ignorance | indifference | knows | maybe | medium-light skin tone | shrug | shrugging | whatever | who | woman</annotation>
+		<annotation cp="🤷🏼‍♀" type="tts">woman shrugging: medium-light skin tone</annotation>
+		<annotation cp="🤷🏽‍♀">doubt | dunno | guess | idk | ignorance | indifference | knows | maybe | medium skin tone | shrug | shrugging | whatever | who | woman</annotation>
+		<annotation cp="🤷🏽‍♀" type="tts">woman shrugging: medium skin tone</annotation>
+		<annotation cp="🤷🏾‍♀">doubt | dunno | guess | idk | ignorance | indifference | knows | maybe | medium-dark skin tone | shrug | shrugging | whatever | who | woman</annotation>
+		<annotation cp="🤷🏾‍♀" type="tts">woman shrugging: medium-dark skin tone</annotation>
+		<annotation cp="🤷🏿‍♀">dark skin tone | doubt | dunno | guess | idk | ignorance | indifference | knows | maybe | shrug | shrugging | whatever | who | woman</annotation>
+		<annotation cp="🤷🏿‍♀" type="tts">woman shrugging: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍⚕">doctor | health | healthcare | light skin tone | nurse | therapist | worker</annotation>
+		<annotation cp="🧑🏻‍⚕" type="tts">health worker: light skin tone</annotation>
+		<annotation cp="🧑🏼‍⚕">doctor | health | healthcare | medium-light skin tone | nurse | therapist | worker</annotation>
+		<annotation cp="🧑🏼‍⚕" type="tts">health worker: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍⚕">doctor | health | healthcare | medium skin tone | nurse | therapist | worker</annotation>
+		<annotation cp="🧑🏽‍⚕" type="tts">health worker: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍⚕">doctor | health | healthcare | medium-dark skin tone | nurse | therapist | worker</annotation>
+		<annotation cp="🧑🏾‍⚕" type="tts">health worker: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍⚕">dark skin tone | doctor | health | healthcare | nurse | therapist | worker</annotation>
+		<annotation cp="🧑🏿‍⚕" type="tts">health worker: dark skin tone</annotation>
+		<annotation cp="👨🏻‍⚕">doctor | health | healthcare | light skin tone | man | nurse | therapist | worker</annotation>
+		<annotation cp="👨🏻‍⚕" type="tts">man health worker: light skin tone</annotation>
+		<annotation cp="👨🏼‍⚕">doctor | health | healthcare | man | medium-light skin tone | nurse | therapist | worker</annotation>
+		<annotation cp="👨🏼‍⚕" type="tts">man health worker: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍⚕">doctor | health | healthcare | man | medium skin tone | nurse | therapist | worker</annotation>
+		<annotation cp="👨🏽‍⚕" type="tts">man health worker: medium skin tone</annotation>
+		<annotation cp="👨🏾‍⚕">doctor | health | healthcare | man | medium-dark skin tone | nurse | therapist | worker</annotation>
+		<annotation cp="👨🏾‍⚕" type="tts">man health worker: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍⚕">dark skin tone | doctor | health | healthcare | man | nurse | therapist | worker</annotation>
+		<annotation cp="👨🏿‍⚕" type="tts">man health worker: dark skin tone</annotation>
+		<annotation cp="👩🏻‍⚕">doctor | health | healthcare | light skin tone | nurse | therapist | woman | worker</annotation>
+		<annotation cp="👩🏻‍⚕" type="tts">woman health worker: light skin tone</annotation>
+		<annotation cp="👩🏼‍⚕">doctor | health | healthcare | medium-light skin tone | nurse | therapist | woman | worker</annotation>
+		<annotation cp="👩🏼‍⚕" type="tts">woman health worker: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍⚕">doctor | health | healthcare | medium skin tone | nurse | therapist | woman | worker</annotation>
+		<annotation cp="👩🏽‍⚕" type="tts">woman health worker: medium skin tone</annotation>
+		<annotation cp="👩🏾‍⚕">doctor | health | healthcare | medium-dark skin tone | nurse | therapist | woman | worker</annotation>
+		<annotation cp="👩🏾‍⚕" type="tts">woman health worker: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍⚕">dark skin tone | doctor | health | healthcare | nurse | therapist | woman | worker</annotation>
+		<annotation cp="👩🏿‍⚕" type="tts">woman health worker: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍🎓">graduate | light skin tone | student</annotation>
+		<annotation cp="🧑🏻‍🎓" type="tts">student: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🎓">graduate | medium-light skin tone | student</annotation>
+		<annotation cp="🧑🏼‍🎓" type="tts">student: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🎓">graduate | medium skin tone | student</annotation>
+		<annotation cp="🧑🏽‍🎓" type="tts">student: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🎓">graduate | medium-dark skin tone | student</annotation>
+		<annotation cp="🧑🏾‍🎓" type="tts">student: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🎓">dark skin tone | graduate | student</annotation>
+		<annotation cp="🧑🏿‍🎓" type="tts">student: dark skin tone</annotation>
+		<annotation cp="👨🏻‍🎓">graduate | light skin tone | man | student</annotation>
+		<annotation cp="👨🏻‍🎓" type="tts">man student: light skin tone</annotation>
+		<annotation cp="👨🏼‍🎓">graduate | man | medium-light skin tone | student</annotation>
+		<annotation cp="👨🏼‍🎓" type="tts">man student: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍🎓">graduate | man | medium skin tone | student</annotation>
+		<annotation cp="👨🏽‍🎓" type="tts">man student: medium skin tone</annotation>
+		<annotation cp="👨🏾‍🎓">graduate | man | medium-dark skin tone | student</annotation>
+		<annotation cp="👨🏾‍🎓" type="tts">man student: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍🎓">dark skin tone | graduate | man | student</annotation>
+		<annotation cp="👨🏿‍🎓" type="tts">man student: dark skin tone</annotation>
+		<annotation cp="👩🏻‍🎓">graduate | light skin tone | student | woman</annotation>
+		<annotation cp="👩🏻‍🎓" type="tts">woman student: light skin tone</annotation>
+		<annotation cp="👩🏼‍🎓">graduate | medium-light skin tone | student | woman</annotation>
+		<annotation cp="👩🏼‍🎓" type="tts">woman student: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍🎓">graduate | medium skin tone | student | woman</annotation>
+		<annotation cp="👩🏽‍🎓" type="tts">woman student: medium skin tone</annotation>
+		<annotation cp="👩🏾‍🎓">graduate | medium-dark skin tone | student | woman</annotation>
+		<annotation cp="👩🏾‍🎓" type="tts">woman student: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍🎓">dark skin tone | graduate | student | woman</annotation>
+		<annotation cp="👩🏿‍🎓" type="tts">woman student: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍🏫">instructor | lecturer | light skin tone | professor | teacher</annotation>
+		<annotation cp="🧑🏻‍🏫" type="tts">teacher: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🏫">instructor | lecturer | medium-light skin tone | professor | teacher</annotation>
+		<annotation cp="🧑🏼‍🏫" type="tts">teacher: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🏫">instructor | lecturer | medium skin tone | professor | teacher</annotation>
+		<annotation cp="🧑🏽‍🏫" type="tts">teacher: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🏫">instructor | lecturer | medium-dark skin tone | professor | teacher</annotation>
+		<annotation cp="🧑🏾‍🏫" type="tts">teacher: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🏫">dark skin tone | instructor | lecturer | professor | teacher</annotation>
+		<annotation cp="🧑🏿‍🏫" type="tts">teacher: dark skin tone</annotation>
+		<annotation cp="👨🏻‍🏫">instructor | lecturer | light skin tone | man | professor | teacher</annotation>
+		<annotation cp="👨🏻‍🏫" type="tts">man teacher: light skin tone</annotation>
+		<annotation cp="👨🏼‍🏫">instructor | lecturer | man | medium-light skin tone | professor | teacher</annotation>
+		<annotation cp="👨🏼‍🏫" type="tts">man teacher: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍🏫">instructor | lecturer | man | medium skin tone | professor | teacher</annotation>
+		<annotation cp="👨🏽‍🏫" type="tts">man teacher: medium skin tone</annotation>
+		<annotation cp="👨🏾‍🏫">instructor | lecturer | man | medium-dark skin tone | professor | teacher</annotation>
+		<annotation cp="👨🏾‍🏫" type="tts">man teacher: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍🏫">dark skin tone | instructor | lecturer | man | professor | teacher</annotation>
+		<annotation cp="👨🏿‍🏫" type="tts">man teacher: dark skin tone</annotation>
+		<annotation cp="👩🏻‍🏫">instructor | lecturer | light skin tone | professor | teacher | woman</annotation>
+		<annotation cp="👩🏻‍🏫" type="tts">woman teacher: light skin tone</annotation>
+		<annotation cp="👩🏼‍🏫">instructor | lecturer | medium-light skin tone | professor | teacher | woman</annotation>
+		<annotation cp="👩🏼‍🏫" type="tts">woman teacher: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍🏫">instructor | lecturer | medium skin tone | professor | teacher | woman</annotation>
+		<annotation cp="👩🏽‍🏫" type="tts">woman teacher: medium skin tone</annotation>
+		<annotation cp="👩🏾‍🏫">instructor | lecturer | medium-dark skin tone | professor | teacher | woman</annotation>
+		<annotation cp="👩🏾‍🏫" type="tts">woman teacher: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍🏫">dark skin tone | instructor | lecturer | professor | teacher | woman</annotation>
+		<annotation cp="👩🏿‍🏫" type="tts">woman teacher: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍⚖">judge | justice | law | light skin tone | scales</annotation>
+		<annotation cp="🧑🏻‍⚖" type="tts">judge: light skin tone</annotation>
+		<annotation cp="🧑🏼‍⚖">judge | justice | law | medium-light skin tone | scales</annotation>
+		<annotation cp="🧑🏼‍⚖" type="tts">judge: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍⚖">judge | justice | law | medium skin tone | scales</annotation>
+		<annotation cp="🧑🏽‍⚖" type="tts">judge: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍⚖">judge | justice | law | medium-dark skin tone | scales</annotation>
+		<annotation cp="🧑🏾‍⚖" type="tts">judge: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍⚖">dark skin tone | judge | justice | law | scales</annotation>
+		<annotation cp="🧑🏿‍⚖" type="tts">judge: dark skin tone</annotation>
+		<annotation cp="👨🏻‍⚖">judge | justice | law | light skin tone | man | scales</annotation>
+		<annotation cp="👨🏻‍⚖" type="tts">man judge: light skin tone</annotation>
+		<annotation cp="👨🏼‍⚖">judge | justice | law | man | medium-light skin tone | scales</annotation>
+		<annotation cp="👨🏼‍⚖" type="tts">man judge: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍⚖">judge | justice | law | man | medium skin tone | scales</annotation>
+		<annotation cp="👨🏽‍⚖" type="tts">man judge: medium skin tone</annotation>
+		<annotation cp="👨🏾‍⚖">judge | justice | law | man | medium-dark skin tone | scales</annotation>
+		<annotation cp="👨🏾‍⚖" type="tts">man judge: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍⚖">dark skin tone | judge | justice | law | man | scales</annotation>
+		<annotation cp="👨🏿‍⚖" type="tts">man judge: dark skin tone</annotation>
+		<annotation cp="👩🏻‍⚖">judge | justice | law | light skin tone | scales | woman</annotation>
+		<annotation cp="👩🏻‍⚖" type="tts">woman judge: light skin tone</annotation>
+		<annotation cp="👩🏼‍⚖">judge | justice | law | medium-light skin tone | scales | woman</annotation>
+		<annotation cp="👩🏼‍⚖" type="tts">woman judge: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍⚖">judge | justice | law | medium skin tone | scales | woman</annotation>
+		<annotation cp="👩🏽‍⚖" type="tts">woman judge: medium skin tone</annotation>
+		<annotation cp="👩🏾‍⚖">judge | justice | law | medium-dark skin tone | scales | woman</annotation>
+		<annotation cp="👩🏾‍⚖" type="tts">woman judge: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍⚖">dark skin tone | judge | justice | law | scales | woman</annotation>
+		<annotation cp="👩🏿‍⚖" type="tts">woman judge: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍🌾">farmer | gardener | light skin tone | rancher</annotation>
+		<annotation cp="🧑🏻‍🌾" type="tts">farmer: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🌾">farmer | gardener | medium-light skin tone | rancher</annotation>
+		<annotation cp="🧑🏼‍🌾" type="tts">farmer: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🌾">farmer | gardener | medium skin tone | rancher</annotation>
+		<annotation cp="🧑🏽‍🌾" type="tts">farmer: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🌾">farmer | gardener | medium-dark skin tone | rancher</annotation>
+		<annotation cp="🧑🏾‍🌾" type="tts">farmer: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🌾">dark skin tone | farmer | gardener | rancher</annotation>
+		<annotation cp="🧑🏿‍🌾" type="tts">farmer: dark skin tone</annotation>
+		<annotation cp="👨🏻‍🌾">farmer | gardener | light skin tone | man | rancher</annotation>
+		<annotation cp="👨🏻‍🌾" type="tts">man farmer: light skin tone</annotation>
+		<annotation cp="👨🏼‍🌾">farmer | gardener | man | medium-light skin tone | rancher</annotation>
+		<annotation cp="👨🏼‍🌾" type="tts">man farmer: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍🌾">farmer | gardener | man | medium skin tone | rancher</annotation>
+		<annotation cp="👨🏽‍🌾" type="tts">man farmer: medium skin tone</annotation>
+		<annotation cp="👨🏾‍🌾">farmer | gardener | man | medium-dark skin tone | rancher</annotation>
+		<annotation cp="👨🏾‍🌾" type="tts">man farmer: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍🌾">dark skin tone | farmer | gardener | man | rancher</annotation>
+		<annotation cp="👨🏿‍🌾" type="tts">man farmer: dark skin tone</annotation>
+		<annotation cp="👩🏻‍🌾">farmer | gardener | light skin tone | rancher | woman</annotation>
+		<annotation cp="👩🏻‍🌾" type="tts">woman farmer: light skin tone</annotation>
+		<annotation cp="👩🏼‍🌾">farmer | gardener | medium-light skin tone | rancher | woman</annotation>
+		<annotation cp="👩🏼‍🌾" type="tts">woman farmer: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍🌾">farmer | gardener | medium skin tone | rancher | woman</annotation>
+		<annotation cp="👩🏽‍🌾" type="tts">woman farmer: medium skin tone</annotation>
+		<annotation cp="👩🏾‍🌾">farmer | gardener | medium-dark skin tone | rancher | woman</annotation>
+		<annotation cp="👩🏾‍🌾" type="tts">woman farmer: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍🌾">dark skin tone | farmer | gardener | rancher | woman</annotation>
+		<annotation cp="👩🏿‍🌾" type="tts">woman farmer: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍🍳">chef | cook | light skin tone</annotation>
+		<annotation cp="🧑🏻‍🍳" type="tts">cook: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🍳">chef | cook | medium-light skin tone</annotation>
+		<annotation cp="🧑🏼‍🍳" type="tts">cook: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🍳">chef | cook | medium skin tone</annotation>
+		<annotation cp="🧑🏽‍🍳" type="tts">cook: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🍳">chef | cook | medium-dark skin tone</annotation>
+		<annotation cp="🧑🏾‍🍳" type="tts">cook: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🍳">chef | cook | dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🍳" type="tts">cook: dark skin tone</annotation>
+		<annotation cp="👨🏻‍🍳">chef | cook | light skin tone | man</annotation>
+		<annotation cp="👨🏻‍🍳" type="tts">man cook: light skin tone</annotation>
+		<annotation cp="👨🏼‍🍳">chef | cook | man | medium-light skin tone</annotation>
+		<annotation cp="👨🏼‍🍳" type="tts">man cook: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍🍳">chef | cook | man | medium skin tone</annotation>
+		<annotation cp="👨🏽‍🍳" type="tts">man cook: medium skin tone</annotation>
+		<annotation cp="👨🏾‍🍳">chef | cook | man | medium-dark skin tone</annotation>
+		<annotation cp="👨🏾‍🍳" type="tts">man cook: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍🍳">chef | cook | dark skin tone | man</annotation>
+		<annotation cp="👨🏿‍🍳" type="tts">man cook: dark skin tone</annotation>
+		<annotation cp="👩🏻‍🍳">chef | cook | light skin tone | woman</annotation>
+		<annotation cp="👩🏻‍🍳" type="tts">woman cook: light skin tone</annotation>
+		<annotation cp="👩🏼‍🍳">chef | cook | medium-light skin tone | woman</annotation>
+		<annotation cp="👩🏼‍🍳" type="tts">woman cook: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍🍳">chef | cook | medium skin tone | woman</annotation>
+		<annotation cp="👩🏽‍🍳" type="tts">woman cook: medium skin tone</annotation>
+		<annotation cp="👩🏾‍🍳">chef | cook | medium-dark skin tone | woman</annotation>
+		<annotation cp="👩🏾‍🍳" type="tts">woman cook: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍🍳">chef | cook | dark skin tone | woman</annotation>
+		<annotation cp="👩🏿‍🍳" type="tts">woman cook: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍🔧">electrician | light skin tone | mechanic | plumber | tradesperson</annotation>
+		<annotation cp="🧑🏻‍🔧" type="tts">mechanic: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🔧">electrician | mechanic | medium-light skin tone | plumber | tradesperson</annotation>
+		<annotation cp="🧑🏼‍🔧" type="tts">mechanic: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🔧">electrician | mechanic | medium skin tone | plumber | tradesperson</annotation>
+		<annotation cp="🧑🏽‍🔧" type="tts">mechanic: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🔧">electrician | mechanic | medium-dark skin tone | plumber | tradesperson</annotation>
+		<annotation cp="🧑🏾‍🔧" type="tts">mechanic: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🔧">dark skin tone | electrician | mechanic | plumber | tradesperson</annotation>
+		<annotation cp="🧑🏿‍🔧" type="tts">mechanic: dark skin tone</annotation>
+		<annotation cp="👨🏻‍🔧">electrician | light skin tone | man | mechanic | plumber | tradesperson</annotation>
+		<annotation cp="👨🏻‍🔧" type="tts">man mechanic: light skin tone</annotation>
+		<annotation cp="👨🏼‍🔧">electrician | man | mechanic | medium-light skin tone | plumber | tradesperson</annotation>
+		<annotation cp="👨🏼‍🔧" type="tts">man mechanic: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍🔧">electrician | man | mechanic | medium skin tone | plumber | tradesperson</annotation>
+		<annotation cp="👨🏽‍🔧" type="tts">man mechanic: medium skin tone</annotation>
+		<annotation cp="👨🏾‍🔧">electrician | man | mechanic | medium-dark skin tone | plumber | tradesperson</annotation>
+		<annotation cp="👨🏾‍🔧" type="tts">man mechanic: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍🔧">dark skin tone | electrician | man | mechanic | plumber | tradesperson</annotation>
+		<annotation cp="👨🏿‍🔧" type="tts">man mechanic: dark skin tone</annotation>
+		<annotation cp="👩🏻‍🔧">electrician | light skin tone | mechanic | plumber | tradesperson | woman</annotation>
+		<annotation cp="👩🏻‍🔧" type="tts">woman mechanic: light skin tone</annotation>
+		<annotation cp="👩🏼‍🔧">electrician | mechanic | medium-light skin tone | plumber | tradesperson | woman</annotation>
+		<annotation cp="👩🏼‍🔧" type="tts">woman mechanic: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍🔧">electrician | mechanic | medium skin tone | plumber | tradesperson | woman</annotation>
+		<annotation cp="👩🏽‍🔧" type="tts">woman mechanic: medium skin tone</annotation>
+		<annotation cp="👩🏾‍🔧">electrician | mechanic | medium-dark skin tone | plumber | tradesperson | woman</annotation>
+		<annotation cp="👩🏾‍🔧" type="tts">woman mechanic: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍🔧">dark skin tone | electrician | mechanic | plumber | tradesperson | woman</annotation>
+		<annotation cp="👩🏿‍🔧" type="tts">woman mechanic: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍🏭">assembly | factory | industrial | light skin tone | worker</annotation>
+		<annotation cp="🧑🏻‍🏭" type="tts">factory worker: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🏭">assembly | factory | industrial | medium-light skin tone | worker</annotation>
+		<annotation cp="🧑🏼‍🏭" type="tts">factory worker: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🏭">assembly | factory | industrial | medium skin tone | worker</annotation>
+		<annotation cp="🧑🏽‍🏭" type="tts">factory worker: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🏭">assembly | factory | industrial | medium-dark skin tone | worker</annotation>
+		<annotation cp="🧑🏾‍🏭" type="tts">factory worker: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🏭">assembly | dark skin tone | factory | industrial | worker</annotation>
+		<annotation cp="🧑🏿‍🏭" type="tts">factory worker: dark skin tone</annotation>
+		<annotation cp="👨🏻‍🏭">assembly | factory | industrial | light skin tone | man | worker</annotation>
+		<annotation cp="👨🏻‍🏭" type="tts">man factory worker: light skin tone</annotation>
+		<annotation cp="👨🏼‍🏭">assembly | factory | industrial | man | medium-light skin tone | worker</annotation>
+		<annotation cp="👨🏼‍🏭" type="tts">man factory worker: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍🏭">assembly | factory | industrial | man | medium skin tone | worker</annotation>
+		<annotation cp="👨🏽‍🏭" type="tts">man factory worker: medium skin tone</annotation>
+		<annotation cp="👨🏾‍🏭">assembly | factory | industrial | man | medium-dark skin tone | worker</annotation>
+		<annotation cp="👨🏾‍🏭" type="tts">man factory worker: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍🏭">assembly | dark skin tone | factory | industrial | man | worker</annotation>
+		<annotation cp="👨🏿‍🏭" type="tts">man factory worker: dark skin tone</annotation>
+		<annotation cp="👩🏻‍🏭">assembly | factory | industrial | light skin tone | woman | worker</annotation>
+		<annotation cp="👩🏻‍🏭" type="tts">woman factory worker: light skin tone</annotation>
+		<annotation cp="👩🏼‍🏭">assembly | factory | industrial | medium-light skin tone | woman | worker</annotation>
+		<annotation cp="👩🏼‍🏭" type="tts">woman factory worker: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍🏭">assembly | factory | industrial | medium skin tone | woman | worker</annotation>
+		<annotation cp="👩🏽‍🏭" type="tts">woman factory worker: medium skin tone</annotation>
+		<annotation cp="👩🏾‍🏭">assembly | factory | industrial | medium-dark skin tone | woman | worker</annotation>
+		<annotation cp="👩🏾‍🏭" type="tts">woman factory worker: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍🏭">assembly | dark skin tone | factory | industrial | woman | worker</annotation>
+		<annotation cp="👩🏿‍🏭" type="tts">woman factory worker: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍💼">architect | business | light skin tone | manager | office | white-collar | worker</annotation>
+		<annotation cp="🧑🏻‍💼" type="tts">office worker: light skin tone</annotation>
+		<annotation cp="🧑🏼‍💼">architect | business | manager | medium-light skin tone | office | white-collar | worker</annotation>
+		<annotation cp="🧑🏼‍💼" type="tts">office worker: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍💼">architect | business | manager | medium skin tone | office | white-collar | worker</annotation>
+		<annotation cp="🧑🏽‍💼" type="tts">office worker: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍💼">architect | business | manager | medium-dark skin tone | office | white-collar | worker</annotation>
+		<annotation cp="🧑🏾‍💼" type="tts">office worker: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍💼">architect | business | dark skin tone | manager | office | white-collar | worker</annotation>
+		<annotation cp="🧑🏿‍💼" type="tts">office worker: dark skin tone</annotation>
+		<annotation cp="👨🏻‍💼">architect | business | light skin tone | man | manager | office | white-collar | worker</annotation>
+		<annotation cp="👨🏻‍💼" type="tts">man office worker: light skin tone</annotation>
+		<annotation cp="👨🏼‍💼">architect | business | man | manager | medium-light skin tone | office | white-collar | worker</annotation>
+		<annotation cp="👨🏼‍💼" type="tts">man office worker: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍💼">architect | business | man | manager | medium skin tone | office | white-collar | worker</annotation>
+		<annotation cp="👨🏽‍💼" type="tts">man office worker: medium skin tone</annotation>
+		<annotation cp="👨🏾‍💼">architect | business | man | manager | medium-dark skin tone | office | white-collar | worker</annotation>
+		<annotation cp="👨🏾‍💼" type="tts">man office worker: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍💼">architect | business | dark skin tone | man | manager | office | white-collar | worker</annotation>
+		<annotation cp="👨🏿‍💼" type="tts">man office worker: dark skin tone</annotation>
+		<annotation cp="👩🏻‍💼">architect | business | light skin tone | manager | office | white-collar | woman | worker</annotation>
+		<annotation cp="👩🏻‍💼" type="tts">woman office worker: light skin tone</annotation>
+		<annotation cp="👩🏼‍💼">architect | business | manager | medium-light skin tone | office | white-collar | woman | worker</annotation>
+		<annotation cp="👩🏼‍💼" type="tts">woman office worker: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍💼">architect | business | manager | medium skin tone | office | white-collar | woman | worker</annotation>
+		<annotation cp="👩🏽‍💼" type="tts">woman office worker: medium skin tone</annotation>
+		<annotation cp="👩🏾‍💼">architect | business | manager | medium-dark skin tone | office | white-collar | woman | worker</annotation>
+		<annotation cp="👩🏾‍💼" type="tts">woman office worker: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍💼">architect | business | dark skin tone | manager | office | white-collar | woman | worker</annotation>
+		<annotation cp="👩🏿‍💼" type="tts">woman office worker: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍🔬">biologist | chemist | engineer | light skin tone | mathematician | physicist | scientist</annotation>
+		<annotation cp="🧑🏻‍🔬" type="tts">scientist: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🔬">biologist | chemist | engineer | mathematician | medium-light skin tone | physicist | scientist</annotation>
+		<annotation cp="🧑🏼‍🔬" type="tts">scientist: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🔬">biologist | chemist | engineer | mathematician | medium skin tone | physicist | scientist</annotation>
+		<annotation cp="🧑🏽‍🔬" type="tts">scientist: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🔬">biologist | chemist | engineer | mathematician | medium-dark skin tone | physicist | scientist</annotation>
+		<annotation cp="🧑🏾‍🔬" type="tts">scientist: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🔬">biologist | chemist | dark skin tone | engineer | mathematician | physicist | scientist</annotation>
+		<annotation cp="🧑🏿‍🔬" type="tts">scientist: dark skin tone</annotation>
+		<annotation cp="👨🏻‍🔬">biologist | chemist | engineer | light skin tone | man | mathematician | physicist | scientist</annotation>
+		<annotation cp="👨🏻‍🔬" type="tts">man scientist: light skin tone</annotation>
+		<annotation cp="👨🏼‍🔬">biologist | chemist | engineer | man | mathematician | medium-light skin tone | physicist | scientist</annotation>
+		<annotation cp="👨🏼‍🔬" type="tts">man scientist: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍🔬">biologist | chemist | engineer | man | mathematician | medium skin tone | physicist | scientist</annotation>
+		<annotation cp="👨🏽‍🔬" type="tts">man scientist: medium skin tone</annotation>
+		<annotation cp="👨🏾‍🔬">biologist | chemist | engineer | man | mathematician | medium-dark skin tone | physicist | scientist</annotation>
+		<annotation cp="👨🏾‍🔬" type="tts">man scientist: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍🔬">biologist | chemist | dark skin tone | engineer | man | mathematician | physicist | scientist</annotation>
+		<annotation cp="👨🏿‍🔬" type="tts">man scientist: dark skin tone</annotation>
+		<annotation cp="👩🏻‍🔬">biologist | chemist | engineer | light skin tone | mathematician | physicist | scientist | woman</annotation>
+		<annotation cp="👩🏻‍🔬" type="tts">woman scientist: light skin tone</annotation>
+		<annotation cp="👩🏼‍🔬">biologist | chemist | engineer | mathematician | medium-light skin tone | physicist | scientist | woman</annotation>
+		<annotation cp="👩🏼‍🔬" type="tts">woman scientist: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍🔬">biologist | chemist | engineer | mathematician | medium skin tone | physicist | scientist | woman</annotation>
+		<annotation cp="👩🏽‍🔬" type="tts">woman scientist: medium skin tone</annotation>
+		<annotation cp="👩🏾‍🔬">biologist | chemist | engineer | mathematician | medium-dark skin tone | physicist | scientist | woman</annotation>
+		<annotation cp="👩🏾‍🔬" type="tts">woman scientist: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍🔬">biologist | chemist | dark skin tone | engineer | mathematician | physicist | scientist | woman</annotation>
+		<annotation cp="👩🏿‍🔬" type="tts">woman scientist: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍💻">coder | computer | developer | inventor | light skin tone | software | technologist</annotation>
+		<annotation cp="🧑🏻‍💻" type="tts">technologist: light skin tone</annotation>
+		<annotation cp="🧑🏼‍💻">coder | computer | developer | inventor | medium-light skin tone | software | technologist</annotation>
+		<annotation cp="🧑🏼‍💻" type="tts">technologist: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍💻">coder | computer | developer | inventor | medium skin tone | software | technologist</annotation>
+		<annotation cp="🧑🏽‍💻" type="tts">technologist: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍💻">coder | computer | developer | inventor | medium-dark skin tone | software | technologist</annotation>
+		<annotation cp="🧑🏾‍💻" type="tts">technologist: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍💻">coder | computer | dark skin tone | developer | inventor | software | technologist</annotation>
+		<annotation cp="🧑🏿‍💻" type="tts">technologist: dark skin tone</annotation>
+		<annotation cp="👨🏻‍💻">coder | computer | developer | inventor | light skin tone | man | software | technologist</annotation>
+		<annotation cp="👨🏻‍💻" type="tts">man technologist: light skin tone</annotation>
+		<annotation cp="👨🏼‍💻">coder | computer | developer | inventor | man | medium-light skin tone | software | technologist</annotation>
+		<annotation cp="👨🏼‍💻" type="tts">man technologist: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍💻">coder | computer | developer | inventor | man | medium skin tone | software | technologist</annotation>
+		<annotation cp="👨🏽‍💻" type="tts">man technologist: medium skin tone</annotation>
+		<annotation cp="👨🏾‍💻">coder | computer | developer | inventor | man | medium-dark skin tone | software | technologist</annotation>
+		<annotation cp="👨🏾‍💻" type="tts">man technologist: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍💻">coder | computer | dark skin tone | developer | inventor | man | software | technologist</annotation>
+		<annotation cp="👨🏿‍💻" type="tts">man technologist: dark skin tone</annotation>
+		<annotation cp="👩🏻‍💻">coder | computer | developer | inventor | light skin tone | software | technologist | woman</annotation>
+		<annotation cp="👩🏻‍💻" type="tts">woman technologist: light skin tone</annotation>
+		<annotation cp="👩🏼‍💻">coder | computer | developer | inventor | medium-light skin tone | software | technologist | woman</annotation>
+		<annotation cp="👩🏼‍💻" type="tts">woman technologist: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍💻">coder | computer | developer | inventor | medium skin tone | software | technologist | woman</annotation>
+		<annotation cp="👩🏽‍💻" type="tts">woman technologist: medium skin tone</annotation>
+		<annotation cp="👩🏾‍💻">coder | computer | developer | inventor | medium-dark skin tone | software | technologist | woman</annotation>
+		<annotation cp="👩🏾‍💻" type="tts">woman technologist: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍💻">coder | computer | dark skin tone | developer | inventor | software | technologist | woman</annotation>
+		<annotation cp="👩🏿‍💻" type="tts">woman technologist: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍🎤">actor | entertainer | light skin tone | rock | rockstar | singer | star</annotation>
+		<annotation cp="🧑🏻‍🎤" type="tts">singer: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🎤">actor | entertainer | medium-light skin tone | rock | rockstar | singer | star</annotation>
+		<annotation cp="🧑🏼‍🎤" type="tts">singer: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🎤">actor | entertainer | medium skin tone | rock | rockstar | singer | star</annotation>
+		<annotation cp="🧑🏽‍🎤" type="tts">singer: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🎤">actor | entertainer | medium-dark skin tone | rock | rockstar | singer | star</annotation>
+		<annotation cp="🧑🏾‍🎤" type="tts">singer: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🎤">actor | dark skin tone | entertainer | rock | rockstar | singer | star</annotation>
+		<annotation cp="🧑🏿‍🎤" type="tts">singer: dark skin tone</annotation>
+		<annotation cp="👨🏻‍🎤">actor | entertainer | light skin tone | man | rock | rockstar | singer | star</annotation>
+		<annotation cp="👨🏻‍🎤" type="tts">man singer: light skin tone</annotation>
+		<annotation cp="👨🏼‍🎤">actor | entertainer | man | medium-light skin tone | rock | rockstar | singer | star</annotation>
+		<annotation cp="👨🏼‍🎤" type="tts">man singer: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍🎤">actor | entertainer | man | medium skin tone | rock | rockstar | singer | star</annotation>
+		<annotation cp="👨🏽‍🎤" type="tts">man singer: medium skin tone</annotation>
+		<annotation cp="👨🏾‍🎤">actor | entertainer | man | medium-dark skin tone | rock | rockstar | singer | star</annotation>
+		<annotation cp="👨🏾‍🎤" type="tts">man singer: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍🎤">actor | dark skin tone | entertainer | man | rock | rockstar | singer | star</annotation>
+		<annotation cp="👨🏿‍🎤" type="tts">man singer: dark skin tone</annotation>
+		<annotation cp="👩🏻‍🎤">actor | entertainer | light skin tone | rock | rockstar | singer | star | woman</annotation>
+		<annotation cp="👩🏻‍🎤" type="tts">woman singer: light skin tone</annotation>
+		<annotation cp="👩🏼‍🎤">actor | entertainer | medium-light skin tone | rock | rockstar | singer | star | woman</annotation>
+		<annotation cp="👩🏼‍🎤" type="tts">woman singer: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍🎤">actor | entertainer | medium skin tone | rock | rockstar | singer | star | woman</annotation>
+		<annotation cp="👩🏽‍🎤" type="tts">woman singer: medium skin tone</annotation>
+		<annotation cp="👩🏾‍🎤">actor | entertainer | medium-dark skin tone | rock | rockstar | singer | star | woman</annotation>
+		<annotation cp="👩🏾‍🎤" type="tts">woman singer: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍🎤">actor | dark skin tone | entertainer | rock | rockstar | singer | star | woman</annotation>
+		<annotation cp="👩🏿‍🎤" type="tts">woman singer: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍🎨">artist | light skin tone | palette</annotation>
+		<annotation cp="🧑🏻‍🎨" type="tts">artist: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🎨">artist | medium-light skin tone | palette</annotation>
+		<annotation cp="🧑🏼‍🎨" type="tts">artist: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🎨">artist | medium skin tone | palette</annotation>
+		<annotation cp="🧑🏽‍🎨" type="tts">artist: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🎨">artist | medium-dark skin tone | palette</annotation>
+		<annotation cp="🧑🏾‍🎨" type="tts">artist: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🎨">artist | dark skin tone | palette</annotation>
+		<annotation cp="🧑🏿‍🎨" type="tts">artist: dark skin tone</annotation>
+		<annotation cp="👨🏻‍🎨">artist | light skin tone | man | palette</annotation>
+		<annotation cp="👨🏻‍🎨" type="tts">man artist: light skin tone</annotation>
+		<annotation cp="👨🏼‍🎨">artist | man | medium-light skin tone | palette</annotation>
+		<annotation cp="👨🏼‍🎨" type="tts">man artist: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍🎨">artist | man | medium skin tone | palette</annotation>
+		<annotation cp="👨🏽‍🎨" type="tts">man artist: medium skin tone</annotation>
+		<annotation cp="👨🏾‍🎨">artist | man | medium-dark skin tone | palette</annotation>
+		<annotation cp="👨🏾‍🎨" type="tts">man artist: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍🎨">artist | dark skin tone | man | palette</annotation>
+		<annotation cp="👨🏿‍🎨" type="tts">man artist: dark skin tone</annotation>
+		<annotation cp="👩🏻‍🎨">artist | light skin tone | palette | woman</annotation>
+		<annotation cp="👩🏻‍🎨" type="tts">woman artist: light skin tone</annotation>
+		<annotation cp="👩🏼‍🎨">artist | medium-light skin tone | palette | woman</annotation>
+		<annotation cp="👩🏼‍🎨" type="tts">woman artist: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍🎨">artist | medium skin tone | palette | woman</annotation>
+		<annotation cp="👩🏽‍🎨" type="tts">woman artist: medium skin tone</annotation>
+		<annotation cp="👩🏾‍🎨">artist | medium-dark skin tone | palette | woman</annotation>
+		<annotation cp="👩🏾‍🎨" type="tts">woman artist: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍🎨">artist | dark skin tone | palette | woman</annotation>
+		<annotation cp="👩🏿‍🎨" type="tts">woman artist: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍✈">light skin tone | pilot | plane</annotation>
+		<annotation cp="🧑🏻‍✈" type="tts">pilot: light skin tone</annotation>
+		<annotation cp="🧑🏼‍✈">medium-light skin tone | pilot | plane</annotation>
+		<annotation cp="🧑🏼‍✈" type="tts">pilot: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍✈">medium skin tone | pilot | plane</annotation>
+		<annotation cp="🧑🏽‍✈" type="tts">pilot: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍✈">medium-dark skin tone | pilot | plane</annotation>
+		<annotation cp="🧑🏾‍✈" type="tts">pilot: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍✈">dark skin tone | pilot | plane</annotation>
+		<annotation cp="🧑🏿‍✈" type="tts">pilot: dark skin tone</annotation>
+		<annotation cp="👨🏻‍✈">light skin tone | man | pilot | plane</annotation>
+		<annotation cp="👨🏻‍✈" type="tts">man pilot: light skin tone</annotation>
+		<annotation cp="👨🏼‍✈">man | medium-light skin tone | pilot | plane</annotation>
+		<annotation cp="👨🏼‍✈" type="tts">man pilot: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍✈">man | medium skin tone | pilot | plane</annotation>
+		<annotation cp="👨🏽‍✈" type="tts">man pilot: medium skin tone</annotation>
+		<annotation cp="👨🏾‍✈">man | medium-dark skin tone | pilot | plane</annotation>
+		<annotation cp="👨🏾‍✈" type="tts">man pilot: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍✈">dark skin tone | man | pilot | plane</annotation>
+		<annotation cp="👨🏿‍✈" type="tts">man pilot: dark skin tone</annotation>
+		<annotation cp="👩🏻‍✈">light skin tone | pilot | plane | woman</annotation>
+		<annotation cp="👩🏻‍✈" type="tts">woman pilot: light skin tone</annotation>
+		<annotation cp="👩🏼‍✈">medium-light skin tone | pilot | plane | woman</annotation>
+		<annotation cp="👩🏼‍✈" type="tts">woman pilot: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍✈">medium skin tone | pilot | plane | woman</annotation>
+		<annotation cp="👩🏽‍✈" type="tts">woman pilot: medium skin tone</annotation>
+		<annotation cp="👩🏾‍✈">medium-dark skin tone | pilot | plane | woman</annotation>
+		<annotation cp="👩🏾‍✈" type="tts">woman pilot: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍✈">dark skin tone | pilot | plane | woman</annotation>
+		<annotation cp="👩🏿‍✈" type="tts">woman pilot: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍🚀">astronaut | light skin tone | rocket | space</annotation>
+		<annotation cp="🧑🏻‍🚀" type="tts">astronaut: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🚀">astronaut | medium-light skin tone | rocket | space</annotation>
+		<annotation cp="🧑🏼‍🚀" type="tts">astronaut: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🚀">astronaut | medium skin tone | rocket | space</annotation>
+		<annotation cp="🧑🏽‍🚀" type="tts">astronaut: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🚀">astronaut | medium-dark skin tone | rocket | space</annotation>
+		<annotation cp="🧑🏾‍🚀" type="tts">astronaut: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🚀">astronaut | dark skin tone | rocket | space</annotation>
+		<annotation cp="🧑🏿‍🚀" type="tts">astronaut: dark skin tone</annotation>
+		<annotation cp="👨🏻‍🚀">astronaut | light skin tone | man | rocket | space</annotation>
+		<annotation cp="👨🏻‍🚀" type="tts">man astronaut: light skin tone</annotation>
+		<annotation cp="👨🏼‍🚀">astronaut | man | medium-light skin tone | rocket | space</annotation>
+		<annotation cp="👨🏼‍🚀" type="tts">man astronaut: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍🚀">astronaut | man | medium skin tone | rocket | space</annotation>
+		<annotation cp="👨🏽‍🚀" type="tts">man astronaut: medium skin tone</annotation>
+		<annotation cp="👨🏾‍🚀">astronaut | man | medium-dark skin tone | rocket | space</annotation>
+		<annotation cp="👨🏾‍🚀" type="tts">man astronaut: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍🚀">astronaut | dark skin tone | man | rocket | space</annotation>
+		<annotation cp="👨🏿‍🚀" type="tts">man astronaut: dark skin tone</annotation>
+		<annotation cp="👩🏻‍🚀">astronaut | light skin tone | rocket | space | woman</annotation>
+		<annotation cp="👩🏻‍🚀" type="tts">woman astronaut: light skin tone</annotation>
+		<annotation cp="👩🏼‍🚀">astronaut | medium-light skin tone | rocket | space | woman</annotation>
+		<annotation cp="👩🏼‍🚀" type="tts">woman astronaut: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍🚀">astronaut | medium skin tone | rocket | space | woman</annotation>
+		<annotation cp="👩🏽‍🚀" type="tts">woman astronaut: medium skin tone</annotation>
+		<annotation cp="👩🏾‍🚀">astronaut | medium-dark skin tone | rocket | space | woman</annotation>
+		<annotation cp="👩🏾‍🚀" type="tts">woman astronaut: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍🚀">astronaut | dark skin tone | rocket | space | woman</annotation>
+		<annotation cp="👩🏿‍🚀" type="tts">woman astronaut: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍🚒">fire | firefighter | firetruck | light skin tone</annotation>
+		<annotation cp="🧑🏻‍🚒" type="tts">firefighter: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🚒">fire | firefighter | firetruck | medium-light skin tone</annotation>
+		<annotation cp="🧑🏼‍🚒" type="tts">firefighter: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🚒">fire | firefighter | firetruck | medium skin tone</annotation>
+		<annotation cp="🧑🏽‍🚒" type="tts">firefighter: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🚒">fire | firefighter | firetruck | medium-dark skin tone</annotation>
+		<annotation cp="🧑🏾‍🚒" type="tts">firefighter: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🚒">dark skin tone | fire | firefighter | firetruck</annotation>
+		<annotation cp="🧑🏿‍🚒" type="tts">firefighter: dark skin tone</annotation>
+		<annotation cp="👨🏻‍🚒">fire | firefighter | firetruck | light skin tone | man</annotation>
+		<annotation cp="👨🏻‍🚒" type="tts">man firefighter: light skin tone</annotation>
+		<annotation cp="👨🏼‍🚒">fire | firefighter | firetruck | man | medium-light skin tone</annotation>
+		<annotation cp="👨🏼‍🚒" type="tts">man firefighter: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍🚒">fire | firefighter | firetruck | man | medium skin tone</annotation>
+		<annotation cp="👨🏽‍🚒" type="tts">man firefighter: medium skin tone</annotation>
+		<annotation cp="👨🏾‍🚒">fire | firefighter | firetruck | man | medium-dark skin tone</annotation>
+		<annotation cp="👨🏾‍🚒" type="tts">man firefighter: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍🚒">dark skin tone | fire | firefighter | firetruck | man</annotation>
+		<annotation cp="👨🏿‍🚒" type="tts">man firefighter: dark skin tone</annotation>
+		<annotation cp="👩🏻‍🚒">fire | firefighter | firetruck | light skin tone | woman</annotation>
+		<annotation cp="👩🏻‍🚒" type="tts">woman firefighter: light skin tone</annotation>
+		<annotation cp="👩🏼‍🚒">fire | firefighter | firetruck | medium-light skin tone | woman</annotation>
+		<annotation cp="👩🏼‍🚒" type="tts">woman firefighter: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍🚒">fire | firefighter | firetruck | medium skin tone | woman</annotation>
+		<annotation cp="👩🏽‍🚒" type="tts">woman firefighter: medium skin tone</annotation>
+		<annotation cp="👩🏾‍🚒">fire | firefighter | firetruck | medium-dark skin tone | woman</annotation>
+		<annotation cp="👩🏾‍🚒" type="tts">woman firefighter: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍🚒">dark skin tone | fire | firefighter | firetruck | woman</annotation>
+		<annotation cp="👩🏿‍🚒" type="tts">woman firefighter: dark skin tone</annotation>
+		<annotation cp="👮🏻">apprehend | arrest | citation | cop | law | light skin tone | officer | over | police | pulled | undercover</annotation>
+		<annotation cp="👮🏻" type="tts">police officer: light skin tone</annotation>
+		<annotation cp="👮🏼">apprehend | arrest | citation | cop | law | medium-light skin tone | officer | over | police | pulled | undercover</annotation>
+		<annotation cp="👮🏼" type="tts">police officer: medium-light skin tone</annotation>
+		<annotation cp="👮🏽">apprehend | arrest | citation | cop | law | medium skin tone | officer | over | police | pulled | undercover</annotation>
+		<annotation cp="👮🏽" type="tts">police officer: medium skin tone</annotation>
+		<annotation cp="👮🏾">apprehend | arrest | citation | cop | law | medium-dark skin tone | officer | over | police | pulled | undercover</annotation>
+		<annotation cp="👮🏾" type="tts">police officer: medium-dark skin tone</annotation>
+		<annotation cp="👮🏿">apprehend | arrest | citation | cop | dark skin tone | law | officer | over | police | pulled | undercover</annotation>
+		<annotation cp="👮🏿" type="tts">police officer: dark skin tone</annotation>
+		<annotation cp="👮🏻‍♂">apprehend | arrest | citation | cop | law | light skin tone | man | officer | over | police | pulled | undercover</annotation>
+		<annotation cp="👮🏻‍♂" type="tts">man police officer: light skin tone</annotation>
+		<annotation cp="👮🏼‍♂">apprehend | arrest | citation | cop | law | man | medium-light skin tone | officer | over | police | pulled | undercover</annotation>
+		<annotation cp="👮🏼‍♂" type="tts">man police officer: medium-light skin tone</annotation>
+		<annotation cp="👮🏽‍♂">apprehend | arrest | citation | cop | law | man | medium skin tone | officer | over | police | pulled | undercover</annotation>
+		<annotation cp="👮🏽‍♂" type="tts">man police officer: medium skin tone</annotation>
+		<annotation cp="👮🏾‍♂">apprehend | arrest | citation | cop | law | man | medium-dark skin tone | officer | over | police | pulled | undercover</annotation>
+		<annotation cp="👮🏾‍♂" type="tts">man police officer: medium-dark skin tone</annotation>
+		<annotation cp="👮🏿‍♂">apprehend | arrest | citation | cop | dark skin tone | law | man | officer | over | police | pulled | undercover</annotation>
+		<annotation cp="👮🏿‍♂" type="tts">man police officer: dark skin tone</annotation>
+		<annotation cp="👮🏻‍♀">apprehend | arrest | citation | cop | law | light skin tone | officer | over | police | pulled | undercover | woman</annotation>
+		<annotation cp="👮🏻‍♀" type="tts">woman police officer: light skin tone</annotation>
+		<annotation cp="👮🏼‍♀">apprehend | arrest | citation | cop | law | medium-light skin tone | officer | over | police | pulled | undercover | woman</annotation>
+		<annotation cp="👮🏼‍♀" type="tts">woman police officer: medium-light skin tone</annotation>
+		<annotation cp="👮🏽‍♀">apprehend | arrest | citation | cop | law | medium skin tone | officer | over | police | pulled | undercover | woman</annotation>
+		<annotation cp="👮🏽‍♀" type="tts">woman police officer: medium skin tone</annotation>
+		<annotation cp="👮🏾‍♀">apprehend | arrest | citation | cop | law | medium-dark skin tone | officer | over | police | pulled | undercover | woman</annotation>
+		<annotation cp="👮🏾‍♀" type="tts">woman police officer: medium-dark skin tone</annotation>
+		<annotation cp="👮🏿‍♀">apprehend | arrest | citation | cop | dark skin tone | law | officer | over | police | pulled | undercover | woman</annotation>
+		<annotation cp="👮🏿‍♀" type="tts">woman police officer: dark skin tone</annotation>
+		<annotation cp="🕵🏻">detective | light skin tone | sleuth | spy</annotation>
+		<annotation cp="🕵🏻" type="tts">detective: light skin tone</annotation>
+		<annotation cp="🕵🏼">detective | medium-light skin tone | sleuth | spy</annotation>
+		<annotation cp="🕵🏼" type="tts">detective: medium-light skin tone</annotation>
+		<annotation cp="🕵🏽">detective | medium skin tone | sleuth | spy</annotation>
+		<annotation cp="🕵🏽" type="tts">detective: medium skin tone</annotation>
+		<annotation cp="🕵🏾">detective | medium-dark skin tone | sleuth | spy</annotation>
+		<annotation cp="🕵🏾" type="tts">detective: medium-dark skin tone</annotation>
+		<annotation cp="🕵🏿">dark skin tone | detective | sleuth | spy</annotation>
+		<annotation cp="🕵🏿" type="tts">detective: dark skin tone</annotation>
+		<annotation cp="🕵🏻‍♂">detective | light skin tone | man | sleuth | spy</annotation>
+		<annotation cp="🕵🏻‍♂" type="tts">man detective: light skin tone</annotation>
+		<annotation cp="🕵🏼‍♂">detective | man | medium-light skin tone | sleuth | spy</annotation>
+		<annotation cp="🕵🏼‍♂" type="tts">man detective: medium-light skin tone</annotation>
+		<annotation cp="🕵🏽‍♂">detective | man | medium skin tone | sleuth | spy</annotation>
+		<annotation cp="🕵🏽‍♂" type="tts">man detective: medium skin tone</annotation>
+		<annotation cp="🕵🏾‍♂">detective | man | medium-dark skin tone | sleuth | spy</annotation>
+		<annotation cp="🕵🏾‍♂" type="tts">man detective: medium-dark skin tone</annotation>
+		<annotation cp="🕵🏿‍♂">dark skin tone | detective | man | sleuth | spy</annotation>
+		<annotation cp="🕵🏿‍♂" type="tts">man detective: dark skin tone</annotation>
+		<annotation cp="🕵🏻‍♀">detective | light skin tone | sleuth | spy | woman</annotation>
+		<annotation cp="🕵🏻‍♀" type="tts">woman detective: light skin tone</annotation>
+		<annotation cp="🕵🏼‍♀">detective | medium-light skin tone | sleuth | spy | woman</annotation>
+		<annotation cp="🕵🏼‍♀" type="tts">woman detective: medium-light skin tone</annotation>
+		<annotation cp="🕵🏽‍♀">detective | medium skin tone | sleuth | spy | woman</annotation>
+		<annotation cp="🕵🏽‍♀" type="tts">woman detective: medium skin tone</annotation>
+		<annotation cp="🕵🏾‍♀">detective | medium-dark skin tone | sleuth | spy | woman</annotation>
+		<annotation cp="🕵🏾‍♀" type="tts">woman detective: medium-dark skin tone</annotation>
+		<annotation cp="🕵🏿‍♀">dark skin tone | detective | sleuth | spy | woman</annotation>
+		<annotation cp="🕵🏿‍♀" type="tts">woman detective: dark skin tone</annotation>
+		<annotation cp="💂🏻">buckingham | guard | helmet | light skin tone | london | palace</annotation>
+		<annotation cp="💂🏻" type="tts">guard: light skin tone</annotation>
+		<annotation cp="💂🏼">buckingham | guard | helmet | london | medium-light skin tone | palace</annotation>
+		<annotation cp="💂🏼" type="tts">guard: medium-light skin tone</annotation>
+		<annotation cp="💂🏽">buckingham | guard | helmet | london | medium skin tone | palace</annotation>
+		<annotation cp="💂🏽" type="tts">guard: medium skin tone</annotation>
+		<annotation cp="💂🏾">buckingham | guard | helmet | london | medium-dark skin tone | palace</annotation>
+		<annotation cp="💂🏾" type="tts">guard: medium-dark skin tone</annotation>
+		<annotation cp="💂🏿">buckingham | dark skin tone | guard | helmet | london | palace</annotation>
+		<annotation cp="💂🏿" type="tts">guard: dark skin tone</annotation>
+		<annotation cp="💂🏻‍♂">buckingham | guard | helmet | light skin tone | london | man | palace</annotation>
+		<annotation cp="💂🏻‍♂" type="tts">man guard: light skin tone</annotation>
+		<annotation cp="💂🏼‍♂">buckingham | guard | helmet | london | man | medium-light skin tone | palace</annotation>
+		<annotation cp="💂🏼‍♂" type="tts">man guard: medium-light skin tone</annotation>
+		<annotation cp="💂🏽‍♂">buckingham | guard | helmet | london | man | medium skin tone | palace</annotation>
+		<annotation cp="💂🏽‍♂" type="tts">man guard: medium skin tone</annotation>
+		<annotation cp="💂🏾‍♂">buckingham | guard | helmet | london | man | medium-dark skin tone | palace</annotation>
+		<annotation cp="💂🏾‍♂" type="tts">man guard: medium-dark skin tone</annotation>
+		<annotation cp="💂🏿‍♂">buckingham | dark skin tone | guard | helmet | london | man | palace</annotation>
+		<annotation cp="💂🏿‍♂" type="tts">man guard: dark skin tone</annotation>
+		<annotation cp="💂🏻‍♀">buckingham | guard | helmet | light skin tone | london | palace | woman</annotation>
+		<annotation cp="💂🏻‍♀" type="tts">woman guard: light skin tone</annotation>
+		<annotation cp="💂🏼‍♀">buckingham | guard | helmet | london | medium-light skin tone | palace | woman</annotation>
+		<annotation cp="💂🏼‍♀" type="tts">woman guard: medium-light skin tone</annotation>
+		<annotation cp="💂🏽‍♀">buckingham | guard | helmet | london | medium skin tone | palace | woman</annotation>
+		<annotation cp="💂🏽‍♀" type="tts">woman guard: medium skin tone</annotation>
+		<annotation cp="💂🏾‍♀">buckingham | guard | helmet | london | medium-dark skin tone | palace | woman</annotation>
+		<annotation cp="💂🏾‍♀" type="tts">woman guard: medium-dark skin tone</annotation>
+		<annotation cp="💂🏿‍♀">buckingham | dark skin tone | guard | helmet | london | palace | woman</annotation>
+		<annotation cp="💂🏿‍♀" type="tts">woman guard: dark skin tone</annotation>
+		<annotation cp="🥷🏻">assassin | fight | fighter | hidden | light skin tone | ninja | person | secret | skills | sly | soldier | stealth | war</annotation>
+		<annotation cp="🥷🏻" type="tts">ninja: light skin tone</annotation>
+		<annotation cp="🥷🏼">assassin | fight | fighter | hidden | medium-light skin tone | ninja | person | secret | skills | sly | soldier | stealth | war</annotation>
+		<annotation cp="🥷🏼" type="tts">ninja: medium-light skin tone</annotation>
+		<annotation cp="🥷🏽">assassin | fight | fighter | hidden | medium skin tone | ninja | person | secret | skills | sly | soldier | stealth | war</annotation>
+		<annotation cp="🥷🏽" type="tts">ninja: medium skin tone</annotation>
+		<annotation cp="🥷🏾">assassin | fight | fighter | hidden | medium-dark skin tone | ninja | person | secret | skills | sly | soldier | stealth | war</annotation>
+		<annotation cp="🥷🏾" type="tts">ninja: medium-dark skin tone</annotation>
+		<annotation cp="🥷🏿">assassin | dark skin tone | fight | fighter | hidden | ninja | person | secret | skills | sly | soldier | stealth | war</annotation>
+		<annotation cp="🥷🏿" type="tts">ninja: dark skin tone</annotation>
+		<annotation cp="👷🏻">build | construction | fix | hardhat | hat | light skin tone | man | person | rebuild | remodel | repair | work | worker</annotation>
+		<annotation cp="👷🏻" type="tts">construction worker: light skin tone</annotation>
+		<annotation cp="👷🏼">build | construction | fix | hardhat | hat | man | medium-light skin tone | person | rebuild | remodel | repair | work | worker</annotation>
+		<annotation cp="👷🏼" type="tts">construction worker: medium-light skin tone</annotation>
+		<annotation cp="👷🏽">build | construction | fix | hardhat | hat | man | medium skin tone | person | rebuild | remodel | repair | work | worker</annotation>
+		<annotation cp="👷🏽" type="tts">construction worker: medium skin tone</annotation>
+		<annotation cp="👷🏾">build | construction | fix | hardhat | hat | man | medium-dark skin tone | person | rebuild | remodel | repair | work | worker</annotation>
+		<annotation cp="👷🏾" type="tts">construction worker: medium-dark skin tone</annotation>
+		<annotation cp="👷🏿">build | construction | dark skin tone | fix | hardhat | hat | man | person | rebuild | remodel | repair | work | worker</annotation>
+		<annotation cp="👷🏿" type="tts">construction worker: dark skin tone</annotation>
+		<annotation cp="👷🏻‍♂">build | construction | fix | hardhat | hat | light skin tone | man | rebuild | remodel | repair | work | worker</annotation>
+		<annotation cp="👷🏻‍♂" type="tts">man construction worker: light skin tone</annotation>
+		<annotation cp="👷🏼‍♂">build | construction | fix | hardhat | hat | man | medium-light skin tone | rebuild | remodel | repair | work | worker</annotation>
+		<annotation cp="👷🏼‍♂" type="tts">man construction worker: medium-light skin tone</annotation>
+		<annotation cp="👷🏽‍♂">build | construction | fix | hardhat | hat | man | medium skin tone | rebuild | remodel | repair | work | worker</annotation>
+		<annotation cp="👷🏽‍♂" type="tts">man construction worker: medium skin tone</annotation>
+		<annotation cp="👷🏾‍♂">build | construction | fix | hardhat | hat | man | medium-dark skin tone | rebuild | remodel | repair | work | worker</annotation>
+		<annotation cp="👷🏾‍♂" type="tts">man construction worker: medium-dark skin tone</annotation>
+		<annotation cp="👷🏿‍♂">build | construction | dark skin tone | fix | hardhat | hat | man | rebuild | remodel | repair | work | worker</annotation>
+		<annotation cp="👷🏿‍♂" type="tts">man construction worker: dark skin tone</annotation>
+		<annotation cp="👷🏻‍♀">build | construction | fix | hardhat | hat | light skin tone | man | rebuild | remodel | repair | woman | work | worker</annotation>
+		<annotation cp="👷🏻‍♀" type="tts">woman construction worker: light skin tone</annotation>
+		<annotation cp="👷🏼‍♀">build | construction | fix | hardhat | hat | man | medium-light skin tone | rebuild | remodel | repair | woman | work | worker</annotation>
+		<annotation cp="👷🏼‍♀" type="tts">woman construction worker: medium-light skin tone</annotation>
+		<annotation cp="👷🏽‍♀">build | construction | fix | hardhat | hat | man | medium skin tone | rebuild | remodel | repair | woman | work | worker</annotation>
+		<annotation cp="👷🏽‍♀" type="tts">woman construction worker: medium skin tone</annotation>
+		<annotation cp="👷🏾‍♀">build | construction | fix | hardhat | hat | man | medium-dark skin tone | rebuild | remodel | repair | woman | work | worker</annotation>
+		<annotation cp="👷🏾‍♀" type="tts">woman construction worker: medium-dark skin tone</annotation>
+		<annotation cp="👷🏿‍♀">build | construction | dark skin tone | fix | hardhat | hat | man | rebuild | remodel | repair | woman | work | worker</annotation>
+		<annotation cp="👷🏿‍♀" type="tts">woman construction worker: dark skin tone</annotation>
+		<annotation cp="🫅🏻">crown | light skin tone | monarch | noble | person | regal | royal | royalty</annotation>
+		<annotation cp="🫅🏻" type="tts">person with crown: light skin tone</annotation>
+		<annotation cp="🫅🏼">crown | medium-light skin tone | monarch | noble | person | regal | royal | royalty</annotation>
+		<annotation cp="🫅🏼" type="tts">person with crown: medium-light skin tone</annotation>
+		<annotation cp="🫅🏽">crown | medium skin tone | monarch | noble | person | regal | royal | royalty</annotation>
+		<annotation cp="🫅🏽" type="tts">person with crown: medium skin tone</annotation>
+		<annotation cp="🫅🏾">crown | medium-dark skin tone | monarch | noble | person | regal | royal | royalty</annotation>
+		<annotation cp="🫅🏾" type="tts">person with crown: medium-dark skin tone</annotation>
+		<annotation cp="🫅🏿">crown | dark skin tone | monarch | noble | person | regal | royal | royalty</annotation>
+		<annotation cp="🫅🏿" type="tts">person with crown: dark skin tone</annotation>
+		<annotation cp="🤴🏻">crown | fairy | fairytale | fantasy | king | light skin tone | prince | royal | royalty | tale</annotation>
+		<annotation cp="🤴🏻" type="tts">prince: light skin tone</annotation>
+		<annotation cp="🤴🏼">crown | fairy | fairytale | fantasy | king | medium-light skin tone | prince | royal | royalty | tale</annotation>
+		<annotation cp="🤴🏼" type="tts">prince: medium-light skin tone</annotation>
+		<annotation cp="🤴🏽">crown | fairy | fairytale | fantasy | king | medium skin tone | prince | royal | royalty | tale</annotation>
+		<annotation cp="🤴🏽" type="tts">prince: medium skin tone</annotation>
+		<annotation cp="🤴🏾">crown | fairy | fairytale | fantasy | king | medium-dark skin tone | prince | royal | royalty | tale</annotation>
+		<annotation cp="🤴🏾" type="tts">prince: medium-dark skin tone</annotation>
+		<annotation cp="🤴🏿">crown | dark skin tone | fairy | fairytale | fantasy | king | prince | royal | royalty | tale</annotation>
+		<annotation cp="🤴🏿" type="tts">prince: dark skin tone</annotation>
+		<annotation cp="👸🏻">crown | fairy | fairytale | fantasy | light skin tone | princess | queen | royal | royalty | tale</annotation>
+		<annotation cp="👸🏻" type="tts">princess: light skin tone</annotation>
+		<annotation cp="👸🏼">crown | fairy | fairytale | fantasy | medium-light skin tone | princess | queen | royal | royalty | tale</annotation>
+		<annotation cp="👸🏼" type="tts">princess: medium-light skin tone</annotation>
+		<annotation cp="👸🏽">crown | fairy | fairytale | fantasy | medium skin tone | princess | queen | royal | royalty | tale</annotation>
+		<annotation cp="👸🏽" type="tts">princess: medium skin tone</annotation>
+		<annotation cp="👸🏾">crown | fairy | fairytale | fantasy | medium-dark skin tone | princess | queen | royal | royalty | tale</annotation>
+		<annotation cp="👸🏾" type="tts">princess: medium-dark skin tone</annotation>
+		<annotation cp="👸🏿">crown | dark skin tone | fairy | fairytale | fantasy | princess | queen | royal | royalty | tale</annotation>
+		<annotation cp="👸🏿" type="tts">princess: dark skin tone</annotation>
+		<annotation cp="👳🏻">light skin tone | person | turban | wearing</annotation>
+		<annotation cp="👳🏻" type="tts">person wearing turban: light skin tone</annotation>
+		<annotation cp="👳🏼">medium-light skin tone | person | turban | wearing</annotation>
+		<annotation cp="👳🏼" type="tts">person wearing turban: medium-light skin tone</annotation>
+		<annotation cp="👳🏽">medium skin tone | person | turban | wearing</annotation>
+		<annotation cp="👳🏽" type="tts">person wearing turban: medium skin tone</annotation>
+		<annotation cp="👳🏾">medium-dark skin tone | person | turban | wearing</annotation>
+		<annotation cp="👳🏾" type="tts">person wearing turban: medium-dark skin tone</annotation>
+		<annotation cp="👳🏿">dark skin tone | person | turban | wearing</annotation>
+		<annotation cp="👳🏿" type="tts">person wearing turban: dark skin tone</annotation>
+		<annotation cp="👳🏻‍♂">light skin tone | man | turban | wearing</annotation>
+		<annotation cp="👳🏻‍♂" type="tts">man wearing turban: light skin tone</annotation>
+		<annotation cp="👳🏼‍♂">man | medium-light skin tone | turban | wearing</annotation>
+		<annotation cp="👳🏼‍♂" type="tts">man wearing turban: medium-light skin tone</annotation>
+		<annotation cp="👳🏽‍♂">man | medium skin tone | turban | wearing</annotation>
+		<annotation cp="👳🏽‍♂" type="tts">man wearing turban: medium skin tone</annotation>
+		<annotation cp="👳🏾‍♂">man | medium-dark skin tone | turban | wearing</annotation>
+		<annotation cp="👳🏾‍♂" type="tts">man wearing turban: medium-dark skin tone</annotation>
+		<annotation cp="👳🏿‍♂">dark skin tone | man | turban | wearing</annotation>
+		<annotation cp="👳🏿‍♂" type="tts">man wearing turban: dark skin tone</annotation>
+		<annotation cp="👳🏻‍♀">light skin tone | turban | wearing | woman</annotation>
+		<annotation cp="👳🏻‍♀" type="tts">woman wearing turban: light skin tone</annotation>
+		<annotation cp="👳🏼‍♀">medium-light skin tone | turban | wearing | woman</annotation>
+		<annotation cp="👳🏼‍♀" type="tts">woman wearing turban: medium-light skin tone</annotation>
+		<annotation cp="👳🏽‍♀">medium skin tone | turban | wearing | woman</annotation>
+		<annotation cp="👳🏽‍♀" type="tts">woman wearing turban: medium skin tone</annotation>
+		<annotation cp="👳🏾‍♀">medium-dark skin tone | turban | wearing | woman</annotation>
+		<annotation cp="👳🏾‍♀" type="tts">woman wearing turban: medium-dark skin tone</annotation>
+		<annotation cp="👳🏿‍♀">dark skin tone | turban | wearing | woman</annotation>
+		<annotation cp="👳🏿‍♀" type="tts">woman wearing turban: dark skin tone</annotation>
+		<annotation cp="👲🏻">cap | Chinese | gua | guapi | hat | light skin tone | mao | person | pi | skullcap</annotation>
+		<annotation cp="👲🏻" type="tts">person with skullcap: light skin tone</annotation>
+		<annotation cp="👲🏼">cap | Chinese | gua | guapi | hat | mao | medium-light skin tone | person | pi | skullcap</annotation>
+		<annotation cp="👲🏼" type="tts">person with skullcap: medium-light skin tone</annotation>
+		<annotation cp="👲🏽">cap | Chinese | gua | guapi | hat | mao | medium skin tone | person | pi | skullcap</annotation>
+		<annotation cp="👲🏽" type="tts">person with skullcap: medium skin tone</annotation>
+		<annotation cp="👲🏾">cap | Chinese | gua | guapi | hat | mao | medium-dark skin tone | person | pi | skullcap</annotation>
+		<annotation cp="👲🏾" type="tts">person with skullcap: medium-dark skin tone</annotation>
+		<annotation cp="👲🏿">cap | Chinese | dark skin tone | gua | guapi | hat | mao | person | pi | skullcap</annotation>
+		<annotation cp="👲🏿" type="tts">person with skullcap: dark skin tone</annotation>
+		<annotation cp="🧕🏻">bandana | head | headscarf | hijab | kerchief | light skin tone | mantilla | tichel | woman</annotation>
+		<annotation cp="🧕🏻" type="tts">woman with headscarf: light skin tone</annotation>
+		<annotation cp="🧕🏼">bandana | head | headscarf | hijab | kerchief | mantilla | medium-light skin tone | tichel | woman</annotation>
+		<annotation cp="🧕🏼" type="tts">woman with headscarf: medium-light skin tone</annotation>
+		<annotation cp="🧕🏽">bandana | head | headscarf | hijab | kerchief | mantilla | medium skin tone | tichel | woman</annotation>
+		<annotation cp="🧕🏽" type="tts">woman with headscarf: medium skin tone</annotation>
+		<annotation cp="🧕🏾">bandana | head | headscarf | hijab | kerchief | mantilla | medium-dark skin tone | tichel | woman</annotation>
+		<annotation cp="🧕🏾" type="tts">woman with headscarf: medium-dark skin tone</annotation>
+		<annotation cp="🧕🏿">bandana | dark skin tone | head | headscarf | hijab | kerchief | mantilla | tichel | woman</annotation>
+		<annotation cp="🧕🏿" type="tts">woman with headscarf: dark skin tone</annotation>
+		<annotation cp="🤵🏻">formal | light skin tone | person | tuxedo | wedding</annotation>
+		<annotation cp="🤵🏻" type="tts">person in tuxedo: light skin tone</annotation>
+		<annotation cp="🤵🏼">formal | medium-light skin tone | person | tuxedo | wedding</annotation>
+		<annotation cp="🤵🏼" type="tts">person in tuxedo: medium-light skin tone</annotation>
+		<annotation cp="🤵🏽">formal | medium skin tone | person | tuxedo | wedding</annotation>
+		<annotation cp="🤵🏽" type="tts">person in tuxedo: medium skin tone</annotation>
+		<annotation cp="🤵🏾">formal | medium-dark skin tone | person | tuxedo | wedding</annotation>
+		<annotation cp="🤵🏾" type="tts">person in tuxedo: medium-dark skin tone</annotation>
+		<annotation cp="🤵🏿">dark skin tone | formal | person | tuxedo | wedding</annotation>
+		<annotation cp="🤵🏿" type="tts">person in tuxedo: dark skin tone</annotation>
+		<annotation cp="🤵🏻‍♂">formal | groom | light skin tone | man | tuxedo | wedding</annotation>
+		<annotation cp="🤵🏻‍♂" type="tts">man in tuxedo: light skin tone</annotation>
+		<annotation cp="🤵🏼‍♂">formal | groom | man | medium-light skin tone | tuxedo | wedding</annotation>
+		<annotation cp="🤵🏼‍♂" type="tts">man in tuxedo: medium-light skin tone</annotation>
+		<annotation cp="🤵🏽‍♂">formal | groom | man | medium skin tone | tuxedo | wedding</annotation>
+		<annotation cp="🤵🏽‍♂" type="tts">man in tuxedo: medium skin tone</annotation>
+		<annotation cp="🤵🏾‍♂">formal | groom | man | medium-dark skin tone | tuxedo | wedding</annotation>
+		<annotation cp="🤵🏾‍♂" type="tts">man in tuxedo: medium-dark skin tone</annotation>
+		<annotation cp="🤵🏿‍♂">dark skin tone | formal | groom | man | tuxedo | wedding</annotation>
+		<annotation cp="🤵🏿‍♂" type="tts">man in tuxedo: dark skin tone</annotation>
+		<annotation cp="🤵🏻‍♀">formal | light skin tone | tuxedo | wedding | woman</annotation>
+		<annotation cp="🤵🏻‍♀" type="tts">woman in tuxedo: light skin tone</annotation>
+		<annotation cp="🤵🏼‍♀">formal | medium-light skin tone | tuxedo | wedding | woman</annotation>
+		<annotation cp="🤵🏼‍♀" type="tts">woman in tuxedo: medium-light skin tone</annotation>
+		<annotation cp="🤵🏽‍♀">formal | medium skin tone | tuxedo | wedding | woman</annotation>
+		<annotation cp="🤵🏽‍♀" type="tts">woman in tuxedo: medium skin tone</annotation>
+		<annotation cp="🤵🏾‍♀">formal | medium-dark skin tone | tuxedo | wedding | woman</annotation>
+		<annotation cp="🤵🏾‍♀" type="tts">woman in tuxedo: medium-dark skin tone</annotation>
+		<annotation cp="🤵🏿‍♀">dark skin tone | formal | tuxedo | wedding | woman</annotation>
+		<annotation cp="🤵🏿‍♀" type="tts">woman in tuxedo: dark skin tone</annotation>
+		<annotation cp="👰🏻">light skin tone | person | veil | wedding</annotation>
+		<annotation cp="👰🏻" type="tts">person with veil: light skin tone</annotation>
+		<annotation cp="👰🏼">medium-light skin tone | person | veil | wedding</annotation>
+		<annotation cp="👰🏼" type="tts">person with veil: medium-light skin tone</annotation>
+		<annotation cp="👰🏽">medium skin tone | person | veil | wedding</annotation>
+		<annotation cp="👰🏽" type="tts">person with veil: medium skin tone</annotation>
+		<annotation cp="👰🏾">medium-dark skin tone | person | veil | wedding</annotation>
+		<annotation cp="👰🏾" type="tts">person with veil: medium-dark skin tone</annotation>
+		<annotation cp="👰🏿">dark skin tone | person | veil | wedding</annotation>
+		<annotation cp="👰🏿" type="tts">person with veil: dark skin tone</annotation>
+		<annotation cp="👰🏻‍♂">light skin tone | man | veil | wedding</annotation>
+		<annotation cp="👰🏻‍♂" type="tts">man with veil: light skin tone</annotation>
+		<annotation cp="👰🏼‍♂">man | medium-light skin tone | veil | wedding</annotation>
+		<annotation cp="👰🏼‍♂" type="tts">man with veil: medium-light skin tone</annotation>
+		<annotation cp="👰🏽‍♂">man | medium skin tone | veil | wedding</annotation>
+		<annotation cp="👰🏽‍♂" type="tts">man with veil: medium skin tone</annotation>
+		<annotation cp="👰🏾‍♂">man | medium-dark skin tone | veil | wedding</annotation>
+		<annotation cp="👰🏾‍♂" type="tts">man with veil: medium-dark skin tone</annotation>
+		<annotation cp="👰🏿‍♂">dark skin tone | man | veil | wedding</annotation>
+		<annotation cp="👰🏿‍♂" type="tts">man with veil: dark skin tone</annotation>
+		<annotation cp="👰🏻‍♀">bride | light skin tone | veil | wedding | woman</annotation>
+		<annotation cp="👰🏻‍♀" type="tts">woman with veil: light skin tone</annotation>
+		<annotation cp="👰🏼‍♀">bride | medium-light skin tone | veil | wedding | woman</annotation>
+		<annotation cp="👰🏼‍♀" type="tts">woman with veil: medium-light skin tone</annotation>
+		<annotation cp="👰🏽‍♀">bride | medium skin tone | veil | wedding | woman</annotation>
+		<annotation cp="👰🏽‍♀" type="tts">woman with veil: medium skin tone</annotation>
+		<annotation cp="👰🏾‍♀">bride | medium-dark skin tone | veil | wedding | woman</annotation>
+		<annotation cp="👰🏾‍♀" type="tts">woman with veil: medium-dark skin tone</annotation>
+		<annotation cp="👰🏿‍♀">bride | dark skin tone | veil | wedding | woman</annotation>
+		<annotation cp="👰🏿‍♀" type="tts">woman with veil: dark skin tone</annotation>
+		<annotation cp="🤰🏻">light skin tone | pregnant | woman</annotation>
+		<annotation cp="🤰🏻" type="tts">pregnant woman: light skin tone</annotation>
+		<annotation cp="🤰🏼">medium-light skin tone | pregnant | woman</annotation>
+		<annotation cp="🤰🏼" type="tts">pregnant woman: medium-light skin tone</annotation>
+		<annotation cp="🤰🏽">medium skin tone | pregnant | woman</annotation>
+		<annotation cp="🤰🏽" type="tts">pregnant woman: medium skin tone</annotation>
+		<annotation cp="🤰🏾">medium-dark skin tone | pregnant | woman</annotation>
+		<annotation cp="🤰🏾" type="tts">pregnant woman: medium-dark skin tone</annotation>
+		<annotation cp="🤰🏿">dark skin tone | pregnant | woman</annotation>
+		<annotation cp="🤰🏿" type="tts">pregnant woman: dark skin tone</annotation>
+		<annotation cp="🫃🏻">belly | bloated | full | light skin tone | man | overeat | pregnant</annotation>
+		<annotation cp="🫃🏻" type="tts">pregnant man: light skin tone</annotation>
+		<annotation cp="🫃🏼">belly | bloated | full | man | medium-light skin tone | overeat | pregnant</annotation>
+		<annotation cp="🫃🏼" type="tts">pregnant man: medium-light skin tone</annotation>
+		<annotation cp="🫃🏽">belly | bloated | full | man | medium skin tone | overeat | pregnant</annotation>
+		<annotation cp="🫃🏽" type="tts">pregnant man: medium skin tone</annotation>
+		<annotation cp="🫃🏾">belly | bloated | full | man | medium-dark skin tone | overeat | pregnant</annotation>
+		<annotation cp="🫃🏾" type="tts">pregnant man: medium-dark skin tone</annotation>
+		<annotation cp="🫃🏿">belly | bloated | dark skin tone | full | man | overeat | pregnant</annotation>
+		<annotation cp="🫃🏿" type="tts">pregnant man: dark skin tone</annotation>
+		<annotation cp="🫄🏻">belly | bloated | full | light skin tone | overeat | person | pregnant | stuffed</annotation>
+		<annotation cp="🫄🏻" type="tts">pregnant person: light skin tone</annotation>
+		<annotation cp="🫄🏼">belly | bloated | full | medium-light skin tone | overeat | person | pregnant | stuffed</annotation>
+		<annotation cp="🫄🏼" type="tts">pregnant person: medium-light skin tone</annotation>
+		<annotation cp="🫄🏽">belly | bloated | full | medium skin tone | overeat | person | pregnant | stuffed</annotation>
+		<annotation cp="🫄🏽" type="tts">pregnant person: medium skin tone</annotation>
+		<annotation cp="🫄🏾">belly | bloated | full | medium-dark skin tone | overeat | person | pregnant | stuffed</annotation>
+		<annotation cp="🫄🏾" type="tts">pregnant person: medium-dark skin tone</annotation>
+		<annotation cp="🫄🏿">belly | bloated | dark skin tone | full | overeat | person | pregnant | stuffed</annotation>
+		<annotation cp="🫄🏿" type="tts">pregnant person: dark skin tone</annotation>
+		<annotation cp="🤱🏻">baby | breast | breast-feeding | feeding | light skin tone | mom | mother | nursing | woman</annotation>
+		<annotation cp="🤱🏻" type="tts">breast-feeding: light skin tone</annotation>
+		<annotation cp="🤱🏼">baby | breast | breast-feeding | feeding | medium-light skin tone | mom | mother | nursing | woman</annotation>
+		<annotation cp="🤱🏼" type="tts">breast-feeding: medium-light skin tone</annotation>
+		<annotation cp="🤱🏽">baby | breast | breast-feeding | feeding | medium skin tone | mom | mother | nursing | woman</annotation>
+		<annotation cp="🤱🏽" type="tts">breast-feeding: medium skin tone</annotation>
+		<annotation cp="🤱🏾">baby | breast | breast-feeding | feeding | medium-dark skin tone | mom | mother | nursing | woman</annotation>
+		<annotation cp="🤱🏾" type="tts">breast-feeding: medium-dark skin tone</annotation>
+		<annotation cp="🤱🏿">baby | breast | breast-feeding | dark skin tone | feeding | mom | mother | nursing | woman</annotation>
+		<annotation cp="🤱🏿" type="tts">breast-feeding: dark skin tone</annotation>
+		<annotation cp="👩🏻‍🍼">baby | feed | feeding | light skin tone | mom | mother | nanny | newborn | nursing | woman</annotation>
+		<annotation cp="👩🏻‍🍼" type="tts">woman feeding baby: light skin tone</annotation>
+		<annotation cp="👩🏼‍🍼">baby | feed | feeding | medium-light skin tone | mom | mother | nanny | newborn | nursing | woman</annotation>
+		<annotation cp="👩🏼‍🍼" type="tts">woman feeding baby: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍🍼">baby | feed | feeding | medium skin tone | mom | mother | nanny | newborn | nursing | woman</annotation>
+		<annotation cp="👩🏽‍🍼" type="tts">woman feeding baby: medium skin tone</annotation>
+		<annotation cp="👩🏾‍🍼">baby | feed | feeding | medium-dark skin tone | mom | mother | nanny | newborn | nursing | woman</annotation>
+		<annotation cp="👩🏾‍🍼" type="tts">woman feeding baby: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍🍼">baby | dark skin tone | feed | feeding | mom | mother | nanny | newborn | nursing | woman</annotation>
+		<annotation cp="👩🏿‍🍼" type="tts">woman feeding baby: dark skin tone</annotation>
+		<annotation cp="👨🏻‍🍼">baby | dad | father | feed | feeding | light skin tone | man | nanny | newborn | nursing</annotation>
+		<annotation cp="👨🏻‍🍼" type="tts">man feeding baby: light skin tone</annotation>
+		<annotation cp="👨🏼‍🍼">baby | dad | father | feed | feeding | man | medium-light skin tone | nanny | newborn | nursing</annotation>
+		<annotation cp="👨🏼‍🍼" type="tts">man feeding baby: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍🍼">baby | dad | father | feed | feeding | man | medium skin tone | nanny | newborn | nursing</annotation>
+		<annotation cp="👨🏽‍🍼" type="tts">man feeding baby: medium skin tone</annotation>
+		<annotation cp="👨🏾‍🍼">baby | dad | father | feed | feeding | man | medium-dark skin tone | nanny | newborn | nursing</annotation>
+		<annotation cp="👨🏾‍🍼" type="tts">man feeding baby: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍🍼">baby | dad | dark skin tone | father | feed | feeding | man | nanny | newborn | nursing</annotation>
+		<annotation cp="👨🏿‍🍼" type="tts">man feeding baby: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍🍼">baby | feed | feeding | light skin tone | nanny | newborn | nursing | parent</annotation>
+		<annotation cp="🧑🏻‍🍼" type="tts">person feeding baby: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🍼">baby | feed | feeding | medium-light skin tone | nanny | newborn | nursing | parent</annotation>
+		<annotation cp="🧑🏼‍🍼" type="tts">person feeding baby: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🍼">baby | feed | feeding | medium skin tone | nanny | newborn | nursing | parent</annotation>
+		<annotation cp="🧑🏽‍🍼" type="tts">person feeding baby: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🍼">baby | feed | feeding | medium-dark skin tone | nanny | newborn | nursing | parent</annotation>
+		<annotation cp="🧑🏾‍🍼" type="tts">person feeding baby: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🍼">baby | dark skin tone | feed | feeding | nanny | newborn | nursing | parent</annotation>
+		<annotation cp="🧑🏿‍🍼" type="tts">person feeding baby: dark skin tone</annotation>
+		<annotation cp="👼🏻">angel | baby | church | face | fairy | fairytale | fantasy | light skin tone | tale</annotation>
+		<annotation cp="👼🏻" type="tts">baby angel: light skin tone</annotation>
+		<annotation cp="👼🏼">angel | baby | church | face | fairy | fairytale | fantasy | medium-light skin tone | tale</annotation>
+		<annotation cp="👼🏼" type="tts">baby angel: medium-light skin tone</annotation>
+		<annotation cp="👼🏽">angel | baby | church | face | fairy | fairytale | fantasy | medium skin tone | tale</annotation>
+		<annotation cp="👼🏽" type="tts">baby angel: medium skin tone</annotation>
+		<annotation cp="👼🏾">angel | baby | church | face | fairy | fairytale | fantasy | medium-dark skin tone | tale</annotation>
+		<annotation cp="👼🏾" type="tts">baby angel: medium-dark skin tone</annotation>
+		<annotation cp="👼🏿">angel | baby | church | dark skin tone | face | fairy | fairytale | fantasy | tale</annotation>
+		<annotation cp="👼🏿" type="tts">baby angel: dark skin tone</annotation>
+		<annotation cp="🎅🏻">celebration | Christmas | claus | fairy | fantasy | father | holiday | light skin tone | merry | santa | tale | xmas</annotation>
+		<annotation cp="🎅🏻" type="tts">Santa Claus: light skin tone</annotation>
+		<annotation cp="🎅🏼">celebration | Christmas | claus | fairy | fantasy | father | holiday | medium-light skin tone | merry | santa | tale | xmas</annotation>
+		<annotation cp="🎅🏼" type="tts">Santa Claus: medium-light skin tone</annotation>
+		<annotation cp="🎅🏽">celebration | Christmas | claus | fairy | fantasy | father | holiday | medium skin tone | merry | santa | tale | xmas</annotation>
+		<annotation cp="🎅🏽" type="tts">Santa Claus: medium skin tone</annotation>
+		<annotation cp="🎅🏾">celebration | Christmas | claus | fairy | fantasy | father | holiday | medium-dark skin tone | merry | santa | tale | xmas</annotation>
+		<annotation cp="🎅🏾" type="tts">Santa Claus: medium-dark skin tone</annotation>
+		<annotation cp="🎅🏿">celebration | Christmas | claus | dark skin tone | fairy | fantasy | father | holiday | merry | santa | tale | xmas</annotation>
+		<annotation cp="🎅🏿" type="tts">Santa Claus: dark skin tone</annotation>
+		<annotation cp="🤶🏻">celebration | Christmas | claus | fairy | fantasy | holiday | light skin tone | merry | mother | Mrs | santa | tale | xmas</annotation>
+		<annotation cp="🤶🏻" type="tts">Mrs. Claus: light skin tone</annotation>
+		<annotation cp="🤶🏼">celebration | Christmas | claus | fairy | fantasy | holiday | medium-light skin tone | merry | mother | Mrs | santa | tale | xmas</annotation>
+		<annotation cp="🤶🏼" type="tts">Mrs. Claus: medium-light skin tone</annotation>
+		<annotation cp="🤶🏽">celebration | Christmas | claus | fairy | fantasy | holiday | medium skin tone | merry | mother | Mrs | santa | tale | xmas</annotation>
+		<annotation cp="🤶🏽" type="tts">Mrs. Claus: medium skin tone</annotation>
+		<annotation cp="🤶🏾">celebration | Christmas | claus | fairy | fantasy | holiday | medium-dark skin tone | merry | mother | Mrs | santa | tale | xmas</annotation>
+		<annotation cp="🤶🏾" type="tts">Mrs. Claus: medium-dark skin tone</annotation>
+		<annotation cp="🤶🏿">celebration | Christmas | claus | dark skin tone | fairy | fantasy | holiday | merry | mother | Mrs | santa | tale | xmas</annotation>
+		<annotation cp="🤶🏿" type="tts">Mrs. Claus: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍🎄">celebration | Christmas | claus | fairy | fantasy | holiday | light skin tone | merry | Mx | santa | tale | xmas</annotation>
+		<annotation cp="🧑🏻‍🎄" type="tts">Mx Claus: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🎄">celebration | Christmas | claus | fairy | fantasy | holiday | medium-light skin tone | merry | Mx | santa | tale | xmas</annotation>
+		<annotation cp="🧑🏼‍🎄" type="tts">Mx Claus: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🎄">celebration | Christmas | claus | fairy | fantasy | holiday | medium skin tone | merry | Mx | santa | tale | xmas</annotation>
+		<annotation cp="🧑🏽‍🎄" type="tts">Mx Claus: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🎄">celebration | Christmas | claus | fairy | fantasy | holiday | medium-dark skin tone | merry | Mx | santa | tale | xmas</annotation>
+		<annotation cp="🧑🏾‍🎄" type="tts">Mx Claus: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🎄">celebration | Christmas | claus | dark skin tone | fairy | fantasy | holiday | merry | Mx | santa | tale | xmas</annotation>
+		<annotation cp="🧑🏿‍🎄" type="tts">Mx Claus: dark skin tone</annotation>
+		<annotation cp="🦸🏻">good | hero | light skin tone | superhero | superpower</annotation>
+		<annotation cp="🦸🏻" type="tts">superhero: light skin tone</annotation>
+		<annotation cp="🦸🏼">good | hero | medium-light skin tone | superhero | superpower</annotation>
+		<annotation cp="🦸🏼" type="tts">superhero: medium-light skin tone</annotation>
+		<annotation cp="🦸🏽">good | hero | medium skin tone | superhero | superpower</annotation>
+		<annotation cp="🦸🏽" type="tts">superhero: medium skin tone</annotation>
+		<annotation cp="🦸🏾">good | hero | medium-dark skin tone | superhero | superpower</annotation>
+		<annotation cp="🦸🏾" type="tts">superhero: medium-dark skin tone</annotation>
+		<annotation cp="🦸🏿">dark skin tone | good | hero | superhero | superpower</annotation>
+		<annotation cp="🦸🏿" type="tts">superhero: dark skin tone</annotation>
+		<annotation cp="🦸🏻‍♂">good | hero | light skin tone | man | superhero | superpower</annotation>
+		<annotation cp="🦸🏻‍♂" type="tts">man superhero: light skin tone</annotation>
+		<annotation cp="🦸🏼‍♂">good | hero | man | medium-light skin tone | superhero | superpower</annotation>
+		<annotation cp="🦸🏼‍♂" type="tts">man superhero: medium-light skin tone</annotation>
+		<annotation cp="🦸🏽‍♂">good | hero | man | medium skin tone | superhero | superpower</annotation>
+		<annotation cp="🦸🏽‍♂" type="tts">man superhero: medium skin tone</annotation>
+		<annotation cp="🦸🏾‍♂">good | hero | man | medium-dark skin tone | superhero | superpower</annotation>
+		<annotation cp="🦸🏾‍♂" type="tts">man superhero: medium-dark skin tone</annotation>
+		<annotation cp="🦸🏿‍♂">dark skin tone | good | hero | man | superhero | superpower</annotation>
+		<annotation cp="🦸🏿‍♂" type="tts">man superhero: dark skin tone</annotation>
+		<annotation cp="🦸🏻‍♀">good | hero | heroine | light skin tone | superhero | superpower | woman</annotation>
+		<annotation cp="🦸🏻‍♀" type="tts">woman superhero: light skin tone</annotation>
+		<annotation cp="🦸🏼‍♀">good | hero | heroine | medium-light skin tone | superhero | superpower | woman</annotation>
+		<annotation cp="🦸🏼‍♀" type="tts">woman superhero: medium-light skin tone</annotation>
+		<annotation cp="🦸🏽‍♀">good | hero | heroine | medium skin tone | superhero | superpower | woman</annotation>
+		<annotation cp="🦸🏽‍♀" type="tts">woman superhero: medium skin tone</annotation>
+		<annotation cp="🦸🏾‍♀">good | hero | heroine | medium-dark skin tone | superhero | superpower | woman</annotation>
+		<annotation cp="🦸🏾‍♀" type="tts">woman superhero: medium-dark skin tone</annotation>
+		<annotation cp="🦸🏿‍♀">dark skin tone | good | hero | heroine | superhero | superpower | woman</annotation>
+		<annotation cp="🦸🏿‍♀" type="tts">woman superhero: dark skin tone</annotation>
+		<annotation cp="🦹🏻">bad | criminal | evil | light skin tone | superpower | supervillain | villain</annotation>
+		<annotation cp="🦹🏻" type="tts">supervillain: light skin tone</annotation>
+		<annotation cp="🦹🏼">bad | criminal | evil | medium-light skin tone | superpower | supervillain | villain</annotation>
+		<annotation cp="🦹🏼" type="tts">supervillain: medium-light skin tone</annotation>
+		<annotation cp="🦹🏽">bad | criminal | evil | medium skin tone | superpower | supervillain | villain</annotation>
+		<annotation cp="🦹🏽" type="tts">supervillain: medium skin tone</annotation>
+		<annotation cp="🦹🏾">bad | criminal | evil | medium-dark skin tone | superpower | supervillain | villain</annotation>
+		<annotation cp="🦹🏾" type="tts">supervillain: medium-dark skin tone</annotation>
+		<annotation cp="🦹🏿">bad | criminal | dark skin tone | evil | superpower | supervillain | villain</annotation>
+		<annotation cp="🦹🏿" type="tts">supervillain: dark skin tone</annotation>
+		<annotation cp="🦹🏻‍♂">bad | criminal | evil | light skin tone | man | superpower | supervillain | villain</annotation>
+		<annotation cp="🦹🏻‍♂" type="tts">man supervillain: light skin tone</annotation>
+		<annotation cp="🦹🏼‍♂">bad | criminal | evil | man | medium-light skin tone | superpower | supervillain | villain</annotation>
+		<annotation cp="🦹🏼‍♂" type="tts">man supervillain: medium-light skin tone</annotation>
+		<annotation cp="🦹🏽‍♂">bad | criminal | evil | man | medium skin tone | superpower | supervillain | villain</annotation>
+		<annotation cp="🦹🏽‍♂" type="tts">man supervillain: medium skin tone</annotation>
+		<annotation cp="🦹🏾‍♂">bad | criminal | evil | man | medium-dark skin tone | superpower | supervillain | villain</annotation>
+		<annotation cp="🦹🏾‍♂" type="tts">man supervillain: medium-dark skin tone</annotation>
+		<annotation cp="🦹🏿‍♂">bad | criminal | dark skin tone | evil | man | superpower | supervillain | villain</annotation>
+		<annotation cp="🦹🏿‍♂" type="tts">man supervillain: dark skin tone</annotation>
+		<annotation cp="🦹🏻‍♀">bad | criminal | evil | light skin tone | superpower | supervillain | villain | woman</annotation>
+		<annotation cp="🦹🏻‍♀" type="tts">woman supervillain: light skin tone</annotation>
+		<annotation cp="🦹🏼‍♀">bad | criminal | evil | medium-light skin tone | superpower | supervillain | villain | woman</annotation>
+		<annotation cp="🦹🏼‍♀" type="tts">woman supervillain: medium-light skin tone</annotation>
+		<annotation cp="🦹🏽‍♀">bad | criminal | evil | medium skin tone | superpower | supervillain | villain | woman</annotation>
+		<annotation cp="🦹🏽‍♀" type="tts">woman supervillain: medium skin tone</annotation>
+		<annotation cp="🦹🏾‍♀">bad | criminal | evil | medium-dark skin tone | superpower | supervillain | villain | woman</annotation>
+		<annotation cp="🦹🏾‍♀" type="tts">woman supervillain: medium-dark skin tone</annotation>
+		<annotation cp="🦹🏿‍♀">bad | criminal | dark skin tone | evil | superpower | supervillain | villain | woman</annotation>
+		<annotation cp="🦹🏿‍♀" type="tts">woman supervillain: dark skin tone</annotation>
+		<annotation cp="🧙🏻">fantasy | light skin tone | mage | magic | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard</annotation>
+		<annotation cp="🧙🏻" type="tts">mage: light skin tone</annotation>
+		<annotation cp="🧙🏼">fantasy | mage | magic | medium-light skin tone | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard</annotation>
+		<annotation cp="🧙🏼" type="tts">mage: medium-light skin tone</annotation>
+		<annotation cp="🧙🏽">fantasy | mage | magic | medium skin tone | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard</annotation>
+		<annotation cp="🧙🏽" type="tts">mage: medium skin tone</annotation>
+		<annotation cp="🧙🏾">fantasy | mage | magic | medium-dark skin tone | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard</annotation>
+		<annotation cp="🧙🏾" type="tts">mage: medium-dark skin tone</annotation>
+		<annotation cp="🧙🏿">dark skin tone | fantasy | mage | magic | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard</annotation>
+		<annotation cp="🧙🏿" type="tts">mage: dark skin tone</annotation>
+		<annotation cp="🧙🏻‍♂">fantasy | light skin tone | mage | magic | man | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard</annotation>
+		<annotation cp="🧙🏻‍♂" type="tts">man mage: light skin tone</annotation>
+		<annotation cp="🧙🏼‍♂">fantasy | mage | magic | man | medium-light skin tone | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard</annotation>
+		<annotation cp="🧙🏼‍♂" type="tts">man mage: medium-light skin tone</annotation>
+		<annotation cp="🧙🏽‍♂">fantasy | mage | magic | man | medium skin tone | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard</annotation>
+		<annotation cp="🧙🏽‍♂" type="tts">man mage: medium skin tone</annotation>
+		<annotation cp="🧙🏾‍♂">fantasy | mage | magic | man | medium-dark skin tone | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard</annotation>
+		<annotation cp="🧙🏾‍♂" type="tts">man mage: medium-dark skin tone</annotation>
+		<annotation cp="🧙🏿‍♂">dark skin tone | fantasy | mage | magic | man | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard</annotation>
+		<annotation cp="🧙🏿‍♂" type="tts">man mage: dark skin tone</annotation>
+		<annotation cp="🧙🏻‍♀">fantasy | light skin tone | mage | magic | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard | woman</annotation>
+		<annotation cp="🧙🏻‍♀" type="tts">woman mage: light skin tone</annotation>
+		<annotation cp="🧙🏼‍♀">fantasy | mage | magic | medium-light skin tone | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard | woman</annotation>
+		<annotation cp="🧙🏼‍♀" type="tts">woman mage: medium-light skin tone</annotation>
+		<annotation cp="🧙🏽‍♀">fantasy | mage | magic | medium skin tone | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard | woman</annotation>
+		<annotation cp="🧙🏽‍♀" type="tts">woman mage: medium skin tone</annotation>
+		<annotation cp="🧙🏾‍♀">fantasy | mage | magic | medium-dark skin tone | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard | woman</annotation>
+		<annotation cp="🧙🏾‍♀" type="tts">woman mage: medium-dark skin tone</annotation>
+		<annotation cp="🧙🏿‍♀">dark skin tone | fantasy | mage | magic | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard | woman</annotation>
+		<annotation cp="🧙🏿‍♀" type="tts">woman mage: dark skin tone</annotation>
+		<annotation cp="🧚🏻">fairy | fairytale | fantasy | light skin tone | myth | person | pixie | tale | wings</annotation>
+		<annotation cp="🧚🏻" type="tts">fairy: light skin tone</annotation>
+		<annotation cp="🧚🏼">fairy | fairytale | fantasy | medium-light skin tone | myth | person | pixie | tale | wings</annotation>
+		<annotation cp="🧚🏼" type="tts">fairy: medium-light skin tone</annotation>
+		<annotation cp="🧚🏽">fairy | fairytale | fantasy | medium skin tone | myth | person | pixie | tale | wings</annotation>
+		<annotation cp="🧚🏽" type="tts">fairy: medium skin tone</annotation>
+		<annotation cp="🧚🏾">fairy | fairytale | fantasy | medium-dark skin tone | myth | person | pixie | tale | wings</annotation>
+		<annotation cp="🧚🏾" type="tts">fairy: medium-dark skin tone</annotation>
+		<annotation cp="🧚🏿">dark skin tone | fairy | fairytale | fantasy | myth | person | pixie | tale | wings</annotation>
+		<annotation cp="🧚🏿" type="tts">fairy: dark skin tone</annotation>
+		<annotation cp="🧚🏻‍♂">fairy | fairytale | fantasy | light skin tone | man | myth | Oberon | person | pixie | Puck | tale | wings</annotation>
+		<annotation cp="🧚🏻‍♂" type="tts">man fairy: light skin tone</annotation>
+		<annotation cp="🧚🏼‍♂">fairy | fairytale | fantasy | man | medium-light skin tone | myth | Oberon | person | pixie | Puck | tale | wings</annotation>
+		<annotation cp="🧚🏼‍♂" type="tts">man fairy: medium-light skin tone</annotation>
+		<annotation cp="🧚🏽‍♂">fairy | fairytale | fantasy | man | medium skin tone | myth | Oberon | person | pixie | Puck | tale | wings</annotation>
+		<annotation cp="🧚🏽‍♂" type="tts">man fairy: medium skin tone</annotation>
+		<annotation cp="🧚🏾‍♂">fairy | fairytale | fantasy | man | medium-dark skin tone | myth | Oberon | person | pixie | Puck | tale | wings</annotation>
+		<annotation cp="🧚🏾‍♂" type="tts">man fairy: medium-dark skin tone</annotation>
+		<annotation cp="🧚🏿‍♂">dark skin tone | fairy | fairytale | fantasy | man | myth | Oberon | person | pixie | Puck | tale | wings</annotation>
+		<annotation cp="🧚🏿‍♂" type="tts">man fairy: dark skin tone</annotation>
+		<annotation cp="🧚🏻‍♀">fairy | fairytale | fantasy | light skin tone | myth | person | pixie | tale | Titania | wings | woman</annotation>
+		<annotation cp="🧚🏻‍♀" type="tts">woman fairy: light skin tone</annotation>
+		<annotation cp="🧚🏼‍♀">fairy | fairytale | fantasy | medium-light skin tone | myth | person | pixie | tale | Titania | wings | woman</annotation>
+		<annotation cp="🧚🏼‍♀" type="tts">woman fairy: medium-light skin tone</annotation>
+		<annotation cp="🧚🏽‍♀">fairy | fairytale | fantasy | medium skin tone | myth | person | pixie | tale | Titania | wings | woman</annotation>
+		<annotation cp="🧚🏽‍♀" type="tts">woman fairy: medium skin tone</annotation>
+		<annotation cp="🧚🏾‍♀">fairy | fairytale | fantasy | medium-dark skin tone | myth | person | pixie | tale | Titania | wings | woman</annotation>
+		<annotation cp="🧚🏾‍♀" type="tts">woman fairy: medium-dark skin tone</annotation>
+		<annotation cp="🧚🏿‍♀">dark skin tone | fairy | fairytale | fantasy | myth | person | pixie | tale | Titania | wings | woman</annotation>
+		<annotation cp="🧚🏿‍♀" type="tts">woman fairy: dark skin tone</annotation>
+		<annotation cp="🧛🏻">blood | Dracula | fangs | halloween | light skin tone | scary | supernatural | teeth | undead | vampire</annotation>
+		<annotation cp="🧛🏻" type="tts">vampire: light skin tone</annotation>
+		<annotation cp="🧛🏼">blood | Dracula | fangs | halloween | medium-light skin tone | scary | supernatural | teeth | undead | vampire</annotation>
+		<annotation cp="🧛🏼" type="tts">vampire: medium-light skin tone</annotation>
+		<annotation cp="🧛🏽">blood | Dracula | fangs | halloween | medium skin tone | scary | supernatural | teeth | undead | vampire</annotation>
+		<annotation cp="🧛🏽" type="tts">vampire: medium skin tone</annotation>
+		<annotation cp="🧛🏾">blood | Dracula | fangs | halloween | medium-dark skin tone | scary | supernatural | teeth | undead | vampire</annotation>
+		<annotation cp="🧛🏾" type="tts">vampire: medium-dark skin tone</annotation>
+		<annotation cp="🧛🏿">blood | dark skin tone | Dracula | fangs | halloween | scary | supernatural | teeth | undead | vampire</annotation>
+		<annotation cp="🧛🏿" type="tts">vampire: dark skin tone</annotation>
+		<annotation cp="🧛🏻‍♂">blood | fangs | halloween | light skin tone | man | scary | supernatural | teeth | undead | vampire</annotation>
+		<annotation cp="🧛🏻‍♂" type="tts">man vampire: light skin tone</annotation>
+		<annotation cp="🧛🏼‍♂">blood | fangs | halloween | man | medium-light skin tone | scary | supernatural | teeth | undead | vampire</annotation>
+		<annotation cp="🧛🏼‍♂" type="tts">man vampire: medium-light skin tone</annotation>
+		<annotation cp="🧛🏽‍♂">blood | fangs | halloween | man | medium skin tone | scary | supernatural | teeth | undead | vampire</annotation>
+		<annotation cp="🧛🏽‍♂" type="tts">man vampire: medium skin tone</annotation>
+		<annotation cp="🧛🏾‍♂">blood | fangs | halloween | man | medium-dark skin tone | scary | supernatural | teeth | undead | vampire</annotation>
+		<annotation cp="🧛🏾‍♂" type="tts">man vampire: medium-dark skin tone</annotation>
+		<annotation cp="🧛🏿‍♂">blood | dark skin tone | fangs | halloween | man | scary | supernatural | teeth | undead | vampire</annotation>
+		<annotation cp="🧛🏿‍♂" type="tts">man vampire: dark skin tone</annotation>
+		<annotation cp="🧛🏻‍♀">blood | fangs | halloween | light skin tone | scary | supernatural | teeth | undead | vampire | woman</annotation>
+		<annotation cp="🧛🏻‍♀" type="tts">woman vampire: light skin tone</annotation>
+		<annotation cp="🧛🏼‍♀">blood | fangs | halloween | medium-light skin tone | scary | supernatural | teeth | undead | vampire | woman</annotation>
+		<annotation cp="🧛🏼‍♀" type="tts">woman vampire: medium-light skin tone</annotation>
+		<annotation cp="🧛🏽‍♀">blood | fangs | halloween | medium skin tone | scary | supernatural | teeth | undead | vampire | woman</annotation>
+		<annotation cp="🧛🏽‍♀" type="tts">woman vampire: medium skin tone</annotation>
+		<annotation cp="🧛🏾‍♀">blood | fangs | halloween | medium-dark skin tone | scary | supernatural | teeth | undead | vampire | woman</annotation>
+		<annotation cp="🧛🏾‍♀" type="tts">woman vampire: medium-dark skin tone</annotation>
+		<annotation cp="🧛🏿‍♀">blood | dark skin tone | fangs | halloween | scary | supernatural | teeth | undead | vampire | woman</annotation>
+		<annotation cp="🧛🏿‍♀" type="tts">woman vampire: dark skin tone</annotation>
+		<annotation cp="🧜🏻">creature | fairytale | folklore | light skin tone | merperson | ocean | sea | siren | trident</annotation>
+		<annotation cp="🧜🏻" type="tts">merperson: light skin tone</annotation>
+		<annotation cp="🧜🏼">creature | fairytale | folklore | medium-light skin tone | merperson | ocean | sea | siren | trident</annotation>
+		<annotation cp="🧜🏼" type="tts">merperson: medium-light skin tone</annotation>
+		<annotation cp="🧜🏽">creature | fairytale | folklore | medium skin tone | merperson | ocean | sea | siren | trident</annotation>
+		<annotation cp="🧜🏽" type="tts">merperson: medium skin tone</annotation>
+		<annotation cp="🧜🏾">creature | fairytale | folklore | medium-dark skin tone | merperson | ocean | sea | siren | trident</annotation>
+		<annotation cp="🧜🏾" type="tts">merperson: medium-dark skin tone</annotation>
+		<annotation cp="🧜🏿">creature | dark skin tone | fairytale | folklore | merperson | ocean | sea | siren | trident</annotation>
+		<annotation cp="🧜🏿" type="tts">merperson: dark skin tone</annotation>
+		<annotation cp="🧜🏻‍♂">creature | fairytale | folklore | light skin tone | merman | Neptune | ocean | Poseidon | sea | siren | trident | Triton</annotation>
+		<annotation cp="🧜🏻‍♂" type="tts">merman: light skin tone</annotation>
+		<annotation cp="🧜🏼‍♂">creature | fairytale | folklore | medium-light skin tone | merman | Neptune | ocean | Poseidon | sea | siren | trident | Triton</annotation>
+		<annotation cp="🧜🏼‍♂" type="tts">merman: medium-light skin tone</annotation>
+		<annotation cp="🧜🏽‍♂">creature | fairytale | folklore | medium skin tone | merman | Neptune | ocean | Poseidon | sea | siren | trident | Triton</annotation>
+		<annotation cp="🧜🏽‍♂" type="tts">merman: medium skin tone</annotation>
+		<annotation cp="🧜🏾‍♂">creature | fairytale | folklore | medium-dark skin tone | merman | Neptune | ocean | Poseidon | sea | siren | trident | Triton</annotation>
+		<annotation cp="🧜🏾‍♂" type="tts">merman: medium-dark skin tone</annotation>
+		<annotation cp="🧜🏿‍♂">creature | dark skin tone | fairytale | folklore | merman | Neptune | ocean | Poseidon | sea | siren | trident | Triton</annotation>
+		<annotation cp="🧜🏿‍♂" type="tts">merman: dark skin tone</annotation>
+		<annotation cp="🧜🏻‍♀">creature | fairytale | folklore | light skin tone | mermaid | merwoman | ocean | sea | siren | trident</annotation>
+		<annotation cp="🧜🏻‍♀" type="tts">mermaid: light skin tone</annotation>
+		<annotation cp="🧜🏼‍♀">creature | fairytale | folklore | medium-light skin tone | mermaid | merwoman | ocean | sea | siren | trident</annotation>
+		<annotation cp="🧜🏼‍♀" type="tts">mermaid: medium-light skin tone</annotation>
+		<annotation cp="🧜🏽‍♀">creature | fairytale | folklore | medium skin tone | mermaid | merwoman | ocean | sea | siren | trident</annotation>
+		<annotation cp="🧜🏽‍♀" type="tts">mermaid: medium skin tone</annotation>
+		<annotation cp="🧜🏾‍♀">creature | fairytale | folklore | medium-dark skin tone | mermaid | merwoman | ocean | sea | siren | trident</annotation>
+		<annotation cp="🧜🏾‍♀" type="tts">mermaid: medium-dark skin tone</annotation>
+		<annotation cp="🧜🏿‍♀">creature | dark skin tone | fairytale | folklore | mermaid | merwoman | ocean | sea | siren | trident</annotation>
+		<annotation cp="🧜🏿‍♀" type="tts">mermaid: dark skin tone</annotation>
+		<annotation cp="🧝🏻">elf | elves | enchantment | fantasy | folklore | light skin tone | magic | magical | myth</annotation>
+		<annotation cp="🧝🏻" type="tts">elf: light skin tone</annotation>
+		<annotation cp="🧝🏼">elf | elves | enchantment | fantasy | folklore | magic | magical | medium-light skin tone | myth</annotation>
+		<annotation cp="🧝🏼" type="tts">elf: medium-light skin tone</annotation>
+		<annotation cp="🧝🏽">elf | elves | enchantment | fantasy | folklore | magic | magical | medium skin tone | myth</annotation>
+		<annotation cp="🧝🏽" type="tts">elf: medium skin tone</annotation>
+		<annotation cp="🧝🏾">elf | elves | enchantment | fantasy | folklore | magic | magical | medium-dark skin tone | myth</annotation>
+		<annotation cp="🧝🏾" type="tts">elf: medium-dark skin tone</annotation>
+		<annotation cp="🧝🏿">dark skin tone | elf | elves | enchantment | fantasy | folklore | magic | magical | myth</annotation>
+		<annotation cp="🧝🏿" type="tts">elf: dark skin tone</annotation>
+		<annotation cp="🧝🏻‍♂">elf | elves | enchantment | fantasy | folklore | light skin tone | magic | magical | man | myth</annotation>
+		<annotation cp="🧝🏻‍♂" type="tts">man elf: light skin tone</annotation>
+		<annotation cp="🧝🏼‍♂">elf | elves | enchantment | fantasy | folklore | magic | magical | man | medium-light skin tone | myth</annotation>
+		<annotation cp="🧝🏼‍♂" type="tts">man elf: medium-light skin tone</annotation>
+		<annotation cp="🧝🏽‍♂">elf | elves | enchantment | fantasy | folklore | magic | magical | man | medium skin tone | myth</annotation>
+		<annotation cp="🧝🏽‍♂" type="tts">man elf: medium skin tone</annotation>
+		<annotation cp="🧝🏾‍♂">elf | elves | enchantment | fantasy | folklore | magic | magical | man | medium-dark skin tone | myth</annotation>
+		<annotation cp="🧝🏾‍♂" type="tts">man elf: medium-dark skin tone</annotation>
+		<annotation cp="🧝🏿‍♂">dark skin tone | elf | elves | enchantment | fantasy | folklore | magic | magical | man | myth</annotation>
+		<annotation cp="🧝🏿‍♂" type="tts">man elf: dark skin tone</annotation>
+		<annotation cp="🧝🏻‍♀">elf | elves | enchantment | fantasy | folklore | light skin tone | magic | magical | myth | woman</annotation>
+		<annotation cp="🧝🏻‍♀" type="tts">woman elf: light skin tone</annotation>
+		<annotation cp="🧝🏼‍♀">elf | elves | enchantment | fantasy | folklore | magic | magical | medium-light skin tone | myth | woman</annotation>
+		<annotation cp="🧝🏼‍♀" type="tts">woman elf: medium-light skin tone</annotation>
+		<annotation cp="🧝🏽‍♀">elf | elves | enchantment | fantasy | folklore | magic | magical | medium skin tone | myth | woman</annotation>
+		<annotation cp="🧝🏽‍♀" type="tts">woman elf: medium skin tone</annotation>
+		<annotation cp="🧝🏾‍♀">elf | elves | enchantment | fantasy | folklore | magic | magical | medium-dark skin tone | myth | woman</annotation>
+		<annotation cp="🧝🏾‍♀" type="tts">woman elf: medium-dark skin tone</annotation>
+		<annotation cp="🧝🏿‍♀">dark skin tone | elf | elves | enchantment | fantasy | folklore | magic | magical | myth | woman</annotation>
+		<annotation cp="🧝🏿‍♀" type="tts">woman elf: dark skin tone</annotation>
+		<annotation cp="💆🏻">face | getting | headache | light skin tone | massage | person | relax | relaxing | salon | soothe | spa | tension | therapy | treatment</annotation>
+		<annotation cp="💆🏻" type="tts">person getting massage: light skin tone</annotation>
+		<annotation cp="💆🏼">face | getting | headache | massage | medium-light skin tone | person | relax | relaxing | salon | soothe | spa | tension | therapy | treatment</annotation>
+		<annotation cp="💆🏼" type="tts">person getting massage: medium-light skin tone</annotation>
+		<annotation cp="💆🏽">face | getting | headache | massage | medium skin tone | person | relax | relaxing | salon | soothe | spa | tension | therapy | treatment</annotation>
+		<annotation cp="💆🏽" type="tts">person getting massage: medium skin tone</annotation>
+		<annotation cp="💆🏾">face | getting | headache | massage | medium-dark skin tone | person | relax | relaxing | salon | soothe | spa | tension | therapy | treatment</annotation>
+		<annotation cp="💆🏾" type="tts">person getting massage: medium-dark skin tone</annotation>
+		<annotation cp="💆🏿">dark skin tone | face | getting | headache | massage | person | relax | relaxing | salon | soothe | spa | tension | therapy | treatment</annotation>
+		<annotation cp="💆🏿" type="tts">person getting massage: dark skin tone</annotation>
+		<annotation cp="💆🏻‍♂">face | getting | headache | light skin tone | man | massage | relax | relaxing | salon | soothe | spa | tension | therapy | treatment</annotation>
+		<annotation cp="💆🏻‍♂" type="tts">man getting massage: light skin tone</annotation>
+		<annotation cp="💆🏼‍♂">face | getting | headache | man | massage | medium-light skin tone | relax | relaxing | salon | soothe | spa | tension | therapy | treatment</annotation>
+		<annotation cp="💆🏼‍♂" type="tts">man getting massage: medium-light skin tone</annotation>
+		<annotation cp="💆🏽‍♂">face | getting | headache | man | massage | medium skin tone | relax | relaxing | salon | soothe | spa | tension | therapy | treatment</annotation>
+		<annotation cp="💆🏽‍♂" type="tts">man getting massage: medium skin tone</annotation>
+		<annotation cp="💆🏾‍♂">face | getting | headache | man | massage | medium-dark skin tone | relax | relaxing | salon | soothe | spa | tension | therapy | treatment</annotation>
+		<annotation cp="💆🏾‍♂" type="tts">man getting massage: medium-dark skin tone</annotation>
+		<annotation cp="💆🏿‍♂">dark skin tone | face | getting | headache | man | massage | relax | relaxing | salon | soothe | spa | tension | therapy | treatment</annotation>
+		<annotation cp="💆🏿‍♂" type="tts">man getting massage: dark skin tone</annotation>
+		<annotation cp="💆🏻‍♀">face | getting | headache | light skin tone | massage | relax | relaxing | salon | soothe | spa | tension | therapy | treatment | woman</annotation>
+		<annotation cp="💆🏻‍♀" type="tts">woman getting massage: light skin tone</annotation>
+		<annotation cp="💆🏼‍♀">face | getting | headache | massage | medium-light skin tone | relax | relaxing | salon | soothe | spa | tension | therapy | treatment | woman</annotation>
+		<annotation cp="💆🏼‍♀" type="tts">woman getting massage: medium-light skin tone</annotation>
+		<annotation cp="💆🏽‍♀">face | getting | headache | massage | medium skin tone | relax | relaxing | salon | soothe | spa | tension | therapy | treatment | woman</annotation>
+		<annotation cp="💆🏽‍♀" type="tts">woman getting massage: medium skin tone</annotation>
+		<annotation cp="💆🏾‍♀">face | getting | headache | massage | medium-dark skin tone | relax | relaxing | salon | soothe | spa | tension | therapy | treatment | woman</annotation>
+		<annotation cp="💆🏾‍♀" type="tts">woman getting massage: medium-dark skin tone</annotation>
+		<annotation cp="💆🏿‍♀">dark skin tone | face | getting | headache | massage | relax | relaxing | salon | soothe | spa | tension | therapy | treatment | woman</annotation>
+		<annotation cp="💆🏿‍♀" type="tts">woman getting massage: dark skin tone</annotation>
+		<annotation cp="💇🏻">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | light skin tone | parlor | person | shears | style</annotation>
+		<annotation cp="💇🏻" type="tts">person getting haircut: light skin tone</annotation>
+		<annotation cp="💇🏼">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | medium-light skin tone | parlor | person | shears | style</annotation>
+		<annotation cp="💇🏼" type="tts">person getting haircut: medium-light skin tone</annotation>
+		<annotation cp="💇🏽">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | medium skin tone | parlor | person | shears | style</annotation>
+		<annotation cp="💇🏽" type="tts">person getting haircut: medium skin tone</annotation>
+		<annotation cp="💇🏾">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | medium-dark skin tone | parlor | person | shears | style</annotation>
+		<annotation cp="💇🏾" type="tts">person getting haircut: medium-dark skin tone</annotation>
+		<annotation cp="💇🏿">barber | beauty | chop | cosmetology | cut | dark skin tone | groom | hair | haircut | parlor | person | shears | style</annotation>
+		<annotation cp="💇🏿" type="tts">person getting haircut: dark skin tone</annotation>
+		<annotation cp="💇🏻‍♂">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | light skin tone | man | parlor | person | shears | style</annotation>
+		<annotation cp="💇🏻‍♂" type="tts">man getting haircut: light skin tone</annotation>
+		<annotation cp="💇🏼‍♂">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | man | medium-light skin tone | parlor | person | shears | style</annotation>
+		<annotation cp="💇🏼‍♂" type="tts">man getting haircut: medium-light skin tone</annotation>
+		<annotation cp="💇🏽‍♂">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | man | medium skin tone | parlor | person | shears | style</annotation>
+		<annotation cp="💇🏽‍♂" type="tts">man getting haircut: medium skin tone</annotation>
+		<annotation cp="💇🏾‍♂">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | man | medium-dark skin tone | parlor | person | shears | style</annotation>
+		<annotation cp="💇🏾‍♂" type="tts">man getting haircut: medium-dark skin tone</annotation>
+		<annotation cp="💇🏿‍♂">barber | beauty | chop | cosmetology | cut | dark skin tone | groom | hair | haircut | man | parlor | person | shears | style</annotation>
+		<annotation cp="💇🏿‍♂" type="tts">man getting haircut: dark skin tone</annotation>
+		<annotation cp="💇🏻‍♀">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | light skin tone | parlor | person | shears | style | woman</annotation>
+		<annotation cp="💇🏻‍♀" type="tts">woman getting haircut: light skin tone</annotation>
+		<annotation cp="💇🏼‍♀">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | medium-light skin tone | parlor | person | shears | style | woman</annotation>
+		<annotation cp="💇🏼‍♀" type="tts">woman getting haircut: medium-light skin tone</annotation>
+		<annotation cp="💇🏽‍♀">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | medium skin tone | parlor | person | shears | style | woman</annotation>
+		<annotation cp="💇🏽‍♀" type="tts">woman getting haircut: medium skin tone</annotation>
+		<annotation cp="💇🏾‍♀">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | medium-dark skin tone | parlor | person | shears | style | woman</annotation>
+		<annotation cp="💇🏾‍♀" type="tts">woman getting haircut: medium-dark skin tone</annotation>
+		<annotation cp="💇🏿‍♀">barber | beauty | chop | cosmetology | cut | dark skin tone | groom | hair | haircut | parlor | person | shears | style | woman</annotation>
+		<annotation cp="💇🏿‍♀" type="tts">woman getting haircut: dark skin tone</annotation>
+		<annotation cp="🚶🏻">amble | gait | hike | light skin tone | man | pace | pedestrian | person | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏻" type="tts">person walking: light skin tone</annotation>
+		<annotation cp="🚶🏼">amble | gait | hike | man | medium-light skin tone | pace | pedestrian | person | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏼" type="tts">person walking: medium-light skin tone</annotation>
+		<annotation cp="🚶🏽">amble | gait | hike | man | medium skin tone | pace | pedestrian | person | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏽" type="tts">person walking: medium skin tone</annotation>
+		<annotation cp="🚶🏾">amble | gait | hike | man | medium-dark skin tone | pace | pedestrian | person | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏾" type="tts">person walking: medium-dark skin tone</annotation>
+		<annotation cp="🚶🏿">amble | dark skin tone | gait | hike | man | pace | pedestrian | person | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏿" type="tts">person walking: dark skin tone</annotation>
+		<annotation cp="🚶🏻‍♂">amble | gait | hike | light skin tone | man | pace | pedestrian | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏻‍♂" type="tts">man walking: light skin tone</annotation>
+		<annotation cp="🚶🏼‍♂">amble | gait | hike | man | medium-light skin tone | pace | pedestrian | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏼‍♂" type="tts">man walking: medium-light skin tone</annotation>
+		<annotation cp="🚶🏽‍♂">amble | gait | hike | man | medium skin tone | pace | pedestrian | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏽‍♂" type="tts">man walking: medium skin tone</annotation>
+		<annotation cp="🚶🏾‍♂">amble | gait | hike | man | medium-dark skin tone | pace | pedestrian | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏾‍♂" type="tts">man walking: medium-dark skin tone</annotation>
+		<annotation cp="🚶🏿‍♂">amble | dark skin tone | gait | hike | man | pace | pedestrian | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏿‍♂" type="tts">man walking: dark skin tone</annotation>
+		<annotation cp="🚶🏻‍♀">amble | gait | hike | light skin tone | man | pace | pedestrian | stride | stroll | walk | walking | woman</annotation>
+		<annotation cp="🚶🏻‍♀" type="tts">woman walking: light skin tone</annotation>
+		<annotation cp="🚶🏼‍♀">amble | gait | hike | man | medium-light skin tone | pace | pedestrian | stride | stroll | walk | walking | woman</annotation>
+		<annotation cp="🚶🏼‍♀" type="tts">woman walking: medium-light skin tone</annotation>
+		<annotation cp="🚶🏽‍♀">amble | gait | hike | man | medium skin tone | pace | pedestrian | stride | stroll | walk | walking | woman</annotation>
+		<annotation cp="🚶🏽‍♀" type="tts">woman walking: medium skin tone</annotation>
+		<annotation cp="🚶🏾‍♀">amble | gait | hike | man | medium-dark skin tone | pace | pedestrian | stride | stroll | walk | walking | woman</annotation>
+		<annotation cp="🚶🏾‍♀" type="tts">woman walking: medium-dark skin tone</annotation>
+		<annotation cp="🚶🏿‍♀">amble | dark skin tone | gait | hike | man | pace | pedestrian | stride | stroll | walk | walking | woman</annotation>
+		<annotation cp="🚶🏿‍♀" type="tts">woman walking: dark skin tone</annotation>
+		<annotation cp="🚶‍➡">amble | facing | gait | hike | man | pace | pedestrian | person | right | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶‍➡" type="tts">person walking: facing right</annotation>
+		<annotation cp="🚶🏻‍➡">amble | facing | gait | hike | light skin tone | man | pace | pedestrian | person | right | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏻‍➡" type="tts">person walking: light skin tone, facing right</annotation>
+		<annotation cp="🚶🏼‍➡">amble | facing | gait | hike | man | medium-light skin tone | pace | pedestrian | person | right | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏼‍➡" type="tts">person walking: medium-light skin tone, facing right</annotation>
+		<annotation cp="🚶🏽‍➡">amble | facing | gait | hike | man | medium skin tone | pace | pedestrian | person | right | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏽‍➡" type="tts">person walking: medium skin tone, facing right</annotation>
+		<annotation cp="🚶🏾‍➡">amble | facing | gait | hike | man | medium-dark skin tone | pace | pedestrian | person | right | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏾‍➡" type="tts">person walking: medium-dark skin tone, facing right</annotation>
+		<annotation cp="🚶🏿‍➡">amble | dark skin tone | facing | gait | hike | man | pace | pedestrian | person | right | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏿‍➡" type="tts">person walking: dark skin tone, facing right</annotation>
+		<annotation cp="🚶‍♀‍➡">amble | facing | gait | hike | man | pace | pedestrian | right | stride | stroll | walk | walking | woman</annotation>
+		<annotation cp="🚶‍♀‍➡" type="tts">woman walking: facing right</annotation>
+		<annotation cp="🚶🏻‍♀‍➡">amble | facing | gait | hike | light skin tone | man | pace | pedestrian | right | stride | stroll | walk | walking | woman</annotation>
+		<annotation cp="🚶🏻‍♀‍➡" type="tts">woman walking: light skin tone, facing right</annotation>
+		<annotation cp="🚶🏼‍♀‍➡">amble | facing | gait | hike | man | medium-light skin tone | pace | pedestrian | right | stride | stroll | walk | walking | woman</annotation>
+		<annotation cp="🚶🏼‍♀‍➡" type="tts">woman walking: medium-light skin tone, facing right</annotation>
+		<annotation cp="🚶🏽‍♀‍➡">amble | facing | gait | hike | man | medium skin tone | pace | pedestrian | right | stride | stroll | walk | walking | woman</annotation>
+		<annotation cp="🚶🏽‍♀‍➡" type="tts">woman walking: medium skin tone, facing right</annotation>
+		<annotation cp="🚶🏾‍♀‍➡">amble | facing | gait | hike | man | medium-dark skin tone | pace | pedestrian | right | stride | stroll | walk | walking | woman</annotation>
+		<annotation cp="🚶🏾‍♀‍➡" type="tts">woman walking: medium-dark skin tone, facing right</annotation>
+		<annotation cp="🚶🏿‍♀‍➡">amble | dark skin tone | facing | gait | hike | man | pace | pedestrian | right | stride | stroll | walk | walking | woman</annotation>
+		<annotation cp="🚶🏿‍♀‍➡" type="tts">woman walking: dark skin tone, facing right</annotation>
+		<annotation cp="🚶‍♂‍➡">amble | facing | gait | hike | man | pace | pedestrian | right | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶‍♂‍➡" type="tts">man walking: facing right</annotation>
+		<annotation cp="🚶🏻‍♂‍➡">amble | facing | gait | hike | light skin tone | man | pace | pedestrian | right | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏻‍♂‍➡" type="tts">man walking: light skin tone, facing right</annotation>
+		<annotation cp="🚶🏼‍♂‍➡">amble | facing | gait | hike | man | medium-light skin tone | pace | pedestrian | right | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏼‍♂‍➡" type="tts">man walking: medium-light skin tone, facing right</annotation>
+		<annotation cp="🚶🏽‍♂‍➡">amble | facing | gait | hike | man | medium skin tone | pace | pedestrian | right | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏽‍♂‍➡" type="tts">man walking: medium skin tone, facing right</annotation>
+		<annotation cp="🚶🏾‍♂‍➡">amble | facing | gait | hike | man | medium-dark skin tone | pace | pedestrian | right | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏾‍♂‍➡" type="tts">man walking: medium-dark skin tone, facing right</annotation>
+		<annotation cp="🚶🏿‍♂‍➡">amble | dark skin tone | facing | gait | hike | man | pace | pedestrian | right | stride | stroll | walk | walking</annotation>
+		<annotation cp="🚶🏿‍♂‍➡" type="tts">man walking: dark skin tone, facing right</annotation>
+		<annotation cp="🧍🏻">light skin tone | person | stand | standing</annotation>
+		<annotation cp="🧍🏻" type="tts">person standing: light skin tone</annotation>
+		<annotation cp="🧍🏼">medium-light skin tone | person | stand | standing</annotation>
+		<annotation cp="🧍🏼" type="tts">person standing: medium-light skin tone</annotation>
+		<annotation cp="🧍🏽">medium skin tone | person | stand | standing</annotation>
+		<annotation cp="🧍🏽" type="tts">person standing: medium skin tone</annotation>
+		<annotation cp="🧍🏾">medium-dark skin tone | person | stand | standing</annotation>
+		<annotation cp="🧍🏾" type="tts">person standing: medium-dark skin tone</annotation>
+		<annotation cp="🧍🏿">dark skin tone | person | stand | standing</annotation>
+		<annotation cp="🧍🏿" type="tts">person standing: dark skin tone</annotation>
+		<annotation cp="🧍🏻‍♂">light skin tone | man | stand | standing</annotation>
+		<annotation cp="🧍🏻‍♂" type="tts">man standing: light skin tone</annotation>
+		<annotation cp="🧍🏼‍♂">man | medium-light skin tone | stand | standing</annotation>
+		<annotation cp="🧍🏼‍♂" type="tts">man standing: medium-light skin tone</annotation>
+		<annotation cp="🧍🏽‍♂">man | medium skin tone | stand | standing</annotation>
+		<annotation cp="🧍🏽‍♂" type="tts">man standing: medium skin tone</annotation>
+		<annotation cp="🧍🏾‍♂">man | medium-dark skin tone | stand | standing</annotation>
+		<annotation cp="🧍🏾‍♂" type="tts">man standing: medium-dark skin tone</annotation>
+		<annotation cp="🧍🏿‍♂">dark skin tone | man | stand | standing</annotation>
+		<annotation cp="🧍🏿‍♂" type="tts">man standing: dark skin tone</annotation>
+		<annotation cp="🧍🏻‍♀">light skin tone | stand | standing | woman</annotation>
+		<annotation cp="🧍🏻‍♀" type="tts">woman standing: light skin tone</annotation>
+		<annotation cp="🧍🏼‍♀">medium-light skin tone | stand | standing | woman</annotation>
+		<annotation cp="🧍🏼‍♀" type="tts">woman standing: medium-light skin tone</annotation>
+		<annotation cp="🧍🏽‍♀">medium skin tone | stand | standing | woman</annotation>
+		<annotation cp="🧍🏽‍♀" type="tts">woman standing: medium skin tone</annotation>
+		<annotation cp="🧍🏾‍♀">medium-dark skin tone | stand | standing | woman</annotation>
+		<annotation cp="🧍🏾‍♀" type="tts">woman standing: medium-dark skin tone</annotation>
+		<annotation cp="🧍🏿‍♀">dark skin tone | stand | standing | woman</annotation>
+		<annotation cp="🧍🏿‍♀" type="tts">woman standing: dark skin tone</annotation>
+		<annotation cp="🧎🏻">kneel | kneeling | knees | light skin tone | person</annotation>
+		<annotation cp="🧎🏻" type="tts">person kneeling: light skin tone</annotation>
+		<annotation cp="🧎🏼">kneel | kneeling | knees | medium-light skin tone | person</annotation>
+		<annotation cp="🧎🏼" type="tts">person kneeling: medium-light skin tone</annotation>
+		<annotation cp="🧎🏽">kneel | kneeling | knees | medium skin tone | person</annotation>
+		<annotation cp="🧎🏽" type="tts">person kneeling: medium skin tone</annotation>
+		<annotation cp="🧎🏾">kneel | kneeling | knees | medium-dark skin tone | person</annotation>
+		<annotation cp="🧎🏾" type="tts">person kneeling: medium-dark skin tone</annotation>
+		<annotation cp="🧎🏿">dark skin tone | kneel | kneeling | knees | person</annotation>
+		<annotation cp="🧎🏿" type="tts">person kneeling: dark skin tone</annotation>
+		<annotation cp="🧎🏻‍♂">kneel | kneeling | knees | light skin tone | man</annotation>
+		<annotation cp="🧎🏻‍♂" type="tts">man kneeling: light skin tone</annotation>
+		<annotation cp="🧎🏼‍♂">kneel | kneeling | knees | man | medium-light skin tone</annotation>
+		<annotation cp="🧎🏼‍♂" type="tts">man kneeling: medium-light skin tone</annotation>
+		<annotation cp="🧎🏽‍♂">kneel | kneeling | knees | man | medium skin tone</annotation>
+		<annotation cp="🧎🏽‍♂" type="tts">man kneeling: medium skin tone</annotation>
+		<annotation cp="🧎🏾‍♂">kneel | kneeling | knees | man | medium-dark skin tone</annotation>
+		<annotation cp="🧎🏾‍♂" type="tts">man kneeling: medium-dark skin tone</annotation>
+		<annotation cp="🧎🏿‍♂">dark skin tone | kneel | kneeling | knees | man</annotation>
+		<annotation cp="🧎🏿‍♂" type="tts">man kneeling: dark skin tone</annotation>
+		<annotation cp="🧎🏻‍♀">kneel | kneeling | knees | light skin tone | woman</annotation>
+		<annotation cp="🧎🏻‍♀" type="tts">woman kneeling: light skin tone</annotation>
+		<annotation cp="🧎🏼‍♀">kneel | kneeling | knees | medium-light skin tone | woman</annotation>
+		<annotation cp="🧎🏼‍♀" type="tts">woman kneeling: medium-light skin tone</annotation>
+		<annotation cp="🧎🏽‍♀">kneel | kneeling | knees | medium skin tone | woman</annotation>
+		<annotation cp="🧎🏽‍♀" type="tts">woman kneeling: medium skin tone</annotation>
+		<annotation cp="🧎🏾‍♀">kneel | kneeling | knees | medium-dark skin tone | woman</annotation>
+		<annotation cp="🧎🏾‍♀" type="tts">woman kneeling: medium-dark skin tone</annotation>
+		<annotation cp="🧎🏿‍♀">dark skin tone | kneel | kneeling | knees | woman</annotation>
+		<annotation cp="🧎🏿‍♀" type="tts">woman kneeling: dark skin tone</annotation>
+		<annotation cp="🧎‍➡">facing | kneel | kneeling | knees | person | right</annotation>
+		<annotation cp="🧎‍➡" type="tts">person kneeling: facing right</annotation>
+		<annotation cp="🧎🏻‍➡">facing | kneel | kneeling | knees | light skin tone | person | right</annotation>
+		<annotation cp="🧎🏻‍➡" type="tts">person kneeling: light skin tone, facing right</annotation>
+		<annotation cp="🧎🏼‍➡">facing | kneel | kneeling | knees | medium-light skin tone | person | right</annotation>
+		<annotation cp="🧎🏼‍➡" type="tts">person kneeling: medium-light skin tone, facing right</annotation>
+		<annotation cp="🧎🏽‍➡">facing | kneel | kneeling | knees | medium skin tone | person | right</annotation>
+		<annotation cp="🧎🏽‍➡" type="tts">person kneeling: medium skin tone, facing right</annotation>
+		<annotation cp="🧎🏾‍➡">facing | kneel | kneeling | knees | medium-dark skin tone | person | right</annotation>
+		<annotation cp="🧎🏾‍➡" type="tts">person kneeling: medium-dark skin tone, facing right</annotation>
+		<annotation cp="🧎🏿‍➡">dark skin tone | facing | kneel | kneeling | knees | person | right</annotation>
+		<annotation cp="🧎🏿‍➡" type="tts">person kneeling: dark skin tone, facing right</annotation>
+		<annotation cp="🧎‍♀‍➡">facing | kneel | kneeling | knees | right | woman</annotation>
+		<annotation cp="🧎‍♀‍➡" type="tts">woman kneeling: facing right</annotation>
+		<annotation cp="🧎🏻‍♀‍➡">facing | kneel | kneeling | knees | light skin tone | right | woman</annotation>
+		<annotation cp="🧎🏻‍♀‍➡" type="tts">woman kneeling: light skin tone, facing right</annotation>
+		<annotation cp="🧎🏼‍♀‍➡">facing | kneel | kneeling | knees | medium-light skin tone | right | woman</annotation>
+		<annotation cp="🧎🏼‍♀‍➡" type="tts">woman kneeling: medium-light skin tone, facing right</annotation>
+		<annotation cp="🧎🏽‍♀‍➡">facing | kneel | kneeling | knees | medium skin tone | right | woman</annotation>
+		<annotation cp="🧎🏽‍♀‍➡" type="tts">woman kneeling: medium skin tone, facing right</annotation>
+		<annotation cp="🧎🏾‍♀‍➡">facing | kneel | kneeling | knees | medium-dark skin tone | right | woman</annotation>
+		<annotation cp="🧎🏾‍♀‍➡" type="tts">woman kneeling: medium-dark skin tone, facing right</annotation>
+		<annotation cp="🧎🏿‍♀‍➡">dark skin tone | facing | kneel | kneeling | knees | right | woman</annotation>
+		<annotation cp="🧎🏿‍♀‍➡" type="tts">woman kneeling: dark skin tone, facing right</annotation>
+		<annotation cp="🧎‍♂‍➡">facing | kneel | kneeling | knees | man | right</annotation>
+		<annotation cp="🧎‍♂‍➡" type="tts">man kneeling: facing right</annotation>
+		<annotation cp="🧎🏻‍♂‍➡">facing | kneel | kneeling | knees | light skin tone | man | right</annotation>
+		<annotation cp="🧎🏻‍♂‍➡" type="tts">man kneeling: light skin tone, facing right</annotation>
+		<annotation cp="🧎🏼‍♂‍➡">facing | kneel | kneeling | knees | man | medium-light skin tone | right</annotation>
+		<annotation cp="🧎🏼‍♂‍➡" type="tts">man kneeling: medium-light skin tone, facing right</annotation>
+		<annotation cp="🧎🏽‍♂‍➡">facing | kneel | kneeling | knees | man | medium skin tone | right</annotation>
+		<annotation cp="🧎🏽‍♂‍➡" type="tts">man kneeling: medium skin tone, facing right</annotation>
+		<annotation cp="🧎🏾‍♂‍➡">facing | kneel | kneeling | knees | man | medium-dark skin tone | right</annotation>
+		<annotation cp="🧎🏾‍♂‍➡" type="tts">man kneeling: medium-dark skin tone, facing right</annotation>
+		<annotation cp="🧎🏿‍♂‍➡">dark skin tone | facing | kneel | kneeling | knees | man | right</annotation>
+		<annotation cp="🧎🏿‍♂‍➡" type="tts">man kneeling: dark skin tone, facing right</annotation>
+		<annotation cp="🧑🏻‍🦯">accessibility | blind | cane | light skin tone | person | probing | white</annotation>
+		<annotation cp="🧑🏻‍🦯" type="tts">person with white cane: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🦯">accessibility | blind | cane | medium-light skin tone | person | probing | white</annotation>
+		<annotation cp="🧑🏼‍🦯" type="tts">person with white cane: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🦯">accessibility | blind | cane | medium skin tone | person | probing | white</annotation>
+		<annotation cp="🧑🏽‍🦯" type="tts">person with white cane: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🦯">accessibility | blind | cane | medium-dark skin tone | person | probing | white</annotation>
+		<annotation cp="🧑🏾‍🦯" type="tts">person with white cane: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🦯">accessibility | blind | cane | dark skin tone | person | probing | white</annotation>
+		<annotation cp="🧑🏿‍🦯" type="tts">person with white cane: dark skin tone</annotation>
+		<annotation cp="🧑‍🦯‍➡">accessibility | blind | cane | facing | person | probing | right | white</annotation>
+		<annotation cp="🧑‍🦯‍➡" type="tts">person with white cane: facing right</annotation>
+		<annotation cp="🧑🏻‍🦯‍➡">accessibility | blind | cane | facing | light skin tone | person | probing | right | white</annotation>
+		<annotation cp="🧑🏻‍🦯‍➡" type="tts">person with white cane: light skin tone, facing right</annotation>
+		<annotation cp="🧑🏼‍🦯‍➡">accessibility | blind | cane | facing | medium-light skin tone | person | probing | right | white</annotation>
+		<annotation cp="🧑🏼‍🦯‍➡" type="tts">person with white cane: medium-light skin tone, facing right</annotation>
+		<annotation cp="🧑🏽‍🦯‍➡">accessibility | blind | cane | facing | medium skin tone | person | probing | right | white</annotation>
+		<annotation cp="🧑🏽‍🦯‍➡" type="tts">person with white cane: medium skin tone, facing right</annotation>
+		<annotation cp="🧑🏾‍🦯‍➡">accessibility | blind | cane | facing | medium-dark skin tone | person | probing | right | white</annotation>
+		<annotation cp="🧑🏾‍🦯‍➡" type="tts">person with white cane: medium-dark skin tone, facing right</annotation>
+		<annotation cp="🧑🏿‍🦯‍➡">accessibility | blind | cane | dark skin tone | facing | person | probing | right | white</annotation>
+		<annotation cp="🧑🏿‍🦯‍➡" type="tts">person with white cane: dark skin tone, facing right</annotation>
+		<annotation cp="👨🏻‍🦯">accessibility | blind | cane | light skin tone | man | probing | white</annotation>
+		<annotation cp="👨🏻‍🦯" type="tts">man with white cane: light skin tone</annotation>
+		<annotation cp="👨🏼‍🦯">accessibility | blind | cane | man | medium-light skin tone | probing | white</annotation>
+		<annotation cp="👨🏼‍🦯" type="tts">man with white cane: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍🦯">accessibility | blind | cane | man | medium skin tone | probing | white</annotation>
+		<annotation cp="👨🏽‍🦯" type="tts">man with white cane: medium skin tone</annotation>
+		<annotation cp="👨🏾‍🦯">accessibility | blind | cane | man | medium-dark skin tone | probing | white</annotation>
+		<annotation cp="👨🏾‍🦯" type="tts">man with white cane: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍🦯">accessibility | blind | cane | dark skin tone | man | probing | white</annotation>
+		<annotation cp="👨🏿‍🦯" type="tts">man with white cane: dark skin tone</annotation>
+		<annotation cp="👨‍🦯‍➡">accessibility | blind | cane | facing | man | probing | right | white</annotation>
+		<annotation cp="👨‍🦯‍➡" type="tts">man with white cane: facing right</annotation>
+		<annotation cp="👨🏻‍🦯‍➡">accessibility | blind | cane | facing | light skin tone | man | probing | right | white</annotation>
+		<annotation cp="👨🏻‍🦯‍➡" type="tts">man with white cane: light skin tone, facing right</annotation>
+		<annotation cp="👨🏼‍🦯‍➡">accessibility | blind | cane | facing | man | medium-light skin tone | probing | right | white</annotation>
+		<annotation cp="👨🏼‍🦯‍➡" type="tts">man with white cane: medium-light skin tone, facing right</annotation>
+		<annotation cp="👨🏽‍🦯‍➡">accessibility | blind | cane | facing | man | medium skin tone | probing | right | white</annotation>
+		<annotation cp="👨🏽‍🦯‍➡" type="tts">man with white cane: medium skin tone, facing right</annotation>
+		<annotation cp="👨🏾‍🦯‍➡">accessibility | blind | cane | facing | man | medium-dark skin tone | probing | right | white</annotation>
+		<annotation cp="👨🏾‍🦯‍➡" type="tts">man with white cane: medium-dark skin tone, facing right</annotation>
+		<annotation cp="👨🏿‍🦯‍➡">accessibility | blind | cane | dark skin tone | facing | man | probing | right | white</annotation>
+		<annotation cp="👨🏿‍🦯‍➡" type="tts">man with white cane: dark skin tone, facing right</annotation>
+		<annotation cp="👩🏻‍🦯">accessibility | blind | cane | light skin tone | probing | white | woman</annotation>
+		<annotation cp="👩🏻‍🦯" type="tts">woman with white cane: light skin tone</annotation>
+		<annotation cp="👩🏼‍🦯">accessibility | blind | cane | medium-light skin tone | probing | white | woman</annotation>
+		<annotation cp="👩🏼‍🦯" type="tts">woman with white cane: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍🦯">accessibility | blind | cane | medium skin tone | probing | white | woman</annotation>
+		<annotation cp="👩🏽‍🦯" type="tts">woman with white cane: medium skin tone</annotation>
+		<annotation cp="👩🏾‍🦯">accessibility | blind | cane | medium-dark skin tone | probing | white | woman</annotation>
+		<annotation cp="👩🏾‍🦯" type="tts">woman with white cane: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍🦯">accessibility | blind | cane | dark skin tone | probing | white | woman</annotation>
+		<annotation cp="👩🏿‍🦯" type="tts">woman with white cane: dark skin tone</annotation>
+		<annotation cp="👩‍🦯‍➡">accessibility | blind | cane | facing | probing | right | white | woman</annotation>
+		<annotation cp="👩‍🦯‍➡" type="tts">woman with white cane: facing right</annotation>
+		<annotation cp="👩🏻‍🦯‍➡">accessibility | blind | cane | facing | light skin tone | probing | right | white | woman</annotation>
+		<annotation cp="👩🏻‍🦯‍➡" type="tts">woman with white cane: light skin tone, facing right</annotation>
+		<annotation cp="👩🏼‍🦯‍➡">accessibility | blind | cane | facing | medium-light skin tone | probing | right | white | woman</annotation>
+		<annotation cp="👩🏼‍🦯‍➡" type="tts">woman with white cane: medium-light skin tone, facing right</annotation>
+		<annotation cp="👩🏽‍🦯‍➡">accessibility | blind | cane | facing | medium skin tone | probing | right | white | woman</annotation>
+		<annotation cp="👩🏽‍🦯‍➡" type="tts">woman with white cane: medium skin tone, facing right</annotation>
+		<annotation cp="👩🏾‍🦯‍➡">accessibility | blind | cane | facing | medium-dark skin tone | probing | right | white | woman</annotation>
+		<annotation cp="👩🏾‍🦯‍➡" type="tts">woman with white cane: medium-dark skin tone, facing right</annotation>
+		<annotation cp="👩🏿‍🦯‍➡">accessibility | blind | cane | dark skin tone | facing | probing | right | white | woman</annotation>
+		<annotation cp="👩🏿‍🦯‍➡" type="tts">woman with white cane: dark skin tone, facing right</annotation>
+		<annotation cp="🧑🏻‍🦼">accessibility | light skin tone | motorized | person | wheelchair</annotation>
+		<annotation cp="🧑🏻‍🦼" type="tts">person in motorized wheelchair: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🦼">accessibility | medium-light skin tone | motorized | person | wheelchair</annotation>
+		<annotation cp="🧑🏼‍🦼" type="tts">person in motorized wheelchair: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🦼">accessibility | medium skin tone | motorized | person | wheelchair</annotation>
+		<annotation cp="🧑🏽‍🦼" type="tts">person in motorized wheelchair: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🦼">accessibility | medium-dark skin tone | motorized | person | wheelchair</annotation>
+		<annotation cp="🧑🏾‍🦼" type="tts">person in motorized wheelchair: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🦼">accessibility | dark skin tone | motorized | person | wheelchair</annotation>
+		<annotation cp="🧑🏿‍🦼" type="tts">person in motorized wheelchair: dark skin tone</annotation>
+		<annotation cp="🧑‍🦼‍➡">accessibility | facing | motorized | person | right | wheelchair</annotation>
+		<annotation cp="🧑‍🦼‍➡" type="tts">person in motorized wheelchair: facing right</annotation>
+		<annotation cp="🧑🏻‍🦼‍➡">accessibility | facing | light skin tone | motorized | person | right | wheelchair</annotation>
+		<annotation cp="🧑🏻‍🦼‍➡" type="tts">person in motorized wheelchair: light skin tone, facing right</annotation>
+		<annotation cp="🧑🏼‍🦼‍➡">accessibility | facing | medium-light skin tone | motorized | person | right | wheelchair</annotation>
+		<annotation cp="🧑🏼‍🦼‍➡" type="tts">person in motorized wheelchair: medium-light skin tone, facing right</annotation>
+		<annotation cp="🧑🏽‍🦼‍➡">accessibility | facing | medium skin tone | motorized | person | right | wheelchair</annotation>
+		<annotation cp="🧑🏽‍🦼‍➡" type="tts">person in motorized wheelchair: medium skin tone, facing right</annotation>
+		<annotation cp="🧑🏾‍🦼‍➡">accessibility | facing | medium-dark skin tone | motorized | person | right | wheelchair</annotation>
+		<annotation cp="🧑🏾‍🦼‍➡" type="tts">person in motorized wheelchair: medium-dark skin tone, facing right</annotation>
+		<annotation cp="🧑🏿‍🦼‍➡">accessibility | dark skin tone | facing | motorized | person | right | wheelchair</annotation>
+		<annotation cp="🧑🏿‍🦼‍➡" type="tts">person in motorized wheelchair: dark skin tone, facing right</annotation>
+		<annotation cp="👨🏻‍🦼">accessibility | light skin tone | man | motorized | wheelchair</annotation>
+		<annotation cp="👨🏻‍🦼" type="tts">man in motorized wheelchair: light skin tone</annotation>
+		<annotation cp="👨🏼‍🦼">accessibility | man | medium-light skin tone | motorized | wheelchair</annotation>
+		<annotation cp="👨🏼‍🦼" type="tts">man in motorized wheelchair: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍🦼">accessibility | man | medium skin tone | motorized | wheelchair</annotation>
+		<annotation cp="👨🏽‍🦼" type="tts">man in motorized wheelchair: medium skin tone</annotation>
+		<annotation cp="👨🏾‍🦼">accessibility | man | medium-dark skin tone | motorized | wheelchair</annotation>
+		<annotation cp="👨🏾‍🦼" type="tts">man in motorized wheelchair: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍🦼">accessibility | dark skin tone | man | motorized | wheelchair</annotation>
+		<annotation cp="👨🏿‍🦼" type="tts">man in motorized wheelchair: dark skin tone</annotation>
+		<annotation cp="👨‍🦼‍➡">accessibility | facing | man | motorized | right | wheelchair</annotation>
+		<annotation cp="👨‍🦼‍➡" type="tts">man in motorized wheelchair: facing right</annotation>
+		<annotation cp="👨🏻‍🦼‍➡">accessibility | facing | light skin tone | man | motorized | right | wheelchair</annotation>
+		<annotation cp="👨🏻‍🦼‍➡" type="tts">man in motorized wheelchair: light skin tone, facing right</annotation>
+		<annotation cp="👨🏼‍🦼‍➡">accessibility | facing | man | medium-light skin tone | motorized | right | wheelchair</annotation>
+		<annotation cp="👨🏼‍🦼‍➡" type="tts">man in motorized wheelchair: medium-light skin tone, facing right</annotation>
+		<annotation cp="👨🏽‍🦼‍➡">accessibility | facing | man | medium skin tone | motorized | right | wheelchair</annotation>
+		<annotation cp="👨🏽‍🦼‍➡" type="tts">man in motorized wheelchair: medium skin tone, facing right</annotation>
+		<annotation cp="👨🏾‍🦼‍➡">accessibility | facing | man | medium-dark skin tone | motorized | right | wheelchair</annotation>
+		<annotation cp="👨🏾‍🦼‍➡" type="tts">man in motorized wheelchair: medium-dark skin tone, facing right</annotation>
+		<annotation cp="👨🏿‍🦼‍➡">accessibility | dark skin tone | facing | man | motorized | right | wheelchair</annotation>
+		<annotation cp="👨🏿‍🦼‍➡" type="tts">man in motorized wheelchair: dark skin tone, facing right</annotation>
+		<annotation cp="👩🏻‍🦼">accessibility | light skin tone | motorized | wheelchair | woman</annotation>
+		<annotation cp="👩🏻‍🦼" type="tts">woman in motorized wheelchair: light skin tone</annotation>
+		<annotation cp="👩🏼‍🦼">accessibility | medium-light skin tone | motorized | wheelchair | woman</annotation>
+		<annotation cp="👩🏼‍🦼" type="tts">woman in motorized wheelchair: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍🦼">accessibility | medium skin tone | motorized | wheelchair | woman</annotation>
+		<annotation cp="👩🏽‍🦼" type="tts">woman in motorized wheelchair: medium skin tone</annotation>
+		<annotation cp="👩🏾‍🦼">accessibility | medium-dark skin tone | motorized | wheelchair | woman</annotation>
+		<annotation cp="👩🏾‍🦼" type="tts">woman in motorized wheelchair: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍🦼">accessibility | dark skin tone | motorized | wheelchair | woman</annotation>
+		<annotation cp="👩🏿‍🦼" type="tts">woman in motorized wheelchair: dark skin tone</annotation>
+		<annotation cp="👩‍🦼‍➡">accessibility | facing | motorized | right | wheelchair | woman</annotation>
+		<annotation cp="👩‍🦼‍➡" type="tts">woman in motorized wheelchair: facing right</annotation>
+		<annotation cp="👩🏻‍🦼‍➡">accessibility | facing | light skin tone | motorized | right | wheelchair | woman</annotation>
+		<annotation cp="👩🏻‍🦼‍➡" type="tts">woman in motorized wheelchair: light skin tone, facing right</annotation>
+		<annotation cp="👩🏼‍🦼‍➡">accessibility | facing | medium-light skin tone | motorized | right | wheelchair | woman</annotation>
+		<annotation cp="👩🏼‍🦼‍➡" type="tts">woman in motorized wheelchair: medium-light skin tone, facing right</annotation>
+		<annotation cp="👩🏽‍🦼‍➡">accessibility | facing | medium skin tone | motorized | right | wheelchair | woman</annotation>
+		<annotation cp="👩🏽‍🦼‍➡" type="tts">woman in motorized wheelchair: medium skin tone, facing right</annotation>
+		<annotation cp="👩🏾‍🦼‍➡">accessibility | facing | medium-dark skin tone | motorized | right | wheelchair | woman</annotation>
+		<annotation cp="👩🏾‍🦼‍➡" type="tts">woman in motorized wheelchair: medium-dark skin tone, facing right</annotation>
+		<annotation cp="👩🏿‍🦼‍➡">accessibility | dark skin tone | facing | motorized | right | wheelchair | woman</annotation>
+		<annotation cp="👩🏿‍🦼‍➡" type="tts">woman in motorized wheelchair: dark skin tone, facing right</annotation>
+		<annotation cp="🧑🏻‍🦽">accessibility | light skin tone | manual | person | wheelchair</annotation>
+		<annotation cp="🧑🏻‍🦽" type="tts">person in manual wheelchair: light skin tone</annotation>
+		<annotation cp="🧑🏼‍🦽">accessibility | manual | medium-light skin tone | person | wheelchair</annotation>
+		<annotation cp="🧑🏼‍🦽" type="tts">person in manual wheelchair: medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🦽">accessibility | manual | medium skin tone | person | wheelchair</annotation>
+		<annotation cp="🧑🏽‍🦽" type="tts">person in manual wheelchair: medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🦽">accessibility | manual | medium-dark skin tone | person | wheelchair</annotation>
+		<annotation cp="🧑🏾‍🦽" type="tts">person in manual wheelchair: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🦽">accessibility | dark skin tone | manual | person | wheelchair</annotation>
+		<annotation cp="🧑🏿‍🦽" type="tts">person in manual wheelchair: dark skin tone</annotation>
+		<annotation cp="🧑‍🦽‍➡">accessibility | facing | manual | person | right | wheelchair</annotation>
+		<annotation cp="🧑‍🦽‍➡" type="tts">person in manual wheelchair: facing right</annotation>
+		<annotation cp="🧑🏻‍🦽‍➡">accessibility | facing | light skin tone | manual | person | right | wheelchair</annotation>
+		<annotation cp="🧑🏻‍🦽‍➡" type="tts">person in manual wheelchair: light skin tone, facing right</annotation>
+		<annotation cp="🧑🏼‍🦽‍➡">accessibility | facing | manual | medium-light skin tone | person | right | wheelchair</annotation>
+		<annotation cp="🧑🏼‍🦽‍➡" type="tts">person in manual wheelchair: medium-light skin tone, facing right</annotation>
+		<annotation cp="🧑🏽‍🦽‍➡">accessibility | facing | manual | medium skin tone | person | right | wheelchair</annotation>
+		<annotation cp="🧑🏽‍🦽‍➡" type="tts">person in manual wheelchair: medium skin tone, facing right</annotation>
+		<annotation cp="🧑🏾‍🦽‍➡">accessibility | facing | manual | medium-dark skin tone | person | right | wheelchair</annotation>
+		<annotation cp="🧑🏾‍🦽‍➡" type="tts">person in manual wheelchair: medium-dark skin tone, facing right</annotation>
+		<annotation cp="🧑🏿‍🦽‍➡">accessibility | dark skin tone | facing | manual | person | right | wheelchair</annotation>
+		<annotation cp="🧑🏿‍🦽‍➡" type="tts">person in manual wheelchair: dark skin tone, facing right</annotation>
+		<annotation cp="👨🏻‍🦽">accessibility | light skin tone | man | manual | wheelchair</annotation>
+		<annotation cp="👨🏻‍🦽" type="tts">man in manual wheelchair: light skin tone</annotation>
+		<annotation cp="👨🏼‍🦽">accessibility | man | manual | medium-light skin tone | wheelchair</annotation>
+		<annotation cp="👨🏼‍🦽" type="tts">man in manual wheelchair: medium-light skin tone</annotation>
+		<annotation cp="👨🏽‍🦽">accessibility | man | manual | medium skin tone | wheelchair</annotation>
+		<annotation cp="👨🏽‍🦽" type="tts">man in manual wheelchair: medium skin tone</annotation>
+		<annotation cp="👨🏾‍🦽">accessibility | man | manual | medium-dark skin tone | wheelchair</annotation>
+		<annotation cp="👨🏾‍🦽" type="tts">man in manual wheelchair: medium-dark skin tone</annotation>
+		<annotation cp="👨🏿‍🦽">accessibility | dark skin tone | man | manual | wheelchair</annotation>
+		<annotation cp="👨🏿‍🦽" type="tts">man in manual wheelchair: dark skin tone</annotation>
+		<annotation cp="👨‍🦽‍➡">accessibility | facing | man | manual | right | wheelchair</annotation>
+		<annotation cp="👨‍🦽‍➡" type="tts">man in manual wheelchair: facing right</annotation>
+		<annotation cp="👨🏻‍🦽‍➡">accessibility | facing | light skin tone | man | manual | right | wheelchair</annotation>
+		<annotation cp="👨🏻‍🦽‍➡" type="tts">man in manual wheelchair: light skin tone, facing right</annotation>
+		<annotation cp="👨🏼‍🦽‍➡">accessibility | facing | man | manual | medium-light skin tone | right | wheelchair</annotation>
+		<annotation cp="👨🏼‍🦽‍➡" type="tts">man in manual wheelchair: medium-light skin tone, facing right</annotation>
+		<annotation cp="👨🏽‍🦽‍➡">accessibility | facing | man | manual | medium skin tone | right | wheelchair</annotation>
+		<annotation cp="👨🏽‍🦽‍➡" type="tts">man in manual wheelchair: medium skin tone, facing right</annotation>
+		<annotation cp="👨🏾‍🦽‍➡">accessibility | facing | man | manual | medium-dark skin tone | right | wheelchair</annotation>
+		<annotation cp="👨🏾‍🦽‍➡" type="tts">man in manual wheelchair: medium-dark skin tone, facing right</annotation>
+		<annotation cp="👨🏿‍🦽‍➡">accessibility | dark skin tone | facing | man | manual | right | wheelchair</annotation>
+		<annotation cp="👨🏿‍🦽‍➡" type="tts">man in manual wheelchair: dark skin tone, facing right</annotation>
+		<annotation cp="👩🏻‍🦽">accessibility | light skin tone | manual | wheelchair | woman</annotation>
+		<annotation cp="👩🏻‍🦽" type="tts">woman in manual wheelchair: light skin tone</annotation>
+		<annotation cp="👩🏼‍🦽">accessibility | manual | medium-light skin tone | wheelchair | woman</annotation>
+		<annotation cp="👩🏼‍🦽" type="tts">woman in manual wheelchair: medium-light skin tone</annotation>
+		<annotation cp="👩🏽‍🦽">accessibility | manual | medium skin tone | wheelchair | woman</annotation>
+		<annotation cp="👩🏽‍🦽" type="tts">woman in manual wheelchair: medium skin tone</annotation>
+		<annotation cp="👩🏾‍🦽">accessibility | manual | medium-dark skin tone | wheelchair | woman</annotation>
+		<annotation cp="👩🏾‍🦽" type="tts">woman in manual wheelchair: medium-dark skin tone</annotation>
+		<annotation cp="👩🏿‍🦽">accessibility | dark skin tone | manual | wheelchair | woman</annotation>
+		<annotation cp="👩🏿‍🦽" type="tts">woman in manual wheelchair: dark skin tone</annotation>
+		<annotation cp="👩‍🦽‍➡">accessibility | facing | manual | right | wheelchair | woman</annotation>
+		<annotation cp="👩‍🦽‍➡" type="tts">woman in manual wheelchair: facing right</annotation>
+		<annotation cp="👩🏻‍🦽‍➡">accessibility | facing | light skin tone | manual | right | wheelchair | woman</annotation>
+		<annotation cp="👩🏻‍🦽‍➡" type="tts">woman in manual wheelchair: light skin tone, facing right</annotation>
+		<annotation cp="👩🏼‍🦽‍➡">accessibility | facing | manual | medium-light skin tone | right | wheelchair | woman</annotation>
+		<annotation cp="👩🏼‍🦽‍➡" type="tts">woman in manual wheelchair: medium-light skin tone, facing right</annotation>
+		<annotation cp="👩🏽‍🦽‍➡">accessibility | facing | manual | medium skin tone | right | wheelchair | woman</annotation>
+		<annotation cp="👩🏽‍🦽‍➡" type="tts">woman in manual wheelchair: medium skin tone, facing right</annotation>
+		<annotation cp="👩🏾‍🦽‍➡">accessibility | facing | manual | medium-dark skin tone | right | wheelchair | woman</annotation>
+		<annotation cp="👩🏾‍🦽‍➡" type="tts">woman in manual wheelchair: medium-dark skin tone, facing right</annotation>
+		<annotation cp="👩🏿‍🦽‍➡">accessibility | dark skin tone | facing | manual | right | wheelchair | woman</annotation>
+		<annotation cp="👩🏿‍🦽‍➡" type="tts">woman in manual wheelchair: dark skin tone, facing right</annotation>
+		<annotation cp="🏃🏻">fast | hurry | light skin tone | marathon | move | person | quick | race | racing | run | rush | speed</annotation>
+		<annotation cp="🏃🏻" type="tts">person running: light skin tone</annotation>
+		<annotation cp="🏃🏼">fast | hurry | marathon | medium-light skin tone | move | person | quick | race | racing | run | rush | speed</annotation>
+		<annotation cp="🏃🏼" type="tts">person running: medium-light skin tone</annotation>
+		<annotation cp="🏃🏽">fast | hurry | marathon | medium skin tone | move | person | quick | race | racing | run | rush | speed</annotation>
+		<annotation cp="🏃🏽" type="tts">person running: medium skin tone</annotation>
+		<annotation cp="🏃🏾">fast | hurry | marathon | medium-dark skin tone | move | person | quick | race | racing | run | rush | speed</annotation>
+		<annotation cp="🏃🏾" type="tts">person running: medium-dark skin tone</annotation>
+		<annotation cp="🏃🏿">dark skin tone | fast | hurry | marathon | move | person | quick | race | racing | run | rush | speed</annotation>
+		<annotation cp="🏃🏿" type="tts">person running: dark skin tone</annotation>
+		<annotation cp="🏃🏻‍♂">fast | hurry | light skin tone | man | marathon | move | quick | race | racing | run | rush | speed</annotation>
+		<annotation cp="🏃🏻‍♂" type="tts">man running: light skin tone</annotation>
+		<annotation cp="🏃🏼‍♂">fast | hurry | man | marathon | medium-light skin tone | move | quick | race | racing | run | rush | speed</annotation>
+		<annotation cp="🏃🏼‍♂" type="tts">man running: medium-light skin tone</annotation>
+		<annotation cp="🏃🏽‍♂">fast | hurry | man | marathon | medium skin tone | move | quick | race | racing | run | rush | speed</annotation>
+		<annotation cp="🏃🏽‍♂" type="tts">man running: medium skin tone</annotation>
+		<annotation cp="🏃🏾‍♂">fast | hurry | man | marathon | medium-dark skin tone | move | quick | race | racing | run | rush | speed</annotation>
+		<annotation cp="🏃🏾‍♂" type="tts">man running: medium-dark skin tone</annotation>
+		<annotation cp="🏃🏿‍♂">dark skin tone | fast | hurry | man | marathon | move | quick | race | racing | run | rush | speed</annotation>
+		<annotation cp="🏃🏿‍♂" type="tts">man running: dark skin tone</annotation>
+		<annotation cp="🏃🏻‍♀">fast | hurry | light skin tone | marathon | move | quick | race | racing | run | rush | speed | woman</annotation>
+		<annotation cp="🏃🏻‍♀" type="tts">woman running: light skin tone</annotation>
+		<annotation cp="🏃🏼‍♀">fast | hurry | marathon | medium-light skin tone | move | quick | race | racing | run | rush | speed | woman</annotation>
+		<annotation cp="🏃🏼‍♀" type="tts">woman running: medium-light skin tone</annotation>
+		<annotation cp="🏃🏽‍♀">fast | hurry | marathon | medium skin tone | move | quick | race | racing | run | rush | speed | woman</annotation>
+		<annotation cp="🏃🏽‍♀" type="tts">woman running: medium skin tone</annotation>
+		<annotation cp="🏃🏾‍♀">fast | hurry | marathon | medium-dark skin tone | move | quick | race | racing | run | rush | speed | woman</annotation>
+		<annotation cp="🏃🏾‍♀" type="tts">woman running: medium-dark skin tone</annotation>
+		<annotation cp="🏃🏿‍♀">dark skin tone | fast | hurry | marathon | move | quick | race | racing | run | rush | speed | woman</annotation>
+		<annotation cp="🏃🏿‍♀" type="tts">woman running: dark skin tone</annotation>
+		<annotation cp="🏃‍➡">facing | fast | hurry | marathon | move | person | quick | race | racing | right | run | rush | speed</annotation>
+		<annotation cp="🏃‍➡" type="tts">person running: facing right</annotation>
+		<annotation cp="🏃🏻‍➡">facing | fast | hurry | light skin tone | marathon | move | person | quick | race | racing | right | run | rush | speed</annotation>
+		<annotation cp="🏃🏻‍➡" type="tts">person running: light skin tone, facing right</annotation>
+		<annotation cp="🏃🏼‍➡">facing | fast | hurry | marathon | medium-light skin tone | move | person | quick | race | racing | right | run | rush | speed</annotation>
+		<annotation cp="🏃🏼‍➡" type="tts">person running: medium-light skin tone, facing right</annotation>
+		<annotation cp="🏃🏽‍➡">facing | fast | hurry | marathon | medium skin tone | move | person | quick | race | racing | right | run | rush | speed</annotation>
+		<annotation cp="🏃🏽‍➡" type="tts">person running: medium skin tone, facing right</annotation>
+		<annotation cp="🏃🏾‍➡">facing | fast | hurry | marathon | medium-dark skin tone | move | person | quick | race | racing | right | run | rush | speed</annotation>
+		<annotation cp="🏃🏾‍➡" type="tts">person running: medium-dark skin tone, facing right</annotation>
+		<annotation cp="🏃🏿‍➡">dark skin tone | facing | fast | hurry | marathon | move | person | quick | race | racing | right | run | rush | speed</annotation>
+		<annotation cp="🏃🏿‍➡" type="tts">person running: dark skin tone, facing right</annotation>
+		<annotation cp="🏃‍♀‍➡">facing | fast | hurry | marathon | move | quick | race | racing | right | run | rush | speed | woman</annotation>
+		<annotation cp="🏃‍♀‍➡" type="tts">woman running: facing right</annotation>
+		<annotation cp="🏃🏻‍♀‍➡">facing | fast | hurry | light skin tone | marathon | move | quick | race | racing | right | run | rush | speed | woman</annotation>
+		<annotation cp="🏃🏻‍♀‍➡" type="tts">woman running: light skin tone, facing right</annotation>
+		<annotation cp="🏃🏼‍♀‍➡">facing | fast | hurry | marathon | medium-light skin tone | move | quick | race | racing | right | run | rush | speed | woman</annotation>
+		<annotation cp="🏃🏼‍♀‍➡" type="tts">woman running: medium-light skin tone, facing right</annotation>
+		<annotation cp="🏃🏽‍♀‍➡">facing | fast | hurry | marathon | medium skin tone | move | quick | race | racing | right | run | rush | speed | woman</annotation>
+		<annotation cp="🏃🏽‍♀‍➡" type="tts">woman running: medium skin tone, facing right</annotation>
+		<annotation cp="🏃🏾‍♀‍➡">facing | fast | hurry | marathon | medium-dark skin tone | move | quick | race | racing | right | run | rush | speed | woman</annotation>
+		<annotation cp="🏃🏾‍♀‍➡" type="tts">woman running: medium-dark skin tone, facing right</annotation>
+		<annotation cp="🏃🏿‍♀‍➡">dark skin tone | facing | fast | hurry | marathon | move | quick | race | racing | right | run | rush | speed | woman</annotation>
+		<annotation cp="🏃🏿‍♀‍➡" type="tts">woman running: dark skin tone, facing right</annotation>
+		<annotation cp="🏃‍♂‍➡">facing | fast | hurry | man | marathon | move | quick | race | racing | right | run | rush | speed</annotation>
+		<annotation cp="🏃‍♂‍➡" type="tts">man running: facing right</annotation>
+		<annotation cp="🏃🏻‍♂‍➡">facing | fast | hurry | light skin tone | man | marathon | move | quick | race | racing | right | run | rush | speed</annotation>
+		<annotation cp="🏃🏻‍♂‍➡" type="tts">man running: light skin tone, facing right</annotation>
+		<annotation cp="🏃🏼‍♂‍➡">facing | fast | hurry | man | marathon | medium-light skin tone | move | quick | race | racing | right | run | rush | speed</annotation>
+		<annotation cp="🏃🏼‍♂‍➡" type="tts">man running: medium-light skin tone, facing right</annotation>
+		<annotation cp="🏃🏽‍♂‍➡">facing | fast | hurry | man | marathon | medium skin tone | move | quick | race | racing | right | run | rush | speed</annotation>
+		<annotation cp="🏃🏽‍♂‍➡" type="tts">man running: medium skin tone, facing right</annotation>
+		<annotation cp="🏃🏾‍♂‍➡">facing | fast | hurry | man | marathon | medium-dark skin tone | move | quick | race | racing | right | run | rush | speed</annotation>
+		<annotation cp="🏃🏾‍♂‍➡" type="tts">man running: medium-dark skin tone, facing right</annotation>
+		<annotation cp="🏃🏿‍♂‍➡">dark skin tone | facing | fast | hurry | man | marathon | move | quick | race | racing | right | run | rush | speed</annotation>
+		<annotation cp="🏃🏿‍♂‍➡" type="tts">man running: dark skin tone, facing right</annotation>
+		<annotation cp="💃🏻">dance | dancer | dancing | elegant | festive | flair | flamenco | groove | let’s | light skin tone | salsa | tango | woman</annotation>
+		<annotation cp="💃🏻" type="tts">woman dancing: light skin tone</annotation>
+		<annotation cp="💃🏼">dance | dancer | dancing | elegant | festive | flair | flamenco | groove | let’s | medium-light skin tone | salsa | tango | woman</annotation>
+		<annotation cp="💃🏼" type="tts">woman dancing: medium-light skin tone</annotation>
+		<annotation cp="💃🏽">dance | dancer | dancing | elegant | festive | flair | flamenco | groove | let’s | medium skin tone | salsa | tango | woman</annotation>
+		<annotation cp="💃🏽" type="tts">woman dancing: medium skin tone</annotation>
+		<annotation cp="💃🏾">dance | dancer | dancing | elegant | festive | flair | flamenco | groove | let’s | medium-dark skin tone | salsa | tango | woman</annotation>
+		<annotation cp="💃🏾" type="tts">woman dancing: medium-dark skin tone</annotation>
+		<annotation cp="💃🏿">dance | dancer | dancing | dark skin tone | elegant | festive | flair | flamenco | groove | let’s | salsa | tango | woman</annotation>
+		<annotation cp="💃🏿" type="tts">woman dancing: dark skin tone</annotation>
+		<annotation cp="🕺🏻">dance | dancer | dancing | elegant | festive | flair | flamenco | groove | let’s | light skin tone | man | salsa | tango</annotation>
+		<annotation cp="🕺🏻" type="tts">man dancing: light skin tone</annotation>
+		<annotation cp="🕺🏼">dance | dancer | dancing | elegant | festive | flair | flamenco | groove | let’s | man | medium-light skin tone | salsa | tango</annotation>
+		<annotation cp="🕺🏼" type="tts">man dancing: medium-light skin tone</annotation>
+		<annotation cp="🕺🏽">dance | dancer | dancing | elegant | festive | flair | flamenco | groove | let’s | man | medium skin tone | salsa | tango</annotation>
+		<annotation cp="🕺🏽" type="tts">man dancing: medium skin tone</annotation>
+		<annotation cp="🕺🏾">dance | dancer | dancing | elegant | festive | flair | flamenco | groove | let’s | man | medium-dark skin tone | salsa | tango</annotation>
+		<annotation cp="🕺🏾" type="tts">man dancing: medium-dark skin tone</annotation>
+		<annotation cp="🕺🏿">dance | dancer | dancing | dark skin tone | elegant | festive | flair | flamenco | groove | let’s | man | salsa | tango</annotation>
+		<annotation cp="🕺🏿" type="tts">man dancing: dark skin tone</annotation>
+		<annotation cp="🕴🏻">business | levitating | light skin tone | person | suit</annotation>
+		<annotation cp="🕴🏻" type="tts">person in suit levitating: light skin tone</annotation>
+		<annotation cp="🕴🏼">business | levitating | medium-light skin tone | person | suit</annotation>
+		<annotation cp="🕴🏼" type="tts">person in suit levitating: medium-light skin tone</annotation>
+		<annotation cp="🕴🏽">business | levitating | medium skin tone | person | suit</annotation>
+		<annotation cp="🕴🏽" type="tts">person in suit levitating: medium skin tone</annotation>
+		<annotation cp="🕴🏾">business | levitating | medium-dark skin tone | person | suit</annotation>
+		<annotation cp="🕴🏾" type="tts">person in suit levitating: medium-dark skin tone</annotation>
+		<annotation cp="🕴🏿">business | dark skin tone | levitating | person | suit</annotation>
+		<annotation cp="🕴🏿" type="tts">person in suit levitating: dark skin tone</annotation>
+		<annotation cp="🧖🏻">day | light skin tone | luxurious | pamper | person | relax | room | sauna | spa | steam | steambath | unwind</annotation>
+		<annotation cp="🧖🏻" type="tts">person in steamy room: light skin tone</annotation>
+		<annotation cp="🧖🏼">day | luxurious | medium-light skin tone | pamper | person | relax | room | sauna | spa | steam | steambath | unwind</annotation>
+		<annotation cp="🧖🏼" type="tts">person in steamy room: medium-light skin tone</annotation>
+		<annotation cp="🧖🏽">day | luxurious | medium skin tone | pamper | person | relax | room | sauna | spa | steam | steambath | unwind</annotation>
+		<annotation cp="🧖🏽" type="tts">person in steamy room: medium skin tone</annotation>
+		<annotation cp="🧖🏾">day | luxurious | medium-dark skin tone | pamper | person | relax | room | sauna | spa | steam | steambath | unwind</annotation>
+		<annotation cp="🧖🏾" type="tts">person in steamy room: medium-dark skin tone</annotation>
+		<annotation cp="🧖🏿">dark skin tone | day | luxurious | pamper | person | relax | room | sauna | spa | steam | steambath | unwind</annotation>
+		<annotation cp="🧖🏿" type="tts">person in steamy room: dark skin tone</annotation>
+		<annotation cp="🧖🏻‍♂">day | light skin tone | luxurious | man | pamper | relax | room | sauna | spa | steam | steambath | unwind</annotation>
+		<annotation cp="🧖🏻‍♂" type="tts">man in steamy room: light skin tone</annotation>
+		<annotation cp="🧖🏼‍♂">day | luxurious | man | medium-light skin tone | pamper | relax | room | sauna | spa | steam | steambath | unwind</annotation>
+		<annotation cp="🧖🏼‍♂" type="tts">man in steamy room: medium-light skin tone</annotation>
+		<annotation cp="🧖🏽‍♂">day | luxurious | man | medium skin tone | pamper | relax | room | sauna | spa | steam | steambath | unwind</annotation>
+		<annotation cp="🧖🏽‍♂" type="tts">man in steamy room: medium skin tone</annotation>
+		<annotation cp="🧖🏾‍♂">day | luxurious | man | medium-dark skin tone | pamper | relax | room | sauna | spa | steam | steambath | unwind</annotation>
+		<annotation cp="🧖🏾‍♂" type="tts">man in steamy room: medium-dark skin tone</annotation>
+		<annotation cp="🧖🏿‍♂">dark skin tone | day | luxurious | man | pamper | relax | room | sauna | spa | steam | steambath | unwind</annotation>
+		<annotation cp="🧖🏿‍♂" type="tts">man in steamy room: dark skin tone</annotation>
+		<annotation cp="🧖🏻‍♀">day | light skin tone | luxurious | pamper | relax | room | sauna | spa | steam | steambath | unwind | woman</annotation>
+		<annotation cp="🧖🏻‍♀" type="tts">woman in steamy room: light skin tone</annotation>
+		<annotation cp="🧖🏼‍♀">day | luxurious | medium-light skin tone | pamper | relax | room | sauna | spa | steam | steambath | unwind | woman</annotation>
+		<annotation cp="🧖🏼‍♀" type="tts">woman in steamy room: medium-light skin tone</annotation>
+		<annotation cp="🧖🏽‍♀">day | luxurious | medium skin tone | pamper | relax | room | sauna | spa | steam | steambath | unwind | woman</annotation>
+		<annotation cp="🧖🏽‍♀" type="tts">woman in steamy room: medium skin tone</annotation>
+		<annotation cp="🧖🏾‍♀">day | luxurious | medium-dark skin tone | pamper | relax | room | sauna | spa | steam | steambath | unwind | woman</annotation>
+		<annotation cp="🧖🏾‍♀" type="tts">woman in steamy room: medium-dark skin tone</annotation>
+		<annotation cp="🧖🏿‍♀">dark skin tone | day | luxurious | pamper | relax | room | sauna | spa | steam | steambath | unwind | woman</annotation>
+		<annotation cp="🧖🏿‍♀" type="tts">woman in steamy room: dark skin tone</annotation>
+		<annotation cp="🧗🏻">climb | climber | climbing | light skin tone | mountain | person | rock | scale | up</annotation>
+		<annotation cp="🧗🏻" type="tts">person climbing: light skin tone</annotation>
+		<annotation cp="🧗🏼">climb | climber | climbing | medium-light skin tone | mountain | person | rock | scale | up</annotation>
+		<annotation cp="🧗🏼" type="tts">person climbing: medium-light skin tone</annotation>
+		<annotation cp="🧗🏽">climb | climber | climbing | medium skin tone | mountain | person | rock | scale | up</annotation>
+		<annotation cp="🧗🏽" type="tts">person climbing: medium skin tone</annotation>
+		<annotation cp="🧗🏾">climb | climber | climbing | medium-dark skin tone | mountain | person | rock | scale | up</annotation>
+		<annotation cp="🧗🏾" type="tts">person climbing: medium-dark skin tone</annotation>
+		<annotation cp="🧗🏿">climb | climber | climbing | dark skin tone | mountain | person | rock | scale | up</annotation>
+		<annotation cp="🧗🏿" type="tts">person climbing: dark skin tone</annotation>
+		<annotation cp="🧗🏻‍♂">climb | climber | climbing | light skin tone | man | mountain | rock | scale | up</annotation>
+		<annotation cp="🧗🏻‍♂" type="tts">man climbing: light skin tone</annotation>
+		<annotation cp="🧗🏼‍♂">climb | climber | climbing | man | medium-light skin tone | mountain | rock | scale | up</annotation>
+		<annotation cp="🧗🏼‍♂" type="tts">man climbing: medium-light skin tone</annotation>
+		<annotation cp="🧗🏽‍♂">climb | climber | climbing | man | medium skin tone | mountain | rock | scale | up</annotation>
+		<annotation cp="🧗🏽‍♂" type="tts">man climbing: medium skin tone</annotation>
+		<annotation cp="🧗🏾‍♂">climb | climber | climbing | man | medium-dark skin tone | mountain | rock | scale | up</annotation>
+		<annotation cp="🧗🏾‍♂" type="tts">man climbing: medium-dark skin tone</annotation>
+		<annotation cp="🧗🏿‍♂">climb | climber | climbing | dark skin tone | man | mountain | rock | scale | up</annotation>
+		<annotation cp="🧗🏿‍♂" type="tts">man climbing: dark skin tone</annotation>
+		<annotation cp="🧗🏻‍♀">climb | climber | climbing | light skin tone | mountain | rock | scale | up | woman</annotation>
+		<annotation cp="🧗🏻‍♀" type="tts">woman climbing: light skin tone</annotation>
+		<annotation cp="🧗🏼‍♀">climb | climber | climbing | medium-light skin tone | mountain | rock | scale | up | woman</annotation>
+		<annotation cp="🧗🏼‍♀" type="tts">woman climbing: medium-light skin tone</annotation>
+		<annotation cp="🧗🏽‍♀">climb | climber | climbing | medium skin tone | mountain | rock | scale | up | woman</annotation>
+		<annotation cp="🧗🏽‍♀" type="tts">woman climbing: medium skin tone</annotation>
+		<annotation cp="🧗🏾‍♀">climb | climber | climbing | medium-dark skin tone | mountain | rock | scale | up | woman</annotation>
+		<annotation cp="🧗🏾‍♀" type="tts">woman climbing: medium-dark skin tone</annotation>
+		<annotation cp="🧗🏿‍♀">climb | climber | climbing | dark skin tone | mountain | rock | scale | up | woman</annotation>
+		<annotation cp="🧗🏿‍♀" type="tts">woman climbing: dark skin tone</annotation>
+		<annotation cp="🏇🏻">horse | jockey | light skin tone | racehorse | racing | riding | sport</annotation>
+		<annotation cp="🏇🏻" type="tts">horse racing: light skin tone</annotation>
+		<annotation cp="🏇🏼">horse | jockey | medium-light skin tone | racehorse | racing | riding | sport</annotation>
+		<annotation cp="🏇🏼" type="tts">horse racing: medium-light skin tone</annotation>
+		<annotation cp="🏇🏽">horse | jockey | medium skin tone | racehorse | racing | riding | sport</annotation>
+		<annotation cp="🏇🏽" type="tts">horse racing: medium skin tone</annotation>
+		<annotation cp="🏇🏾">horse | jockey | medium-dark skin tone | racehorse | racing | riding | sport</annotation>
+		<annotation cp="🏇🏾" type="tts">horse racing: medium-dark skin tone</annotation>
+		<annotation cp="🏇🏿">dark skin tone | horse | jockey | racehorse | racing | riding | sport</annotation>
+		<annotation cp="🏇🏿" type="tts">horse racing: dark skin tone</annotation>
+		<annotation cp="🏂🏻">light skin tone | ski | snow | snowboard | snowboarder | sport</annotation>
+		<annotation cp="🏂🏻" type="tts">snowboarder: light skin tone</annotation>
+		<annotation cp="🏂🏼">medium-light skin tone | ski | snow | snowboard | snowboarder | sport</annotation>
+		<annotation cp="🏂🏼" type="tts">snowboarder: medium-light skin tone</annotation>
+		<annotation cp="🏂🏽">medium skin tone | ski | snow | snowboard | snowboarder | sport</annotation>
+		<annotation cp="🏂🏽" type="tts">snowboarder: medium skin tone</annotation>
+		<annotation cp="🏂🏾">medium-dark skin tone | ski | snow | snowboard | snowboarder | sport</annotation>
+		<annotation cp="🏂🏾" type="tts">snowboarder: medium-dark skin tone</annotation>
+		<annotation cp="🏂🏿">dark skin tone | ski | snow | snowboard | snowboarder | sport</annotation>
+		<annotation cp="🏂🏿" type="tts">snowboarder: dark skin tone</annotation>
+		<annotation cp="🏌🏻">ball | birdie | caddy | driving | golf | golfing | green | light skin tone | person | pga | putt | range | tee</annotation>
+		<annotation cp="🏌🏻" type="tts">person golfing: light skin tone</annotation>
+		<annotation cp="🏌🏼">ball | birdie | caddy | driving | golf | golfing | green | medium-light skin tone | person | pga | putt | range | tee</annotation>
+		<annotation cp="🏌🏼" type="tts">person golfing: medium-light skin tone</annotation>
+		<annotation cp="🏌🏽">ball | birdie | caddy | driving | golf | golfing | green | medium skin tone | person | pga | putt | range | tee</annotation>
+		<annotation cp="🏌🏽" type="tts">person golfing: medium skin tone</annotation>
+		<annotation cp="🏌🏾">ball | birdie | caddy | driving | golf | golfing | green | medium-dark skin tone | person | pga | putt | range | tee</annotation>
+		<annotation cp="🏌🏾" type="tts">person golfing: medium-dark skin tone</annotation>
+		<annotation cp="🏌🏿">ball | birdie | caddy | dark skin tone | driving | golf | golfing | green | person | pga | putt | range | tee</annotation>
+		<annotation cp="🏌🏿" type="tts">person golfing: dark skin tone</annotation>
+		<annotation cp="🏌🏻‍♂">ball | birdie | caddy | driving | golf | golfing | green | light skin tone | man | pga | putt | range | tee</annotation>
+		<annotation cp="🏌🏻‍♂" type="tts">man golfing: light skin tone</annotation>
+		<annotation cp="🏌🏼‍♂">ball | birdie | caddy | driving | golf | golfing | green | man | medium-light skin tone | pga | putt | range | tee</annotation>
+		<annotation cp="🏌🏼‍♂" type="tts">man golfing: medium-light skin tone</annotation>
+		<annotation cp="🏌🏽‍♂">ball | birdie | caddy | driving | golf | golfing | green | man | medium skin tone | pga | putt | range | tee</annotation>
+		<annotation cp="🏌🏽‍♂" type="tts">man golfing: medium skin tone</annotation>
+		<annotation cp="🏌🏾‍♂">ball | birdie | caddy | driving | golf | golfing | green | man | medium-dark skin tone | pga | putt | range | tee</annotation>
+		<annotation cp="🏌🏾‍♂" type="tts">man golfing: medium-dark skin tone</annotation>
+		<annotation cp="🏌🏿‍♂">ball | birdie | caddy | dark skin tone | driving | golf | golfing | green | man | pga | putt | range | tee</annotation>
+		<annotation cp="🏌🏿‍♂" type="tts">man golfing: dark skin tone</annotation>
+		<annotation cp="🏌🏻‍♀">ball | birdie | caddy | driving | golf | golfing | green | light skin tone | pga | putt | range | tee | woman</annotation>
+		<annotation cp="🏌🏻‍♀" type="tts">woman golfing: light skin tone</annotation>
+		<annotation cp="🏌🏼‍♀">ball | birdie | caddy | driving | golf | golfing | green | medium-light skin tone | pga | putt | range | tee | woman</annotation>
+		<annotation cp="🏌🏼‍♀" type="tts">woman golfing: medium-light skin tone</annotation>
+		<annotation cp="🏌🏽‍♀">ball | birdie | caddy | driving | golf | golfing | green | medium skin tone | pga | putt | range | tee | woman</annotation>
+		<annotation cp="🏌🏽‍♀" type="tts">woman golfing: medium skin tone</annotation>
+		<annotation cp="🏌🏾‍♀">ball | birdie | caddy | driving | golf | golfing | green | medium-dark skin tone | pga | putt | range | tee | woman</annotation>
+		<annotation cp="🏌🏾‍♀" type="tts">woman golfing: medium-dark skin tone</annotation>
+		<annotation cp="🏌🏿‍♀">ball | birdie | caddy | dark skin tone | driving | golf | golfing | green | pga | putt | range | tee | woman</annotation>
+		<annotation cp="🏌🏿‍♀" type="tts">woman golfing: dark skin tone</annotation>
+		<annotation cp="🏄🏻">beach | light skin tone | ocean | person | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄🏻" type="tts">person surfing: light skin tone</annotation>
+		<annotation cp="🏄🏼">beach | medium-light skin tone | ocean | person | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄🏼" type="tts">person surfing: medium-light skin tone</annotation>
+		<annotation cp="🏄🏽">beach | medium skin tone | ocean | person | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄🏽" type="tts">person surfing: medium skin tone</annotation>
+		<annotation cp="🏄🏾">beach | medium-dark skin tone | ocean | person | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄🏾" type="tts">person surfing: medium-dark skin tone</annotation>
+		<annotation cp="🏄🏿">beach | dark skin tone | ocean | person | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄🏿" type="tts">person surfing: dark skin tone</annotation>
+		<annotation cp="🏄🏻‍♂">beach | light skin tone | man | ocean | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄🏻‍♂" type="tts">man surfing: light skin tone</annotation>
+		<annotation cp="🏄🏼‍♂">beach | man | medium-light skin tone | ocean | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄🏼‍♂" type="tts">man surfing: medium-light skin tone</annotation>
+		<annotation cp="🏄🏽‍♂">beach | man | medium skin tone | ocean | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄🏽‍♂" type="tts">man surfing: medium skin tone</annotation>
+		<annotation cp="🏄🏾‍♂">beach | man | medium-dark skin tone | ocean | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄🏾‍♂" type="tts">man surfing: medium-dark skin tone</annotation>
+		<annotation cp="🏄🏿‍♂">beach | dark skin tone | man | ocean | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄🏿‍♂" type="tts">man surfing: dark skin tone</annotation>
+		<annotation cp="🏄🏻‍♀">beach | light skin tone | ocean | person | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄🏻‍♀" type="tts">woman surfing: light skin tone</annotation>
+		<annotation cp="🏄🏼‍♀">beach | medium-light skin tone | ocean | person | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄🏼‍♀" type="tts">woman surfing: medium-light skin tone</annotation>
+		<annotation cp="🏄🏽‍♀">beach | medium skin tone | ocean | person | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄🏽‍♀" type="tts">woman surfing: medium skin tone</annotation>
+		<annotation cp="🏄🏾‍♀">beach | medium-dark skin tone | ocean | person | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄🏾‍♀" type="tts">woman surfing: medium-dark skin tone</annotation>
+		<annotation cp="🏄🏿‍♀">beach | dark skin tone | ocean | person | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄🏿‍♀" type="tts">woman surfing: dark skin tone</annotation>
+		<annotation cp="🚣🏻">boat | canoe | cruise | fishing | lake | light skin tone | oar | paddle | person | raft | river | row | rowboat | rowing</annotation>
+		<annotation cp="🚣🏻" type="tts">person rowing boat: light skin tone</annotation>
+		<annotation cp="🚣🏼">boat | canoe | cruise | fishing | lake | medium-light skin tone | oar | paddle | person | raft | river | row | rowboat | rowing</annotation>
+		<annotation cp="🚣🏼" type="tts">person rowing boat: medium-light skin tone</annotation>
+		<annotation cp="🚣🏽">boat | canoe | cruise | fishing | lake | medium skin tone | oar | paddle | person | raft | river | row | rowboat | rowing</annotation>
+		<annotation cp="🚣🏽" type="tts">person rowing boat: medium skin tone</annotation>
+		<annotation cp="🚣🏾">boat | canoe | cruise | fishing | lake | medium-dark skin tone | oar | paddle | person | raft | river | row | rowboat | rowing</annotation>
+		<annotation cp="🚣🏾" type="tts">person rowing boat: medium-dark skin tone</annotation>
+		<annotation cp="🚣🏿">boat | canoe | cruise | dark skin tone | fishing | lake | oar | paddle | person | raft | river | row | rowboat | rowing</annotation>
+		<annotation cp="🚣🏿" type="tts">person rowing boat: dark skin tone</annotation>
+		<annotation cp="🚣🏻‍♂">boat | canoe | cruise | fishing | lake | light skin tone | man | oar | paddle | raft | river | row | rowboat | rowing</annotation>
+		<annotation cp="🚣🏻‍♂" type="tts">man rowing boat: light skin tone</annotation>
+		<annotation cp="🚣🏼‍♂">boat | canoe | cruise | fishing | lake | man | medium-light skin tone | oar | paddle | raft | river | row | rowboat | rowing</annotation>
+		<annotation cp="🚣🏼‍♂" type="tts">man rowing boat: medium-light skin tone</annotation>
+		<annotation cp="🚣🏽‍♂">boat | canoe | cruise | fishing | lake | man | medium skin tone | oar | paddle | raft | river | row | rowboat | rowing</annotation>
+		<annotation cp="🚣🏽‍♂" type="tts">man rowing boat: medium skin tone</annotation>
+		<annotation cp="🚣🏾‍♂">boat | canoe | cruise | fishing | lake | man | medium-dark skin tone | oar | paddle | raft | river | row | rowboat | rowing</annotation>
+		<annotation cp="🚣🏾‍♂" type="tts">man rowing boat: medium-dark skin tone</annotation>
+		<annotation cp="🚣🏿‍♂">boat | canoe | cruise | dark skin tone | fishing | lake | man | oar | paddle | raft | river | row | rowboat | rowing</annotation>
+		<annotation cp="🚣🏿‍♂" type="tts">man rowing boat: dark skin tone</annotation>
+		<annotation cp="🚣🏻‍♀">boat | canoe | cruise | fishing | lake | light skin tone | oar | paddle | raft | river | row | rowboat | rowing | woman</annotation>
+		<annotation cp="🚣🏻‍♀" type="tts">woman rowing boat: light skin tone</annotation>
+		<annotation cp="🚣🏼‍♀">boat | canoe | cruise | fishing | lake | medium-light skin tone | oar | paddle | raft | river | row | rowboat | rowing | woman</annotation>
+		<annotation cp="🚣🏼‍♀" type="tts">woman rowing boat: medium-light skin tone</annotation>
+		<annotation cp="🚣🏽‍♀">boat | canoe | cruise | fishing | lake | medium skin tone | oar | paddle | raft | river | row | rowboat | rowing | woman</annotation>
+		<annotation cp="🚣🏽‍♀" type="tts">woman rowing boat: medium skin tone</annotation>
+		<annotation cp="🚣🏾‍♀">boat | canoe | cruise | fishing | lake | medium-dark skin tone | oar | paddle | raft | river | row | rowboat | rowing | woman</annotation>
+		<annotation cp="🚣🏾‍♀" type="tts">woman rowing boat: medium-dark skin tone</annotation>
+		<annotation cp="🚣🏿‍♀">boat | canoe | cruise | dark skin tone | fishing | lake | oar | paddle | raft | river | row | rowboat | rowing | woman</annotation>
+		<annotation cp="🚣🏿‍♀" type="tts">woman rowing boat: dark skin tone</annotation>
+		<annotation cp="🏊🏻">freestyle | light skin tone | person | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊🏻" type="tts">person swimming: light skin tone</annotation>
+		<annotation cp="🏊🏼">freestyle | medium-light skin tone | person | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊🏼" type="tts">person swimming: medium-light skin tone</annotation>
+		<annotation cp="🏊🏽">freestyle | medium skin tone | person | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊🏽" type="tts">person swimming: medium skin tone</annotation>
+		<annotation cp="🏊🏾">freestyle | medium-dark skin tone | person | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊🏾" type="tts">person swimming: medium-dark skin tone</annotation>
+		<annotation cp="🏊🏿">dark skin tone | freestyle | person | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊🏿" type="tts">person swimming: dark skin tone</annotation>
+		<annotation cp="🏊🏻‍♂">freestyle | light skin tone | man | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊🏻‍♂" type="tts">man swimming: light skin tone</annotation>
+		<annotation cp="🏊🏼‍♂">freestyle | man | medium-light skin tone | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊🏼‍♂" type="tts">man swimming: medium-light skin tone</annotation>
+		<annotation cp="🏊🏽‍♂">freestyle | man | medium skin tone | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊🏽‍♂" type="tts">man swimming: medium skin tone</annotation>
+		<annotation cp="🏊🏾‍♂">freestyle | man | medium-dark skin tone | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊🏾‍♂" type="tts">man swimming: medium-dark skin tone</annotation>
+		<annotation cp="🏊🏿‍♂">dark skin tone | freestyle | man | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊🏿‍♂" type="tts">man swimming: dark skin tone</annotation>
+		<annotation cp="🏊🏻‍♀">freestyle | light skin tone | man | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊🏻‍♀" type="tts">woman swimming: light skin tone</annotation>
+		<annotation cp="🏊🏼‍♀">freestyle | man | medium-light skin tone | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊🏼‍♀" type="tts">woman swimming: medium-light skin tone</annotation>
+		<annotation cp="🏊🏽‍♀">freestyle | man | medium skin tone | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊🏽‍♀" type="tts">woman swimming: medium skin tone</annotation>
+		<annotation cp="🏊🏾‍♀">freestyle | man | medium-dark skin tone | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊🏾‍♀" type="tts">woman swimming: medium-dark skin tone</annotation>
+		<annotation cp="🏊🏿‍♀">dark skin tone | freestyle | man | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊🏿‍♀" type="tts">woman swimming: dark skin tone</annotation>
+		<annotation cp="⛹🏻">athletic | ball | basketball | bouncing | championship | dribble | light skin tone | net | person | player | throw</annotation>
+		<annotation cp="⛹🏻" type="tts">person bouncing ball: light skin tone</annotation>
+		<annotation cp="⛹🏼">athletic | ball | basketball | bouncing | championship | dribble | medium-light skin tone | net | person | player | throw</annotation>
+		<annotation cp="⛹🏼" type="tts">person bouncing ball: medium-light skin tone</annotation>
+		<annotation cp="⛹🏽">athletic | ball | basketball | bouncing | championship | dribble | medium skin tone | net | person | player | throw</annotation>
+		<annotation cp="⛹🏽" type="tts">person bouncing ball: medium skin tone</annotation>
+		<annotation cp="⛹🏾">athletic | ball | basketball | bouncing | championship | dribble | medium-dark skin tone | net | person | player | throw</annotation>
+		<annotation cp="⛹🏾" type="tts">person bouncing ball: medium-dark skin tone</annotation>
+		<annotation cp="⛹🏿">athletic | ball | basketball | bouncing | championship | dark skin tone | dribble | net | person | player | throw</annotation>
+		<annotation cp="⛹🏿" type="tts">person bouncing ball: dark skin tone</annotation>
+		<annotation cp="⛹🏻‍♂">athletic | ball | basketball | bouncing | championship | dribble | light skin tone | man | net | player | throw</annotation>
+		<annotation cp="⛹🏻‍♂" type="tts">man bouncing ball: light skin tone</annotation>
+		<annotation cp="⛹🏼‍♂">athletic | ball | basketball | bouncing | championship | dribble | man | medium-light skin tone | net | player | throw</annotation>
+		<annotation cp="⛹🏼‍♂" type="tts">man bouncing ball: medium-light skin tone</annotation>
+		<annotation cp="⛹🏽‍♂">athletic | ball | basketball | bouncing | championship | dribble | man | medium skin tone | net | player | throw</annotation>
+		<annotation cp="⛹🏽‍♂" type="tts">man bouncing ball: medium skin tone</annotation>
+		<annotation cp="⛹🏾‍♂">athletic | ball | basketball | bouncing | championship | dribble | man | medium-dark skin tone | net | player | throw</annotation>
+		<annotation cp="⛹🏾‍♂" type="tts">man bouncing ball: medium-dark skin tone</annotation>
+		<annotation cp="⛹🏿‍♂">athletic | ball | basketball | bouncing | championship | dark skin tone | dribble | man | net | player | throw</annotation>
+		<annotation cp="⛹🏿‍♂" type="tts">man bouncing ball: dark skin tone</annotation>
+		<annotation cp="⛹🏻‍♀">athletic | ball | basketball | bouncing | championship | dribble | light skin tone | net | player | throw | woman</annotation>
+		<annotation cp="⛹🏻‍♀" type="tts">woman bouncing ball: light skin tone</annotation>
+		<annotation cp="⛹🏼‍♀">athletic | ball | basketball | bouncing | championship | dribble | medium-light skin tone | net | player | throw | woman</annotation>
+		<annotation cp="⛹🏼‍♀" type="tts">woman bouncing ball: medium-light skin tone</annotation>
+		<annotation cp="⛹🏽‍♀">athletic | ball | basketball | bouncing | championship | dribble | medium skin tone | net | player | throw | woman</annotation>
+		<annotation cp="⛹🏽‍♀" type="tts">woman bouncing ball: medium skin tone</annotation>
+		<annotation cp="⛹🏾‍♀">athletic | ball | basketball | bouncing | championship | dribble | medium-dark skin tone | net | player | throw | woman</annotation>
+		<annotation cp="⛹🏾‍♀" type="tts">woman bouncing ball: medium-dark skin tone</annotation>
+		<annotation cp="⛹🏿‍♀">athletic | ball | basketball | bouncing | championship | dark skin tone | dribble | net | player | throw | woman</annotation>
+		<annotation cp="⛹🏿‍♀" type="tts">woman bouncing ball: dark skin tone</annotation>
+		<annotation cp="🏋🏻">barbell | bodybuilder | deadlift | lifter | lifting | light skin tone | person | powerlifting | weight | weightlifter | weights | workout</annotation>
+		<annotation cp="🏋🏻" type="tts">person lifting weights: light skin tone</annotation>
+		<annotation cp="🏋🏼">barbell | bodybuilder | deadlift | lifter | lifting | medium-light skin tone | person | powerlifting | weight | weightlifter | weights | workout</annotation>
+		<annotation cp="🏋🏼" type="tts">person lifting weights: medium-light skin tone</annotation>
+		<annotation cp="🏋🏽">barbell | bodybuilder | deadlift | lifter | lifting | medium skin tone | person | powerlifting | weight | weightlifter | weights | workout</annotation>
+		<annotation cp="🏋🏽" type="tts">person lifting weights: medium skin tone</annotation>
+		<annotation cp="🏋🏾">barbell | bodybuilder | deadlift | lifter | lifting | medium-dark skin tone | person | powerlifting | weight | weightlifter | weights | workout</annotation>
+		<annotation cp="🏋🏾" type="tts">person lifting weights: medium-dark skin tone</annotation>
+		<annotation cp="🏋🏿">barbell | bodybuilder | dark skin tone | deadlift | lifter | lifting | person | powerlifting | weight | weightlifter | weights | workout</annotation>
+		<annotation cp="🏋🏿" type="tts">person lifting weights: dark skin tone</annotation>
+		<annotation cp="🏋🏻‍♂">barbell | bodybuilder | deadlift | lifter | lifting | light skin tone | man | powerlifting | weight | weightlifter | weights | workout</annotation>
+		<annotation cp="🏋🏻‍♂" type="tts">man lifting weights: light skin tone</annotation>
+		<annotation cp="🏋🏼‍♂">barbell | bodybuilder | deadlift | lifter | lifting | man | medium-light skin tone | powerlifting | weight | weightlifter | weights | workout</annotation>
+		<annotation cp="🏋🏼‍♂" type="tts">man lifting weights: medium-light skin tone</annotation>
+		<annotation cp="🏋🏽‍♂">barbell | bodybuilder | deadlift | lifter | lifting | man | medium skin tone | powerlifting | weight | weightlifter | weights | workout</annotation>
+		<annotation cp="🏋🏽‍♂" type="tts">man lifting weights: medium skin tone</annotation>
+		<annotation cp="🏋🏾‍♂">barbell | bodybuilder | deadlift | lifter | lifting | man | medium-dark skin tone | powerlifting | weight | weightlifter | weights | workout</annotation>
+		<annotation cp="🏋🏾‍♂" type="tts">man lifting weights: medium-dark skin tone</annotation>
+		<annotation cp="🏋🏿‍♂">barbell | bodybuilder | dark skin tone | deadlift | lifter | lifting | man | powerlifting | weight | weightlifter | weights | workout</annotation>
+		<annotation cp="🏋🏿‍♂" type="tts">man lifting weights: dark skin tone</annotation>
+		<annotation cp="🏋🏻‍♀">barbell | bodybuilder | deadlift | lifter | lifting | light skin tone | powerlifting | weight | weightlifter | weights | woman | workout</annotation>
+		<annotation cp="🏋🏻‍♀" type="tts">woman lifting weights: light skin tone</annotation>
+		<annotation cp="🏋🏼‍♀">barbell | bodybuilder | deadlift | lifter | lifting | medium-light skin tone | powerlifting | weight | weightlifter | weights | woman | workout</annotation>
+		<annotation cp="🏋🏼‍♀" type="tts">woman lifting weights: medium-light skin tone</annotation>
+		<annotation cp="🏋🏽‍♀">barbell | bodybuilder | deadlift | lifter | lifting | medium skin tone | powerlifting | weight | weightlifter | weights | woman | workout</annotation>
+		<annotation cp="🏋🏽‍♀" type="tts">woman lifting weights: medium skin tone</annotation>
+		<annotation cp="🏋🏾‍♀">barbell | bodybuilder | deadlift | lifter | lifting | medium-dark skin tone | powerlifting | weight | weightlifter | weights | woman | workout</annotation>
+		<annotation cp="🏋🏾‍♀" type="tts">woman lifting weights: medium-dark skin tone</annotation>
+		<annotation cp="🏋🏿‍♀">barbell | bodybuilder | dark skin tone | deadlift | lifter | lifting | powerlifting | weight | weightlifter | weights | woman | workout</annotation>
+		<annotation cp="🏋🏿‍♀" type="tts">woman lifting weights: dark skin tone</annotation>
+		<annotation cp="🚴🏻">bicycle | bicyclist | bike | biking | cycle | cyclist | light skin tone | person | riding | sport</annotation>
+		<annotation cp="🚴🏻" type="tts">person biking: light skin tone</annotation>
+		<annotation cp="🚴🏼">bicycle | bicyclist | bike | biking | cycle | cyclist | medium-light skin tone | person | riding | sport</annotation>
+		<annotation cp="🚴🏼" type="tts">person biking: medium-light skin tone</annotation>
+		<annotation cp="🚴🏽">bicycle | bicyclist | bike | biking | cycle | cyclist | medium skin tone | person | riding | sport</annotation>
+		<annotation cp="🚴🏽" type="tts">person biking: medium skin tone</annotation>
+		<annotation cp="🚴🏾">bicycle | bicyclist | bike | biking | cycle | cyclist | medium-dark skin tone | person | riding | sport</annotation>
+		<annotation cp="🚴🏾" type="tts">person biking: medium-dark skin tone</annotation>
+		<annotation cp="🚴🏿">bicycle | bicyclist | bike | biking | cycle | cyclist | dark skin tone | person | riding | sport</annotation>
+		<annotation cp="🚴🏿" type="tts">person biking: dark skin tone</annotation>
+		<annotation cp="🚴🏻‍♂">bicycle | bicyclist | bike | biking | cycle | cyclist | light skin tone | man | riding | sport</annotation>
+		<annotation cp="🚴🏻‍♂" type="tts">man biking: light skin tone</annotation>
+		<annotation cp="🚴🏼‍♂">bicycle | bicyclist | bike | biking | cycle | cyclist | man | medium-light skin tone | riding | sport</annotation>
+		<annotation cp="🚴🏼‍♂" type="tts">man biking: medium-light skin tone</annotation>
+		<annotation cp="🚴🏽‍♂">bicycle | bicyclist | bike | biking | cycle | cyclist | man | medium skin tone | riding | sport</annotation>
+		<annotation cp="🚴🏽‍♂" type="tts">man biking: medium skin tone</annotation>
+		<annotation cp="🚴🏾‍♂">bicycle | bicyclist | bike | biking | cycle | cyclist | man | medium-dark skin tone | riding | sport</annotation>
+		<annotation cp="🚴🏾‍♂" type="tts">man biking: medium-dark skin tone</annotation>
+		<annotation cp="🚴🏿‍♂">bicycle | bicyclist | bike | biking | cycle | cyclist | dark skin tone | man | riding | sport</annotation>
+		<annotation cp="🚴🏿‍♂" type="tts">man biking: dark skin tone</annotation>
+		<annotation cp="🚴🏻‍♀">bicycle | bicyclist | bike | biking | cycle | cyclist | light skin tone | riding | sport | woman</annotation>
+		<annotation cp="🚴🏻‍♀" type="tts">woman biking: light skin tone</annotation>
+		<annotation cp="🚴🏼‍♀">bicycle | bicyclist | bike | biking | cycle | cyclist | medium-light skin tone | riding | sport | woman</annotation>
+		<annotation cp="🚴🏼‍♀" type="tts">woman biking: medium-light skin tone</annotation>
+		<annotation cp="🚴🏽‍♀">bicycle | bicyclist | bike | biking | cycle | cyclist | medium skin tone | riding | sport | woman</annotation>
+		<annotation cp="🚴🏽‍♀" type="tts">woman biking: medium skin tone</annotation>
+		<annotation cp="🚴🏾‍♀">bicycle | bicyclist | bike | biking | cycle | cyclist | medium-dark skin tone | riding | sport | woman</annotation>
+		<annotation cp="🚴🏾‍♀" type="tts">woman biking: medium-dark skin tone</annotation>
+		<annotation cp="🚴🏿‍♀">bicycle | bicyclist | bike | biking | cycle | cyclist | dark skin tone | riding | sport | woman</annotation>
+		<annotation cp="🚴🏿‍♀" type="tts">woman biking: dark skin tone</annotation>
+		<annotation cp="🚵🏻">bicycle | bicyclist | bike | biking | cycle | cyclist | light skin tone | mountain | person | riding | sport</annotation>
+		<annotation cp="🚵🏻" type="tts">person mountain biking: light skin tone</annotation>
+		<annotation cp="🚵🏼">bicycle | bicyclist | bike | biking | cycle | cyclist | medium-light skin tone | mountain | person | riding | sport</annotation>
+		<annotation cp="🚵🏼" type="tts">person mountain biking: medium-light skin tone</annotation>
+		<annotation cp="🚵🏽">bicycle | bicyclist | bike | biking | cycle | cyclist | medium skin tone | mountain | person | riding | sport</annotation>
+		<annotation cp="🚵🏽" type="tts">person mountain biking: medium skin tone</annotation>
+		<annotation cp="🚵🏾">bicycle | bicyclist | bike | biking | cycle | cyclist | medium-dark skin tone | mountain | person | riding | sport</annotation>
+		<annotation cp="🚵🏾" type="tts">person mountain biking: medium-dark skin tone</annotation>
+		<annotation cp="🚵🏿">bicycle | bicyclist | bike | biking | cycle | cyclist | dark skin tone | mountain | person | riding | sport</annotation>
+		<annotation cp="🚵🏿" type="tts">person mountain biking: dark skin tone</annotation>
+		<annotation cp="🚵🏻‍♂">bicycle | bicyclist | bike | biking | cycle | cyclist | light skin tone | man | mountain | riding | sport</annotation>
+		<annotation cp="🚵🏻‍♂" type="tts">man mountain biking: light skin tone</annotation>
+		<annotation cp="🚵🏼‍♂">bicycle | bicyclist | bike | biking | cycle | cyclist | man | medium-light skin tone | mountain | riding | sport</annotation>
+		<annotation cp="🚵🏼‍♂" type="tts">man mountain biking: medium-light skin tone</annotation>
+		<annotation cp="🚵🏽‍♂">bicycle | bicyclist | bike | biking | cycle | cyclist | man | medium skin tone | mountain | riding | sport</annotation>
+		<annotation cp="🚵🏽‍♂" type="tts">man mountain biking: medium skin tone</annotation>
+		<annotation cp="🚵🏾‍♂">bicycle | bicyclist | bike | biking | cycle | cyclist | man | medium-dark skin tone | mountain | riding | sport</annotation>
+		<annotation cp="🚵🏾‍♂" type="tts">man mountain biking: medium-dark skin tone</annotation>
+		<annotation cp="🚵🏿‍♂">bicycle | bicyclist | bike | biking | cycle | cyclist | dark skin tone | man | mountain | riding | sport</annotation>
+		<annotation cp="🚵🏿‍♂" type="tts">man mountain biking: dark skin tone</annotation>
+		<annotation cp="🚵🏻‍♀">bicycle | bicyclist | bike | biking | cycle | cyclist | light skin tone | mountain | riding | sport | woman</annotation>
+		<annotation cp="🚵🏻‍♀" type="tts">woman mountain biking: light skin tone</annotation>
+		<annotation cp="🚵🏼‍♀">bicycle | bicyclist | bike | biking | cycle | cyclist | medium-light skin tone | mountain | riding | sport | woman</annotation>
+		<annotation cp="🚵🏼‍♀" type="tts">woman mountain biking: medium-light skin tone</annotation>
+		<annotation cp="🚵🏽‍♀">bicycle | bicyclist | bike | biking | cycle | cyclist | medium skin tone | mountain | riding | sport | woman</annotation>
+		<annotation cp="🚵🏽‍♀" type="tts">woman mountain biking: medium skin tone</annotation>
+		<annotation cp="🚵🏾‍♀">bicycle | bicyclist | bike | biking | cycle | cyclist | medium-dark skin tone | mountain | riding | sport | woman</annotation>
+		<annotation cp="🚵🏾‍♀" type="tts">woman mountain biking: medium-dark skin tone</annotation>
+		<annotation cp="🚵🏿‍♀">bicycle | bicyclist | bike | biking | cycle | cyclist | dark skin tone | mountain | riding | sport | woman</annotation>
+		<annotation cp="🚵🏿‍♀" type="tts">woman mountain biking: dark skin tone</annotation>
+		<annotation cp="🤸🏻">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | light skin tone | person | somersault</annotation>
+		<annotation cp="🤸🏻" type="tts">person cartwheeling: light skin tone</annotation>
+		<annotation cp="🤸🏼">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | medium-light skin tone | person | somersault</annotation>
+		<annotation cp="🤸🏼" type="tts">person cartwheeling: medium-light skin tone</annotation>
+		<annotation cp="🤸🏽">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | medium skin tone | person | somersault</annotation>
+		<annotation cp="🤸🏽" type="tts">person cartwheeling: medium skin tone</annotation>
+		<annotation cp="🤸🏾">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | medium-dark skin tone | person | somersault</annotation>
+		<annotation cp="🤸🏾" type="tts">person cartwheeling: medium-dark skin tone</annotation>
+		<annotation cp="🤸🏿">active | cartwheel | cartwheeling | dark skin tone | excited | flip | gymnastics | happy | person | somersault</annotation>
+		<annotation cp="🤸🏿" type="tts">person cartwheeling: dark skin tone</annotation>
+		<annotation cp="🤸🏻‍♂">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | light skin tone | man | somersault</annotation>
+		<annotation cp="🤸🏻‍♂" type="tts">man cartwheeling: light skin tone</annotation>
+		<annotation cp="🤸🏼‍♂">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | man | medium-light skin tone | somersault</annotation>
+		<annotation cp="🤸🏼‍♂" type="tts">man cartwheeling: medium-light skin tone</annotation>
+		<annotation cp="🤸🏽‍♂">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | man | medium skin tone | somersault</annotation>
+		<annotation cp="🤸🏽‍♂" type="tts">man cartwheeling: medium skin tone</annotation>
+		<annotation cp="🤸🏾‍♂">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | man | medium-dark skin tone | somersault</annotation>
+		<annotation cp="🤸🏾‍♂" type="tts">man cartwheeling: medium-dark skin tone</annotation>
+		<annotation cp="🤸🏿‍♂">active | cartwheel | cartwheeling | dark skin tone | excited | flip | gymnastics | happy | man | somersault</annotation>
+		<annotation cp="🤸🏿‍♂" type="tts">man cartwheeling: dark skin tone</annotation>
+		<annotation cp="🤸🏻‍♀">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | light skin tone | somersault | woman</annotation>
+		<annotation cp="🤸🏻‍♀" type="tts">woman cartwheeling: light skin tone</annotation>
+		<annotation cp="🤸🏼‍♀">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | medium-light skin tone | somersault | woman</annotation>
+		<annotation cp="🤸🏼‍♀" type="tts">woman cartwheeling: medium-light skin tone</annotation>
+		<annotation cp="🤸🏽‍♀">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | medium skin tone | somersault | woman</annotation>
+		<annotation cp="🤸🏽‍♀" type="tts">woman cartwheeling: medium skin tone</annotation>
+		<annotation cp="🤸🏾‍♀">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | medium-dark skin tone | somersault | woman</annotation>
+		<annotation cp="🤸🏾‍♀" type="tts">woman cartwheeling: medium-dark skin tone</annotation>
+		<annotation cp="🤸🏿‍♀">active | cartwheel | cartwheeling | dark skin tone | excited | flip | gymnastics | happy | somersault | woman</annotation>
+		<annotation cp="🤸🏿‍♀" type="tts">woman cartwheeling: dark skin tone</annotation>
+		<annotation cp="🤽🏻">light skin tone | person | playing | polo | sport | swimming | water | waterpolo</annotation>
+		<annotation cp="🤽🏻" type="tts">person playing water polo: light skin tone</annotation>
+		<annotation cp="🤽🏼">medium-light skin tone | person | playing | polo | sport | swimming | water | waterpolo</annotation>
+		<annotation cp="🤽🏼" type="tts">person playing water polo: medium-light skin tone</annotation>
+		<annotation cp="🤽🏽">medium skin tone | person | playing | polo | sport | swimming | water | waterpolo</annotation>
+		<annotation cp="🤽🏽" type="tts">person playing water polo: medium skin tone</annotation>
+		<annotation cp="🤽🏾">medium-dark skin tone | person | playing | polo | sport | swimming | water | waterpolo</annotation>
+		<annotation cp="🤽🏾" type="tts">person playing water polo: medium-dark skin tone</annotation>
+		<annotation cp="🤽🏿">dark skin tone | person | playing | polo | sport | swimming | water | waterpolo</annotation>
+		<annotation cp="🤽🏿" type="tts">person playing water polo: dark skin tone</annotation>
+		<annotation cp="🤽🏻‍♂">light skin tone | man | playing | polo | sport | swimming | water | waterpolo</annotation>
+		<annotation cp="🤽🏻‍♂" type="tts">man playing water polo: light skin tone</annotation>
+		<annotation cp="🤽🏼‍♂">man | medium-light skin tone | playing | polo | sport | swimming | water | waterpolo</annotation>
+		<annotation cp="🤽🏼‍♂" type="tts">man playing water polo: medium-light skin tone</annotation>
+		<annotation cp="🤽🏽‍♂">man | medium skin tone | playing | polo | sport | swimming | water | waterpolo</annotation>
+		<annotation cp="🤽🏽‍♂" type="tts">man playing water polo: medium skin tone</annotation>
+		<annotation cp="🤽🏾‍♂">man | medium-dark skin tone | playing | polo | sport | swimming | water | waterpolo</annotation>
+		<annotation cp="🤽🏾‍♂" type="tts">man playing water polo: medium-dark skin tone</annotation>
+		<annotation cp="🤽🏿‍♂">dark skin tone | man | playing | polo | sport | swimming | water | waterpolo</annotation>
+		<annotation cp="🤽🏿‍♂" type="tts">man playing water polo: dark skin tone</annotation>
+		<annotation cp="🤽🏻‍♀">light skin tone | playing | polo | sport | swimming | water | waterpolo | woman</annotation>
+		<annotation cp="🤽🏻‍♀" type="tts">woman playing water polo: light skin tone</annotation>
+		<annotation cp="🤽🏼‍♀">medium-light skin tone | playing | polo | sport | swimming | water | waterpolo | woman</annotation>
+		<annotation cp="🤽🏼‍♀" type="tts">woman playing water polo: medium-light skin tone</annotation>
+		<annotation cp="🤽🏽‍♀">medium skin tone | playing | polo | sport | swimming | water | waterpolo | woman</annotation>
+		<annotation cp="🤽🏽‍♀" type="tts">woman playing water polo: medium skin tone</annotation>
+		<annotation cp="🤽🏾‍♀">medium-dark skin tone | playing | polo | sport | swimming | water | waterpolo | woman</annotation>
+		<annotation cp="🤽🏾‍♀" type="tts">woman playing water polo: medium-dark skin tone</annotation>
+		<annotation cp="🤽🏿‍♀">dark skin tone | playing | polo | sport | swimming | water | waterpolo | woman</annotation>
+		<annotation cp="🤽🏿‍♀" type="tts">woman playing water polo: dark skin tone</annotation>
+		<annotation cp="🤾🏻">athletics | ball | catch | chuck | handball | hurl | light skin tone | lob | person | pitch | playing | sport | throw | toss</annotation>
+		<annotation cp="🤾🏻" type="tts">person playing handball: light skin tone</annotation>
+		<annotation cp="🤾🏼">athletics | ball | catch | chuck | handball | hurl | lob | medium-light skin tone | person | pitch | playing | sport | throw | toss</annotation>
+		<annotation cp="🤾🏼" type="tts">person playing handball: medium-light skin tone</annotation>
+		<annotation cp="🤾🏽">athletics | ball | catch | chuck | handball | hurl | lob | medium skin tone | person | pitch | playing | sport | throw | toss</annotation>
+		<annotation cp="🤾🏽" type="tts">person playing handball: medium skin tone</annotation>
+		<annotation cp="🤾🏾">athletics | ball | catch | chuck | handball | hurl | lob | medium-dark skin tone | person | pitch | playing | sport | throw | toss</annotation>
+		<annotation cp="🤾🏾" type="tts">person playing handball: medium-dark skin tone</annotation>
+		<annotation cp="🤾🏿">athletics | ball | catch | chuck | dark skin tone | handball | hurl | lob | person | pitch | playing | sport | throw | toss</annotation>
+		<annotation cp="🤾🏿" type="tts">person playing handball: dark skin tone</annotation>
+		<annotation cp="🤾🏻‍♂">athletics | ball | catch | chuck | handball | hurl | light skin tone | lob | man | pitch | playing | sport | throw | toss</annotation>
+		<annotation cp="🤾🏻‍♂" type="tts">man playing handball: light skin tone</annotation>
+		<annotation cp="🤾🏼‍♂">athletics | ball | catch | chuck | handball | hurl | lob | man | medium-light skin tone | pitch | playing | sport | throw | toss</annotation>
+		<annotation cp="🤾🏼‍♂" type="tts">man playing handball: medium-light skin tone</annotation>
+		<annotation cp="🤾🏽‍♂">athletics | ball | catch | chuck | handball | hurl | lob | man | medium skin tone | pitch | playing | sport | throw | toss</annotation>
+		<annotation cp="🤾🏽‍♂" type="tts">man playing handball: medium skin tone</annotation>
+		<annotation cp="🤾🏾‍♂">athletics | ball | catch | chuck | handball | hurl | lob | man | medium-dark skin tone | pitch | playing | sport | throw | toss</annotation>
+		<annotation cp="🤾🏾‍♂" type="tts">man playing handball: medium-dark skin tone</annotation>
+		<annotation cp="🤾🏿‍♂">athletics | ball | catch | chuck | dark skin tone | handball | hurl | lob | man | pitch | playing | sport | throw | toss</annotation>
+		<annotation cp="🤾🏿‍♂" type="tts">man playing handball: dark skin tone</annotation>
+		<annotation cp="🤾🏻‍♀">athletics | ball | catch | chuck | handball | hurl | light skin tone | lob | pitch | playing | sport | throw | toss | woman</annotation>
+		<annotation cp="🤾🏻‍♀" type="tts">woman playing handball: light skin tone</annotation>
+		<annotation cp="🤾🏼‍♀">athletics | ball | catch | chuck | handball | hurl | lob | medium-light skin tone | pitch | playing | sport | throw | toss | woman</annotation>
+		<annotation cp="🤾🏼‍♀" type="tts">woman playing handball: medium-light skin tone</annotation>
+		<annotation cp="🤾🏽‍♀">athletics | ball | catch | chuck | handball | hurl | lob | medium skin tone | pitch | playing | sport | throw | toss | woman</annotation>
+		<annotation cp="🤾🏽‍♀" type="tts">woman playing handball: medium skin tone</annotation>
+		<annotation cp="🤾🏾‍♀">athletics | ball | catch | chuck | handball | hurl | lob | medium-dark skin tone | pitch | playing | sport | throw | toss | woman</annotation>
+		<annotation cp="🤾🏾‍♀" type="tts">woman playing handball: medium-dark skin tone</annotation>
+		<annotation cp="🤾🏿‍♀">athletics | ball | catch | chuck | dark skin tone | handball | hurl | lob | pitch | playing | sport | throw | toss | woman</annotation>
+		<annotation cp="🤾🏿‍♀" type="tts">woman playing handball: dark skin tone</annotation>
+		<annotation cp="🤹🏻">act | balance | balancing | handle | juggle | juggling | light skin tone | manage | multitask | person | skill</annotation>
+		<annotation cp="🤹🏻" type="tts">person juggling: light skin tone</annotation>
+		<annotation cp="🤹🏼">act | balance | balancing | handle | juggle | juggling | manage | medium-light skin tone | multitask | person | skill</annotation>
+		<annotation cp="🤹🏼" type="tts">person juggling: medium-light skin tone</annotation>
+		<annotation cp="🤹🏽">act | balance | balancing | handle | juggle | juggling | manage | medium skin tone | multitask | person | skill</annotation>
+		<annotation cp="🤹🏽" type="tts">person juggling: medium skin tone</annotation>
+		<annotation cp="🤹🏾">act | balance | balancing | handle | juggle | juggling | manage | medium-dark skin tone | multitask | person | skill</annotation>
+		<annotation cp="🤹🏾" type="tts">person juggling: medium-dark skin tone</annotation>
+		<annotation cp="🤹🏿">act | balance | balancing | dark skin tone | handle | juggle | juggling | manage | multitask | person | skill</annotation>
+		<annotation cp="🤹🏿" type="tts">person juggling: dark skin tone</annotation>
+		<annotation cp="🤹🏻‍♂">act | balance | balancing | handle | juggle | juggling | light skin tone | man | manage | multitask | skill</annotation>
+		<annotation cp="🤹🏻‍♂" type="tts">man juggling: light skin tone</annotation>
+		<annotation cp="🤹🏼‍♂">act | balance | balancing | handle | juggle | juggling | man | manage | medium-light skin tone | multitask | skill</annotation>
+		<annotation cp="🤹🏼‍♂" type="tts">man juggling: medium-light skin tone</annotation>
+		<annotation cp="🤹🏽‍♂">act | balance | balancing | handle | juggle | juggling | man | manage | medium skin tone | multitask | skill</annotation>
+		<annotation cp="🤹🏽‍♂" type="tts">man juggling: medium skin tone</annotation>
+		<annotation cp="🤹🏾‍♂">act | balance | balancing | handle | juggle | juggling | man | manage | medium-dark skin tone | multitask | skill</annotation>
+		<annotation cp="🤹🏾‍♂" type="tts">man juggling: medium-dark skin tone</annotation>
+		<annotation cp="🤹🏿‍♂">act | balance | balancing | dark skin tone | handle | juggle | juggling | man | manage | multitask | skill</annotation>
+		<annotation cp="🤹🏿‍♂" type="tts">man juggling: dark skin tone</annotation>
+		<annotation cp="🤹🏻‍♀">act | balance | balancing | handle | juggle | juggling | light skin tone | manage | multitask | skill | woman</annotation>
+		<annotation cp="🤹🏻‍♀" type="tts">woman juggling: light skin tone</annotation>
+		<annotation cp="🤹🏼‍♀">act | balance | balancing | handle | juggle | juggling | manage | medium-light skin tone | multitask | skill | woman</annotation>
+		<annotation cp="🤹🏼‍♀" type="tts">woman juggling: medium-light skin tone</annotation>
+		<annotation cp="🤹🏽‍♀">act | balance | balancing | handle | juggle | juggling | manage | medium skin tone | multitask | skill | woman</annotation>
+		<annotation cp="🤹🏽‍♀" type="tts">woman juggling: medium skin tone</annotation>
+		<annotation cp="🤹🏾‍♀">act | balance | balancing | handle | juggle | juggling | manage | medium-dark skin tone | multitask | skill | woman</annotation>
+		<annotation cp="🤹🏾‍♀" type="tts">woman juggling: medium-dark skin tone</annotation>
+		<annotation cp="🤹🏿‍♀">act | balance | balancing | dark skin tone | handle | juggle | juggling | manage | multitask | skill | woman</annotation>
+		<annotation cp="🤹🏿‍♀" type="tts">woman juggling: dark skin tone</annotation>
+		<annotation cp="🧘🏻">cross | legged | legs | light skin tone | lotus | meditation | peace | person | position | relax | serenity | yoga | yogi | zen</annotation>
+		<annotation cp="🧘🏻" type="tts">person in lotus position: light skin tone</annotation>
+		<annotation cp="🧘🏼">cross | legged | legs | lotus | meditation | medium-light skin tone | peace | person | position | relax | serenity | yoga | yogi | zen</annotation>
+		<annotation cp="🧘🏼" type="tts">person in lotus position: medium-light skin tone</annotation>
+		<annotation cp="🧘🏽">cross | legged | legs | lotus | meditation | medium skin tone | peace | person | position | relax | serenity | yoga | yogi | zen</annotation>
+		<annotation cp="🧘🏽" type="tts">person in lotus position: medium skin tone</annotation>
+		<annotation cp="🧘🏾">cross | legged | legs | lotus | meditation | medium-dark skin tone | peace | person | position | relax | serenity | yoga | yogi | zen</annotation>
+		<annotation cp="🧘🏾" type="tts">person in lotus position: medium-dark skin tone</annotation>
+		<annotation cp="🧘🏿">cross | dark skin tone | legged | legs | lotus | meditation | peace | person | position | relax | serenity | yoga | yogi | zen</annotation>
+		<annotation cp="🧘🏿" type="tts">person in lotus position: dark skin tone</annotation>
+		<annotation cp="🧘🏻‍♂">cross | legged | legs | light skin tone | lotus | man | meditation | peace | position | relax | serenity | yoga | yogi | zen</annotation>
+		<annotation cp="🧘🏻‍♂" type="tts">man in lotus position: light skin tone</annotation>
+		<annotation cp="🧘🏼‍♂">cross | legged | legs | lotus | man | meditation | medium-light skin tone | peace | position | relax | serenity | yoga | yogi | zen</annotation>
+		<annotation cp="🧘🏼‍♂" type="tts">man in lotus position: medium-light skin tone</annotation>
+		<annotation cp="🧘🏽‍♂">cross | legged | legs | lotus | man | meditation | medium skin tone | peace | position | relax | serenity | yoga | yogi | zen</annotation>
+		<annotation cp="🧘🏽‍♂" type="tts">man in lotus position: medium skin tone</annotation>
+		<annotation cp="🧘🏾‍♂">cross | legged | legs | lotus | man | meditation | medium-dark skin tone | peace | position | relax | serenity | yoga | yogi | zen</annotation>
+		<annotation cp="🧘🏾‍♂" type="tts">man in lotus position: medium-dark skin tone</annotation>
+		<annotation cp="🧘🏿‍♂">cross | dark skin tone | legged | legs | lotus | man | meditation | peace | position | relax | serenity | yoga | yogi | zen</annotation>
+		<annotation cp="🧘🏿‍♂" type="tts">man in lotus position: dark skin tone</annotation>
+		<annotation cp="🧘🏻‍♀">cross | legged | legs | light skin tone | lotus | meditation | peace | position | relax | serenity | woman | yoga | yogi | zen</annotation>
+		<annotation cp="🧘🏻‍♀" type="tts">woman in lotus position: light skin tone</annotation>
+		<annotation cp="🧘🏼‍♀">cross | legged | legs | lotus | meditation | medium-light skin tone | peace | position | relax | serenity | woman | yoga | yogi | zen</annotation>
+		<annotation cp="🧘🏼‍♀" type="tts">woman in lotus position: medium-light skin tone</annotation>
+		<annotation cp="🧘🏽‍♀">cross | legged | legs | lotus | meditation | medium skin tone | peace | position | relax | serenity | woman | yoga | yogi | zen</annotation>
+		<annotation cp="🧘🏽‍♀" type="tts">woman in lotus position: medium skin tone</annotation>
+		<annotation cp="🧘🏾‍♀">cross | legged | legs | lotus | meditation | medium-dark skin tone | peace | position | relax | serenity | woman | yoga | yogi | zen</annotation>
+		<annotation cp="🧘🏾‍♀" type="tts">woman in lotus position: medium-dark skin tone</annotation>
+		<annotation cp="🧘🏿‍♀">cross | dark skin tone | legged | legs | lotus | meditation | peace | position | relax | serenity | woman | yoga | yogi | zen</annotation>
+		<annotation cp="🧘🏿‍♀" type="tts">woman in lotus position: dark skin tone</annotation>
+		<annotation cp="🛀🏻">bath | bathtub | light skin tone | person | taking | tub</annotation>
+		<annotation cp="🛀🏻" type="tts">person taking bath: light skin tone</annotation>
+		<annotation cp="🛀🏼">bath | bathtub | medium-light skin tone | person | taking | tub</annotation>
+		<annotation cp="🛀🏼" type="tts">person taking bath: medium-light skin tone</annotation>
+		<annotation cp="🛀🏽">bath | bathtub | medium skin tone | person | taking | tub</annotation>
+		<annotation cp="🛀🏽" type="tts">person taking bath: medium skin tone</annotation>
+		<annotation cp="🛀🏾">bath | bathtub | medium-dark skin tone | person | taking | tub</annotation>
+		<annotation cp="🛀🏾" type="tts">person taking bath: medium-dark skin tone</annotation>
+		<annotation cp="🛀🏿">bath | bathtub | dark skin tone | person | taking | tub</annotation>
+		<annotation cp="🛀🏿" type="tts">person taking bath: dark skin tone</annotation>
+		<annotation cp="🛌🏻">bed | bedtime | good | goodnight | hotel | light skin tone | nap | night | person | sleep | tired | zzz</annotation>
+		<annotation cp="🛌🏻" type="tts">person in bed: light skin tone</annotation>
+		<annotation cp="🛌🏼">bed | bedtime | good | goodnight | hotel | medium-light skin tone | nap | night | person | sleep | tired | zzz</annotation>
+		<annotation cp="🛌🏼" type="tts">person in bed: medium-light skin tone</annotation>
+		<annotation cp="🛌🏽">bed | bedtime | good | goodnight | hotel | medium skin tone | nap | night | person | sleep | tired | zzz</annotation>
+		<annotation cp="🛌🏽" type="tts">person in bed: medium skin tone</annotation>
+		<annotation cp="🛌🏾">bed | bedtime | good | goodnight | hotel | medium-dark skin tone | nap | night | person | sleep | tired | zzz</annotation>
+		<annotation cp="🛌🏾" type="tts">person in bed: medium-dark skin tone</annotation>
+		<annotation cp="🛌🏿">bed | bedtime | dark skin tone | good | goodnight | hotel | nap | night | person | sleep | tired | zzz</annotation>
+		<annotation cp="🛌🏿" type="tts">person in bed: dark skin tone</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏻">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | light skin tone | people | twins</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏻" type="tts">people holding hands: light skin tone</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏼">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | light skin tone | medium-light skin tone | people | twins</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏼" type="tts">people holding hands: light skin tone, medium-light skin tone</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏽">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | light skin tone | medium skin tone | people | twins</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏽" type="tts">people holding hands: light skin tone, medium skin tone</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏾">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | light skin tone | medium-dark skin tone | people | twins</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏾" type="tts">people holding hands: light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏿">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | light skin tone | people | twins</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏿" type="tts">people holding hands: light skin tone, dark skin tone</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏻">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | light skin tone | medium-light skin tone | people | twins</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏻" type="tts">people holding hands: medium-light skin tone, light skin tone</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏼">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | medium-light skin tone | people | twins</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏼" type="tts">people holding hands: medium-light skin tone</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏽">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | medium skin tone | medium-light skin tone | people | twins</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏽" type="tts">people holding hands: medium-light skin tone, medium skin tone</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏾">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | medium-dark skin tone | medium-light skin tone | people | twins</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏾" type="tts">people holding hands: medium-light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏿">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | medium-light skin tone | people | twins</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏿" type="tts">people holding hands: medium-light skin tone, dark skin tone</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏻">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | light skin tone | medium skin tone | people | twins</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏻" type="tts">people holding hands: medium skin tone, light skin tone</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏼">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | medium skin tone | medium-light skin tone | people | twins</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏼" type="tts">people holding hands: medium skin tone, medium-light skin tone</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏽">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | medium skin tone | people | twins</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏽" type="tts">people holding hands: medium skin tone</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏾">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | medium skin tone | medium-dark skin tone | people | twins</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏾" type="tts">people holding hands: medium skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏿">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | medium skin tone | people | twins</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏿" type="tts">people holding hands: medium skin tone, dark skin tone</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏻">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | light skin tone | medium-dark skin tone | people | twins</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏻" type="tts">people holding hands: medium-dark skin tone, light skin tone</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏼">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | medium-dark skin tone | medium-light skin tone | people | twins</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏼" type="tts">people holding hands: medium-dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏽">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | medium skin tone | medium-dark skin tone | people | twins</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏽" type="tts">people holding hands: medium-dark skin tone, medium skin tone</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏾">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | medium-dark skin tone | people | twins</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏾" type="tts">people holding hands: medium-dark skin tone</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏿">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | medium-dark skin tone | people | twins</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏿" type="tts">people holding hands: medium-dark skin tone, dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏻">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | light skin tone | people | twins</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏻" type="tts">people holding hands: dark skin tone, light skin tone</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏼">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | medium-light skin tone | people | twins</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏼" type="tts">people holding hands: dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏽">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | medium skin tone | people | twins</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏽" type="tts">people holding hands: dark skin tone, medium skin tone</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏾">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | medium-dark skin tone | people | twins</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏾" type="tts">people holding hands: dark skin tone, medium-dark skin tone</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏿">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | people | twins</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏿" type="tts">people holding hands: dark skin tone</annotation>
+		<annotation cp="👭🏻">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | light skin tone | sisters | twins | women</annotation>
+		<annotation cp="👭🏻" type="tts">women holding hands: light skin tone</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏼">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | light skin tone | medium-light skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏼" type="tts">women holding hands: light skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏽">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | light skin tone | medium skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏽" type="tts">women holding hands: light skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏾">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | light skin tone | medium-dark skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏾" type="tts">women holding hands: light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏿">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | girls | hand | hold | light skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏿" type="tts">women holding hands: light skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏻">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | light skin tone | medium-light skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏻" type="tts">women holding hands: medium-light skin tone, light skin tone</annotation>
+		<annotation cp="👭🏼">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | medium-light skin tone | sisters | twins | women</annotation>
+		<annotation cp="👭🏼" type="tts">women holding hands: medium-light skin tone</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏽">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | medium skin tone | medium-light skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏽" type="tts">women holding hands: medium-light skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏾">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | medium-dark skin tone | medium-light skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏾" type="tts">women holding hands: medium-light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏿">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | girls | hand | hold | medium-light skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏿" type="tts">women holding hands: medium-light skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏻">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | light skin tone | medium skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏻" type="tts">women holding hands: medium skin tone, light skin tone</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏼">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | medium skin tone | medium-light skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏼" type="tts">women holding hands: medium skin tone, medium-light skin tone</annotation>
+		<annotation cp="👭🏽">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | medium skin tone | sisters | twins | women</annotation>
+		<annotation cp="👭🏽" type="tts">women holding hands: medium skin tone</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏾">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | medium skin tone | medium-dark skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏾" type="tts">women holding hands: medium skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏿">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | girls | hand | hold | medium skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏿" type="tts">women holding hands: medium skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏻">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | light skin tone | medium-dark skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏻" type="tts">women holding hands: medium-dark skin tone, light skin tone</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏼">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | medium-dark skin tone | medium-light skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏼" type="tts">women holding hands: medium-dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏽">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | medium skin tone | medium-dark skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏽" type="tts">women holding hands: medium-dark skin tone, medium skin tone</annotation>
+		<annotation cp="👭🏾">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | medium-dark skin tone | sisters | twins | women</annotation>
+		<annotation cp="👭🏾" type="tts">women holding hands: medium-dark skin tone</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏿">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | girls | hand | hold | medium-dark skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏿" type="tts">women holding hands: medium-dark skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏻">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | girls | hand | hold | light skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏻" type="tts">women holding hands: dark skin tone, light skin tone</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏼">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | girls | hand | hold | medium-light skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏼" type="tts">women holding hands: dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏽">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | girls | hand | hold | medium skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏽" type="tts">women holding hands: dark skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏾">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | girls | hand | hold | medium-dark skin tone | sisters | twins | women</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏾" type="tts">women holding hands: dark skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👭🏿">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | girls | hand | hold | sisters | twins | women</annotation>
+		<annotation cp="👭🏿" type="tts">women holding hands: dark skin tone</annotation>
+		<annotation cp="👫🏻">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | light skin tone | man | twins | woman</annotation>
+		<annotation cp="👫🏻" type="tts">woman and man holding hands: light skin tone</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏼">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | light skin tone | man | medium-light skin tone | twins | woman</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏼" type="tts">woman and man holding hands: light skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏽">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | light skin tone | man | medium skin tone | twins | woman</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏽" type="tts">woman and man holding hands: light skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏾">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | light skin tone | man | medium-dark skin tone | twins | woman</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏾" type="tts">woman and man holding hands: light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏿">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | light skin tone | man | twins | woman</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏿" type="tts">woman and man holding hands: light skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏻">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | light skin tone | man | medium-light skin tone | twins | woman</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏻" type="tts">woman and man holding hands: medium-light skin tone, light skin tone</annotation>
+		<annotation cp="👫🏼">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | man | medium-light skin tone | twins | woman</annotation>
+		<annotation cp="👫🏼" type="tts">woman and man holding hands: medium-light skin tone</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏽">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | man | medium skin tone | medium-light skin tone | twins | woman</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏽" type="tts">woman and man holding hands: medium-light skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏾">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | man | medium-dark skin tone | medium-light skin tone | twins | woman</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏾" type="tts">woman and man holding hands: medium-light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏿">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | man | medium-light skin tone | twins | woman</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏿" type="tts">woman and man holding hands: medium-light skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏻">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | light skin tone | man | medium skin tone | twins | woman</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏻" type="tts">woman and man holding hands: medium skin tone, light skin tone</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏼">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | man | medium skin tone | medium-light skin tone | twins | woman</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏼" type="tts">woman and man holding hands: medium skin tone, medium-light skin tone</annotation>
+		<annotation cp="👫🏽">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | man | medium skin tone | twins | woman</annotation>
+		<annotation cp="👫🏽" type="tts">woman and man holding hands: medium skin tone</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏾">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | man | medium skin tone | medium-dark skin tone | twins | woman</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏾" type="tts">woman and man holding hands: medium skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏿">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | man | medium skin tone | twins | woman</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏿" type="tts">woman and man holding hands: medium skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏻">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | light skin tone | man | medium-dark skin tone | twins | woman</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏻" type="tts">woman and man holding hands: medium-dark skin tone, light skin tone</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏼">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | man | medium-dark skin tone | medium-light skin tone | twins | woman</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏼" type="tts">woman and man holding hands: medium-dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏽">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | man | medium skin tone | medium-dark skin tone | twins | woman</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏽" type="tts">woman and man holding hands: medium-dark skin tone, medium skin tone</annotation>
+		<annotation cp="👫🏾">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | man | medium-dark skin tone | twins | woman</annotation>
+		<annotation cp="👫🏾" type="tts">woman and man holding hands: medium-dark skin tone</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏿">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | man | medium-dark skin tone | twins | woman</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏿" type="tts">woman and man holding hands: medium-dark skin tone, dark skin tone</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏻">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | light skin tone | man | twins | woman</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏻" type="tts">woman and man holding hands: dark skin tone, light skin tone</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏼">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | man | medium-light skin tone | twins | woman</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏼" type="tts">woman and man holding hands: dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏽">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | man | medium skin tone | twins | woman</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏽" type="tts">woman and man holding hands: dark skin tone, medium skin tone</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏾">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | man | medium-dark skin tone | twins | woman</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏾" type="tts">woman and man holding hands: dark skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👫🏿">bae | bestie | bff | couple | dark skin tone | dating | flirt | friends | hand | hold | man | twins | woman</annotation>
+		<annotation cp="👫🏿" type="tts">woman and man holding hands: dark skin tone</annotation>
+		<annotation cp="👬🏻">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | light skin tone | men | twins</annotation>
+		<annotation cp="👬🏻" type="tts">men holding hands: light skin tone</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏼">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | light skin tone | medium-light skin tone | men | twins</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏼" type="tts">men holding hands: light skin tone, medium-light skin tone</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏽">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | light skin tone | medium skin tone | men | twins</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏽" type="tts">men holding hands: light skin tone, medium skin tone</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏾">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | light skin tone | medium-dark skin tone | men | twins</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏾" type="tts">men holding hands: light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏿">bae | bestie | bff | boys | brothers | couple | dark skin tone | dating | flirt | friends | hand | hold | light skin tone | men | twins</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏿" type="tts">men holding hands: light skin tone, dark skin tone</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏻">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | light skin tone | medium-light skin tone | men | twins</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏻" type="tts">men holding hands: medium-light skin tone, light skin tone</annotation>
+		<annotation cp="👬🏼">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | medium-light skin tone | men | twins</annotation>
+		<annotation cp="👬🏼" type="tts">men holding hands: medium-light skin tone</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏽">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | medium skin tone | medium-light skin tone | men | twins</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏽" type="tts">men holding hands: medium-light skin tone, medium skin tone</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏾">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | medium-dark skin tone | medium-light skin tone | men | twins</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏾" type="tts">men holding hands: medium-light skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏿">bae | bestie | bff | boys | brothers | couple | dark skin tone | dating | flirt | friends | hand | hold | medium-light skin tone | men | twins</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏿" type="tts">men holding hands: medium-light skin tone, dark skin tone</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏻">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | light skin tone | medium skin tone | men | twins</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏻" type="tts">men holding hands: medium skin tone, light skin tone</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏼">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | medium skin tone | medium-light skin tone | men | twins</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏼" type="tts">men holding hands: medium skin tone, medium-light skin tone</annotation>
+		<annotation cp="👬🏽">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | medium skin tone | men | twins</annotation>
+		<annotation cp="👬🏽" type="tts">men holding hands: medium skin tone</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏾">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | medium skin tone | medium-dark skin tone | men | twins</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏾" type="tts">men holding hands: medium skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏿">bae | bestie | bff | boys | brothers | couple | dark skin tone | dating | flirt | friends | hand | hold | medium skin tone | men | twins</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏿" type="tts">men holding hands: medium skin tone, dark skin tone</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏻">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | light skin tone | medium-dark skin tone | men | twins</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏻" type="tts">men holding hands: medium-dark skin tone, light skin tone</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏼">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | medium-dark skin tone | medium-light skin tone | men | twins</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏼" type="tts">men holding hands: medium-dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏽">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | medium skin tone | medium-dark skin tone | men | twins</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏽" type="tts">men holding hands: medium-dark skin tone, medium skin tone</annotation>
+		<annotation cp="👬🏾">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | medium-dark skin tone | men | twins</annotation>
+		<annotation cp="👬🏾" type="tts">men holding hands: medium-dark skin tone</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏿">bae | bestie | bff | boys | brothers | couple | dark skin tone | dating | flirt | friends | hand | hold | medium-dark skin tone | men | twins</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏿" type="tts">men holding hands: medium-dark skin tone, dark skin tone</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏻">bae | bestie | bff | boys | brothers | couple | dark skin tone | dating | flirt | friends | hand | hold | light skin tone | men | twins</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏻" type="tts">men holding hands: dark skin tone, light skin tone</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏼">bae | bestie | bff | boys | brothers | couple | dark skin tone | dating | flirt | friends | hand | hold | medium-light skin tone | men | twins</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏼" type="tts">men holding hands: dark skin tone, medium-light skin tone</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏽">bae | bestie | bff | boys | brothers | couple | dark skin tone | dating | flirt | friends | hand | hold | medium skin tone | men | twins</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏽" type="tts">men holding hands: dark skin tone, medium skin tone</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏾">bae | bestie | bff | boys | brothers | couple | dark skin tone | dating | flirt | friends | hand | hold | medium-dark skin tone | men | twins</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏾" type="tts">men holding hands: dark skin tone, medium-dark skin tone</annotation>
+		<annotation cp="👬🏿">bae | bestie | bff | boys | brothers | couple | dark skin tone | dating | flirt | friends | hand | hold | men | twins</annotation>
+		<annotation cp="👬🏿" type="tts">men holding hands: dark skin tone</annotation>
+		<annotation cp="💏🏻">anniversary | babe | bae | couple | date | dating | heart | kiss | light skin tone | love | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="💏🏻" type="tts">kiss: light skin tone</annotation>
+		<annotation cp="💏🏼">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium-light skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="💏🏼" type="tts">kiss: medium-light skin tone</annotation>
+		<annotation cp="💏🏽">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="💏🏽" type="tts">kiss: medium skin tone</annotation>
+		<annotation cp="💏🏾">anniversary | babe | bae | couple | date | dating | heart | kiss | love | medium-dark skin tone | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="💏🏾" type="tts">kiss: medium-dark skin tone</annotation>
+		<annotation cp="💏🏿">anniversary | babe | bae | couple | dark skin tone | date | dating | heart | kiss | love | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="💏🏿" type="tts">kiss: dark skin tone</annotation>
+		<annotation cp="👩‍❤‍💋‍👨">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩‍❤‍💋‍👨" type="tts">kiss: woman, man</annotation>
+		<annotation cp="👨‍❤‍💋‍👨">anniversary | babe | bae | couple | date | dating | heart | kiss | love | man | mwah | person | romance | together | xoxo</annotation>
+		<annotation cp="👨‍❤‍💋‍👨" type="tts">kiss: man, man</annotation>
+		<annotation cp="👩‍❤‍💋‍👩">anniversary | babe | bae | couple | date | dating | heart | kiss | love | mwah | person | romance | together | woman | xoxo</annotation>
+		<annotation cp="👩‍❤‍💋‍👩" type="tts">kiss: woman, woman</annotation>
+		<annotation cp="💑🏻">anniversary | babe | bae | couple | dating | heart | kiss | light skin tone | love | person | relationship | romance | together | you</annotation>
+		<annotation cp="💑🏻" type="tts">couple with heart: light skin tone</annotation>
+		<annotation cp="💑🏼">anniversary | babe | bae | couple | dating | heart | kiss | love | medium-light skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="💑🏼" type="tts">couple with heart: medium-light skin tone</annotation>
+		<annotation cp="💑🏽">anniversary | babe | bae | couple | dating | heart | kiss | love | medium skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="💑🏽" type="tts">couple with heart: medium skin tone</annotation>
+		<annotation cp="💑🏾">anniversary | babe | bae | couple | dating | heart | kiss | love | medium-dark skin tone | person | relationship | romance | together | you</annotation>
+		<annotation cp="💑🏾" type="tts">couple with heart: medium-dark skin tone</annotation>
+		<annotation cp="💑🏿">anniversary | babe | bae | couple | dark skin tone | dating | heart | kiss | love | person | relationship | romance | together | you</annotation>
+		<annotation cp="💑🏿" type="tts">couple with heart: dark skin tone</annotation>
+		<annotation cp="👩‍❤‍👨">anniversary | babe | bae | couple | dating | heart | kiss | love | man | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩‍❤‍👨" type="tts">couple with heart: woman, man</annotation>
+		<annotation cp="👨‍❤‍👨">anniversary | babe | bae | couple | dating | heart | kiss | love | man | person | relationship | romance | together | you</annotation>
+		<annotation cp="👨‍❤‍👨" type="tts">couple with heart: man, man</annotation>
+		<annotation cp="👩‍❤‍👩">anniversary | babe | bae | couple | dating | heart | kiss | love | person | relationship | romance | together | woman | you</annotation>
+		<annotation cp="👩‍❤‍👩" type="tts">couple with heart: woman, woman</annotation>
+		<annotation cp="👨‍👩‍👦">boy | child | family | man | woman</annotation>
+		<annotation cp="👨‍👩‍👦" type="tts">family: man, woman, boy</annotation>
+		<annotation cp="👨‍👩‍👧">child | family | girl | man | woman</annotation>
+		<annotation cp="👨‍👩‍👧" type="tts">family: man, woman, girl</annotation>
+		<annotation cp="👨‍👩‍👧‍👦">boy | child | family | girl | man | woman</annotation>
+		<annotation cp="👨‍👩‍👧‍👦" type="tts">family: man, woman, girl, boy</annotation>
+		<annotation cp="👨‍👩‍👦‍👦">boy | child | family | man | woman</annotation>
+		<annotation cp="👨‍👩‍👦‍👦" type="tts">family: man, woman, boy, boy</annotation>
+		<annotation cp="👨‍👩‍👧‍👧">child | family | girl | man | woman</annotation>
+		<annotation cp="👨‍👩‍👧‍👧" type="tts">family: man, woman, girl, girl</annotation>
+		<annotation cp="👨‍👨‍👦">boy | child | family | man</annotation>
+		<annotation cp="👨‍👨‍👦" type="tts">family: man, man, boy</annotation>
+		<annotation cp="👨‍👨‍👧">child | family | girl | man</annotation>
+		<annotation cp="👨‍👨‍👧" type="tts">family: man, man, girl</annotation>
+		<annotation cp="👨‍👨‍👧‍👦">boy | child | family | girl | man</annotation>
+		<annotation cp="👨‍👨‍👧‍👦" type="tts">family: man, man, girl, boy</annotation>
+		<annotation cp="👨‍👨‍👦‍👦">boy | child | family | man</annotation>
+		<annotation cp="👨‍👨‍👦‍👦" type="tts">family: man, man, boy, boy</annotation>
+		<annotation cp="👨‍👨‍👧‍👧">child | family | girl | man</annotation>
+		<annotation cp="👨‍👨‍👧‍👧" type="tts">family: man, man, girl, girl</annotation>
+		<annotation cp="👩‍👩‍👦">boy | child | family | woman</annotation>
+		<annotation cp="👩‍👩‍👦" type="tts">family: woman, woman, boy</annotation>
+		<annotation cp="👩‍👩‍👧">child | family | girl | woman</annotation>
+		<annotation cp="👩‍👩‍👧" type="tts">family: woman, woman, girl</annotation>
+		<annotation cp="👩‍👩‍👧‍👦">boy | child | family | girl | woman</annotation>
+		<annotation cp="👩‍👩‍👧‍👦" type="tts">family: woman, woman, girl, boy</annotation>
+		<annotation cp="👩‍👩‍👦‍👦">boy | child | family | woman</annotation>
+		<annotation cp="👩‍👩‍👦‍👦" type="tts">family: woman, woman, boy, boy</annotation>
+		<annotation cp="👩‍👩‍👧‍👧">child | family | girl | woman</annotation>
+		<annotation cp="👩‍👩‍👧‍👧" type="tts">family: woman, woman, girl, girl</annotation>
+		<annotation cp="👨‍👦">boy | child | family | man</annotation>
+		<annotation cp="👨‍👦" type="tts">family: man, boy</annotation>
+		<annotation cp="👨‍👦‍👦">boy | child | family | man</annotation>
+		<annotation cp="👨‍👦‍👦" type="tts">family: man, boy, boy</annotation>
+		<annotation cp="👨‍👧">child | family | girl | man</annotation>
+		<annotation cp="👨‍👧" type="tts">family: man, girl</annotation>
+		<annotation cp="👨‍👧‍👦">boy | child | family | girl | man</annotation>
+		<annotation cp="👨‍👧‍👦" type="tts">family: man, girl, boy</annotation>
+		<annotation cp="👨‍👧‍👧">child | family | girl | man</annotation>
+		<annotation cp="👨‍👧‍👧" type="tts">family: man, girl, girl</annotation>
+		<annotation cp="👩‍👦">boy | child | family | woman</annotation>
+		<annotation cp="👩‍👦" type="tts">family: woman, boy</annotation>
+		<annotation cp="👩‍👦‍👦">boy | child | family | woman</annotation>
+		<annotation cp="👩‍👦‍👦" type="tts">family: woman, boy, boy</annotation>
+		<annotation cp="👩‍👧">child | family | girl | woman</annotation>
+		<annotation cp="👩‍👧" type="tts">family: woman, girl</annotation>
+		<annotation cp="👩‍👧‍👦">boy | child | family | girl | woman</annotation>
+		<annotation cp="👩‍👧‍👦" type="tts">family: woman, girl, boy</annotation>
+		<annotation cp="👩‍👧‍👧">child | family | girl | woman</annotation>
+		<annotation cp="👩‍👧‍👧" type="tts">family: woman, girl, girl</annotation>
+		<annotation cp="#⃣">keycap</annotation>
+		<annotation cp="#⃣" type="tts">keycap: #</annotation>
+		<annotation cp="*⃣">keycap</annotation>
+		<annotation cp="*⃣" type="tts">keycap: *</annotation>
+		<annotation cp="🔟">keycap</annotation>
+		<annotation cp="🔟" type="tts">keycap: 10</annotation>
+		<annotation cp="🇦🇨">flag</annotation>
+		<annotation cp="🇦🇨" type="tts">flag: Ascension Island</annotation>
+		<annotation cp="🇦🇩">flag</annotation>
+		<annotation cp="🇦🇩" type="tts">flag: Andorra</annotation>
+		<annotation cp="🇦🇪">flag</annotation>
+		<annotation cp="🇦🇪" type="tts">flag: United Arab Emirates</annotation>
+		<annotation cp="🇦🇫">flag</annotation>
+		<annotation cp="🇦🇫" type="tts">flag: Afghanistan</annotation>
+		<annotation cp="🇦🇬">flag</annotation>
+		<annotation cp="🇦🇬" type="tts">flag: Antigua &amp; Barbuda</annotation>
+		<annotation cp="🇦🇮">flag</annotation>
+		<annotation cp="🇦🇮" type="tts">flag: Anguilla</annotation>
+		<annotation cp="🇦🇱">flag</annotation>
+		<annotation cp="🇦🇱" type="tts">flag: Albania</annotation>
+		<annotation cp="🇦🇲">flag</annotation>
+		<annotation cp="🇦🇲" type="tts">flag: Armenia</annotation>
+		<annotation cp="🇦🇴">flag</annotation>
+		<annotation cp="🇦🇴" type="tts">flag: Angola</annotation>
+		<annotation cp="🇦🇶">flag</annotation>
+		<annotation cp="🇦🇶" type="tts">flag: Antarctica</annotation>
+		<annotation cp="🇦🇷">flag</annotation>
+		<annotation cp="🇦🇷" type="tts">flag: Argentina</annotation>
+		<annotation cp="🇦🇸">flag</annotation>
+		<annotation cp="🇦🇸" type="tts">flag: American Samoa</annotation>
+		<annotation cp="🇦🇹">flag</annotation>
+		<annotation cp="🇦🇹" type="tts">flag: Austria</annotation>
+		<annotation cp="🇦🇺">flag</annotation>
+		<annotation cp="🇦🇺" type="tts">flag: Australia</annotation>
+		<annotation cp="🇦🇼">flag</annotation>
+		<annotation cp="🇦🇼" type="tts">flag: Aruba</annotation>
+		<annotation cp="🇦🇽">flag</annotation>
+		<annotation cp="🇦🇽" type="tts">flag: Åland Islands</annotation>
+		<annotation cp="🇦🇿">flag</annotation>
+		<annotation cp="🇦🇿" type="tts">flag: Azerbaijan</annotation>
+		<annotation cp="🇧🇦">flag</annotation>
+		<annotation cp="🇧🇦" type="tts">flag: Bosnia &amp; Herzegovina</annotation>
+		<annotation cp="🇧🇧">flag</annotation>
+		<annotation cp="🇧🇧" type="tts">flag: Barbados</annotation>
+		<annotation cp="🇧🇩">flag</annotation>
+		<annotation cp="🇧🇩" type="tts">flag: Bangladesh</annotation>
+		<annotation cp="🇧🇪">flag</annotation>
+		<annotation cp="🇧🇪" type="tts">flag: Belgium</annotation>
+		<annotation cp="🇧🇫">flag</annotation>
+		<annotation cp="🇧🇫" type="tts">flag: Burkina Faso</annotation>
+		<annotation cp="🇧🇬">flag</annotation>
+		<annotation cp="🇧🇬" type="tts">flag: Bulgaria</annotation>
+		<annotation cp="🇧🇭">flag</annotation>
+		<annotation cp="🇧🇭" type="tts">flag: Bahrain</annotation>
+		<annotation cp="🇧🇮">flag</annotation>
+		<annotation cp="🇧🇮" type="tts">flag: Burundi</annotation>
+		<annotation cp="🇧🇯">flag</annotation>
+		<annotation cp="🇧🇯" type="tts">flag: Benin</annotation>
+		<annotation cp="🇧🇱">flag</annotation>
+		<annotation cp="🇧🇱" type="tts">flag: St. Barthélemy</annotation>
+		<annotation cp="🇧🇲">flag</annotation>
+		<annotation cp="🇧🇲" type="tts">flag: Bermuda</annotation>
+		<annotation cp="🇧🇳">flag</annotation>
+		<annotation cp="🇧🇳" type="tts">flag: Brunei</annotation>
+		<annotation cp="🇧🇴">flag</annotation>
+		<annotation cp="🇧🇴" type="tts">flag: Bolivia</annotation>
+		<annotation cp="🇧🇶">flag</annotation>
+		<annotation cp="🇧🇶" type="tts">flag: Caribbean Netherlands</annotation>
+		<annotation cp="🇧🇷">flag</annotation>
+		<annotation cp="🇧🇷" type="tts">flag: Brazil</annotation>
+		<annotation cp="🇧🇸">flag</annotation>
+		<annotation cp="🇧🇸" type="tts">flag: Bahamas</annotation>
+		<annotation cp="🇧🇹">flag</annotation>
+		<annotation cp="🇧🇹" type="tts">flag: Bhutan</annotation>
+		<annotation cp="🇧🇻">flag</annotation>
+		<annotation cp="🇧🇻" type="tts">flag: Bouvet Island</annotation>
+		<annotation cp="🇧🇼">flag</annotation>
+		<annotation cp="🇧🇼" type="tts">flag: Botswana</annotation>
+		<annotation cp="🇧🇾">flag</annotation>
+		<annotation cp="🇧🇾" type="tts">flag: Belarus</annotation>
+		<annotation cp="🇧🇿">flag</annotation>
+		<annotation cp="🇧🇿" type="tts">flag: Belize</annotation>
+		<annotation cp="🇨🇦">flag</annotation>
+		<annotation cp="🇨🇦" type="tts">flag: Canada</annotation>
+		<annotation cp="🇨🇨">flag</annotation>
+		<annotation cp="🇨🇨" type="tts">flag: Cocos (Keeling) Islands</annotation>
+		<annotation cp="🇨🇩">flag</annotation>
+		<annotation cp="🇨🇩" type="tts">flag: Congo - Kinshasa</annotation>
+		<annotation cp="🇨🇫">flag</annotation>
+		<annotation cp="🇨🇫" type="tts">flag: Central African Republic</annotation>
+		<annotation cp="🇨🇬">flag</annotation>
+		<annotation cp="🇨🇬" type="tts">flag: Congo - Brazzaville</annotation>
+		<annotation cp="🇨🇭">flag</annotation>
+		<annotation cp="🇨🇭" type="tts">flag: Switzerland</annotation>
+		<annotation cp="🇨🇮">flag</annotation>
+		<annotation cp="🇨🇮" type="tts">flag: Côte d’Ivoire</annotation>
+		<annotation cp="🇨🇰">flag</annotation>
+		<annotation cp="🇨🇰" type="tts">flag: Cook Islands</annotation>
+		<annotation cp="🇨🇱">flag</annotation>
+		<annotation cp="🇨🇱" type="tts">flag: Chile</annotation>
+		<annotation cp="🇨🇲">flag</annotation>
+		<annotation cp="🇨🇲" type="tts">flag: Cameroon</annotation>
+		<annotation cp="🇨🇳">flag</annotation>
+		<annotation cp="🇨🇳" type="tts">flag: China</annotation>
+		<annotation cp="🇨🇴">flag</annotation>
+		<annotation cp="🇨🇴" type="tts">flag: Colombia</annotation>
+		<annotation cp="🇨🇵">flag</annotation>
+		<annotation cp="🇨🇵" type="tts">flag: Clipperton Island</annotation>
+		<annotation cp="🇨🇶">flag</annotation>
+		<annotation cp="🇨🇶" type="tts">flag: Sark</annotation>
+		<annotation cp="🇨🇷">flag</annotation>
+		<annotation cp="🇨🇷" type="tts">flag: Costa Rica</annotation>
+		<annotation cp="🇨🇺">flag</annotation>
+		<annotation cp="🇨🇺" type="tts">flag: Cuba</annotation>
+		<annotation cp="🇨🇻">flag</annotation>
+		<annotation cp="🇨🇻" type="tts">flag: Cape Verde</annotation>
+		<annotation cp="🇨🇼">flag</annotation>
+		<annotation cp="🇨🇼" type="tts">flag: Curaçao</annotation>
+		<annotation cp="🇨🇽">flag</annotation>
+		<annotation cp="🇨🇽" type="tts">flag: Christmas Island</annotation>
+		<annotation cp="🇨🇾">flag</annotation>
+		<annotation cp="🇨🇾" type="tts">flag: Cyprus</annotation>
+		<annotation cp="🇨🇿">flag</annotation>
+		<annotation cp="🇨🇿" type="tts">flag: Czechia</annotation>
+		<annotation cp="🇩🇪">flag</annotation>
+		<annotation cp="🇩🇪" type="tts">flag: Germany</annotation>
+		<annotation cp="🇩🇬">flag</annotation>
+		<annotation cp="🇩🇬" type="tts">flag: Diego Garcia</annotation>
+		<annotation cp="🇩🇯">flag</annotation>
+		<annotation cp="🇩🇯" type="tts">flag: Djibouti</annotation>
+		<annotation cp="🇩🇰">flag</annotation>
+		<annotation cp="🇩🇰" type="tts">flag: Denmark</annotation>
+		<annotation cp="🇩🇲">flag</annotation>
+		<annotation cp="🇩🇲" type="tts">flag: Dominica</annotation>
+		<annotation cp="🇩🇴">flag</annotation>
+		<annotation cp="🇩🇴" type="tts">flag: Dominican Republic</annotation>
+		<annotation cp="🇩🇿">flag</annotation>
+		<annotation cp="🇩🇿" type="tts">flag: Algeria</annotation>
+		<annotation cp="🇪🇦">flag</annotation>
+		<annotation cp="🇪🇦" type="tts">flag: Ceuta &amp; Melilla</annotation>
+		<annotation cp="🇪🇨">flag</annotation>
+		<annotation cp="🇪🇨" type="tts">flag: Ecuador</annotation>
+		<annotation cp="🇪🇪">flag</annotation>
+		<annotation cp="🇪🇪" type="tts">flag: Estonia</annotation>
+		<annotation cp="🇪🇬">flag</annotation>
+		<annotation cp="🇪🇬" type="tts">flag: Egypt</annotation>
+		<annotation cp="🇪🇭">flag</annotation>
+		<annotation cp="🇪🇭" type="tts">flag: Western Sahara</annotation>
+		<annotation cp="🇪🇷">flag</annotation>
+		<annotation cp="🇪🇷" type="tts">flag: Eritrea</annotation>
+		<annotation cp="🇪🇸">flag</annotation>
+		<annotation cp="🇪🇸" type="tts">flag: Spain</annotation>
+		<annotation cp="🇪🇹">flag</annotation>
+		<annotation cp="🇪🇹" type="tts">flag: Ethiopia</annotation>
+		<annotation cp="🇪🇺">flag</annotation>
+		<annotation cp="🇪🇺" type="tts">flag: European Union</annotation>
+		<annotation cp="🇫🇮">flag</annotation>
+		<annotation cp="🇫🇮" type="tts">flag: Finland</annotation>
+		<annotation cp="🇫🇯">flag</annotation>
+		<annotation cp="🇫🇯" type="tts">flag: Fiji</annotation>
+		<annotation cp="🇫🇰">flag</annotation>
+		<annotation cp="🇫🇰" type="tts">flag: Falkland Islands</annotation>
+		<annotation cp="🇫🇲">flag</annotation>
+		<annotation cp="🇫🇲" type="tts">flag: Micronesia</annotation>
+		<annotation cp="🇫🇴">flag</annotation>
+		<annotation cp="🇫🇴" type="tts">flag: Faroe Islands</annotation>
+		<annotation cp="🇫🇷">flag</annotation>
+		<annotation cp="🇫🇷" type="tts">flag: France</annotation>
+		<annotation cp="🇬🇦">flag</annotation>
+		<annotation cp="🇬🇦" type="tts">flag: Gabon</annotation>
+		<annotation cp="🇬🇧">flag</annotation>
+		<annotation cp="🇬🇧" type="tts">flag: United Kingdom</annotation>
+		<annotation cp="🇬🇩">flag</annotation>
+		<annotation cp="🇬🇩" type="tts">flag: Grenada</annotation>
+		<annotation cp="🇬🇪">flag</annotation>
+		<annotation cp="🇬🇪" type="tts">flag: Georgia</annotation>
+		<annotation cp="🇬🇫">flag</annotation>
+		<annotation cp="🇬🇫" type="tts">flag: French Guiana</annotation>
+		<annotation cp="🇬🇬">flag</annotation>
+		<annotation cp="🇬🇬" type="tts">flag: Guernsey</annotation>
+		<annotation cp="🇬🇭">flag</annotation>
+		<annotation cp="🇬🇭" type="tts">flag: Ghana</annotation>
+		<annotation cp="🇬🇮">flag</annotation>
+		<annotation cp="🇬🇮" type="tts">flag: Gibraltar</annotation>
+		<annotation cp="🇬🇱">flag</annotation>
+		<annotation cp="🇬🇱" type="tts">flag: Greenland</annotation>
+		<annotation cp="🇬🇲">flag</annotation>
+		<annotation cp="🇬🇲" type="tts">flag: Gambia</annotation>
+		<annotation cp="🇬🇳">flag</annotation>
+		<annotation cp="🇬🇳" type="tts">flag: Guinea</annotation>
+		<annotation cp="🇬🇵">flag</annotation>
+		<annotation cp="🇬🇵" type="tts">flag: Guadeloupe</annotation>
+		<annotation cp="🇬🇶">flag</annotation>
+		<annotation cp="🇬🇶" type="tts">flag: Equatorial Guinea</annotation>
+		<annotation cp="🇬🇷">flag</annotation>
+		<annotation cp="🇬🇷" type="tts">flag: Greece</annotation>
+		<annotation cp="🇬🇸">flag</annotation>
+		<annotation cp="🇬🇸" type="tts">flag: South Georgia &amp; South Sandwich Islands</annotation>
+		<annotation cp="🇬🇹">flag</annotation>
+		<annotation cp="🇬🇹" type="tts">flag: Guatemala</annotation>
+		<annotation cp="🇬🇺">flag</annotation>
+		<annotation cp="🇬🇺" type="tts">flag: Guam</annotation>
+		<annotation cp="🇬🇼">flag</annotation>
+		<annotation cp="🇬🇼" type="tts">flag: Guinea-Bissau</annotation>
+		<annotation cp="🇬🇾">flag</annotation>
+		<annotation cp="🇬🇾" type="tts">flag: Guyana</annotation>
+		<annotation cp="🇭🇰">flag</annotation>
+		<annotation cp="🇭🇰" type="tts">flag: Hong Kong SAR China</annotation>
+		<annotation cp="🇭🇲">flag</annotation>
+		<annotation cp="🇭🇲" type="tts">flag: Heard &amp; McDonald Islands</annotation>
+		<annotation cp="🇭🇳">flag</annotation>
+		<annotation cp="🇭🇳" type="tts">flag: Honduras</annotation>
+		<annotation cp="🇭🇷">flag</annotation>
+		<annotation cp="🇭🇷" type="tts">flag: Croatia</annotation>
+		<annotation cp="🇭🇹">flag</annotation>
+		<annotation cp="🇭🇹" type="tts">flag: Haiti</annotation>
+		<annotation cp="🇭🇺">flag</annotation>
+		<annotation cp="🇭🇺" type="tts">flag: Hungary</annotation>
+		<annotation cp="🇮🇨">flag</annotation>
+		<annotation cp="🇮🇨" type="tts">flag: Canary Islands</annotation>
+		<annotation cp="🇮🇩">flag</annotation>
+		<annotation cp="🇮🇩" type="tts">flag: Indonesia</annotation>
+		<annotation cp="🇮🇪">flag</annotation>
+		<annotation cp="🇮🇪" type="tts">flag: Ireland</annotation>
+		<annotation cp="🇮🇱">flag</annotation>
+		<annotation cp="🇮🇱" type="tts">flag: Israel</annotation>
+		<annotation cp="🇮🇲">flag</annotation>
+		<annotation cp="🇮🇲" type="tts">flag: Isle of Man</annotation>
+		<annotation cp="🇮🇳">flag</annotation>
+		<annotation cp="🇮🇳" type="tts">flag: India</annotation>
+		<annotation cp="🇮🇴">flag</annotation>
+		<annotation cp="🇮🇴" type="tts">flag: British Indian Ocean Territory</annotation>
+		<annotation cp="🇮🇶">flag</annotation>
+		<annotation cp="🇮🇶" type="tts">flag: Iraq</annotation>
+		<annotation cp="🇮🇷">flag</annotation>
+		<annotation cp="🇮🇷" type="tts">flag: Iran</annotation>
+		<annotation cp="🇮🇸">flag</annotation>
+		<annotation cp="🇮🇸" type="tts">flag: Iceland</annotation>
+		<annotation cp="🇮🇹">flag</annotation>
+		<annotation cp="🇮🇹" type="tts">flag: Italy</annotation>
+		<annotation cp="🇯🇪">flag</annotation>
+		<annotation cp="🇯🇪" type="tts">flag: Jersey</annotation>
+		<annotation cp="🇯🇲">flag</annotation>
+		<annotation cp="🇯🇲" type="tts">flag: Jamaica</annotation>
+		<annotation cp="🇯🇴">flag</annotation>
+		<annotation cp="🇯🇴" type="tts">flag: Jordan</annotation>
+		<annotation cp="🇯🇵">flag</annotation>
+		<annotation cp="🇯🇵" type="tts">flag: Japan</annotation>
+		<annotation cp="🇰🇪">flag</annotation>
+		<annotation cp="🇰🇪" type="tts">flag: Kenya</annotation>
+		<annotation cp="🇰🇬">flag</annotation>
+		<annotation cp="🇰🇬" type="tts">flag: Kyrgyzstan</annotation>
+		<annotation cp="🇰🇭">flag</annotation>
+		<annotation cp="🇰🇭" type="tts">flag: Cambodia</annotation>
+		<annotation cp="🇰🇮">flag</annotation>
+		<annotation cp="🇰🇮" type="tts">flag: Kiribati</annotation>
+		<annotation cp="🇰🇲">flag</annotation>
+		<annotation cp="🇰🇲" type="tts">flag: Comoros</annotation>
+		<annotation cp="🇰🇳">flag</annotation>
+		<annotation cp="🇰🇳" type="tts">flag: St. Kitts &amp; Nevis</annotation>
+		<annotation cp="🇰🇵">flag</annotation>
+		<annotation cp="🇰🇵" type="tts">flag: North Korea</annotation>
+		<annotation cp="🇰🇷">flag</annotation>
+		<annotation cp="🇰🇷" type="tts">flag: South Korea</annotation>
+		<annotation cp="🇰🇼">flag</annotation>
+		<annotation cp="🇰🇼" type="tts">flag: Kuwait</annotation>
+		<annotation cp="🇰🇾">flag</annotation>
+		<annotation cp="🇰🇾" type="tts">flag: Cayman Islands</annotation>
+		<annotation cp="🇰🇿">flag</annotation>
+		<annotation cp="🇰🇿" type="tts">flag: Kazakhstan</annotation>
+		<annotation cp="🇱🇦">flag</annotation>
+		<annotation cp="🇱🇦" type="tts">flag: Laos</annotation>
+		<annotation cp="🇱🇧">flag</annotation>
+		<annotation cp="🇱🇧" type="tts">flag: Lebanon</annotation>
+		<annotation cp="🇱🇨">flag</annotation>
+		<annotation cp="🇱🇨" type="tts">flag: St. Lucia</annotation>
+		<annotation cp="🇱🇮">flag</annotation>
+		<annotation cp="🇱🇮" type="tts">flag: Liechtenstein</annotation>
+		<annotation cp="🇱🇰">flag</annotation>
+		<annotation cp="🇱🇰" type="tts">flag: Sri Lanka</annotation>
+		<annotation cp="🇱🇷">flag</annotation>
+		<annotation cp="🇱🇷" type="tts">flag: Liberia</annotation>
+		<annotation cp="🇱🇸">flag</annotation>
+		<annotation cp="🇱🇸" type="tts">flag: Lesotho</annotation>
+		<annotation cp="🇱🇹">flag</annotation>
+		<annotation cp="🇱🇹" type="tts">flag: Lithuania</annotation>
+		<annotation cp="🇱🇺">flag</annotation>
+		<annotation cp="🇱🇺" type="tts">flag: Luxembourg</annotation>
+		<annotation cp="🇱🇻">flag</annotation>
+		<annotation cp="🇱🇻" type="tts">flag: Latvia</annotation>
+		<annotation cp="🇱🇾">flag</annotation>
+		<annotation cp="🇱🇾" type="tts">flag: Libya</annotation>
+		<annotation cp="🇲🇦">flag</annotation>
+		<annotation cp="🇲🇦" type="tts">flag: Morocco</annotation>
+		<annotation cp="🇲🇨">flag</annotation>
+		<annotation cp="🇲🇨" type="tts">flag: Monaco</annotation>
+		<annotation cp="🇲🇩">flag</annotation>
+		<annotation cp="🇲🇩" type="tts">flag: Moldova</annotation>
+		<annotation cp="🇲🇪">flag</annotation>
+		<annotation cp="🇲🇪" type="tts">flag: Montenegro</annotation>
+		<annotation cp="🇲🇫">flag</annotation>
+		<annotation cp="🇲🇫" type="tts">flag: St. Martin</annotation>
+		<annotation cp="🇲🇬">flag</annotation>
+		<annotation cp="🇲🇬" type="tts">flag: Madagascar</annotation>
+		<annotation cp="🇲🇭">flag</annotation>
+		<annotation cp="🇲🇭" type="tts">flag: Marshall Islands</annotation>
+		<annotation cp="🇲🇰">flag</annotation>
+		<annotation cp="🇲🇰" type="tts">flag: North Macedonia</annotation>
+		<annotation cp="🇲🇱">flag</annotation>
+		<annotation cp="🇲🇱" type="tts">flag: Mali</annotation>
+		<annotation cp="🇲🇲">flag</annotation>
+		<annotation cp="🇲🇲" type="tts">flag: Myanmar (Burma)</annotation>
+		<annotation cp="🇲🇳">flag</annotation>
+		<annotation cp="🇲🇳" type="tts">flag: Mongolia</annotation>
+		<annotation cp="🇲🇴">flag</annotation>
+		<annotation cp="🇲🇴" type="tts">flag: Macao SAR China</annotation>
+		<annotation cp="🇲🇵">flag</annotation>
+		<annotation cp="🇲🇵" type="tts">flag: Northern Mariana Islands</annotation>
+		<annotation cp="🇲🇶">flag</annotation>
+		<annotation cp="🇲🇶" type="tts">flag: Martinique</annotation>
+		<annotation cp="🇲🇷">flag</annotation>
+		<annotation cp="🇲🇷" type="tts">flag: Mauritania</annotation>
+		<annotation cp="🇲🇸">flag</annotation>
+		<annotation cp="🇲🇸" type="tts">flag: Montserrat</annotation>
+		<annotation cp="🇲🇹">flag</annotation>
+		<annotation cp="🇲🇹" type="tts">flag: Malta</annotation>
+		<annotation cp="🇲🇺">flag</annotation>
+		<annotation cp="🇲🇺" type="tts">flag: Mauritius</annotation>
+		<annotation cp="🇲🇻">flag</annotation>
+		<annotation cp="🇲🇻" type="tts">flag: Maldives</annotation>
+		<annotation cp="🇲🇼">flag</annotation>
+		<annotation cp="🇲🇼" type="tts">flag: Malawi</annotation>
+		<annotation cp="🇲🇽">flag</annotation>
+		<annotation cp="🇲🇽" type="tts">flag: Mexico</annotation>
+		<annotation cp="🇲🇾">flag</annotation>
+		<annotation cp="🇲🇾" type="tts">flag: Malaysia</annotation>
+		<annotation cp="🇲🇿">flag</annotation>
+		<annotation cp="🇲🇿" type="tts">flag: Mozambique</annotation>
+		<annotation cp="🇳🇦">flag</annotation>
+		<annotation cp="🇳🇦" type="tts">flag: Namibia</annotation>
+		<annotation cp="🇳🇨">flag</annotation>
+		<annotation cp="🇳🇨" type="tts">flag: New Caledonia</annotation>
+		<annotation cp="🇳🇪">flag</annotation>
+		<annotation cp="🇳🇪" type="tts">flag: Niger</annotation>
+		<annotation cp="🇳🇫">flag</annotation>
+		<annotation cp="🇳🇫" type="tts">flag: Norfolk Island</annotation>
+		<annotation cp="🇳🇬">flag</annotation>
+		<annotation cp="🇳🇬" type="tts">flag: Nigeria</annotation>
+		<annotation cp="🇳🇮">flag</annotation>
+		<annotation cp="🇳🇮" type="tts">flag: Nicaragua</annotation>
+		<annotation cp="🇳🇱">flag</annotation>
+		<annotation cp="🇳🇱" type="tts">flag: Netherlands</annotation>
+		<annotation cp="🇳🇴">flag</annotation>
+		<annotation cp="🇳🇴" type="tts">flag: Norway</annotation>
+		<annotation cp="🇳🇵">flag</annotation>
+		<annotation cp="🇳🇵" type="tts">flag: Nepal</annotation>
+		<annotation cp="🇳🇷">flag</annotation>
+		<annotation cp="🇳🇷" type="tts">flag: Nauru</annotation>
+		<annotation cp="🇳🇺">flag</annotation>
+		<annotation cp="🇳🇺" type="tts">flag: Niue</annotation>
+		<annotation cp="🇳🇿">flag</annotation>
+		<annotation cp="🇳🇿" type="tts">flag: New Zealand</annotation>
+		<annotation cp="🇴🇲">flag</annotation>
+		<annotation cp="🇴🇲" type="tts">flag: Oman</annotation>
+		<annotation cp="🇵🇦">flag</annotation>
+		<annotation cp="🇵🇦" type="tts">flag: Panama</annotation>
+		<annotation cp="🇵🇪">flag</annotation>
+		<annotation cp="🇵🇪" type="tts">flag: Peru</annotation>
+		<annotation cp="🇵🇫">flag</annotation>
+		<annotation cp="🇵🇫" type="tts">flag: French Polynesia</annotation>
+		<annotation cp="🇵🇬">flag</annotation>
+		<annotation cp="🇵🇬" type="tts">flag: Papua New Guinea</annotation>
+		<annotation cp="🇵🇭">flag</annotation>
+		<annotation cp="🇵🇭" type="tts">flag: Philippines</annotation>
+		<annotation cp="🇵🇰">flag</annotation>
+		<annotation cp="🇵🇰" type="tts">flag: Pakistan</annotation>
+		<annotation cp="🇵🇱">flag</annotation>
+		<annotation cp="🇵🇱" type="tts">flag: Poland</annotation>
+		<annotation cp="🇵🇲">flag</annotation>
+		<annotation cp="🇵🇲" type="tts">flag: St. Pierre &amp; Miquelon</annotation>
+		<annotation cp="🇵🇳">flag</annotation>
+		<annotation cp="🇵🇳" type="tts">flag: Pitcairn Islands</annotation>
+		<annotation cp="🇵🇷">flag</annotation>
+		<annotation cp="🇵🇷" type="tts">flag: Puerto Rico</annotation>
+		<annotation cp="🇵🇸">flag</annotation>
+		<annotation cp="🇵🇸" type="tts">flag: Palestinian Territories</annotation>
+		<annotation cp="🇵🇹">flag</annotation>
+		<annotation cp="🇵🇹" type="tts">flag: Portugal</annotation>
+		<annotation cp="🇵🇼">flag</annotation>
+		<annotation cp="🇵🇼" type="tts">flag: Palau</annotation>
+		<annotation cp="🇵🇾">flag</annotation>
+		<annotation cp="🇵🇾" type="tts">flag: Paraguay</annotation>
+		<annotation cp="🇶🇦">flag</annotation>
+		<annotation cp="🇶🇦" type="tts">flag: Qatar</annotation>
+		<annotation cp="🇷🇪">flag</annotation>
+		<annotation cp="🇷🇪" type="tts">flag: Réunion</annotation>
+		<annotation cp="🇷🇴">flag</annotation>
+		<annotation cp="🇷🇴" type="tts">flag: Romania</annotation>
+		<annotation cp="🇷🇸">flag</annotation>
+		<annotation cp="🇷🇸" type="tts">flag: Serbia</annotation>
+		<annotation cp="🇷🇺">flag</annotation>
+		<annotation cp="🇷🇺" type="tts">flag: Russia</annotation>
+		<annotation cp="🇷🇼">flag</annotation>
+		<annotation cp="🇷🇼" type="tts">flag: Rwanda</annotation>
+		<annotation cp="🇸🇦">flag</annotation>
+		<annotation cp="🇸🇦" type="tts">flag: Saudi Arabia</annotation>
+		<annotation cp="🇸🇧">flag</annotation>
+		<annotation cp="🇸🇧" type="tts">flag: Solomon Islands</annotation>
+		<annotation cp="🇸🇨">flag</annotation>
+		<annotation cp="🇸🇨" type="tts">flag: Seychelles</annotation>
+		<annotation cp="🇸🇩">flag</annotation>
+		<annotation cp="🇸🇩" type="tts">flag: Sudan</annotation>
+		<annotation cp="🇸🇪">flag</annotation>
+		<annotation cp="🇸🇪" type="tts">flag: Sweden</annotation>
+		<annotation cp="🇸🇬">flag</annotation>
+		<annotation cp="🇸🇬" type="tts">flag: Singapore</annotation>
+		<annotation cp="🇸🇭">flag</annotation>
+		<annotation cp="🇸🇭" type="tts">flag: St. Helena</annotation>
+		<annotation cp="🇸🇮">flag</annotation>
+		<annotation cp="🇸🇮" type="tts">flag: Slovenia</annotation>
+		<annotation cp="🇸🇯">flag</annotation>
+		<annotation cp="🇸🇯" type="tts">flag: Svalbard &amp; Jan Mayen</annotation>
+		<annotation cp="🇸🇰">flag</annotation>
+		<annotation cp="🇸🇰" type="tts">flag: Slovakia</annotation>
+		<annotation cp="🇸🇱">flag</annotation>
+		<annotation cp="🇸🇱" type="tts">flag: Sierra Leone</annotation>
+		<annotation cp="🇸🇲">flag</annotation>
+		<annotation cp="🇸🇲" type="tts">flag: San Marino</annotation>
+		<annotation cp="🇸🇳">flag</annotation>
+		<annotation cp="🇸🇳" type="tts">flag: Senegal</annotation>
+		<annotation cp="🇸🇴">flag</annotation>
+		<annotation cp="🇸🇴" type="tts">flag: Somalia</annotation>
+		<annotation cp="🇸🇷">flag</annotation>
+		<annotation cp="🇸🇷" type="tts">flag: Suriname</annotation>
+		<annotation cp="🇸🇸">flag</annotation>
+		<annotation cp="🇸🇸" type="tts">flag: South Sudan</annotation>
+		<annotation cp="🇸🇹">flag</annotation>
+		<annotation cp="🇸🇹" type="tts">flag: São Tomé &amp; Príncipe</annotation>
+		<annotation cp="🇸🇻">flag</annotation>
+		<annotation cp="🇸🇻" type="tts">flag: El Salvador</annotation>
+		<annotation cp="🇸🇽">flag</annotation>
+		<annotation cp="🇸🇽" type="tts">flag: Sint Maarten</annotation>
+		<annotation cp="🇸🇾">flag</annotation>
+		<annotation cp="🇸🇾" type="tts">flag: Syria</annotation>
+		<annotation cp="🇸🇿">flag</annotation>
+		<annotation cp="🇸🇿" type="tts">flag: Eswatini</annotation>
+		<annotation cp="🇹🇦">flag</annotation>
+		<annotation cp="🇹🇦" type="tts">flag: Tristan da Cunha</annotation>
+		<annotation cp="🇹🇨">flag</annotation>
+		<annotation cp="🇹🇨" type="tts">flag: Turks &amp; Caicos Islands</annotation>
+		<annotation cp="🇹🇩">flag</annotation>
+		<annotation cp="🇹🇩" type="tts">flag: Chad</annotation>
+		<annotation cp="🇹🇫">flag</annotation>
+		<annotation cp="🇹🇫" type="tts">flag: French Southern Territories</annotation>
+		<annotation cp="🇹🇬">flag</annotation>
+		<annotation cp="🇹🇬" type="tts">flag: Togo</annotation>
+		<annotation cp="🇹🇭">flag</annotation>
+		<annotation cp="🇹🇭" type="tts">flag: Thailand</annotation>
+		<annotation cp="🇹🇯">flag</annotation>
+		<annotation cp="🇹🇯" type="tts">flag: Tajikistan</annotation>
+		<annotation cp="🇹🇰">flag</annotation>
+		<annotation cp="🇹🇰" type="tts">flag: Tokelau</annotation>
+		<annotation cp="🇹🇱">flag</annotation>
+		<annotation cp="🇹🇱" type="tts">flag: Timor-Leste</annotation>
+		<annotation cp="🇹🇲">flag</annotation>
+		<annotation cp="🇹🇲" type="tts">flag: Turkmenistan</annotation>
+		<annotation cp="🇹🇳">flag</annotation>
+		<annotation cp="🇹🇳" type="tts">flag: Tunisia</annotation>
+		<annotation cp="🇹🇴">flag</annotation>
+		<annotation cp="🇹🇴" type="tts">flag: Tonga</annotation>
+		<annotation cp="🇹🇷">flag</annotation>
+		<annotation cp="🇹🇷" type="tts">flag: Türkiye</annotation>
+		<annotation cp="🇹🇹">flag</annotation>
+		<annotation cp="🇹🇹" type="tts">flag: Trinidad &amp; Tobago</annotation>
+		<annotation cp="🇹🇻">flag</annotation>
+		<annotation cp="🇹🇻" type="tts">flag: Tuvalu</annotation>
+		<annotation cp="🇹🇼">flag</annotation>
+		<annotation cp="🇹🇼" type="tts">flag: Taiwan</annotation>
+		<annotation cp="🇹🇿">flag</annotation>
+		<annotation cp="🇹🇿" type="tts">flag: Tanzania</annotation>
+		<annotation cp="🇺🇦">flag</annotation>
+		<annotation cp="🇺🇦" type="tts">flag: Ukraine</annotation>
+		<annotation cp="🇺🇬">flag</annotation>
+		<annotation cp="🇺🇬" type="tts">flag: Uganda</annotation>
+		<annotation cp="🇺🇲">flag</annotation>
+		<annotation cp="🇺🇲" type="tts">flag: U.S. Outlying Islands</annotation>
+		<annotation cp="🇺🇳">flag</annotation>
+		<annotation cp="🇺🇳" type="tts">flag: United Nations</annotation>
+		<annotation cp="🇺🇸">flag</annotation>
+		<annotation cp="🇺🇸" type="tts">flag: United States</annotation>
+		<annotation cp="🇺🇾">flag</annotation>
+		<annotation cp="🇺🇾" type="tts">flag: Uruguay</annotation>
+		<annotation cp="🇺🇿">flag</annotation>
+		<annotation cp="🇺🇿" type="tts">flag: Uzbekistan</annotation>
+		<annotation cp="🇻🇦">flag</annotation>
+		<annotation cp="🇻🇦" type="tts">flag: Vatican City</annotation>
+		<annotation cp="🇻🇨">flag</annotation>
+		<annotation cp="🇻🇨" type="tts">flag: St. Vincent &amp; Grenadines</annotation>
+		<annotation cp="🇻🇪">flag</annotation>
+		<annotation cp="🇻🇪" type="tts">flag: Venezuela</annotation>
+		<annotation cp="🇻🇬">flag</annotation>
+		<annotation cp="🇻🇬" type="tts">flag: British Virgin Islands</annotation>
+		<annotation cp="🇻🇮">flag</annotation>
+		<annotation cp="🇻🇮" type="tts">flag: U.S. Virgin Islands</annotation>
+		<annotation cp="🇻🇳">flag</annotation>
+		<annotation cp="🇻🇳" type="tts">flag: Vietnam</annotation>
+		<annotation cp="🇻🇺">flag</annotation>
+		<annotation cp="🇻🇺" type="tts">flag: Vanuatu</annotation>
+		<annotation cp="🇼🇫">flag</annotation>
+		<annotation cp="🇼🇫" type="tts">flag: Wallis &amp; Futuna</annotation>
+		<annotation cp="🇼🇸">flag</annotation>
+		<annotation cp="🇼🇸" type="tts">flag: Samoa</annotation>
+		<annotation cp="🇽🇰">flag</annotation>
+		<annotation cp="🇽🇰" type="tts">flag: Kosovo</annotation>
+		<annotation cp="🇾🇪">flag</annotation>
+		<annotation cp="🇾🇪" type="tts">flag: Yemen</annotation>
+		<annotation cp="🇾🇹">flag</annotation>
+		<annotation cp="🇾🇹" type="tts">flag: Mayotte</annotation>
+		<annotation cp="🇿🇦">flag</annotation>
+		<annotation cp="🇿🇦" type="tts">flag: South Africa</annotation>
+		<annotation cp="🇿🇲">flag</annotation>
+		<annotation cp="🇿🇲" type="tts">flag: Zambia</annotation>
+		<annotation cp="🇿🇼">flag</annotation>
+		<annotation cp="🇿🇼" type="tts">flag: Zimbabwe</annotation>
+		<annotation cp="🏴󠁧󠁢󠁥󠁮󠁧󠁿">flag</annotation>
+		<annotation cp="🏴󠁧󠁢󠁥󠁮󠁧󠁿" type="tts">flag: England</annotation>
+		<annotation cp="🏴󠁧󠁢󠁳󠁣󠁴󠁿">flag</annotation>
+		<annotation cp="🏴󠁧󠁢󠁳󠁣󠁴󠁿" type="tts">flag: Scotland</annotation>
+		<annotation cp="🏴󠁧󠁢󠁷󠁬󠁳󠁿">flag</annotation>
+		<annotation cp="🏴󠁧󠁢󠁷󠁬󠁳󠁿" type="tts">flag: Wales</annotation>
+		<annotation cp="¤" type="tts">Unknown Currency</annotation>
+		<annotation cp="֏" type="tts">Armenian Dram</annotation>
+		<annotation cp="؋" type="tts">Afghan Afghani</annotation>
+		<annotation cp="৳" type="tts">Bangladeshi Taka</annotation>
+		<annotation cp="฿" type="tts">Thai Baht</annotation>
+		<annotation cp="៛" type="tts">Cambodian Riel</annotation>
+		<annotation cp="₡" type="tts">Costa Rican Colón</annotation>
+		<annotation cp="₦" type="tts">Nigerian Naira</annotation>
+		<annotation cp="₪" type="tts">Israeli New Shekel</annotation>
+		<annotation cp="₫" type="tts">Vietnamese Dong</annotation>
+		<annotation cp="₭" type="tts">Laotian Kip</annotation>
+		<annotation cp="₮" type="tts">Mongolian Tugrik</annotation>
+		<annotation cp="₲" type="tts">Paraguayan Guarani</annotation>
+		<annotation cp="₴" type="tts">Ukrainian Hryvnia</annotation>
+		<annotation cp="₵" type="tts">Ghanaian Cedi</annotation>
+		<annotation cp="₸" type="tts">Kazakhstani Tenge</annotation>
+		<annotation cp="₺" type="tts">Turkish Lira</annotation>
+		<annotation cp="₼" type="tts">Azerbaijani Manat</annotation>
+		<annotation cp="₾" type="tts">Georgian Lari</annotation>
+		<annotation cp="0⃣">keycap</annotation>
+		<annotation cp="0⃣" type="tts">keycap: 0</annotation>
+		<annotation cp="1⃣">keycap</annotation>
+		<annotation cp="1⃣" type="tts">keycap: 1</annotation>
+		<annotation cp="2⃣">keycap</annotation>
+		<annotation cp="2⃣" type="tts">keycap: 2</annotation>
+		<annotation cp="3⃣">keycap</annotation>
+		<annotation cp="3⃣" type="tts">keycap: 3</annotation>
+		<annotation cp="4⃣">keycap</annotation>
+		<annotation cp="4⃣" type="tts">keycap: 4</annotation>
+		<annotation cp="5⃣">keycap</annotation>
+		<annotation cp="5⃣" type="tts">keycap: 5</annotation>
+		<annotation cp="6⃣">keycap</annotation>
+		<annotation cp="6⃣" type="tts">keycap: 6</annotation>
+		<annotation cp="7⃣">keycap</annotation>
+		<annotation cp="7⃣" type="tts">keycap: 7</annotation>
+		<annotation cp="8⃣">keycap</annotation>
+		<annotation cp="8⃣" type="tts">keycap: 8</annotation>
+		<annotation cp="9⃣">keycap</annotation>
+		<annotation cp="9⃣" type="tts">keycap: 9</annotation>
+		<annotation cp="₧" type="tts">Spanish Peseta</annotation>
+	</annotations>
+</ldml>

--- a/tools/unicode/emoji-test.txt
+++ b/tools/unicode/emoji-test.txt
@@ -1,0 +1,5331 @@
+# emoji-test.txt
+# Date: 2024-08-14, 23:51:54 GMT
+# © 2024 Unicode®, Inc.
+# Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+# For terms of use and license, see https://www.unicode.org/terms_of_use.html
+#
+# Emoji Keyboard/Display Test Data for UTS #51
+# Version: 16.0
+#
+# For documentation and usage, see https://www.unicode.org/reports/tr51
+#
+# This file provides data for testing which emoji forms should be in keyboards and which should also be displayed/processed.
+# Format: code points; status # emoji name
+#     Code points — list of one or more hex code points, separated by spaces
+#     Status
+#       component           — an Emoji_Component,
+#                             excluding Regional_Indicators, ASCII, and non-Emoji.
+#       fully-qualified     — a fully-qualified emoji (see ED-18 in UTS #51),
+#                             excluding Emoji_Component
+#       minimally-qualified — a minimally-qualified emoji (see ED-18a in UTS #51)
+#       unqualified         — a unqualified emoji (See ED-19 in UTS #51)
+# Notes:
+#   • This includes the emoji components that need emoji presentation (skin tone and hair)
+#     when isolated, but omits the components that need not have an emoji
+#     presentation when isolated.
+#   • The RGI set is covered by the listed fully-qualified emoji. 
+#   • The listed minimally-qualified and unqualified cover all cases where an
+#     element of the RGI set is missing one or more emoji presentation selectors.
+#   • The file is in CLDR order, not codepoint order. This is recommended (but not required!) for keyboard palettes.
+#   • The groups and subgroups are illustrative. See the Emoji Order chart for more information.
+
+
+# group: Smileys & Emotion
+
+# subgroup: face-smiling
+1F600                                                  ; fully-qualified     # 😀 E1.0 grinning face
+1F603                                                  ; fully-qualified     # 😃 E0.6 grinning face with big eyes
+1F604                                                  ; fully-qualified     # 😄 E0.6 grinning face with smiling eyes
+1F601                                                  ; fully-qualified     # 😁 E0.6 beaming face with smiling eyes
+1F606                                                  ; fully-qualified     # 😆 E0.6 grinning squinting face
+1F605                                                  ; fully-qualified     # 😅 E0.6 grinning face with sweat
+1F923                                                  ; fully-qualified     # 🤣 E3.0 rolling on the floor laughing
+1F602                                                  ; fully-qualified     # 😂 E0.6 face with tears of joy
+1F642                                                  ; fully-qualified     # 🙂 E1.0 slightly smiling face
+1F643                                                  ; fully-qualified     # 🙃 E1.0 upside-down face
+1FAE0                                                  ; fully-qualified     # 🫠 E14.0 melting face
+1F609                                                  ; fully-qualified     # 😉 E0.6 winking face
+1F60A                                                  ; fully-qualified     # 😊 E0.6 smiling face with smiling eyes
+1F607                                                  ; fully-qualified     # 😇 E1.0 smiling face with halo
+
+# subgroup: face-affection
+1F970                                                  ; fully-qualified     # 🥰 E11.0 smiling face with hearts
+1F60D                                                  ; fully-qualified     # 😍 E0.6 smiling face with heart-eyes
+1F929                                                  ; fully-qualified     # 🤩 E5.0 star-struck
+1F618                                                  ; fully-qualified     # 😘 E0.6 face blowing a kiss
+1F617                                                  ; fully-qualified     # 😗 E1.0 kissing face
+263A FE0F                                              ; fully-qualified     # ☺️ E0.6 smiling face
+263A                                                   ; unqualified         # ☺ E0.6 smiling face
+1F61A                                                  ; fully-qualified     # 😚 E0.6 kissing face with closed eyes
+1F619                                                  ; fully-qualified     # 😙 E1.0 kissing face with smiling eyes
+1F972                                                  ; fully-qualified     # 🥲 E13.0 smiling face with tear
+
+# subgroup: face-tongue
+1F60B                                                  ; fully-qualified     # 😋 E0.6 face savoring food
+1F61B                                                  ; fully-qualified     # 😛 E1.0 face with tongue
+1F61C                                                  ; fully-qualified     # 😜 E0.6 winking face with tongue
+1F92A                                                  ; fully-qualified     # 🤪 E5.0 zany face
+1F61D                                                  ; fully-qualified     # 😝 E0.6 squinting face with tongue
+1F911                                                  ; fully-qualified     # 🤑 E1.0 money-mouth face
+
+# subgroup: face-hand
+1F917                                                  ; fully-qualified     # 🤗 E1.0 smiling face with open hands
+1F92D                                                  ; fully-qualified     # 🤭 E5.0 face with hand over mouth
+1FAE2                                                  ; fully-qualified     # 🫢 E14.0 face with open eyes and hand over mouth
+1FAE3                                                  ; fully-qualified     # 🫣 E14.0 face with peeking eye
+1F92B                                                  ; fully-qualified     # 🤫 E5.0 shushing face
+1F914                                                  ; fully-qualified     # 🤔 E1.0 thinking face
+1FAE1                                                  ; fully-qualified     # 🫡 E14.0 saluting face
+
+# subgroup: face-neutral-skeptical
+1F910                                                  ; fully-qualified     # 🤐 E1.0 zipper-mouth face
+1F928                                                  ; fully-qualified     # 🤨 E5.0 face with raised eyebrow
+1F610                                                  ; fully-qualified     # 😐 E0.7 neutral face
+1F611                                                  ; fully-qualified     # 😑 E1.0 expressionless face
+1F636                                                  ; fully-qualified     # 😶 E1.0 face without mouth
+1FAE5                                                  ; fully-qualified     # 🫥 E14.0 dotted line face
+1F636 200D 1F32B FE0F                                  ; fully-qualified     # 😶‍🌫️ E13.1 face in clouds
+1F636 200D 1F32B                                       ; minimally-qualified # 😶‍🌫 E13.1 face in clouds
+1F60F                                                  ; fully-qualified     # 😏 E0.6 smirking face
+1F612                                                  ; fully-qualified     # 😒 E0.6 unamused face
+1F644                                                  ; fully-qualified     # 🙄 E1.0 face with rolling eyes
+1F62C                                                  ; fully-qualified     # 😬 E1.0 grimacing face
+1F62E 200D 1F4A8                                       ; fully-qualified     # 😮‍💨 E13.1 face exhaling
+1F925                                                  ; fully-qualified     # 🤥 E3.0 lying face
+1FAE8                                                  ; fully-qualified     # 🫨 E15.0 shaking face
+1F642 200D 2194 FE0F                                   ; fully-qualified     # 🙂‍↔️ E15.1 head shaking horizontally
+1F642 200D 2194                                        ; minimally-qualified # 🙂‍↔ E15.1 head shaking horizontally
+1F642 200D 2195 FE0F                                   ; fully-qualified     # 🙂‍↕️ E15.1 head shaking vertically
+1F642 200D 2195                                        ; minimally-qualified # 🙂‍↕ E15.1 head shaking vertically
+
+# subgroup: face-sleepy
+1F60C                                                  ; fully-qualified     # 😌 E0.6 relieved face
+1F614                                                  ; fully-qualified     # 😔 E0.6 pensive face
+1F62A                                                  ; fully-qualified     # 😪 E0.6 sleepy face
+1F924                                                  ; fully-qualified     # 🤤 E3.0 drooling face
+1F634                                                  ; fully-qualified     # 😴 E1.0 sleeping face
+1FAE9                                                  ; fully-qualified     # 🫩 E16.0 face with bags under eyes
+
+# subgroup: face-unwell
+1F637                                                  ; fully-qualified     # 😷 E0.6 face with medical mask
+1F912                                                  ; fully-qualified     # 🤒 E1.0 face with thermometer
+1F915                                                  ; fully-qualified     # 🤕 E1.0 face with head-bandage
+1F922                                                  ; fully-qualified     # 🤢 E3.0 nauseated face
+1F92E                                                  ; fully-qualified     # 🤮 E5.0 face vomiting
+1F927                                                  ; fully-qualified     # 🤧 E3.0 sneezing face
+1F975                                                  ; fully-qualified     # 🥵 E11.0 hot face
+1F976                                                  ; fully-qualified     # 🥶 E11.0 cold face
+1F974                                                  ; fully-qualified     # 🥴 E11.0 woozy face
+1F635                                                  ; fully-qualified     # 😵 E0.6 face with crossed-out eyes
+1F635 200D 1F4AB                                       ; fully-qualified     # 😵‍💫 E13.1 face with spiral eyes
+1F92F                                                  ; fully-qualified     # 🤯 E5.0 exploding head
+
+# subgroup: face-hat
+1F920                                                  ; fully-qualified     # 🤠 E3.0 cowboy hat face
+1F973                                                  ; fully-qualified     # 🥳 E11.0 partying face
+1F978                                                  ; fully-qualified     # 🥸 E13.0 disguised face
+
+# subgroup: face-glasses
+1F60E                                                  ; fully-qualified     # 😎 E1.0 smiling face with sunglasses
+1F913                                                  ; fully-qualified     # 🤓 E1.0 nerd face
+1F9D0                                                  ; fully-qualified     # 🧐 E5.0 face with monocle
+
+# subgroup: face-concerned
+1F615                                                  ; fully-qualified     # 😕 E1.0 confused face
+1FAE4                                                  ; fully-qualified     # 🫤 E14.0 face with diagonal mouth
+1F61F                                                  ; fully-qualified     # 😟 E1.0 worried face
+1F641                                                  ; fully-qualified     # 🙁 E1.0 slightly frowning face
+2639 FE0F                                              ; fully-qualified     # ☹️ E0.7 frowning face
+2639                                                   ; unqualified         # ☹ E0.7 frowning face
+1F62E                                                  ; fully-qualified     # 😮 E1.0 face with open mouth
+1F62F                                                  ; fully-qualified     # 😯 E1.0 hushed face
+1F632                                                  ; fully-qualified     # 😲 E0.6 astonished face
+1F633                                                  ; fully-qualified     # 😳 E0.6 flushed face
+1F97A                                                  ; fully-qualified     # 🥺 E11.0 pleading face
+1F979                                                  ; fully-qualified     # 🥹 E14.0 face holding back tears
+1F626                                                  ; fully-qualified     # 😦 E1.0 frowning face with open mouth
+1F627                                                  ; fully-qualified     # 😧 E1.0 anguished face
+1F628                                                  ; fully-qualified     # 😨 E0.6 fearful face
+1F630                                                  ; fully-qualified     # 😰 E0.6 anxious face with sweat
+1F625                                                  ; fully-qualified     # 😥 E0.6 sad but relieved face
+1F622                                                  ; fully-qualified     # 😢 E0.6 crying face
+1F62D                                                  ; fully-qualified     # 😭 E0.6 loudly crying face
+1F631                                                  ; fully-qualified     # 😱 E0.6 face screaming in fear
+1F616                                                  ; fully-qualified     # 😖 E0.6 confounded face
+1F623                                                  ; fully-qualified     # 😣 E0.6 persevering face
+1F61E                                                  ; fully-qualified     # 😞 E0.6 disappointed face
+1F613                                                  ; fully-qualified     # 😓 E0.6 downcast face with sweat
+1F629                                                  ; fully-qualified     # 😩 E0.6 weary face
+1F62B                                                  ; fully-qualified     # 😫 E0.6 tired face
+1F971                                                  ; fully-qualified     # 🥱 E12.0 yawning face
+
+# subgroup: face-negative
+1F624                                                  ; fully-qualified     # 😤 E0.6 face with steam from nose
+1F621                                                  ; fully-qualified     # 😡 E0.6 enraged face
+1F620                                                  ; fully-qualified     # 😠 E0.6 angry face
+1F92C                                                  ; fully-qualified     # 🤬 E5.0 face with symbols on mouth
+1F608                                                  ; fully-qualified     # 😈 E1.0 smiling face with horns
+1F47F                                                  ; fully-qualified     # 👿 E0.6 angry face with horns
+1F480                                                  ; fully-qualified     # 💀 E0.6 skull
+2620 FE0F                                              ; fully-qualified     # ☠️ E1.0 skull and crossbones
+2620                                                   ; unqualified         # ☠ E1.0 skull and crossbones
+
+# subgroup: face-costume
+1F4A9                                                  ; fully-qualified     # 💩 E0.6 pile of poo
+1F921                                                  ; fully-qualified     # 🤡 E3.0 clown face
+1F479                                                  ; fully-qualified     # 👹 E0.6 ogre
+1F47A                                                  ; fully-qualified     # 👺 E0.6 goblin
+1F47B                                                  ; fully-qualified     # 👻 E0.6 ghost
+1F47D                                                  ; fully-qualified     # 👽 E0.6 alien
+1F47E                                                  ; fully-qualified     # 👾 E0.6 alien monster
+1F916                                                  ; fully-qualified     # 🤖 E1.0 robot
+
+# subgroup: cat-face
+1F63A                                                  ; fully-qualified     # 😺 E0.6 grinning cat
+1F638                                                  ; fully-qualified     # 😸 E0.6 grinning cat with smiling eyes
+1F639                                                  ; fully-qualified     # 😹 E0.6 cat with tears of joy
+1F63B                                                  ; fully-qualified     # 😻 E0.6 smiling cat with heart-eyes
+1F63C                                                  ; fully-qualified     # 😼 E0.6 cat with wry smile
+1F63D                                                  ; fully-qualified     # 😽 E0.6 kissing cat
+1F640                                                  ; fully-qualified     # 🙀 E0.6 weary cat
+1F63F                                                  ; fully-qualified     # 😿 E0.6 crying cat
+1F63E                                                  ; fully-qualified     # 😾 E0.6 pouting cat
+
+# subgroup: monkey-face
+1F648                                                  ; fully-qualified     # 🙈 E0.6 see-no-evil monkey
+1F649                                                  ; fully-qualified     # 🙉 E0.6 hear-no-evil monkey
+1F64A                                                  ; fully-qualified     # 🙊 E0.6 speak-no-evil monkey
+
+# subgroup: heart
+1F48C                                                  ; fully-qualified     # 💌 E0.6 love letter
+1F498                                                  ; fully-qualified     # 💘 E0.6 heart with arrow
+1F49D                                                  ; fully-qualified     # 💝 E0.6 heart with ribbon
+1F496                                                  ; fully-qualified     # 💖 E0.6 sparkling heart
+1F497                                                  ; fully-qualified     # 💗 E0.6 growing heart
+1F493                                                  ; fully-qualified     # 💓 E0.6 beating heart
+1F49E                                                  ; fully-qualified     # 💞 E0.6 revolving hearts
+1F495                                                  ; fully-qualified     # 💕 E0.6 two hearts
+1F49F                                                  ; fully-qualified     # 💟 E0.6 heart decoration
+2763 FE0F                                              ; fully-qualified     # ❣️ E1.0 heart exclamation
+2763                                                   ; unqualified         # ❣ E1.0 heart exclamation
+1F494                                                  ; fully-qualified     # 💔 E0.6 broken heart
+2764 FE0F 200D 1F525                                   ; fully-qualified     # ❤️‍🔥 E13.1 heart on fire
+2764 200D 1F525                                        ; unqualified         # ❤‍🔥 E13.1 heart on fire
+2764 FE0F 200D 1FA79                                   ; fully-qualified     # ❤️‍🩹 E13.1 mending heart
+2764 200D 1FA79                                        ; unqualified         # ❤‍🩹 E13.1 mending heart
+2764 FE0F                                              ; fully-qualified     # ❤️ E0.6 red heart
+2764                                                   ; unqualified         # ❤ E0.6 red heart
+1FA77                                                  ; fully-qualified     # 🩷 E15.0 pink heart
+1F9E1                                                  ; fully-qualified     # 🧡 E5.0 orange heart
+1F49B                                                  ; fully-qualified     # 💛 E0.6 yellow heart
+1F49A                                                  ; fully-qualified     # 💚 E0.6 green heart
+1F499                                                  ; fully-qualified     # 💙 E0.6 blue heart
+1FA75                                                  ; fully-qualified     # 🩵 E15.0 light blue heart
+1F49C                                                  ; fully-qualified     # 💜 E0.6 purple heart
+1F90E                                                  ; fully-qualified     # 🤎 E12.0 brown heart
+1F5A4                                                  ; fully-qualified     # 🖤 E3.0 black heart
+1FA76                                                  ; fully-qualified     # 🩶 E15.0 grey heart
+1F90D                                                  ; fully-qualified     # 🤍 E12.0 white heart
+
+# subgroup: emotion
+1F48B                                                  ; fully-qualified     # 💋 E0.6 kiss mark
+1F4AF                                                  ; fully-qualified     # 💯 E0.6 hundred points
+1F4A2                                                  ; fully-qualified     # 💢 E0.6 anger symbol
+1F4A5                                                  ; fully-qualified     # 💥 E0.6 collision
+1F4AB                                                  ; fully-qualified     # 💫 E0.6 dizzy
+1F4A6                                                  ; fully-qualified     # 💦 E0.6 sweat droplets
+1F4A8                                                  ; fully-qualified     # 💨 E0.6 dashing away
+1F573 FE0F                                             ; fully-qualified     # 🕳️ E0.7 hole
+1F573                                                  ; unqualified         # 🕳 E0.7 hole
+1F4AC                                                  ; fully-qualified     # 💬 E0.6 speech balloon
+1F441 FE0F 200D 1F5E8 FE0F                             ; fully-qualified     # 👁️‍🗨️ E2.0 eye in speech bubble
+1F441 200D 1F5E8 FE0F                                  ; unqualified         # 👁‍🗨️ E2.0 eye in speech bubble
+1F441 FE0F 200D 1F5E8                                  ; minimally-qualified # 👁️‍🗨 E2.0 eye in speech bubble
+1F441 200D 1F5E8                                       ; unqualified         # 👁‍🗨 E2.0 eye in speech bubble
+1F5E8 FE0F                                             ; fully-qualified     # 🗨️ E2.0 left speech bubble
+1F5E8                                                  ; unqualified         # 🗨 E2.0 left speech bubble
+1F5EF FE0F                                             ; fully-qualified     # 🗯️ E0.7 right anger bubble
+1F5EF                                                  ; unqualified         # 🗯 E0.7 right anger bubble
+1F4AD                                                  ; fully-qualified     # 💭 E1.0 thought balloon
+1F4A4                                                  ; fully-qualified     # 💤 E0.6 ZZZ
+
+# Smileys & Emotion subtotal:		185
+# Smileys & Emotion subtotal:		185	w/o modifiers
+
+# group: People & Body
+
+# subgroup: hand-fingers-open
+1F44B                                                  ; fully-qualified     # 👋 E0.6 waving hand
+1F44B 1F3FB                                            ; fully-qualified     # 👋🏻 E1.0 waving hand: light skin tone
+1F44B 1F3FC                                            ; fully-qualified     # 👋🏼 E1.0 waving hand: medium-light skin tone
+1F44B 1F3FD                                            ; fully-qualified     # 👋🏽 E1.0 waving hand: medium skin tone
+1F44B 1F3FE                                            ; fully-qualified     # 👋🏾 E1.0 waving hand: medium-dark skin tone
+1F44B 1F3FF                                            ; fully-qualified     # 👋🏿 E1.0 waving hand: dark skin tone
+1F91A                                                  ; fully-qualified     # 🤚 E3.0 raised back of hand
+1F91A 1F3FB                                            ; fully-qualified     # 🤚🏻 E3.0 raised back of hand: light skin tone
+1F91A 1F3FC                                            ; fully-qualified     # 🤚🏼 E3.0 raised back of hand: medium-light skin tone
+1F91A 1F3FD                                            ; fully-qualified     # 🤚🏽 E3.0 raised back of hand: medium skin tone
+1F91A 1F3FE                                            ; fully-qualified     # 🤚🏾 E3.0 raised back of hand: medium-dark skin tone
+1F91A 1F3FF                                            ; fully-qualified     # 🤚🏿 E3.0 raised back of hand: dark skin tone
+1F590 FE0F                                             ; fully-qualified     # 🖐️ E0.7 hand with fingers splayed
+1F590                                                  ; unqualified         # 🖐 E0.7 hand with fingers splayed
+1F590 1F3FB                                            ; fully-qualified     # 🖐🏻 E1.0 hand with fingers splayed: light skin tone
+1F590 1F3FC                                            ; fully-qualified     # 🖐🏼 E1.0 hand with fingers splayed: medium-light skin tone
+1F590 1F3FD                                            ; fully-qualified     # 🖐🏽 E1.0 hand with fingers splayed: medium skin tone
+1F590 1F3FE                                            ; fully-qualified     # 🖐🏾 E1.0 hand with fingers splayed: medium-dark skin tone
+1F590 1F3FF                                            ; fully-qualified     # 🖐🏿 E1.0 hand with fingers splayed: dark skin tone
+270B                                                   ; fully-qualified     # ✋ E0.6 raised hand
+270B 1F3FB                                             ; fully-qualified     # ✋🏻 E1.0 raised hand: light skin tone
+270B 1F3FC                                             ; fully-qualified     # ✋🏼 E1.0 raised hand: medium-light skin tone
+270B 1F3FD                                             ; fully-qualified     # ✋🏽 E1.0 raised hand: medium skin tone
+270B 1F3FE                                             ; fully-qualified     # ✋🏾 E1.0 raised hand: medium-dark skin tone
+270B 1F3FF                                             ; fully-qualified     # ✋🏿 E1.0 raised hand: dark skin tone
+1F596                                                  ; fully-qualified     # 🖖 E1.0 vulcan salute
+1F596 1F3FB                                            ; fully-qualified     # 🖖🏻 E1.0 vulcan salute: light skin tone
+1F596 1F3FC                                            ; fully-qualified     # 🖖🏼 E1.0 vulcan salute: medium-light skin tone
+1F596 1F3FD                                            ; fully-qualified     # 🖖🏽 E1.0 vulcan salute: medium skin tone
+1F596 1F3FE                                            ; fully-qualified     # 🖖🏾 E1.0 vulcan salute: medium-dark skin tone
+1F596 1F3FF                                            ; fully-qualified     # 🖖🏿 E1.0 vulcan salute: dark skin tone
+1FAF1                                                  ; fully-qualified     # 🫱 E14.0 rightwards hand
+1FAF1 1F3FB                                            ; fully-qualified     # 🫱🏻 E14.0 rightwards hand: light skin tone
+1FAF1 1F3FC                                            ; fully-qualified     # 🫱🏼 E14.0 rightwards hand: medium-light skin tone
+1FAF1 1F3FD                                            ; fully-qualified     # 🫱🏽 E14.0 rightwards hand: medium skin tone
+1FAF1 1F3FE                                            ; fully-qualified     # 🫱🏾 E14.0 rightwards hand: medium-dark skin tone
+1FAF1 1F3FF                                            ; fully-qualified     # 🫱🏿 E14.0 rightwards hand: dark skin tone
+1FAF2                                                  ; fully-qualified     # 🫲 E14.0 leftwards hand
+1FAF2 1F3FB                                            ; fully-qualified     # 🫲🏻 E14.0 leftwards hand: light skin tone
+1FAF2 1F3FC                                            ; fully-qualified     # 🫲🏼 E14.0 leftwards hand: medium-light skin tone
+1FAF2 1F3FD                                            ; fully-qualified     # 🫲🏽 E14.0 leftwards hand: medium skin tone
+1FAF2 1F3FE                                            ; fully-qualified     # 🫲🏾 E14.0 leftwards hand: medium-dark skin tone
+1FAF2 1F3FF                                            ; fully-qualified     # 🫲🏿 E14.0 leftwards hand: dark skin tone
+1FAF3                                                  ; fully-qualified     # 🫳 E14.0 palm down hand
+1FAF3 1F3FB                                            ; fully-qualified     # 🫳🏻 E14.0 palm down hand: light skin tone
+1FAF3 1F3FC                                            ; fully-qualified     # 🫳🏼 E14.0 palm down hand: medium-light skin tone
+1FAF3 1F3FD                                            ; fully-qualified     # 🫳🏽 E14.0 palm down hand: medium skin tone
+1FAF3 1F3FE                                            ; fully-qualified     # 🫳🏾 E14.0 palm down hand: medium-dark skin tone
+1FAF3 1F3FF                                            ; fully-qualified     # 🫳🏿 E14.0 palm down hand: dark skin tone
+1FAF4                                                  ; fully-qualified     # 🫴 E14.0 palm up hand
+1FAF4 1F3FB                                            ; fully-qualified     # 🫴🏻 E14.0 palm up hand: light skin tone
+1FAF4 1F3FC                                            ; fully-qualified     # 🫴🏼 E14.0 palm up hand: medium-light skin tone
+1FAF4 1F3FD                                            ; fully-qualified     # 🫴🏽 E14.0 palm up hand: medium skin tone
+1FAF4 1F3FE                                            ; fully-qualified     # 🫴🏾 E14.0 palm up hand: medium-dark skin tone
+1FAF4 1F3FF                                            ; fully-qualified     # 🫴🏿 E14.0 palm up hand: dark skin tone
+1FAF7                                                  ; fully-qualified     # 🫷 E15.0 leftwards pushing hand
+1FAF7 1F3FB                                            ; fully-qualified     # 🫷🏻 E15.0 leftwards pushing hand: light skin tone
+1FAF7 1F3FC                                            ; fully-qualified     # 🫷🏼 E15.0 leftwards pushing hand: medium-light skin tone
+1FAF7 1F3FD                                            ; fully-qualified     # 🫷🏽 E15.0 leftwards pushing hand: medium skin tone
+1FAF7 1F3FE                                            ; fully-qualified     # 🫷🏾 E15.0 leftwards pushing hand: medium-dark skin tone
+1FAF7 1F3FF                                            ; fully-qualified     # 🫷🏿 E15.0 leftwards pushing hand: dark skin tone
+1FAF8                                                  ; fully-qualified     # 🫸 E15.0 rightwards pushing hand
+1FAF8 1F3FB                                            ; fully-qualified     # 🫸🏻 E15.0 rightwards pushing hand: light skin tone
+1FAF8 1F3FC                                            ; fully-qualified     # 🫸🏼 E15.0 rightwards pushing hand: medium-light skin tone
+1FAF8 1F3FD                                            ; fully-qualified     # 🫸🏽 E15.0 rightwards pushing hand: medium skin tone
+1FAF8 1F3FE                                            ; fully-qualified     # 🫸🏾 E15.0 rightwards pushing hand: medium-dark skin tone
+1FAF8 1F3FF                                            ; fully-qualified     # 🫸🏿 E15.0 rightwards pushing hand: dark skin tone
+
+# subgroup: hand-fingers-partial
+1F44C                                                  ; fully-qualified     # 👌 E0.6 OK hand
+1F44C 1F3FB                                            ; fully-qualified     # 👌🏻 E1.0 OK hand: light skin tone
+1F44C 1F3FC                                            ; fully-qualified     # 👌🏼 E1.0 OK hand: medium-light skin tone
+1F44C 1F3FD                                            ; fully-qualified     # 👌🏽 E1.0 OK hand: medium skin tone
+1F44C 1F3FE                                            ; fully-qualified     # 👌🏾 E1.0 OK hand: medium-dark skin tone
+1F44C 1F3FF                                            ; fully-qualified     # 👌🏿 E1.0 OK hand: dark skin tone
+1F90C                                                  ; fully-qualified     # 🤌 E13.0 pinched fingers
+1F90C 1F3FB                                            ; fully-qualified     # 🤌🏻 E13.0 pinched fingers: light skin tone
+1F90C 1F3FC                                            ; fully-qualified     # 🤌🏼 E13.0 pinched fingers: medium-light skin tone
+1F90C 1F3FD                                            ; fully-qualified     # 🤌🏽 E13.0 pinched fingers: medium skin tone
+1F90C 1F3FE                                            ; fully-qualified     # 🤌🏾 E13.0 pinched fingers: medium-dark skin tone
+1F90C 1F3FF                                            ; fully-qualified     # 🤌🏿 E13.0 pinched fingers: dark skin tone
+1F90F                                                  ; fully-qualified     # 🤏 E12.0 pinching hand
+1F90F 1F3FB                                            ; fully-qualified     # 🤏🏻 E12.0 pinching hand: light skin tone
+1F90F 1F3FC                                            ; fully-qualified     # 🤏🏼 E12.0 pinching hand: medium-light skin tone
+1F90F 1F3FD                                            ; fully-qualified     # 🤏🏽 E12.0 pinching hand: medium skin tone
+1F90F 1F3FE                                            ; fully-qualified     # 🤏🏾 E12.0 pinching hand: medium-dark skin tone
+1F90F 1F3FF                                            ; fully-qualified     # 🤏🏿 E12.0 pinching hand: dark skin tone
+270C FE0F                                              ; fully-qualified     # ✌️ E0.6 victory hand
+270C                                                   ; unqualified         # ✌ E0.6 victory hand
+270C 1F3FB                                             ; fully-qualified     # ✌🏻 E1.0 victory hand: light skin tone
+270C 1F3FC                                             ; fully-qualified     # ✌🏼 E1.0 victory hand: medium-light skin tone
+270C 1F3FD                                             ; fully-qualified     # ✌🏽 E1.0 victory hand: medium skin tone
+270C 1F3FE                                             ; fully-qualified     # ✌🏾 E1.0 victory hand: medium-dark skin tone
+270C 1F3FF                                             ; fully-qualified     # ✌🏿 E1.0 victory hand: dark skin tone
+1F91E                                                  ; fully-qualified     # 🤞 E3.0 crossed fingers
+1F91E 1F3FB                                            ; fully-qualified     # 🤞🏻 E3.0 crossed fingers: light skin tone
+1F91E 1F3FC                                            ; fully-qualified     # 🤞🏼 E3.0 crossed fingers: medium-light skin tone
+1F91E 1F3FD                                            ; fully-qualified     # 🤞🏽 E3.0 crossed fingers: medium skin tone
+1F91E 1F3FE                                            ; fully-qualified     # 🤞🏾 E3.0 crossed fingers: medium-dark skin tone
+1F91E 1F3FF                                            ; fully-qualified     # 🤞🏿 E3.0 crossed fingers: dark skin tone
+1FAF0                                                  ; fully-qualified     # 🫰 E14.0 hand with index finger and thumb crossed
+1FAF0 1F3FB                                            ; fully-qualified     # 🫰🏻 E14.0 hand with index finger and thumb crossed: light skin tone
+1FAF0 1F3FC                                            ; fully-qualified     # 🫰🏼 E14.0 hand with index finger and thumb crossed: medium-light skin tone
+1FAF0 1F3FD                                            ; fully-qualified     # 🫰🏽 E14.0 hand with index finger and thumb crossed: medium skin tone
+1FAF0 1F3FE                                            ; fully-qualified     # 🫰🏾 E14.0 hand with index finger and thumb crossed: medium-dark skin tone
+1FAF0 1F3FF                                            ; fully-qualified     # 🫰🏿 E14.0 hand with index finger and thumb crossed: dark skin tone
+1F91F                                                  ; fully-qualified     # 🤟 E5.0 love-you gesture
+1F91F 1F3FB                                            ; fully-qualified     # 🤟🏻 E5.0 love-you gesture: light skin tone
+1F91F 1F3FC                                            ; fully-qualified     # 🤟🏼 E5.0 love-you gesture: medium-light skin tone
+1F91F 1F3FD                                            ; fully-qualified     # 🤟🏽 E5.0 love-you gesture: medium skin tone
+1F91F 1F3FE                                            ; fully-qualified     # 🤟🏾 E5.0 love-you gesture: medium-dark skin tone
+1F91F 1F3FF                                            ; fully-qualified     # 🤟🏿 E5.0 love-you gesture: dark skin tone
+1F918                                                  ; fully-qualified     # 🤘 E1.0 sign of the horns
+1F918 1F3FB                                            ; fully-qualified     # 🤘🏻 E1.0 sign of the horns: light skin tone
+1F918 1F3FC                                            ; fully-qualified     # 🤘🏼 E1.0 sign of the horns: medium-light skin tone
+1F918 1F3FD                                            ; fully-qualified     # 🤘🏽 E1.0 sign of the horns: medium skin tone
+1F918 1F3FE                                            ; fully-qualified     # 🤘🏾 E1.0 sign of the horns: medium-dark skin tone
+1F918 1F3FF                                            ; fully-qualified     # 🤘🏿 E1.0 sign of the horns: dark skin tone
+1F919                                                  ; fully-qualified     # 🤙 E3.0 call me hand
+1F919 1F3FB                                            ; fully-qualified     # 🤙🏻 E3.0 call me hand: light skin tone
+1F919 1F3FC                                            ; fully-qualified     # 🤙🏼 E3.0 call me hand: medium-light skin tone
+1F919 1F3FD                                            ; fully-qualified     # 🤙🏽 E3.0 call me hand: medium skin tone
+1F919 1F3FE                                            ; fully-qualified     # 🤙🏾 E3.0 call me hand: medium-dark skin tone
+1F919 1F3FF                                            ; fully-qualified     # 🤙🏿 E3.0 call me hand: dark skin tone
+
+# subgroup: hand-single-finger
+1F448                                                  ; fully-qualified     # 👈 E0.6 backhand index pointing left
+1F448 1F3FB                                            ; fully-qualified     # 👈🏻 E1.0 backhand index pointing left: light skin tone
+1F448 1F3FC                                            ; fully-qualified     # 👈🏼 E1.0 backhand index pointing left: medium-light skin tone
+1F448 1F3FD                                            ; fully-qualified     # 👈🏽 E1.0 backhand index pointing left: medium skin tone
+1F448 1F3FE                                            ; fully-qualified     # 👈🏾 E1.0 backhand index pointing left: medium-dark skin tone
+1F448 1F3FF                                            ; fully-qualified     # 👈🏿 E1.0 backhand index pointing left: dark skin tone
+1F449                                                  ; fully-qualified     # 👉 E0.6 backhand index pointing right
+1F449 1F3FB                                            ; fully-qualified     # 👉🏻 E1.0 backhand index pointing right: light skin tone
+1F449 1F3FC                                            ; fully-qualified     # 👉🏼 E1.0 backhand index pointing right: medium-light skin tone
+1F449 1F3FD                                            ; fully-qualified     # 👉🏽 E1.0 backhand index pointing right: medium skin tone
+1F449 1F3FE                                            ; fully-qualified     # 👉🏾 E1.0 backhand index pointing right: medium-dark skin tone
+1F449 1F3FF                                            ; fully-qualified     # 👉🏿 E1.0 backhand index pointing right: dark skin tone
+1F446                                                  ; fully-qualified     # 👆 E0.6 backhand index pointing up
+1F446 1F3FB                                            ; fully-qualified     # 👆🏻 E1.0 backhand index pointing up: light skin tone
+1F446 1F3FC                                            ; fully-qualified     # 👆🏼 E1.0 backhand index pointing up: medium-light skin tone
+1F446 1F3FD                                            ; fully-qualified     # 👆🏽 E1.0 backhand index pointing up: medium skin tone
+1F446 1F3FE                                            ; fully-qualified     # 👆🏾 E1.0 backhand index pointing up: medium-dark skin tone
+1F446 1F3FF                                            ; fully-qualified     # 👆🏿 E1.0 backhand index pointing up: dark skin tone
+1F595                                                  ; fully-qualified     # 🖕 E1.0 middle finger
+1F595 1F3FB                                            ; fully-qualified     # 🖕🏻 E1.0 middle finger: light skin tone
+1F595 1F3FC                                            ; fully-qualified     # 🖕🏼 E1.0 middle finger: medium-light skin tone
+1F595 1F3FD                                            ; fully-qualified     # 🖕🏽 E1.0 middle finger: medium skin tone
+1F595 1F3FE                                            ; fully-qualified     # 🖕🏾 E1.0 middle finger: medium-dark skin tone
+1F595 1F3FF                                            ; fully-qualified     # 🖕🏿 E1.0 middle finger: dark skin tone
+1F447                                                  ; fully-qualified     # 👇 E0.6 backhand index pointing down
+1F447 1F3FB                                            ; fully-qualified     # 👇🏻 E1.0 backhand index pointing down: light skin tone
+1F447 1F3FC                                            ; fully-qualified     # 👇🏼 E1.0 backhand index pointing down: medium-light skin tone
+1F447 1F3FD                                            ; fully-qualified     # 👇🏽 E1.0 backhand index pointing down: medium skin tone
+1F447 1F3FE                                            ; fully-qualified     # 👇🏾 E1.0 backhand index pointing down: medium-dark skin tone
+1F447 1F3FF                                            ; fully-qualified     # 👇🏿 E1.0 backhand index pointing down: dark skin tone
+261D FE0F                                              ; fully-qualified     # ☝️ E0.6 index pointing up
+261D                                                   ; unqualified         # ☝ E0.6 index pointing up
+261D 1F3FB                                             ; fully-qualified     # ☝🏻 E1.0 index pointing up: light skin tone
+261D 1F3FC                                             ; fully-qualified     # ☝🏼 E1.0 index pointing up: medium-light skin tone
+261D 1F3FD                                             ; fully-qualified     # ☝🏽 E1.0 index pointing up: medium skin tone
+261D 1F3FE                                             ; fully-qualified     # ☝🏾 E1.0 index pointing up: medium-dark skin tone
+261D 1F3FF                                             ; fully-qualified     # ☝🏿 E1.0 index pointing up: dark skin tone
+1FAF5                                                  ; fully-qualified     # 🫵 E14.0 index pointing at the viewer
+1FAF5 1F3FB                                            ; fully-qualified     # 🫵🏻 E14.0 index pointing at the viewer: light skin tone
+1FAF5 1F3FC                                            ; fully-qualified     # 🫵🏼 E14.0 index pointing at the viewer: medium-light skin tone
+1FAF5 1F3FD                                            ; fully-qualified     # 🫵🏽 E14.0 index pointing at the viewer: medium skin tone
+1FAF5 1F3FE                                            ; fully-qualified     # 🫵🏾 E14.0 index pointing at the viewer: medium-dark skin tone
+1FAF5 1F3FF                                            ; fully-qualified     # 🫵🏿 E14.0 index pointing at the viewer: dark skin tone
+
+# subgroup: hand-fingers-closed
+1F44D                                                  ; fully-qualified     # 👍 E0.6 thumbs up
+1F44D 1F3FB                                            ; fully-qualified     # 👍🏻 E1.0 thumbs up: light skin tone
+1F44D 1F3FC                                            ; fully-qualified     # 👍🏼 E1.0 thumbs up: medium-light skin tone
+1F44D 1F3FD                                            ; fully-qualified     # 👍🏽 E1.0 thumbs up: medium skin tone
+1F44D 1F3FE                                            ; fully-qualified     # 👍🏾 E1.0 thumbs up: medium-dark skin tone
+1F44D 1F3FF                                            ; fully-qualified     # 👍🏿 E1.0 thumbs up: dark skin tone
+1F44E                                                  ; fully-qualified     # 👎 E0.6 thumbs down
+1F44E 1F3FB                                            ; fully-qualified     # 👎🏻 E1.0 thumbs down: light skin tone
+1F44E 1F3FC                                            ; fully-qualified     # 👎🏼 E1.0 thumbs down: medium-light skin tone
+1F44E 1F3FD                                            ; fully-qualified     # 👎🏽 E1.0 thumbs down: medium skin tone
+1F44E 1F3FE                                            ; fully-qualified     # 👎🏾 E1.0 thumbs down: medium-dark skin tone
+1F44E 1F3FF                                            ; fully-qualified     # 👎🏿 E1.0 thumbs down: dark skin tone
+270A                                                   ; fully-qualified     # ✊ E0.6 raised fist
+270A 1F3FB                                             ; fully-qualified     # ✊🏻 E1.0 raised fist: light skin tone
+270A 1F3FC                                             ; fully-qualified     # ✊🏼 E1.0 raised fist: medium-light skin tone
+270A 1F3FD                                             ; fully-qualified     # ✊🏽 E1.0 raised fist: medium skin tone
+270A 1F3FE                                             ; fully-qualified     # ✊🏾 E1.0 raised fist: medium-dark skin tone
+270A 1F3FF                                             ; fully-qualified     # ✊🏿 E1.0 raised fist: dark skin tone
+1F44A                                                  ; fully-qualified     # 👊 E0.6 oncoming fist
+1F44A 1F3FB                                            ; fully-qualified     # 👊🏻 E1.0 oncoming fist: light skin tone
+1F44A 1F3FC                                            ; fully-qualified     # 👊🏼 E1.0 oncoming fist: medium-light skin tone
+1F44A 1F3FD                                            ; fully-qualified     # 👊🏽 E1.0 oncoming fist: medium skin tone
+1F44A 1F3FE                                            ; fully-qualified     # 👊🏾 E1.0 oncoming fist: medium-dark skin tone
+1F44A 1F3FF                                            ; fully-qualified     # 👊🏿 E1.0 oncoming fist: dark skin tone
+1F91B                                                  ; fully-qualified     # 🤛 E3.0 left-facing fist
+1F91B 1F3FB                                            ; fully-qualified     # 🤛🏻 E3.0 left-facing fist: light skin tone
+1F91B 1F3FC                                            ; fully-qualified     # 🤛🏼 E3.0 left-facing fist: medium-light skin tone
+1F91B 1F3FD                                            ; fully-qualified     # 🤛🏽 E3.0 left-facing fist: medium skin tone
+1F91B 1F3FE                                            ; fully-qualified     # 🤛🏾 E3.0 left-facing fist: medium-dark skin tone
+1F91B 1F3FF                                            ; fully-qualified     # 🤛🏿 E3.0 left-facing fist: dark skin tone
+1F91C                                                  ; fully-qualified     # 🤜 E3.0 right-facing fist
+1F91C 1F3FB                                            ; fully-qualified     # 🤜🏻 E3.0 right-facing fist: light skin tone
+1F91C 1F3FC                                            ; fully-qualified     # 🤜🏼 E3.0 right-facing fist: medium-light skin tone
+1F91C 1F3FD                                            ; fully-qualified     # 🤜🏽 E3.0 right-facing fist: medium skin tone
+1F91C 1F3FE                                            ; fully-qualified     # 🤜🏾 E3.0 right-facing fist: medium-dark skin tone
+1F91C 1F3FF                                            ; fully-qualified     # 🤜🏿 E3.0 right-facing fist: dark skin tone
+
+# subgroup: hands
+1F44F                                                  ; fully-qualified     # 👏 E0.6 clapping hands
+1F44F 1F3FB                                            ; fully-qualified     # 👏🏻 E1.0 clapping hands: light skin tone
+1F44F 1F3FC                                            ; fully-qualified     # 👏🏼 E1.0 clapping hands: medium-light skin tone
+1F44F 1F3FD                                            ; fully-qualified     # 👏🏽 E1.0 clapping hands: medium skin tone
+1F44F 1F3FE                                            ; fully-qualified     # 👏🏾 E1.0 clapping hands: medium-dark skin tone
+1F44F 1F3FF                                            ; fully-qualified     # 👏🏿 E1.0 clapping hands: dark skin tone
+1F64C                                                  ; fully-qualified     # 🙌 E0.6 raising hands
+1F64C 1F3FB                                            ; fully-qualified     # 🙌🏻 E1.0 raising hands: light skin tone
+1F64C 1F3FC                                            ; fully-qualified     # 🙌🏼 E1.0 raising hands: medium-light skin tone
+1F64C 1F3FD                                            ; fully-qualified     # 🙌🏽 E1.0 raising hands: medium skin tone
+1F64C 1F3FE                                            ; fully-qualified     # 🙌🏾 E1.0 raising hands: medium-dark skin tone
+1F64C 1F3FF                                            ; fully-qualified     # 🙌🏿 E1.0 raising hands: dark skin tone
+1FAF6                                                  ; fully-qualified     # 🫶 E14.0 heart hands
+1FAF6 1F3FB                                            ; fully-qualified     # 🫶🏻 E14.0 heart hands: light skin tone
+1FAF6 1F3FC                                            ; fully-qualified     # 🫶🏼 E14.0 heart hands: medium-light skin tone
+1FAF6 1F3FD                                            ; fully-qualified     # 🫶🏽 E14.0 heart hands: medium skin tone
+1FAF6 1F3FE                                            ; fully-qualified     # 🫶🏾 E14.0 heart hands: medium-dark skin tone
+1FAF6 1F3FF                                            ; fully-qualified     # 🫶🏿 E14.0 heart hands: dark skin tone
+1F450                                                  ; fully-qualified     # 👐 E0.6 open hands
+1F450 1F3FB                                            ; fully-qualified     # 👐🏻 E1.0 open hands: light skin tone
+1F450 1F3FC                                            ; fully-qualified     # 👐🏼 E1.0 open hands: medium-light skin tone
+1F450 1F3FD                                            ; fully-qualified     # 👐🏽 E1.0 open hands: medium skin tone
+1F450 1F3FE                                            ; fully-qualified     # 👐🏾 E1.0 open hands: medium-dark skin tone
+1F450 1F3FF                                            ; fully-qualified     # 👐🏿 E1.0 open hands: dark skin tone
+1F932                                                  ; fully-qualified     # 🤲 E5.0 palms up together
+1F932 1F3FB                                            ; fully-qualified     # 🤲🏻 E5.0 palms up together: light skin tone
+1F932 1F3FC                                            ; fully-qualified     # 🤲🏼 E5.0 palms up together: medium-light skin tone
+1F932 1F3FD                                            ; fully-qualified     # 🤲🏽 E5.0 palms up together: medium skin tone
+1F932 1F3FE                                            ; fully-qualified     # 🤲🏾 E5.0 palms up together: medium-dark skin tone
+1F932 1F3FF                                            ; fully-qualified     # 🤲🏿 E5.0 palms up together: dark skin tone
+1F91D                                                  ; fully-qualified     # 🤝 E3.0 handshake
+1F91D 1F3FB                                            ; fully-qualified     # 🤝🏻 E14.0 handshake: light skin tone
+1F91D 1F3FC                                            ; fully-qualified     # 🤝🏼 E14.0 handshake: medium-light skin tone
+1F91D 1F3FD                                            ; fully-qualified     # 🤝🏽 E14.0 handshake: medium skin tone
+1F91D 1F3FE                                            ; fully-qualified     # 🤝🏾 E14.0 handshake: medium-dark skin tone
+1F91D 1F3FF                                            ; fully-qualified     # 🤝🏿 E14.0 handshake: dark skin tone
+1FAF1 1F3FB 200D 1FAF2 1F3FC                           ; fully-qualified     # 🫱🏻‍🫲🏼 E14.0 handshake: light skin tone, medium-light skin tone
+1FAF1 1F3FB 200D 1FAF2 1F3FD                           ; fully-qualified     # 🫱🏻‍🫲🏽 E14.0 handshake: light skin tone, medium skin tone
+1FAF1 1F3FB 200D 1FAF2 1F3FE                           ; fully-qualified     # 🫱🏻‍🫲🏾 E14.0 handshake: light skin tone, medium-dark skin tone
+1FAF1 1F3FB 200D 1FAF2 1F3FF                           ; fully-qualified     # 🫱🏻‍🫲🏿 E14.0 handshake: light skin tone, dark skin tone
+1FAF1 1F3FC 200D 1FAF2 1F3FB                           ; fully-qualified     # 🫱🏼‍🫲🏻 E14.0 handshake: medium-light skin tone, light skin tone
+1FAF1 1F3FC 200D 1FAF2 1F3FD                           ; fully-qualified     # 🫱🏼‍🫲🏽 E14.0 handshake: medium-light skin tone, medium skin tone
+1FAF1 1F3FC 200D 1FAF2 1F3FE                           ; fully-qualified     # 🫱🏼‍🫲🏾 E14.0 handshake: medium-light skin tone, medium-dark skin tone
+1FAF1 1F3FC 200D 1FAF2 1F3FF                           ; fully-qualified     # 🫱🏼‍🫲🏿 E14.0 handshake: medium-light skin tone, dark skin tone
+1FAF1 1F3FD 200D 1FAF2 1F3FB                           ; fully-qualified     # 🫱🏽‍🫲🏻 E14.0 handshake: medium skin tone, light skin tone
+1FAF1 1F3FD 200D 1FAF2 1F3FC                           ; fully-qualified     # 🫱🏽‍🫲🏼 E14.0 handshake: medium skin tone, medium-light skin tone
+1FAF1 1F3FD 200D 1FAF2 1F3FE                           ; fully-qualified     # 🫱🏽‍🫲🏾 E14.0 handshake: medium skin tone, medium-dark skin tone
+1FAF1 1F3FD 200D 1FAF2 1F3FF                           ; fully-qualified     # 🫱🏽‍🫲🏿 E14.0 handshake: medium skin tone, dark skin tone
+1FAF1 1F3FE 200D 1FAF2 1F3FB                           ; fully-qualified     # 🫱🏾‍🫲🏻 E14.0 handshake: medium-dark skin tone, light skin tone
+1FAF1 1F3FE 200D 1FAF2 1F3FC                           ; fully-qualified     # 🫱🏾‍🫲🏼 E14.0 handshake: medium-dark skin tone, medium-light skin tone
+1FAF1 1F3FE 200D 1FAF2 1F3FD                           ; fully-qualified     # 🫱🏾‍🫲🏽 E14.0 handshake: medium-dark skin tone, medium skin tone
+1FAF1 1F3FE 200D 1FAF2 1F3FF                           ; fully-qualified     # 🫱🏾‍🫲🏿 E14.0 handshake: medium-dark skin tone, dark skin tone
+1FAF1 1F3FF 200D 1FAF2 1F3FB                           ; fully-qualified     # 🫱🏿‍🫲🏻 E14.0 handshake: dark skin tone, light skin tone
+1FAF1 1F3FF 200D 1FAF2 1F3FC                           ; fully-qualified     # 🫱🏿‍🫲🏼 E14.0 handshake: dark skin tone, medium-light skin tone
+1FAF1 1F3FF 200D 1FAF2 1F3FD                           ; fully-qualified     # 🫱🏿‍🫲🏽 E14.0 handshake: dark skin tone, medium skin tone
+1FAF1 1F3FF 200D 1FAF2 1F3FE                           ; fully-qualified     # 🫱🏿‍🫲🏾 E14.0 handshake: dark skin tone, medium-dark skin tone
+1F64F                                                  ; fully-qualified     # 🙏 E0.6 folded hands
+1F64F 1F3FB                                            ; fully-qualified     # 🙏🏻 E1.0 folded hands: light skin tone
+1F64F 1F3FC                                            ; fully-qualified     # 🙏🏼 E1.0 folded hands: medium-light skin tone
+1F64F 1F3FD                                            ; fully-qualified     # 🙏🏽 E1.0 folded hands: medium skin tone
+1F64F 1F3FE                                            ; fully-qualified     # 🙏🏾 E1.0 folded hands: medium-dark skin tone
+1F64F 1F3FF                                            ; fully-qualified     # 🙏🏿 E1.0 folded hands: dark skin tone
+
+# subgroup: hand-prop
+270D FE0F                                              ; fully-qualified     # ✍️ E0.7 writing hand
+270D                                                   ; unqualified         # ✍ E0.7 writing hand
+270D 1F3FB                                             ; fully-qualified     # ✍🏻 E1.0 writing hand: light skin tone
+270D 1F3FC                                             ; fully-qualified     # ✍🏼 E1.0 writing hand: medium-light skin tone
+270D 1F3FD                                             ; fully-qualified     # ✍🏽 E1.0 writing hand: medium skin tone
+270D 1F3FE                                             ; fully-qualified     # ✍🏾 E1.0 writing hand: medium-dark skin tone
+270D 1F3FF                                             ; fully-qualified     # ✍🏿 E1.0 writing hand: dark skin tone
+1F485                                                  ; fully-qualified     # 💅 E0.6 nail polish
+1F485 1F3FB                                            ; fully-qualified     # 💅🏻 E1.0 nail polish: light skin tone
+1F485 1F3FC                                            ; fully-qualified     # 💅🏼 E1.0 nail polish: medium-light skin tone
+1F485 1F3FD                                            ; fully-qualified     # 💅🏽 E1.0 nail polish: medium skin tone
+1F485 1F3FE                                            ; fully-qualified     # 💅🏾 E1.0 nail polish: medium-dark skin tone
+1F485 1F3FF                                            ; fully-qualified     # 💅🏿 E1.0 nail polish: dark skin tone
+1F933                                                  ; fully-qualified     # 🤳 E3.0 selfie
+1F933 1F3FB                                            ; fully-qualified     # 🤳🏻 E3.0 selfie: light skin tone
+1F933 1F3FC                                            ; fully-qualified     # 🤳🏼 E3.0 selfie: medium-light skin tone
+1F933 1F3FD                                            ; fully-qualified     # 🤳🏽 E3.0 selfie: medium skin tone
+1F933 1F3FE                                            ; fully-qualified     # 🤳🏾 E3.0 selfie: medium-dark skin tone
+1F933 1F3FF                                            ; fully-qualified     # 🤳🏿 E3.0 selfie: dark skin tone
+
+# subgroup: body-parts
+1F4AA                                                  ; fully-qualified     # 💪 E0.6 flexed biceps
+1F4AA 1F3FB                                            ; fully-qualified     # 💪🏻 E1.0 flexed biceps: light skin tone
+1F4AA 1F3FC                                            ; fully-qualified     # 💪🏼 E1.0 flexed biceps: medium-light skin tone
+1F4AA 1F3FD                                            ; fully-qualified     # 💪🏽 E1.0 flexed biceps: medium skin tone
+1F4AA 1F3FE                                            ; fully-qualified     # 💪🏾 E1.0 flexed biceps: medium-dark skin tone
+1F4AA 1F3FF                                            ; fully-qualified     # 💪🏿 E1.0 flexed biceps: dark skin tone
+1F9BE                                                  ; fully-qualified     # 🦾 E12.0 mechanical arm
+1F9BF                                                  ; fully-qualified     # 🦿 E12.0 mechanical leg
+1F9B5                                                  ; fully-qualified     # 🦵 E11.0 leg
+1F9B5 1F3FB                                            ; fully-qualified     # 🦵🏻 E11.0 leg: light skin tone
+1F9B5 1F3FC                                            ; fully-qualified     # 🦵🏼 E11.0 leg: medium-light skin tone
+1F9B5 1F3FD                                            ; fully-qualified     # 🦵🏽 E11.0 leg: medium skin tone
+1F9B5 1F3FE                                            ; fully-qualified     # 🦵🏾 E11.0 leg: medium-dark skin tone
+1F9B5 1F3FF                                            ; fully-qualified     # 🦵🏿 E11.0 leg: dark skin tone
+1F9B6                                                  ; fully-qualified     # 🦶 E11.0 foot
+1F9B6 1F3FB                                            ; fully-qualified     # 🦶🏻 E11.0 foot: light skin tone
+1F9B6 1F3FC                                            ; fully-qualified     # 🦶🏼 E11.0 foot: medium-light skin tone
+1F9B6 1F3FD                                            ; fully-qualified     # 🦶🏽 E11.0 foot: medium skin tone
+1F9B6 1F3FE                                            ; fully-qualified     # 🦶🏾 E11.0 foot: medium-dark skin tone
+1F9B6 1F3FF                                            ; fully-qualified     # 🦶🏿 E11.0 foot: dark skin tone
+1F442                                                  ; fully-qualified     # 👂 E0.6 ear
+1F442 1F3FB                                            ; fully-qualified     # 👂🏻 E1.0 ear: light skin tone
+1F442 1F3FC                                            ; fully-qualified     # 👂🏼 E1.0 ear: medium-light skin tone
+1F442 1F3FD                                            ; fully-qualified     # 👂🏽 E1.0 ear: medium skin tone
+1F442 1F3FE                                            ; fully-qualified     # 👂🏾 E1.0 ear: medium-dark skin tone
+1F442 1F3FF                                            ; fully-qualified     # 👂🏿 E1.0 ear: dark skin tone
+1F9BB                                                  ; fully-qualified     # 🦻 E12.0 ear with hearing aid
+1F9BB 1F3FB                                            ; fully-qualified     # 🦻🏻 E12.0 ear with hearing aid: light skin tone
+1F9BB 1F3FC                                            ; fully-qualified     # 🦻🏼 E12.0 ear with hearing aid: medium-light skin tone
+1F9BB 1F3FD                                            ; fully-qualified     # 🦻🏽 E12.0 ear with hearing aid: medium skin tone
+1F9BB 1F3FE                                            ; fully-qualified     # 🦻🏾 E12.0 ear with hearing aid: medium-dark skin tone
+1F9BB 1F3FF                                            ; fully-qualified     # 🦻🏿 E12.0 ear with hearing aid: dark skin tone
+1F443                                                  ; fully-qualified     # 👃 E0.6 nose
+1F443 1F3FB                                            ; fully-qualified     # 👃🏻 E1.0 nose: light skin tone
+1F443 1F3FC                                            ; fully-qualified     # 👃🏼 E1.0 nose: medium-light skin tone
+1F443 1F3FD                                            ; fully-qualified     # 👃🏽 E1.0 nose: medium skin tone
+1F443 1F3FE                                            ; fully-qualified     # 👃🏾 E1.0 nose: medium-dark skin tone
+1F443 1F3FF                                            ; fully-qualified     # 👃🏿 E1.0 nose: dark skin tone
+1F9E0                                                  ; fully-qualified     # 🧠 E5.0 brain
+1FAC0                                                  ; fully-qualified     # 🫀 E13.0 anatomical heart
+1FAC1                                                  ; fully-qualified     # 🫁 E13.0 lungs
+1F9B7                                                  ; fully-qualified     # 🦷 E11.0 tooth
+1F9B4                                                  ; fully-qualified     # 🦴 E11.0 bone
+1F440                                                  ; fully-qualified     # 👀 E0.6 eyes
+1F441 FE0F                                             ; fully-qualified     # 👁️ E0.7 eye
+1F441                                                  ; unqualified         # 👁 E0.7 eye
+1F445                                                  ; fully-qualified     # 👅 E0.6 tongue
+1F444                                                  ; fully-qualified     # 👄 E0.6 mouth
+1FAE6                                                  ; fully-qualified     # 🫦 E14.0 biting lip
+
+# subgroup: person
+1F476                                                  ; fully-qualified     # 👶 E0.6 baby
+1F476 1F3FB                                            ; fully-qualified     # 👶🏻 E1.0 baby: light skin tone
+1F476 1F3FC                                            ; fully-qualified     # 👶🏼 E1.0 baby: medium-light skin tone
+1F476 1F3FD                                            ; fully-qualified     # 👶🏽 E1.0 baby: medium skin tone
+1F476 1F3FE                                            ; fully-qualified     # 👶🏾 E1.0 baby: medium-dark skin tone
+1F476 1F3FF                                            ; fully-qualified     # 👶🏿 E1.0 baby: dark skin tone
+1F9D2                                                  ; fully-qualified     # 🧒 E5.0 child
+1F9D2 1F3FB                                            ; fully-qualified     # 🧒🏻 E5.0 child: light skin tone
+1F9D2 1F3FC                                            ; fully-qualified     # 🧒🏼 E5.0 child: medium-light skin tone
+1F9D2 1F3FD                                            ; fully-qualified     # 🧒🏽 E5.0 child: medium skin tone
+1F9D2 1F3FE                                            ; fully-qualified     # 🧒🏾 E5.0 child: medium-dark skin tone
+1F9D2 1F3FF                                            ; fully-qualified     # 🧒🏿 E5.0 child: dark skin tone
+1F466                                                  ; fully-qualified     # 👦 E0.6 boy
+1F466 1F3FB                                            ; fully-qualified     # 👦🏻 E1.0 boy: light skin tone
+1F466 1F3FC                                            ; fully-qualified     # 👦🏼 E1.0 boy: medium-light skin tone
+1F466 1F3FD                                            ; fully-qualified     # 👦🏽 E1.0 boy: medium skin tone
+1F466 1F3FE                                            ; fully-qualified     # 👦🏾 E1.0 boy: medium-dark skin tone
+1F466 1F3FF                                            ; fully-qualified     # 👦🏿 E1.0 boy: dark skin tone
+1F467                                                  ; fully-qualified     # 👧 E0.6 girl
+1F467 1F3FB                                            ; fully-qualified     # 👧🏻 E1.0 girl: light skin tone
+1F467 1F3FC                                            ; fully-qualified     # 👧🏼 E1.0 girl: medium-light skin tone
+1F467 1F3FD                                            ; fully-qualified     # 👧🏽 E1.0 girl: medium skin tone
+1F467 1F3FE                                            ; fully-qualified     # 👧🏾 E1.0 girl: medium-dark skin tone
+1F467 1F3FF                                            ; fully-qualified     # 👧🏿 E1.0 girl: dark skin tone
+1F9D1                                                  ; fully-qualified     # 🧑 E5.0 person
+1F9D1 1F3FB                                            ; fully-qualified     # 🧑🏻 E5.0 person: light skin tone
+1F9D1 1F3FC                                            ; fully-qualified     # 🧑🏼 E5.0 person: medium-light skin tone
+1F9D1 1F3FD                                            ; fully-qualified     # 🧑🏽 E5.0 person: medium skin tone
+1F9D1 1F3FE                                            ; fully-qualified     # 🧑🏾 E5.0 person: medium-dark skin tone
+1F9D1 1F3FF                                            ; fully-qualified     # 🧑🏿 E5.0 person: dark skin tone
+1F471                                                  ; fully-qualified     # 👱 E0.6 person: blond hair
+1F471 1F3FB                                            ; fully-qualified     # 👱🏻 E1.0 person: light skin tone, blond hair
+1F471 1F3FC                                            ; fully-qualified     # 👱🏼 E1.0 person: medium-light skin tone, blond hair
+1F471 1F3FD                                            ; fully-qualified     # 👱🏽 E1.0 person: medium skin tone, blond hair
+1F471 1F3FE                                            ; fully-qualified     # 👱🏾 E1.0 person: medium-dark skin tone, blond hair
+1F471 1F3FF                                            ; fully-qualified     # 👱🏿 E1.0 person: dark skin tone, blond hair
+1F468                                                  ; fully-qualified     # 👨 E0.6 man
+1F468 1F3FB                                            ; fully-qualified     # 👨🏻 E1.0 man: light skin tone
+1F468 1F3FC                                            ; fully-qualified     # 👨🏼 E1.0 man: medium-light skin tone
+1F468 1F3FD                                            ; fully-qualified     # 👨🏽 E1.0 man: medium skin tone
+1F468 1F3FE                                            ; fully-qualified     # 👨🏾 E1.0 man: medium-dark skin tone
+1F468 1F3FF                                            ; fully-qualified     # 👨🏿 E1.0 man: dark skin tone
+1F9D4                                                  ; fully-qualified     # 🧔 E5.0 person: beard
+1F9D4 1F3FB                                            ; fully-qualified     # 🧔🏻 E5.0 person: light skin tone, beard
+1F9D4 1F3FC                                            ; fully-qualified     # 🧔🏼 E5.0 person: medium-light skin tone, beard
+1F9D4 1F3FD                                            ; fully-qualified     # 🧔🏽 E5.0 person: medium skin tone, beard
+1F9D4 1F3FE                                            ; fully-qualified     # 🧔🏾 E5.0 person: medium-dark skin tone, beard
+1F9D4 1F3FF                                            ; fully-qualified     # 🧔🏿 E5.0 person: dark skin tone, beard
+1F9D4 200D 2642 FE0F                                   ; fully-qualified     # 🧔‍♂️ E13.1 man: beard
+1F9D4 200D 2642                                        ; minimally-qualified # 🧔‍♂ E13.1 man: beard
+1F9D4 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🧔🏻‍♂️ E13.1 man: light skin tone, beard
+1F9D4 1F3FB 200D 2642                                  ; minimally-qualified # 🧔🏻‍♂ E13.1 man: light skin tone, beard
+1F9D4 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🧔🏼‍♂️ E13.1 man: medium-light skin tone, beard
+1F9D4 1F3FC 200D 2642                                  ; minimally-qualified # 🧔🏼‍♂ E13.1 man: medium-light skin tone, beard
+1F9D4 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🧔🏽‍♂️ E13.1 man: medium skin tone, beard
+1F9D4 1F3FD 200D 2642                                  ; minimally-qualified # 🧔🏽‍♂ E13.1 man: medium skin tone, beard
+1F9D4 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🧔🏾‍♂️ E13.1 man: medium-dark skin tone, beard
+1F9D4 1F3FE 200D 2642                                  ; minimally-qualified # 🧔🏾‍♂ E13.1 man: medium-dark skin tone, beard
+1F9D4 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🧔🏿‍♂️ E13.1 man: dark skin tone, beard
+1F9D4 1F3FF 200D 2642                                  ; minimally-qualified # 🧔🏿‍♂ E13.1 man: dark skin tone, beard
+1F9D4 200D 2640 FE0F                                   ; fully-qualified     # 🧔‍♀️ E13.1 woman: beard
+1F9D4 200D 2640                                        ; minimally-qualified # 🧔‍♀ E13.1 woman: beard
+1F9D4 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🧔🏻‍♀️ E13.1 woman: light skin tone, beard
+1F9D4 1F3FB 200D 2640                                  ; minimally-qualified # 🧔🏻‍♀ E13.1 woman: light skin tone, beard
+1F9D4 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🧔🏼‍♀️ E13.1 woman: medium-light skin tone, beard
+1F9D4 1F3FC 200D 2640                                  ; minimally-qualified # 🧔🏼‍♀ E13.1 woman: medium-light skin tone, beard
+1F9D4 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🧔🏽‍♀️ E13.1 woman: medium skin tone, beard
+1F9D4 1F3FD 200D 2640                                  ; minimally-qualified # 🧔🏽‍♀ E13.1 woman: medium skin tone, beard
+1F9D4 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🧔🏾‍♀️ E13.1 woman: medium-dark skin tone, beard
+1F9D4 1F3FE 200D 2640                                  ; minimally-qualified # 🧔🏾‍♀ E13.1 woman: medium-dark skin tone, beard
+1F9D4 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🧔🏿‍♀️ E13.1 woman: dark skin tone, beard
+1F9D4 1F3FF 200D 2640                                  ; minimally-qualified # 🧔🏿‍♀ E13.1 woman: dark skin tone, beard
+1F468 200D 1F9B0                                       ; fully-qualified     # 👨‍🦰 E11.0 man: red hair
+1F468 1F3FB 200D 1F9B0                                 ; fully-qualified     # 👨🏻‍🦰 E11.0 man: light skin tone, red hair
+1F468 1F3FC 200D 1F9B0                                 ; fully-qualified     # 👨🏼‍🦰 E11.0 man: medium-light skin tone, red hair
+1F468 1F3FD 200D 1F9B0                                 ; fully-qualified     # 👨🏽‍🦰 E11.0 man: medium skin tone, red hair
+1F468 1F3FE 200D 1F9B0                                 ; fully-qualified     # 👨🏾‍🦰 E11.0 man: medium-dark skin tone, red hair
+1F468 1F3FF 200D 1F9B0                                 ; fully-qualified     # 👨🏿‍🦰 E11.0 man: dark skin tone, red hair
+1F468 200D 1F9B1                                       ; fully-qualified     # 👨‍🦱 E11.0 man: curly hair
+1F468 1F3FB 200D 1F9B1                                 ; fully-qualified     # 👨🏻‍🦱 E11.0 man: light skin tone, curly hair
+1F468 1F3FC 200D 1F9B1                                 ; fully-qualified     # 👨🏼‍🦱 E11.0 man: medium-light skin tone, curly hair
+1F468 1F3FD 200D 1F9B1                                 ; fully-qualified     # 👨🏽‍🦱 E11.0 man: medium skin tone, curly hair
+1F468 1F3FE 200D 1F9B1                                 ; fully-qualified     # 👨🏾‍🦱 E11.0 man: medium-dark skin tone, curly hair
+1F468 1F3FF 200D 1F9B1                                 ; fully-qualified     # 👨🏿‍🦱 E11.0 man: dark skin tone, curly hair
+1F468 200D 1F9B3                                       ; fully-qualified     # 👨‍🦳 E11.0 man: white hair
+1F468 1F3FB 200D 1F9B3                                 ; fully-qualified     # 👨🏻‍🦳 E11.0 man: light skin tone, white hair
+1F468 1F3FC 200D 1F9B3                                 ; fully-qualified     # 👨🏼‍🦳 E11.0 man: medium-light skin tone, white hair
+1F468 1F3FD 200D 1F9B3                                 ; fully-qualified     # 👨🏽‍🦳 E11.0 man: medium skin tone, white hair
+1F468 1F3FE 200D 1F9B3                                 ; fully-qualified     # 👨🏾‍🦳 E11.0 man: medium-dark skin tone, white hair
+1F468 1F3FF 200D 1F9B3                                 ; fully-qualified     # 👨🏿‍🦳 E11.0 man: dark skin tone, white hair
+1F468 200D 1F9B2                                       ; fully-qualified     # 👨‍🦲 E11.0 man: bald
+1F468 1F3FB 200D 1F9B2                                 ; fully-qualified     # 👨🏻‍🦲 E11.0 man: light skin tone, bald
+1F468 1F3FC 200D 1F9B2                                 ; fully-qualified     # 👨🏼‍🦲 E11.0 man: medium-light skin tone, bald
+1F468 1F3FD 200D 1F9B2                                 ; fully-qualified     # 👨🏽‍🦲 E11.0 man: medium skin tone, bald
+1F468 1F3FE 200D 1F9B2                                 ; fully-qualified     # 👨🏾‍🦲 E11.0 man: medium-dark skin tone, bald
+1F468 1F3FF 200D 1F9B2                                 ; fully-qualified     # 👨🏿‍🦲 E11.0 man: dark skin tone, bald
+1F469                                                  ; fully-qualified     # 👩 E0.6 woman
+1F469 1F3FB                                            ; fully-qualified     # 👩🏻 E1.0 woman: light skin tone
+1F469 1F3FC                                            ; fully-qualified     # 👩🏼 E1.0 woman: medium-light skin tone
+1F469 1F3FD                                            ; fully-qualified     # 👩🏽 E1.0 woman: medium skin tone
+1F469 1F3FE                                            ; fully-qualified     # 👩🏾 E1.0 woman: medium-dark skin tone
+1F469 1F3FF                                            ; fully-qualified     # 👩🏿 E1.0 woman: dark skin tone
+1F469 200D 1F9B0                                       ; fully-qualified     # 👩‍🦰 E11.0 woman: red hair
+1F469 1F3FB 200D 1F9B0                                 ; fully-qualified     # 👩🏻‍🦰 E11.0 woman: light skin tone, red hair
+1F469 1F3FC 200D 1F9B0                                 ; fully-qualified     # 👩🏼‍🦰 E11.0 woman: medium-light skin tone, red hair
+1F469 1F3FD 200D 1F9B0                                 ; fully-qualified     # 👩🏽‍🦰 E11.0 woman: medium skin tone, red hair
+1F469 1F3FE 200D 1F9B0                                 ; fully-qualified     # 👩🏾‍🦰 E11.0 woman: medium-dark skin tone, red hair
+1F469 1F3FF 200D 1F9B0                                 ; fully-qualified     # 👩🏿‍🦰 E11.0 woman: dark skin tone, red hair
+1F9D1 200D 1F9B0                                       ; fully-qualified     # 🧑‍🦰 E12.1 person: red hair
+1F9D1 1F3FB 200D 1F9B0                                 ; fully-qualified     # 🧑🏻‍🦰 E12.1 person: light skin tone, red hair
+1F9D1 1F3FC 200D 1F9B0                                 ; fully-qualified     # 🧑🏼‍🦰 E12.1 person: medium-light skin tone, red hair
+1F9D1 1F3FD 200D 1F9B0                                 ; fully-qualified     # 🧑🏽‍🦰 E12.1 person: medium skin tone, red hair
+1F9D1 1F3FE 200D 1F9B0                                 ; fully-qualified     # 🧑🏾‍🦰 E12.1 person: medium-dark skin tone, red hair
+1F9D1 1F3FF 200D 1F9B0                                 ; fully-qualified     # 🧑🏿‍🦰 E12.1 person: dark skin tone, red hair
+1F469 200D 1F9B1                                       ; fully-qualified     # 👩‍🦱 E11.0 woman: curly hair
+1F469 1F3FB 200D 1F9B1                                 ; fully-qualified     # 👩🏻‍🦱 E11.0 woman: light skin tone, curly hair
+1F469 1F3FC 200D 1F9B1                                 ; fully-qualified     # 👩🏼‍🦱 E11.0 woman: medium-light skin tone, curly hair
+1F469 1F3FD 200D 1F9B1                                 ; fully-qualified     # 👩🏽‍🦱 E11.0 woman: medium skin tone, curly hair
+1F469 1F3FE 200D 1F9B1                                 ; fully-qualified     # 👩🏾‍🦱 E11.0 woman: medium-dark skin tone, curly hair
+1F469 1F3FF 200D 1F9B1                                 ; fully-qualified     # 👩🏿‍🦱 E11.0 woman: dark skin tone, curly hair
+1F9D1 200D 1F9B1                                       ; fully-qualified     # 🧑‍🦱 E12.1 person: curly hair
+1F9D1 1F3FB 200D 1F9B1                                 ; fully-qualified     # 🧑🏻‍🦱 E12.1 person: light skin tone, curly hair
+1F9D1 1F3FC 200D 1F9B1                                 ; fully-qualified     # 🧑🏼‍🦱 E12.1 person: medium-light skin tone, curly hair
+1F9D1 1F3FD 200D 1F9B1                                 ; fully-qualified     # 🧑🏽‍🦱 E12.1 person: medium skin tone, curly hair
+1F9D1 1F3FE 200D 1F9B1                                 ; fully-qualified     # 🧑🏾‍🦱 E12.1 person: medium-dark skin tone, curly hair
+1F9D1 1F3FF 200D 1F9B1                                 ; fully-qualified     # 🧑🏿‍🦱 E12.1 person: dark skin tone, curly hair
+1F469 200D 1F9B3                                       ; fully-qualified     # 👩‍🦳 E11.0 woman: white hair
+1F469 1F3FB 200D 1F9B3                                 ; fully-qualified     # 👩🏻‍🦳 E11.0 woman: light skin tone, white hair
+1F469 1F3FC 200D 1F9B3                                 ; fully-qualified     # 👩🏼‍🦳 E11.0 woman: medium-light skin tone, white hair
+1F469 1F3FD 200D 1F9B3                                 ; fully-qualified     # 👩🏽‍🦳 E11.0 woman: medium skin tone, white hair
+1F469 1F3FE 200D 1F9B3                                 ; fully-qualified     # 👩🏾‍🦳 E11.0 woman: medium-dark skin tone, white hair
+1F469 1F3FF 200D 1F9B3                                 ; fully-qualified     # 👩🏿‍🦳 E11.0 woman: dark skin tone, white hair
+1F9D1 200D 1F9B3                                       ; fully-qualified     # 🧑‍🦳 E12.1 person: white hair
+1F9D1 1F3FB 200D 1F9B3                                 ; fully-qualified     # 🧑🏻‍🦳 E12.1 person: light skin tone, white hair
+1F9D1 1F3FC 200D 1F9B3                                 ; fully-qualified     # 🧑🏼‍🦳 E12.1 person: medium-light skin tone, white hair
+1F9D1 1F3FD 200D 1F9B3                                 ; fully-qualified     # 🧑🏽‍🦳 E12.1 person: medium skin tone, white hair
+1F9D1 1F3FE 200D 1F9B3                                 ; fully-qualified     # 🧑🏾‍🦳 E12.1 person: medium-dark skin tone, white hair
+1F9D1 1F3FF 200D 1F9B3                                 ; fully-qualified     # 🧑🏿‍🦳 E12.1 person: dark skin tone, white hair
+1F469 200D 1F9B2                                       ; fully-qualified     # 👩‍🦲 E11.0 woman: bald
+1F469 1F3FB 200D 1F9B2                                 ; fully-qualified     # 👩🏻‍🦲 E11.0 woman: light skin tone, bald
+1F469 1F3FC 200D 1F9B2                                 ; fully-qualified     # 👩🏼‍🦲 E11.0 woman: medium-light skin tone, bald
+1F469 1F3FD 200D 1F9B2                                 ; fully-qualified     # 👩🏽‍🦲 E11.0 woman: medium skin tone, bald
+1F469 1F3FE 200D 1F9B2                                 ; fully-qualified     # 👩🏾‍🦲 E11.0 woman: medium-dark skin tone, bald
+1F469 1F3FF 200D 1F9B2                                 ; fully-qualified     # 👩🏿‍🦲 E11.0 woman: dark skin tone, bald
+1F9D1 200D 1F9B2                                       ; fully-qualified     # 🧑‍🦲 E12.1 person: bald
+1F9D1 1F3FB 200D 1F9B2                                 ; fully-qualified     # 🧑🏻‍🦲 E12.1 person: light skin tone, bald
+1F9D1 1F3FC 200D 1F9B2                                 ; fully-qualified     # 🧑🏼‍🦲 E12.1 person: medium-light skin tone, bald
+1F9D1 1F3FD 200D 1F9B2                                 ; fully-qualified     # 🧑🏽‍🦲 E12.1 person: medium skin tone, bald
+1F9D1 1F3FE 200D 1F9B2                                 ; fully-qualified     # 🧑🏾‍🦲 E12.1 person: medium-dark skin tone, bald
+1F9D1 1F3FF 200D 1F9B2                                 ; fully-qualified     # 🧑🏿‍🦲 E12.1 person: dark skin tone, bald
+1F471 200D 2640 FE0F                                   ; fully-qualified     # 👱‍♀️ E4.0 woman: blond hair
+1F471 200D 2640                                        ; minimally-qualified # 👱‍♀ E4.0 woman: blond hair
+1F471 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 👱🏻‍♀️ E4.0 woman: light skin tone, blond hair
+1F471 1F3FB 200D 2640                                  ; minimally-qualified # 👱🏻‍♀ E4.0 woman: light skin tone, blond hair
+1F471 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 👱🏼‍♀️ E4.0 woman: medium-light skin tone, blond hair
+1F471 1F3FC 200D 2640                                  ; minimally-qualified # 👱🏼‍♀ E4.0 woman: medium-light skin tone, blond hair
+1F471 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 👱🏽‍♀️ E4.0 woman: medium skin tone, blond hair
+1F471 1F3FD 200D 2640                                  ; minimally-qualified # 👱🏽‍♀ E4.0 woman: medium skin tone, blond hair
+1F471 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 👱🏾‍♀️ E4.0 woman: medium-dark skin tone, blond hair
+1F471 1F3FE 200D 2640                                  ; minimally-qualified # 👱🏾‍♀ E4.0 woman: medium-dark skin tone, blond hair
+1F471 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 👱🏿‍♀️ E4.0 woman: dark skin tone, blond hair
+1F471 1F3FF 200D 2640                                  ; minimally-qualified # 👱🏿‍♀ E4.0 woman: dark skin tone, blond hair
+1F471 200D 2642 FE0F                                   ; fully-qualified     # 👱‍♂️ E4.0 man: blond hair
+1F471 200D 2642                                        ; minimally-qualified # 👱‍♂ E4.0 man: blond hair
+1F471 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 👱🏻‍♂️ E4.0 man: light skin tone, blond hair
+1F471 1F3FB 200D 2642                                  ; minimally-qualified # 👱🏻‍♂ E4.0 man: light skin tone, blond hair
+1F471 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 👱🏼‍♂️ E4.0 man: medium-light skin tone, blond hair
+1F471 1F3FC 200D 2642                                  ; minimally-qualified # 👱🏼‍♂ E4.0 man: medium-light skin tone, blond hair
+1F471 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 👱🏽‍♂️ E4.0 man: medium skin tone, blond hair
+1F471 1F3FD 200D 2642                                  ; minimally-qualified # 👱🏽‍♂ E4.0 man: medium skin tone, blond hair
+1F471 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 👱🏾‍♂️ E4.0 man: medium-dark skin tone, blond hair
+1F471 1F3FE 200D 2642                                  ; minimally-qualified # 👱🏾‍♂ E4.0 man: medium-dark skin tone, blond hair
+1F471 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 👱🏿‍♂️ E4.0 man: dark skin tone, blond hair
+1F471 1F3FF 200D 2642                                  ; minimally-qualified # 👱🏿‍♂ E4.0 man: dark skin tone, blond hair
+1F9D3                                                  ; fully-qualified     # 🧓 E5.0 older person
+1F9D3 1F3FB                                            ; fully-qualified     # 🧓🏻 E5.0 older person: light skin tone
+1F9D3 1F3FC                                            ; fully-qualified     # 🧓🏼 E5.0 older person: medium-light skin tone
+1F9D3 1F3FD                                            ; fully-qualified     # 🧓🏽 E5.0 older person: medium skin tone
+1F9D3 1F3FE                                            ; fully-qualified     # 🧓🏾 E5.0 older person: medium-dark skin tone
+1F9D3 1F3FF                                            ; fully-qualified     # 🧓🏿 E5.0 older person: dark skin tone
+1F474                                                  ; fully-qualified     # 👴 E0.6 old man
+1F474 1F3FB                                            ; fully-qualified     # 👴🏻 E1.0 old man: light skin tone
+1F474 1F3FC                                            ; fully-qualified     # 👴🏼 E1.0 old man: medium-light skin tone
+1F474 1F3FD                                            ; fully-qualified     # 👴🏽 E1.0 old man: medium skin tone
+1F474 1F3FE                                            ; fully-qualified     # 👴🏾 E1.0 old man: medium-dark skin tone
+1F474 1F3FF                                            ; fully-qualified     # 👴🏿 E1.0 old man: dark skin tone
+1F475                                                  ; fully-qualified     # 👵 E0.6 old woman
+1F475 1F3FB                                            ; fully-qualified     # 👵🏻 E1.0 old woman: light skin tone
+1F475 1F3FC                                            ; fully-qualified     # 👵🏼 E1.0 old woman: medium-light skin tone
+1F475 1F3FD                                            ; fully-qualified     # 👵🏽 E1.0 old woman: medium skin tone
+1F475 1F3FE                                            ; fully-qualified     # 👵🏾 E1.0 old woman: medium-dark skin tone
+1F475 1F3FF                                            ; fully-qualified     # 👵🏿 E1.0 old woman: dark skin tone
+
+# subgroup: person-gesture
+1F64D                                                  ; fully-qualified     # 🙍 E0.6 person frowning
+1F64D 1F3FB                                            ; fully-qualified     # 🙍🏻 E1.0 person frowning: light skin tone
+1F64D 1F3FC                                            ; fully-qualified     # 🙍🏼 E1.0 person frowning: medium-light skin tone
+1F64D 1F3FD                                            ; fully-qualified     # 🙍🏽 E1.0 person frowning: medium skin tone
+1F64D 1F3FE                                            ; fully-qualified     # 🙍🏾 E1.0 person frowning: medium-dark skin tone
+1F64D 1F3FF                                            ; fully-qualified     # 🙍🏿 E1.0 person frowning: dark skin tone
+1F64D 200D 2642 FE0F                                   ; fully-qualified     # 🙍‍♂️ E4.0 man frowning
+1F64D 200D 2642                                        ; minimally-qualified # 🙍‍♂ E4.0 man frowning
+1F64D 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🙍🏻‍♂️ E4.0 man frowning: light skin tone
+1F64D 1F3FB 200D 2642                                  ; minimally-qualified # 🙍🏻‍♂ E4.0 man frowning: light skin tone
+1F64D 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🙍🏼‍♂️ E4.0 man frowning: medium-light skin tone
+1F64D 1F3FC 200D 2642                                  ; minimally-qualified # 🙍🏼‍♂ E4.0 man frowning: medium-light skin tone
+1F64D 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🙍🏽‍♂️ E4.0 man frowning: medium skin tone
+1F64D 1F3FD 200D 2642                                  ; minimally-qualified # 🙍🏽‍♂ E4.0 man frowning: medium skin tone
+1F64D 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🙍🏾‍♂️ E4.0 man frowning: medium-dark skin tone
+1F64D 1F3FE 200D 2642                                  ; minimally-qualified # 🙍🏾‍♂ E4.0 man frowning: medium-dark skin tone
+1F64D 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🙍🏿‍♂️ E4.0 man frowning: dark skin tone
+1F64D 1F3FF 200D 2642                                  ; minimally-qualified # 🙍🏿‍♂ E4.0 man frowning: dark skin tone
+1F64D 200D 2640 FE0F                                   ; fully-qualified     # 🙍‍♀️ E4.0 woman frowning
+1F64D 200D 2640                                        ; minimally-qualified # 🙍‍♀ E4.0 woman frowning
+1F64D 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🙍🏻‍♀️ E4.0 woman frowning: light skin tone
+1F64D 1F3FB 200D 2640                                  ; minimally-qualified # 🙍🏻‍♀ E4.0 woman frowning: light skin tone
+1F64D 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🙍🏼‍♀️ E4.0 woman frowning: medium-light skin tone
+1F64D 1F3FC 200D 2640                                  ; minimally-qualified # 🙍🏼‍♀ E4.0 woman frowning: medium-light skin tone
+1F64D 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🙍🏽‍♀️ E4.0 woman frowning: medium skin tone
+1F64D 1F3FD 200D 2640                                  ; minimally-qualified # 🙍🏽‍♀ E4.0 woman frowning: medium skin tone
+1F64D 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🙍🏾‍♀️ E4.0 woman frowning: medium-dark skin tone
+1F64D 1F3FE 200D 2640                                  ; minimally-qualified # 🙍🏾‍♀ E4.0 woman frowning: medium-dark skin tone
+1F64D 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🙍🏿‍♀️ E4.0 woman frowning: dark skin tone
+1F64D 1F3FF 200D 2640                                  ; minimally-qualified # 🙍🏿‍♀ E4.0 woman frowning: dark skin tone
+1F64E                                                  ; fully-qualified     # 🙎 E0.6 person pouting
+1F64E 1F3FB                                            ; fully-qualified     # 🙎🏻 E1.0 person pouting: light skin tone
+1F64E 1F3FC                                            ; fully-qualified     # 🙎🏼 E1.0 person pouting: medium-light skin tone
+1F64E 1F3FD                                            ; fully-qualified     # 🙎🏽 E1.0 person pouting: medium skin tone
+1F64E 1F3FE                                            ; fully-qualified     # 🙎🏾 E1.0 person pouting: medium-dark skin tone
+1F64E 1F3FF                                            ; fully-qualified     # 🙎🏿 E1.0 person pouting: dark skin tone
+1F64E 200D 2642 FE0F                                   ; fully-qualified     # 🙎‍♂️ E4.0 man pouting
+1F64E 200D 2642                                        ; minimally-qualified # 🙎‍♂ E4.0 man pouting
+1F64E 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🙎🏻‍♂️ E4.0 man pouting: light skin tone
+1F64E 1F3FB 200D 2642                                  ; minimally-qualified # 🙎🏻‍♂ E4.0 man pouting: light skin tone
+1F64E 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🙎🏼‍♂️ E4.0 man pouting: medium-light skin tone
+1F64E 1F3FC 200D 2642                                  ; minimally-qualified # 🙎🏼‍♂ E4.0 man pouting: medium-light skin tone
+1F64E 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🙎🏽‍♂️ E4.0 man pouting: medium skin tone
+1F64E 1F3FD 200D 2642                                  ; minimally-qualified # 🙎🏽‍♂ E4.0 man pouting: medium skin tone
+1F64E 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🙎🏾‍♂️ E4.0 man pouting: medium-dark skin tone
+1F64E 1F3FE 200D 2642                                  ; minimally-qualified # 🙎🏾‍♂ E4.0 man pouting: medium-dark skin tone
+1F64E 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🙎🏿‍♂️ E4.0 man pouting: dark skin tone
+1F64E 1F3FF 200D 2642                                  ; minimally-qualified # 🙎🏿‍♂ E4.0 man pouting: dark skin tone
+1F64E 200D 2640 FE0F                                   ; fully-qualified     # 🙎‍♀️ E4.0 woman pouting
+1F64E 200D 2640                                        ; minimally-qualified # 🙎‍♀ E4.0 woman pouting
+1F64E 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🙎🏻‍♀️ E4.0 woman pouting: light skin tone
+1F64E 1F3FB 200D 2640                                  ; minimally-qualified # 🙎🏻‍♀ E4.0 woman pouting: light skin tone
+1F64E 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🙎🏼‍♀️ E4.0 woman pouting: medium-light skin tone
+1F64E 1F3FC 200D 2640                                  ; minimally-qualified # 🙎🏼‍♀ E4.0 woman pouting: medium-light skin tone
+1F64E 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🙎🏽‍♀️ E4.0 woman pouting: medium skin tone
+1F64E 1F3FD 200D 2640                                  ; minimally-qualified # 🙎🏽‍♀ E4.0 woman pouting: medium skin tone
+1F64E 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🙎🏾‍♀️ E4.0 woman pouting: medium-dark skin tone
+1F64E 1F3FE 200D 2640                                  ; minimally-qualified # 🙎🏾‍♀ E4.0 woman pouting: medium-dark skin tone
+1F64E 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🙎🏿‍♀️ E4.0 woman pouting: dark skin tone
+1F64E 1F3FF 200D 2640                                  ; minimally-qualified # 🙎🏿‍♀ E4.0 woman pouting: dark skin tone
+1F645                                                  ; fully-qualified     # 🙅 E0.6 person gesturing NO
+1F645 1F3FB                                            ; fully-qualified     # 🙅🏻 E1.0 person gesturing NO: light skin tone
+1F645 1F3FC                                            ; fully-qualified     # 🙅🏼 E1.0 person gesturing NO: medium-light skin tone
+1F645 1F3FD                                            ; fully-qualified     # 🙅🏽 E1.0 person gesturing NO: medium skin tone
+1F645 1F3FE                                            ; fully-qualified     # 🙅🏾 E1.0 person gesturing NO: medium-dark skin tone
+1F645 1F3FF                                            ; fully-qualified     # 🙅🏿 E1.0 person gesturing NO: dark skin tone
+1F645 200D 2642 FE0F                                   ; fully-qualified     # 🙅‍♂️ E4.0 man gesturing NO
+1F645 200D 2642                                        ; minimally-qualified # 🙅‍♂ E4.0 man gesturing NO
+1F645 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🙅🏻‍♂️ E4.0 man gesturing NO: light skin tone
+1F645 1F3FB 200D 2642                                  ; minimally-qualified # 🙅🏻‍♂ E4.0 man gesturing NO: light skin tone
+1F645 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🙅🏼‍♂️ E4.0 man gesturing NO: medium-light skin tone
+1F645 1F3FC 200D 2642                                  ; minimally-qualified # 🙅🏼‍♂ E4.0 man gesturing NO: medium-light skin tone
+1F645 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🙅🏽‍♂️ E4.0 man gesturing NO: medium skin tone
+1F645 1F3FD 200D 2642                                  ; minimally-qualified # 🙅🏽‍♂ E4.0 man gesturing NO: medium skin tone
+1F645 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🙅🏾‍♂️ E4.0 man gesturing NO: medium-dark skin tone
+1F645 1F3FE 200D 2642                                  ; minimally-qualified # 🙅🏾‍♂ E4.0 man gesturing NO: medium-dark skin tone
+1F645 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🙅🏿‍♂️ E4.0 man gesturing NO: dark skin tone
+1F645 1F3FF 200D 2642                                  ; minimally-qualified # 🙅🏿‍♂ E4.0 man gesturing NO: dark skin tone
+1F645 200D 2640 FE0F                                   ; fully-qualified     # 🙅‍♀️ E4.0 woman gesturing NO
+1F645 200D 2640                                        ; minimally-qualified # 🙅‍♀ E4.0 woman gesturing NO
+1F645 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🙅🏻‍♀️ E4.0 woman gesturing NO: light skin tone
+1F645 1F3FB 200D 2640                                  ; minimally-qualified # 🙅🏻‍♀ E4.0 woman gesturing NO: light skin tone
+1F645 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🙅🏼‍♀️ E4.0 woman gesturing NO: medium-light skin tone
+1F645 1F3FC 200D 2640                                  ; minimally-qualified # 🙅🏼‍♀ E4.0 woman gesturing NO: medium-light skin tone
+1F645 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🙅🏽‍♀️ E4.0 woman gesturing NO: medium skin tone
+1F645 1F3FD 200D 2640                                  ; minimally-qualified # 🙅🏽‍♀ E4.0 woman gesturing NO: medium skin tone
+1F645 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🙅🏾‍♀️ E4.0 woman gesturing NO: medium-dark skin tone
+1F645 1F3FE 200D 2640                                  ; minimally-qualified # 🙅🏾‍♀ E4.0 woman gesturing NO: medium-dark skin tone
+1F645 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🙅🏿‍♀️ E4.0 woman gesturing NO: dark skin tone
+1F645 1F3FF 200D 2640                                  ; minimally-qualified # 🙅🏿‍♀ E4.0 woman gesturing NO: dark skin tone
+1F646                                                  ; fully-qualified     # 🙆 E0.6 person gesturing OK
+1F646 1F3FB                                            ; fully-qualified     # 🙆🏻 E1.0 person gesturing OK: light skin tone
+1F646 1F3FC                                            ; fully-qualified     # 🙆🏼 E1.0 person gesturing OK: medium-light skin tone
+1F646 1F3FD                                            ; fully-qualified     # 🙆🏽 E1.0 person gesturing OK: medium skin tone
+1F646 1F3FE                                            ; fully-qualified     # 🙆🏾 E1.0 person gesturing OK: medium-dark skin tone
+1F646 1F3FF                                            ; fully-qualified     # 🙆🏿 E1.0 person gesturing OK: dark skin tone
+1F646 200D 2642 FE0F                                   ; fully-qualified     # 🙆‍♂️ E4.0 man gesturing OK
+1F646 200D 2642                                        ; minimally-qualified # 🙆‍♂ E4.0 man gesturing OK
+1F646 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🙆🏻‍♂️ E4.0 man gesturing OK: light skin tone
+1F646 1F3FB 200D 2642                                  ; minimally-qualified # 🙆🏻‍♂ E4.0 man gesturing OK: light skin tone
+1F646 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🙆🏼‍♂️ E4.0 man gesturing OK: medium-light skin tone
+1F646 1F3FC 200D 2642                                  ; minimally-qualified # 🙆🏼‍♂ E4.0 man gesturing OK: medium-light skin tone
+1F646 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🙆🏽‍♂️ E4.0 man gesturing OK: medium skin tone
+1F646 1F3FD 200D 2642                                  ; minimally-qualified # 🙆🏽‍♂ E4.0 man gesturing OK: medium skin tone
+1F646 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🙆🏾‍♂️ E4.0 man gesturing OK: medium-dark skin tone
+1F646 1F3FE 200D 2642                                  ; minimally-qualified # 🙆🏾‍♂ E4.0 man gesturing OK: medium-dark skin tone
+1F646 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🙆🏿‍♂️ E4.0 man gesturing OK: dark skin tone
+1F646 1F3FF 200D 2642                                  ; minimally-qualified # 🙆🏿‍♂ E4.0 man gesturing OK: dark skin tone
+1F646 200D 2640 FE0F                                   ; fully-qualified     # 🙆‍♀️ E4.0 woman gesturing OK
+1F646 200D 2640                                        ; minimally-qualified # 🙆‍♀ E4.0 woman gesturing OK
+1F646 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🙆🏻‍♀️ E4.0 woman gesturing OK: light skin tone
+1F646 1F3FB 200D 2640                                  ; minimally-qualified # 🙆🏻‍♀ E4.0 woman gesturing OK: light skin tone
+1F646 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🙆🏼‍♀️ E4.0 woman gesturing OK: medium-light skin tone
+1F646 1F3FC 200D 2640                                  ; minimally-qualified # 🙆🏼‍♀ E4.0 woman gesturing OK: medium-light skin tone
+1F646 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🙆🏽‍♀️ E4.0 woman gesturing OK: medium skin tone
+1F646 1F3FD 200D 2640                                  ; minimally-qualified # 🙆🏽‍♀ E4.0 woman gesturing OK: medium skin tone
+1F646 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🙆🏾‍♀️ E4.0 woman gesturing OK: medium-dark skin tone
+1F646 1F3FE 200D 2640                                  ; minimally-qualified # 🙆🏾‍♀ E4.0 woman gesturing OK: medium-dark skin tone
+1F646 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🙆🏿‍♀️ E4.0 woman gesturing OK: dark skin tone
+1F646 1F3FF 200D 2640                                  ; minimally-qualified # 🙆🏿‍♀ E4.0 woman gesturing OK: dark skin tone
+1F481                                                  ; fully-qualified     # 💁 E0.6 person tipping hand
+1F481 1F3FB                                            ; fully-qualified     # 💁🏻 E1.0 person tipping hand: light skin tone
+1F481 1F3FC                                            ; fully-qualified     # 💁🏼 E1.0 person tipping hand: medium-light skin tone
+1F481 1F3FD                                            ; fully-qualified     # 💁🏽 E1.0 person tipping hand: medium skin tone
+1F481 1F3FE                                            ; fully-qualified     # 💁🏾 E1.0 person tipping hand: medium-dark skin tone
+1F481 1F3FF                                            ; fully-qualified     # 💁🏿 E1.0 person tipping hand: dark skin tone
+1F481 200D 2642 FE0F                                   ; fully-qualified     # 💁‍♂️ E4.0 man tipping hand
+1F481 200D 2642                                        ; minimally-qualified # 💁‍♂ E4.0 man tipping hand
+1F481 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 💁🏻‍♂️ E4.0 man tipping hand: light skin tone
+1F481 1F3FB 200D 2642                                  ; minimally-qualified # 💁🏻‍♂ E4.0 man tipping hand: light skin tone
+1F481 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 💁🏼‍♂️ E4.0 man tipping hand: medium-light skin tone
+1F481 1F3FC 200D 2642                                  ; minimally-qualified # 💁🏼‍♂ E4.0 man tipping hand: medium-light skin tone
+1F481 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 💁🏽‍♂️ E4.0 man tipping hand: medium skin tone
+1F481 1F3FD 200D 2642                                  ; minimally-qualified # 💁🏽‍♂ E4.0 man tipping hand: medium skin tone
+1F481 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 💁🏾‍♂️ E4.0 man tipping hand: medium-dark skin tone
+1F481 1F3FE 200D 2642                                  ; minimally-qualified # 💁🏾‍♂ E4.0 man tipping hand: medium-dark skin tone
+1F481 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 💁🏿‍♂️ E4.0 man tipping hand: dark skin tone
+1F481 1F3FF 200D 2642                                  ; minimally-qualified # 💁🏿‍♂ E4.0 man tipping hand: dark skin tone
+1F481 200D 2640 FE0F                                   ; fully-qualified     # 💁‍♀️ E4.0 woman tipping hand
+1F481 200D 2640                                        ; minimally-qualified # 💁‍♀ E4.0 woman tipping hand
+1F481 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 💁🏻‍♀️ E4.0 woman tipping hand: light skin tone
+1F481 1F3FB 200D 2640                                  ; minimally-qualified # 💁🏻‍♀ E4.0 woman tipping hand: light skin tone
+1F481 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 💁🏼‍♀️ E4.0 woman tipping hand: medium-light skin tone
+1F481 1F3FC 200D 2640                                  ; minimally-qualified # 💁🏼‍♀ E4.0 woman tipping hand: medium-light skin tone
+1F481 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 💁🏽‍♀️ E4.0 woman tipping hand: medium skin tone
+1F481 1F3FD 200D 2640                                  ; minimally-qualified # 💁🏽‍♀ E4.0 woman tipping hand: medium skin tone
+1F481 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 💁🏾‍♀️ E4.0 woman tipping hand: medium-dark skin tone
+1F481 1F3FE 200D 2640                                  ; minimally-qualified # 💁🏾‍♀ E4.0 woman tipping hand: medium-dark skin tone
+1F481 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 💁🏿‍♀️ E4.0 woman tipping hand: dark skin tone
+1F481 1F3FF 200D 2640                                  ; minimally-qualified # 💁🏿‍♀ E4.0 woman tipping hand: dark skin tone
+1F64B                                                  ; fully-qualified     # 🙋 E0.6 person raising hand
+1F64B 1F3FB                                            ; fully-qualified     # 🙋🏻 E1.0 person raising hand: light skin tone
+1F64B 1F3FC                                            ; fully-qualified     # 🙋🏼 E1.0 person raising hand: medium-light skin tone
+1F64B 1F3FD                                            ; fully-qualified     # 🙋🏽 E1.0 person raising hand: medium skin tone
+1F64B 1F3FE                                            ; fully-qualified     # 🙋🏾 E1.0 person raising hand: medium-dark skin tone
+1F64B 1F3FF                                            ; fully-qualified     # 🙋🏿 E1.0 person raising hand: dark skin tone
+1F64B 200D 2642 FE0F                                   ; fully-qualified     # 🙋‍♂️ E4.0 man raising hand
+1F64B 200D 2642                                        ; minimally-qualified # 🙋‍♂ E4.0 man raising hand
+1F64B 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🙋🏻‍♂️ E4.0 man raising hand: light skin tone
+1F64B 1F3FB 200D 2642                                  ; minimally-qualified # 🙋🏻‍♂ E4.0 man raising hand: light skin tone
+1F64B 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🙋🏼‍♂️ E4.0 man raising hand: medium-light skin tone
+1F64B 1F3FC 200D 2642                                  ; minimally-qualified # 🙋🏼‍♂ E4.0 man raising hand: medium-light skin tone
+1F64B 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🙋🏽‍♂️ E4.0 man raising hand: medium skin tone
+1F64B 1F3FD 200D 2642                                  ; minimally-qualified # 🙋🏽‍♂ E4.0 man raising hand: medium skin tone
+1F64B 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🙋🏾‍♂️ E4.0 man raising hand: medium-dark skin tone
+1F64B 1F3FE 200D 2642                                  ; minimally-qualified # 🙋🏾‍♂ E4.0 man raising hand: medium-dark skin tone
+1F64B 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🙋🏿‍♂️ E4.0 man raising hand: dark skin tone
+1F64B 1F3FF 200D 2642                                  ; minimally-qualified # 🙋🏿‍♂ E4.0 man raising hand: dark skin tone
+1F64B 200D 2640 FE0F                                   ; fully-qualified     # 🙋‍♀️ E4.0 woman raising hand
+1F64B 200D 2640                                        ; minimally-qualified # 🙋‍♀ E4.0 woman raising hand
+1F64B 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🙋🏻‍♀️ E4.0 woman raising hand: light skin tone
+1F64B 1F3FB 200D 2640                                  ; minimally-qualified # 🙋🏻‍♀ E4.0 woman raising hand: light skin tone
+1F64B 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🙋🏼‍♀️ E4.0 woman raising hand: medium-light skin tone
+1F64B 1F3FC 200D 2640                                  ; minimally-qualified # 🙋🏼‍♀ E4.0 woman raising hand: medium-light skin tone
+1F64B 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🙋🏽‍♀️ E4.0 woman raising hand: medium skin tone
+1F64B 1F3FD 200D 2640                                  ; minimally-qualified # 🙋🏽‍♀ E4.0 woman raising hand: medium skin tone
+1F64B 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🙋🏾‍♀️ E4.0 woman raising hand: medium-dark skin tone
+1F64B 1F3FE 200D 2640                                  ; minimally-qualified # 🙋🏾‍♀ E4.0 woman raising hand: medium-dark skin tone
+1F64B 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🙋🏿‍♀️ E4.0 woman raising hand: dark skin tone
+1F64B 1F3FF 200D 2640                                  ; minimally-qualified # 🙋🏿‍♀ E4.0 woman raising hand: dark skin tone
+1F9CF                                                  ; fully-qualified     # 🧏 E12.0 deaf person
+1F9CF 1F3FB                                            ; fully-qualified     # 🧏🏻 E12.0 deaf person: light skin tone
+1F9CF 1F3FC                                            ; fully-qualified     # 🧏🏼 E12.0 deaf person: medium-light skin tone
+1F9CF 1F3FD                                            ; fully-qualified     # 🧏🏽 E12.0 deaf person: medium skin tone
+1F9CF 1F3FE                                            ; fully-qualified     # 🧏🏾 E12.0 deaf person: medium-dark skin tone
+1F9CF 1F3FF                                            ; fully-qualified     # 🧏🏿 E12.0 deaf person: dark skin tone
+1F9CF 200D 2642 FE0F                                   ; fully-qualified     # 🧏‍♂️ E12.0 deaf man
+1F9CF 200D 2642                                        ; minimally-qualified # 🧏‍♂ E12.0 deaf man
+1F9CF 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🧏🏻‍♂️ E12.0 deaf man: light skin tone
+1F9CF 1F3FB 200D 2642                                  ; minimally-qualified # 🧏🏻‍♂ E12.0 deaf man: light skin tone
+1F9CF 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🧏🏼‍♂️ E12.0 deaf man: medium-light skin tone
+1F9CF 1F3FC 200D 2642                                  ; minimally-qualified # 🧏🏼‍♂ E12.0 deaf man: medium-light skin tone
+1F9CF 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🧏🏽‍♂️ E12.0 deaf man: medium skin tone
+1F9CF 1F3FD 200D 2642                                  ; minimally-qualified # 🧏🏽‍♂ E12.0 deaf man: medium skin tone
+1F9CF 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🧏🏾‍♂️ E12.0 deaf man: medium-dark skin tone
+1F9CF 1F3FE 200D 2642                                  ; minimally-qualified # 🧏🏾‍♂ E12.0 deaf man: medium-dark skin tone
+1F9CF 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🧏🏿‍♂️ E12.0 deaf man: dark skin tone
+1F9CF 1F3FF 200D 2642                                  ; minimally-qualified # 🧏🏿‍♂ E12.0 deaf man: dark skin tone
+1F9CF 200D 2640 FE0F                                   ; fully-qualified     # 🧏‍♀️ E12.0 deaf woman
+1F9CF 200D 2640                                        ; minimally-qualified # 🧏‍♀ E12.0 deaf woman
+1F9CF 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🧏🏻‍♀️ E12.0 deaf woman: light skin tone
+1F9CF 1F3FB 200D 2640                                  ; minimally-qualified # 🧏🏻‍♀ E12.0 deaf woman: light skin tone
+1F9CF 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🧏🏼‍♀️ E12.0 deaf woman: medium-light skin tone
+1F9CF 1F3FC 200D 2640                                  ; minimally-qualified # 🧏🏼‍♀ E12.0 deaf woman: medium-light skin tone
+1F9CF 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🧏🏽‍♀️ E12.0 deaf woman: medium skin tone
+1F9CF 1F3FD 200D 2640                                  ; minimally-qualified # 🧏🏽‍♀ E12.0 deaf woman: medium skin tone
+1F9CF 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🧏🏾‍♀️ E12.0 deaf woman: medium-dark skin tone
+1F9CF 1F3FE 200D 2640                                  ; minimally-qualified # 🧏🏾‍♀ E12.0 deaf woman: medium-dark skin tone
+1F9CF 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🧏🏿‍♀️ E12.0 deaf woman: dark skin tone
+1F9CF 1F3FF 200D 2640                                  ; minimally-qualified # 🧏🏿‍♀ E12.0 deaf woman: dark skin tone
+1F647                                                  ; fully-qualified     # 🙇 E0.6 person bowing
+1F647 1F3FB                                            ; fully-qualified     # 🙇🏻 E1.0 person bowing: light skin tone
+1F647 1F3FC                                            ; fully-qualified     # 🙇🏼 E1.0 person bowing: medium-light skin tone
+1F647 1F3FD                                            ; fully-qualified     # 🙇🏽 E1.0 person bowing: medium skin tone
+1F647 1F3FE                                            ; fully-qualified     # 🙇🏾 E1.0 person bowing: medium-dark skin tone
+1F647 1F3FF                                            ; fully-qualified     # 🙇🏿 E1.0 person bowing: dark skin tone
+1F647 200D 2642 FE0F                                   ; fully-qualified     # 🙇‍♂️ E4.0 man bowing
+1F647 200D 2642                                        ; minimally-qualified # 🙇‍♂ E4.0 man bowing
+1F647 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🙇🏻‍♂️ E4.0 man bowing: light skin tone
+1F647 1F3FB 200D 2642                                  ; minimally-qualified # 🙇🏻‍♂ E4.0 man bowing: light skin tone
+1F647 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🙇🏼‍♂️ E4.0 man bowing: medium-light skin tone
+1F647 1F3FC 200D 2642                                  ; minimally-qualified # 🙇🏼‍♂ E4.0 man bowing: medium-light skin tone
+1F647 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🙇🏽‍♂️ E4.0 man bowing: medium skin tone
+1F647 1F3FD 200D 2642                                  ; minimally-qualified # 🙇🏽‍♂ E4.0 man bowing: medium skin tone
+1F647 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🙇🏾‍♂️ E4.0 man bowing: medium-dark skin tone
+1F647 1F3FE 200D 2642                                  ; minimally-qualified # 🙇🏾‍♂ E4.0 man bowing: medium-dark skin tone
+1F647 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🙇🏿‍♂️ E4.0 man bowing: dark skin tone
+1F647 1F3FF 200D 2642                                  ; minimally-qualified # 🙇🏿‍♂ E4.0 man bowing: dark skin tone
+1F647 200D 2640 FE0F                                   ; fully-qualified     # 🙇‍♀️ E4.0 woman bowing
+1F647 200D 2640                                        ; minimally-qualified # 🙇‍♀ E4.0 woman bowing
+1F647 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🙇🏻‍♀️ E4.0 woman bowing: light skin tone
+1F647 1F3FB 200D 2640                                  ; minimally-qualified # 🙇🏻‍♀ E4.0 woman bowing: light skin tone
+1F647 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🙇🏼‍♀️ E4.0 woman bowing: medium-light skin tone
+1F647 1F3FC 200D 2640                                  ; minimally-qualified # 🙇🏼‍♀ E4.0 woman bowing: medium-light skin tone
+1F647 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🙇🏽‍♀️ E4.0 woman bowing: medium skin tone
+1F647 1F3FD 200D 2640                                  ; minimally-qualified # 🙇🏽‍♀ E4.0 woman bowing: medium skin tone
+1F647 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🙇🏾‍♀️ E4.0 woman bowing: medium-dark skin tone
+1F647 1F3FE 200D 2640                                  ; minimally-qualified # 🙇🏾‍♀ E4.0 woman bowing: medium-dark skin tone
+1F647 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🙇🏿‍♀️ E4.0 woman bowing: dark skin tone
+1F647 1F3FF 200D 2640                                  ; minimally-qualified # 🙇🏿‍♀ E4.0 woman bowing: dark skin tone
+1F926                                                  ; fully-qualified     # 🤦 E3.0 person facepalming
+1F926 1F3FB                                            ; fully-qualified     # 🤦🏻 E3.0 person facepalming: light skin tone
+1F926 1F3FC                                            ; fully-qualified     # 🤦🏼 E3.0 person facepalming: medium-light skin tone
+1F926 1F3FD                                            ; fully-qualified     # 🤦🏽 E3.0 person facepalming: medium skin tone
+1F926 1F3FE                                            ; fully-qualified     # 🤦🏾 E3.0 person facepalming: medium-dark skin tone
+1F926 1F3FF                                            ; fully-qualified     # 🤦🏿 E3.0 person facepalming: dark skin tone
+1F926 200D 2642 FE0F                                   ; fully-qualified     # 🤦‍♂️ E4.0 man facepalming
+1F926 200D 2642                                        ; minimally-qualified # 🤦‍♂ E4.0 man facepalming
+1F926 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🤦🏻‍♂️ E4.0 man facepalming: light skin tone
+1F926 1F3FB 200D 2642                                  ; minimally-qualified # 🤦🏻‍♂ E4.0 man facepalming: light skin tone
+1F926 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🤦🏼‍♂️ E4.0 man facepalming: medium-light skin tone
+1F926 1F3FC 200D 2642                                  ; minimally-qualified # 🤦🏼‍♂ E4.0 man facepalming: medium-light skin tone
+1F926 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🤦🏽‍♂️ E4.0 man facepalming: medium skin tone
+1F926 1F3FD 200D 2642                                  ; minimally-qualified # 🤦🏽‍♂ E4.0 man facepalming: medium skin tone
+1F926 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🤦🏾‍♂️ E4.0 man facepalming: medium-dark skin tone
+1F926 1F3FE 200D 2642                                  ; minimally-qualified # 🤦🏾‍♂ E4.0 man facepalming: medium-dark skin tone
+1F926 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🤦🏿‍♂️ E4.0 man facepalming: dark skin tone
+1F926 1F3FF 200D 2642                                  ; minimally-qualified # 🤦🏿‍♂ E4.0 man facepalming: dark skin tone
+1F926 200D 2640 FE0F                                   ; fully-qualified     # 🤦‍♀️ E4.0 woman facepalming
+1F926 200D 2640                                        ; minimally-qualified # 🤦‍♀ E4.0 woman facepalming
+1F926 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🤦🏻‍♀️ E4.0 woman facepalming: light skin tone
+1F926 1F3FB 200D 2640                                  ; minimally-qualified # 🤦🏻‍♀ E4.0 woman facepalming: light skin tone
+1F926 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🤦🏼‍♀️ E4.0 woman facepalming: medium-light skin tone
+1F926 1F3FC 200D 2640                                  ; minimally-qualified # 🤦🏼‍♀ E4.0 woman facepalming: medium-light skin tone
+1F926 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🤦🏽‍♀️ E4.0 woman facepalming: medium skin tone
+1F926 1F3FD 200D 2640                                  ; minimally-qualified # 🤦🏽‍♀ E4.0 woman facepalming: medium skin tone
+1F926 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🤦🏾‍♀️ E4.0 woman facepalming: medium-dark skin tone
+1F926 1F3FE 200D 2640                                  ; minimally-qualified # 🤦🏾‍♀ E4.0 woman facepalming: medium-dark skin tone
+1F926 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🤦🏿‍♀️ E4.0 woman facepalming: dark skin tone
+1F926 1F3FF 200D 2640                                  ; minimally-qualified # 🤦🏿‍♀ E4.0 woman facepalming: dark skin tone
+1F937                                                  ; fully-qualified     # 🤷 E3.0 person shrugging
+1F937 1F3FB                                            ; fully-qualified     # 🤷🏻 E3.0 person shrugging: light skin tone
+1F937 1F3FC                                            ; fully-qualified     # 🤷🏼 E3.0 person shrugging: medium-light skin tone
+1F937 1F3FD                                            ; fully-qualified     # 🤷🏽 E3.0 person shrugging: medium skin tone
+1F937 1F3FE                                            ; fully-qualified     # 🤷🏾 E3.0 person shrugging: medium-dark skin tone
+1F937 1F3FF                                            ; fully-qualified     # 🤷🏿 E3.0 person shrugging: dark skin tone
+1F937 200D 2642 FE0F                                   ; fully-qualified     # 🤷‍♂️ E4.0 man shrugging
+1F937 200D 2642                                        ; minimally-qualified # 🤷‍♂ E4.0 man shrugging
+1F937 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🤷🏻‍♂️ E4.0 man shrugging: light skin tone
+1F937 1F3FB 200D 2642                                  ; minimally-qualified # 🤷🏻‍♂ E4.0 man shrugging: light skin tone
+1F937 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🤷🏼‍♂️ E4.0 man shrugging: medium-light skin tone
+1F937 1F3FC 200D 2642                                  ; minimally-qualified # 🤷🏼‍♂ E4.0 man shrugging: medium-light skin tone
+1F937 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🤷🏽‍♂️ E4.0 man shrugging: medium skin tone
+1F937 1F3FD 200D 2642                                  ; minimally-qualified # 🤷🏽‍♂ E4.0 man shrugging: medium skin tone
+1F937 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🤷🏾‍♂️ E4.0 man shrugging: medium-dark skin tone
+1F937 1F3FE 200D 2642                                  ; minimally-qualified # 🤷🏾‍♂ E4.0 man shrugging: medium-dark skin tone
+1F937 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🤷🏿‍♂️ E4.0 man shrugging: dark skin tone
+1F937 1F3FF 200D 2642                                  ; minimally-qualified # 🤷🏿‍♂ E4.0 man shrugging: dark skin tone
+1F937 200D 2640 FE0F                                   ; fully-qualified     # 🤷‍♀️ E4.0 woman shrugging
+1F937 200D 2640                                        ; minimally-qualified # 🤷‍♀ E4.0 woman shrugging
+1F937 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🤷🏻‍♀️ E4.0 woman shrugging: light skin tone
+1F937 1F3FB 200D 2640                                  ; minimally-qualified # 🤷🏻‍♀ E4.0 woman shrugging: light skin tone
+1F937 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🤷🏼‍♀️ E4.0 woman shrugging: medium-light skin tone
+1F937 1F3FC 200D 2640                                  ; minimally-qualified # 🤷🏼‍♀ E4.0 woman shrugging: medium-light skin tone
+1F937 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🤷🏽‍♀️ E4.0 woman shrugging: medium skin tone
+1F937 1F3FD 200D 2640                                  ; minimally-qualified # 🤷🏽‍♀ E4.0 woman shrugging: medium skin tone
+1F937 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🤷🏾‍♀️ E4.0 woman shrugging: medium-dark skin tone
+1F937 1F3FE 200D 2640                                  ; minimally-qualified # 🤷🏾‍♀ E4.0 woman shrugging: medium-dark skin tone
+1F937 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🤷🏿‍♀️ E4.0 woman shrugging: dark skin tone
+1F937 1F3FF 200D 2640                                  ; minimally-qualified # 🤷🏿‍♀ E4.0 woman shrugging: dark skin tone
+
+# subgroup: person-role
+1F9D1 200D 2695 FE0F                                   ; fully-qualified     # 🧑‍⚕️ E12.1 health worker
+1F9D1 200D 2695                                        ; minimally-qualified # 🧑‍⚕ E12.1 health worker
+1F9D1 1F3FB 200D 2695 FE0F                             ; fully-qualified     # 🧑🏻‍⚕️ E12.1 health worker: light skin tone
+1F9D1 1F3FB 200D 2695                                  ; minimally-qualified # 🧑🏻‍⚕ E12.1 health worker: light skin tone
+1F9D1 1F3FC 200D 2695 FE0F                             ; fully-qualified     # 🧑🏼‍⚕️ E12.1 health worker: medium-light skin tone
+1F9D1 1F3FC 200D 2695                                  ; minimally-qualified # 🧑🏼‍⚕ E12.1 health worker: medium-light skin tone
+1F9D1 1F3FD 200D 2695 FE0F                             ; fully-qualified     # 🧑🏽‍⚕️ E12.1 health worker: medium skin tone
+1F9D1 1F3FD 200D 2695                                  ; minimally-qualified # 🧑🏽‍⚕ E12.1 health worker: medium skin tone
+1F9D1 1F3FE 200D 2695 FE0F                             ; fully-qualified     # 🧑🏾‍⚕️ E12.1 health worker: medium-dark skin tone
+1F9D1 1F3FE 200D 2695                                  ; minimally-qualified # 🧑🏾‍⚕ E12.1 health worker: medium-dark skin tone
+1F9D1 1F3FF 200D 2695 FE0F                             ; fully-qualified     # 🧑🏿‍⚕️ E12.1 health worker: dark skin tone
+1F9D1 1F3FF 200D 2695                                  ; minimally-qualified # 🧑🏿‍⚕ E12.1 health worker: dark skin tone
+1F468 200D 2695 FE0F                                   ; fully-qualified     # 👨‍⚕️ E4.0 man health worker
+1F468 200D 2695                                        ; minimally-qualified # 👨‍⚕ E4.0 man health worker
+1F468 1F3FB 200D 2695 FE0F                             ; fully-qualified     # 👨🏻‍⚕️ E4.0 man health worker: light skin tone
+1F468 1F3FB 200D 2695                                  ; minimally-qualified # 👨🏻‍⚕ E4.0 man health worker: light skin tone
+1F468 1F3FC 200D 2695 FE0F                             ; fully-qualified     # 👨🏼‍⚕️ E4.0 man health worker: medium-light skin tone
+1F468 1F3FC 200D 2695                                  ; minimally-qualified # 👨🏼‍⚕ E4.0 man health worker: medium-light skin tone
+1F468 1F3FD 200D 2695 FE0F                             ; fully-qualified     # 👨🏽‍⚕️ E4.0 man health worker: medium skin tone
+1F468 1F3FD 200D 2695                                  ; minimally-qualified # 👨🏽‍⚕ E4.0 man health worker: medium skin tone
+1F468 1F3FE 200D 2695 FE0F                             ; fully-qualified     # 👨🏾‍⚕️ E4.0 man health worker: medium-dark skin tone
+1F468 1F3FE 200D 2695                                  ; minimally-qualified # 👨🏾‍⚕ E4.0 man health worker: medium-dark skin tone
+1F468 1F3FF 200D 2695 FE0F                             ; fully-qualified     # 👨🏿‍⚕️ E4.0 man health worker: dark skin tone
+1F468 1F3FF 200D 2695                                  ; minimally-qualified # 👨🏿‍⚕ E4.0 man health worker: dark skin tone
+1F469 200D 2695 FE0F                                   ; fully-qualified     # 👩‍⚕️ E4.0 woman health worker
+1F469 200D 2695                                        ; minimally-qualified # 👩‍⚕ E4.0 woman health worker
+1F469 1F3FB 200D 2695 FE0F                             ; fully-qualified     # 👩🏻‍⚕️ E4.0 woman health worker: light skin tone
+1F469 1F3FB 200D 2695                                  ; minimally-qualified # 👩🏻‍⚕ E4.0 woman health worker: light skin tone
+1F469 1F3FC 200D 2695 FE0F                             ; fully-qualified     # 👩🏼‍⚕️ E4.0 woman health worker: medium-light skin tone
+1F469 1F3FC 200D 2695                                  ; minimally-qualified # 👩🏼‍⚕ E4.0 woman health worker: medium-light skin tone
+1F469 1F3FD 200D 2695 FE0F                             ; fully-qualified     # 👩🏽‍⚕️ E4.0 woman health worker: medium skin tone
+1F469 1F3FD 200D 2695                                  ; minimally-qualified # 👩🏽‍⚕ E4.0 woman health worker: medium skin tone
+1F469 1F3FE 200D 2695 FE0F                             ; fully-qualified     # 👩🏾‍⚕️ E4.0 woman health worker: medium-dark skin tone
+1F469 1F3FE 200D 2695                                  ; minimally-qualified # 👩🏾‍⚕ E4.0 woman health worker: medium-dark skin tone
+1F469 1F3FF 200D 2695 FE0F                             ; fully-qualified     # 👩🏿‍⚕️ E4.0 woman health worker: dark skin tone
+1F469 1F3FF 200D 2695                                  ; minimally-qualified # 👩🏿‍⚕ E4.0 woman health worker: dark skin tone
+1F9D1 200D 1F393                                       ; fully-qualified     # 🧑‍🎓 E12.1 student
+1F9D1 1F3FB 200D 1F393                                 ; fully-qualified     # 🧑🏻‍🎓 E12.1 student: light skin tone
+1F9D1 1F3FC 200D 1F393                                 ; fully-qualified     # 🧑🏼‍🎓 E12.1 student: medium-light skin tone
+1F9D1 1F3FD 200D 1F393                                 ; fully-qualified     # 🧑🏽‍🎓 E12.1 student: medium skin tone
+1F9D1 1F3FE 200D 1F393                                 ; fully-qualified     # 🧑🏾‍🎓 E12.1 student: medium-dark skin tone
+1F9D1 1F3FF 200D 1F393                                 ; fully-qualified     # 🧑🏿‍🎓 E12.1 student: dark skin tone
+1F468 200D 1F393                                       ; fully-qualified     # 👨‍🎓 E4.0 man student
+1F468 1F3FB 200D 1F393                                 ; fully-qualified     # 👨🏻‍🎓 E4.0 man student: light skin tone
+1F468 1F3FC 200D 1F393                                 ; fully-qualified     # 👨🏼‍🎓 E4.0 man student: medium-light skin tone
+1F468 1F3FD 200D 1F393                                 ; fully-qualified     # 👨🏽‍🎓 E4.0 man student: medium skin tone
+1F468 1F3FE 200D 1F393                                 ; fully-qualified     # 👨🏾‍🎓 E4.0 man student: medium-dark skin tone
+1F468 1F3FF 200D 1F393                                 ; fully-qualified     # 👨🏿‍🎓 E4.0 man student: dark skin tone
+1F469 200D 1F393                                       ; fully-qualified     # 👩‍🎓 E4.0 woman student
+1F469 1F3FB 200D 1F393                                 ; fully-qualified     # 👩🏻‍🎓 E4.0 woman student: light skin tone
+1F469 1F3FC 200D 1F393                                 ; fully-qualified     # 👩🏼‍🎓 E4.0 woman student: medium-light skin tone
+1F469 1F3FD 200D 1F393                                 ; fully-qualified     # 👩🏽‍🎓 E4.0 woman student: medium skin tone
+1F469 1F3FE 200D 1F393                                 ; fully-qualified     # 👩🏾‍🎓 E4.0 woman student: medium-dark skin tone
+1F469 1F3FF 200D 1F393                                 ; fully-qualified     # 👩🏿‍🎓 E4.0 woman student: dark skin tone
+1F9D1 200D 1F3EB                                       ; fully-qualified     # 🧑‍🏫 E12.1 teacher
+1F9D1 1F3FB 200D 1F3EB                                 ; fully-qualified     # 🧑🏻‍🏫 E12.1 teacher: light skin tone
+1F9D1 1F3FC 200D 1F3EB                                 ; fully-qualified     # 🧑🏼‍🏫 E12.1 teacher: medium-light skin tone
+1F9D1 1F3FD 200D 1F3EB                                 ; fully-qualified     # 🧑🏽‍🏫 E12.1 teacher: medium skin tone
+1F9D1 1F3FE 200D 1F3EB                                 ; fully-qualified     # 🧑🏾‍🏫 E12.1 teacher: medium-dark skin tone
+1F9D1 1F3FF 200D 1F3EB                                 ; fully-qualified     # 🧑🏿‍🏫 E12.1 teacher: dark skin tone
+1F468 200D 1F3EB                                       ; fully-qualified     # 👨‍🏫 E4.0 man teacher
+1F468 1F3FB 200D 1F3EB                                 ; fully-qualified     # 👨🏻‍🏫 E4.0 man teacher: light skin tone
+1F468 1F3FC 200D 1F3EB                                 ; fully-qualified     # 👨🏼‍🏫 E4.0 man teacher: medium-light skin tone
+1F468 1F3FD 200D 1F3EB                                 ; fully-qualified     # 👨🏽‍🏫 E4.0 man teacher: medium skin tone
+1F468 1F3FE 200D 1F3EB                                 ; fully-qualified     # 👨🏾‍🏫 E4.0 man teacher: medium-dark skin tone
+1F468 1F3FF 200D 1F3EB                                 ; fully-qualified     # 👨🏿‍🏫 E4.0 man teacher: dark skin tone
+1F469 200D 1F3EB                                       ; fully-qualified     # 👩‍🏫 E4.0 woman teacher
+1F469 1F3FB 200D 1F3EB                                 ; fully-qualified     # 👩🏻‍🏫 E4.0 woman teacher: light skin tone
+1F469 1F3FC 200D 1F3EB                                 ; fully-qualified     # 👩🏼‍🏫 E4.0 woman teacher: medium-light skin tone
+1F469 1F3FD 200D 1F3EB                                 ; fully-qualified     # 👩🏽‍🏫 E4.0 woman teacher: medium skin tone
+1F469 1F3FE 200D 1F3EB                                 ; fully-qualified     # 👩🏾‍🏫 E4.0 woman teacher: medium-dark skin tone
+1F469 1F3FF 200D 1F3EB                                 ; fully-qualified     # 👩🏿‍🏫 E4.0 woman teacher: dark skin tone
+1F9D1 200D 2696 FE0F                                   ; fully-qualified     # 🧑‍⚖️ E12.1 judge
+1F9D1 200D 2696                                        ; minimally-qualified # 🧑‍⚖ E12.1 judge
+1F9D1 1F3FB 200D 2696 FE0F                             ; fully-qualified     # 🧑🏻‍⚖️ E12.1 judge: light skin tone
+1F9D1 1F3FB 200D 2696                                  ; minimally-qualified # 🧑🏻‍⚖ E12.1 judge: light skin tone
+1F9D1 1F3FC 200D 2696 FE0F                             ; fully-qualified     # 🧑🏼‍⚖️ E12.1 judge: medium-light skin tone
+1F9D1 1F3FC 200D 2696                                  ; minimally-qualified # 🧑🏼‍⚖ E12.1 judge: medium-light skin tone
+1F9D1 1F3FD 200D 2696 FE0F                             ; fully-qualified     # 🧑🏽‍⚖️ E12.1 judge: medium skin tone
+1F9D1 1F3FD 200D 2696                                  ; minimally-qualified # 🧑🏽‍⚖ E12.1 judge: medium skin tone
+1F9D1 1F3FE 200D 2696 FE0F                             ; fully-qualified     # 🧑🏾‍⚖️ E12.1 judge: medium-dark skin tone
+1F9D1 1F3FE 200D 2696                                  ; minimally-qualified # 🧑🏾‍⚖ E12.1 judge: medium-dark skin tone
+1F9D1 1F3FF 200D 2696 FE0F                             ; fully-qualified     # 🧑🏿‍⚖️ E12.1 judge: dark skin tone
+1F9D1 1F3FF 200D 2696                                  ; minimally-qualified # 🧑🏿‍⚖ E12.1 judge: dark skin tone
+1F468 200D 2696 FE0F                                   ; fully-qualified     # 👨‍⚖️ E4.0 man judge
+1F468 200D 2696                                        ; minimally-qualified # 👨‍⚖ E4.0 man judge
+1F468 1F3FB 200D 2696 FE0F                             ; fully-qualified     # 👨🏻‍⚖️ E4.0 man judge: light skin tone
+1F468 1F3FB 200D 2696                                  ; minimally-qualified # 👨🏻‍⚖ E4.0 man judge: light skin tone
+1F468 1F3FC 200D 2696 FE0F                             ; fully-qualified     # 👨🏼‍⚖️ E4.0 man judge: medium-light skin tone
+1F468 1F3FC 200D 2696                                  ; minimally-qualified # 👨🏼‍⚖ E4.0 man judge: medium-light skin tone
+1F468 1F3FD 200D 2696 FE0F                             ; fully-qualified     # 👨🏽‍⚖️ E4.0 man judge: medium skin tone
+1F468 1F3FD 200D 2696                                  ; minimally-qualified # 👨🏽‍⚖ E4.0 man judge: medium skin tone
+1F468 1F3FE 200D 2696 FE0F                             ; fully-qualified     # 👨🏾‍⚖️ E4.0 man judge: medium-dark skin tone
+1F468 1F3FE 200D 2696                                  ; minimally-qualified # 👨🏾‍⚖ E4.0 man judge: medium-dark skin tone
+1F468 1F3FF 200D 2696 FE0F                             ; fully-qualified     # 👨🏿‍⚖️ E4.0 man judge: dark skin tone
+1F468 1F3FF 200D 2696                                  ; minimally-qualified # 👨🏿‍⚖ E4.0 man judge: dark skin tone
+1F469 200D 2696 FE0F                                   ; fully-qualified     # 👩‍⚖️ E4.0 woman judge
+1F469 200D 2696                                        ; minimally-qualified # 👩‍⚖ E4.0 woman judge
+1F469 1F3FB 200D 2696 FE0F                             ; fully-qualified     # 👩🏻‍⚖️ E4.0 woman judge: light skin tone
+1F469 1F3FB 200D 2696                                  ; minimally-qualified # 👩🏻‍⚖ E4.0 woman judge: light skin tone
+1F469 1F3FC 200D 2696 FE0F                             ; fully-qualified     # 👩🏼‍⚖️ E4.0 woman judge: medium-light skin tone
+1F469 1F3FC 200D 2696                                  ; minimally-qualified # 👩🏼‍⚖ E4.0 woman judge: medium-light skin tone
+1F469 1F3FD 200D 2696 FE0F                             ; fully-qualified     # 👩🏽‍⚖️ E4.0 woman judge: medium skin tone
+1F469 1F3FD 200D 2696                                  ; minimally-qualified # 👩🏽‍⚖ E4.0 woman judge: medium skin tone
+1F469 1F3FE 200D 2696 FE0F                             ; fully-qualified     # 👩🏾‍⚖️ E4.0 woman judge: medium-dark skin tone
+1F469 1F3FE 200D 2696                                  ; minimally-qualified # 👩🏾‍⚖ E4.0 woman judge: medium-dark skin tone
+1F469 1F3FF 200D 2696 FE0F                             ; fully-qualified     # 👩🏿‍⚖️ E4.0 woman judge: dark skin tone
+1F469 1F3FF 200D 2696                                  ; minimally-qualified # 👩🏿‍⚖ E4.0 woman judge: dark skin tone
+1F9D1 200D 1F33E                                       ; fully-qualified     # 🧑‍🌾 E12.1 farmer
+1F9D1 1F3FB 200D 1F33E                                 ; fully-qualified     # 🧑🏻‍🌾 E12.1 farmer: light skin tone
+1F9D1 1F3FC 200D 1F33E                                 ; fully-qualified     # 🧑🏼‍🌾 E12.1 farmer: medium-light skin tone
+1F9D1 1F3FD 200D 1F33E                                 ; fully-qualified     # 🧑🏽‍🌾 E12.1 farmer: medium skin tone
+1F9D1 1F3FE 200D 1F33E                                 ; fully-qualified     # 🧑🏾‍🌾 E12.1 farmer: medium-dark skin tone
+1F9D1 1F3FF 200D 1F33E                                 ; fully-qualified     # 🧑🏿‍🌾 E12.1 farmer: dark skin tone
+1F468 200D 1F33E                                       ; fully-qualified     # 👨‍🌾 E4.0 man farmer
+1F468 1F3FB 200D 1F33E                                 ; fully-qualified     # 👨🏻‍🌾 E4.0 man farmer: light skin tone
+1F468 1F3FC 200D 1F33E                                 ; fully-qualified     # 👨🏼‍🌾 E4.0 man farmer: medium-light skin tone
+1F468 1F3FD 200D 1F33E                                 ; fully-qualified     # 👨🏽‍🌾 E4.0 man farmer: medium skin tone
+1F468 1F3FE 200D 1F33E                                 ; fully-qualified     # 👨🏾‍🌾 E4.0 man farmer: medium-dark skin tone
+1F468 1F3FF 200D 1F33E                                 ; fully-qualified     # 👨🏿‍🌾 E4.0 man farmer: dark skin tone
+1F469 200D 1F33E                                       ; fully-qualified     # 👩‍🌾 E4.0 woman farmer
+1F469 1F3FB 200D 1F33E                                 ; fully-qualified     # 👩🏻‍🌾 E4.0 woman farmer: light skin tone
+1F469 1F3FC 200D 1F33E                                 ; fully-qualified     # 👩🏼‍🌾 E4.0 woman farmer: medium-light skin tone
+1F469 1F3FD 200D 1F33E                                 ; fully-qualified     # 👩🏽‍🌾 E4.0 woman farmer: medium skin tone
+1F469 1F3FE 200D 1F33E                                 ; fully-qualified     # 👩🏾‍🌾 E4.0 woman farmer: medium-dark skin tone
+1F469 1F3FF 200D 1F33E                                 ; fully-qualified     # 👩🏿‍🌾 E4.0 woman farmer: dark skin tone
+1F9D1 200D 1F373                                       ; fully-qualified     # 🧑‍🍳 E12.1 cook
+1F9D1 1F3FB 200D 1F373                                 ; fully-qualified     # 🧑🏻‍🍳 E12.1 cook: light skin tone
+1F9D1 1F3FC 200D 1F373                                 ; fully-qualified     # 🧑🏼‍🍳 E12.1 cook: medium-light skin tone
+1F9D1 1F3FD 200D 1F373                                 ; fully-qualified     # 🧑🏽‍🍳 E12.1 cook: medium skin tone
+1F9D1 1F3FE 200D 1F373                                 ; fully-qualified     # 🧑🏾‍🍳 E12.1 cook: medium-dark skin tone
+1F9D1 1F3FF 200D 1F373                                 ; fully-qualified     # 🧑🏿‍🍳 E12.1 cook: dark skin tone
+1F468 200D 1F373                                       ; fully-qualified     # 👨‍🍳 E4.0 man cook
+1F468 1F3FB 200D 1F373                                 ; fully-qualified     # 👨🏻‍🍳 E4.0 man cook: light skin tone
+1F468 1F3FC 200D 1F373                                 ; fully-qualified     # 👨🏼‍🍳 E4.0 man cook: medium-light skin tone
+1F468 1F3FD 200D 1F373                                 ; fully-qualified     # 👨🏽‍🍳 E4.0 man cook: medium skin tone
+1F468 1F3FE 200D 1F373                                 ; fully-qualified     # 👨🏾‍🍳 E4.0 man cook: medium-dark skin tone
+1F468 1F3FF 200D 1F373                                 ; fully-qualified     # 👨🏿‍🍳 E4.0 man cook: dark skin tone
+1F469 200D 1F373                                       ; fully-qualified     # 👩‍🍳 E4.0 woman cook
+1F469 1F3FB 200D 1F373                                 ; fully-qualified     # 👩🏻‍🍳 E4.0 woman cook: light skin tone
+1F469 1F3FC 200D 1F373                                 ; fully-qualified     # 👩🏼‍🍳 E4.0 woman cook: medium-light skin tone
+1F469 1F3FD 200D 1F373                                 ; fully-qualified     # 👩🏽‍🍳 E4.0 woman cook: medium skin tone
+1F469 1F3FE 200D 1F373                                 ; fully-qualified     # 👩🏾‍🍳 E4.0 woman cook: medium-dark skin tone
+1F469 1F3FF 200D 1F373                                 ; fully-qualified     # 👩🏿‍🍳 E4.0 woman cook: dark skin tone
+1F9D1 200D 1F527                                       ; fully-qualified     # 🧑‍🔧 E12.1 mechanic
+1F9D1 1F3FB 200D 1F527                                 ; fully-qualified     # 🧑🏻‍🔧 E12.1 mechanic: light skin tone
+1F9D1 1F3FC 200D 1F527                                 ; fully-qualified     # 🧑🏼‍🔧 E12.1 mechanic: medium-light skin tone
+1F9D1 1F3FD 200D 1F527                                 ; fully-qualified     # 🧑🏽‍🔧 E12.1 mechanic: medium skin tone
+1F9D1 1F3FE 200D 1F527                                 ; fully-qualified     # 🧑🏾‍🔧 E12.1 mechanic: medium-dark skin tone
+1F9D1 1F3FF 200D 1F527                                 ; fully-qualified     # 🧑🏿‍🔧 E12.1 mechanic: dark skin tone
+1F468 200D 1F527                                       ; fully-qualified     # 👨‍🔧 E4.0 man mechanic
+1F468 1F3FB 200D 1F527                                 ; fully-qualified     # 👨🏻‍🔧 E4.0 man mechanic: light skin tone
+1F468 1F3FC 200D 1F527                                 ; fully-qualified     # 👨🏼‍🔧 E4.0 man mechanic: medium-light skin tone
+1F468 1F3FD 200D 1F527                                 ; fully-qualified     # 👨🏽‍🔧 E4.0 man mechanic: medium skin tone
+1F468 1F3FE 200D 1F527                                 ; fully-qualified     # 👨🏾‍🔧 E4.0 man mechanic: medium-dark skin tone
+1F468 1F3FF 200D 1F527                                 ; fully-qualified     # 👨🏿‍🔧 E4.0 man mechanic: dark skin tone
+1F469 200D 1F527                                       ; fully-qualified     # 👩‍🔧 E4.0 woman mechanic
+1F469 1F3FB 200D 1F527                                 ; fully-qualified     # 👩🏻‍🔧 E4.0 woman mechanic: light skin tone
+1F469 1F3FC 200D 1F527                                 ; fully-qualified     # 👩🏼‍🔧 E4.0 woman mechanic: medium-light skin tone
+1F469 1F3FD 200D 1F527                                 ; fully-qualified     # 👩🏽‍🔧 E4.0 woman mechanic: medium skin tone
+1F469 1F3FE 200D 1F527                                 ; fully-qualified     # 👩🏾‍🔧 E4.0 woman mechanic: medium-dark skin tone
+1F469 1F3FF 200D 1F527                                 ; fully-qualified     # 👩🏿‍🔧 E4.0 woman mechanic: dark skin tone
+1F9D1 200D 1F3ED                                       ; fully-qualified     # 🧑‍🏭 E12.1 factory worker
+1F9D1 1F3FB 200D 1F3ED                                 ; fully-qualified     # 🧑🏻‍🏭 E12.1 factory worker: light skin tone
+1F9D1 1F3FC 200D 1F3ED                                 ; fully-qualified     # 🧑🏼‍🏭 E12.1 factory worker: medium-light skin tone
+1F9D1 1F3FD 200D 1F3ED                                 ; fully-qualified     # 🧑🏽‍🏭 E12.1 factory worker: medium skin tone
+1F9D1 1F3FE 200D 1F3ED                                 ; fully-qualified     # 🧑🏾‍🏭 E12.1 factory worker: medium-dark skin tone
+1F9D1 1F3FF 200D 1F3ED                                 ; fully-qualified     # 🧑🏿‍🏭 E12.1 factory worker: dark skin tone
+1F468 200D 1F3ED                                       ; fully-qualified     # 👨‍🏭 E4.0 man factory worker
+1F468 1F3FB 200D 1F3ED                                 ; fully-qualified     # 👨🏻‍🏭 E4.0 man factory worker: light skin tone
+1F468 1F3FC 200D 1F3ED                                 ; fully-qualified     # 👨🏼‍🏭 E4.0 man factory worker: medium-light skin tone
+1F468 1F3FD 200D 1F3ED                                 ; fully-qualified     # 👨🏽‍🏭 E4.0 man factory worker: medium skin tone
+1F468 1F3FE 200D 1F3ED                                 ; fully-qualified     # 👨🏾‍🏭 E4.0 man factory worker: medium-dark skin tone
+1F468 1F3FF 200D 1F3ED                                 ; fully-qualified     # 👨🏿‍🏭 E4.0 man factory worker: dark skin tone
+1F469 200D 1F3ED                                       ; fully-qualified     # 👩‍🏭 E4.0 woman factory worker
+1F469 1F3FB 200D 1F3ED                                 ; fully-qualified     # 👩🏻‍🏭 E4.0 woman factory worker: light skin tone
+1F469 1F3FC 200D 1F3ED                                 ; fully-qualified     # 👩🏼‍🏭 E4.0 woman factory worker: medium-light skin tone
+1F469 1F3FD 200D 1F3ED                                 ; fully-qualified     # 👩🏽‍🏭 E4.0 woman factory worker: medium skin tone
+1F469 1F3FE 200D 1F3ED                                 ; fully-qualified     # 👩🏾‍🏭 E4.0 woman factory worker: medium-dark skin tone
+1F469 1F3FF 200D 1F3ED                                 ; fully-qualified     # 👩🏿‍🏭 E4.0 woman factory worker: dark skin tone
+1F9D1 200D 1F4BC                                       ; fully-qualified     # 🧑‍💼 E12.1 office worker
+1F9D1 1F3FB 200D 1F4BC                                 ; fully-qualified     # 🧑🏻‍💼 E12.1 office worker: light skin tone
+1F9D1 1F3FC 200D 1F4BC                                 ; fully-qualified     # 🧑🏼‍💼 E12.1 office worker: medium-light skin tone
+1F9D1 1F3FD 200D 1F4BC                                 ; fully-qualified     # 🧑🏽‍💼 E12.1 office worker: medium skin tone
+1F9D1 1F3FE 200D 1F4BC                                 ; fully-qualified     # 🧑🏾‍💼 E12.1 office worker: medium-dark skin tone
+1F9D1 1F3FF 200D 1F4BC                                 ; fully-qualified     # 🧑🏿‍💼 E12.1 office worker: dark skin tone
+1F468 200D 1F4BC                                       ; fully-qualified     # 👨‍💼 E4.0 man office worker
+1F468 1F3FB 200D 1F4BC                                 ; fully-qualified     # 👨🏻‍💼 E4.0 man office worker: light skin tone
+1F468 1F3FC 200D 1F4BC                                 ; fully-qualified     # 👨🏼‍💼 E4.0 man office worker: medium-light skin tone
+1F468 1F3FD 200D 1F4BC                                 ; fully-qualified     # 👨🏽‍💼 E4.0 man office worker: medium skin tone
+1F468 1F3FE 200D 1F4BC                                 ; fully-qualified     # 👨🏾‍💼 E4.0 man office worker: medium-dark skin tone
+1F468 1F3FF 200D 1F4BC                                 ; fully-qualified     # 👨🏿‍💼 E4.0 man office worker: dark skin tone
+1F469 200D 1F4BC                                       ; fully-qualified     # 👩‍💼 E4.0 woman office worker
+1F469 1F3FB 200D 1F4BC                                 ; fully-qualified     # 👩🏻‍💼 E4.0 woman office worker: light skin tone
+1F469 1F3FC 200D 1F4BC                                 ; fully-qualified     # 👩🏼‍💼 E4.0 woman office worker: medium-light skin tone
+1F469 1F3FD 200D 1F4BC                                 ; fully-qualified     # 👩🏽‍💼 E4.0 woman office worker: medium skin tone
+1F469 1F3FE 200D 1F4BC                                 ; fully-qualified     # 👩🏾‍💼 E4.0 woman office worker: medium-dark skin tone
+1F469 1F3FF 200D 1F4BC                                 ; fully-qualified     # 👩🏿‍💼 E4.0 woman office worker: dark skin tone
+1F9D1 200D 1F52C                                       ; fully-qualified     # 🧑‍🔬 E12.1 scientist
+1F9D1 1F3FB 200D 1F52C                                 ; fully-qualified     # 🧑🏻‍🔬 E12.1 scientist: light skin tone
+1F9D1 1F3FC 200D 1F52C                                 ; fully-qualified     # 🧑🏼‍🔬 E12.1 scientist: medium-light skin tone
+1F9D1 1F3FD 200D 1F52C                                 ; fully-qualified     # 🧑🏽‍🔬 E12.1 scientist: medium skin tone
+1F9D1 1F3FE 200D 1F52C                                 ; fully-qualified     # 🧑🏾‍🔬 E12.1 scientist: medium-dark skin tone
+1F9D1 1F3FF 200D 1F52C                                 ; fully-qualified     # 🧑🏿‍🔬 E12.1 scientist: dark skin tone
+1F468 200D 1F52C                                       ; fully-qualified     # 👨‍🔬 E4.0 man scientist
+1F468 1F3FB 200D 1F52C                                 ; fully-qualified     # 👨🏻‍🔬 E4.0 man scientist: light skin tone
+1F468 1F3FC 200D 1F52C                                 ; fully-qualified     # 👨🏼‍🔬 E4.0 man scientist: medium-light skin tone
+1F468 1F3FD 200D 1F52C                                 ; fully-qualified     # 👨🏽‍🔬 E4.0 man scientist: medium skin tone
+1F468 1F3FE 200D 1F52C                                 ; fully-qualified     # 👨🏾‍🔬 E4.0 man scientist: medium-dark skin tone
+1F468 1F3FF 200D 1F52C                                 ; fully-qualified     # 👨🏿‍🔬 E4.0 man scientist: dark skin tone
+1F469 200D 1F52C                                       ; fully-qualified     # 👩‍🔬 E4.0 woman scientist
+1F469 1F3FB 200D 1F52C                                 ; fully-qualified     # 👩🏻‍🔬 E4.0 woman scientist: light skin tone
+1F469 1F3FC 200D 1F52C                                 ; fully-qualified     # 👩🏼‍🔬 E4.0 woman scientist: medium-light skin tone
+1F469 1F3FD 200D 1F52C                                 ; fully-qualified     # 👩🏽‍🔬 E4.0 woman scientist: medium skin tone
+1F469 1F3FE 200D 1F52C                                 ; fully-qualified     # 👩🏾‍🔬 E4.0 woman scientist: medium-dark skin tone
+1F469 1F3FF 200D 1F52C                                 ; fully-qualified     # 👩🏿‍🔬 E4.0 woman scientist: dark skin tone
+1F9D1 200D 1F4BB                                       ; fully-qualified     # 🧑‍💻 E12.1 technologist
+1F9D1 1F3FB 200D 1F4BB                                 ; fully-qualified     # 🧑🏻‍💻 E12.1 technologist: light skin tone
+1F9D1 1F3FC 200D 1F4BB                                 ; fully-qualified     # 🧑🏼‍💻 E12.1 technologist: medium-light skin tone
+1F9D1 1F3FD 200D 1F4BB                                 ; fully-qualified     # 🧑🏽‍💻 E12.1 technologist: medium skin tone
+1F9D1 1F3FE 200D 1F4BB                                 ; fully-qualified     # 🧑🏾‍💻 E12.1 technologist: medium-dark skin tone
+1F9D1 1F3FF 200D 1F4BB                                 ; fully-qualified     # 🧑🏿‍💻 E12.1 technologist: dark skin tone
+1F468 200D 1F4BB                                       ; fully-qualified     # 👨‍💻 E4.0 man technologist
+1F468 1F3FB 200D 1F4BB                                 ; fully-qualified     # 👨🏻‍💻 E4.0 man technologist: light skin tone
+1F468 1F3FC 200D 1F4BB                                 ; fully-qualified     # 👨🏼‍💻 E4.0 man technologist: medium-light skin tone
+1F468 1F3FD 200D 1F4BB                                 ; fully-qualified     # 👨🏽‍💻 E4.0 man technologist: medium skin tone
+1F468 1F3FE 200D 1F4BB                                 ; fully-qualified     # 👨🏾‍💻 E4.0 man technologist: medium-dark skin tone
+1F468 1F3FF 200D 1F4BB                                 ; fully-qualified     # 👨🏿‍💻 E4.0 man technologist: dark skin tone
+1F469 200D 1F4BB                                       ; fully-qualified     # 👩‍💻 E4.0 woman technologist
+1F469 1F3FB 200D 1F4BB                                 ; fully-qualified     # 👩🏻‍💻 E4.0 woman technologist: light skin tone
+1F469 1F3FC 200D 1F4BB                                 ; fully-qualified     # 👩🏼‍💻 E4.0 woman technologist: medium-light skin tone
+1F469 1F3FD 200D 1F4BB                                 ; fully-qualified     # 👩🏽‍💻 E4.0 woman technologist: medium skin tone
+1F469 1F3FE 200D 1F4BB                                 ; fully-qualified     # 👩🏾‍💻 E4.0 woman technologist: medium-dark skin tone
+1F469 1F3FF 200D 1F4BB                                 ; fully-qualified     # 👩🏿‍💻 E4.0 woman technologist: dark skin tone
+1F9D1 200D 1F3A4                                       ; fully-qualified     # 🧑‍🎤 E12.1 singer
+1F9D1 1F3FB 200D 1F3A4                                 ; fully-qualified     # 🧑🏻‍🎤 E12.1 singer: light skin tone
+1F9D1 1F3FC 200D 1F3A4                                 ; fully-qualified     # 🧑🏼‍🎤 E12.1 singer: medium-light skin tone
+1F9D1 1F3FD 200D 1F3A4                                 ; fully-qualified     # 🧑🏽‍🎤 E12.1 singer: medium skin tone
+1F9D1 1F3FE 200D 1F3A4                                 ; fully-qualified     # 🧑🏾‍🎤 E12.1 singer: medium-dark skin tone
+1F9D1 1F3FF 200D 1F3A4                                 ; fully-qualified     # 🧑🏿‍🎤 E12.1 singer: dark skin tone
+1F468 200D 1F3A4                                       ; fully-qualified     # 👨‍🎤 E4.0 man singer
+1F468 1F3FB 200D 1F3A4                                 ; fully-qualified     # 👨🏻‍🎤 E4.0 man singer: light skin tone
+1F468 1F3FC 200D 1F3A4                                 ; fully-qualified     # 👨🏼‍🎤 E4.0 man singer: medium-light skin tone
+1F468 1F3FD 200D 1F3A4                                 ; fully-qualified     # 👨🏽‍🎤 E4.0 man singer: medium skin tone
+1F468 1F3FE 200D 1F3A4                                 ; fully-qualified     # 👨🏾‍🎤 E4.0 man singer: medium-dark skin tone
+1F468 1F3FF 200D 1F3A4                                 ; fully-qualified     # 👨🏿‍🎤 E4.0 man singer: dark skin tone
+1F469 200D 1F3A4                                       ; fully-qualified     # 👩‍🎤 E4.0 woman singer
+1F469 1F3FB 200D 1F3A4                                 ; fully-qualified     # 👩🏻‍🎤 E4.0 woman singer: light skin tone
+1F469 1F3FC 200D 1F3A4                                 ; fully-qualified     # 👩🏼‍🎤 E4.0 woman singer: medium-light skin tone
+1F469 1F3FD 200D 1F3A4                                 ; fully-qualified     # 👩🏽‍🎤 E4.0 woman singer: medium skin tone
+1F469 1F3FE 200D 1F3A4                                 ; fully-qualified     # 👩🏾‍🎤 E4.0 woman singer: medium-dark skin tone
+1F469 1F3FF 200D 1F3A4                                 ; fully-qualified     # 👩🏿‍🎤 E4.0 woman singer: dark skin tone
+1F9D1 200D 1F3A8                                       ; fully-qualified     # 🧑‍🎨 E12.1 artist
+1F9D1 1F3FB 200D 1F3A8                                 ; fully-qualified     # 🧑🏻‍🎨 E12.1 artist: light skin tone
+1F9D1 1F3FC 200D 1F3A8                                 ; fully-qualified     # 🧑🏼‍🎨 E12.1 artist: medium-light skin tone
+1F9D1 1F3FD 200D 1F3A8                                 ; fully-qualified     # 🧑🏽‍🎨 E12.1 artist: medium skin tone
+1F9D1 1F3FE 200D 1F3A8                                 ; fully-qualified     # 🧑🏾‍🎨 E12.1 artist: medium-dark skin tone
+1F9D1 1F3FF 200D 1F3A8                                 ; fully-qualified     # 🧑🏿‍🎨 E12.1 artist: dark skin tone
+1F468 200D 1F3A8                                       ; fully-qualified     # 👨‍🎨 E4.0 man artist
+1F468 1F3FB 200D 1F3A8                                 ; fully-qualified     # 👨🏻‍🎨 E4.0 man artist: light skin tone
+1F468 1F3FC 200D 1F3A8                                 ; fully-qualified     # 👨🏼‍🎨 E4.0 man artist: medium-light skin tone
+1F468 1F3FD 200D 1F3A8                                 ; fully-qualified     # 👨🏽‍🎨 E4.0 man artist: medium skin tone
+1F468 1F3FE 200D 1F3A8                                 ; fully-qualified     # 👨🏾‍🎨 E4.0 man artist: medium-dark skin tone
+1F468 1F3FF 200D 1F3A8                                 ; fully-qualified     # 👨🏿‍🎨 E4.0 man artist: dark skin tone
+1F469 200D 1F3A8                                       ; fully-qualified     # 👩‍🎨 E4.0 woman artist
+1F469 1F3FB 200D 1F3A8                                 ; fully-qualified     # 👩🏻‍🎨 E4.0 woman artist: light skin tone
+1F469 1F3FC 200D 1F3A8                                 ; fully-qualified     # 👩🏼‍🎨 E4.0 woman artist: medium-light skin tone
+1F469 1F3FD 200D 1F3A8                                 ; fully-qualified     # 👩🏽‍🎨 E4.0 woman artist: medium skin tone
+1F469 1F3FE 200D 1F3A8                                 ; fully-qualified     # 👩🏾‍🎨 E4.0 woman artist: medium-dark skin tone
+1F469 1F3FF 200D 1F3A8                                 ; fully-qualified     # 👩🏿‍🎨 E4.0 woman artist: dark skin tone
+1F9D1 200D 2708 FE0F                                   ; fully-qualified     # 🧑‍✈️ E12.1 pilot
+1F9D1 200D 2708                                        ; minimally-qualified # 🧑‍✈ E12.1 pilot
+1F9D1 1F3FB 200D 2708 FE0F                             ; fully-qualified     # 🧑🏻‍✈️ E12.1 pilot: light skin tone
+1F9D1 1F3FB 200D 2708                                  ; minimally-qualified # 🧑🏻‍✈ E12.1 pilot: light skin tone
+1F9D1 1F3FC 200D 2708 FE0F                             ; fully-qualified     # 🧑🏼‍✈️ E12.1 pilot: medium-light skin tone
+1F9D1 1F3FC 200D 2708                                  ; minimally-qualified # 🧑🏼‍✈ E12.1 pilot: medium-light skin tone
+1F9D1 1F3FD 200D 2708 FE0F                             ; fully-qualified     # 🧑🏽‍✈️ E12.1 pilot: medium skin tone
+1F9D1 1F3FD 200D 2708                                  ; minimally-qualified # 🧑🏽‍✈ E12.1 pilot: medium skin tone
+1F9D1 1F3FE 200D 2708 FE0F                             ; fully-qualified     # 🧑🏾‍✈️ E12.1 pilot: medium-dark skin tone
+1F9D1 1F3FE 200D 2708                                  ; minimally-qualified # 🧑🏾‍✈ E12.1 pilot: medium-dark skin tone
+1F9D1 1F3FF 200D 2708 FE0F                             ; fully-qualified     # 🧑🏿‍✈️ E12.1 pilot: dark skin tone
+1F9D1 1F3FF 200D 2708                                  ; minimally-qualified # 🧑🏿‍✈ E12.1 pilot: dark skin tone
+1F468 200D 2708 FE0F                                   ; fully-qualified     # 👨‍✈️ E4.0 man pilot
+1F468 200D 2708                                        ; minimally-qualified # 👨‍✈ E4.0 man pilot
+1F468 1F3FB 200D 2708 FE0F                             ; fully-qualified     # 👨🏻‍✈️ E4.0 man pilot: light skin tone
+1F468 1F3FB 200D 2708                                  ; minimally-qualified # 👨🏻‍✈ E4.0 man pilot: light skin tone
+1F468 1F3FC 200D 2708 FE0F                             ; fully-qualified     # 👨🏼‍✈️ E4.0 man pilot: medium-light skin tone
+1F468 1F3FC 200D 2708                                  ; minimally-qualified # 👨🏼‍✈ E4.0 man pilot: medium-light skin tone
+1F468 1F3FD 200D 2708 FE0F                             ; fully-qualified     # 👨🏽‍✈️ E4.0 man pilot: medium skin tone
+1F468 1F3FD 200D 2708                                  ; minimally-qualified # 👨🏽‍✈ E4.0 man pilot: medium skin tone
+1F468 1F3FE 200D 2708 FE0F                             ; fully-qualified     # 👨🏾‍✈️ E4.0 man pilot: medium-dark skin tone
+1F468 1F3FE 200D 2708                                  ; minimally-qualified # 👨🏾‍✈ E4.0 man pilot: medium-dark skin tone
+1F468 1F3FF 200D 2708 FE0F                             ; fully-qualified     # 👨🏿‍✈️ E4.0 man pilot: dark skin tone
+1F468 1F3FF 200D 2708                                  ; minimally-qualified # 👨🏿‍✈ E4.0 man pilot: dark skin tone
+1F469 200D 2708 FE0F                                   ; fully-qualified     # 👩‍✈️ E4.0 woman pilot
+1F469 200D 2708                                        ; minimally-qualified # 👩‍✈ E4.0 woman pilot
+1F469 1F3FB 200D 2708 FE0F                             ; fully-qualified     # 👩🏻‍✈️ E4.0 woman pilot: light skin tone
+1F469 1F3FB 200D 2708                                  ; minimally-qualified # 👩🏻‍✈ E4.0 woman pilot: light skin tone
+1F469 1F3FC 200D 2708 FE0F                             ; fully-qualified     # 👩🏼‍✈️ E4.0 woman pilot: medium-light skin tone
+1F469 1F3FC 200D 2708                                  ; minimally-qualified # 👩🏼‍✈ E4.0 woman pilot: medium-light skin tone
+1F469 1F3FD 200D 2708 FE0F                             ; fully-qualified     # 👩🏽‍✈️ E4.0 woman pilot: medium skin tone
+1F469 1F3FD 200D 2708                                  ; minimally-qualified # 👩🏽‍✈ E4.0 woman pilot: medium skin tone
+1F469 1F3FE 200D 2708 FE0F                             ; fully-qualified     # 👩🏾‍✈️ E4.0 woman pilot: medium-dark skin tone
+1F469 1F3FE 200D 2708                                  ; minimally-qualified # 👩🏾‍✈ E4.0 woman pilot: medium-dark skin tone
+1F469 1F3FF 200D 2708 FE0F                             ; fully-qualified     # 👩🏿‍✈️ E4.0 woman pilot: dark skin tone
+1F469 1F3FF 200D 2708                                  ; minimally-qualified # 👩🏿‍✈ E4.0 woman pilot: dark skin tone
+1F9D1 200D 1F680                                       ; fully-qualified     # 🧑‍🚀 E12.1 astronaut
+1F9D1 1F3FB 200D 1F680                                 ; fully-qualified     # 🧑🏻‍🚀 E12.1 astronaut: light skin tone
+1F9D1 1F3FC 200D 1F680                                 ; fully-qualified     # 🧑🏼‍🚀 E12.1 astronaut: medium-light skin tone
+1F9D1 1F3FD 200D 1F680                                 ; fully-qualified     # 🧑🏽‍🚀 E12.1 astronaut: medium skin tone
+1F9D1 1F3FE 200D 1F680                                 ; fully-qualified     # 🧑🏾‍🚀 E12.1 astronaut: medium-dark skin tone
+1F9D1 1F3FF 200D 1F680                                 ; fully-qualified     # 🧑🏿‍🚀 E12.1 astronaut: dark skin tone
+1F468 200D 1F680                                       ; fully-qualified     # 👨‍🚀 E4.0 man astronaut
+1F468 1F3FB 200D 1F680                                 ; fully-qualified     # 👨🏻‍🚀 E4.0 man astronaut: light skin tone
+1F468 1F3FC 200D 1F680                                 ; fully-qualified     # 👨🏼‍🚀 E4.0 man astronaut: medium-light skin tone
+1F468 1F3FD 200D 1F680                                 ; fully-qualified     # 👨🏽‍🚀 E4.0 man astronaut: medium skin tone
+1F468 1F3FE 200D 1F680                                 ; fully-qualified     # 👨🏾‍🚀 E4.0 man astronaut: medium-dark skin tone
+1F468 1F3FF 200D 1F680                                 ; fully-qualified     # 👨🏿‍🚀 E4.0 man astronaut: dark skin tone
+1F469 200D 1F680                                       ; fully-qualified     # 👩‍🚀 E4.0 woman astronaut
+1F469 1F3FB 200D 1F680                                 ; fully-qualified     # 👩🏻‍🚀 E4.0 woman astronaut: light skin tone
+1F469 1F3FC 200D 1F680                                 ; fully-qualified     # 👩🏼‍🚀 E4.0 woman astronaut: medium-light skin tone
+1F469 1F3FD 200D 1F680                                 ; fully-qualified     # 👩🏽‍🚀 E4.0 woman astronaut: medium skin tone
+1F469 1F3FE 200D 1F680                                 ; fully-qualified     # 👩🏾‍🚀 E4.0 woman astronaut: medium-dark skin tone
+1F469 1F3FF 200D 1F680                                 ; fully-qualified     # 👩🏿‍🚀 E4.0 woman astronaut: dark skin tone
+1F9D1 200D 1F692                                       ; fully-qualified     # 🧑‍🚒 E12.1 firefighter
+1F9D1 1F3FB 200D 1F692                                 ; fully-qualified     # 🧑🏻‍🚒 E12.1 firefighter: light skin tone
+1F9D1 1F3FC 200D 1F692                                 ; fully-qualified     # 🧑🏼‍🚒 E12.1 firefighter: medium-light skin tone
+1F9D1 1F3FD 200D 1F692                                 ; fully-qualified     # 🧑🏽‍🚒 E12.1 firefighter: medium skin tone
+1F9D1 1F3FE 200D 1F692                                 ; fully-qualified     # 🧑🏾‍🚒 E12.1 firefighter: medium-dark skin tone
+1F9D1 1F3FF 200D 1F692                                 ; fully-qualified     # 🧑🏿‍🚒 E12.1 firefighter: dark skin tone
+1F468 200D 1F692                                       ; fully-qualified     # 👨‍🚒 E4.0 man firefighter
+1F468 1F3FB 200D 1F692                                 ; fully-qualified     # 👨🏻‍🚒 E4.0 man firefighter: light skin tone
+1F468 1F3FC 200D 1F692                                 ; fully-qualified     # 👨🏼‍🚒 E4.0 man firefighter: medium-light skin tone
+1F468 1F3FD 200D 1F692                                 ; fully-qualified     # 👨🏽‍🚒 E4.0 man firefighter: medium skin tone
+1F468 1F3FE 200D 1F692                                 ; fully-qualified     # 👨🏾‍🚒 E4.0 man firefighter: medium-dark skin tone
+1F468 1F3FF 200D 1F692                                 ; fully-qualified     # 👨🏿‍🚒 E4.0 man firefighter: dark skin tone
+1F469 200D 1F692                                       ; fully-qualified     # 👩‍🚒 E4.0 woman firefighter
+1F469 1F3FB 200D 1F692                                 ; fully-qualified     # 👩🏻‍🚒 E4.0 woman firefighter: light skin tone
+1F469 1F3FC 200D 1F692                                 ; fully-qualified     # 👩🏼‍🚒 E4.0 woman firefighter: medium-light skin tone
+1F469 1F3FD 200D 1F692                                 ; fully-qualified     # 👩🏽‍🚒 E4.0 woman firefighter: medium skin tone
+1F469 1F3FE 200D 1F692                                 ; fully-qualified     # 👩🏾‍🚒 E4.0 woman firefighter: medium-dark skin tone
+1F469 1F3FF 200D 1F692                                 ; fully-qualified     # 👩🏿‍🚒 E4.0 woman firefighter: dark skin tone
+1F46E                                                  ; fully-qualified     # 👮 E0.6 police officer
+1F46E 1F3FB                                            ; fully-qualified     # 👮🏻 E1.0 police officer: light skin tone
+1F46E 1F3FC                                            ; fully-qualified     # 👮🏼 E1.0 police officer: medium-light skin tone
+1F46E 1F3FD                                            ; fully-qualified     # 👮🏽 E1.0 police officer: medium skin tone
+1F46E 1F3FE                                            ; fully-qualified     # 👮🏾 E1.0 police officer: medium-dark skin tone
+1F46E 1F3FF                                            ; fully-qualified     # 👮🏿 E1.0 police officer: dark skin tone
+1F46E 200D 2642 FE0F                                   ; fully-qualified     # 👮‍♂️ E4.0 man police officer
+1F46E 200D 2642                                        ; minimally-qualified # 👮‍♂ E4.0 man police officer
+1F46E 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 👮🏻‍♂️ E4.0 man police officer: light skin tone
+1F46E 1F3FB 200D 2642                                  ; minimally-qualified # 👮🏻‍♂ E4.0 man police officer: light skin tone
+1F46E 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 👮🏼‍♂️ E4.0 man police officer: medium-light skin tone
+1F46E 1F3FC 200D 2642                                  ; minimally-qualified # 👮🏼‍♂ E4.0 man police officer: medium-light skin tone
+1F46E 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 👮🏽‍♂️ E4.0 man police officer: medium skin tone
+1F46E 1F3FD 200D 2642                                  ; minimally-qualified # 👮🏽‍♂ E4.0 man police officer: medium skin tone
+1F46E 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 👮🏾‍♂️ E4.0 man police officer: medium-dark skin tone
+1F46E 1F3FE 200D 2642                                  ; minimally-qualified # 👮🏾‍♂ E4.0 man police officer: medium-dark skin tone
+1F46E 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 👮🏿‍♂️ E4.0 man police officer: dark skin tone
+1F46E 1F3FF 200D 2642                                  ; minimally-qualified # 👮🏿‍♂ E4.0 man police officer: dark skin tone
+1F46E 200D 2640 FE0F                                   ; fully-qualified     # 👮‍♀️ E4.0 woman police officer
+1F46E 200D 2640                                        ; minimally-qualified # 👮‍♀ E4.0 woman police officer
+1F46E 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 👮🏻‍♀️ E4.0 woman police officer: light skin tone
+1F46E 1F3FB 200D 2640                                  ; minimally-qualified # 👮🏻‍♀ E4.0 woman police officer: light skin tone
+1F46E 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 👮🏼‍♀️ E4.0 woman police officer: medium-light skin tone
+1F46E 1F3FC 200D 2640                                  ; minimally-qualified # 👮🏼‍♀ E4.0 woman police officer: medium-light skin tone
+1F46E 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 👮🏽‍♀️ E4.0 woman police officer: medium skin tone
+1F46E 1F3FD 200D 2640                                  ; minimally-qualified # 👮🏽‍♀ E4.0 woman police officer: medium skin tone
+1F46E 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 👮🏾‍♀️ E4.0 woman police officer: medium-dark skin tone
+1F46E 1F3FE 200D 2640                                  ; minimally-qualified # 👮🏾‍♀ E4.0 woman police officer: medium-dark skin tone
+1F46E 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 👮🏿‍♀️ E4.0 woman police officer: dark skin tone
+1F46E 1F3FF 200D 2640                                  ; minimally-qualified # 👮🏿‍♀ E4.0 woman police officer: dark skin tone
+1F575 FE0F                                             ; fully-qualified     # 🕵️ E0.7 detective
+1F575                                                  ; unqualified         # 🕵 E0.7 detective
+1F575 1F3FB                                            ; fully-qualified     # 🕵🏻 E2.0 detective: light skin tone
+1F575 1F3FC                                            ; fully-qualified     # 🕵🏼 E2.0 detective: medium-light skin tone
+1F575 1F3FD                                            ; fully-qualified     # 🕵🏽 E2.0 detective: medium skin tone
+1F575 1F3FE                                            ; fully-qualified     # 🕵🏾 E2.0 detective: medium-dark skin tone
+1F575 1F3FF                                            ; fully-qualified     # 🕵🏿 E2.0 detective: dark skin tone
+1F575 FE0F 200D 2642 FE0F                              ; fully-qualified     # 🕵️‍♂️ E4.0 man detective
+1F575 200D 2642 FE0F                                   ; unqualified         # 🕵‍♂️ E4.0 man detective
+1F575 FE0F 200D 2642                                   ; minimally-qualified # 🕵️‍♂ E4.0 man detective
+1F575 200D 2642                                        ; unqualified         # 🕵‍♂ E4.0 man detective
+1F575 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🕵🏻‍♂️ E4.0 man detective: light skin tone
+1F575 1F3FB 200D 2642                                  ; minimally-qualified # 🕵🏻‍♂ E4.0 man detective: light skin tone
+1F575 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🕵🏼‍♂️ E4.0 man detective: medium-light skin tone
+1F575 1F3FC 200D 2642                                  ; minimally-qualified # 🕵🏼‍♂ E4.0 man detective: medium-light skin tone
+1F575 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🕵🏽‍♂️ E4.0 man detective: medium skin tone
+1F575 1F3FD 200D 2642                                  ; minimally-qualified # 🕵🏽‍♂ E4.0 man detective: medium skin tone
+1F575 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🕵🏾‍♂️ E4.0 man detective: medium-dark skin tone
+1F575 1F3FE 200D 2642                                  ; minimally-qualified # 🕵🏾‍♂ E4.0 man detective: medium-dark skin tone
+1F575 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🕵🏿‍♂️ E4.0 man detective: dark skin tone
+1F575 1F3FF 200D 2642                                  ; minimally-qualified # 🕵🏿‍♂ E4.0 man detective: dark skin tone
+1F575 FE0F 200D 2640 FE0F                              ; fully-qualified     # 🕵️‍♀️ E4.0 woman detective
+1F575 200D 2640 FE0F                                   ; unqualified         # 🕵‍♀️ E4.0 woman detective
+1F575 FE0F 200D 2640                                   ; minimally-qualified # 🕵️‍♀ E4.0 woman detective
+1F575 200D 2640                                        ; unqualified         # 🕵‍♀ E4.0 woman detective
+1F575 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🕵🏻‍♀️ E4.0 woman detective: light skin tone
+1F575 1F3FB 200D 2640                                  ; minimally-qualified # 🕵🏻‍♀ E4.0 woman detective: light skin tone
+1F575 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🕵🏼‍♀️ E4.0 woman detective: medium-light skin tone
+1F575 1F3FC 200D 2640                                  ; minimally-qualified # 🕵🏼‍♀ E4.0 woman detective: medium-light skin tone
+1F575 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🕵🏽‍♀️ E4.0 woman detective: medium skin tone
+1F575 1F3FD 200D 2640                                  ; minimally-qualified # 🕵🏽‍♀ E4.0 woman detective: medium skin tone
+1F575 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🕵🏾‍♀️ E4.0 woman detective: medium-dark skin tone
+1F575 1F3FE 200D 2640                                  ; minimally-qualified # 🕵🏾‍♀ E4.0 woman detective: medium-dark skin tone
+1F575 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🕵🏿‍♀️ E4.0 woman detective: dark skin tone
+1F575 1F3FF 200D 2640                                  ; minimally-qualified # 🕵🏿‍♀ E4.0 woman detective: dark skin tone
+1F482                                                  ; fully-qualified     # 💂 E0.6 guard
+1F482 1F3FB                                            ; fully-qualified     # 💂🏻 E1.0 guard: light skin tone
+1F482 1F3FC                                            ; fully-qualified     # 💂🏼 E1.0 guard: medium-light skin tone
+1F482 1F3FD                                            ; fully-qualified     # 💂🏽 E1.0 guard: medium skin tone
+1F482 1F3FE                                            ; fully-qualified     # 💂🏾 E1.0 guard: medium-dark skin tone
+1F482 1F3FF                                            ; fully-qualified     # 💂🏿 E1.0 guard: dark skin tone
+1F482 200D 2642 FE0F                                   ; fully-qualified     # 💂‍♂️ E4.0 man guard
+1F482 200D 2642                                        ; minimally-qualified # 💂‍♂ E4.0 man guard
+1F482 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 💂🏻‍♂️ E4.0 man guard: light skin tone
+1F482 1F3FB 200D 2642                                  ; minimally-qualified # 💂🏻‍♂ E4.0 man guard: light skin tone
+1F482 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 💂🏼‍♂️ E4.0 man guard: medium-light skin tone
+1F482 1F3FC 200D 2642                                  ; minimally-qualified # 💂🏼‍♂ E4.0 man guard: medium-light skin tone
+1F482 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 💂🏽‍♂️ E4.0 man guard: medium skin tone
+1F482 1F3FD 200D 2642                                  ; minimally-qualified # 💂🏽‍♂ E4.0 man guard: medium skin tone
+1F482 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 💂🏾‍♂️ E4.0 man guard: medium-dark skin tone
+1F482 1F3FE 200D 2642                                  ; minimally-qualified # 💂🏾‍♂ E4.0 man guard: medium-dark skin tone
+1F482 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 💂🏿‍♂️ E4.0 man guard: dark skin tone
+1F482 1F3FF 200D 2642                                  ; minimally-qualified # 💂🏿‍♂ E4.0 man guard: dark skin tone
+1F482 200D 2640 FE0F                                   ; fully-qualified     # 💂‍♀️ E4.0 woman guard
+1F482 200D 2640                                        ; minimally-qualified # 💂‍♀ E4.0 woman guard
+1F482 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 💂🏻‍♀️ E4.0 woman guard: light skin tone
+1F482 1F3FB 200D 2640                                  ; minimally-qualified # 💂🏻‍♀ E4.0 woman guard: light skin tone
+1F482 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 💂🏼‍♀️ E4.0 woman guard: medium-light skin tone
+1F482 1F3FC 200D 2640                                  ; minimally-qualified # 💂🏼‍♀ E4.0 woman guard: medium-light skin tone
+1F482 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 💂🏽‍♀️ E4.0 woman guard: medium skin tone
+1F482 1F3FD 200D 2640                                  ; minimally-qualified # 💂🏽‍♀ E4.0 woman guard: medium skin tone
+1F482 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 💂🏾‍♀️ E4.0 woman guard: medium-dark skin tone
+1F482 1F3FE 200D 2640                                  ; minimally-qualified # 💂🏾‍♀ E4.0 woman guard: medium-dark skin tone
+1F482 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 💂🏿‍♀️ E4.0 woman guard: dark skin tone
+1F482 1F3FF 200D 2640                                  ; minimally-qualified # 💂🏿‍♀ E4.0 woman guard: dark skin tone
+1F977                                                  ; fully-qualified     # 🥷 E13.0 ninja
+1F977 1F3FB                                            ; fully-qualified     # 🥷🏻 E13.0 ninja: light skin tone
+1F977 1F3FC                                            ; fully-qualified     # 🥷🏼 E13.0 ninja: medium-light skin tone
+1F977 1F3FD                                            ; fully-qualified     # 🥷🏽 E13.0 ninja: medium skin tone
+1F977 1F3FE                                            ; fully-qualified     # 🥷🏾 E13.0 ninja: medium-dark skin tone
+1F977 1F3FF                                            ; fully-qualified     # 🥷🏿 E13.0 ninja: dark skin tone
+1F477                                                  ; fully-qualified     # 👷 E0.6 construction worker
+1F477 1F3FB                                            ; fully-qualified     # 👷🏻 E1.0 construction worker: light skin tone
+1F477 1F3FC                                            ; fully-qualified     # 👷🏼 E1.0 construction worker: medium-light skin tone
+1F477 1F3FD                                            ; fully-qualified     # 👷🏽 E1.0 construction worker: medium skin tone
+1F477 1F3FE                                            ; fully-qualified     # 👷🏾 E1.0 construction worker: medium-dark skin tone
+1F477 1F3FF                                            ; fully-qualified     # 👷🏿 E1.0 construction worker: dark skin tone
+1F477 200D 2642 FE0F                                   ; fully-qualified     # 👷‍♂️ E4.0 man construction worker
+1F477 200D 2642                                        ; minimally-qualified # 👷‍♂ E4.0 man construction worker
+1F477 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 👷🏻‍♂️ E4.0 man construction worker: light skin tone
+1F477 1F3FB 200D 2642                                  ; minimally-qualified # 👷🏻‍♂ E4.0 man construction worker: light skin tone
+1F477 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 👷🏼‍♂️ E4.0 man construction worker: medium-light skin tone
+1F477 1F3FC 200D 2642                                  ; minimally-qualified # 👷🏼‍♂ E4.0 man construction worker: medium-light skin tone
+1F477 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 👷🏽‍♂️ E4.0 man construction worker: medium skin tone
+1F477 1F3FD 200D 2642                                  ; minimally-qualified # 👷🏽‍♂ E4.0 man construction worker: medium skin tone
+1F477 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 👷🏾‍♂️ E4.0 man construction worker: medium-dark skin tone
+1F477 1F3FE 200D 2642                                  ; minimally-qualified # 👷🏾‍♂ E4.0 man construction worker: medium-dark skin tone
+1F477 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 👷🏿‍♂️ E4.0 man construction worker: dark skin tone
+1F477 1F3FF 200D 2642                                  ; minimally-qualified # 👷🏿‍♂ E4.0 man construction worker: dark skin tone
+1F477 200D 2640 FE0F                                   ; fully-qualified     # 👷‍♀️ E4.0 woman construction worker
+1F477 200D 2640                                        ; minimally-qualified # 👷‍♀ E4.0 woman construction worker
+1F477 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 👷🏻‍♀️ E4.0 woman construction worker: light skin tone
+1F477 1F3FB 200D 2640                                  ; minimally-qualified # 👷🏻‍♀ E4.0 woman construction worker: light skin tone
+1F477 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 👷🏼‍♀️ E4.0 woman construction worker: medium-light skin tone
+1F477 1F3FC 200D 2640                                  ; minimally-qualified # 👷🏼‍♀ E4.0 woman construction worker: medium-light skin tone
+1F477 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 👷🏽‍♀️ E4.0 woman construction worker: medium skin tone
+1F477 1F3FD 200D 2640                                  ; minimally-qualified # 👷🏽‍♀ E4.0 woman construction worker: medium skin tone
+1F477 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 👷🏾‍♀️ E4.0 woman construction worker: medium-dark skin tone
+1F477 1F3FE 200D 2640                                  ; minimally-qualified # 👷🏾‍♀ E4.0 woman construction worker: medium-dark skin tone
+1F477 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 👷🏿‍♀️ E4.0 woman construction worker: dark skin tone
+1F477 1F3FF 200D 2640                                  ; minimally-qualified # 👷🏿‍♀ E4.0 woman construction worker: dark skin tone
+1FAC5                                                  ; fully-qualified     # 🫅 E14.0 person with crown
+1FAC5 1F3FB                                            ; fully-qualified     # 🫅🏻 E14.0 person with crown: light skin tone
+1FAC5 1F3FC                                            ; fully-qualified     # 🫅🏼 E14.0 person with crown: medium-light skin tone
+1FAC5 1F3FD                                            ; fully-qualified     # 🫅🏽 E14.0 person with crown: medium skin tone
+1FAC5 1F3FE                                            ; fully-qualified     # 🫅🏾 E14.0 person with crown: medium-dark skin tone
+1FAC5 1F3FF                                            ; fully-qualified     # 🫅🏿 E14.0 person with crown: dark skin tone
+1F934                                                  ; fully-qualified     # 🤴 E3.0 prince
+1F934 1F3FB                                            ; fully-qualified     # 🤴🏻 E3.0 prince: light skin tone
+1F934 1F3FC                                            ; fully-qualified     # 🤴🏼 E3.0 prince: medium-light skin tone
+1F934 1F3FD                                            ; fully-qualified     # 🤴🏽 E3.0 prince: medium skin tone
+1F934 1F3FE                                            ; fully-qualified     # 🤴🏾 E3.0 prince: medium-dark skin tone
+1F934 1F3FF                                            ; fully-qualified     # 🤴🏿 E3.0 prince: dark skin tone
+1F478                                                  ; fully-qualified     # 👸 E0.6 princess
+1F478 1F3FB                                            ; fully-qualified     # 👸🏻 E1.0 princess: light skin tone
+1F478 1F3FC                                            ; fully-qualified     # 👸🏼 E1.0 princess: medium-light skin tone
+1F478 1F3FD                                            ; fully-qualified     # 👸🏽 E1.0 princess: medium skin tone
+1F478 1F3FE                                            ; fully-qualified     # 👸🏾 E1.0 princess: medium-dark skin tone
+1F478 1F3FF                                            ; fully-qualified     # 👸🏿 E1.0 princess: dark skin tone
+1F473                                                  ; fully-qualified     # 👳 E0.6 person wearing turban
+1F473 1F3FB                                            ; fully-qualified     # 👳🏻 E1.0 person wearing turban: light skin tone
+1F473 1F3FC                                            ; fully-qualified     # 👳🏼 E1.0 person wearing turban: medium-light skin tone
+1F473 1F3FD                                            ; fully-qualified     # 👳🏽 E1.0 person wearing turban: medium skin tone
+1F473 1F3FE                                            ; fully-qualified     # 👳🏾 E1.0 person wearing turban: medium-dark skin tone
+1F473 1F3FF                                            ; fully-qualified     # 👳🏿 E1.0 person wearing turban: dark skin tone
+1F473 200D 2642 FE0F                                   ; fully-qualified     # 👳‍♂️ E4.0 man wearing turban
+1F473 200D 2642                                        ; minimally-qualified # 👳‍♂ E4.0 man wearing turban
+1F473 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 👳🏻‍♂️ E4.0 man wearing turban: light skin tone
+1F473 1F3FB 200D 2642                                  ; minimally-qualified # 👳🏻‍♂ E4.0 man wearing turban: light skin tone
+1F473 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 👳🏼‍♂️ E4.0 man wearing turban: medium-light skin tone
+1F473 1F3FC 200D 2642                                  ; minimally-qualified # 👳🏼‍♂ E4.0 man wearing turban: medium-light skin tone
+1F473 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 👳🏽‍♂️ E4.0 man wearing turban: medium skin tone
+1F473 1F3FD 200D 2642                                  ; minimally-qualified # 👳🏽‍♂ E4.0 man wearing turban: medium skin tone
+1F473 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 👳🏾‍♂️ E4.0 man wearing turban: medium-dark skin tone
+1F473 1F3FE 200D 2642                                  ; minimally-qualified # 👳🏾‍♂ E4.0 man wearing turban: medium-dark skin tone
+1F473 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 👳🏿‍♂️ E4.0 man wearing turban: dark skin tone
+1F473 1F3FF 200D 2642                                  ; minimally-qualified # 👳🏿‍♂ E4.0 man wearing turban: dark skin tone
+1F473 200D 2640 FE0F                                   ; fully-qualified     # 👳‍♀️ E4.0 woman wearing turban
+1F473 200D 2640                                        ; minimally-qualified # 👳‍♀ E4.0 woman wearing turban
+1F473 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 👳🏻‍♀️ E4.0 woman wearing turban: light skin tone
+1F473 1F3FB 200D 2640                                  ; minimally-qualified # 👳🏻‍♀ E4.0 woman wearing turban: light skin tone
+1F473 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 👳🏼‍♀️ E4.0 woman wearing turban: medium-light skin tone
+1F473 1F3FC 200D 2640                                  ; minimally-qualified # 👳🏼‍♀ E4.0 woman wearing turban: medium-light skin tone
+1F473 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 👳🏽‍♀️ E4.0 woman wearing turban: medium skin tone
+1F473 1F3FD 200D 2640                                  ; minimally-qualified # 👳🏽‍♀ E4.0 woman wearing turban: medium skin tone
+1F473 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 👳🏾‍♀️ E4.0 woman wearing turban: medium-dark skin tone
+1F473 1F3FE 200D 2640                                  ; minimally-qualified # 👳🏾‍♀ E4.0 woman wearing turban: medium-dark skin tone
+1F473 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 👳🏿‍♀️ E4.0 woman wearing turban: dark skin tone
+1F473 1F3FF 200D 2640                                  ; minimally-qualified # 👳🏿‍♀ E4.0 woman wearing turban: dark skin tone
+1F472                                                  ; fully-qualified     # 👲 E0.6 person with skullcap
+1F472 1F3FB                                            ; fully-qualified     # 👲🏻 E1.0 person with skullcap: light skin tone
+1F472 1F3FC                                            ; fully-qualified     # 👲🏼 E1.0 person with skullcap: medium-light skin tone
+1F472 1F3FD                                            ; fully-qualified     # 👲🏽 E1.0 person with skullcap: medium skin tone
+1F472 1F3FE                                            ; fully-qualified     # 👲🏾 E1.0 person with skullcap: medium-dark skin tone
+1F472 1F3FF                                            ; fully-qualified     # 👲🏿 E1.0 person with skullcap: dark skin tone
+1F9D5                                                  ; fully-qualified     # 🧕 E5.0 woman with headscarf
+1F9D5 1F3FB                                            ; fully-qualified     # 🧕🏻 E5.0 woman with headscarf: light skin tone
+1F9D5 1F3FC                                            ; fully-qualified     # 🧕🏼 E5.0 woman with headscarf: medium-light skin tone
+1F9D5 1F3FD                                            ; fully-qualified     # 🧕🏽 E5.0 woman with headscarf: medium skin tone
+1F9D5 1F3FE                                            ; fully-qualified     # 🧕🏾 E5.0 woman with headscarf: medium-dark skin tone
+1F9D5 1F3FF                                            ; fully-qualified     # 🧕🏿 E5.0 woman with headscarf: dark skin tone
+1F935                                                  ; fully-qualified     # 🤵 E3.0 person in tuxedo
+1F935 1F3FB                                            ; fully-qualified     # 🤵🏻 E3.0 person in tuxedo: light skin tone
+1F935 1F3FC                                            ; fully-qualified     # 🤵🏼 E3.0 person in tuxedo: medium-light skin tone
+1F935 1F3FD                                            ; fully-qualified     # 🤵🏽 E3.0 person in tuxedo: medium skin tone
+1F935 1F3FE                                            ; fully-qualified     # 🤵🏾 E3.0 person in tuxedo: medium-dark skin tone
+1F935 1F3FF                                            ; fully-qualified     # 🤵🏿 E3.0 person in tuxedo: dark skin tone
+1F935 200D 2642 FE0F                                   ; fully-qualified     # 🤵‍♂️ E13.0 man in tuxedo
+1F935 200D 2642                                        ; minimally-qualified # 🤵‍♂ E13.0 man in tuxedo
+1F935 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🤵🏻‍♂️ E13.0 man in tuxedo: light skin tone
+1F935 1F3FB 200D 2642                                  ; minimally-qualified # 🤵🏻‍♂ E13.0 man in tuxedo: light skin tone
+1F935 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🤵🏼‍♂️ E13.0 man in tuxedo: medium-light skin tone
+1F935 1F3FC 200D 2642                                  ; minimally-qualified # 🤵🏼‍♂ E13.0 man in tuxedo: medium-light skin tone
+1F935 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🤵🏽‍♂️ E13.0 man in tuxedo: medium skin tone
+1F935 1F3FD 200D 2642                                  ; minimally-qualified # 🤵🏽‍♂ E13.0 man in tuxedo: medium skin tone
+1F935 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🤵🏾‍♂️ E13.0 man in tuxedo: medium-dark skin tone
+1F935 1F3FE 200D 2642                                  ; minimally-qualified # 🤵🏾‍♂ E13.0 man in tuxedo: medium-dark skin tone
+1F935 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🤵🏿‍♂️ E13.0 man in tuxedo: dark skin tone
+1F935 1F3FF 200D 2642                                  ; minimally-qualified # 🤵🏿‍♂ E13.0 man in tuxedo: dark skin tone
+1F935 200D 2640 FE0F                                   ; fully-qualified     # 🤵‍♀️ E13.0 woman in tuxedo
+1F935 200D 2640                                        ; minimally-qualified # 🤵‍♀ E13.0 woman in tuxedo
+1F935 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🤵🏻‍♀️ E13.0 woman in tuxedo: light skin tone
+1F935 1F3FB 200D 2640                                  ; minimally-qualified # 🤵🏻‍♀ E13.0 woman in tuxedo: light skin tone
+1F935 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🤵🏼‍♀️ E13.0 woman in tuxedo: medium-light skin tone
+1F935 1F3FC 200D 2640                                  ; minimally-qualified # 🤵🏼‍♀ E13.0 woman in tuxedo: medium-light skin tone
+1F935 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🤵🏽‍♀️ E13.0 woman in tuxedo: medium skin tone
+1F935 1F3FD 200D 2640                                  ; minimally-qualified # 🤵🏽‍♀ E13.0 woman in tuxedo: medium skin tone
+1F935 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🤵🏾‍♀️ E13.0 woman in tuxedo: medium-dark skin tone
+1F935 1F3FE 200D 2640                                  ; minimally-qualified # 🤵🏾‍♀ E13.0 woman in tuxedo: medium-dark skin tone
+1F935 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🤵🏿‍♀️ E13.0 woman in tuxedo: dark skin tone
+1F935 1F3FF 200D 2640                                  ; minimally-qualified # 🤵🏿‍♀ E13.0 woman in tuxedo: dark skin tone
+1F470                                                  ; fully-qualified     # 👰 E0.6 person with veil
+1F470 1F3FB                                            ; fully-qualified     # 👰🏻 E1.0 person with veil: light skin tone
+1F470 1F3FC                                            ; fully-qualified     # 👰🏼 E1.0 person with veil: medium-light skin tone
+1F470 1F3FD                                            ; fully-qualified     # 👰🏽 E1.0 person with veil: medium skin tone
+1F470 1F3FE                                            ; fully-qualified     # 👰🏾 E1.0 person with veil: medium-dark skin tone
+1F470 1F3FF                                            ; fully-qualified     # 👰🏿 E1.0 person with veil: dark skin tone
+1F470 200D 2642 FE0F                                   ; fully-qualified     # 👰‍♂️ E13.0 man with veil
+1F470 200D 2642                                        ; minimally-qualified # 👰‍♂ E13.0 man with veil
+1F470 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 👰🏻‍♂️ E13.0 man with veil: light skin tone
+1F470 1F3FB 200D 2642                                  ; minimally-qualified # 👰🏻‍♂ E13.0 man with veil: light skin tone
+1F470 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 👰🏼‍♂️ E13.0 man with veil: medium-light skin tone
+1F470 1F3FC 200D 2642                                  ; minimally-qualified # 👰🏼‍♂ E13.0 man with veil: medium-light skin tone
+1F470 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 👰🏽‍♂️ E13.0 man with veil: medium skin tone
+1F470 1F3FD 200D 2642                                  ; minimally-qualified # 👰🏽‍♂ E13.0 man with veil: medium skin tone
+1F470 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 👰🏾‍♂️ E13.0 man with veil: medium-dark skin tone
+1F470 1F3FE 200D 2642                                  ; minimally-qualified # 👰🏾‍♂ E13.0 man with veil: medium-dark skin tone
+1F470 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 👰🏿‍♂️ E13.0 man with veil: dark skin tone
+1F470 1F3FF 200D 2642                                  ; minimally-qualified # 👰🏿‍♂ E13.0 man with veil: dark skin tone
+1F470 200D 2640 FE0F                                   ; fully-qualified     # 👰‍♀️ E13.0 woman with veil
+1F470 200D 2640                                        ; minimally-qualified # 👰‍♀ E13.0 woman with veil
+1F470 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 👰🏻‍♀️ E13.0 woman with veil: light skin tone
+1F470 1F3FB 200D 2640                                  ; minimally-qualified # 👰🏻‍♀ E13.0 woman with veil: light skin tone
+1F470 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 👰🏼‍♀️ E13.0 woman with veil: medium-light skin tone
+1F470 1F3FC 200D 2640                                  ; minimally-qualified # 👰🏼‍♀ E13.0 woman with veil: medium-light skin tone
+1F470 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 👰🏽‍♀️ E13.0 woman with veil: medium skin tone
+1F470 1F3FD 200D 2640                                  ; minimally-qualified # 👰🏽‍♀ E13.0 woman with veil: medium skin tone
+1F470 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 👰🏾‍♀️ E13.0 woman with veil: medium-dark skin tone
+1F470 1F3FE 200D 2640                                  ; minimally-qualified # 👰🏾‍♀ E13.0 woman with veil: medium-dark skin tone
+1F470 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 👰🏿‍♀️ E13.0 woman with veil: dark skin tone
+1F470 1F3FF 200D 2640                                  ; minimally-qualified # 👰🏿‍♀ E13.0 woman with veil: dark skin tone
+1F930                                                  ; fully-qualified     # 🤰 E3.0 pregnant woman
+1F930 1F3FB                                            ; fully-qualified     # 🤰🏻 E3.0 pregnant woman: light skin tone
+1F930 1F3FC                                            ; fully-qualified     # 🤰🏼 E3.0 pregnant woman: medium-light skin tone
+1F930 1F3FD                                            ; fully-qualified     # 🤰🏽 E3.0 pregnant woman: medium skin tone
+1F930 1F3FE                                            ; fully-qualified     # 🤰🏾 E3.0 pregnant woman: medium-dark skin tone
+1F930 1F3FF                                            ; fully-qualified     # 🤰🏿 E3.0 pregnant woman: dark skin tone
+1FAC3                                                  ; fully-qualified     # 🫃 E14.0 pregnant man
+1FAC3 1F3FB                                            ; fully-qualified     # 🫃🏻 E14.0 pregnant man: light skin tone
+1FAC3 1F3FC                                            ; fully-qualified     # 🫃🏼 E14.0 pregnant man: medium-light skin tone
+1FAC3 1F3FD                                            ; fully-qualified     # 🫃🏽 E14.0 pregnant man: medium skin tone
+1FAC3 1F3FE                                            ; fully-qualified     # 🫃🏾 E14.0 pregnant man: medium-dark skin tone
+1FAC3 1F3FF                                            ; fully-qualified     # 🫃🏿 E14.0 pregnant man: dark skin tone
+1FAC4                                                  ; fully-qualified     # 🫄 E14.0 pregnant person
+1FAC4 1F3FB                                            ; fully-qualified     # 🫄🏻 E14.0 pregnant person: light skin tone
+1FAC4 1F3FC                                            ; fully-qualified     # 🫄🏼 E14.0 pregnant person: medium-light skin tone
+1FAC4 1F3FD                                            ; fully-qualified     # 🫄🏽 E14.0 pregnant person: medium skin tone
+1FAC4 1F3FE                                            ; fully-qualified     # 🫄🏾 E14.0 pregnant person: medium-dark skin tone
+1FAC4 1F3FF                                            ; fully-qualified     # 🫄🏿 E14.0 pregnant person: dark skin tone
+1F931                                                  ; fully-qualified     # 🤱 E5.0 breast-feeding
+1F931 1F3FB                                            ; fully-qualified     # 🤱🏻 E5.0 breast-feeding: light skin tone
+1F931 1F3FC                                            ; fully-qualified     # 🤱🏼 E5.0 breast-feeding: medium-light skin tone
+1F931 1F3FD                                            ; fully-qualified     # 🤱🏽 E5.0 breast-feeding: medium skin tone
+1F931 1F3FE                                            ; fully-qualified     # 🤱🏾 E5.0 breast-feeding: medium-dark skin tone
+1F931 1F3FF                                            ; fully-qualified     # 🤱🏿 E5.0 breast-feeding: dark skin tone
+1F469 200D 1F37C                                       ; fully-qualified     # 👩‍🍼 E13.0 woman feeding baby
+1F469 1F3FB 200D 1F37C                                 ; fully-qualified     # 👩🏻‍🍼 E13.0 woman feeding baby: light skin tone
+1F469 1F3FC 200D 1F37C                                 ; fully-qualified     # 👩🏼‍🍼 E13.0 woman feeding baby: medium-light skin tone
+1F469 1F3FD 200D 1F37C                                 ; fully-qualified     # 👩🏽‍🍼 E13.0 woman feeding baby: medium skin tone
+1F469 1F3FE 200D 1F37C                                 ; fully-qualified     # 👩🏾‍🍼 E13.0 woman feeding baby: medium-dark skin tone
+1F469 1F3FF 200D 1F37C                                 ; fully-qualified     # 👩🏿‍🍼 E13.0 woman feeding baby: dark skin tone
+1F468 200D 1F37C                                       ; fully-qualified     # 👨‍🍼 E13.0 man feeding baby
+1F468 1F3FB 200D 1F37C                                 ; fully-qualified     # 👨🏻‍🍼 E13.0 man feeding baby: light skin tone
+1F468 1F3FC 200D 1F37C                                 ; fully-qualified     # 👨🏼‍🍼 E13.0 man feeding baby: medium-light skin tone
+1F468 1F3FD 200D 1F37C                                 ; fully-qualified     # 👨🏽‍🍼 E13.0 man feeding baby: medium skin tone
+1F468 1F3FE 200D 1F37C                                 ; fully-qualified     # 👨🏾‍🍼 E13.0 man feeding baby: medium-dark skin tone
+1F468 1F3FF 200D 1F37C                                 ; fully-qualified     # 👨🏿‍🍼 E13.0 man feeding baby: dark skin tone
+1F9D1 200D 1F37C                                       ; fully-qualified     # 🧑‍🍼 E13.0 person feeding baby
+1F9D1 1F3FB 200D 1F37C                                 ; fully-qualified     # 🧑🏻‍🍼 E13.0 person feeding baby: light skin tone
+1F9D1 1F3FC 200D 1F37C                                 ; fully-qualified     # 🧑🏼‍🍼 E13.0 person feeding baby: medium-light skin tone
+1F9D1 1F3FD 200D 1F37C                                 ; fully-qualified     # 🧑🏽‍🍼 E13.0 person feeding baby: medium skin tone
+1F9D1 1F3FE 200D 1F37C                                 ; fully-qualified     # 🧑🏾‍🍼 E13.0 person feeding baby: medium-dark skin tone
+1F9D1 1F3FF 200D 1F37C                                 ; fully-qualified     # 🧑🏿‍🍼 E13.0 person feeding baby: dark skin tone
+
+# subgroup: person-fantasy
+1F47C                                                  ; fully-qualified     # 👼 E0.6 baby angel
+1F47C 1F3FB                                            ; fully-qualified     # 👼🏻 E1.0 baby angel: light skin tone
+1F47C 1F3FC                                            ; fully-qualified     # 👼🏼 E1.0 baby angel: medium-light skin tone
+1F47C 1F3FD                                            ; fully-qualified     # 👼🏽 E1.0 baby angel: medium skin tone
+1F47C 1F3FE                                            ; fully-qualified     # 👼🏾 E1.0 baby angel: medium-dark skin tone
+1F47C 1F3FF                                            ; fully-qualified     # 👼🏿 E1.0 baby angel: dark skin tone
+1F385                                                  ; fully-qualified     # 🎅 E0.6 Santa Claus
+1F385 1F3FB                                            ; fully-qualified     # 🎅🏻 E1.0 Santa Claus: light skin tone
+1F385 1F3FC                                            ; fully-qualified     # 🎅🏼 E1.0 Santa Claus: medium-light skin tone
+1F385 1F3FD                                            ; fully-qualified     # 🎅🏽 E1.0 Santa Claus: medium skin tone
+1F385 1F3FE                                            ; fully-qualified     # 🎅🏾 E1.0 Santa Claus: medium-dark skin tone
+1F385 1F3FF                                            ; fully-qualified     # 🎅🏿 E1.0 Santa Claus: dark skin tone
+1F936                                                  ; fully-qualified     # 🤶 E3.0 Mrs. Claus
+1F936 1F3FB                                            ; fully-qualified     # 🤶🏻 E3.0 Mrs. Claus: light skin tone
+1F936 1F3FC                                            ; fully-qualified     # 🤶🏼 E3.0 Mrs. Claus: medium-light skin tone
+1F936 1F3FD                                            ; fully-qualified     # 🤶🏽 E3.0 Mrs. Claus: medium skin tone
+1F936 1F3FE                                            ; fully-qualified     # 🤶🏾 E3.0 Mrs. Claus: medium-dark skin tone
+1F936 1F3FF                                            ; fully-qualified     # 🤶🏿 E3.0 Mrs. Claus: dark skin tone
+1F9D1 200D 1F384                                       ; fully-qualified     # 🧑‍🎄 E13.0 Mx Claus
+1F9D1 1F3FB 200D 1F384                                 ; fully-qualified     # 🧑🏻‍🎄 E13.0 Mx Claus: light skin tone
+1F9D1 1F3FC 200D 1F384                                 ; fully-qualified     # 🧑🏼‍🎄 E13.0 Mx Claus: medium-light skin tone
+1F9D1 1F3FD 200D 1F384                                 ; fully-qualified     # 🧑🏽‍🎄 E13.0 Mx Claus: medium skin tone
+1F9D1 1F3FE 200D 1F384                                 ; fully-qualified     # 🧑🏾‍🎄 E13.0 Mx Claus: medium-dark skin tone
+1F9D1 1F3FF 200D 1F384                                 ; fully-qualified     # 🧑🏿‍🎄 E13.0 Mx Claus: dark skin tone
+1F9B8                                                  ; fully-qualified     # 🦸 E11.0 superhero
+1F9B8 1F3FB                                            ; fully-qualified     # 🦸🏻 E11.0 superhero: light skin tone
+1F9B8 1F3FC                                            ; fully-qualified     # 🦸🏼 E11.0 superhero: medium-light skin tone
+1F9B8 1F3FD                                            ; fully-qualified     # 🦸🏽 E11.0 superhero: medium skin tone
+1F9B8 1F3FE                                            ; fully-qualified     # 🦸🏾 E11.0 superhero: medium-dark skin tone
+1F9B8 1F3FF                                            ; fully-qualified     # 🦸🏿 E11.0 superhero: dark skin tone
+1F9B8 200D 2642 FE0F                                   ; fully-qualified     # 🦸‍♂️ E11.0 man superhero
+1F9B8 200D 2642                                        ; minimally-qualified # 🦸‍♂ E11.0 man superhero
+1F9B8 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🦸🏻‍♂️ E11.0 man superhero: light skin tone
+1F9B8 1F3FB 200D 2642                                  ; minimally-qualified # 🦸🏻‍♂ E11.0 man superhero: light skin tone
+1F9B8 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🦸🏼‍♂️ E11.0 man superhero: medium-light skin tone
+1F9B8 1F3FC 200D 2642                                  ; minimally-qualified # 🦸🏼‍♂ E11.0 man superhero: medium-light skin tone
+1F9B8 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🦸🏽‍♂️ E11.0 man superhero: medium skin tone
+1F9B8 1F3FD 200D 2642                                  ; minimally-qualified # 🦸🏽‍♂ E11.0 man superhero: medium skin tone
+1F9B8 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🦸🏾‍♂️ E11.0 man superhero: medium-dark skin tone
+1F9B8 1F3FE 200D 2642                                  ; minimally-qualified # 🦸🏾‍♂ E11.0 man superhero: medium-dark skin tone
+1F9B8 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🦸🏿‍♂️ E11.0 man superhero: dark skin tone
+1F9B8 1F3FF 200D 2642                                  ; minimally-qualified # 🦸🏿‍♂ E11.0 man superhero: dark skin tone
+1F9B8 200D 2640 FE0F                                   ; fully-qualified     # 🦸‍♀️ E11.0 woman superhero
+1F9B8 200D 2640                                        ; minimally-qualified # 🦸‍♀ E11.0 woman superhero
+1F9B8 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🦸🏻‍♀️ E11.0 woman superhero: light skin tone
+1F9B8 1F3FB 200D 2640                                  ; minimally-qualified # 🦸🏻‍♀ E11.0 woman superhero: light skin tone
+1F9B8 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🦸🏼‍♀️ E11.0 woman superhero: medium-light skin tone
+1F9B8 1F3FC 200D 2640                                  ; minimally-qualified # 🦸🏼‍♀ E11.0 woman superhero: medium-light skin tone
+1F9B8 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🦸🏽‍♀️ E11.0 woman superhero: medium skin tone
+1F9B8 1F3FD 200D 2640                                  ; minimally-qualified # 🦸🏽‍♀ E11.0 woman superhero: medium skin tone
+1F9B8 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🦸🏾‍♀️ E11.0 woman superhero: medium-dark skin tone
+1F9B8 1F3FE 200D 2640                                  ; minimally-qualified # 🦸🏾‍♀ E11.0 woman superhero: medium-dark skin tone
+1F9B8 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🦸🏿‍♀️ E11.0 woman superhero: dark skin tone
+1F9B8 1F3FF 200D 2640                                  ; minimally-qualified # 🦸🏿‍♀ E11.0 woman superhero: dark skin tone
+1F9B9                                                  ; fully-qualified     # 🦹 E11.0 supervillain
+1F9B9 1F3FB                                            ; fully-qualified     # 🦹🏻 E11.0 supervillain: light skin tone
+1F9B9 1F3FC                                            ; fully-qualified     # 🦹🏼 E11.0 supervillain: medium-light skin tone
+1F9B9 1F3FD                                            ; fully-qualified     # 🦹🏽 E11.0 supervillain: medium skin tone
+1F9B9 1F3FE                                            ; fully-qualified     # 🦹🏾 E11.0 supervillain: medium-dark skin tone
+1F9B9 1F3FF                                            ; fully-qualified     # 🦹🏿 E11.0 supervillain: dark skin tone
+1F9B9 200D 2642 FE0F                                   ; fully-qualified     # 🦹‍♂️ E11.0 man supervillain
+1F9B9 200D 2642                                        ; minimally-qualified # 🦹‍♂ E11.0 man supervillain
+1F9B9 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🦹🏻‍♂️ E11.0 man supervillain: light skin tone
+1F9B9 1F3FB 200D 2642                                  ; minimally-qualified # 🦹🏻‍♂ E11.0 man supervillain: light skin tone
+1F9B9 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🦹🏼‍♂️ E11.0 man supervillain: medium-light skin tone
+1F9B9 1F3FC 200D 2642                                  ; minimally-qualified # 🦹🏼‍♂ E11.0 man supervillain: medium-light skin tone
+1F9B9 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🦹🏽‍♂️ E11.0 man supervillain: medium skin tone
+1F9B9 1F3FD 200D 2642                                  ; minimally-qualified # 🦹🏽‍♂ E11.0 man supervillain: medium skin tone
+1F9B9 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🦹🏾‍♂️ E11.0 man supervillain: medium-dark skin tone
+1F9B9 1F3FE 200D 2642                                  ; minimally-qualified # 🦹🏾‍♂ E11.0 man supervillain: medium-dark skin tone
+1F9B9 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🦹🏿‍♂️ E11.0 man supervillain: dark skin tone
+1F9B9 1F3FF 200D 2642                                  ; minimally-qualified # 🦹🏿‍♂ E11.0 man supervillain: dark skin tone
+1F9B9 200D 2640 FE0F                                   ; fully-qualified     # 🦹‍♀️ E11.0 woman supervillain
+1F9B9 200D 2640                                        ; minimally-qualified # 🦹‍♀ E11.0 woman supervillain
+1F9B9 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🦹🏻‍♀️ E11.0 woman supervillain: light skin tone
+1F9B9 1F3FB 200D 2640                                  ; minimally-qualified # 🦹🏻‍♀ E11.0 woman supervillain: light skin tone
+1F9B9 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🦹🏼‍♀️ E11.0 woman supervillain: medium-light skin tone
+1F9B9 1F3FC 200D 2640                                  ; minimally-qualified # 🦹🏼‍♀ E11.0 woman supervillain: medium-light skin tone
+1F9B9 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🦹🏽‍♀️ E11.0 woman supervillain: medium skin tone
+1F9B9 1F3FD 200D 2640                                  ; minimally-qualified # 🦹🏽‍♀ E11.0 woman supervillain: medium skin tone
+1F9B9 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🦹🏾‍♀️ E11.0 woman supervillain: medium-dark skin tone
+1F9B9 1F3FE 200D 2640                                  ; minimally-qualified # 🦹🏾‍♀ E11.0 woman supervillain: medium-dark skin tone
+1F9B9 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🦹🏿‍♀️ E11.0 woman supervillain: dark skin tone
+1F9B9 1F3FF 200D 2640                                  ; minimally-qualified # 🦹🏿‍♀ E11.0 woman supervillain: dark skin tone
+1F9D9                                                  ; fully-qualified     # 🧙 E5.0 mage
+1F9D9 1F3FB                                            ; fully-qualified     # 🧙🏻 E5.0 mage: light skin tone
+1F9D9 1F3FC                                            ; fully-qualified     # 🧙🏼 E5.0 mage: medium-light skin tone
+1F9D9 1F3FD                                            ; fully-qualified     # 🧙🏽 E5.0 mage: medium skin tone
+1F9D9 1F3FE                                            ; fully-qualified     # 🧙🏾 E5.0 mage: medium-dark skin tone
+1F9D9 1F3FF                                            ; fully-qualified     # 🧙🏿 E5.0 mage: dark skin tone
+1F9D9 200D 2642 FE0F                                   ; fully-qualified     # 🧙‍♂️ E5.0 man mage
+1F9D9 200D 2642                                        ; minimally-qualified # 🧙‍♂ E5.0 man mage
+1F9D9 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🧙🏻‍♂️ E5.0 man mage: light skin tone
+1F9D9 1F3FB 200D 2642                                  ; minimally-qualified # 🧙🏻‍♂ E5.0 man mage: light skin tone
+1F9D9 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🧙🏼‍♂️ E5.0 man mage: medium-light skin tone
+1F9D9 1F3FC 200D 2642                                  ; minimally-qualified # 🧙🏼‍♂ E5.0 man mage: medium-light skin tone
+1F9D9 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🧙🏽‍♂️ E5.0 man mage: medium skin tone
+1F9D9 1F3FD 200D 2642                                  ; minimally-qualified # 🧙🏽‍♂ E5.0 man mage: medium skin tone
+1F9D9 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🧙🏾‍♂️ E5.0 man mage: medium-dark skin tone
+1F9D9 1F3FE 200D 2642                                  ; minimally-qualified # 🧙🏾‍♂ E5.0 man mage: medium-dark skin tone
+1F9D9 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🧙🏿‍♂️ E5.0 man mage: dark skin tone
+1F9D9 1F3FF 200D 2642                                  ; minimally-qualified # 🧙🏿‍♂ E5.0 man mage: dark skin tone
+1F9D9 200D 2640 FE0F                                   ; fully-qualified     # 🧙‍♀️ E5.0 woman mage
+1F9D9 200D 2640                                        ; minimally-qualified # 🧙‍♀ E5.0 woman mage
+1F9D9 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🧙🏻‍♀️ E5.0 woman mage: light skin tone
+1F9D9 1F3FB 200D 2640                                  ; minimally-qualified # 🧙🏻‍♀ E5.0 woman mage: light skin tone
+1F9D9 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🧙🏼‍♀️ E5.0 woman mage: medium-light skin tone
+1F9D9 1F3FC 200D 2640                                  ; minimally-qualified # 🧙🏼‍♀ E5.0 woman mage: medium-light skin tone
+1F9D9 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🧙🏽‍♀️ E5.0 woman mage: medium skin tone
+1F9D9 1F3FD 200D 2640                                  ; minimally-qualified # 🧙🏽‍♀ E5.0 woman mage: medium skin tone
+1F9D9 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🧙🏾‍♀️ E5.0 woman mage: medium-dark skin tone
+1F9D9 1F3FE 200D 2640                                  ; minimally-qualified # 🧙🏾‍♀ E5.0 woman mage: medium-dark skin tone
+1F9D9 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🧙🏿‍♀️ E5.0 woman mage: dark skin tone
+1F9D9 1F3FF 200D 2640                                  ; minimally-qualified # 🧙🏿‍♀ E5.0 woman mage: dark skin tone
+1F9DA                                                  ; fully-qualified     # 🧚 E5.0 fairy
+1F9DA 1F3FB                                            ; fully-qualified     # 🧚🏻 E5.0 fairy: light skin tone
+1F9DA 1F3FC                                            ; fully-qualified     # 🧚🏼 E5.0 fairy: medium-light skin tone
+1F9DA 1F3FD                                            ; fully-qualified     # 🧚🏽 E5.0 fairy: medium skin tone
+1F9DA 1F3FE                                            ; fully-qualified     # 🧚🏾 E5.0 fairy: medium-dark skin tone
+1F9DA 1F3FF                                            ; fully-qualified     # 🧚🏿 E5.0 fairy: dark skin tone
+1F9DA 200D 2642 FE0F                                   ; fully-qualified     # 🧚‍♂️ E5.0 man fairy
+1F9DA 200D 2642                                        ; minimally-qualified # 🧚‍♂ E5.0 man fairy
+1F9DA 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🧚🏻‍♂️ E5.0 man fairy: light skin tone
+1F9DA 1F3FB 200D 2642                                  ; minimally-qualified # 🧚🏻‍♂ E5.0 man fairy: light skin tone
+1F9DA 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🧚🏼‍♂️ E5.0 man fairy: medium-light skin tone
+1F9DA 1F3FC 200D 2642                                  ; minimally-qualified # 🧚🏼‍♂ E5.0 man fairy: medium-light skin tone
+1F9DA 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🧚🏽‍♂️ E5.0 man fairy: medium skin tone
+1F9DA 1F3FD 200D 2642                                  ; minimally-qualified # 🧚🏽‍♂ E5.0 man fairy: medium skin tone
+1F9DA 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🧚🏾‍♂️ E5.0 man fairy: medium-dark skin tone
+1F9DA 1F3FE 200D 2642                                  ; minimally-qualified # 🧚🏾‍♂ E5.0 man fairy: medium-dark skin tone
+1F9DA 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🧚🏿‍♂️ E5.0 man fairy: dark skin tone
+1F9DA 1F3FF 200D 2642                                  ; minimally-qualified # 🧚🏿‍♂ E5.0 man fairy: dark skin tone
+1F9DA 200D 2640 FE0F                                   ; fully-qualified     # 🧚‍♀️ E5.0 woman fairy
+1F9DA 200D 2640                                        ; minimally-qualified # 🧚‍♀ E5.0 woman fairy
+1F9DA 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🧚🏻‍♀️ E5.0 woman fairy: light skin tone
+1F9DA 1F3FB 200D 2640                                  ; minimally-qualified # 🧚🏻‍♀ E5.0 woman fairy: light skin tone
+1F9DA 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🧚🏼‍♀️ E5.0 woman fairy: medium-light skin tone
+1F9DA 1F3FC 200D 2640                                  ; minimally-qualified # 🧚🏼‍♀ E5.0 woman fairy: medium-light skin tone
+1F9DA 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🧚🏽‍♀️ E5.0 woman fairy: medium skin tone
+1F9DA 1F3FD 200D 2640                                  ; minimally-qualified # 🧚🏽‍♀ E5.0 woman fairy: medium skin tone
+1F9DA 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🧚🏾‍♀️ E5.0 woman fairy: medium-dark skin tone
+1F9DA 1F3FE 200D 2640                                  ; minimally-qualified # 🧚🏾‍♀ E5.0 woman fairy: medium-dark skin tone
+1F9DA 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🧚🏿‍♀️ E5.0 woman fairy: dark skin tone
+1F9DA 1F3FF 200D 2640                                  ; minimally-qualified # 🧚🏿‍♀ E5.0 woman fairy: dark skin tone
+1F9DB                                                  ; fully-qualified     # 🧛 E5.0 vampire
+1F9DB 1F3FB                                            ; fully-qualified     # 🧛🏻 E5.0 vampire: light skin tone
+1F9DB 1F3FC                                            ; fully-qualified     # 🧛🏼 E5.0 vampire: medium-light skin tone
+1F9DB 1F3FD                                            ; fully-qualified     # 🧛🏽 E5.0 vampire: medium skin tone
+1F9DB 1F3FE                                            ; fully-qualified     # 🧛🏾 E5.0 vampire: medium-dark skin tone
+1F9DB 1F3FF                                            ; fully-qualified     # 🧛🏿 E5.0 vampire: dark skin tone
+1F9DB 200D 2642 FE0F                                   ; fully-qualified     # 🧛‍♂️ E5.0 man vampire
+1F9DB 200D 2642                                        ; minimally-qualified # 🧛‍♂ E5.0 man vampire
+1F9DB 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🧛🏻‍♂️ E5.0 man vampire: light skin tone
+1F9DB 1F3FB 200D 2642                                  ; minimally-qualified # 🧛🏻‍♂ E5.0 man vampire: light skin tone
+1F9DB 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🧛🏼‍♂️ E5.0 man vampire: medium-light skin tone
+1F9DB 1F3FC 200D 2642                                  ; minimally-qualified # 🧛🏼‍♂ E5.0 man vampire: medium-light skin tone
+1F9DB 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🧛🏽‍♂️ E5.0 man vampire: medium skin tone
+1F9DB 1F3FD 200D 2642                                  ; minimally-qualified # 🧛🏽‍♂ E5.0 man vampire: medium skin tone
+1F9DB 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🧛🏾‍♂️ E5.0 man vampire: medium-dark skin tone
+1F9DB 1F3FE 200D 2642                                  ; minimally-qualified # 🧛🏾‍♂ E5.0 man vampire: medium-dark skin tone
+1F9DB 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🧛🏿‍♂️ E5.0 man vampire: dark skin tone
+1F9DB 1F3FF 200D 2642                                  ; minimally-qualified # 🧛🏿‍♂ E5.0 man vampire: dark skin tone
+1F9DB 200D 2640 FE0F                                   ; fully-qualified     # 🧛‍♀️ E5.0 woman vampire
+1F9DB 200D 2640                                        ; minimally-qualified # 🧛‍♀ E5.0 woman vampire
+1F9DB 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🧛🏻‍♀️ E5.0 woman vampire: light skin tone
+1F9DB 1F3FB 200D 2640                                  ; minimally-qualified # 🧛🏻‍♀ E5.0 woman vampire: light skin tone
+1F9DB 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🧛🏼‍♀️ E5.0 woman vampire: medium-light skin tone
+1F9DB 1F3FC 200D 2640                                  ; minimally-qualified # 🧛🏼‍♀ E5.0 woman vampire: medium-light skin tone
+1F9DB 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🧛🏽‍♀️ E5.0 woman vampire: medium skin tone
+1F9DB 1F3FD 200D 2640                                  ; minimally-qualified # 🧛🏽‍♀ E5.0 woman vampire: medium skin tone
+1F9DB 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🧛🏾‍♀️ E5.0 woman vampire: medium-dark skin tone
+1F9DB 1F3FE 200D 2640                                  ; minimally-qualified # 🧛🏾‍♀ E5.0 woman vampire: medium-dark skin tone
+1F9DB 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🧛🏿‍♀️ E5.0 woman vampire: dark skin tone
+1F9DB 1F3FF 200D 2640                                  ; minimally-qualified # 🧛🏿‍♀ E5.0 woman vampire: dark skin tone
+1F9DC                                                  ; fully-qualified     # 🧜 E5.0 merperson
+1F9DC 1F3FB                                            ; fully-qualified     # 🧜🏻 E5.0 merperson: light skin tone
+1F9DC 1F3FC                                            ; fully-qualified     # 🧜🏼 E5.0 merperson: medium-light skin tone
+1F9DC 1F3FD                                            ; fully-qualified     # 🧜🏽 E5.0 merperson: medium skin tone
+1F9DC 1F3FE                                            ; fully-qualified     # 🧜🏾 E5.0 merperson: medium-dark skin tone
+1F9DC 1F3FF                                            ; fully-qualified     # 🧜🏿 E5.0 merperson: dark skin tone
+1F9DC 200D 2642 FE0F                                   ; fully-qualified     # 🧜‍♂️ E5.0 merman
+1F9DC 200D 2642                                        ; minimally-qualified # 🧜‍♂ E5.0 merman
+1F9DC 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🧜🏻‍♂️ E5.0 merman: light skin tone
+1F9DC 1F3FB 200D 2642                                  ; minimally-qualified # 🧜🏻‍♂ E5.0 merman: light skin tone
+1F9DC 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🧜🏼‍♂️ E5.0 merman: medium-light skin tone
+1F9DC 1F3FC 200D 2642                                  ; minimally-qualified # 🧜🏼‍♂ E5.0 merman: medium-light skin tone
+1F9DC 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🧜🏽‍♂️ E5.0 merman: medium skin tone
+1F9DC 1F3FD 200D 2642                                  ; minimally-qualified # 🧜🏽‍♂ E5.0 merman: medium skin tone
+1F9DC 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🧜🏾‍♂️ E5.0 merman: medium-dark skin tone
+1F9DC 1F3FE 200D 2642                                  ; minimally-qualified # 🧜🏾‍♂ E5.0 merman: medium-dark skin tone
+1F9DC 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🧜🏿‍♂️ E5.0 merman: dark skin tone
+1F9DC 1F3FF 200D 2642                                  ; minimally-qualified # 🧜🏿‍♂ E5.0 merman: dark skin tone
+1F9DC 200D 2640 FE0F                                   ; fully-qualified     # 🧜‍♀️ E5.0 mermaid
+1F9DC 200D 2640                                        ; minimally-qualified # 🧜‍♀ E5.0 mermaid
+1F9DC 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🧜🏻‍♀️ E5.0 mermaid: light skin tone
+1F9DC 1F3FB 200D 2640                                  ; minimally-qualified # 🧜🏻‍♀ E5.0 mermaid: light skin tone
+1F9DC 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🧜🏼‍♀️ E5.0 mermaid: medium-light skin tone
+1F9DC 1F3FC 200D 2640                                  ; minimally-qualified # 🧜🏼‍♀ E5.0 mermaid: medium-light skin tone
+1F9DC 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🧜🏽‍♀️ E5.0 mermaid: medium skin tone
+1F9DC 1F3FD 200D 2640                                  ; minimally-qualified # 🧜🏽‍♀ E5.0 mermaid: medium skin tone
+1F9DC 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🧜🏾‍♀️ E5.0 mermaid: medium-dark skin tone
+1F9DC 1F3FE 200D 2640                                  ; minimally-qualified # 🧜🏾‍♀ E5.0 mermaid: medium-dark skin tone
+1F9DC 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🧜🏿‍♀️ E5.0 mermaid: dark skin tone
+1F9DC 1F3FF 200D 2640                                  ; minimally-qualified # 🧜🏿‍♀ E5.0 mermaid: dark skin tone
+1F9DD                                                  ; fully-qualified     # 🧝 E5.0 elf
+1F9DD 1F3FB                                            ; fully-qualified     # 🧝🏻 E5.0 elf: light skin tone
+1F9DD 1F3FC                                            ; fully-qualified     # 🧝🏼 E5.0 elf: medium-light skin tone
+1F9DD 1F3FD                                            ; fully-qualified     # 🧝🏽 E5.0 elf: medium skin tone
+1F9DD 1F3FE                                            ; fully-qualified     # 🧝🏾 E5.0 elf: medium-dark skin tone
+1F9DD 1F3FF                                            ; fully-qualified     # 🧝🏿 E5.0 elf: dark skin tone
+1F9DD 200D 2642 FE0F                                   ; fully-qualified     # 🧝‍♂️ E5.0 man elf
+1F9DD 200D 2642                                        ; minimally-qualified # 🧝‍♂ E5.0 man elf
+1F9DD 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🧝🏻‍♂️ E5.0 man elf: light skin tone
+1F9DD 1F3FB 200D 2642                                  ; minimally-qualified # 🧝🏻‍♂ E5.0 man elf: light skin tone
+1F9DD 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🧝🏼‍♂️ E5.0 man elf: medium-light skin tone
+1F9DD 1F3FC 200D 2642                                  ; minimally-qualified # 🧝🏼‍♂ E5.0 man elf: medium-light skin tone
+1F9DD 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🧝🏽‍♂️ E5.0 man elf: medium skin tone
+1F9DD 1F3FD 200D 2642                                  ; minimally-qualified # 🧝🏽‍♂ E5.0 man elf: medium skin tone
+1F9DD 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🧝🏾‍♂️ E5.0 man elf: medium-dark skin tone
+1F9DD 1F3FE 200D 2642                                  ; minimally-qualified # 🧝🏾‍♂ E5.0 man elf: medium-dark skin tone
+1F9DD 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🧝🏿‍♂️ E5.0 man elf: dark skin tone
+1F9DD 1F3FF 200D 2642                                  ; minimally-qualified # 🧝🏿‍♂ E5.0 man elf: dark skin tone
+1F9DD 200D 2640 FE0F                                   ; fully-qualified     # 🧝‍♀️ E5.0 woman elf
+1F9DD 200D 2640                                        ; minimally-qualified # 🧝‍♀ E5.0 woman elf
+1F9DD 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🧝🏻‍♀️ E5.0 woman elf: light skin tone
+1F9DD 1F3FB 200D 2640                                  ; minimally-qualified # 🧝🏻‍♀ E5.0 woman elf: light skin tone
+1F9DD 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🧝🏼‍♀️ E5.0 woman elf: medium-light skin tone
+1F9DD 1F3FC 200D 2640                                  ; minimally-qualified # 🧝🏼‍♀ E5.0 woman elf: medium-light skin tone
+1F9DD 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🧝🏽‍♀️ E5.0 woman elf: medium skin tone
+1F9DD 1F3FD 200D 2640                                  ; minimally-qualified # 🧝🏽‍♀ E5.0 woman elf: medium skin tone
+1F9DD 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🧝🏾‍♀️ E5.0 woman elf: medium-dark skin tone
+1F9DD 1F3FE 200D 2640                                  ; minimally-qualified # 🧝🏾‍♀ E5.0 woman elf: medium-dark skin tone
+1F9DD 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🧝🏿‍♀️ E5.0 woman elf: dark skin tone
+1F9DD 1F3FF 200D 2640                                  ; minimally-qualified # 🧝🏿‍♀ E5.0 woman elf: dark skin tone
+1F9DE                                                  ; fully-qualified     # 🧞 E5.0 genie
+1F9DE 200D 2642 FE0F                                   ; fully-qualified     # 🧞‍♂️ E5.0 man genie
+1F9DE 200D 2642                                        ; minimally-qualified # 🧞‍♂ E5.0 man genie
+1F9DE 200D 2640 FE0F                                   ; fully-qualified     # 🧞‍♀️ E5.0 woman genie
+1F9DE 200D 2640                                        ; minimally-qualified # 🧞‍♀ E5.0 woman genie
+1F9DF                                                  ; fully-qualified     # 🧟 E5.0 zombie
+1F9DF 200D 2642 FE0F                                   ; fully-qualified     # 🧟‍♂️ E5.0 man zombie
+1F9DF 200D 2642                                        ; minimally-qualified # 🧟‍♂ E5.0 man zombie
+1F9DF 200D 2640 FE0F                                   ; fully-qualified     # 🧟‍♀️ E5.0 woman zombie
+1F9DF 200D 2640                                        ; minimally-qualified # 🧟‍♀ E5.0 woman zombie
+1F9CC                                                  ; fully-qualified     # 🧌 E14.0 troll
+
+# subgroup: person-activity
+1F486                                                  ; fully-qualified     # 💆 E0.6 person getting massage
+1F486 1F3FB                                            ; fully-qualified     # 💆🏻 E1.0 person getting massage: light skin tone
+1F486 1F3FC                                            ; fully-qualified     # 💆🏼 E1.0 person getting massage: medium-light skin tone
+1F486 1F3FD                                            ; fully-qualified     # 💆🏽 E1.0 person getting massage: medium skin tone
+1F486 1F3FE                                            ; fully-qualified     # 💆🏾 E1.0 person getting massage: medium-dark skin tone
+1F486 1F3FF                                            ; fully-qualified     # 💆🏿 E1.0 person getting massage: dark skin tone
+1F486 200D 2642 FE0F                                   ; fully-qualified     # 💆‍♂️ E4.0 man getting massage
+1F486 200D 2642                                        ; minimally-qualified # 💆‍♂ E4.0 man getting massage
+1F486 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 💆🏻‍♂️ E4.0 man getting massage: light skin tone
+1F486 1F3FB 200D 2642                                  ; minimally-qualified # 💆🏻‍♂ E4.0 man getting massage: light skin tone
+1F486 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 💆🏼‍♂️ E4.0 man getting massage: medium-light skin tone
+1F486 1F3FC 200D 2642                                  ; minimally-qualified # 💆🏼‍♂ E4.0 man getting massage: medium-light skin tone
+1F486 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 💆🏽‍♂️ E4.0 man getting massage: medium skin tone
+1F486 1F3FD 200D 2642                                  ; minimally-qualified # 💆🏽‍♂ E4.0 man getting massage: medium skin tone
+1F486 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 💆🏾‍♂️ E4.0 man getting massage: medium-dark skin tone
+1F486 1F3FE 200D 2642                                  ; minimally-qualified # 💆🏾‍♂ E4.0 man getting massage: medium-dark skin tone
+1F486 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 💆🏿‍♂️ E4.0 man getting massage: dark skin tone
+1F486 1F3FF 200D 2642                                  ; minimally-qualified # 💆🏿‍♂ E4.0 man getting massage: dark skin tone
+1F486 200D 2640 FE0F                                   ; fully-qualified     # 💆‍♀️ E4.0 woman getting massage
+1F486 200D 2640                                        ; minimally-qualified # 💆‍♀ E4.0 woman getting massage
+1F486 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 💆🏻‍♀️ E4.0 woman getting massage: light skin tone
+1F486 1F3FB 200D 2640                                  ; minimally-qualified # 💆🏻‍♀ E4.0 woman getting massage: light skin tone
+1F486 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 💆🏼‍♀️ E4.0 woman getting massage: medium-light skin tone
+1F486 1F3FC 200D 2640                                  ; minimally-qualified # 💆🏼‍♀ E4.0 woman getting massage: medium-light skin tone
+1F486 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 💆🏽‍♀️ E4.0 woman getting massage: medium skin tone
+1F486 1F3FD 200D 2640                                  ; minimally-qualified # 💆🏽‍♀ E4.0 woman getting massage: medium skin tone
+1F486 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 💆🏾‍♀️ E4.0 woman getting massage: medium-dark skin tone
+1F486 1F3FE 200D 2640                                  ; minimally-qualified # 💆🏾‍♀ E4.0 woman getting massage: medium-dark skin tone
+1F486 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 💆🏿‍♀️ E4.0 woman getting massage: dark skin tone
+1F486 1F3FF 200D 2640                                  ; minimally-qualified # 💆🏿‍♀ E4.0 woman getting massage: dark skin tone
+1F487                                                  ; fully-qualified     # 💇 E0.6 person getting haircut
+1F487 1F3FB                                            ; fully-qualified     # 💇🏻 E1.0 person getting haircut: light skin tone
+1F487 1F3FC                                            ; fully-qualified     # 💇🏼 E1.0 person getting haircut: medium-light skin tone
+1F487 1F3FD                                            ; fully-qualified     # 💇🏽 E1.0 person getting haircut: medium skin tone
+1F487 1F3FE                                            ; fully-qualified     # 💇🏾 E1.0 person getting haircut: medium-dark skin tone
+1F487 1F3FF                                            ; fully-qualified     # 💇🏿 E1.0 person getting haircut: dark skin tone
+1F487 200D 2642 FE0F                                   ; fully-qualified     # 💇‍♂️ E4.0 man getting haircut
+1F487 200D 2642                                        ; minimally-qualified # 💇‍♂ E4.0 man getting haircut
+1F487 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 💇🏻‍♂️ E4.0 man getting haircut: light skin tone
+1F487 1F3FB 200D 2642                                  ; minimally-qualified # 💇🏻‍♂ E4.0 man getting haircut: light skin tone
+1F487 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 💇🏼‍♂️ E4.0 man getting haircut: medium-light skin tone
+1F487 1F3FC 200D 2642                                  ; minimally-qualified # 💇🏼‍♂ E4.0 man getting haircut: medium-light skin tone
+1F487 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 💇🏽‍♂️ E4.0 man getting haircut: medium skin tone
+1F487 1F3FD 200D 2642                                  ; minimally-qualified # 💇🏽‍♂ E4.0 man getting haircut: medium skin tone
+1F487 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 💇🏾‍♂️ E4.0 man getting haircut: medium-dark skin tone
+1F487 1F3FE 200D 2642                                  ; minimally-qualified # 💇🏾‍♂ E4.0 man getting haircut: medium-dark skin tone
+1F487 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 💇🏿‍♂️ E4.0 man getting haircut: dark skin tone
+1F487 1F3FF 200D 2642                                  ; minimally-qualified # 💇🏿‍♂ E4.0 man getting haircut: dark skin tone
+1F487 200D 2640 FE0F                                   ; fully-qualified     # 💇‍♀️ E4.0 woman getting haircut
+1F487 200D 2640                                        ; minimally-qualified # 💇‍♀ E4.0 woman getting haircut
+1F487 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 💇🏻‍♀️ E4.0 woman getting haircut: light skin tone
+1F487 1F3FB 200D 2640                                  ; minimally-qualified # 💇🏻‍♀ E4.0 woman getting haircut: light skin tone
+1F487 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 💇🏼‍♀️ E4.0 woman getting haircut: medium-light skin tone
+1F487 1F3FC 200D 2640                                  ; minimally-qualified # 💇🏼‍♀ E4.0 woman getting haircut: medium-light skin tone
+1F487 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 💇🏽‍♀️ E4.0 woman getting haircut: medium skin tone
+1F487 1F3FD 200D 2640                                  ; minimally-qualified # 💇🏽‍♀ E4.0 woman getting haircut: medium skin tone
+1F487 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 💇🏾‍♀️ E4.0 woman getting haircut: medium-dark skin tone
+1F487 1F3FE 200D 2640                                  ; minimally-qualified # 💇🏾‍♀ E4.0 woman getting haircut: medium-dark skin tone
+1F487 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 💇🏿‍♀️ E4.0 woman getting haircut: dark skin tone
+1F487 1F3FF 200D 2640                                  ; minimally-qualified # 💇🏿‍♀ E4.0 woman getting haircut: dark skin tone
+1F6B6                                                  ; fully-qualified     # 🚶 E0.6 person walking
+1F6B6 1F3FB                                            ; fully-qualified     # 🚶🏻 E1.0 person walking: light skin tone
+1F6B6 1F3FC                                            ; fully-qualified     # 🚶🏼 E1.0 person walking: medium-light skin tone
+1F6B6 1F3FD                                            ; fully-qualified     # 🚶🏽 E1.0 person walking: medium skin tone
+1F6B6 1F3FE                                            ; fully-qualified     # 🚶🏾 E1.0 person walking: medium-dark skin tone
+1F6B6 1F3FF                                            ; fully-qualified     # 🚶🏿 E1.0 person walking: dark skin tone
+1F6B6 200D 2642 FE0F                                   ; fully-qualified     # 🚶‍♂️ E4.0 man walking
+1F6B6 200D 2642                                        ; minimally-qualified # 🚶‍♂ E4.0 man walking
+1F6B6 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🚶🏻‍♂️ E4.0 man walking: light skin tone
+1F6B6 1F3FB 200D 2642                                  ; minimally-qualified # 🚶🏻‍♂ E4.0 man walking: light skin tone
+1F6B6 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🚶🏼‍♂️ E4.0 man walking: medium-light skin tone
+1F6B6 1F3FC 200D 2642                                  ; minimally-qualified # 🚶🏼‍♂ E4.0 man walking: medium-light skin tone
+1F6B6 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🚶🏽‍♂️ E4.0 man walking: medium skin tone
+1F6B6 1F3FD 200D 2642                                  ; minimally-qualified # 🚶🏽‍♂ E4.0 man walking: medium skin tone
+1F6B6 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🚶🏾‍♂️ E4.0 man walking: medium-dark skin tone
+1F6B6 1F3FE 200D 2642                                  ; minimally-qualified # 🚶🏾‍♂ E4.0 man walking: medium-dark skin tone
+1F6B6 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🚶🏿‍♂️ E4.0 man walking: dark skin tone
+1F6B6 1F3FF 200D 2642                                  ; minimally-qualified # 🚶🏿‍♂ E4.0 man walking: dark skin tone
+1F6B6 200D 2640 FE0F                                   ; fully-qualified     # 🚶‍♀️ E4.0 woman walking
+1F6B6 200D 2640                                        ; minimally-qualified # 🚶‍♀ E4.0 woman walking
+1F6B6 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🚶🏻‍♀️ E4.0 woman walking: light skin tone
+1F6B6 1F3FB 200D 2640                                  ; minimally-qualified # 🚶🏻‍♀ E4.0 woman walking: light skin tone
+1F6B6 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🚶🏼‍♀️ E4.0 woman walking: medium-light skin tone
+1F6B6 1F3FC 200D 2640                                  ; minimally-qualified # 🚶🏼‍♀ E4.0 woman walking: medium-light skin tone
+1F6B6 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🚶🏽‍♀️ E4.0 woman walking: medium skin tone
+1F6B6 1F3FD 200D 2640                                  ; minimally-qualified # 🚶🏽‍♀ E4.0 woman walking: medium skin tone
+1F6B6 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🚶🏾‍♀️ E4.0 woman walking: medium-dark skin tone
+1F6B6 1F3FE 200D 2640                                  ; minimally-qualified # 🚶🏾‍♀ E4.0 woman walking: medium-dark skin tone
+1F6B6 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🚶🏿‍♀️ E4.0 woman walking: dark skin tone
+1F6B6 1F3FF 200D 2640                                  ; minimally-qualified # 🚶🏿‍♀ E4.0 woman walking: dark skin tone
+1F6B6 200D 27A1 FE0F                                   ; fully-qualified     # 🚶‍➡️ E15.1 person walking facing right
+1F6B6 200D 27A1                                        ; minimally-qualified # 🚶‍➡ E15.1 person walking facing right
+1F6B6 1F3FB 200D 27A1 FE0F                             ; fully-qualified     # 🚶🏻‍➡️ E15.1 person walking facing right: light skin tone
+1F6B6 1F3FB 200D 27A1                                  ; minimally-qualified # 🚶🏻‍➡ E15.1 person walking facing right: light skin tone
+1F6B6 1F3FC 200D 27A1 FE0F                             ; fully-qualified     # 🚶🏼‍➡️ E15.1 person walking facing right: medium-light skin tone
+1F6B6 1F3FC 200D 27A1                                  ; minimally-qualified # 🚶🏼‍➡ E15.1 person walking facing right: medium-light skin tone
+1F6B6 1F3FD 200D 27A1 FE0F                             ; fully-qualified     # 🚶🏽‍➡️ E15.1 person walking facing right: medium skin tone
+1F6B6 1F3FD 200D 27A1                                  ; minimally-qualified # 🚶🏽‍➡ E15.1 person walking facing right: medium skin tone
+1F6B6 1F3FE 200D 27A1 FE0F                             ; fully-qualified     # 🚶🏾‍➡️ E15.1 person walking facing right: medium-dark skin tone
+1F6B6 1F3FE 200D 27A1                                  ; minimally-qualified # 🚶🏾‍➡ E15.1 person walking facing right: medium-dark skin tone
+1F6B6 1F3FF 200D 27A1 FE0F                             ; fully-qualified     # 🚶🏿‍➡️ E15.1 person walking facing right: dark skin tone
+1F6B6 1F3FF 200D 27A1                                  ; minimally-qualified # 🚶🏿‍➡ E15.1 person walking facing right: dark skin tone
+1F6B6 200D 2640 FE0F 200D 27A1 FE0F                    ; fully-qualified     # 🚶‍♀️‍➡️ E15.1 woman walking facing right
+1F6B6 200D 2640 200D 27A1 FE0F                         ; minimally-qualified # 🚶‍♀‍➡️ E15.1 woman walking facing right
+1F6B6 200D 2640 FE0F 200D 27A1                         ; minimally-qualified # 🚶‍♀️‍➡ E15.1 woman walking facing right
+1F6B6 200D 2640 200D 27A1                              ; minimally-qualified # 🚶‍♀‍➡ E15.1 woman walking facing right
+1F6B6 1F3FB 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏻‍♀️‍➡️ E15.1 woman walking facing right: light skin tone
+1F6B6 1F3FB 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏻‍♀‍➡️ E15.1 woman walking facing right: light skin tone
+1F6B6 1F3FB 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏻‍♀️‍➡ E15.1 woman walking facing right: light skin tone
+1F6B6 1F3FB 200D 2640 200D 27A1                        ; minimally-qualified # 🚶🏻‍♀‍➡ E15.1 woman walking facing right: light skin tone
+1F6B6 1F3FC 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏼‍♀️‍➡️ E15.1 woman walking facing right: medium-light skin tone
+1F6B6 1F3FC 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏼‍♀‍➡️ E15.1 woman walking facing right: medium-light skin tone
+1F6B6 1F3FC 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏼‍♀️‍➡ E15.1 woman walking facing right: medium-light skin tone
+1F6B6 1F3FC 200D 2640 200D 27A1                        ; minimally-qualified # 🚶🏼‍♀‍➡ E15.1 woman walking facing right: medium-light skin tone
+1F6B6 1F3FD 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏽‍♀️‍➡️ E15.1 woman walking facing right: medium skin tone
+1F6B6 1F3FD 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏽‍♀‍➡️ E15.1 woman walking facing right: medium skin tone
+1F6B6 1F3FD 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏽‍♀️‍➡ E15.1 woman walking facing right: medium skin tone
+1F6B6 1F3FD 200D 2640 200D 27A1                        ; minimally-qualified # 🚶🏽‍♀‍➡ E15.1 woman walking facing right: medium skin tone
+1F6B6 1F3FE 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏾‍♀️‍➡️ E15.1 woman walking facing right: medium-dark skin tone
+1F6B6 1F3FE 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏾‍♀‍➡️ E15.1 woman walking facing right: medium-dark skin tone
+1F6B6 1F3FE 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏾‍♀️‍➡ E15.1 woman walking facing right: medium-dark skin tone
+1F6B6 1F3FE 200D 2640 200D 27A1                        ; minimally-qualified # 🚶🏾‍♀‍➡ E15.1 woman walking facing right: medium-dark skin tone
+1F6B6 1F3FF 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏿‍♀️‍➡️ E15.1 woman walking facing right: dark skin tone
+1F6B6 1F3FF 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏿‍♀‍➡️ E15.1 woman walking facing right: dark skin tone
+1F6B6 1F3FF 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏿‍♀️‍➡ E15.1 woman walking facing right: dark skin tone
+1F6B6 1F3FF 200D 2640 200D 27A1                        ; minimally-qualified # 🚶🏿‍♀‍➡ E15.1 woman walking facing right: dark skin tone
+1F6B6 200D 2642 FE0F 200D 27A1 FE0F                    ; fully-qualified     # 🚶‍♂️‍➡️ E15.1 man walking facing right
+1F6B6 200D 2642 200D 27A1 FE0F                         ; minimally-qualified # 🚶‍♂‍➡️ E15.1 man walking facing right
+1F6B6 200D 2642 FE0F 200D 27A1                         ; minimally-qualified # 🚶‍♂️‍➡ E15.1 man walking facing right
+1F6B6 200D 2642 200D 27A1                              ; minimally-qualified # 🚶‍♂‍➡ E15.1 man walking facing right
+1F6B6 1F3FB 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏻‍♂️‍➡️ E15.1 man walking facing right: light skin tone
+1F6B6 1F3FB 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏻‍♂‍➡️ E15.1 man walking facing right: light skin tone
+1F6B6 1F3FB 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏻‍♂️‍➡ E15.1 man walking facing right: light skin tone
+1F6B6 1F3FB 200D 2642 200D 27A1                        ; minimally-qualified # 🚶🏻‍♂‍➡ E15.1 man walking facing right: light skin tone
+1F6B6 1F3FC 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏼‍♂️‍➡️ E15.1 man walking facing right: medium-light skin tone
+1F6B6 1F3FC 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏼‍♂‍➡️ E15.1 man walking facing right: medium-light skin tone
+1F6B6 1F3FC 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏼‍♂️‍➡ E15.1 man walking facing right: medium-light skin tone
+1F6B6 1F3FC 200D 2642 200D 27A1                        ; minimally-qualified # 🚶🏼‍♂‍➡ E15.1 man walking facing right: medium-light skin tone
+1F6B6 1F3FD 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏽‍♂️‍➡️ E15.1 man walking facing right: medium skin tone
+1F6B6 1F3FD 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏽‍♂‍➡️ E15.1 man walking facing right: medium skin tone
+1F6B6 1F3FD 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏽‍♂️‍➡ E15.1 man walking facing right: medium skin tone
+1F6B6 1F3FD 200D 2642 200D 27A1                        ; minimally-qualified # 🚶🏽‍♂‍➡ E15.1 man walking facing right: medium skin tone
+1F6B6 1F3FE 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏾‍♂️‍➡️ E15.1 man walking facing right: medium-dark skin tone
+1F6B6 1F3FE 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏾‍♂‍➡️ E15.1 man walking facing right: medium-dark skin tone
+1F6B6 1F3FE 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏾‍♂️‍➡ E15.1 man walking facing right: medium-dark skin tone
+1F6B6 1F3FE 200D 2642 200D 27A1                        ; minimally-qualified # 🚶🏾‍♂‍➡ E15.1 man walking facing right: medium-dark skin tone
+1F6B6 1F3FF 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏿‍♂️‍➡️ E15.1 man walking facing right: dark skin tone
+1F6B6 1F3FF 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏿‍♂‍➡️ E15.1 man walking facing right: dark skin tone
+1F6B6 1F3FF 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏿‍♂️‍➡ E15.1 man walking facing right: dark skin tone
+1F6B6 1F3FF 200D 2642 200D 27A1                        ; minimally-qualified # 🚶🏿‍♂‍➡ E15.1 man walking facing right: dark skin tone
+1F9CD                                                  ; fully-qualified     # 🧍 E12.0 person standing
+1F9CD 1F3FB                                            ; fully-qualified     # 🧍🏻 E12.0 person standing: light skin tone
+1F9CD 1F3FC                                            ; fully-qualified     # 🧍🏼 E12.0 person standing: medium-light skin tone
+1F9CD 1F3FD                                            ; fully-qualified     # 🧍🏽 E12.0 person standing: medium skin tone
+1F9CD 1F3FE                                            ; fully-qualified     # 🧍🏾 E12.0 person standing: medium-dark skin tone
+1F9CD 1F3FF                                            ; fully-qualified     # 🧍🏿 E12.0 person standing: dark skin tone
+1F9CD 200D 2642 FE0F                                   ; fully-qualified     # 🧍‍♂️ E12.0 man standing
+1F9CD 200D 2642                                        ; minimally-qualified # 🧍‍♂ E12.0 man standing
+1F9CD 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🧍🏻‍♂️ E12.0 man standing: light skin tone
+1F9CD 1F3FB 200D 2642                                  ; minimally-qualified # 🧍🏻‍♂ E12.0 man standing: light skin tone
+1F9CD 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🧍🏼‍♂️ E12.0 man standing: medium-light skin tone
+1F9CD 1F3FC 200D 2642                                  ; minimally-qualified # 🧍🏼‍♂ E12.0 man standing: medium-light skin tone
+1F9CD 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🧍🏽‍♂️ E12.0 man standing: medium skin tone
+1F9CD 1F3FD 200D 2642                                  ; minimally-qualified # 🧍🏽‍♂ E12.0 man standing: medium skin tone
+1F9CD 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🧍🏾‍♂️ E12.0 man standing: medium-dark skin tone
+1F9CD 1F3FE 200D 2642                                  ; minimally-qualified # 🧍🏾‍♂ E12.0 man standing: medium-dark skin tone
+1F9CD 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🧍🏿‍♂️ E12.0 man standing: dark skin tone
+1F9CD 1F3FF 200D 2642                                  ; minimally-qualified # 🧍🏿‍♂ E12.0 man standing: dark skin tone
+1F9CD 200D 2640 FE0F                                   ; fully-qualified     # 🧍‍♀️ E12.0 woman standing
+1F9CD 200D 2640                                        ; minimally-qualified # 🧍‍♀ E12.0 woman standing
+1F9CD 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🧍🏻‍♀️ E12.0 woman standing: light skin tone
+1F9CD 1F3FB 200D 2640                                  ; minimally-qualified # 🧍🏻‍♀ E12.0 woman standing: light skin tone
+1F9CD 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🧍🏼‍♀️ E12.0 woman standing: medium-light skin tone
+1F9CD 1F3FC 200D 2640                                  ; minimally-qualified # 🧍🏼‍♀ E12.0 woman standing: medium-light skin tone
+1F9CD 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🧍🏽‍♀️ E12.0 woman standing: medium skin tone
+1F9CD 1F3FD 200D 2640                                  ; minimally-qualified # 🧍🏽‍♀ E12.0 woman standing: medium skin tone
+1F9CD 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🧍🏾‍♀️ E12.0 woman standing: medium-dark skin tone
+1F9CD 1F3FE 200D 2640                                  ; minimally-qualified # 🧍🏾‍♀ E12.0 woman standing: medium-dark skin tone
+1F9CD 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🧍🏿‍♀️ E12.0 woman standing: dark skin tone
+1F9CD 1F3FF 200D 2640                                  ; minimally-qualified # 🧍🏿‍♀ E12.0 woman standing: dark skin tone
+1F9CE                                                  ; fully-qualified     # 🧎 E12.0 person kneeling
+1F9CE 1F3FB                                            ; fully-qualified     # 🧎🏻 E12.0 person kneeling: light skin tone
+1F9CE 1F3FC                                            ; fully-qualified     # 🧎🏼 E12.0 person kneeling: medium-light skin tone
+1F9CE 1F3FD                                            ; fully-qualified     # 🧎🏽 E12.0 person kneeling: medium skin tone
+1F9CE 1F3FE                                            ; fully-qualified     # 🧎🏾 E12.0 person kneeling: medium-dark skin tone
+1F9CE 1F3FF                                            ; fully-qualified     # 🧎🏿 E12.0 person kneeling: dark skin tone
+1F9CE 200D 2642 FE0F                                   ; fully-qualified     # 🧎‍♂️ E12.0 man kneeling
+1F9CE 200D 2642                                        ; minimally-qualified # 🧎‍♂ E12.0 man kneeling
+1F9CE 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🧎🏻‍♂️ E12.0 man kneeling: light skin tone
+1F9CE 1F3FB 200D 2642                                  ; minimally-qualified # 🧎🏻‍♂ E12.0 man kneeling: light skin tone
+1F9CE 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🧎🏼‍♂️ E12.0 man kneeling: medium-light skin tone
+1F9CE 1F3FC 200D 2642                                  ; minimally-qualified # 🧎🏼‍♂ E12.0 man kneeling: medium-light skin tone
+1F9CE 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🧎🏽‍♂️ E12.0 man kneeling: medium skin tone
+1F9CE 1F3FD 200D 2642                                  ; minimally-qualified # 🧎🏽‍♂ E12.0 man kneeling: medium skin tone
+1F9CE 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🧎🏾‍♂️ E12.0 man kneeling: medium-dark skin tone
+1F9CE 1F3FE 200D 2642                                  ; minimally-qualified # 🧎🏾‍♂ E12.0 man kneeling: medium-dark skin tone
+1F9CE 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🧎🏿‍♂️ E12.0 man kneeling: dark skin tone
+1F9CE 1F3FF 200D 2642                                  ; minimally-qualified # 🧎🏿‍♂ E12.0 man kneeling: dark skin tone
+1F9CE 200D 2640 FE0F                                   ; fully-qualified     # 🧎‍♀️ E12.0 woman kneeling
+1F9CE 200D 2640                                        ; minimally-qualified # 🧎‍♀ E12.0 woman kneeling
+1F9CE 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🧎🏻‍♀️ E12.0 woman kneeling: light skin tone
+1F9CE 1F3FB 200D 2640                                  ; minimally-qualified # 🧎🏻‍♀ E12.0 woman kneeling: light skin tone
+1F9CE 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🧎🏼‍♀️ E12.0 woman kneeling: medium-light skin tone
+1F9CE 1F3FC 200D 2640                                  ; minimally-qualified # 🧎🏼‍♀ E12.0 woman kneeling: medium-light skin tone
+1F9CE 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🧎🏽‍♀️ E12.0 woman kneeling: medium skin tone
+1F9CE 1F3FD 200D 2640                                  ; minimally-qualified # 🧎🏽‍♀ E12.0 woman kneeling: medium skin tone
+1F9CE 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🧎🏾‍♀️ E12.0 woman kneeling: medium-dark skin tone
+1F9CE 1F3FE 200D 2640                                  ; minimally-qualified # 🧎🏾‍♀ E12.0 woman kneeling: medium-dark skin tone
+1F9CE 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🧎🏿‍♀️ E12.0 woman kneeling: dark skin tone
+1F9CE 1F3FF 200D 2640                                  ; minimally-qualified # 🧎🏿‍♀ E12.0 woman kneeling: dark skin tone
+1F9CE 200D 27A1 FE0F                                   ; fully-qualified     # 🧎‍➡️ E15.1 person kneeling facing right
+1F9CE 200D 27A1                                        ; minimally-qualified # 🧎‍➡ E15.1 person kneeling facing right
+1F9CE 1F3FB 200D 27A1 FE0F                             ; fully-qualified     # 🧎🏻‍➡️ E15.1 person kneeling facing right: light skin tone
+1F9CE 1F3FB 200D 27A1                                  ; minimally-qualified # 🧎🏻‍➡ E15.1 person kneeling facing right: light skin tone
+1F9CE 1F3FC 200D 27A1 FE0F                             ; fully-qualified     # 🧎🏼‍➡️ E15.1 person kneeling facing right: medium-light skin tone
+1F9CE 1F3FC 200D 27A1                                  ; minimally-qualified # 🧎🏼‍➡ E15.1 person kneeling facing right: medium-light skin tone
+1F9CE 1F3FD 200D 27A1 FE0F                             ; fully-qualified     # 🧎🏽‍➡️ E15.1 person kneeling facing right: medium skin tone
+1F9CE 1F3FD 200D 27A1                                  ; minimally-qualified # 🧎🏽‍➡ E15.1 person kneeling facing right: medium skin tone
+1F9CE 1F3FE 200D 27A1 FE0F                             ; fully-qualified     # 🧎🏾‍➡️ E15.1 person kneeling facing right: medium-dark skin tone
+1F9CE 1F3FE 200D 27A1                                  ; minimally-qualified # 🧎🏾‍➡ E15.1 person kneeling facing right: medium-dark skin tone
+1F9CE 1F3FF 200D 27A1 FE0F                             ; fully-qualified     # 🧎🏿‍➡️ E15.1 person kneeling facing right: dark skin tone
+1F9CE 1F3FF 200D 27A1                                  ; minimally-qualified # 🧎🏿‍➡ E15.1 person kneeling facing right: dark skin tone
+1F9CE 200D 2640 FE0F 200D 27A1 FE0F                    ; fully-qualified     # 🧎‍♀️‍➡️ E15.1 woman kneeling facing right
+1F9CE 200D 2640 200D 27A1 FE0F                         ; minimally-qualified # 🧎‍♀‍➡️ E15.1 woman kneeling facing right
+1F9CE 200D 2640 FE0F 200D 27A1                         ; minimally-qualified # 🧎‍♀️‍➡ E15.1 woman kneeling facing right
+1F9CE 200D 2640 200D 27A1                              ; minimally-qualified # 🧎‍♀‍➡ E15.1 woman kneeling facing right
+1F9CE 1F3FB 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏻‍♀️‍➡️ E15.1 woman kneeling facing right: light skin tone
+1F9CE 1F3FB 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏻‍♀‍➡️ E15.1 woman kneeling facing right: light skin tone
+1F9CE 1F3FB 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏻‍♀️‍➡ E15.1 woman kneeling facing right: light skin tone
+1F9CE 1F3FB 200D 2640 200D 27A1                        ; minimally-qualified # 🧎🏻‍♀‍➡ E15.1 woman kneeling facing right: light skin tone
+1F9CE 1F3FC 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏼‍♀️‍➡️ E15.1 woman kneeling facing right: medium-light skin tone
+1F9CE 1F3FC 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏼‍♀‍➡️ E15.1 woman kneeling facing right: medium-light skin tone
+1F9CE 1F3FC 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏼‍♀️‍➡ E15.1 woman kneeling facing right: medium-light skin tone
+1F9CE 1F3FC 200D 2640 200D 27A1                        ; minimally-qualified # 🧎🏼‍♀‍➡ E15.1 woman kneeling facing right: medium-light skin tone
+1F9CE 1F3FD 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏽‍♀️‍➡️ E15.1 woman kneeling facing right: medium skin tone
+1F9CE 1F3FD 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏽‍♀‍➡️ E15.1 woman kneeling facing right: medium skin tone
+1F9CE 1F3FD 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏽‍♀️‍➡ E15.1 woman kneeling facing right: medium skin tone
+1F9CE 1F3FD 200D 2640 200D 27A1                        ; minimally-qualified # 🧎🏽‍♀‍➡ E15.1 woman kneeling facing right: medium skin tone
+1F9CE 1F3FE 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏾‍♀️‍➡️ E15.1 woman kneeling facing right: medium-dark skin tone
+1F9CE 1F3FE 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏾‍♀‍➡️ E15.1 woman kneeling facing right: medium-dark skin tone
+1F9CE 1F3FE 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏾‍♀️‍➡ E15.1 woman kneeling facing right: medium-dark skin tone
+1F9CE 1F3FE 200D 2640 200D 27A1                        ; minimally-qualified # 🧎🏾‍♀‍➡ E15.1 woman kneeling facing right: medium-dark skin tone
+1F9CE 1F3FF 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏿‍♀️‍➡️ E15.1 woman kneeling facing right: dark skin tone
+1F9CE 1F3FF 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏿‍♀‍➡️ E15.1 woman kneeling facing right: dark skin tone
+1F9CE 1F3FF 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏿‍♀️‍➡ E15.1 woman kneeling facing right: dark skin tone
+1F9CE 1F3FF 200D 2640 200D 27A1                        ; minimally-qualified # 🧎🏿‍♀‍➡ E15.1 woman kneeling facing right: dark skin tone
+1F9CE 200D 2642 FE0F 200D 27A1 FE0F                    ; fully-qualified     # 🧎‍♂️‍➡️ E15.1 man kneeling facing right
+1F9CE 200D 2642 200D 27A1 FE0F                         ; minimally-qualified # 🧎‍♂‍➡️ E15.1 man kneeling facing right
+1F9CE 200D 2642 FE0F 200D 27A1                         ; minimally-qualified # 🧎‍♂️‍➡ E15.1 man kneeling facing right
+1F9CE 200D 2642 200D 27A1                              ; minimally-qualified # 🧎‍♂‍➡ E15.1 man kneeling facing right
+1F9CE 1F3FB 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏻‍♂️‍➡️ E15.1 man kneeling facing right: light skin tone
+1F9CE 1F3FB 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏻‍♂‍➡️ E15.1 man kneeling facing right: light skin tone
+1F9CE 1F3FB 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏻‍♂️‍➡ E15.1 man kneeling facing right: light skin tone
+1F9CE 1F3FB 200D 2642 200D 27A1                        ; minimally-qualified # 🧎🏻‍♂‍➡ E15.1 man kneeling facing right: light skin tone
+1F9CE 1F3FC 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏼‍♂️‍➡️ E15.1 man kneeling facing right: medium-light skin tone
+1F9CE 1F3FC 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏼‍♂‍➡️ E15.1 man kneeling facing right: medium-light skin tone
+1F9CE 1F3FC 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏼‍♂️‍➡ E15.1 man kneeling facing right: medium-light skin tone
+1F9CE 1F3FC 200D 2642 200D 27A1                        ; minimally-qualified # 🧎🏼‍♂‍➡ E15.1 man kneeling facing right: medium-light skin tone
+1F9CE 1F3FD 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏽‍♂️‍➡️ E15.1 man kneeling facing right: medium skin tone
+1F9CE 1F3FD 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏽‍♂‍➡️ E15.1 man kneeling facing right: medium skin tone
+1F9CE 1F3FD 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏽‍♂️‍➡ E15.1 man kneeling facing right: medium skin tone
+1F9CE 1F3FD 200D 2642 200D 27A1                        ; minimally-qualified # 🧎🏽‍♂‍➡ E15.1 man kneeling facing right: medium skin tone
+1F9CE 1F3FE 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏾‍♂️‍➡️ E15.1 man kneeling facing right: medium-dark skin tone
+1F9CE 1F3FE 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏾‍♂‍➡️ E15.1 man kneeling facing right: medium-dark skin tone
+1F9CE 1F3FE 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏾‍♂️‍➡ E15.1 man kneeling facing right: medium-dark skin tone
+1F9CE 1F3FE 200D 2642 200D 27A1                        ; minimally-qualified # 🧎🏾‍♂‍➡ E15.1 man kneeling facing right: medium-dark skin tone
+1F9CE 1F3FF 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏿‍♂️‍➡️ E15.1 man kneeling facing right: dark skin tone
+1F9CE 1F3FF 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏿‍♂‍➡️ E15.1 man kneeling facing right: dark skin tone
+1F9CE 1F3FF 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏿‍♂️‍➡ E15.1 man kneeling facing right: dark skin tone
+1F9CE 1F3FF 200D 2642 200D 27A1                        ; minimally-qualified # 🧎🏿‍♂‍➡ E15.1 man kneeling facing right: dark skin tone
+1F9D1 200D 1F9AF                                       ; fully-qualified     # 🧑‍🦯 E12.1 person with white cane
+1F9D1 1F3FB 200D 1F9AF                                 ; fully-qualified     # 🧑🏻‍🦯 E12.1 person with white cane: light skin tone
+1F9D1 1F3FC 200D 1F9AF                                 ; fully-qualified     # 🧑🏼‍🦯 E12.1 person with white cane: medium-light skin tone
+1F9D1 1F3FD 200D 1F9AF                                 ; fully-qualified     # 🧑🏽‍🦯 E12.1 person with white cane: medium skin tone
+1F9D1 1F3FE 200D 1F9AF                                 ; fully-qualified     # 🧑🏾‍🦯 E12.1 person with white cane: medium-dark skin tone
+1F9D1 1F3FF 200D 1F9AF                                 ; fully-qualified     # 🧑🏿‍🦯 E12.1 person with white cane: dark skin tone
+1F9D1 200D 1F9AF 200D 27A1 FE0F                        ; fully-qualified     # 🧑‍🦯‍➡️ E15.1 person with white cane facing right
+1F9D1 200D 1F9AF 200D 27A1                             ; minimally-qualified # 🧑‍🦯‍➡ E15.1 person with white cane facing right
+1F9D1 1F3FB 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏻‍🦯‍➡️ E15.1 person with white cane facing right: light skin tone
+1F9D1 1F3FB 200D 1F9AF 200D 27A1                       ; minimally-qualified # 🧑🏻‍🦯‍➡ E15.1 person with white cane facing right: light skin tone
+1F9D1 1F3FC 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏼‍🦯‍➡️ E15.1 person with white cane facing right: medium-light skin tone
+1F9D1 1F3FC 200D 1F9AF 200D 27A1                       ; minimally-qualified # 🧑🏼‍🦯‍➡ E15.1 person with white cane facing right: medium-light skin tone
+1F9D1 1F3FD 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏽‍🦯‍➡️ E15.1 person with white cane facing right: medium skin tone
+1F9D1 1F3FD 200D 1F9AF 200D 27A1                       ; minimally-qualified # 🧑🏽‍🦯‍➡ E15.1 person with white cane facing right: medium skin tone
+1F9D1 1F3FE 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏾‍🦯‍➡️ E15.1 person with white cane facing right: medium-dark skin tone
+1F9D1 1F3FE 200D 1F9AF 200D 27A1                       ; minimally-qualified # 🧑🏾‍🦯‍➡ E15.1 person with white cane facing right: medium-dark skin tone
+1F9D1 1F3FF 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏿‍🦯‍➡️ E15.1 person with white cane facing right: dark skin tone
+1F9D1 1F3FF 200D 1F9AF 200D 27A1                       ; minimally-qualified # 🧑🏿‍🦯‍➡ E15.1 person with white cane facing right: dark skin tone
+1F468 200D 1F9AF                                       ; fully-qualified     # 👨‍🦯 E12.0 man with white cane
+1F468 1F3FB 200D 1F9AF                                 ; fully-qualified     # 👨🏻‍🦯 E12.0 man with white cane: light skin tone
+1F468 1F3FC 200D 1F9AF                                 ; fully-qualified     # 👨🏼‍🦯 E12.0 man with white cane: medium-light skin tone
+1F468 1F3FD 200D 1F9AF                                 ; fully-qualified     # 👨🏽‍🦯 E12.0 man with white cane: medium skin tone
+1F468 1F3FE 200D 1F9AF                                 ; fully-qualified     # 👨🏾‍🦯 E12.0 man with white cane: medium-dark skin tone
+1F468 1F3FF 200D 1F9AF                                 ; fully-qualified     # 👨🏿‍🦯 E12.0 man with white cane: dark skin tone
+1F468 200D 1F9AF 200D 27A1 FE0F                        ; fully-qualified     # 👨‍🦯‍➡️ E15.1 man with white cane facing right
+1F468 200D 1F9AF 200D 27A1                             ; minimally-qualified # 👨‍🦯‍➡ E15.1 man with white cane facing right
+1F468 1F3FB 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👨🏻‍🦯‍➡️ E15.1 man with white cane facing right: light skin tone
+1F468 1F3FB 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👨🏻‍🦯‍➡ E15.1 man with white cane facing right: light skin tone
+1F468 1F3FC 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👨🏼‍🦯‍➡️ E15.1 man with white cane facing right: medium-light skin tone
+1F468 1F3FC 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👨🏼‍🦯‍➡ E15.1 man with white cane facing right: medium-light skin tone
+1F468 1F3FD 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👨🏽‍🦯‍➡️ E15.1 man with white cane facing right: medium skin tone
+1F468 1F3FD 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👨🏽‍🦯‍➡ E15.1 man with white cane facing right: medium skin tone
+1F468 1F3FE 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👨🏾‍🦯‍➡️ E15.1 man with white cane facing right: medium-dark skin tone
+1F468 1F3FE 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👨🏾‍🦯‍➡ E15.1 man with white cane facing right: medium-dark skin tone
+1F468 1F3FF 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👨🏿‍🦯‍➡️ E15.1 man with white cane facing right: dark skin tone
+1F468 1F3FF 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👨🏿‍🦯‍➡ E15.1 man with white cane facing right: dark skin tone
+1F469 200D 1F9AF                                       ; fully-qualified     # 👩‍🦯 E12.0 woman with white cane
+1F469 1F3FB 200D 1F9AF                                 ; fully-qualified     # 👩🏻‍🦯 E12.0 woman with white cane: light skin tone
+1F469 1F3FC 200D 1F9AF                                 ; fully-qualified     # 👩🏼‍🦯 E12.0 woman with white cane: medium-light skin tone
+1F469 1F3FD 200D 1F9AF                                 ; fully-qualified     # 👩🏽‍🦯 E12.0 woman with white cane: medium skin tone
+1F469 1F3FE 200D 1F9AF                                 ; fully-qualified     # 👩🏾‍🦯 E12.0 woman with white cane: medium-dark skin tone
+1F469 1F3FF 200D 1F9AF                                 ; fully-qualified     # 👩🏿‍🦯 E12.0 woman with white cane: dark skin tone
+1F469 200D 1F9AF 200D 27A1 FE0F                        ; fully-qualified     # 👩‍🦯‍➡️ E15.1 woman with white cane facing right
+1F469 200D 1F9AF 200D 27A1                             ; minimally-qualified # 👩‍🦯‍➡ E15.1 woman with white cane facing right
+1F469 1F3FB 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👩🏻‍🦯‍➡️ E15.1 woman with white cane facing right: light skin tone
+1F469 1F3FB 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👩🏻‍🦯‍➡ E15.1 woman with white cane facing right: light skin tone
+1F469 1F3FC 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👩🏼‍🦯‍➡️ E15.1 woman with white cane facing right: medium-light skin tone
+1F469 1F3FC 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👩🏼‍🦯‍➡ E15.1 woman with white cane facing right: medium-light skin tone
+1F469 1F3FD 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👩🏽‍🦯‍➡️ E15.1 woman with white cane facing right: medium skin tone
+1F469 1F3FD 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👩🏽‍🦯‍➡ E15.1 woman with white cane facing right: medium skin tone
+1F469 1F3FE 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👩🏾‍🦯‍➡️ E15.1 woman with white cane facing right: medium-dark skin tone
+1F469 1F3FE 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👩🏾‍🦯‍➡ E15.1 woman with white cane facing right: medium-dark skin tone
+1F469 1F3FF 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👩🏿‍🦯‍➡️ E15.1 woman with white cane facing right: dark skin tone
+1F469 1F3FF 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👩🏿‍🦯‍➡ E15.1 woman with white cane facing right: dark skin tone
+1F9D1 200D 1F9BC                                       ; fully-qualified     # 🧑‍🦼 E12.1 person in motorized wheelchair
+1F9D1 1F3FB 200D 1F9BC                                 ; fully-qualified     # 🧑🏻‍🦼 E12.1 person in motorized wheelchair: light skin tone
+1F9D1 1F3FC 200D 1F9BC                                 ; fully-qualified     # 🧑🏼‍🦼 E12.1 person in motorized wheelchair: medium-light skin tone
+1F9D1 1F3FD 200D 1F9BC                                 ; fully-qualified     # 🧑🏽‍🦼 E12.1 person in motorized wheelchair: medium skin tone
+1F9D1 1F3FE 200D 1F9BC                                 ; fully-qualified     # 🧑🏾‍🦼 E12.1 person in motorized wheelchair: medium-dark skin tone
+1F9D1 1F3FF 200D 1F9BC                                 ; fully-qualified     # 🧑🏿‍🦼 E12.1 person in motorized wheelchair: dark skin tone
+1F9D1 200D 1F9BC 200D 27A1 FE0F                        ; fully-qualified     # 🧑‍🦼‍➡️ E15.1 person in motorized wheelchair facing right
+1F9D1 200D 1F9BC 200D 27A1                             ; minimally-qualified # 🧑‍🦼‍➡ E15.1 person in motorized wheelchair facing right
+1F9D1 1F3FB 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏻‍🦼‍➡️ E15.1 person in motorized wheelchair facing right: light skin tone
+1F9D1 1F3FB 200D 1F9BC 200D 27A1                       ; minimally-qualified # 🧑🏻‍🦼‍➡ E15.1 person in motorized wheelchair facing right: light skin tone
+1F9D1 1F3FC 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏼‍🦼‍➡️ E15.1 person in motorized wheelchair facing right: medium-light skin tone
+1F9D1 1F3FC 200D 1F9BC 200D 27A1                       ; minimally-qualified # 🧑🏼‍🦼‍➡ E15.1 person in motorized wheelchair facing right: medium-light skin tone
+1F9D1 1F3FD 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏽‍🦼‍➡️ E15.1 person in motorized wheelchair facing right: medium skin tone
+1F9D1 1F3FD 200D 1F9BC 200D 27A1                       ; minimally-qualified # 🧑🏽‍🦼‍➡ E15.1 person in motorized wheelchair facing right: medium skin tone
+1F9D1 1F3FE 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏾‍🦼‍➡️ E15.1 person in motorized wheelchair facing right: medium-dark skin tone
+1F9D1 1F3FE 200D 1F9BC 200D 27A1                       ; minimally-qualified # 🧑🏾‍🦼‍➡ E15.1 person in motorized wheelchair facing right: medium-dark skin tone
+1F9D1 1F3FF 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏿‍🦼‍➡️ E15.1 person in motorized wheelchair facing right: dark skin tone
+1F9D1 1F3FF 200D 1F9BC 200D 27A1                       ; minimally-qualified # 🧑🏿‍🦼‍➡ E15.1 person in motorized wheelchair facing right: dark skin tone
+1F468 200D 1F9BC                                       ; fully-qualified     # 👨‍🦼 E12.0 man in motorized wheelchair
+1F468 1F3FB 200D 1F9BC                                 ; fully-qualified     # 👨🏻‍🦼 E12.0 man in motorized wheelchair: light skin tone
+1F468 1F3FC 200D 1F9BC                                 ; fully-qualified     # 👨🏼‍🦼 E12.0 man in motorized wheelchair: medium-light skin tone
+1F468 1F3FD 200D 1F9BC                                 ; fully-qualified     # 👨🏽‍🦼 E12.0 man in motorized wheelchair: medium skin tone
+1F468 1F3FE 200D 1F9BC                                 ; fully-qualified     # 👨🏾‍🦼 E12.0 man in motorized wheelchair: medium-dark skin tone
+1F468 1F3FF 200D 1F9BC                                 ; fully-qualified     # 👨🏿‍🦼 E12.0 man in motorized wheelchair: dark skin tone
+1F468 200D 1F9BC 200D 27A1 FE0F                        ; fully-qualified     # 👨‍🦼‍➡️ E15.1 man in motorized wheelchair facing right
+1F468 200D 1F9BC 200D 27A1                             ; minimally-qualified # 👨‍🦼‍➡ E15.1 man in motorized wheelchair facing right
+1F468 1F3FB 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👨🏻‍🦼‍➡️ E15.1 man in motorized wheelchair facing right: light skin tone
+1F468 1F3FB 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👨🏻‍🦼‍➡ E15.1 man in motorized wheelchair facing right: light skin tone
+1F468 1F3FC 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👨🏼‍🦼‍➡️ E15.1 man in motorized wheelchair facing right: medium-light skin tone
+1F468 1F3FC 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👨🏼‍🦼‍➡ E15.1 man in motorized wheelchair facing right: medium-light skin tone
+1F468 1F3FD 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👨🏽‍🦼‍➡️ E15.1 man in motorized wheelchair facing right: medium skin tone
+1F468 1F3FD 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👨🏽‍🦼‍➡ E15.1 man in motorized wheelchair facing right: medium skin tone
+1F468 1F3FE 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👨🏾‍🦼‍➡️ E15.1 man in motorized wheelchair facing right: medium-dark skin tone
+1F468 1F3FE 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👨🏾‍🦼‍➡ E15.1 man in motorized wheelchair facing right: medium-dark skin tone
+1F468 1F3FF 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👨🏿‍🦼‍➡️ E15.1 man in motorized wheelchair facing right: dark skin tone
+1F468 1F3FF 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👨🏿‍🦼‍➡ E15.1 man in motorized wheelchair facing right: dark skin tone
+1F469 200D 1F9BC                                       ; fully-qualified     # 👩‍🦼 E12.0 woman in motorized wheelchair
+1F469 1F3FB 200D 1F9BC                                 ; fully-qualified     # 👩🏻‍🦼 E12.0 woman in motorized wheelchair: light skin tone
+1F469 1F3FC 200D 1F9BC                                 ; fully-qualified     # 👩🏼‍🦼 E12.0 woman in motorized wheelchair: medium-light skin tone
+1F469 1F3FD 200D 1F9BC                                 ; fully-qualified     # 👩🏽‍🦼 E12.0 woman in motorized wheelchair: medium skin tone
+1F469 1F3FE 200D 1F9BC                                 ; fully-qualified     # 👩🏾‍🦼 E12.0 woman in motorized wheelchair: medium-dark skin tone
+1F469 1F3FF 200D 1F9BC                                 ; fully-qualified     # 👩🏿‍🦼 E12.0 woman in motorized wheelchair: dark skin tone
+1F469 200D 1F9BC 200D 27A1 FE0F                        ; fully-qualified     # 👩‍🦼‍➡️ E15.1 woman in motorized wheelchair facing right
+1F469 200D 1F9BC 200D 27A1                             ; minimally-qualified # 👩‍🦼‍➡ E15.1 woman in motorized wheelchair facing right
+1F469 1F3FB 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👩🏻‍🦼‍➡️ E15.1 woman in motorized wheelchair facing right: light skin tone
+1F469 1F3FB 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👩🏻‍🦼‍➡ E15.1 woman in motorized wheelchair facing right: light skin tone
+1F469 1F3FC 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👩🏼‍🦼‍➡️ E15.1 woman in motorized wheelchair facing right: medium-light skin tone
+1F469 1F3FC 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👩🏼‍🦼‍➡ E15.1 woman in motorized wheelchair facing right: medium-light skin tone
+1F469 1F3FD 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👩🏽‍🦼‍➡️ E15.1 woman in motorized wheelchair facing right: medium skin tone
+1F469 1F3FD 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👩🏽‍🦼‍➡ E15.1 woman in motorized wheelchair facing right: medium skin tone
+1F469 1F3FE 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👩🏾‍🦼‍➡️ E15.1 woman in motorized wheelchair facing right: medium-dark skin tone
+1F469 1F3FE 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👩🏾‍🦼‍➡ E15.1 woman in motorized wheelchair facing right: medium-dark skin tone
+1F469 1F3FF 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👩🏿‍🦼‍➡️ E15.1 woman in motorized wheelchair facing right: dark skin tone
+1F469 1F3FF 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👩🏿‍🦼‍➡ E15.1 woman in motorized wheelchair facing right: dark skin tone
+1F9D1 200D 1F9BD                                       ; fully-qualified     # 🧑‍🦽 E12.1 person in manual wheelchair
+1F9D1 1F3FB 200D 1F9BD                                 ; fully-qualified     # 🧑🏻‍🦽 E12.1 person in manual wheelchair: light skin tone
+1F9D1 1F3FC 200D 1F9BD                                 ; fully-qualified     # 🧑🏼‍🦽 E12.1 person in manual wheelchair: medium-light skin tone
+1F9D1 1F3FD 200D 1F9BD                                 ; fully-qualified     # 🧑🏽‍🦽 E12.1 person in manual wheelchair: medium skin tone
+1F9D1 1F3FE 200D 1F9BD                                 ; fully-qualified     # 🧑🏾‍🦽 E12.1 person in manual wheelchair: medium-dark skin tone
+1F9D1 1F3FF 200D 1F9BD                                 ; fully-qualified     # 🧑🏿‍🦽 E12.1 person in manual wheelchair: dark skin tone
+1F9D1 200D 1F9BD 200D 27A1 FE0F                        ; fully-qualified     # 🧑‍🦽‍➡️ E15.1 person in manual wheelchair facing right
+1F9D1 200D 1F9BD 200D 27A1                             ; minimally-qualified # 🧑‍🦽‍➡ E15.1 person in manual wheelchair facing right
+1F9D1 1F3FB 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏻‍🦽‍➡️ E15.1 person in manual wheelchair facing right: light skin tone
+1F9D1 1F3FB 200D 1F9BD 200D 27A1                       ; minimally-qualified # 🧑🏻‍🦽‍➡ E15.1 person in manual wheelchair facing right: light skin tone
+1F9D1 1F3FC 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏼‍🦽‍➡️ E15.1 person in manual wheelchair facing right: medium-light skin tone
+1F9D1 1F3FC 200D 1F9BD 200D 27A1                       ; minimally-qualified # 🧑🏼‍🦽‍➡ E15.1 person in manual wheelchair facing right: medium-light skin tone
+1F9D1 1F3FD 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏽‍🦽‍➡️ E15.1 person in manual wheelchair facing right: medium skin tone
+1F9D1 1F3FD 200D 1F9BD 200D 27A1                       ; minimally-qualified # 🧑🏽‍🦽‍➡ E15.1 person in manual wheelchair facing right: medium skin tone
+1F9D1 1F3FE 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏾‍🦽‍➡️ E15.1 person in manual wheelchair facing right: medium-dark skin tone
+1F9D1 1F3FE 200D 1F9BD 200D 27A1                       ; minimally-qualified # 🧑🏾‍🦽‍➡ E15.1 person in manual wheelchair facing right: medium-dark skin tone
+1F9D1 1F3FF 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏿‍🦽‍➡️ E15.1 person in manual wheelchair facing right: dark skin tone
+1F9D1 1F3FF 200D 1F9BD 200D 27A1                       ; minimally-qualified # 🧑🏿‍🦽‍➡ E15.1 person in manual wheelchair facing right: dark skin tone
+1F468 200D 1F9BD                                       ; fully-qualified     # 👨‍🦽 E12.0 man in manual wheelchair
+1F468 1F3FB 200D 1F9BD                                 ; fully-qualified     # 👨🏻‍🦽 E12.0 man in manual wheelchair: light skin tone
+1F468 1F3FC 200D 1F9BD                                 ; fully-qualified     # 👨🏼‍🦽 E12.0 man in manual wheelchair: medium-light skin tone
+1F468 1F3FD 200D 1F9BD                                 ; fully-qualified     # 👨🏽‍🦽 E12.0 man in manual wheelchair: medium skin tone
+1F468 1F3FE 200D 1F9BD                                 ; fully-qualified     # 👨🏾‍🦽 E12.0 man in manual wheelchair: medium-dark skin tone
+1F468 1F3FF 200D 1F9BD                                 ; fully-qualified     # 👨🏿‍🦽 E12.0 man in manual wheelchair: dark skin tone
+1F468 200D 1F9BD 200D 27A1 FE0F                        ; fully-qualified     # 👨‍🦽‍➡️ E15.1 man in manual wheelchair facing right
+1F468 200D 1F9BD 200D 27A1                             ; minimally-qualified # 👨‍🦽‍➡ E15.1 man in manual wheelchair facing right
+1F468 1F3FB 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👨🏻‍🦽‍➡️ E15.1 man in manual wheelchair facing right: light skin tone
+1F468 1F3FB 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👨🏻‍🦽‍➡ E15.1 man in manual wheelchair facing right: light skin tone
+1F468 1F3FC 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👨🏼‍🦽‍➡️ E15.1 man in manual wheelchair facing right: medium-light skin tone
+1F468 1F3FC 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👨🏼‍🦽‍➡ E15.1 man in manual wheelchair facing right: medium-light skin tone
+1F468 1F3FD 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👨🏽‍🦽‍➡️ E15.1 man in manual wheelchair facing right: medium skin tone
+1F468 1F3FD 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👨🏽‍🦽‍➡ E15.1 man in manual wheelchair facing right: medium skin tone
+1F468 1F3FE 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👨🏾‍🦽‍➡️ E15.1 man in manual wheelchair facing right: medium-dark skin tone
+1F468 1F3FE 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👨🏾‍🦽‍➡ E15.1 man in manual wheelchair facing right: medium-dark skin tone
+1F468 1F3FF 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👨🏿‍🦽‍➡️ E15.1 man in manual wheelchair facing right: dark skin tone
+1F468 1F3FF 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👨🏿‍🦽‍➡ E15.1 man in manual wheelchair facing right: dark skin tone
+1F469 200D 1F9BD                                       ; fully-qualified     # 👩‍🦽 E12.0 woman in manual wheelchair
+1F469 1F3FB 200D 1F9BD                                 ; fully-qualified     # 👩🏻‍🦽 E12.0 woman in manual wheelchair: light skin tone
+1F469 1F3FC 200D 1F9BD                                 ; fully-qualified     # 👩🏼‍🦽 E12.0 woman in manual wheelchair: medium-light skin tone
+1F469 1F3FD 200D 1F9BD                                 ; fully-qualified     # 👩🏽‍🦽 E12.0 woman in manual wheelchair: medium skin tone
+1F469 1F3FE 200D 1F9BD                                 ; fully-qualified     # 👩🏾‍🦽 E12.0 woman in manual wheelchair: medium-dark skin tone
+1F469 1F3FF 200D 1F9BD                                 ; fully-qualified     # 👩🏿‍🦽 E12.0 woman in manual wheelchair: dark skin tone
+1F469 200D 1F9BD 200D 27A1 FE0F                        ; fully-qualified     # 👩‍🦽‍➡️ E15.1 woman in manual wheelchair facing right
+1F469 200D 1F9BD 200D 27A1                             ; minimally-qualified # 👩‍🦽‍➡ E15.1 woman in manual wheelchair facing right
+1F469 1F3FB 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👩🏻‍🦽‍➡️ E15.1 woman in manual wheelchair facing right: light skin tone
+1F469 1F3FB 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👩🏻‍🦽‍➡ E15.1 woman in manual wheelchair facing right: light skin tone
+1F469 1F3FC 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👩🏼‍🦽‍➡️ E15.1 woman in manual wheelchair facing right: medium-light skin tone
+1F469 1F3FC 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👩🏼‍🦽‍➡ E15.1 woman in manual wheelchair facing right: medium-light skin tone
+1F469 1F3FD 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👩🏽‍🦽‍➡️ E15.1 woman in manual wheelchair facing right: medium skin tone
+1F469 1F3FD 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👩🏽‍🦽‍➡ E15.1 woman in manual wheelchair facing right: medium skin tone
+1F469 1F3FE 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👩🏾‍🦽‍➡️ E15.1 woman in manual wheelchair facing right: medium-dark skin tone
+1F469 1F3FE 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👩🏾‍🦽‍➡ E15.1 woman in manual wheelchair facing right: medium-dark skin tone
+1F469 1F3FF 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👩🏿‍🦽‍➡️ E15.1 woman in manual wheelchair facing right: dark skin tone
+1F469 1F3FF 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👩🏿‍🦽‍➡ E15.1 woman in manual wheelchair facing right: dark skin tone
+1F3C3                                                  ; fully-qualified     # 🏃 E0.6 person running
+1F3C3 1F3FB                                            ; fully-qualified     # 🏃🏻 E1.0 person running: light skin tone
+1F3C3 1F3FC                                            ; fully-qualified     # 🏃🏼 E1.0 person running: medium-light skin tone
+1F3C3 1F3FD                                            ; fully-qualified     # 🏃🏽 E1.0 person running: medium skin tone
+1F3C3 1F3FE                                            ; fully-qualified     # 🏃🏾 E1.0 person running: medium-dark skin tone
+1F3C3 1F3FF                                            ; fully-qualified     # 🏃🏿 E1.0 person running: dark skin tone
+1F3C3 200D 2642 FE0F                                   ; fully-qualified     # 🏃‍♂️ E4.0 man running
+1F3C3 200D 2642                                        ; minimally-qualified # 🏃‍♂ E4.0 man running
+1F3C3 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🏃🏻‍♂️ E4.0 man running: light skin tone
+1F3C3 1F3FB 200D 2642                                  ; minimally-qualified # 🏃🏻‍♂ E4.0 man running: light skin tone
+1F3C3 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🏃🏼‍♂️ E4.0 man running: medium-light skin tone
+1F3C3 1F3FC 200D 2642                                  ; minimally-qualified # 🏃🏼‍♂ E4.0 man running: medium-light skin tone
+1F3C3 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🏃🏽‍♂️ E4.0 man running: medium skin tone
+1F3C3 1F3FD 200D 2642                                  ; minimally-qualified # 🏃🏽‍♂ E4.0 man running: medium skin tone
+1F3C3 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🏃🏾‍♂️ E4.0 man running: medium-dark skin tone
+1F3C3 1F3FE 200D 2642                                  ; minimally-qualified # 🏃🏾‍♂ E4.0 man running: medium-dark skin tone
+1F3C3 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🏃🏿‍♂️ E4.0 man running: dark skin tone
+1F3C3 1F3FF 200D 2642                                  ; minimally-qualified # 🏃🏿‍♂ E4.0 man running: dark skin tone
+1F3C3 200D 2640 FE0F                                   ; fully-qualified     # 🏃‍♀️ E4.0 woman running
+1F3C3 200D 2640                                        ; minimally-qualified # 🏃‍♀ E4.0 woman running
+1F3C3 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🏃🏻‍♀️ E4.0 woman running: light skin tone
+1F3C3 1F3FB 200D 2640                                  ; minimally-qualified # 🏃🏻‍♀ E4.0 woman running: light skin tone
+1F3C3 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🏃🏼‍♀️ E4.0 woman running: medium-light skin tone
+1F3C3 1F3FC 200D 2640                                  ; minimally-qualified # 🏃🏼‍♀ E4.0 woman running: medium-light skin tone
+1F3C3 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🏃🏽‍♀️ E4.0 woman running: medium skin tone
+1F3C3 1F3FD 200D 2640                                  ; minimally-qualified # 🏃🏽‍♀ E4.0 woman running: medium skin tone
+1F3C3 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🏃🏾‍♀️ E4.0 woman running: medium-dark skin tone
+1F3C3 1F3FE 200D 2640                                  ; minimally-qualified # 🏃🏾‍♀ E4.0 woman running: medium-dark skin tone
+1F3C3 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🏃🏿‍♀️ E4.0 woman running: dark skin tone
+1F3C3 1F3FF 200D 2640                                  ; minimally-qualified # 🏃🏿‍♀ E4.0 woman running: dark skin tone
+1F3C3 200D 27A1 FE0F                                   ; fully-qualified     # 🏃‍➡️ E15.1 person running facing right
+1F3C3 200D 27A1                                        ; minimally-qualified # 🏃‍➡ E15.1 person running facing right
+1F3C3 1F3FB 200D 27A1 FE0F                             ; fully-qualified     # 🏃🏻‍➡️ E15.1 person running facing right: light skin tone
+1F3C3 1F3FB 200D 27A1                                  ; minimally-qualified # 🏃🏻‍➡ E15.1 person running facing right: light skin tone
+1F3C3 1F3FC 200D 27A1 FE0F                             ; fully-qualified     # 🏃🏼‍➡️ E15.1 person running facing right: medium-light skin tone
+1F3C3 1F3FC 200D 27A1                                  ; minimally-qualified # 🏃🏼‍➡ E15.1 person running facing right: medium-light skin tone
+1F3C3 1F3FD 200D 27A1 FE0F                             ; fully-qualified     # 🏃🏽‍➡️ E15.1 person running facing right: medium skin tone
+1F3C3 1F3FD 200D 27A1                                  ; minimally-qualified # 🏃🏽‍➡ E15.1 person running facing right: medium skin tone
+1F3C3 1F3FE 200D 27A1 FE0F                             ; fully-qualified     # 🏃🏾‍➡️ E15.1 person running facing right: medium-dark skin tone
+1F3C3 1F3FE 200D 27A1                                  ; minimally-qualified # 🏃🏾‍➡ E15.1 person running facing right: medium-dark skin tone
+1F3C3 1F3FF 200D 27A1 FE0F                             ; fully-qualified     # 🏃🏿‍➡️ E15.1 person running facing right: dark skin tone
+1F3C3 1F3FF 200D 27A1                                  ; minimally-qualified # 🏃🏿‍➡ E15.1 person running facing right: dark skin tone
+1F3C3 200D 2640 FE0F 200D 27A1 FE0F                    ; fully-qualified     # 🏃‍♀️‍➡️ E15.1 woman running facing right
+1F3C3 200D 2640 200D 27A1 FE0F                         ; minimally-qualified # 🏃‍♀‍➡️ E15.1 woman running facing right
+1F3C3 200D 2640 FE0F 200D 27A1                         ; minimally-qualified # 🏃‍♀️‍➡ E15.1 woman running facing right
+1F3C3 200D 2640 200D 27A1                              ; minimally-qualified # 🏃‍♀‍➡ E15.1 woman running facing right
+1F3C3 1F3FB 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏻‍♀️‍➡️ E15.1 woman running facing right: light skin tone
+1F3C3 1F3FB 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏻‍♀‍➡️ E15.1 woman running facing right: light skin tone
+1F3C3 1F3FB 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏻‍♀️‍➡ E15.1 woman running facing right: light skin tone
+1F3C3 1F3FB 200D 2640 200D 27A1                        ; minimally-qualified # 🏃🏻‍♀‍➡ E15.1 woman running facing right: light skin tone
+1F3C3 1F3FC 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏼‍♀️‍➡️ E15.1 woman running facing right: medium-light skin tone
+1F3C3 1F3FC 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏼‍♀‍➡️ E15.1 woman running facing right: medium-light skin tone
+1F3C3 1F3FC 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏼‍♀️‍➡ E15.1 woman running facing right: medium-light skin tone
+1F3C3 1F3FC 200D 2640 200D 27A1                        ; minimally-qualified # 🏃🏼‍♀‍➡ E15.1 woman running facing right: medium-light skin tone
+1F3C3 1F3FD 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏽‍♀️‍➡️ E15.1 woman running facing right: medium skin tone
+1F3C3 1F3FD 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏽‍♀‍➡️ E15.1 woman running facing right: medium skin tone
+1F3C3 1F3FD 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏽‍♀️‍➡ E15.1 woman running facing right: medium skin tone
+1F3C3 1F3FD 200D 2640 200D 27A1                        ; minimally-qualified # 🏃🏽‍♀‍➡ E15.1 woman running facing right: medium skin tone
+1F3C3 1F3FE 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏾‍♀️‍➡️ E15.1 woman running facing right: medium-dark skin tone
+1F3C3 1F3FE 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏾‍♀‍➡️ E15.1 woman running facing right: medium-dark skin tone
+1F3C3 1F3FE 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏾‍♀️‍➡ E15.1 woman running facing right: medium-dark skin tone
+1F3C3 1F3FE 200D 2640 200D 27A1                        ; minimally-qualified # 🏃🏾‍♀‍➡ E15.1 woman running facing right: medium-dark skin tone
+1F3C3 1F3FF 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏿‍♀️‍➡️ E15.1 woman running facing right: dark skin tone
+1F3C3 1F3FF 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏿‍♀‍➡️ E15.1 woman running facing right: dark skin tone
+1F3C3 1F3FF 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏿‍♀️‍➡ E15.1 woman running facing right: dark skin tone
+1F3C3 1F3FF 200D 2640 200D 27A1                        ; minimally-qualified # 🏃🏿‍♀‍➡ E15.1 woman running facing right: dark skin tone
+1F3C3 200D 2642 FE0F 200D 27A1 FE0F                    ; fully-qualified     # 🏃‍♂️‍➡️ E15.1 man running facing right
+1F3C3 200D 2642 200D 27A1 FE0F                         ; minimally-qualified # 🏃‍♂‍➡️ E15.1 man running facing right
+1F3C3 200D 2642 FE0F 200D 27A1                         ; minimally-qualified # 🏃‍♂️‍➡ E15.1 man running facing right
+1F3C3 200D 2642 200D 27A1                              ; minimally-qualified # 🏃‍♂‍➡ E15.1 man running facing right
+1F3C3 1F3FB 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏻‍♂️‍➡️ E15.1 man running facing right: light skin tone
+1F3C3 1F3FB 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏻‍♂‍➡️ E15.1 man running facing right: light skin tone
+1F3C3 1F3FB 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏻‍♂️‍➡ E15.1 man running facing right: light skin tone
+1F3C3 1F3FB 200D 2642 200D 27A1                        ; minimally-qualified # 🏃🏻‍♂‍➡ E15.1 man running facing right: light skin tone
+1F3C3 1F3FC 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏼‍♂️‍➡️ E15.1 man running facing right: medium-light skin tone
+1F3C3 1F3FC 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏼‍♂‍➡️ E15.1 man running facing right: medium-light skin tone
+1F3C3 1F3FC 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏼‍♂️‍➡ E15.1 man running facing right: medium-light skin tone
+1F3C3 1F3FC 200D 2642 200D 27A1                        ; minimally-qualified # 🏃🏼‍♂‍➡ E15.1 man running facing right: medium-light skin tone
+1F3C3 1F3FD 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏽‍♂️‍➡️ E15.1 man running facing right: medium skin tone
+1F3C3 1F3FD 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏽‍♂‍➡️ E15.1 man running facing right: medium skin tone
+1F3C3 1F3FD 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏽‍♂️‍➡ E15.1 man running facing right: medium skin tone
+1F3C3 1F3FD 200D 2642 200D 27A1                        ; minimally-qualified # 🏃🏽‍♂‍➡ E15.1 man running facing right: medium skin tone
+1F3C3 1F3FE 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏾‍♂️‍➡️ E15.1 man running facing right: medium-dark skin tone
+1F3C3 1F3FE 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏾‍♂‍➡️ E15.1 man running facing right: medium-dark skin tone
+1F3C3 1F3FE 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏾‍♂️‍➡ E15.1 man running facing right: medium-dark skin tone
+1F3C3 1F3FE 200D 2642 200D 27A1                        ; minimally-qualified # 🏃🏾‍♂‍➡ E15.1 man running facing right: medium-dark skin tone
+1F3C3 1F3FF 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏿‍♂️‍➡️ E15.1 man running facing right: dark skin tone
+1F3C3 1F3FF 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏿‍♂‍➡️ E15.1 man running facing right: dark skin tone
+1F3C3 1F3FF 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏿‍♂️‍➡ E15.1 man running facing right: dark skin tone
+1F3C3 1F3FF 200D 2642 200D 27A1                        ; minimally-qualified # 🏃🏿‍♂‍➡ E15.1 man running facing right: dark skin tone
+1F483                                                  ; fully-qualified     # 💃 E0.6 woman dancing
+1F483 1F3FB                                            ; fully-qualified     # 💃🏻 E1.0 woman dancing: light skin tone
+1F483 1F3FC                                            ; fully-qualified     # 💃🏼 E1.0 woman dancing: medium-light skin tone
+1F483 1F3FD                                            ; fully-qualified     # 💃🏽 E1.0 woman dancing: medium skin tone
+1F483 1F3FE                                            ; fully-qualified     # 💃🏾 E1.0 woman dancing: medium-dark skin tone
+1F483 1F3FF                                            ; fully-qualified     # 💃🏿 E1.0 woman dancing: dark skin tone
+1F57A                                                  ; fully-qualified     # 🕺 E3.0 man dancing
+1F57A 1F3FB                                            ; fully-qualified     # 🕺🏻 E3.0 man dancing: light skin tone
+1F57A 1F3FC                                            ; fully-qualified     # 🕺🏼 E3.0 man dancing: medium-light skin tone
+1F57A 1F3FD                                            ; fully-qualified     # 🕺🏽 E3.0 man dancing: medium skin tone
+1F57A 1F3FE                                            ; fully-qualified     # 🕺🏾 E3.0 man dancing: medium-dark skin tone
+1F57A 1F3FF                                            ; fully-qualified     # 🕺🏿 E3.0 man dancing: dark skin tone
+1F574 FE0F                                             ; fully-qualified     # 🕴️ E0.7 person in suit levitating
+1F574                                                  ; unqualified         # 🕴 E0.7 person in suit levitating
+1F574 1F3FB                                            ; fully-qualified     # 🕴🏻 E4.0 person in suit levitating: light skin tone
+1F574 1F3FC                                            ; fully-qualified     # 🕴🏼 E4.0 person in suit levitating: medium-light skin tone
+1F574 1F3FD                                            ; fully-qualified     # 🕴🏽 E4.0 person in suit levitating: medium skin tone
+1F574 1F3FE                                            ; fully-qualified     # 🕴🏾 E4.0 person in suit levitating: medium-dark skin tone
+1F574 1F3FF                                            ; fully-qualified     # 🕴🏿 E4.0 person in suit levitating: dark skin tone
+1F46F                                                  ; fully-qualified     # 👯 E0.6 people with bunny ears
+1F46F 200D 2642 FE0F                                   ; fully-qualified     # 👯‍♂️ E4.0 men with bunny ears
+1F46F 200D 2642                                        ; minimally-qualified # 👯‍♂ E4.0 men with bunny ears
+1F46F 200D 2640 FE0F                                   ; fully-qualified     # 👯‍♀️ E4.0 women with bunny ears
+1F46F 200D 2640                                        ; minimally-qualified # 👯‍♀ E4.0 women with bunny ears
+1F9D6                                                  ; fully-qualified     # 🧖 E5.0 person in steamy room
+1F9D6 1F3FB                                            ; fully-qualified     # 🧖🏻 E5.0 person in steamy room: light skin tone
+1F9D6 1F3FC                                            ; fully-qualified     # 🧖🏼 E5.0 person in steamy room: medium-light skin tone
+1F9D6 1F3FD                                            ; fully-qualified     # 🧖🏽 E5.0 person in steamy room: medium skin tone
+1F9D6 1F3FE                                            ; fully-qualified     # 🧖🏾 E5.0 person in steamy room: medium-dark skin tone
+1F9D6 1F3FF                                            ; fully-qualified     # 🧖🏿 E5.0 person in steamy room: dark skin tone
+1F9D6 200D 2642 FE0F                                   ; fully-qualified     # 🧖‍♂️ E5.0 man in steamy room
+1F9D6 200D 2642                                        ; minimally-qualified # 🧖‍♂ E5.0 man in steamy room
+1F9D6 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🧖🏻‍♂️ E5.0 man in steamy room: light skin tone
+1F9D6 1F3FB 200D 2642                                  ; minimally-qualified # 🧖🏻‍♂ E5.0 man in steamy room: light skin tone
+1F9D6 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🧖🏼‍♂️ E5.0 man in steamy room: medium-light skin tone
+1F9D6 1F3FC 200D 2642                                  ; minimally-qualified # 🧖🏼‍♂ E5.0 man in steamy room: medium-light skin tone
+1F9D6 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🧖🏽‍♂️ E5.0 man in steamy room: medium skin tone
+1F9D6 1F3FD 200D 2642                                  ; minimally-qualified # 🧖🏽‍♂ E5.0 man in steamy room: medium skin tone
+1F9D6 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🧖🏾‍♂️ E5.0 man in steamy room: medium-dark skin tone
+1F9D6 1F3FE 200D 2642                                  ; minimally-qualified # 🧖🏾‍♂ E5.0 man in steamy room: medium-dark skin tone
+1F9D6 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🧖🏿‍♂️ E5.0 man in steamy room: dark skin tone
+1F9D6 1F3FF 200D 2642                                  ; minimally-qualified # 🧖🏿‍♂ E5.0 man in steamy room: dark skin tone
+1F9D6 200D 2640 FE0F                                   ; fully-qualified     # 🧖‍♀️ E5.0 woman in steamy room
+1F9D6 200D 2640                                        ; minimally-qualified # 🧖‍♀ E5.0 woman in steamy room
+1F9D6 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🧖🏻‍♀️ E5.0 woman in steamy room: light skin tone
+1F9D6 1F3FB 200D 2640                                  ; minimally-qualified # 🧖🏻‍♀ E5.0 woman in steamy room: light skin tone
+1F9D6 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🧖🏼‍♀️ E5.0 woman in steamy room: medium-light skin tone
+1F9D6 1F3FC 200D 2640                                  ; minimally-qualified # 🧖🏼‍♀ E5.0 woman in steamy room: medium-light skin tone
+1F9D6 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🧖🏽‍♀️ E5.0 woman in steamy room: medium skin tone
+1F9D6 1F3FD 200D 2640                                  ; minimally-qualified # 🧖🏽‍♀ E5.0 woman in steamy room: medium skin tone
+1F9D6 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🧖🏾‍♀️ E5.0 woman in steamy room: medium-dark skin tone
+1F9D6 1F3FE 200D 2640                                  ; minimally-qualified # 🧖🏾‍♀ E5.0 woman in steamy room: medium-dark skin tone
+1F9D6 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🧖🏿‍♀️ E5.0 woman in steamy room: dark skin tone
+1F9D6 1F3FF 200D 2640                                  ; minimally-qualified # 🧖🏿‍♀ E5.0 woman in steamy room: dark skin tone
+1F9D7                                                  ; fully-qualified     # 🧗 E5.0 person climbing
+1F9D7 1F3FB                                            ; fully-qualified     # 🧗🏻 E5.0 person climbing: light skin tone
+1F9D7 1F3FC                                            ; fully-qualified     # 🧗🏼 E5.0 person climbing: medium-light skin tone
+1F9D7 1F3FD                                            ; fully-qualified     # 🧗🏽 E5.0 person climbing: medium skin tone
+1F9D7 1F3FE                                            ; fully-qualified     # 🧗🏾 E5.0 person climbing: medium-dark skin tone
+1F9D7 1F3FF                                            ; fully-qualified     # 🧗🏿 E5.0 person climbing: dark skin tone
+1F9D7 200D 2642 FE0F                                   ; fully-qualified     # 🧗‍♂️ E5.0 man climbing
+1F9D7 200D 2642                                        ; minimally-qualified # 🧗‍♂ E5.0 man climbing
+1F9D7 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🧗🏻‍♂️ E5.0 man climbing: light skin tone
+1F9D7 1F3FB 200D 2642                                  ; minimally-qualified # 🧗🏻‍♂ E5.0 man climbing: light skin tone
+1F9D7 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🧗🏼‍♂️ E5.0 man climbing: medium-light skin tone
+1F9D7 1F3FC 200D 2642                                  ; minimally-qualified # 🧗🏼‍♂ E5.0 man climbing: medium-light skin tone
+1F9D7 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🧗🏽‍♂️ E5.0 man climbing: medium skin tone
+1F9D7 1F3FD 200D 2642                                  ; minimally-qualified # 🧗🏽‍♂ E5.0 man climbing: medium skin tone
+1F9D7 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🧗🏾‍♂️ E5.0 man climbing: medium-dark skin tone
+1F9D7 1F3FE 200D 2642                                  ; minimally-qualified # 🧗🏾‍♂ E5.0 man climbing: medium-dark skin tone
+1F9D7 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🧗🏿‍♂️ E5.0 man climbing: dark skin tone
+1F9D7 1F3FF 200D 2642                                  ; minimally-qualified # 🧗🏿‍♂ E5.0 man climbing: dark skin tone
+1F9D7 200D 2640 FE0F                                   ; fully-qualified     # 🧗‍♀️ E5.0 woman climbing
+1F9D7 200D 2640                                        ; minimally-qualified # 🧗‍♀ E5.0 woman climbing
+1F9D7 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🧗🏻‍♀️ E5.0 woman climbing: light skin tone
+1F9D7 1F3FB 200D 2640                                  ; minimally-qualified # 🧗🏻‍♀ E5.0 woman climbing: light skin tone
+1F9D7 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🧗🏼‍♀️ E5.0 woman climbing: medium-light skin tone
+1F9D7 1F3FC 200D 2640                                  ; minimally-qualified # 🧗🏼‍♀ E5.0 woman climbing: medium-light skin tone
+1F9D7 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🧗🏽‍♀️ E5.0 woman climbing: medium skin tone
+1F9D7 1F3FD 200D 2640                                  ; minimally-qualified # 🧗🏽‍♀ E5.0 woman climbing: medium skin tone
+1F9D7 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🧗🏾‍♀️ E5.0 woman climbing: medium-dark skin tone
+1F9D7 1F3FE 200D 2640                                  ; minimally-qualified # 🧗🏾‍♀ E5.0 woman climbing: medium-dark skin tone
+1F9D7 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🧗🏿‍♀️ E5.0 woman climbing: dark skin tone
+1F9D7 1F3FF 200D 2640                                  ; minimally-qualified # 🧗🏿‍♀ E5.0 woman climbing: dark skin tone
+
+# subgroup: person-sport
+1F93A                                                  ; fully-qualified     # 🤺 E3.0 person fencing
+1F3C7                                                  ; fully-qualified     # 🏇 E1.0 horse racing
+1F3C7 1F3FB                                            ; fully-qualified     # 🏇🏻 E1.0 horse racing: light skin tone
+1F3C7 1F3FC                                            ; fully-qualified     # 🏇🏼 E1.0 horse racing: medium-light skin tone
+1F3C7 1F3FD                                            ; fully-qualified     # 🏇🏽 E1.0 horse racing: medium skin tone
+1F3C7 1F3FE                                            ; fully-qualified     # 🏇🏾 E1.0 horse racing: medium-dark skin tone
+1F3C7 1F3FF                                            ; fully-qualified     # 🏇🏿 E1.0 horse racing: dark skin tone
+26F7 FE0F                                              ; fully-qualified     # ⛷️ E0.7 skier
+26F7                                                   ; unqualified         # ⛷ E0.7 skier
+1F3C2                                                  ; fully-qualified     # 🏂 E0.6 snowboarder
+1F3C2 1F3FB                                            ; fully-qualified     # 🏂🏻 E1.0 snowboarder: light skin tone
+1F3C2 1F3FC                                            ; fully-qualified     # 🏂🏼 E1.0 snowboarder: medium-light skin tone
+1F3C2 1F3FD                                            ; fully-qualified     # 🏂🏽 E1.0 snowboarder: medium skin tone
+1F3C2 1F3FE                                            ; fully-qualified     # 🏂🏾 E1.0 snowboarder: medium-dark skin tone
+1F3C2 1F3FF                                            ; fully-qualified     # 🏂🏿 E1.0 snowboarder: dark skin tone
+1F3CC FE0F                                             ; fully-qualified     # 🏌️ E0.7 person golfing
+1F3CC                                                  ; unqualified         # 🏌 E0.7 person golfing
+1F3CC 1F3FB                                            ; fully-qualified     # 🏌🏻 E4.0 person golfing: light skin tone
+1F3CC 1F3FC                                            ; fully-qualified     # 🏌🏼 E4.0 person golfing: medium-light skin tone
+1F3CC 1F3FD                                            ; fully-qualified     # 🏌🏽 E4.0 person golfing: medium skin tone
+1F3CC 1F3FE                                            ; fully-qualified     # 🏌🏾 E4.0 person golfing: medium-dark skin tone
+1F3CC 1F3FF                                            ; fully-qualified     # 🏌🏿 E4.0 person golfing: dark skin tone
+1F3CC FE0F 200D 2642 FE0F                              ; fully-qualified     # 🏌️‍♂️ E4.0 man golfing
+1F3CC 200D 2642 FE0F                                   ; unqualified         # 🏌‍♂️ E4.0 man golfing
+1F3CC FE0F 200D 2642                                   ; minimally-qualified # 🏌️‍♂ E4.0 man golfing
+1F3CC 200D 2642                                        ; unqualified         # 🏌‍♂ E4.0 man golfing
+1F3CC 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🏌🏻‍♂️ E4.0 man golfing: light skin tone
+1F3CC 1F3FB 200D 2642                                  ; minimally-qualified # 🏌🏻‍♂ E4.0 man golfing: light skin tone
+1F3CC 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🏌🏼‍♂️ E4.0 man golfing: medium-light skin tone
+1F3CC 1F3FC 200D 2642                                  ; minimally-qualified # 🏌🏼‍♂ E4.0 man golfing: medium-light skin tone
+1F3CC 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🏌🏽‍♂️ E4.0 man golfing: medium skin tone
+1F3CC 1F3FD 200D 2642                                  ; minimally-qualified # 🏌🏽‍♂ E4.0 man golfing: medium skin tone
+1F3CC 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🏌🏾‍♂️ E4.0 man golfing: medium-dark skin tone
+1F3CC 1F3FE 200D 2642                                  ; minimally-qualified # 🏌🏾‍♂ E4.0 man golfing: medium-dark skin tone
+1F3CC 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🏌🏿‍♂️ E4.0 man golfing: dark skin tone
+1F3CC 1F3FF 200D 2642                                  ; minimally-qualified # 🏌🏿‍♂ E4.0 man golfing: dark skin tone
+1F3CC FE0F 200D 2640 FE0F                              ; fully-qualified     # 🏌️‍♀️ E4.0 woman golfing
+1F3CC 200D 2640 FE0F                                   ; unqualified         # 🏌‍♀️ E4.0 woman golfing
+1F3CC FE0F 200D 2640                                   ; minimally-qualified # 🏌️‍♀ E4.0 woman golfing
+1F3CC 200D 2640                                        ; unqualified         # 🏌‍♀ E4.0 woman golfing
+1F3CC 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🏌🏻‍♀️ E4.0 woman golfing: light skin tone
+1F3CC 1F3FB 200D 2640                                  ; minimally-qualified # 🏌🏻‍♀ E4.0 woman golfing: light skin tone
+1F3CC 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🏌🏼‍♀️ E4.0 woman golfing: medium-light skin tone
+1F3CC 1F3FC 200D 2640                                  ; minimally-qualified # 🏌🏼‍♀ E4.0 woman golfing: medium-light skin tone
+1F3CC 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🏌🏽‍♀️ E4.0 woman golfing: medium skin tone
+1F3CC 1F3FD 200D 2640                                  ; minimally-qualified # 🏌🏽‍♀ E4.0 woman golfing: medium skin tone
+1F3CC 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🏌🏾‍♀️ E4.0 woman golfing: medium-dark skin tone
+1F3CC 1F3FE 200D 2640                                  ; minimally-qualified # 🏌🏾‍♀ E4.0 woman golfing: medium-dark skin tone
+1F3CC 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🏌🏿‍♀️ E4.0 woman golfing: dark skin tone
+1F3CC 1F3FF 200D 2640                                  ; minimally-qualified # 🏌🏿‍♀ E4.0 woman golfing: dark skin tone
+1F3C4                                                  ; fully-qualified     # 🏄 E0.6 person surfing
+1F3C4 1F3FB                                            ; fully-qualified     # 🏄🏻 E1.0 person surfing: light skin tone
+1F3C4 1F3FC                                            ; fully-qualified     # 🏄🏼 E1.0 person surfing: medium-light skin tone
+1F3C4 1F3FD                                            ; fully-qualified     # 🏄🏽 E1.0 person surfing: medium skin tone
+1F3C4 1F3FE                                            ; fully-qualified     # 🏄🏾 E1.0 person surfing: medium-dark skin tone
+1F3C4 1F3FF                                            ; fully-qualified     # 🏄🏿 E1.0 person surfing: dark skin tone
+1F3C4 200D 2642 FE0F                                   ; fully-qualified     # 🏄‍♂️ E4.0 man surfing
+1F3C4 200D 2642                                        ; minimally-qualified # 🏄‍♂ E4.0 man surfing
+1F3C4 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🏄🏻‍♂️ E4.0 man surfing: light skin tone
+1F3C4 1F3FB 200D 2642                                  ; minimally-qualified # 🏄🏻‍♂ E4.0 man surfing: light skin tone
+1F3C4 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🏄🏼‍♂️ E4.0 man surfing: medium-light skin tone
+1F3C4 1F3FC 200D 2642                                  ; minimally-qualified # 🏄🏼‍♂ E4.0 man surfing: medium-light skin tone
+1F3C4 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🏄🏽‍♂️ E4.0 man surfing: medium skin tone
+1F3C4 1F3FD 200D 2642                                  ; minimally-qualified # 🏄🏽‍♂ E4.0 man surfing: medium skin tone
+1F3C4 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🏄🏾‍♂️ E4.0 man surfing: medium-dark skin tone
+1F3C4 1F3FE 200D 2642                                  ; minimally-qualified # 🏄🏾‍♂ E4.0 man surfing: medium-dark skin tone
+1F3C4 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🏄🏿‍♂️ E4.0 man surfing: dark skin tone
+1F3C4 1F3FF 200D 2642                                  ; minimally-qualified # 🏄🏿‍♂ E4.0 man surfing: dark skin tone
+1F3C4 200D 2640 FE0F                                   ; fully-qualified     # 🏄‍♀️ E4.0 woman surfing
+1F3C4 200D 2640                                        ; minimally-qualified # 🏄‍♀ E4.0 woman surfing
+1F3C4 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🏄🏻‍♀️ E4.0 woman surfing: light skin tone
+1F3C4 1F3FB 200D 2640                                  ; minimally-qualified # 🏄🏻‍♀ E4.0 woman surfing: light skin tone
+1F3C4 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🏄🏼‍♀️ E4.0 woman surfing: medium-light skin tone
+1F3C4 1F3FC 200D 2640                                  ; minimally-qualified # 🏄🏼‍♀ E4.0 woman surfing: medium-light skin tone
+1F3C4 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🏄🏽‍♀️ E4.0 woman surfing: medium skin tone
+1F3C4 1F3FD 200D 2640                                  ; minimally-qualified # 🏄🏽‍♀ E4.0 woman surfing: medium skin tone
+1F3C4 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🏄🏾‍♀️ E4.0 woman surfing: medium-dark skin tone
+1F3C4 1F3FE 200D 2640                                  ; minimally-qualified # 🏄🏾‍♀ E4.0 woman surfing: medium-dark skin tone
+1F3C4 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🏄🏿‍♀️ E4.0 woman surfing: dark skin tone
+1F3C4 1F3FF 200D 2640                                  ; minimally-qualified # 🏄🏿‍♀ E4.0 woman surfing: dark skin tone
+1F6A3                                                  ; fully-qualified     # 🚣 E1.0 person rowing boat
+1F6A3 1F3FB                                            ; fully-qualified     # 🚣🏻 E1.0 person rowing boat: light skin tone
+1F6A3 1F3FC                                            ; fully-qualified     # 🚣🏼 E1.0 person rowing boat: medium-light skin tone
+1F6A3 1F3FD                                            ; fully-qualified     # 🚣🏽 E1.0 person rowing boat: medium skin tone
+1F6A3 1F3FE                                            ; fully-qualified     # 🚣🏾 E1.0 person rowing boat: medium-dark skin tone
+1F6A3 1F3FF                                            ; fully-qualified     # 🚣🏿 E1.0 person rowing boat: dark skin tone
+1F6A3 200D 2642 FE0F                                   ; fully-qualified     # 🚣‍♂️ E4.0 man rowing boat
+1F6A3 200D 2642                                        ; minimally-qualified # 🚣‍♂ E4.0 man rowing boat
+1F6A3 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🚣🏻‍♂️ E4.0 man rowing boat: light skin tone
+1F6A3 1F3FB 200D 2642                                  ; minimally-qualified # 🚣🏻‍♂ E4.0 man rowing boat: light skin tone
+1F6A3 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🚣🏼‍♂️ E4.0 man rowing boat: medium-light skin tone
+1F6A3 1F3FC 200D 2642                                  ; minimally-qualified # 🚣🏼‍♂ E4.0 man rowing boat: medium-light skin tone
+1F6A3 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🚣🏽‍♂️ E4.0 man rowing boat: medium skin tone
+1F6A3 1F3FD 200D 2642                                  ; minimally-qualified # 🚣🏽‍♂ E4.0 man rowing boat: medium skin tone
+1F6A3 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🚣🏾‍♂️ E4.0 man rowing boat: medium-dark skin tone
+1F6A3 1F3FE 200D 2642                                  ; minimally-qualified # 🚣🏾‍♂ E4.0 man rowing boat: medium-dark skin tone
+1F6A3 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🚣🏿‍♂️ E4.0 man rowing boat: dark skin tone
+1F6A3 1F3FF 200D 2642                                  ; minimally-qualified # 🚣🏿‍♂ E4.0 man rowing boat: dark skin tone
+1F6A3 200D 2640 FE0F                                   ; fully-qualified     # 🚣‍♀️ E4.0 woman rowing boat
+1F6A3 200D 2640                                        ; minimally-qualified # 🚣‍♀ E4.0 woman rowing boat
+1F6A3 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🚣🏻‍♀️ E4.0 woman rowing boat: light skin tone
+1F6A3 1F3FB 200D 2640                                  ; minimally-qualified # 🚣🏻‍♀ E4.0 woman rowing boat: light skin tone
+1F6A3 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🚣🏼‍♀️ E4.0 woman rowing boat: medium-light skin tone
+1F6A3 1F3FC 200D 2640                                  ; minimally-qualified # 🚣🏼‍♀ E4.0 woman rowing boat: medium-light skin tone
+1F6A3 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🚣🏽‍♀️ E4.0 woman rowing boat: medium skin tone
+1F6A3 1F3FD 200D 2640                                  ; minimally-qualified # 🚣🏽‍♀ E4.0 woman rowing boat: medium skin tone
+1F6A3 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🚣🏾‍♀️ E4.0 woman rowing boat: medium-dark skin tone
+1F6A3 1F3FE 200D 2640                                  ; minimally-qualified # 🚣🏾‍♀ E4.0 woman rowing boat: medium-dark skin tone
+1F6A3 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🚣🏿‍♀️ E4.0 woman rowing boat: dark skin tone
+1F6A3 1F3FF 200D 2640                                  ; minimally-qualified # 🚣🏿‍♀ E4.0 woman rowing boat: dark skin tone
+1F3CA                                                  ; fully-qualified     # 🏊 E0.6 person swimming
+1F3CA 1F3FB                                            ; fully-qualified     # 🏊🏻 E1.0 person swimming: light skin tone
+1F3CA 1F3FC                                            ; fully-qualified     # 🏊🏼 E1.0 person swimming: medium-light skin tone
+1F3CA 1F3FD                                            ; fully-qualified     # 🏊🏽 E1.0 person swimming: medium skin tone
+1F3CA 1F3FE                                            ; fully-qualified     # 🏊🏾 E1.0 person swimming: medium-dark skin tone
+1F3CA 1F3FF                                            ; fully-qualified     # 🏊🏿 E1.0 person swimming: dark skin tone
+1F3CA 200D 2642 FE0F                                   ; fully-qualified     # 🏊‍♂️ E4.0 man swimming
+1F3CA 200D 2642                                        ; minimally-qualified # 🏊‍♂ E4.0 man swimming
+1F3CA 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🏊🏻‍♂️ E4.0 man swimming: light skin tone
+1F3CA 1F3FB 200D 2642                                  ; minimally-qualified # 🏊🏻‍♂ E4.0 man swimming: light skin tone
+1F3CA 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🏊🏼‍♂️ E4.0 man swimming: medium-light skin tone
+1F3CA 1F3FC 200D 2642                                  ; minimally-qualified # 🏊🏼‍♂ E4.0 man swimming: medium-light skin tone
+1F3CA 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🏊🏽‍♂️ E4.0 man swimming: medium skin tone
+1F3CA 1F3FD 200D 2642                                  ; minimally-qualified # 🏊🏽‍♂ E4.0 man swimming: medium skin tone
+1F3CA 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🏊🏾‍♂️ E4.0 man swimming: medium-dark skin tone
+1F3CA 1F3FE 200D 2642                                  ; minimally-qualified # 🏊🏾‍♂ E4.0 man swimming: medium-dark skin tone
+1F3CA 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🏊🏿‍♂️ E4.0 man swimming: dark skin tone
+1F3CA 1F3FF 200D 2642                                  ; minimally-qualified # 🏊🏿‍♂ E4.0 man swimming: dark skin tone
+1F3CA 200D 2640 FE0F                                   ; fully-qualified     # 🏊‍♀️ E4.0 woman swimming
+1F3CA 200D 2640                                        ; minimally-qualified # 🏊‍♀ E4.0 woman swimming
+1F3CA 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🏊🏻‍♀️ E4.0 woman swimming: light skin tone
+1F3CA 1F3FB 200D 2640                                  ; minimally-qualified # 🏊🏻‍♀ E4.0 woman swimming: light skin tone
+1F3CA 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🏊🏼‍♀️ E4.0 woman swimming: medium-light skin tone
+1F3CA 1F3FC 200D 2640                                  ; minimally-qualified # 🏊🏼‍♀ E4.0 woman swimming: medium-light skin tone
+1F3CA 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🏊🏽‍♀️ E4.0 woman swimming: medium skin tone
+1F3CA 1F3FD 200D 2640                                  ; minimally-qualified # 🏊🏽‍♀ E4.0 woman swimming: medium skin tone
+1F3CA 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🏊🏾‍♀️ E4.0 woman swimming: medium-dark skin tone
+1F3CA 1F3FE 200D 2640                                  ; minimally-qualified # 🏊🏾‍♀ E4.0 woman swimming: medium-dark skin tone
+1F3CA 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🏊🏿‍♀️ E4.0 woman swimming: dark skin tone
+1F3CA 1F3FF 200D 2640                                  ; minimally-qualified # 🏊🏿‍♀ E4.0 woman swimming: dark skin tone
+26F9 FE0F                                              ; fully-qualified     # ⛹️ E0.7 person bouncing ball
+26F9                                                   ; unqualified         # ⛹ E0.7 person bouncing ball
+26F9 1F3FB                                             ; fully-qualified     # ⛹🏻 E2.0 person bouncing ball: light skin tone
+26F9 1F3FC                                             ; fully-qualified     # ⛹🏼 E2.0 person bouncing ball: medium-light skin tone
+26F9 1F3FD                                             ; fully-qualified     # ⛹🏽 E2.0 person bouncing ball: medium skin tone
+26F9 1F3FE                                             ; fully-qualified     # ⛹🏾 E2.0 person bouncing ball: medium-dark skin tone
+26F9 1F3FF                                             ; fully-qualified     # ⛹🏿 E2.0 person bouncing ball: dark skin tone
+26F9 FE0F 200D 2642 FE0F                               ; fully-qualified     # ⛹️‍♂️ E4.0 man bouncing ball
+26F9 200D 2642 FE0F                                    ; unqualified         # ⛹‍♂️ E4.0 man bouncing ball
+26F9 FE0F 200D 2642                                    ; minimally-qualified # ⛹️‍♂ E4.0 man bouncing ball
+26F9 200D 2642                                         ; unqualified         # ⛹‍♂ E4.0 man bouncing ball
+26F9 1F3FB 200D 2642 FE0F                              ; fully-qualified     # ⛹🏻‍♂️ E4.0 man bouncing ball: light skin tone
+26F9 1F3FB 200D 2642                                   ; minimally-qualified # ⛹🏻‍♂ E4.0 man bouncing ball: light skin tone
+26F9 1F3FC 200D 2642 FE0F                              ; fully-qualified     # ⛹🏼‍♂️ E4.0 man bouncing ball: medium-light skin tone
+26F9 1F3FC 200D 2642                                   ; minimally-qualified # ⛹🏼‍♂ E4.0 man bouncing ball: medium-light skin tone
+26F9 1F3FD 200D 2642 FE0F                              ; fully-qualified     # ⛹🏽‍♂️ E4.0 man bouncing ball: medium skin tone
+26F9 1F3FD 200D 2642                                   ; minimally-qualified # ⛹🏽‍♂ E4.0 man bouncing ball: medium skin tone
+26F9 1F3FE 200D 2642 FE0F                              ; fully-qualified     # ⛹🏾‍♂️ E4.0 man bouncing ball: medium-dark skin tone
+26F9 1F3FE 200D 2642                                   ; minimally-qualified # ⛹🏾‍♂ E4.0 man bouncing ball: medium-dark skin tone
+26F9 1F3FF 200D 2642 FE0F                              ; fully-qualified     # ⛹🏿‍♂️ E4.0 man bouncing ball: dark skin tone
+26F9 1F3FF 200D 2642                                   ; minimally-qualified # ⛹🏿‍♂ E4.0 man bouncing ball: dark skin tone
+26F9 FE0F 200D 2640 FE0F                               ; fully-qualified     # ⛹️‍♀️ E4.0 woman bouncing ball
+26F9 200D 2640 FE0F                                    ; unqualified         # ⛹‍♀️ E4.0 woman bouncing ball
+26F9 FE0F 200D 2640                                    ; minimally-qualified # ⛹️‍♀ E4.0 woman bouncing ball
+26F9 200D 2640                                         ; unqualified         # ⛹‍♀ E4.0 woman bouncing ball
+26F9 1F3FB 200D 2640 FE0F                              ; fully-qualified     # ⛹🏻‍♀️ E4.0 woman bouncing ball: light skin tone
+26F9 1F3FB 200D 2640                                   ; minimally-qualified # ⛹🏻‍♀ E4.0 woman bouncing ball: light skin tone
+26F9 1F3FC 200D 2640 FE0F                              ; fully-qualified     # ⛹🏼‍♀️ E4.0 woman bouncing ball: medium-light skin tone
+26F9 1F3FC 200D 2640                                   ; minimally-qualified # ⛹🏼‍♀ E4.0 woman bouncing ball: medium-light skin tone
+26F9 1F3FD 200D 2640 FE0F                              ; fully-qualified     # ⛹🏽‍♀️ E4.0 woman bouncing ball: medium skin tone
+26F9 1F3FD 200D 2640                                   ; minimally-qualified # ⛹🏽‍♀ E4.0 woman bouncing ball: medium skin tone
+26F9 1F3FE 200D 2640 FE0F                              ; fully-qualified     # ⛹🏾‍♀️ E4.0 woman bouncing ball: medium-dark skin tone
+26F9 1F3FE 200D 2640                                   ; minimally-qualified # ⛹🏾‍♀ E4.0 woman bouncing ball: medium-dark skin tone
+26F9 1F3FF 200D 2640 FE0F                              ; fully-qualified     # ⛹🏿‍♀️ E4.0 woman bouncing ball: dark skin tone
+26F9 1F3FF 200D 2640                                   ; minimally-qualified # ⛹🏿‍♀ E4.0 woman bouncing ball: dark skin tone
+1F3CB FE0F                                             ; fully-qualified     # 🏋️ E0.7 person lifting weights
+1F3CB                                                  ; unqualified         # 🏋 E0.7 person lifting weights
+1F3CB 1F3FB                                            ; fully-qualified     # 🏋🏻 E2.0 person lifting weights: light skin tone
+1F3CB 1F3FC                                            ; fully-qualified     # 🏋🏼 E2.0 person lifting weights: medium-light skin tone
+1F3CB 1F3FD                                            ; fully-qualified     # 🏋🏽 E2.0 person lifting weights: medium skin tone
+1F3CB 1F3FE                                            ; fully-qualified     # 🏋🏾 E2.0 person lifting weights: medium-dark skin tone
+1F3CB 1F3FF                                            ; fully-qualified     # 🏋🏿 E2.0 person lifting weights: dark skin tone
+1F3CB FE0F 200D 2642 FE0F                              ; fully-qualified     # 🏋️‍♂️ E4.0 man lifting weights
+1F3CB 200D 2642 FE0F                                   ; unqualified         # 🏋‍♂️ E4.0 man lifting weights
+1F3CB FE0F 200D 2642                                   ; minimally-qualified # 🏋️‍♂ E4.0 man lifting weights
+1F3CB 200D 2642                                        ; unqualified         # 🏋‍♂ E4.0 man lifting weights
+1F3CB 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🏋🏻‍♂️ E4.0 man lifting weights: light skin tone
+1F3CB 1F3FB 200D 2642                                  ; minimally-qualified # 🏋🏻‍♂ E4.0 man lifting weights: light skin tone
+1F3CB 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🏋🏼‍♂️ E4.0 man lifting weights: medium-light skin tone
+1F3CB 1F3FC 200D 2642                                  ; minimally-qualified # 🏋🏼‍♂ E4.0 man lifting weights: medium-light skin tone
+1F3CB 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🏋🏽‍♂️ E4.0 man lifting weights: medium skin tone
+1F3CB 1F3FD 200D 2642                                  ; minimally-qualified # 🏋🏽‍♂ E4.0 man lifting weights: medium skin tone
+1F3CB 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🏋🏾‍♂️ E4.0 man lifting weights: medium-dark skin tone
+1F3CB 1F3FE 200D 2642                                  ; minimally-qualified # 🏋🏾‍♂ E4.0 man lifting weights: medium-dark skin tone
+1F3CB 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🏋🏿‍♂️ E4.0 man lifting weights: dark skin tone
+1F3CB 1F3FF 200D 2642                                  ; minimally-qualified # 🏋🏿‍♂ E4.0 man lifting weights: dark skin tone
+1F3CB FE0F 200D 2640 FE0F                              ; fully-qualified     # 🏋️‍♀️ E4.0 woman lifting weights
+1F3CB 200D 2640 FE0F                                   ; unqualified         # 🏋‍♀️ E4.0 woman lifting weights
+1F3CB FE0F 200D 2640                                   ; minimally-qualified # 🏋️‍♀ E4.0 woman lifting weights
+1F3CB 200D 2640                                        ; unqualified         # 🏋‍♀ E4.0 woman lifting weights
+1F3CB 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🏋🏻‍♀️ E4.0 woman lifting weights: light skin tone
+1F3CB 1F3FB 200D 2640                                  ; minimally-qualified # 🏋🏻‍♀ E4.0 woman lifting weights: light skin tone
+1F3CB 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🏋🏼‍♀️ E4.0 woman lifting weights: medium-light skin tone
+1F3CB 1F3FC 200D 2640                                  ; minimally-qualified # 🏋🏼‍♀ E4.0 woman lifting weights: medium-light skin tone
+1F3CB 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🏋🏽‍♀️ E4.0 woman lifting weights: medium skin tone
+1F3CB 1F3FD 200D 2640                                  ; minimally-qualified # 🏋🏽‍♀ E4.0 woman lifting weights: medium skin tone
+1F3CB 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🏋🏾‍♀️ E4.0 woman lifting weights: medium-dark skin tone
+1F3CB 1F3FE 200D 2640                                  ; minimally-qualified # 🏋🏾‍♀ E4.0 woman lifting weights: medium-dark skin tone
+1F3CB 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🏋🏿‍♀️ E4.0 woman lifting weights: dark skin tone
+1F3CB 1F3FF 200D 2640                                  ; minimally-qualified # 🏋🏿‍♀ E4.0 woman lifting weights: dark skin tone
+1F6B4                                                  ; fully-qualified     # 🚴 E1.0 person biking
+1F6B4 1F3FB                                            ; fully-qualified     # 🚴🏻 E1.0 person biking: light skin tone
+1F6B4 1F3FC                                            ; fully-qualified     # 🚴🏼 E1.0 person biking: medium-light skin tone
+1F6B4 1F3FD                                            ; fully-qualified     # 🚴🏽 E1.0 person biking: medium skin tone
+1F6B4 1F3FE                                            ; fully-qualified     # 🚴🏾 E1.0 person biking: medium-dark skin tone
+1F6B4 1F3FF                                            ; fully-qualified     # 🚴🏿 E1.0 person biking: dark skin tone
+1F6B4 200D 2642 FE0F                                   ; fully-qualified     # 🚴‍♂️ E4.0 man biking
+1F6B4 200D 2642                                        ; minimally-qualified # 🚴‍♂ E4.0 man biking
+1F6B4 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🚴🏻‍♂️ E4.0 man biking: light skin tone
+1F6B4 1F3FB 200D 2642                                  ; minimally-qualified # 🚴🏻‍♂ E4.0 man biking: light skin tone
+1F6B4 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🚴🏼‍♂️ E4.0 man biking: medium-light skin tone
+1F6B4 1F3FC 200D 2642                                  ; minimally-qualified # 🚴🏼‍♂ E4.0 man biking: medium-light skin tone
+1F6B4 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🚴🏽‍♂️ E4.0 man biking: medium skin tone
+1F6B4 1F3FD 200D 2642                                  ; minimally-qualified # 🚴🏽‍♂ E4.0 man biking: medium skin tone
+1F6B4 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🚴🏾‍♂️ E4.0 man biking: medium-dark skin tone
+1F6B4 1F3FE 200D 2642                                  ; minimally-qualified # 🚴🏾‍♂ E4.0 man biking: medium-dark skin tone
+1F6B4 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🚴🏿‍♂️ E4.0 man biking: dark skin tone
+1F6B4 1F3FF 200D 2642                                  ; minimally-qualified # 🚴🏿‍♂ E4.0 man biking: dark skin tone
+1F6B4 200D 2640 FE0F                                   ; fully-qualified     # 🚴‍♀️ E4.0 woman biking
+1F6B4 200D 2640                                        ; minimally-qualified # 🚴‍♀ E4.0 woman biking
+1F6B4 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🚴🏻‍♀️ E4.0 woman biking: light skin tone
+1F6B4 1F3FB 200D 2640                                  ; minimally-qualified # 🚴🏻‍♀ E4.0 woman biking: light skin tone
+1F6B4 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🚴🏼‍♀️ E4.0 woman biking: medium-light skin tone
+1F6B4 1F3FC 200D 2640                                  ; minimally-qualified # 🚴🏼‍♀ E4.0 woman biking: medium-light skin tone
+1F6B4 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🚴🏽‍♀️ E4.0 woman biking: medium skin tone
+1F6B4 1F3FD 200D 2640                                  ; minimally-qualified # 🚴🏽‍♀ E4.0 woman biking: medium skin tone
+1F6B4 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🚴🏾‍♀️ E4.0 woman biking: medium-dark skin tone
+1F6B4 1F3FE 200D 2640                                  ; minimally-qualified # 🚴🏾‍♀ E4.0 woman biking: medium-dark skin tone
+1F6B4 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🚴🏿‍♀️ E4.0 woman biking: dark skin tone
+1F6B4 1F3FF 200D 2640                                  ; minimally-qualified # 🚴🏿‍♀ E4.0 woman biking: dark skin tone
+1F6B5                                                  ; fully-qualified     # 🚵 E1.0 person mountain biking
+1F6B5 1F3FB                                            ; fully-qualified     # 🚵🏻 E1.0 person mountain biking: light skin tone
+1F6B5 1F3FC                                            ; fully-qualified     # 🚵🏼 E1.0 person mountain biking: medium-light skin tone
+1F6B5 1F3FD                                            ; fully-qualified     # 🚵🏽 E1.0 person mountain biking: medium skin tone
+1F6B5 1F3FE                                            ; fully-qualified     # 🚵🏾 E1.0 person mountain biking: medium-dark skin tone
+1F6B5 1F3FF                                            ; fully-qualified     # 🚵🏿 E1.0 person mountain biking: dark skin tone
+1F6B5 200D 2642 FE0F                                   ; fully-qualified     # 🚵‍♂️ E4.0 man mountain biking
+1F6B5 200D 2642                                        ; minimally-qualified # 🚵‍♂ E4.0 man mountain biking
+1F6B5 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🚵🏻‍♂️ E4.0 man mountain biking: light skin tone
+1F6B5 1F3FB 200D 2642                                  ; minimally-qualified # 🚵🏻‍♂ E4.0 man mountain biking: light skin tone
+1F6B5 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🚵🏼‍♂️ E4.0 man mountain biking: medium-light skin tone
+1F6B5 1F3FC 200D 2642                                  ; minimally-qualified # 🚵🏼‍♂ E4.0 man mountain biking: medium-light skin tone
+1F6B5 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🚵🏽‍♂️ E4.0 man mountain biking: medium skin tone
+1F6B5 1F3FD 200D 2642                                  ; minimally-qualified # 🚵🏽‍♂ E4.0 man mountain biking: medium skin tone
+1F6B5 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🚵🏾‍♂️ E4.0 man mountain biking: medium-dark skin tone
+1F6B5 1F3FE 200D 2642                                  ; minimally-qualified # 🚵🏾‍♂ E4.0 man mountain biking: medium-dark skin tone
+1F6B5 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🚵🏿‍♂️ E4.0 man mountain biking: dark skin tone
+1F6B5 1F3FF 200D 2642                                  ; minimally-qualified # 🚵🏿‍♂ E4.0 man mountain biking: dark skin tone
+1F6B5 200D 2640 FE0F                                   ; fully-qualified     # 🚵‍♀️ E4.0 woman mountain biking
+1F6B5 200D 2640                                        ; minimally-qualified # 🚵‍♀ E4.0 woman mountain biking
+1F6B5 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🚵🏻‍♀️ E4.0 woman mountain biking: light skin tone
+1F6B5 1F3FB 200D 2640                                  ; minimally-qualified # 🚵🏻‍♀ E4.0 woman mountain biking: light skin tone
+1F6B5 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🚵🏼‍♀️ E4.0 woman mountain biking: medium-light skin tone
+1F6B5 1F3FC 200D 2640                                  ; minimally-qualified # 🚵🏼‍♀ E4.0 woman mountain biking: medium-light skin tone
+1F6B5 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🚵🏽‍♀️ E4.0 woman mountain biking: medium skin tone
+1F6B5 1F3FD 200D 2640                                  ; minimally-qualified # 🚵🏽‍♀ E4.0 woman mountain biking: medium skin tone
+1F6B5 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🚵🏾‍♀️ E4.0 woman mountain biking: medium-dark skin tone
+1F6B5 1F3FE 200D 2640                                  ; minimally-qualified # 🚵🏾‍♀ E4.0 woman mountain biking: medium-dark skin tone
+1F6B5 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🚵🏿‍♀️ E4.0 woman mountain biking: dark skin tone
+1F6B5 1F3FF 200D 2640                                  ; minimally-qualified # 🚵🏿‍♀ E4.0 woman mountain biking: dark skin tone
+1F938                                                  ; fully-qualified     # 🤸 E3.0 person cartwheeling
+1F938 1F3FB                                            ; fully-qualified     # 🤸🏻 E3.0 person cartwheeling: light skin tone
+1F938 1F3FC                                            ; fully-qualified     # 🤸🏼 E3.0 person cartwheeling: medium-light skin tone
+1F938 1F3FD                                            ; fully-qualified     # 🤸🏽 E3.0 person cartwheeling: medium skin tone
+1F938 1F3FE                                            ; fully-qualified     # 🤸🏾 E3.0 person cartwheeling: medium-dark skin tone
+1F938 1F3FF                                            ; fully-qualified     # 🤸🏿 E3.0 person cartwheeling: dark skin tone
+1F938 200D 2642 FE0F                                   ; fully-qualified     # 🤸‍♂️ E4.0 man cartwheeling
+1F938 200D 2642                                        ; minimally-qualified # 🤸‍♂ E4.0 man cartwheeling
+1F938 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🤸🏻‍♂️ E4.0 man cartwheeling: light skin tone
+1F938 1F3FB 200D 2642                                  ; minimally-qualified # 🤸🏻‍♂ E4.0 man cartwheeling: light skin tone
+1F938 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🤸🏼‍♂️ E4.0 man cartwheeling: medium-light skin tone
+1F938 1F3FC 200D 2642                                  ; minimally-qualified # 🤸🏼‍♂ E4.0 man cartwheeling: medium-light skin tone
+1F938 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🤸🏽‍♂️ E4.0 man cartwheeling: medium skin tone
+1F938 1F3FD 200D 2642                                  ; minimally-qualified # 🤸🏽‍♂ E4.0 man cartwheeling: medium skin tone
+1F938 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🤸🏾‍♂️ E4.0 man cartwheeling: medium-dark skin tone
+1F938 1F3FE 200D 2642                                  ; minimally-qualified # 🤸🏾‍♂ E4.0 man cartwheeling: medium-dark skin tone
+1F938 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🤸🏿‍♂️ E4.0 man cartwheeling: dark skin tone
+1F938 1F3FF 200D 2642                                  ; minimally-qualified # 🤸🏿‍♂ E4.0 man cartwheeling: dark skin tone
+1F938 200D 2640 FE0F                                   ; fully-qualified     # 🤸‍♀️ E4.0 woman cartwheeling
+1F938 200D 2640                                        ; minimally-qualified # 🤸‍♀ E4.0 woman cartwheeling
+1F938 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🤸🏻‍♀️ E4.0 woman cartwheeling: light skin tone
+1F938 1F3FB 200D 2640                                  ; minimally-qualified # 🤸🏻‍♀ E4.0 woman cartwheeling: light skin tone
+1F938 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🤸🏼‍♀️ E4.0 woman cartwheeling: medium-light skin tone
+1F938 1F3FC 200D 2640                                  ; minimally-qualified # 🤸🏼‍♀ E4.0 woman cartwheeling: medium-light skin tone
+1F938 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🤸🏽‍♀️ E4.0 woman cartwheeling: medium skin tone
+1F938 1F3FD 200D 2640                                  ; minimally-qualified # 🤸🏽‍♀ E4.0 woman cartwheeling: medium skin tone
+1F938 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🤸🏾‍♀️ E4.0 woman cartwheeling: medium-dark skin tone
+1F938 1F3FE 200D 2640                                  ; minimally-qualified # 🤸🏾‍♀ E4.0 woman cartwheeling: medium-dark skin tone
+1F938 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🤸🏿‍♀️ E4.0 woman cartwheeling: dark skin tone
+1F938 1F3FF 200D 2640                                  ; minimally-qualified # 🤸🏿‍♀ E4.0 woman cartwheeling: dark skin tone
+1F93C                                                  ; fully-qualified     # 🤼 E3.0 people wrestling
+1F93C 200D 2642 FE0F                                   ; fully-qualified     # 🤼‍♂️ E4.0 men wrestling
+1F93C 200D 2642                                        ; minimally-qualified # 🤼‍♂ E4.0 men wrestling
+1F93C 200D 2640 FE0F                                   ; fully-qualified     # 🤼‍♀️ E4.0 women wrestling
+1F93C 200D 2640                                        ; minimally-qualified # 🤼‍♀ E4.0 women wrestling
+1F93D                                                  ; fully-qualified     # 🤽 E3.0 person playing water polo
+1F93D 1F3FB                                            ; fully-qualified     # 🤽🏻 E3.0 person playing water polo: light skin tone
+1F93D 1F3FC                                            ; fully-qualified     # 🤽🏼 E3.0 person playing water polo: medium-light skin tone
+1F93D 1F3FD                                            ; fully-qualified     # 🤽🏽 E3.0 person playing water polo: medium skin tone
+1F93D 1F3FE                                            ; fully-qualified     # 🤽🏾 E3.0 person playing water polo: medium-dark skin tone
+1F93D 1F3FF                                            ; fully-qualified     # 🤽🏿 E3.0 person playing water polo: dark skin tone
+1F93D 200D 2642 FE0F                                   ; fully-qualified     # 🤽‍♂️ E4.0 man playing water polo
+1F93D 200D 2642                                        ; minimally-qualified # 🤽‍♂ E4.0 man playing water polo
+1F93D 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🤽🏻‍♂️ E4.0 man playing water polo: light skin tone
+1F93D 1F3FB 200D 2642                                  ; minimally-qualified # 🤽🏻‍♂ E4.0 man playing water polo: light skin tone
+1F93D 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🤽🏼‍♂️ E4.0 man playing water polo: medium-light skin tone
+1F93D 1F3FC 200D 2642                                  ; minimally-qualified # 🤽🏼‍♂ E4.0 man playing water polo: medium-light skin tone
+1F93D 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🤽🏽‍♂️ E4.0 man playing water polo: medium skin tone
+1F93D 1F3FD 200D 2642                                  ; minimally-qualified # 🤽🏽‍♂ E4.0 man playing water polo: medium skin tone
+1F93D 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🤽🏾‍♂️ E4.0 man playing water polo: medium-dark skin tone
+1F93D 1F3FE 200D 2642                                  ; minimally-qualified # 🤽🏾‍♂ E4.0 man playing water polo: medium-dark skin tone
+1F93D 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🤽🏿‍♂️ E4.0 man playing water polo: dark skin tone
+1F93D 1F3FF 200D 2642                                  ; minimally-qualified # 🤽🏿‍♂ E4.0 man playing water polo: dark skin tone
+1F93D 200D 2640 FE0F                                   ; fully-qualified     # 🤽‍♀️ E4.0 woman playing water polo
+1F93D 200D 2640                                        ; minimally-qualified # 🤽‍♀ E4.0 woman playing water polo
+1F93D 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🤽🏻‍♀️ E4.0 woman playing water polo: light skin tone
+1F93D 1F3FB 200D 2640                                  ; minimally-qualified # 🤽🏻‍♀ E4.0 woman playing water polo: light skin tone
+1F93D 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🤽🏼‍♀️ E4.0 woman playing water polo: medium-light skin tone
+1F93D 1F3FC 200D 2640                                  ; minimally-qualified # 🤽🏼‍♀ E4.0 woman playing water polo: medium-light skin tone
+1F93D 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🤽🏽‍♀️ E4.0 woman playing water polo: medium skin tone
+1F93D 1F3FD 200D 2640                                  ; minimally-qualified # 🤽🏽‍♀ E4.0 woman playing water polo: medium skin tone
+1F93D 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🤽🏾‍♀️ E4.0 woman playing water polo: medium-dark skin tone
+1F93D 1F3FE 200D 2640                                  ; minimally-qualified # 🤽🏾‍♀ E4.0 woman playing water polo: medium-dark skin tone
+1F93D 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🤽🏿‍♀️ E4.0 woman playing water polo: dark skin tone
+1F93D 1F3FF 200D 2640                                  ; minimally-qualified # 🤽🏿‍♀ E4.0 woman playing water polo: dark skin tone
+1F93E                                                  ; fully-qualified     # 🤾 E3.0 person playing handball
+1F93E 1F3FB                                            ; fully-qualified     # 🤾🏻 E3.0 person playing handball: light skin tone
+1F93E 1F3FC                                            ; fully-qualified     # 🤾🏼 E3.0 person playing handball: medium-light skin tone
+1F93E 1F3FD                                            ; fully-qualified     # 🤾🏽 E3.0 person playing handball: medium skin tone
+1F93E 1F3FE                                            ; fully-qualified     # 🤾🏾 E3.0 person playing handball: medium-dark skin tone
+1F93E 1F3FF                                            ; fully-qualified     # 🤾🏿 E3.0 person playing handball: dark skin tone
+1F93E 200D 2642 FE0F                                   ; fully-qualified     # 🤾‍♂️ E4.0 man playing handball
+1F93E 200D 2642                                        ; minimally-qualified # 🤾‍♂ E4.0 man playing handball
+1F93E 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🤾🏻‍♂️ E4.0 man playing handball: light skin tone
+1F93E 1F3FB 200D 2642                                  ; minimally-qualified # 🤾🏻‍♂ E4.0 man playing handball: light skin tone
+1F93E 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🤾🏼‍♂️ E4.0 man playing handball: medium-light skin tone
+1F93E 1F3FC 200D 2642                                  ; minimally-qualified # 🤾🏼‍♂ E4.0 man playing handball: medium-light skin tone
+1F93E 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🤾🏽‍♂️ E4.0 man playing handball: medium skin tone
+1F93E 1F3FD 200D 2642                                  ; minimally-qualified # 🤾🏽‍♂ E4.0 man playing handball: medium skin tone
+1F93E 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🤾🏾‍♂️ E4.0 man playing handball: medium-dark skin tone
+1F93E 1F3FE 200D 2642                                  ; minimally-qualified # 🤾🏾‍♂ E4.0 man playing handball: medium-dark skin tone
+1F93E 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🤾🏿‍♂️ E4.0 man playing handball: dark skin tone
+1F93E 1F3FF 200D 2642                                  ; minimally-qualified # 🤾🏿‍♂ E4.0 man playing handball: dark skin tone
+1F93E 200D 2640 FE0F                                   ; fully-qualified     # 🤾‍♀️ E4.0 woman playing handball
+1F93E 200D 2640                                        ; minimally-qualified # 🤾‍♀ E4.0 woman playing handball
+1F93E 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🤾🏻‍♀️ E4.0 woman playing handball: light skin tone
+1F93E 1F3FB 200D 2640                                  ; minimally-qualified # 🤾🏻‍♀ E4.0 woman playing handball: light skin tone
+1F93E 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🤾🏼‍♀️ E4.0 woman playing handball: medium-light skin tone
+1F93E 1F3FC 200D 2640                                  ; minimally-qualified # 🤾🏼‍♀ E4.0 woman playing handball: medium-light skin tone
+1F93E 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🤾🏽‍♀️ E4.0 woman playing handball: medium skin tone
+1F93E 1F3FD 200D 2640                                  ; minimally-qualified # 🤾🏽‍♀ E4.0 woman playing handball: medium skin tone
+1F93E 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🤾🏾‍♀️ E4.0 woman playing handball: medium-dark skin tone
+1F93E 1F3FE 200D 2640                                  ; minimally-qualified # 🤾🏾‍♀ E4.0 woman playing handball: medium-dark skin tone
+1F93E 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🤾🏿‍♀️ E4.0 woman playing handball: dark skin tone
+1F93E 1F3FF 200D 2640                                  ; minimally-qualified # 🤾🏿‍♀ E4.0 woman playing handball: dark skin tone
+1F939                                                  ; fully-qualified     # 🤹 E3.0 person juggling
+1F939 1F3FB                                            ; fully-qualified     # 🤹🏻 E3.0 person juggling: light skin tone
+1F939 1F3FC                                            ; fully-qualified     # 🤹🏼 E3.0 person juggling: medium-light skin tone
+1F939 1F3FD                                            ; fully-qualified     # 🤹🏽 E3.0 person juggling: medium skin tone
+1F939 1F3FE                                            ; fully-qualified     # 🤹🏾 E3.0 person juggling: medium-dark skin tone
+1F939 1F3FF                                            ; fully-qualified     # 🤹🏿 E3.0 person juggling: dark skin tone
+1F939 200D 2642 FE0F                                   ; fully-qualified     # 🤹‍♂️ E4.0 man juggling
+1F939 200D 2642                                        ; minimally-qualified # 🤹‍♂ E4.0 man juggling
+1F939 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🤹🏻‍♂️ E4.0 man juggling: light skin tone
+1F939 1F3FB 200D 2642                                  ; minimally-qualified # 🤹🏻‍♂ E4.0 man juggling: light skin tone
+1F939 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🤹🏼‍♂️ E4.0 man juggling: medium-light skin tone
+1F939 1F3FC 200D 2642                                  ; minimally-qualified # 🤹🏼‍♂ E4.0 man juggling: medium-light skin tone
+1F939 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🤹🏽‍♂️ E4.0 man juggling: medium skin tone
+1F939 1F3FD 200D 2642                                  ; minimally-qualified # 🤹🏽‍♂ E4.0 man juggling: medium skin tone
+1F939 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🤹🏾‍♂️ E4.0 man juggling: medium-dark skin tone
+1F939 1F3FE 200D 2642                                  ; minimally-qualified # 🤹🏾‍♂ E4.0 man juggling: medium-dark skin tone
+1F939 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🤹🏿‍♂️ E4.0 man juggling: dark skin tone
+1F939 1F3FF 200D 2642                                  ; minimally-qualified # 🤹🏿‍♂ E4.0 man juggling: dark skin tone
+1F939 200D 2640 FE0F                                   ; fully-qualified     # 🤹‍♀️ E4.0 woman juggling
+1F939 200D 2640                                        ; minimally-qualified # 🤹‍♀ E4.0 woman juggling
+1F939 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🤹🏻‍♀️ E4.0 woman juggling: light skin tone
+1F939 1F3FB 200D 2640                                  ; minimally-qualified # 🤹🏻‍♀ E4.0 woman juggling: light skin tone
+1F939 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🤹🏼‍♀️ E4.0 woman juggling: medium-light skin tone
+1F939 1F3FC 200D 2640                                  ; minimally-qualified # 🤹🏼‍♀ E4.0 woman juggling: medium-light skin tone
+1F939 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🤹🏽‍♀️ E4.0 woman juggling: medium skin tone
+1F939 1F3FD 200D 2640                                  ; minimally-qualified # 🤹🏽‍♀ E4.0 woman juggling: medium skin tone
+1F939 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🤹🏾‍♀️ E4.0 woman juggling: medium-dark skin tone
+1F939 1F3FE 200D 2640                                  ; minimally-qualified # 🤹🏾‍♀ E4.0 woman juggling: medium-dark skin tone
+1F939 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🤹🏿‍♀️ E4.0 woman juggling: dark skin tone
+1F939 1F3FF 200D 2640                                  ; minimally-qualified # 🤹🏿‍♀ E4.0 woman juggling: dark skin tone
+
+# subgroup: person-resting
+1F9D8                                                  ; fully-qualified     # 🧘 E5.0 person in lotus position
+1F9D8 1F3FB                                            ; fully-qualified     # 🧘🏻 E5.0 person in lotus position: light skin tone
+1F9D8 1F3FC                                            ; fully-qualified     # 🧘🏼 E5.0 person in lotus position: medium-light skin tone
+1F9D8 1F3FD                                            ; fully-qualified     # 🧘🏽 E5.0 person in lotus position: medium skin tone
+1F9D8 1F3FE                                            ; fully-qualified     # 🧘🏾 E5.0 person in lotus position: medium-dark skin tone
+1F9D8 1F3FF                                            ; fully-qualified     # 🧘🏿 E5.0 person in lotus position: dark skin tone
+1F9D8 200D 2642 FE0F                                   ; fully-qualified     # 🧘‍♂️ E5.0 man in lotus position
+1F9D8 200D 2642                                        ; minimally-qualified # 🧘‍♂ E5.0 man in lotus position
+1F9D8 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🧘🏻‍♂️ E5.0 man in lotus position: light skin tone
+1F9D8 1F3FB 200D 2642                                  ; minimally-qualified # 🧘🏻‍♂ E5.0 man in lotus position: light skin tone
+1F9D8 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🧘🏼‍♂️ E5.0 man in lotus position: medium-light skin tone
+1F9D8 1F3FC 200D 2642                                  ; minimally-qualified # 🧘🏼‍♂ E5.0 man in lotus position: medium-light skin tone
+1F9D8 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🧘🏽‍♂️ E5.0 man in lotus position: medium skin tone
+1F9D8 1F3FD 200D 2642                                  ; minimally-qualified # 🧘🏽‍♂ E5.0 man in lotus position: medium skin tone
+1F9D8 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🧘🏾‍♂️ E5.0 man in lotus position: medium-dark skin tone
+1F9D8 1F3FE 200D 2642                                  ; minimally-qualified # 🧘🏾‍♂ E5.0 man in lotus position: medium-dark skin tone
+1F9D8 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🧘🏿‍♂️ E5.0 man in lotus position: dark skin tone
+1F9D8 1F3FF 200D 2642                                  ; minimally-qualified # 🧘🏿‍♂ E5.0 man in lotus position: dark skin tone
+1F9D8 200D 2640 FE0F                                   ; fully-qualified     # 🧘‍♀️ E5.0 woman in lotus position
+1F9D8 200D 2640                                        ; minimally-qualified # 🧘‍♀ E5.0 woman in lotus position
+1F9D8 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🧘🏻‍♀️ E5.0 woman in lotus position: light skin tone
+1F9D8 1F3FB 200D 2640                                  ; minimally-qualified # 🧘🏻‍♀ E5.0 woman in lotus position: light skin tone
+1F9D8 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🧘🏼‍♀️ E5.0 woman in lotus position: medium-light skin tone
+1F9D8 1F3FC 200D 2640                                  ; minimally-qualified # 🧘🏼‍♀ E5.0 woman in lotus position: medium-light skin tone
+1F9D8 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🧘🏽‍♀️ E5.0 woman in lotus position: medium skin tone
+1F9D8 1F3FD 200D 2640                                  ; minimally-qualified # 🧘🏽‍♀ E5.0 woman in lotus position: medium skin tone
+1F9D8 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🧘🏾‍♀️ E5.0 woman in lotus position: medium-dark skin tone
+1F9D8 1F3FE 200D 2640                                  ; minimally-qualified # 🧘🏾‍♀ E5.0 woman in lotus position: medium-dark skin tone
+1F9D8 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🧘🏿‍♀️ E5.0 woman in lotus position: dark skin tone
+1F9D8 1F3FF 200D 2640                                  ; minimally-qualified # 🧘🏿‍♀ E5.0 woman in lotus position: dark skin tone
+1F6C0                                                  ; fully-qualified     # 🛀 E0.6 person taking bath
+1F6C0 1F3FB                                            ; fully-qualified     # 🛀🏻 E1.0 person taking bath: light skin tone
+1F6C0 1F3FC                                            ; fully-qualified     # 🛀🏼 E1.0 person taking bath: medium-light skin tone
+1F6C0 1F3FD                                            ; fully-qualified     # 🛀🏽 E1.0 person taking bath: medium skin tone
+1F6C0 1F3FE                                            ; fully-qualified     # 🛀🏾 E1.0 person taking bath: medium-dark skin tone
+1F6C0 1F3FF                                            ; fully-qualified     # 🛀🏿 E1.0 person taking bath: dark skin tone
+1F6CC                                                  ; fully-qualified     # 🛌 E1.0 person in bed
+1F6CC 1F3FB                                            ; fully-qualified     # 🛌🏻 E4.0 person in bed: light skin tone
+1F6CC 1F3FC                                            ; fully-qualified     # 🛌🏼 E4.0 person in bed: medium-light skin tone
+1F6CC 1F3FD                                            ; fully-qualified     # 🛌🏽 E4.0 person in bed: medium skin tone
+1F6CC 1F3FE                                            ; fully-qualified     # 🛌🏾 E4.0 person in bed: medium-dark skin tone
+1F6CC 1F3FF                                            ; fully-qualified     # 🛌🏿 E4.0 person in bed: dark skin tone
+
+# subgroup: family
+1F9D1 200D 1F91D 200D 1F9D1                            ; fully-qualified     # 🧑‍🤝‍🧑 E12.0 people holding hands
+1F9D1 1F3FB 200D 1F91D 200D 1F9D1 1F3FB                ; fully-qualified     # 🧑🏻‍🤝‍🧑🏻 E12.0 people holding hands: light skin tone
+1F9D1 1F3FB 200D 1F91D 200D 1F9D1 1F3FC                ; fully-qualified     # 🧑🏻‍🤝‍🧑🏼 E12.1 people holding hands: light skin tone, medium-light skin tone
+1F9D1 1F3FB 200D 1F91D 200D 1F9D1 1F3FD                ; fully-qualified     # 🧑🏻‍🤝‍🧑🏽 E12.1 people holding hands: light skin tone, medium skin tone
+1F9D1 1F3FB 200D 1F91D 200D 1F9D1 1F3FE                ; fully-qualified     # 🧑🏻‍🤝‍🧑🏾 E12.1 people holding hands: light skin tone, medium-dark skin tone
+1F9D1 1F3FB 200D 1F91D 200D 1F9D1 1F3FF                ; fully-qualified     # 🧑🏻‍🤝‍🧑🏿 E12.1 people holding hands: light skin tone, dark skin tone
+1F9D1 1F3FC 200D 1F91D 200D 1F9D1 1F3FB                ; fully-qualified     # 🧑🏼‍🤝‍🧑🏻 E12.0 people holding hands: medium-light skin tone, light skin tone
+1F9D1 1F3FC 200D 1F91D 200D 1F9D1 1F3FC                ; fully-qualified     # 🧑🏼‍🤝‍🧑🏼 E12.0 people holding hands: medium-light skin tone
+1F9D1 1F3FC 200D 1F91D 200D 1F9D1 1F3FD                ; fully-qualified     # 🧑🏼‍🤝‍🧑🏽 E12.1 people holding hands: medium-light skin tone, medium skin tone
+1F9D1 1F3FC 200D 1F91D 200D 1F9D1 1F3FE                ; fully-qualified     # 🧑🏼‍🤝‍🧑🏾 E12.1 people holding hands: medium-light skin tone, medium-dark skin tone
+1F9D1 1F3FC 200D 1F91D 200D 1F9D1 1F3FF                ; fully-qualified     # 🧑🏼‍🤝‍🧑🏿 E12.1 people holding hands: medium-light skin tone, dark skin tone
+1F9D1 1F3FD 200D 1F91D 200D 1F9D1 1F3FB                ; fully-qualified     # 🧑🏽‍🤝‍🧑🏻 E12.0 people holding hands: medium skin tone, light skin tone
+1F9D1 1F3FD 200D 1F91D 200D 1F9D1 1F3FC                ; fully-qualified     # 🧑🏽‍🤝‍🧑🏼 E12.0 people holding hands: medium skin tone, medium-light skin tone
+1F9D1 1F3FD 200D 1F91D 200D 1F9D1 1F3FD                ; fully-qualified     # 🧑🏽‍🤝‍🧑🏽 E12.0 people holding hands: medium skin tone
+1F9D1 1F3FD 200D 1F91D 200D 1F9D1 1F3FE                ; fully-qualified     # 🧑🏽‍🤝‍🧑🏾 E12.1 people holding hands: medium skin tone, medium-dark skin tone
+1F9D1 1F3FD 200D 1F91D 200D 1F9D1 1F3FF                ; fully-qualified     # 🧑🏽‍🤝‍🧑🏿 E12.1 people holding hands: medium skin tone, dark skin tone
+1F9D1 1F3FE 200D 1F91D 200D 1F9D1 1F3FB                ; fully-qualified     # 🧑🏾‍🤝‍🧑🏻 E12.0 people holding hands: medium-dark skin tone, light skin tone
+1F9D1 1F3FE 200D 1F91D 200D 1F9D1 1F3FC                ; fully-qualified     # 🧑🏾‍🤝‍🧑🏼 E12.0 people holding hands: medium-dark skin tone, medium-light skin tone
+1F9D1 1F3FE 200D 1F91D 200D 1F9D1 1F3FD                ; fully-qualified     # 🧑🏾‍🤝‍🧑🏽 E12.0 people holding hands: medium-dark skin tone, medium skin tone
+1F9D1 1F3FE 200D 1F91D 200D 1F9D1 1F3FE                ; fully-qualified     # 🧑🏾‍🤝‍🧑🏾 E12.0 people holding hands: medium-dark skin tone
+1F9D1 1F3FE 200D 1F91D 200D 1F9D1 1F3FF                ; fully-qualified     # 🧑🏾‍🤝‍🧑🏿 E12.1 people holding hands: medium-dark skin tone, dark skin tone
+1F9D1 1F3FF 200D 1F91D 200D 1F9D1 1F3FB                ; fully-qualified     # 🧑🏿‍🤝‍🧑🏻 E12.0 people holding hands: dark skin tone, light skin tone
+1F9D1 1F3FF 200D 1F91D 200D 1F9D1 1F3FC                ; fully-qualified     # 🧑🏿‍🤝‍🧑🏼 E12.0 people holding hands: dark skin tone, medium-light skin tone
+1F9D1 1F3FF 200D 1F91D 200D 1F9D1 1F3FD                ; fully-qualified     # 🧑🏿‍🤝‍🧑🏽 E12.0 people holding hands: dark skin tone, medium skin tone
+1F9D1 1F3FF 200D 1F91D 200D 1F9D1 1F3FE                ; fully-qualified     # 🧑🏿‍🤝‍🧑🏾 E12.0 people holding hands: dark skin tone, medium-dark skin tone
+1F9D1 1F3FF 200D 1F91D 200D 1F9D1 1F3FF                ; fully-qualified     # 🧑🏿‍🤝‍🧑🏿 E12.0 people holding hands: dark skin tone
+1F46D                                                  ; fully-qualified     # 👭 E1.0 women holding hands
+1F46D 1F3FB                                            ; fully-qualified     # 👭🏻 E12.0 women holding hands: light skin tone
+1F469 1F3FB 200D 1F91D 200D 1F469 1F3FC                ; fully-qualified     # 👩🏻‍🤝‍👩🏼 E12.1 women holding hands: light skin tone, medium-light skin tone
+1F469 1F3FB 200D 1F91D 200D 1F469 1F3FD                ; fully-qualified     # 👩🏻‍🤝‍👩🏽 E12.1 women holding hands: light skin tone, medium skin tone
+1F469 1F3FB 200D 1F91D 200D 1F469 1F3FE                ; fully-qualified     # 👩🏻‍🤝‍👩🏾 E12.1 women holding hands: light skin tone, medium-dark skin tone
+1F469 1F3FB 200D 1F91D 200D 1F469 1F3FF                ; fully-qualified     # 👩🏻‍🤝‍👩🏿 E12.1 women holding hands: light skin tone, dark skin tone
+1F469 1F3FC 200D 1F91D 200D 1F469 1F3FB                ; fully-qualified     # 👩🏼‍🤝‍👩🏻 E12.0 women holding hands: medium-light skin tone, light skin tone
+1F46D 1F3FC                                            ; fully-qualified     # 👭🏼 E12.0 women holding hands: medium-light skin tone
+1F469 1F3FC 200D 1F91D 200D 1F469 1F3FD                ; fully-qualified     # 👩🏼‍🤝‍👩🏽 E12.1 women holding hands: medium-light skin tone, medium skin tone
+1F469 1F3FC 200D 1F91D 200D 1F469 1F3FE                ; fully-qualified     # 👩🏼‍🤝‍👩🏾 E12.1 women holding hands: medium-light skin tone, medium-dark skin tone
+1F469 1F3FC 200D 1F91D 200D 1F469 1F3FF                ; fully-qualified     # 👩🏼‍🤝‍👩🏿 E12.1 women holding hands: medium-light skin tone, dark skin tone
+1F469 1F3FD 200D 1F91D 200D 1F469 1F3FB                ; fully-qualified     # 👩🏽‍🤝‍👩🏻 E12.0 women holding hands: medium skin tone, light skin tone
+1F469 1F3FD 200D 1F91D 200D 1F469 1F3FC                ; fully-qualified     # 👩🏽‍🤝‍👩🏼 E12.0 women holding hands: medium skin tone, medium-light skin tone
+1F46D 1F3FD                                            ; fully-qualified     # 👭🏽 E12.0 women holding hands: medium skin tone
+1F469 1F3FD 200D 1F91D 200D 1F469 1F3FE                ; fully-qualified     # 👩🏽‍🤝‍👩🏾 E12.1 women holding hands: medium skin tone, medium-dark skin tone
+1F469 1F3FD 200D 1F91D 200D 1F469 1F3FF                ; fully-qualified     # 👩🏽‍🤝‍👩🏿 E12.1 women holding hands: medium skin tone, dark skin tone
+1F469 1F3FE 200D 1F91D 200D 1F469 1F3FB                ; fully-qualified     # 👩🏾‍🤝‍👩🏻 E12.0 women holding hands: medium-dark skin tone, light skin tone
+1F469 1F3FE 200D 1F91D 200D 1F469 1F3FC                ; fully-qualified     # 👩🏾‍🤝‍👩🏼 E12.0 women holding hands: medium-dark skin tone, medium-light skin tone
+1F469 1F3FE 200D 1F91D 200D 1F469 1F3FD                ; fully-qualified     # 👩🏾‍🤝‍👩🏽 E12.0 women holding hands: medium-dark skin tone, medium skin tone
+1F46D 1F3FE                                            ; fully-qualified     # 👭🏾 E12.0 women holding hands: medium-dark skin tone
+1F469 1F3FE 200D 1F91D 200D 1F469 1F3FF                ; fully-qualified     # 👩🏾‍🤝‍👩🏿 E12.1 women holding hands: medium-dark skin tone, dark skin tone
+1F469 1F3FF 200D 1F91D 200D 1F469 1F3FB                ; fully-qualified     # 👩🏿‍🤝‍👩🏻 E12.0 women holding hands: dark skin tone, light skin tone
+1F469 1F3FF 200D 1F91D 200D 1F469 1F3FC                ; fully-qualified     # 👩🏿‍🤝‍👩🏼 E12.0 women holding hands: dark skin tone, medium-light skin tone
+1F469 1F3FF 200D 1F91D 200D 1F469 1F3FD                ; fully-qualified     # 👩🏿‍🤝‍👩🏽 E12.0 women holding hands: dark skin tone, medium skin tone
+1F469 1F3FF 200D 1F91D 200D 1F469 1F3FE                ; fully-qualified     # 👩🏿‍🤝‍👩🏾 E12.0 women holding hands: dark skin tone, medium-dark skin tone
+1F46D 1F3FF                                            ; fully-qualified     # 👭🏿 E12.0 women holding hands: dark skin tone
+1F46B                                                  ; fully-qualified     # 👫 E0.6 woman and man holding hands
+1F46B 1F3FB                                            ; fully-qualified     # 👫🏻 E12.0 woman and man holding hands: light skin tone
+1F469 1F3FB 200D 1F91D 200D 1F468 1F3FC                ; fully-qualified     # 👩🏻‍🤝‍👨🏼 E12.0 woman and man holding hands: light skin tone, medium-light skin tone
+1F469 1F3FB 200D 1F91D 200D 1F468 1F3FD                ; fully-qualified     # 👩🏻‍🤝‍👨🏽 E12.0 woman and man holding hands: light skin tone, medium skin tone
+1F469 1F3FB 200D 1F91D 200D 1F468 1F3FE                ; fully-qualified     # 👩🏻‍🤝‍👨🏾 E12.0 woman and man holding hands: light skin tone, medium-dark skin tone
+1F469 1F3FB 200D 1F91D 200D 1F468 1F3FF                ; fully-qualified     # 👩🏻‍🤝‍👨🏿 E12.0 woman and man holding hands: light skin tone, dark skin tone
+1F469 1F3FC 200D 1F91D 200D 1F468 1F3FB                ; fully-qualified     # 👩🏼‍🤝‍👨🏻 E12.0 woman and man holding hands: medium-light skin tone, light skin tone
+1F46B 1F3FC                                            ; fully-qualified     # 👫🏼 E12.0 woman and man holding hands: medium-light skin tone
+1F469 1F3FC 200D 1F91D 200D 1F468 1F3FD                ; fully-qualified     # 👩🏼‍🤝‍👨🏽 E12.0 woman and man holding hands: medium-light skin tone, medium skin tone
+1F469 1F3FC 200D 1F91D 200D 1F468 1F3FE                ; fully-qualified     # 👩🏼‍🤝‍👨🏾 E12.0 woman and man holding hands: medium-light skin tone, medium-dark skin tone
+1F469 1F3FC 200D 1F91D 200D 1F468 1F3FF                ; fully-qualified     # 👩🏼‍🤝‍👨🏿 E12.0 woman and man holding hands: medium-light skin tone, dark skin tone
+1F469 1F3FD 200D 1F91D 200D 1F468 1F3FB                ; fully-qualified     # 👩🏽‍🤝‍👨🏻 E12.0 woman and man holding hands: medium skin tone, light skin tone
+1F469 1F3FD 200D 1F91D 200D 1F468 1F3FC                ; fully-qualified     # 👩🏽‍🤝‍👨🏼 E12.0 woman and man holding hands: medium skin tone, medium-light skin tone
+1F46B 1F3FD                                            ; fully-qualified     # 👫🏽 E12.0 woman and man holding hands: medium skin tone
+1F469 1F3FD 200D 1F91D 200D 1F468 1F3FE                ; fully-qualified     # 👩🏽‍🤝‍👨🏾 E12.0 woman and man holding hands: medium skin tone, medium-dark skin tone
+1F469 1F3FD 200D 1F91D 200D 1F468 1F3FF                ; fully-qualified     # 👩🏽‍🤝‍👨🏿 E12.0 woman and man holding hands: medium skin tone, dark skin tone
+1F469 1F3FE 200D 1F91D 200D 1F468 1F3FB                ; fully-qualified     # 👩🏾‍🤝‍👨🏻 E12.0 woman and man holding hands: medium-dark skin tone, light skin tone
+1F469 1F3FE 200D 1F91D 200D 1F468 1F3FC                ; fully-qualified     # 👩🏾‍🤝‍👨🏼 E12.0 woman and man holding hands: medium-dark skin tone, medium-light skin tone
+1F469 1F3FE 200D 1F91D 200D 1F468 1F3FD                ; fully-qualified     # 👩🏾‍🤝‍👨🏽 E12.0 woman and man holding hands: medium-dark skin tone, medium skin tone
+1F46B 1F3FE                                            ; fully-qualified     # 👫🏾 E12.0 woman and man holding hands: medium-dark skin tone
+1F469 1F3FE 200D 1F91D 200D 1F468 1F3FF                ; fully-qualified     # 👩🏾‍🤝‍👨🏿 E12.0 woman and man holding hands: medium-dark skin tone, dark skin tone
+1F469 1F3FF 200D 1F91D 200D 1F468 1F3FB                ; fully-qualified     # 👩🏿‍🤝‍👨🏻 E12.0 woman and man holding hands: dark skin tone, light skin tone
+1F469 1F3FF 200D 1F91D 200D 1F468 1F3FC                ; fully-qualified     # 👩🏿‍🤝‍👨🏼 E12.0 woman and man holding hands: dark skin tone, medium-light skin tone
+1F469 1F3FF 200D 1F91D 200D 1F468 1F3FD                ; fully-qualified     # 👩🏿‍🤝‍👨🏽 E12.0 woman and man holding hands: dark skin tone, medium skin tone
+1F469 1F3FF 200D 1F91D 200D 1F468 1F3FE                ; fully-qualified     # 👩🏿‍🤝‍👨🏾 E12.0 woman and man holding hands: dark skin tone, medium-dark skin tone
+1F46B 1F3FF                                            ; fully-qualified     # 👫🏿 E12.0 woman and man holding hands: dark skin tone
+1F46C                                                  ; fully-qualified     # 👬 E1.0 men holding hands
+1F46C 1F3FB                                            ; fully-qualified     # 👬🏻 E12.0 men holding hands: light skin tone
+1F468 1F3FB 200D 1F91D 200D 1F468 1F3FC                ; fully-qualified     # 👨🏻‍🤝‍👨🏼 E12.1 men holding hands: light skin tone, medium-light skin tone
+1F468 1F3FB 200D 1F91D 200D 1F468 1F3FD                ; fully-qualified     # 👨🏻‍🤝‍👨🏽 E12.1 men holding hands: light skin tone, medium skin tone
+1F468 1F3FB 200D 1F91D 200D 1F468 1F3FE                ; fully-qualified     # 👨🏻‍🤝‍👨🏾 E12.1 men holding hands: light skin tone, medium-dark skin tone
+1F468 1F3FB 200D 1F91D 200D 1F468 1F3FF                ; fully-qualified     # 👨🏻‍🤝‍👨🏿 E12.1 men holding hands: light skin tone, dark skin tone
+1F468 1F3FC 200D 1F91D 200D 1F468 1F3FB                ; fully-qualified     # 👨🏼‍🤝‍👨🏻 E12.0 men holding hands: medium-light skin tone, light skin tone
+1F46C 1F3FC                                            ; fully-qualified     # 👬🏼 E12.0 men holding hands: medium-light skin tone
+1F468 1F3FC 200D 1F91D 200D 1F468 1F3FD                ; fully-qualified     # 👨🏼‍🤝‍👨🏽 E12.1 men holding hands: medium-light skin tone, medium skin tone
+1F468 1F3FC 200D 1F91D 200D 1F468 1F3FE                ; fully-qualified     # 👨🏼‍🤝‍👨🏾 E12.1 men holding hands: medium-light skin tone, medium-dark skin tone
+1F468 1F3FC 200D 1F91D 200D 1F468 1F3FF                ; fully-qualified     # 👨🏼‍🤝‍👨🏿 E12.1 men holding hands: medium-light skin tone, dark skin tone
+1F468 1F3FD 200D 1F91D 200D 1F468 1F3FB                ; fully-qualified     # 👨🏽‍🤝‍👨🏻 E12.0 men holding hands: medium skin tone, light skin tone
+1F468 1F3FD 200D 1F91D 200D 1F468 1F3FC                ; fully-qualified     # 👨🏽‍🤝‍👨🏼 E12.0 men holding hands: medium skin tone, medium-light skin tone
+1F46C 1F3FD                                            ; fully-qualified     # 👬🏽 E12.0 men holding hands: medium skin tone
+1F468 1F3FD 200D 1F91D 200D 1F468 1F3FE                ; fully-qualified     # 👨🏽‍🤝‍👨🏾 E12.1 men holding hands: medium skin tone, medium-dark skin tone
+1F468 1F3FD 200D 1F91D 200D 1F468 1F3FF                ; fully-qualified     # 👨🏽‍🤝‍👨🏿 E12.1 men holding hands: medium skin tone, dark skin tone
+1F468 1F3FE 200D 1F91D 200D 1F468 1F3FB                ; fully-qualified     # 👨🏾‍🤝‍👨🏻 E12.0 men holding hands: medium-dark skin tone, light skin tone
+1F468 1F3FE 200D 1F91D 200D 1F468 1F3FC                ; fully-qualified     # 👨🏾‍🤝‍👨🏼 E12.0 men holding hands: medium-dark skin tone, medium-light skin tone
+1F468 1F3FE 200D 1F91D 200D 1F468 1F3FD                ; fully-qualified     # 👨🏾‍🤝‍👨🏽 E12.0 men holding hands: medium-dark skin tone, medium skin tone
+1F46C 1F3FE                                            ; fully-qualified     # 👬🏾 E12.0 men holding hands: medium-dark skin tone
+1F468 1F3FE 200D 1F91D 200D 1F468 1F3FF                ; fully-qualified     # 👨🏾‍🤝‍👨🏿 E12.1 men holding hands: medium-dark skin tone, dark skin tone
+1F468 1F3FF 200D 1F91D 200D 1F468 1F3FB                ; fully-qualified     # 👨🏿‍🤝‍👨🏻 E12.0 men holding hands: dark skin tone, light skin tone
+1F468 1F3FF 200D 1F91D 200D 1F468 1F3FC                ; fully-qualified     # 👨🏿‍🤝‍👨🏼 E12.0 men holding hands: dark skin tone, medium-light skin tone
+1F468 1F3FF 200D 1F91D 200D 1F468 1F3FD                ; fully-qualified     # 👨🏿‍🤝‍👨🏽 E12.0 men holding hands: dark skin tone, medium skin tone
+1F468 1F3FF 200D 1F91D 200D 1F468 1F3FE                ; fully-qualified     # 👨🏿‍🤝‍👨🏾 E12.0 men holding hands: dark skin tone, medium-dark skin tone
+1F46C 1F3FF                                            ; fully-qualified     # 👬🏿 E12.0 men holding hands: dark skin tone
+1F48F                                                  ; fully-qualified     # 💏 E0.6 kiss
+1F48F 1F3FB                                            ; fully-qualified     # 💏🏻 E13.1 kiss: light skin tone
+1F48F 1F3FC                                            ; fully-qualified     # 💏🏼 E13.1 kiss: medium-light skin tone
+1F48F 1F3FD                                            ; fully-qualified     # 💏🏽 E13.1 kiss: medium skin tone
+1F48F 1F3FE                                            ; fully-qualified     # 💏🏾 E13.1 kiss: medium-dark skin tone
+1F48F 1F3FF                                            ; fully-qualified     # 💏🏿 E13.1 kiss: dark skin tone
+1F9D1 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FC ; fully-qualified     # 🧑🏻‍❤️‍💋‍🧑🏼 E13.1 kiss: person, person, light skin tone, medium-light skin tone
+1F9D1 1F3FB 200D 2764 200D 1F48B 200D 1F9D1 1F3FC      ; minimally-qualified # 🧑🏻‍❤‍💋‍🧑🏼 E13.1 kiss: person, person, light skin tone, medium-light skin tone
+1F9D1 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FD ; fully-qualified     # 🧑🏻‍❤️‍💋‍🧑🏽 E13.1 kiss: person, person, light skin tone, medium skin tone
+1F9D1 1F3FB 200D 2764 200D 1F48B 200D 1F9D1 1F3FD      ; minimally-qualified # 🧑🏻‍❤‍💋‍🧑🏽 E13.1 kiss: person, person, light skin tone, medium skin tone
+1F9D1 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FE ; fully-qualified     # 🧑🏻‍❤️‍💋‍🧑🏾 E13.1 kiss: person, person, light skin tone, medium-dark skin tone
+1F9D1 1F3FB 200D 2764 200D 1F48B 200D 1F9D1 1F3FE      ; minimally-qualified # 🧑🏻‍❤‍💋‍🧑🏾 E13.1 kiss: person, person, light skin tone, medium-dark skin tone
+1F9D1 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FF ; fully-qualified     # 🧑🏻‍❤️‍💋‍🧑🏿 E13.1 kiss: person, person, light skin tone, dark skin tone
+1F9D1 1F3FB 200D 2764 200D 1F48B 200D 1F9D1 1F3FF      ; minimally-qualified # 🧑🏻‍❤‍💋‍🧑🏿 E13.1 kiss: person, person, light skin tone, dark skin tone
+1F9D1 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FB ; fully-qualified     # 🧑🏼‍❤️‍💋‍🧑🏻 E13.1 kiss: person, person, medium-light skin tone, light skin tone
+1F9D1 1F3FC 200D 2764 200D 1F48B 200D 1F9D1 1F3FB      ; minimally-qualified # 🧑🏼‍❤‍💋‍🧑🏻 E13.1 kiss: person, person, medium-light skin tone, light skin tone
+1F9D1 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FD ; fully-qualified     # 🧑🏼‍❤️‍💋‍🧑🏽 E13.1 kiss: person, person, medium-light skin tone, medium skin tone
+1F9D1 1F3FC 200D 2764 200D 1F48B 200D 1F9D1 1F3FD      ; minimally-qualified # 🧑🏼‍❤‍💋‍🧑🏽 E13.1 kiss: person, person, medium-light skin tone, medium skin tone
+1F9D1 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FE ; fully-qualified     # 🧑🏼‍❤️‍💋‍🧑🏾 E13.1 kiss: person, person, medium-light skin tone, medium-dark skin tone
+1F9D1 1F3FC 200D 2764 200D 1F48B 200D 1F9D1 1F3FE      ; minimally-qualified # 🧑🏼‍❤‍💋‍🧑🏾 E13.1 kiss: person, person, medium-light skin tone, medium-dark skin tone
+1F9D1 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FF ; fully-qualified     # 🧑🏼‍❤️‍💋‍🧑🏿 E13.1 kiss: person, person, medium-light skin tone, dark skin tone
+1F9D1 1F3FC 200D 2764 200D 1F48B 200D 1F9D1 1F3FF      ; minimally-qualified # 🧑🏼‍❤‍💋‍🧑🏿 E13.1 kiss: person, person, medium-light skin tone, dark skin tone
+1F9D1 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FB ; fully-qualified     # 🧑🏽‍❤️‍💋‍🧑🏻 E13.1 kiss: person, person, medium skin tone, light skin tone
+1F9D1 1F3FD 200D 2764 200D 1F48B 200D 1F9D1 1F3FB      ; minimally-qualified # 🧑🏽‍❤‍💋‍🧑🏻 E13.1 kiss: person, person, medium skin tone, light skin tone
+1F9D1 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FC ; fully-qualified     # 🧑🏽‍❤️‍💋‍🧑🏼 E13.1 kiss: person, person, medium skin tone, medium-light skin tone
+1F9D1 1F3FD 200D 2764 200D 1F48B 200D 1F9D1 1F3FC      ; minimally-qualified # 🧑🏽‍❤‍💋‍🧑🏼 E13.1 kiss: person, person, medium skin tone, medium-light skin tone
+1F9D1 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FE ; fully-qualified     # 🧑🏽‍❤️‍💋‍🧑🏾 E13.1 kiss: person, person, medium skin tone, medium-dark skin tone
+1F9D1 1F3FD 200D 2764 200D 1F48B 200D 1F9D1 1F3FE      ; minimally-qualified # 🧑🏽‍❤‍💋‍🧑🏾 E13.1 kiss: person, person, medium skin tone, medium-dark skin tone
+1F9D1 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FF ; fully-qualified     # 🧑🏽‍❤️‍💋‍🧑🏿 E13.1 kiss: person, person, medium skin tone, dark skin tone
+1F9D1 1F3FD 200D 2764 200D 1F48B 200D 1F9D1 1F3FF      ; minimally-qualified # 🧑🏽‍❤‍💋‍🧑🏿 E13.1 kiss: person, person, medium skin tone, dark skin tone
+1F9D1 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FB ; fully-qualified     # 🧑🏾‍❤️‍💋‍🧑🏻 E13.1 kiss: person, person, medium-dark skin tone, light skin tone
+1F9D1 1F3FE 200D 2764 200D 1F48B 200D 1F9D1 1F3FB      ; minimally-qualified # 🧑🏾‍❤‍💋‍🧑🏻 E13.1 kiss: person, person, medium-dark skin tone, light skin tone
+1F9D1 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FC ; fully-qualified     # 🧑🏾‍❤️‍💋‍🧑🏼 E13.1 kiss: person, person, medium-dark skin tone, medium-light skin tone
+1F9D1 1F3FE 200D 2764 200D 1F48B 200D 1F9D1 1F3FC      ; minimally-qualified # 🧑🏾‍❤‍💋‍🧑🏼 E13.1 kiss: person, person, medium-dark skin tone, medium-light skin tone
+1F9D1 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FD ; fully-qualified     # 🧑🏾‍❤️‍💋‍🧑🏽 E13.1 kiss: person, person, medium-dark skin tone, medium skin tone
+1F9D1 1F3FE 200D 2764 200D 1F48B 200D 1F9D1 1F3FD      ; minimally-qualified # 🧑🏾‍❤‍💋‍🧑🏽 E13.1 kiss: person, person, medium-dark skin tone, medium skin tone
+1F9D1 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FF ; fully-qualified     # 🧑🏾‍❤️‍💋‍🧑🏿 E13.1 kiss: person, person, medium-dark skin tone, dark skin tone
+1F9D1 1F3FE 200D 2764 200D 1F48B 200D 1F9D1 1F3FF      ; minimally-qualified # 🧑🏾‍❤‍💋‍🧑🏿 E13.1 kiss: person, person, medium-dark skin tone, dark skin tone
+1F9D1 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FB ; fully-qualified     # 🧑🏿‍❤️‍💋‍🧑🏻 E13.1 kiss: person, person, dark skin tone, light skin tone
+1F9D1 1F3FF 200D 2764 200D 1F48B 200D 1F9D1 1F3FB      ; minimally-qualified # 🧑🏿‍❤‍💋‍🧑🏻 E13.1 kiss: person, person, dark skin tone, light skin tone
+1F9D1 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FC ; fully-qualified     # 🧑🏿‍❤️‍💋‍🧑🏼 E13.1 kiss: person, person, dark skin tone, medium-light skin tone
+1F9D1 1F3FF 200D 2764 200D 1F48B 200D 1F9D1 1F3FC      ; minimally-qualified # 🧑🏿‍❤‍💋‍🧑🏼 E13.1 kiss: person, person, dark skin tone, medium-light skin tone
+1F9D1 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FD ; fully-qualified     # 🧑🏿‍❤️‍💋‍🧑🏽 E13.1 kiss: person, person, dark skin tone, medium skin tone
+1F9D1 1F3FF 200D 2764 200D 1F48B 200D 1F9D1 1F3FD      ; minimally-qualified # 🧑🏿‍❤‍💋‍🧑🏽 E13.1 kiss: person, person, dark skin tone, medium skin tone
+1F9D1 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F9D1 1F3FE ; fully-qualified     # 🧑🏿‍❤️‍💋‍🧑🏾 E13.1 kiss: person, person, dark skin tone, medium-dark skin tone
+1F9D1 1F3FF 200D 2764 200D 1F48B 200D 1F9D1 1F3FE      ; minimally-qualified # 🧑🏿‍❤‍💋‍🧑🏾 E13.1 kiss: person, person, dark skin tone, medium-dark skin tone
+1F469 200D 2764 FE0F 200D 1F48B 200D 1F468             ; fully-qualified     # 👩‍❤️‍💋‍👨 E2.0 kiss: woman, man
+1F469 200D 2764 200D 1F48B 200D 1F468                  ; minimally-qualified # 👩‍❤‍💋‍👨 E2.0 kiss: woman, man
+1F469 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FB ; fully-qualified     # 👩🏻‍❤️‍💋‍👨🏻 E13.1 kiss: woman, man, light skin tone
+1F469 1F3FB 200D 2764 200D 1F48B 200D 1F468 1F3FB      ; minimally-qualified # 👩🏻‍❤‍💋‍👨🏻 E13.1 kiss: woman, man, light skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FC ; fully-qualified     # 👩🏻‍❤️‍💋‍👨🏼 E13.1 kiss: woman, man, light skin tone, medium-light skin tone
+1F469 1F3FB 200D 2764 200D 1F48B 200D 1F468 1F3FC      ; minimally-qualified # 👩🏻‍❤‍💋‍👨🏼 E13.1 kiss: woman, man, light skin tone, medium-light skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FD ; fully-qualified     # 👩🏻‍❤️‍💋‍👨🏽 E13.1 kiss: woman, man, light skin tone, medium skin tone
+1F469 1F3FB 200D 2764 200D 1F48B 200D 1F468 1F3FD      ; minimally-qualified # 👩🏻‍❤‍💋‍👨🏽 E13.1 kiss: woman, man, light skin tone, medium skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FE ; fully-qualified     # 👩🏻‍❤️‍💋‍👨🏾 E13.1 kiss: woman, man, light skin tone, medium-dark skin tone
+1F469 1F3FB 200D 2764 200D 1F48B 200D 1F468 1F3FE      ; minimally-qualified # 👩🏻‍❤‍💋‍👨🏾 E13.1 kiss: woman, man, light skin tone, medium-dark skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FF ; fully-qualified     # 👩🏻‍❤️‍💋‍👨🏿 E13.1 kiss: woman, man, light skin tone, dark skin tone
+1F469 1F3FB 200D 2764 200D 1F48B 200D 1F468 1F3FF      ; minimally-qualified # 👩🏻‍❤‍💋‍👨🏿 E13.1 kiss: woman, man, light skin tone, dark skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FB ; fully-qualified     # 👩🏼‍❤️‍💋‍👨🏻 E13.1 kiss: woman, man, medium-light skin tone, light skin tone
+1F469 1F3FC 200D 2764 200D 1F48B 200D 1F468 1F3FB      ; minimally-qualified # 👩🏼‍❤‍💋‍👨🏻 E13.1 kiss: woman, man, medium-light skin tone, light skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FC ; fully-qualified     # 👩🏼‍❤️‍💋‍👨🏼 E13.1 kiss: woman, man, medium-light skin tone
+1F469 1F3FC 200D 2764 200D 1F48B 200D 1F468 1F3FC      ; minimally-qualified # 👩🏼‍❤‍💋‍👨🏼 E13.1 kiss: woman, man, medium-light skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FD ; fully-qualified     # 👩🏼‍❤️‍💋‍👨🏽 E13.1 kiss: woman, man, medium-light skin tone, medium skin tone
+1F469 1F3FC 200D 2764 200D 1F48B 200D 1F468 1F3FD      ; minimally-qualified # 👩🏼‍❤‍💋‍👨🏽 E13.1 kiss: woman, man, medium-light skin tone, medium skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FE ; fully-qualified     # 👩🏼‍❤️‍💋‍👨🏾 E13.1 kiss: woman, man, medium-light skin tone, medium-dark skin tone
+1F469 1F3FC 200D 2764 200D 1F48B 200D 1F468 1F3FE      ; minimally-qualified # 👩🏼‍❤‍💋‍👨🏾 E13.1 kiss: woman, man, medium-light skin tone, medium-dark skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FF ; fully-qualified     # 👩🏼‍❤️‍💋‍👨🏿 E13.1 kiss: woman, man, medium-light skin tone, dark skin tone
+1F469 1F3FC 200D 2764 200D 1F48B 200D 1F468 1F3FF      ; minimally-qualified # 👩🏼‍❤‍💋‍👨🏿 E13.1 kiss: woman, man, medium-light skin tone, dark skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FB ; fully-qualified     # 👩🏽‍❤️‍💋‍👨🏻 E13.1 kiss: woman, man, medium skin tone, light skin tone
+1F469 1F3FD 200D 2764 200D 1F48B 200D 1F468 1F3FB      ; minimally-qualified # 👩🏽‍❤‍💋‍👨🏻 E13.1 kiss: woman, man, medium skin tone, light skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FC ; fully-qualified     # 👩🏽‍❤️‍💋‍👨🏼 E13.1 kiss: woman, man, medium skin tone, medium-light skin tone
+1F469 1F3FD 200D 2764 200D 1F48B 200D 1F468 1F3FC      ; minimally-qualified # 👩🏽‍❤‍💋‍👨🏼 E13.1 kiss: woman, man, medium skin tone, medium-light skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FD ; fully-qualified     # 👩🏽‍❤️‍💋‍👨🏽 E13.1 kiss: woman, man, medium skin tone
+1F469 1F3FD 200D 2764 200D 1F48B 200D 1F468 1F3FD      ; minimally-qualified # 👩🏽‍❤‍💋‍👨🏽 E13.1 kiss: woman, man, medium skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FE ; fully-qualified     # 👩🏽‍❤️‍💋‍👨🏾 E13.1 kiss: woman, man, medium skin tone, medium-dark skin tone
+1F469 1F3FD 200D 2764 200D 1F48B 200D 1F468 1F3FE      ; minimally-qualified # 👩🏽‍❤‍💋‍👨🏾 E13.1 kiss: woman, man, medium skin tone, medium-dark skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FF ; fully-qualified     # 👩🏽‍❤️‍💋‍👨🏿 E13.1 kiss: woman, man, medium skin tone, dark skin tone
+1F469 1F3FD 200D 2764 200D 1F48B 200D 1F468 1F3FF      ; minimally-qualified # 👩🏽‍❤‍💋‍👨🏿 E13.1 kiss: woman, man, medium skin tone, dark skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FB ; fully-qualified     # 👩🏾‍❤️‍💋‍👨🏻 E13.1 kiss: woman, man, medium-dark skin tone, light skin tone
+1F469 1F3FE 200D 2764 200D 1F48B 200D 1F468 1F3FB      ; minimally-qualified # 👩🏾‍❤‍💋‍👨🏻 E13.1 kiss: woman, man, medium-dark skin tone, light skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FC ; fully-qualified     # 👩🏾‍❤️‍💋‍👨🏼 E13.1 kiss: woman, man, medium-dark skin tone, medium-light skin tone
+1F469 1F3FE 200D 2764 200D 1F48B 200D 1F468 1F3FC      ; minimally-qualified # 👩🏾‍❤‍💋‍👨🏼 E13.1 kiss: woman, man, medium-dark skin tone, medium-light skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FD ; fully-qualified     # 👩🏾‍❤️‍💋‍👨🏽 E13.1 kiss: woman, man, medium-dark skin tone, medium skin tone
+1F469 1F3FE 200D 2764 200D 1F48B 200D 1F468 1F3FD      ; minimally-qualified # 👩🏾‍❤‍💋‍👨🏽 E13.1 kiss: woman, man, medium-dark skin tone, medium skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FE ; fully-qualified     # 👩🏾‍❤️‍💋‍👨🏾 E13.1 kiss: woman, man, medium-dark skin tone
+1F469 1F3FE 200D 2764 200D 1F48B 200D 1F468 1F3FE      ; minimally-qualified # 👩🏾‍❤‍💋‍👨🏾 E13.1 kiss: woman, man, medium-dark skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FF ; fully-qualified     # 👩🏾‍❤️‍💋‍👨🏿 E13.1 kiss: woman, man, medium-dark skin tone, dark skin tone
+1F469 1F3FE 200D 2764 200D 1F48B 200D 1F468 1F3FF      ; minimally-qualified # 👩🏾‍❤‍💋‍👨🏿 E13.1 kiss: woman, man, medium-dark skin tone, dark skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FB ; fully-qualified     # 👩🏿‍❤️‍💋‍👨🏻 E13.1 kiss: woman, man, dark skin tone, light skin tone
+1F469 1F3FF 200D 2764 200D 1F48B 200D 1F468 1F3FB      ; minimally-qualified # 👩🏿‍❤‍💋‍👨🏻 E13.1 kiss: woman, man, dark skin tone, light skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FC ; fully-qualified     # 👩🏿‍❤️‍💋‍👨🏼 E13.1 kiss: woman, man, dark skin tone, medium-light skin tone
+1F469 1F3FF 200D 2764 200D 1F48B 200D 1F468 1F3FC      ; minimally-qualified # 👩🏿‍❤‍💋‍👨🏼 E13.1 kiss: woman, man, dark skin tone, medium-light skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FD ; fully-qualified     # 👩🏿‍❤️‍💋‍👨🏽 E13.1 kiss: woman, man, dark skin tone, medium skin tone
+1F469 1F3FF 200D 2764 200D 1F48B 200D 1F468 1F3FD      ; minimally-qualified # 👩🏿‍❤‍💋‍👨🏽 E13.1 kiss: woman, man, dark skin tone, medium skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FE ; fully-qualified     # 👩🏿‍❤️‍💋‍👨🏾 E13.1 kiss: woman, man, dark skin tone, medium-dark skin tone
+1F469 1F3FF 200D 2764 200D 1F48B 200D 1F468 1F3FE      ; minimally-qualified # 👩🏿‍❤‍💋‍👨🏾 E13.1 kiss: woman, man, dark skin tone, medium-dark skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FF ; fully-qualified     # 👩🏿‍❤️‍💋‍👨🏿 E13.1 kiss: woman, man, dark skin tone
+1F469 1F3FF 200D 2764 200D 1F48B 200D 1F468 1F3FF      ; minimally-qualified # 👩🏿‍❤‍💋‍👨🏿 E13.1 kiss: woman, man, dark skin tone
+1F468 200D 2764 FE0F 200D 1F48B 200D 1F468             ; fully-qualified     # 👨‍❤️‍💋‍👨 E2.0 kiss: man, man
+1F468 200D 2764 200D 1F48B 200D 1F468                  ; minimally-qualified # 👨‍❤‍💋‍👨 E2.0 kiss: man, man
+1F468 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FB ; fully-qualified     # 👨🏻‍❤️‍💋‍👨🏻 E13.1 kiss: man, man, light skin tone
+1F468 1F3FB 200D 2764 200D 1F48B 200D 1F468 1F3FB      ; minimally-qualified # 👨🏻‍❤‍💋‍👨🏻 E13.1 kiss: man, man, light skin tone
+1F468 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FC ; fully-qualified     # 👨🏻‍❤️‍💋‍👨🏼 E13.1 kiss: man, man, light skin tone, medium-light skin tone
+1F468 1F3FB 200D 2764 200D 1F48B 200D 1F468 1F3FC      ; minimally-qualified # 👨🏻‍❤‍💋‍👨🏼 E13.1 kiss: man, man, light skin tone, medium-light skin tone
+1F468 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FD ; fully-qualified     # 👨🏻‍❤️‍💋‍👨🏽 E13.1 kiss: man, man, light skin tone, medium skin tone
+1F468 1F3FB 200D 2764 200D 1F48B 200D 1F468 1F3FD      ; minimally-qualified # 👨🏻‍❤‍💋‍👨🏽 E13.1 kiss: man, man, light skin tone, medium skin tone
+1F468 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FE ; fully-qualified     # 👨🏻‍❤️‍💋‍👨🏾 E13.1 kiss: man, man, light skin tone, medium-dark skin tone
+1F468 1F3FB 200D 2764 200D 1F48B 200D 1F468 1F3FE      ; minimally-qualified # 👨🏻‍❤‍💋‍👨🏾 E13.1 kiss: man, man, light skin tone, medium-dark skin tone
+1F468 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FF ; fully-qualified     # 👨🏻‍❤️‍💋‍👨🏿 E13.1 kiss: man, man, light skin tone, dark skin tone
+1F468 1F3FB 200D 2764 200D 1F48B 200D 1F468 1F3FF      ; minimally-qualified # 👨🏻‍❤‍💋‍👨🏿 E13.1 kiss: man, man, light skin tone, dark skin tone
+1F468 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FB ; fully-qualified     # 👨🏼‍❤️‍💋‍👨🏻 E13.1 kiss: man, man, medium-light skin tone, light skin tone
+1F468 1F3FC 200D 2764 200D 1F48B 200D 1F468 1F3FB      ; minimally-qualified # 👨🏼‍❤‍💋‍👨🏻 E13.1 kiss: man, man, medium-light skin tone, light skin tone
+1F468 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FC ; fully-qualified     # 👨🏼‍❤️‍💋‍👨🏼 E13.1 kiss: man, man, medium-light skin tone
+1F468 1F3FC 200D 2764 200D 1F48B 200D 1F468 1F3FC      ; minimally-qualified # 👨🏼‍❤‍💋‍👨🏼 E13.1 kiss: man, man, medium-light skin tone
+1F468 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FD ; fully-qualified     # 👨🏼‍❤️‍💋‍👨🏽 E13.1 kiss: man, man, medium-light skin tone, medium skin tone
+1F468 1F3FC 200D 2764 200D 1F48B 200D 1F468 1F3FD      ; minimally-qualified # 👨🏼‍❤‍💋‍👨🏽 E13.1 kiss: man, man, medium-light skin tone, medium skin tone
+1F468 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FE ; fully-qualified     # 👨🏼‍❤️‍💋‍👨🏾 E13.1 kiss: man, man, medium-light skin tone, medium-dark skin tone
+1F468 1F3FC 200D 2764 200D 1F48B 200D 1F468 1F3FE      ; minimally-qualified # 👨🏼‍❤‍💋‍👨🏾 E13.1 kiss: man, man, medium-light skin tone, medium-dark skin tone
+1F468 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FF ; fully-qualified     # 👨🏼‍❤️‍💋‍👨🏿 E13.1 kiss: man, man, medium-light skin tone, dark skin tone
+1F468 1F3FC 200D 2764 200D 1F48B 200D 1F468 1F3FF      ; minimally-qualified # 👨🏼‍❤‍💋‍👨🏿 E13.1 kiss: man, man, medium-light skin tone, dark skin tone
+1F468 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FB ; fully-qualified     # 👨🏽‍❤️‍💋‍👨🏻 E13.1 kiss: man, man, medium skin tone, light skin tone
+1F468 1F3FD 200D 2764 200D 1F48B 200D 1F468 1F3FB      ; minimally-qualified # 👨🏽‍❤‍💋‍👨🏻 E13.1 kiss: man, man, medium skin tone, light skin tone
+1F468 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FC ; fully-qualified     # 👨🏽‍❤️‍💋‍👨🏼 E13.1 kiss: man, man, medium skin tone, medium-light skin tone
+1F468 1F3FD 200D 2764 200D 1F48B 200D 1F468 1F3FC      ; minimally-qualified # 👨🏽‍❤‍💋‍👨🏼 E13.1 kiss: man, man, medium skin tone, medium-light skin tone
+1F468 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FD ; fully-qualified     # 👨🏽‍❤️‍💋‍👨🏽 E13.1 kiss: man, man, medium skin tone
+1F468 1F3FD 200D 2764 200D 1F48B 200D 1F468 1F3FD      ; minimally-qualified # 👨🏽‍❤‍💋‍👨🏽 E13.1 kiss: man, man, medium skin tone
+1F468 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FE ; fully-qualified     # 👨🏽‍❤️‍💋‍👨🏾 E13.1 kiss: man, man, medium skin tone, medium-dark skin tone
+1F468 1F3FD 200D 2764 200D 1F48B 200D 1F468 1F3FE      ; minimally-qualified # 👨🏽‍❤‍💋‍👨🏾 E13.1 kiss: man, man, medium skin tone, medium-dark skin tone
+1F468 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FF ; fully-qualified     # 👨🏽‍❤️‍💋‍👨🏿 E13.1 kiss: man, man, medium skin tone, dark skin tone
+1F468 1F3FD 200D 2764 200D 1F48B 200D 1F468 1F3FF      ; minimally-qualified # 👨🏽‍❤‍💋‍👨🏿 E13.1 kiss: man, man, medium skin tone, dark skin tone
+1F468 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FB ; fully-qualified     # 👨🏾‍❤️‍💋‍👨🏻 E13.1 kiss: man, man, medium-dark skin tone, light skin tone
+1F468 1F3FE 200D 2764 200D 1F48B 200D 1F468 1F3FB      ; minimally-qualified # 👨🏾‍❤‍💋‍👨🏻 E13.1 kiss: man, man, medium-dark skin tone, light skin tone
+1F468 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FC ; fully-qualified     # 👨🏾‍❤️‍💋‍👨🏼 E13.1 kiss: man, man, medium-dark skin tone, medium-light skin tone
+1F468 1F3FE 200D 2764 200D 1F48B 200D 1F468 1F3FC      ; minimally-qualified # 👨🏾‍❤‍💋‍👨🏼 E13.1 kiss: man, man, medium-dark skin tone, medium-light skin tone
+1F468 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FD ; fully-qualified     # 👨🏾‍❤️‍💋‍👨🏽 E13.1 kiss: man, man, medium-dark skin tone, medium skin tone
+1F468 1F3FE 200D 2764 200D 1F48B 200D 1F468 1F3FD      ; minimally-qualified # 👨🏾‍❤‍💋‍👨🏽 E13.1 kiss: man, man, medium-dark skin tone, medium skin tone
+1F468 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FE ; fully-qualified     # 👨🏾‍❤️‍💋‍👨🏾 E13.1 kiss: man, man, medium-dark skin tone
+1F468 1F3FE 200D 2764 200D 1F48B 200D 1F468 1F3FE      ; minimally-qualified # 👨🏾‍❤‍💋‍👨🏾 E13.1 kiss: man, man, medium-dark skin tone
+1F468 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FF ; fully-qualified     # 👨🏾‍❤️‍💋‍👨🏿 E13.1 kiss: man, man, medium-dark skin tone, dark skin tone
+1F468 1F3FE 200D 2764 200D 1F48B 200D 1F468 1F3FF      ; minimally-qualified # 👨🏾‍❤‍💋‍👨🏿 E13.1 kiss: man, man, medium-dark skin tone, dark skin tone
+1F468 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FB ; fully-qualified     # 👨🏿‍❤️‍💋‍👨🏻 E13.1 kiss: man, man, dark skin tone, light skin tone
+1F468 1F3FF 200D 2764 200D 1F48B 200D 1F468 1F3FB      ; minimally-qualified # 👨🏿‍❤‍💋‍👨🏻 E13.1 kiss: man, man, dark skin tone, light skin tone
+1F468 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FC ; fully-qualified     # 👨🏿‍❤️‍💋‍👨🏼 E13.1 kiss: man, man, dark skin tone, medium-light skin tone
+1F468 1F3FF 200D 2764 200D 1F48B 200D 1F468 1F3FC      ; minimally-qualified # 👨🏿‍❤‍💋‍👨🏼 E13.1 kiss: man, man, dark skin tone, medium-light skin tone
+1F468 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FD ; fully-qualified     # 👨🏿‍❤️‍💋‍👨🏽 E13.1 kiss: man, man, dark skin tone, medium skin tone
+1F468 1F3FF 200D 2764 200D 1F48B 200D 1F468 1F3FD      ; minimally-qualified # 👨🏿‍❤‍💋‍👨🏽 E13.1 kiss: man, man, dark skin tone, medium skin tone
+1F468 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FE ; fully-qualified     # 👨🏿‍❤️‍💋‍👨🏾 E13.1 kiss: man, man, dark skin tone, medium-dark skin tone
+1F468 1F3FF 200D 2764 200D 1F48B 200D 1F468 1F3FE      ; minimally-qualified # 👨🏿‍❤‍💋‍👨🏾 E13.1 kiss: man, man, dark skin tone, medium-dark skin tone
+1F468 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F468 1F3FF ; fully-qualified     # 👨🏿‍❤️‍💋‍👨🏿 E13.1 kiss: man, man, dark skin tone
+1F468 1F3FF 200D 2764 200D 1F48B 200D 1F468 1F3FF      ; minimally-qualified # 👨🏿‍❤‍💋‍👨🏿 E13.1 kiss: man, man, dark skin tone
+1F469 200D 2764 FE0F 200D 1F48B 200D 1F469             ; fully-qualified     # 👩‍❤️‍💋‍👩 E2.0 kiss: woman, woman
+1F469 200D 2764 200D 1F48B 200D 1F469                  ; minimally-qualified # 👩‍❤‍💋‍👩 E2.0 kiss: woman, woman
+1F469 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FB ; fully-qualified     # 👩🏻‍❤️‍💋‍👩🏻 E13.1 kiss: woman, woman, light skin tone
+1F469 1F3FB 200D 2764 200D 1F48B 200D 1F469 1F3FB      ; minimally-qualified # 👩🏻‍❤‍💋‍👩🏻 E13.1 kiss: woman, woman, light skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FC ; fully-qualified     # 👩🏻‍❤️‍💋‍👩🏼 E13.1 kiss: woman, woman, light skin tone, medium-light skin tone
+1F469 1F3FB 200D 2764 200D 1F48B 200D 1F469 1F3FC      ; minimally-qualified # 👩🏻‍❤‍💋‍👩🏼 E13.1 kiss: woman, woman, light skin tone, medium-light skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FD ; fully-qualified     # 👩🏻‍❤️‍💋‍👩🏽 E13.1 kiss: woman, woman, light skin tone, medium skin tone
+1F469 1F3FB 200D 2764 200D 1F48B 200D 1F469 1F3FD      ; minimally-qualified # 👩🏻‍❤‍💋‍👩🏽 E13.1 kiss: woman, woman, light skin tone, medium skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FE ; fully-qualified     # 👩🏻‍❤️‍💋‍👩🏾 E13.1 kiss: woman, woman, light skin tone, medium-dark skin tone
+1F469 1F3FB 200D 2764 200D 1F48B 200D 1F469 1F3FE      ; minimally-qualified # 👩🏻‍❤‍💋‍👩🏾 E13.1 kiss: woman, woman, light skin tone, medium-dark skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FF ; fully-qualified     # 👩🏻‍❤️‍💋‍👩🏿 E13.1 kiss: woman, woman, light skin tone, dark skin tone
+1F469 1F3FB 200D 2764 200D 1F48B 200D 1F469 1F3FF      ; minimally-qualified # 👩🏻‍❤‍💋‍👩🏿 E13.1 kiss: woman, woman, light skin tone, dark skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FB ; fully-qualified     # 👩🏼‍❤️‍💋‍👩🏻 E13.1 kiss: woman, woman, medium-light skin tone, light skin tone
+1F469 1F3FC 200D 2764 200D 1F48B 200D 1F469 1F3FB      ; minimally-qualified # 👩🏼‍❤‍💋‍👩🏻 E13.1 kiss: woman, woman, medium-light skin tone, light skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FC ; fully-qualified     # 👩🏼‍❤️‍💋‍👩🏼 E13.1 kiss: woman, woman, medium-light skin tone
+1F469 1F3FC 200D 2764 200D 1F48B 200D 1F469 1F3FC      ; minimally-qualified # 👩🏼‍❤‍💋‍👩🏼 E13.1 kiss: woman, woman, medium-light skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FD ; fully-qualified     # 👩🏼‍❤️‍💋‍👩🏽 E13.1 kiss: woman, woman, medium-light skin tone, medium skin tone
+1F469 1F3FC 200D 2764 200D 1F48B 200D 1F469 1F3FD      ; minimally-qualified # 👩🏼‍❤‍💋‍👩🏽 E13.1 kiss: woman, woman, medium-light skin tone, medium skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FE ; fully-qualified     # 👩🏼‍❤️‍💋‍👩🏾 E13.1 kiss: woman, woman, medium-light skin tone, medium-dark skin tone
+1F469 1F3FC 200D 2764 200D 1F48B 200D 1F469 1F3FE      ; minimally-qualified # 👩🏼‍❤‍💋‍👩🏾 E13.1 kiss: woman, woman, medium-light skin tone, medium-dark skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FF ; fully-qualified     # 👩🏼‍❤️‍💋‍👩🏿 E13.1 kiss: woman, woman, medium-light skin tone, dark skin tone
+1F469 1F3FC 200D 2764 200D 1F48B 200D 1F469 1F3FF      ; minimally-qualified # 👩🏼‍❤‍💋‍👩🏿 E13.1 kiss: woman, woman, medium-light skin tone, dark skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FB ; fully-qualified     # 👩🏽‍❤️‍💋‍👩🏻 E13.1 kiss: woman, woman, medium skin tone, light skin tone
+1F469 1F3FD 200D 2764 200D 1F48B 200D 1F469 1F3FB      ; minimally-qualified # 👩🏽‍❤‍💋‍👩🏻 E13.1 kiss: woman, woman, medium skin tone, light skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FC ; fully-qualified     # 👩🏽‍❤️‍💋‍👩🏼 E13.1 kiss: woman, woman, medium skin tone, medium-light skin tone
+1F469 1F3FD 200D 2764 200D 1F48B 200D 1F469 1F3FC      ; minimally-qualified # 👩🏽‍❤‍💋‍👩🏼 E13.1 kiss: woman, woman, medium skin tone, medium-light skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FD ; fully-qualified     # 👩🏽‍❤️‍💋‍👩🏽 E13.1 kiss: woman, woman, medium skin tone
+1F469 1F3FD 200D 2764 200D 1F48B 200D 1F469 1F3FD      ; minimally-qualified # 👩🏽‍❤‍💋‍👩🏽 E13.1 kiss: woman, woman, medium skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FE ; fully-qualified     # 👩🏽‍❤️‍💋‍👩🏾 E13.1 kiss: woman, woman, medium skin tone, medium-dark skin tone
+1F469 1F3FD 200D 2764 200D 1F48B 200D 1F469 1F3FE      ; minimally-qualified # 👩🏽‍❤‍💋‍👩🏾 E13.1 kiss: woman, woman, medium skin tone, medium-dark skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FF ; fully-qualified     # 👩🏽‍❤️‍💋‍👩🏿 E13.1 kiss: woman, woman, medium skin tone, dark skin tone
+1F469 1F3FD 200D 2764 200D 1F48B 200D 1F469 1F3FF      ; minimally-qualified # 👩🏽‍❤‍💋‍👩🏿 E13.1 kiss: woman, woman, medium skin tone, dark skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FB ; fully-qualified     # 👩🏾‍❤️‍💋‍👩🏻 E13.1 kiss: woman, woman, medium-dark skin tone, light skin tone
+1F469 1F3FE 200D 2764 200D 1F48B 200D 1F469 1F3FB      ; minimally-qualified # 👩🏾‍❤‍💋‍👩🏻 E13.1 kiss: woman, woman, medium-dark skin tone, light skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FC ; fully-qualified     # 👩🏾‍❤️‍💋‍👩🏼 E13.1 kiss: woman, woman, medium-dark skin tone, medium-light skin tone
+1F469 1F3FE 200D 2764 200D 1F48B 200D 1F469 1F3FC      ; minimally-qualified # 👩🏾‍❤‍💋‍👩🏼 E13.1 kiss: woman, woman, medium-dark skin tone, medium-light skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FD ; fully-qualified     # 👩🏾‍❤️‍💋‍👩🏽 E13.1 kiss: woman, woman, medium-dark skin tone, medium skin tone
+1F469 1F3FE 200D 2764 200D 1F48B 200D 1F469 1F3FD      ; minimally-qualified # 👩🏾‍❤‍💋‍👩🏽 E13.1 kiss: woman, woman, medium-dark skin tone, medium skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FE ; fully-qualified     # 👩🏾‍❤️‍💋‍👩🏾 E13.1 kiss: woman, woman, medium-dark skin tone
+1F469 1F3FE 200D 2764 200D 1F48B 200D 1F469 1F3FE      ; minimally-qualified # 👩🏾‍❤‍💋‍👩🏾 E13.1 kiss: woman, woman, medium-dark skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FF ; fully-qualified     # 👩🏾‍❤️‍💋‍👩🏿 E13.1 kiss: woman, woman, medium-dark skin tone, dark skin tone
+1F469 1F3FE 200D 2764 200D 1F48B 200D 1F469 1F3FF      ; minimally-qualified # 👩🏾‍❤‍💋‍👩🏿 E13.1 kiss: woman, woman, medium-dark skin tone, dark skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FB ; fully-qualified     # 👩🏿‍❤️‍💋‍👩🏻 E13.1 kiss: woman, woman, dark skin tone, light skin tone
+1F469 1F3FF 200D 2764 200D 1F48B 200D 1F469 1F3FB      ; minimally-qualified # 👩🏿‍❤‍💋‍👩🏻 E13.1 kiss: woman, woman, dark skin tone, light skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FC ; fully-qualified     # 👩🏿‍❤️‍💋‍👩🏼 E13.1 kiss: woman, woman, dark skin tone, medium-light skin tone
+1F469 1F3FF 200D 2764 200D 1F48B 200D 1F469 1F3FC      ; minimally-qualified # 👩🏿‍❤‍💋‍👩🏼 E13.1 kiss: woman, woman, dark skin tone, medium-light skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FD ; fully-qualified     # 👩🏿‍❤️‍💋‍👩🏽 E13.1 kiss: woman, woman, dark skin tone, medium skin tone
+1F469 1F3FF 200D 2764 200D 1F48B 200D 1F469 1F3FD      ; minimally-qualified # 👩🏿‍❤‍💋‍👩🏽 E13.1 kiss: woman, woman, dark skin tone, medium skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FE ; fully-qualified     # 👩🏿‍❤️‍💋‍👩🏾 E13.1 kiss: woman, woman, dark skin tone, medium-dark skin tone
+1F469 1F3FF 200D 2764 200D 1F48B 200D 1F469 1F3FE      ; minimally-qualified # 👩🏿‍❤‍💋‍👩🏾 E13.1 kiss: woman, woman, dark skin tone, medium-dark skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F48B 200D 1F469 1F3FF ; fully-qualified     # 👩🏿‍❤️‍💋‍👩🏿 E13.1 kiss: woman, woman, dark skin tone
+1F469 1F3FF 200D 2764 200D 1F48B 200D 1F469 1F3FF      ; minimally-qualified # 👩🏿‍❤‍💋‍👩🏿 E13.1 kiss: woman, woman, dark skin tone
+1F491                                                  ; fully-qualified     # 💑 E0.6 couple with heart
+1F491 1F3FB                                            ; fully-qualified     # 💑🏻 E13.1 couple with heart: light skin tone
+1F491 1F3FC                                            ; fully-qualified     # 💑🏼 E13.1 couple with heart: medium-light skin tone
+1F491 1F3FD                                            ; fully-qualified     # 💑🏽 E13.1 couple with heart: medium skin tone
+1F491 1F3FE                                            ; fully-qualified     # 💑🏾 E13.1 couple with heart: medium-dark skin tone
+1F491 1F3FF                                            ; fully-qualified     # 💑🏿 E13.1 couple with heart: dark skin tone
+1F9D1 1F3FB 200D 2764 FE0F 200D 1F9D1 1F3FC            ; fully-qualified     # 🧑🏻‍❤️‍🧑🏼 E13.1 couple with heart: person, person, light skin tone, medium-light skin tone
+1F9D1 1F3FB 200D 2764 200D 1F9D1 1F3FC                 ; minimally-qualified # 🧑🏻‍❤‍🧑🏼 E13.1 couple with heart: person, person, light skin tone, medium-light skin tone
+1F9D1 1F3FB 200D 2764 FE0F 200D 1F9D1 1F3FD            ; fully-qualified     # 🧑🏻‍❤️‍🧑🏽 E13.1 couple with heart: person, person, light skin tone, medium skin tone
+1F9D1 1F3FB 200D 2764 200D 1F9D1 1F3FD                 ; minimally-qualified # 🧑🏻‍❤‍🧑🏽 E13.1 couple with heart: person, person, light skin tone, medium skin tone
+1F9D1 1F3FB 200D 2764 FE0F 200D 1F9D1 1F3FE            ; fully-qualified     # 🧑🏻‍❤️‍🧑🏾 E13.1 couple with heart: person, person, light skin tone, medium-dark skin tone
+1F9D1 1F3FB 200D 2764 200D 1F9D1 1F3FE                 ; minimally-qualified # 🧑🏻‍❤‍🧑🏾 E13.1 couple with heart: person, person, light skin tone, medium-dark skin tone
+1F9D1 1F3FB 200D 2764 FE0F 200D 1F9D1 1F3FF            ; fully-qualified     # 🧑🏻‍❤️‍🧑🏿 E13.1 couple with heart: person, person, light skin tone, dark skin tone
+1F9D1 1F3FB 200D 2764 200D 1F9D1 1F3FF                 ; minimally-qualified # 🧑🏻‍❤‍🧑🏿 E13.1 couple with heart: person, person, light skin tone, dark skin tone
+1F9D1 1F3FC 200D 2764 FE0F 200D 1F9D1 1F3FB            ; fully-qualified     # 🧑🏼‍❤️‍🧑🏻 E13.1 couple with heart: person, person, medium-light skin tone, light skin tone
+1F9D1 1F3FC 200D 2764 200D 1F9D1 1F3FB                 ; minimally-qualified # 🧑🏼‍❤‍🧑🏻 E13.1 couple with heart: person, person, medium-light skin tone, light skin tone
+1F9D1 1F3FC 200D 2764 FE0F 200D 1F9D1 1F3FD            ; fully-qualified     # 🧑🏼‍❤️‍🧑🏽 E13.1 couple with heart: person, person, medium-light skin tone, medium skin tone
+1F9D1 1F3FC 200D 2764 200D 1F9D1 1F3FD                 ; minimally-qualified # 🧑🏼‍❤‍🧑🏽 E13.1 couple with heart: person, person, medium-light skin tone, medium skin tone
+1F9D1 1F3FC 200D 2764 FE0F 200D 1F9D1 1F3FE            ; fully-qualified     # 🧑🏼‍❤️‍🧑🏾 E13.1 couple with heart: person, person, medium-light skin tone, medium-dark skin tone
+1F9D1 1F3FC 200D 2764 200D 1F9D1 1F3FE                 ; minimally-qualified # 🧑🏼‍❤‍🧑🏾 E13.1 couple with heart: person, person, medium-light skin tone, medium-dark skin tone
+1F9D1 1F3FC 200D 2764 FE0F 200D 1F9D1 1F3FF            ; fully-qualified     # 🧑🏼‍❤️‍🧑🏿 E13.1 couple with heart: person, person, medium-light skin tone, dark skin tone
+1F9D1 1F3FC 200D 2764 200D 1F9D1 1F3FF                 ; minimally-qualified # 🧑🏼‍❤‍🧑🏿 E13.1 couple with heart: person, person, medium-light skin tone, dark skin tone
+1F9D1 1F3FD 200D 2764 FE0F 200D 1F9D1 1F3FB            ; fully-qualified     # 🧑🏽‍❤️‍🧑🏻 E13.1 couple with heart: person, person, medium skin tone, light skin tone
+1F9D1 1F3FD 200D 2764 200D 1F9D1 1F3FB                 ; minimally-qualified # 🧑🏽‍❤‍🧑🏻 E13.1 couple with heart: person, person, medium skin tone, light skin tone
+1F9D1 1F3FD 200D 2764 FE0F 200D 1F9D1 1F3FC            ; fully-qualified     # 🧑🏽‍❤️‍🧑🏼 E13.1 couple with heart: person, person, medium skin tone, medium-light skin tone
+1F9D1 1F3FD 200D 2764 200D 1F9D1 1F3FC                 ; minimally-qualified # 🧑🏽‍❤‍🧑🏼 E13.1 couple with heart: person, person, medium skin tone, medium-light skin tone
+1F9D1 1F3FD 200D 2764 FE0F 200D 1F9D1 1F3FE            ; fully-qualified     # 🧑🏽‍❤️‍🧑🏾 E13.1 couple with heart: person, person, medium skin tone, medium-dark skin tone
+1F9D1 1F3FD 200D 2764 200D 1F9D1 1F3FE                 ; minimally-qualified # 🧑🏽‍❤‍🧑🏾 E13.1 couple with heart: person, person, medium skin tone, medium-dark skin tone
+1F9D1 1F3FD 200D 2764 FE0F 200D 1F9D1 1F3FF            ; fully-qualified     # 🧑🏽‍❤️‍🧑🏿 E13.1 couple with heart: person, person, medium skin tone, dark skin tone
+1F9D1 1F3FD 200D 2764 200D 1F9D1 1F3FF                 ; minimally-qualified # 🧑🏽‍❤‍🧑🏿 E13.1 couple with heart: person, person, medium skin tone, dark skin tone
+1F9D1 1F3FE 200D 2764 FE0F 200D 1F9D1 1F3FB            ; fully-qualified     # 🧑🏾‍❤️‍🧑🏻 E13.1 couple with heart: person, person, medium-dark skin tone, light skin tone
+1F9D1 1F3FE 200D 2764 200D 1F9D1 1F3FB                 ; minimally-qualified # 🧑🏾‍❤‍🧑🏻 E13.1 couple with heart: person, person, medium-dark skin tone, light skin tone
+1F9D1 1F3FE 200D 2764 FE0F 200D 1F9D1 1F3FC            ; fully-qualified     # 🧑🏾‍❤️‍🧑🏼 E13.1 couple with heart: person, person, medium-dark skin tone, medium-light skin tone
+1F9D1 1F3FE 200D 2764 200D 1F9D1 1F3FC                 ; minimally-qualified # 🧑🏾‍❤‍🧑🏼 E13.1 couple with heart: person, person, medium-dark skin tone, medium-light skin tone
+1F9D1 1F3FE 200D 2764 FE0F 200D 1F9D1 1F3FD            ; fully-qualified     # 🧑🏾‍❤️‍🧑🏽 E13.1 couple with heart: person, person, medium-dark skin tone, medium skin tone
+1F9D1 1F3FE 200D 2764 200D 1F9D1 1F3FD                 ; minimally-qualified # 🧑🏾‍❤‍🧑🏽 E13.1 couple with heart: person, person, medium-dark skin tone, medium skin tone
+1F9D1 1F3FE 200D 2764 FE0F 200D 1F9D1 1F3FF            ; fully-qualified     # 🧑🏾‍❤️‍🧑🏿 E13.1 couple with heart: person, person, medium-dark skin tone, dark skin tone
+1F9D1 1F3FE 200D 2764 200D 1F9D1 1F3FF                 ; minimally-qualified # 🧑🏾‍❤‍🧑🏿 E13.1 couple with heart: person, person, medium-dark skin tone, dark skin tone
+1F9D1 1F3FF 200D 2764 FE0F 200D 1F9D1 1F3FB            ; fully-qualified     # 🧑🏿‍❤️‍🧑🏻 E13.1 couple with heart: person, person, dark skin tone, light skin tone
+1F9D1 1F3FF 200D 2764 200D 1F9D1 1F3FB                 ; minimally-qualified # 🧑🏿‍❤‍🧑🏻 E13.1 couple with heart: person, person, dark skin tone, light skin tone
+1F9D1 1F3FF 200D 2764 FE0F 200D 1F9D1 1F3FC            ; fully-qualified     # 🧑🏿‍❤️‍🧑🏼 E13.1 couple with heart: person, person, dark skin tone, medium-light skin tone
+1F9D1 1F3FF 200D 2764 200D 1F9D1 1F3FC                 ; minimally-qualified # 🧑🏿‍❤‍🧑🏼 E13.1 couple with heart: person, person, dark skin tone, medium-light skin tone
+1F9D1 1F3FF 200D 2764 FE0F 200D 1F9D1 1F3FD            ; fully-qualified     # 🧑🏿‍❤️‍🧑🏽 E13.1 couple with heart: person, person, dark skin tone, medium skin tone
+1F9D1 1F3FF 200D 2764 200D 1F9D1 1F3FD                 ; minimally-qualified # 🧑🏿‍❤‍🧑🏽 E13.1 couple with heart: person, person, dark skin tone, medium skin tone
+1F9D1 1F3FF 200D 2764 FE0F 200D 1F9D1 1F3FE            ; fully-qualified     # 🧑🏿‍❤️‍🧑🏾 E13.1 couple with heart: person, person, dark skin tone, medium-dark skin tone
+1F9D1 1F3FF 200D 2764 200D 1F9D1 1F3FE                 ; minimally-qualified # 🧑🏿‍❤‍🧑🏾 E13.1 couple with heart: person, person, dark skin tone, medium-dark skin tone
+1F469 200D 2764 FE0F 200D 1F468                        ; fully-qualified     # 👩‍❤️‍👨 E2.0 couple with heart: woman, man
+1F469 200D 2764 200D 1F468                             ; minimally-qualified # 👩‍❤‍👨 E2.0 couple with heart: woman, man
+1F469 1F3FB 200D 2764 FE0F 200D 1F468 1F3FB            ; fully-qualified     # 👩🏻‍❤️‍👨🏻 E13.1 couple with heart: woman, man, light skin tone
+1F469 1F3FB 200D 2764 200D 1F468 1F3FB                 ; minimally-qualified # 👩🏻‍❤‍👨🏻 E13.1 couple with heart: woman, man, light skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F468 1F3FC            ; fully-qualified     # 👩🏻‍❤️‍👨🏼 E13.1 couple with heart: woman, man, light skin tone, medium-light skin tone
+1F469 1F3FB 200D 2764 200D 1F468 1F3FC                 ; minimally-qualified # 👩🏻‍❤‍👨🏼 E13.1 couple with heart: woman, man, light skin tone, medium-light skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F468 1F3FD            ; fully-qualified     # 👩🏻‍❤️‍👨🏽 E13.1 couple with heart: woman, man, light skin tone, medium skin tone
+1F469 1F3FB 200D 2764 200D 1F468 1F3FD                 ; minimally-qualified # 👩🏻‍❤‍👨🏽 E13.1 couple with heart: woman, man, light skin tone, medium skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F468 1F3FE            ; fully-qualified     # 👩🏻‍❤️‍👨🏾 E13.1 couple with heart: woman, man, light skin tone, medium-dark skin tone
+1F469 1F3FB 200D 2764 200D 1F468 1F3FE                 ; minimally-qualified # 👩🏻‍❤‍👨🏾 E13.1 couple with heart: woman, man, light skin tone, medium-dark skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F468 1F3FF            ; fully-qualified     # 👩🏻‍❤️‍👨🏿 E13.1 couple with heart: woman, man, light skin tone, dark skin tone
+1F469 1F3FB 200D 2764 200D 1F468 1F3FF                 ; minimally-qualified # 👩🏻‍❤‍👨🏿 E13.1 couple with heart: woman, man, light skin tone, dark skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F468 1F3FB            ; fully-qualified     # 👩🏼‍❤️‍👨🏻 E13.1 couple with heart: woman, man, medium-light skin tone, light skin tone
+1F469 1F3FC 200D 2764 200D 1F468 1F3FB                 ; minimally-qualified # 👩🏼‍❤‍👨🏻 E13.1 couple with heart: woman, man, medium-light skin tone, light skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F468 1F3FC            ; fully-qualified     # 👩🏼‍❤️‍👨🏼 E13.1 couple with heart: woman, man, medium-light skin tone
+1F469 1F3FC 200D 2764 200D 1F468 1F3FC                 ; minimally-qualified # 👩🏼‍❤‍👨🏼 E13.1 couple with heart: woman, man, medium-light skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F468 1F3FD            ; fully-qualified     # 👩🏼‍❤️‍👨🏽 E13.1 couple with heart: woman, man, medium-light skin tone, medium skin tone
+1F469 1F3FC 200D 2764 200D 1F468 1F3FD                 ; minimally-qualified # 👩🏼‍❤‍👨🏽 E13.1 couple with heart: woman, man, medium-light skin tone, medium skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F468 1F3FE            ; fully-qualified     # 👩🏼‍❤️‍👨🏾 E13.1 couple with heart: woman, man, medium-light skin tone, medium-dark skin tone
+1F469 1F3FC 200D 2764 200D 1F468 1F3FE                 ; minimally-qualified # 👩🏼‍❤‍👨🏾 E13.1 couple with heart: woman, man, medium-light skin tone, medium-dark skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F468 1F3FF            ; fully-qualified     # 👩🏼‍❤️‍👨🏿 E13.1 couple with heart: woman, man, medium-light skin tone, dark skin tone
+1F469 1F3FC 200D 2764 200D 1F468 1F3FF                 ; minimally-qualified # 👩🏼‍❤‍👨🏿 E13.1 couple with heart: woman, man, medium-light skin tone, dark skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F468 1F3FB            ; fully-qualified     # 👩🏽‍❤️‍👨🏻 E13.1 couple with heart: woman, man, medium skin tone, light skin tone
+1F469 1F3FD 200D 2764 200D 1F468 1F3FB                 ; minimally-qualified # 👩🏽‍❤‍👨🏻 E13.1 couple with heart: woman, man, medium skin tone, light skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F468 1F3FC            ; fully-qualified     # 👩🏽‍❤️‍👨🏼 E13.1 couple with heart: woman, man, medium skin tone, medium-light skin tone
+1F469 1F3FD 200D 2764 200D 1F468 1F3FC                 ; minimally-qualified # 👩🏽‍❤‍👨🏼 E13.1 couple with heart: woman, man, medium skin tone, medium-light skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F468 1F3FD            ; fully-qualified     # 👩🏽‍❤️‍👨🏽 E13.1 couple with heart: woman, man, medium skin tone
+1F469 1F3FD 200D 2764 200D 1F468 1F3FD                 ; minimally-qualified # 👩🏽‍❤‍👨🏽 E13.1 couple with heart: woman, man, medium skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F468 1F3FE            ; fully-qualified     # 👩🏽‍❤️‍👨🏾 E13.1 couple with heart: woman, man, medium skin tone, medium-dark skin tone
+1F469 1F3FD 200D 2764 200D 1F468 1F3FE                 ; minimally-qualified # 👩🏽‍❤‍👨🏾 E13.1 couple with heart: woman, man, medium skin tone, medium-dark skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F468 1F3FF            ; fully-qualified     # 👩🏽‍❤️‍👨🏿 E13.1 couple with heart: woman, man, medium skin tone, dark skin tone
+1F469 1F3FD 200D 2764 200D 1F468 1F3FF                 ; minimally-qualified # 👩🏽‍❤‍👨🏿 E13.1 couple with heart: woman, man, medium skin tone, dark skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F468 1F3FB            ; fully-qualified     # 👩🏾‍❤️‍👨🏻 E13.1 couple with heart: woman, man, medium-dark skin tone, light skin tone
+1F469 1F3FE 200D 2764 200D 1F468 1F3FB                 ; minimally-qualified # 👩🏾‍❤‍👨🏻 E13.1 couple with heart: woman, man, medium-dark skin tone, light skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F468 1F3FC            ; fully-qualified     # 👩🏾‍❤️‍👨🏼 E13.1 couple with heart: woman, man, medium-dark skin tone, medium-light skin tone
+1F469 1F3FE 200D 2764 200D 1F468 1F3FC                 ; minimally-qualified # 👩🏾‍❤‍👨🏼 E13.1 couple with heart: woman, man, medium-dark skin tone, medium-light skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F468 1F3FD            ; fully-qualified     # 👩🏾‍❤️‍👨🏽 E13.1 couple with heart: woman, man, medium-dark skin tone, medium skin tone
+1F469 1F3FE 200D 2764 200D 1F468 1F3FD                 ; minimally-qualified # 👩🏾‍❤‍👨🏽 E13.1 couple with heart: woman, man, medium-dark skin tone, medium skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F468 1F3FE            ; fully-qualified     # 👩🏾‍❤️‍👨🏾 E13.1 couple with heart: woman, man, medium-dark skin tone
+1F469 1F3FE 200D 2764 200D 1F468 1F3FE                 ; minimally-qualified # 👩🏾‍❤‍👨🏾 E13.1 couple with heart: woman, man, medium-dark skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F468 1F3FF            ; fully-qualified     # 👩🏾‍❤️‍👨🏿 E13.1 couple with heart: woman, man, medium-dark skin tone, dark skin tone
+1F469 1F3FE 200D 2764 200D 1F468 1F3FF                 ; minimally-qualified # 👩🏾‍❤‍👨🏿 E13.1 couple with heart: woman, man, medium-dark skin tone, dark skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F468 1F3FB            ; fully-qualified     # 👩🏿‍❤️‍👨🏻 E13.1 couple with heart: woman, man, dark skin tone, light skin tone
+1F469 1F3FF 200D 2764 200D 1F468 1F3FB                 ; minimally-qualified # 👩🏿‍❤‍👨🏻 E13.1 couple with heart: woman, man, dark skin tone, light skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F468 1F3FC            ; fully-qualified     # 👩🏿‍❤️‍👨🏼 E13.1 couple with heart: woman, man, dark skin tone, medium-light skin tone
+1F469 1F3FF 200D 2764 200D 1F468 1F3FC                 ; minimally-qualified # 👩🏿‍❤‍👨🏼 E13.1 couple with heart: woman, man, dark skin tone, medium-light skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F468 1F3FD            ; fully-qualified     # 👩🏿‍❤️‍👨🏽 E13.1 couple with heart: woman, man, dark skin tone, medium skin tone
+1F469 1F3FF 200D 2764 200D 1F468 1F3FD                 ; minimally-qualified # 👩🏿‍❤‍👨🏽 E13.1 couple with heart: woman, man, dark skin tone, medium skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F468 1F3FE            ; fully-qualified     # 👩🏿‍❤️‍👨🏾 E13.1 couple with heart: woman, man, dark skin tone, medium-dark skin tone
+1F469 1F3FF 200D 2764 200D 1F468 1F3FE                 ; minimally-qualified # 👩🏿‍❤‍👨🏾 E13.1 couple with heart: woman, man, dark skin tone, medium-dark skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F468 1F3FF            ; fully-qualified     # 👩🏿‍❤️‍👨🏿 E13.1 couple with heart: woman, man, dark skin tone
+1F469 1F3FF 200D 2764 200D 1F468 1F3FF                 ; minimally-qualified # 👩🏿‍❤‍👨🏿 E13.1 couple with heart: woman, man, dark skin tone
+1F468 200D 2764 FE0F 200D 1F468                        ; fully-qualified     # 👨‍❤️‍👨 E2.0 couple with heart: man, man
+1F468 200D 2764 200D 1F468                             ; minimally-qualified # 👨‍❤‍👨 E2.0 couple with heart: man, man
+1F468 1F3FB 200D 2764 FE0F 200D 1F468 1F3FB            ; fully-qualified     # 👨🏻‍❤️‍👨🏻 E13.1 couple with heart: man, man, light skin tone
+1F468 1F3FB 200D 2764 200D 1F468 1F3FB                 ; minimally-qualified # 👨🏻‍❤‍👨🏻 E13.1 couple with heart: man, man, light skin tone
+1F468 1F3FB 200D 2764 FE0F 200D 1F468 1F3FC            ; fully-qualified     # 👨🏻‍❤️‍👨🏼 E13.1 couple with heart: man, man, light skin tone, medium-light skin tone
+1F468 1F3FB 200D 2764 200D 1F468 1F3FC                 ; minimally-qualified # 👨🏻‍❤‍👨🏼 E13.1 couple with heart: man, man, light skin tone, medium-light skin tone
+1F468 1F3FB 200D 2764 FE0F 200D 1F468 1F3FD            ; fully-qualified     # 👨🏻‍❤️‍👨🏽 E13.1 couple with heart: man, man, light skin tone, medium skin tone
+1F468 1F3FB 200D 2764 200D 1F468 1F3FD                 ; minimally-qualified # 👨🏻‍❤‍👨🏽 E13.1 couple with heart: man, man, light skin tone, medium skin tone
+1F468 1F3FB 200D 2764 FE0F 200D 1F468 1F3FE            ; fully-qualified     # 👨🏻‍❤️‍👨🏾 E13.1 couple with heart: man, man, light skin tone, medium-dark skin tone
+1F468 1F3FB 200D 2764 200D 1F468 1F3FE                 ; minimally-qualified # 👨🏻‍❤‍👨🏾 E13.1 couple with heart: man, man, light skin tone, medium-dark skin tone
+1F468 1F3FB 200D 2764 FE0F 200D 1F468 1F3FF            ; fully-qualified     # 👨🏻‍❤️‍👨🏿 E13.1 couple with heart: man, man, light skin tone, dark skin tone
+1F468 1F3FB 200D 2764 200D 1F468 1F3FF                 ; minimally-qualified # 👨🏻‍❤‍👨🏿 E13.1 couple with heart: man, man, light skin tone, dark skin tone
+1F468 1F3FC 200D 2764 FE0F 200D 1F468 1F3FB            ; fully-qualified     # 👨🏼‍❤️‍👨🏻 E13.1 couple with heart: man, man, medium-light skin tone, light skin tone
+1F468 1F3FC 200D 2764 200D 1F468 1F3FB                 ; minimally-qualified # 👨🏼‍❤‍👨🏻 E13.1 couple with heart: man, man, medium-light skin tone, light skin tone
+1F468 1F3FC 200D 2764 FE0F 200D 1F468 1F3FC            ; fully-qualified     # 👨🏼‍❤️‍👨🏼 E13.1 couple with heart: man, man, medium-light skin tone
+1F468 1F3FC 200D 2764 200D 1F468 1F3FC                 ; minimally-qualified # 👨🏼‍❤‍👨🏼 E13.1 couple with heart: man, man, medium-light skin tone
+1F468 1F3FC 200D 2764 FE0F 200D 1F468 1F3FD            ; fully-qualified     # 👨🏼‍❤️‍👨🏽 E13.1 couple with heart: man, man, medium-light skin tone, medium skin tone
+1F468 1F3FC 200D 2764 200D 1F468 1F3FD                 ; minimally-qualified # 👨🏼‍❤‍👨🏽 E13.1 couple with heart: man, man, medium-light skin tone, medium skin tone
+1F468 1F3FC 200D 2764 FE0F 200D 1F468 1F3FE            ; fully-qualified     # 👨🏼‍❤️‍👨🏾 E13.1 couple with heart: man, man, medium-light skin tone, medium-dark skin tone
+1F468 1F3FC 200D 2764 200D 1F468 1F3FE                 ; minimally-qualified # 👨🏼‍❤‍👨🏾 E13.1 couple with heart: man, man, medium-light skin tone, medium-dark skin tone
+1F468 1F3FC 200D 2764 FE0F 200D 1F468 1F3FF            ; fully-qualified     # 👨🏼‍❤️‍👨🏿 E13.1 couple with heart: man, man, medium-light skin tone, dark skin tone
+1F468 1F3FC 200D 2764 200D 1F468 1F3FF                 ; minimally-qualified # 👨🏼‍❤‍👨🏿 E13.1 couple with heart: man, man, medium-light skin tone, dark skin tone
+1F468 1F3FD 200D 2764 FE0F 200D 1F468 1F3FB            ; fully-qualified     # 👨🏽‍❤️‍👨🏻 E13.1 couple with heart: man, man, medium skin tone, light skin tone
+1F468 1F3FD 200D 2764 200D 1F468 1F3FB                 ; minimally-qualified # 👨🏽‍❤‍👨🏻 E13.1 couple with heart: man, man, medium skin tone, light skin tone
+1F468 1F3FD 200D 2764 FE0F 200D 1F468 1F3FC            ; fully-qualified     # 👨🏽‍❤️‍👨🏼 E13.1 couple with heart: man, man, medium skin tone, medium-light skin tone
+1F468 1F3FD 200D 2764 200D 1F468 1F3FC                 ; minimally-qualified # 👨🏽‍❤‍👨🏼 E13.1 couple with heart: man, man, medium skin tone, medium-light skin tone
+1F468 1F3FD 200D 2764 FE0F 200D 1F468 1F3FD            ; fully-qualified     # 👨🏽‍❤️‍👨🏽 E13.1 couple with heart: man, man, medium skin tone
+1F468 1F3FD 200D 2764 200D 1F468 1F3FD                 ; minimally-qualified # 👨🏽‍❤‍👨🏽 E13.1 couple with heart: man, man, medium skin tone
+1F468 1F3FD 200D 2764 FE0F 200D 1F468 1F3FE            ; fully-qualified     # 👨🏽‍❤️‍👨🏾 E13.1 couple with heart: man, man, medium skin tone, medium-dark skin tone
+1F468 1F3FD 200D 2764 200D 1F468 1F3FE                 ; minimally-qualified # 👨🏽‍❤‍👨🏾 E13.1 couple with heart: man, man, medium skin tone, medium-dark skin tone
+1F468 1F3FD 200D 2764 FE0F 200D 1F468 1F3FF            ; fully-qualified     # 👨🏽‍❤️‍👨🏿 E13.1 couple with heart: man, man, medium skin tone, dark skin tone
+1F468 1F3FD 200D 2764 200D 1F468 1F3FF                 ; minimally-qualified # 👨🏽‍❤‍👨🏿 E13.1 couple with heart: man, man, medium skin tone, dark skin tone
+1F468 1F3FE 200D 2764 FE0F 200D 1F468 1F3FB            ; fully-qualified     # 👨🏾‍❤️‍👨🏻 E13.1 couple with heart: man, man, medium-dark skin tone, light skin tone
+1F468 1F3FE 200D 2764 200D 1F468 1F3FB                 ; minimally-qualified # 👨🏾‍❤‍👨🏻 E13.1 couple with heart: man, man, medium-dark skin tone, light skin tone
+1F468 1F3FE 200D 2764 FE0F 200D 1F468 1F3FC            ; fully-qualified     # 👨🏾‍❤️‍👨🏼 E13.1 couple with heart: man, man, medium-dark skin tone, medium-light skin tone
+1F468 1F3FE 200D 2764 200D 1F468 1F3FC                 ; minimally-qualified # 👨🏾‍❤‍👨🏼 E13.1 couple with heart: man, man, medium-dark skin tone, medium-light skin tone
+1F468 1F3FE 200D 2764 FE0F 200D 1F468 1F3FD            ; fully-qualified     # 👨🏾‍❤️‍👨🏽 E13.1 couple with heart: man, man, medium-dark skin tone, medium skin tone
+1F468 1F3FE 200D 2764 200D 1F468 1F3FD                 ; minimally-qualified # 👨🏾‍❤‍👨🏽 E13.1 couple with heart: man, man, medium-dark skin tone, medium skin tone
+1F468 1F3FE 200D 2764 FE0F 200D 1F468 1F3FE            ; fully-qualified     # 👨🏾‍❤️‍👨🏾 E13.1 couple with heart: man, man, medium-dark skin tone
+1F468 1F3FE 200D 2764 200D 1F468 1F3FE                 ; minimally-qualified # 👨🏾‍❤‍👨🏾 E13.1 couple with heart: man, man, medium-dark skin tone
+1F468 1F3FE 200D 2764 FE0F 200D 1F468 1F3FF            ; fully-qualified     # 👨🏾‍❤️‍👨🏿 E13.1 couple with heart: man, man, medium-dark skin tone, dark skin tone
+1F468 1F3FE 200D 2764 200D 1F468 1F3FF                 ; minimally-qualified # 👨🏾‍❤‍👨🏿 E13.1 couple with heart: man, man, medium-dark skin tone, dark skin tone
+1F468 1F3FF 200D 2764 FE0F 200D 1F468 1F3FB            ; fully-qualified     # 👨🏿‍❤️‍👨🏻 E13.1 couple with heart: man, man, dark skin tone, light skin tone
+1F468 1F3FF 200D 2764 200D 1F468 1F3FB                 ; minimally-qualified # 👨🏿‍❤‍👨🏻 E13.1 couple with heart: man, man, dark skin tone, light skin tone
+1F468 1F3FF 200D 2764 FE0F 200D 1F468 1F3FC            ; fully-qualified     # 👨🏿‍❤️‍👨🏼 E13.1 couple with heart: man, man, dark skin tone, medium-light skin tone
+1F468 1F3FF 200D 2764 200D 1F468 1F3FC                 ; minimally-qualified # 👨🏿‍❤‍👨🏼 E13.1 couple with heart: man, man, dark skin tone, medium-light skin tone
+1F468 1F3FF 200D 2764 FE0F 200D 1F468 1F3FD            ; fully-qualified     # 👨🏿‍❤️‍👨🏽 E13.1 couple with heart: man, man, dark skin tone, medium skin tone
+1F468 1F3FF 200D 2764 200D 1F468 1F3FD                 ; minimally-qualified # 👨🏿‍❤‍👨🏽 E13.1 couple with heart: man, man, dark skin tone, medium skin tone
+1F468 1F3FF 200D 2764 FE0F 200D 1F468 1F3FE            ; fully-qualified     # 👨🏿‍❤️‍👨🏾 E13.1 couple with heart: man, man, dark skin tone, medium-dark skin tone
+1F468 1F3FF 200D 2764 200D 1F468 1F3FE                 ; minimally-qualified # 👨🏿‍❤‍👨🏾 E13.1 couple with heart: man, man, dark skin tone, medium-dark skin tone
+1F468 1F3FF 200D 2764 FE0F 200D 1F468 1F3FF            ; fully-qualified     # 👨🏿‍❤️‍👨🏿 E13.1 couple with heart: man, man, dark skin tone
+1F468 1F3FF 200D 2764 200D 1F468 1F3FF                 ; minimally-qualified # 👨🏿‍❤‍👨🏿 E13.1 couple with heart: man, man, dark skin tone
+1F469 200D 2764 FE0F 200D 1F469                        ; fully-qualified     # 👩‍❤️‍👩 E2.0 couple with heart: woman, woman
+1F469 200D 2764 200D 1F469                             ; minimally-qualified # 👩‍❤‍👩 E2.0 couple with heart: woman, woman
+1F469 1F3FB 200D 2764 FE0F 200D 1F469 1F3FB            ; fully-qualified     # 👩🏻‍❤️‍👩🏻 E13.1 couple with heart: woman, woman, light skin tone
+1F469 1F3FB 200D 2764 200D 1F469 1F3FB                 ; minimally-qualified # 👩🏻‍❤‍👩🏻 E13.1 couple with heart: woman, woman, light skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F469 1F3FC            ; fully-qualified     # 👩🏻‍❤️‍👩🏼 E13.1 couple with heart: woman, woman, light skin tone, medium-light skin tone
+1F469 1F3FB 200D 2764 200D 1F469 1F3FC                 ; minimally-qualified # 👩🏻‍❤‍👩🏼 E13.1 couple with heart: woman, woman, light skin tone, medium-light skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F469 1F3FD            ; fully-qualified     # 👩🏻‍❤️‍👩🏽 E13.1 couple with heart: woman, woman, light skin tone, medium skin tone
+1F469 1F3FB 200D 2764 200D 1F469 1F3FD                 ; minimally-qualified # 👩🏻‍❤‍👩🏽 E13.1 couple with heart: woman, woman, light skin tone, medium skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F469 1F3FE            ; fully-qualified     # 👩🏻‍❤️‍👩🏾 E13.1 couple with heart: woman, woman, light skin tone, medium-dark skin tone
+1F469 1F3FB 200D 2764 200D 1F469 1F3FE                 ; minimally-qualified # 👩🏻‍❤‍👩🏾 E13.1 couple with heart: woman, woman, light skin tone, medium-dark skin tone
+1F469 1F3FB 200D 2764 FE0F 200D 1F469 1F3FF            ; fully-qualified     # 👩🏻‍❤️‍👩🏿 E13.1 couple with heart: woman, woman, light skin tone, dark skin tone
+1F469 1F3FB 200D 2764 200D 1F469 1F3FF                 ; minimally-qualified # 👩🏻‍❤‍👩🏿 E13.1 couple with heart: woman, woman, light skin tone, dark skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F469 1F3FB            ; fully-qualified     # 👩🏼‍❤️‍👩🏻 E13.1 couple with heart: woman, woman, medium-light skin tone, light skin tone
+1F469 1F3FC 200D 2764 200D 1F469 1F3FB                 ; minimally-qualified # 👩🏼‍❤‍👩🏻 E13.1 couple with heart: woman, woman, medium-light skin tone, light skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F469 1F3FC            ; fully-qualified     # 👩🏼‍❤️‍👩🏼 E13.1 couple with heart: woman, woman, medium-light skin tone
+1F469 1F3FC 200D 2764 200D 1F469 1F3FC                 ; minimally-qualified # 👩🏼‍❤‍👩🏼 E13.1 couple with heart: woman, woman, medium-light skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F469 1F3FD            ; fully-qualified     # 👩🏼‍❤️‍👩🏽 E13.1 couple with heart: woman, woman, medium-light skin tone, medium skin tone
+1F469 1F3FC 200D 2764 200D 1F469 1F3FD                 ; minimally-qualified # 👩🏼‍❤‍👩🏽 E13.1 couple with heart: woman, woman, medium-light skin tone, medium skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F469 1F3FE            ; fully-qualified     # 👩🏼‍❤️‍👩🏾 E13.1 couple with heart: woman, woman, medium-light skin tone, medium-dark skin tone
+1F469 1F3FC 200D 2764 200D 1F469 1F3FE                 ; minimally-qualified # 👩🏼‍❤‍👩🏾 E13.1 couple with heart: woman, woman, medium-light skin tone, medium-dark skin tone
+1F469 1F3FC 200D 2764 FE0F 200D 1F469 1F3FF            ; fully-qualified     # 👩🏼‍❤️‍👩🏿 E13.1 couple with heart: woman, woman, medium-light skin tone, dark skin tone
+1F469 1F3FC 200D 2764 200D 1F469 1F3FF                 ; minimally-qualified # 👩🏼‍❤‍👩🏿 E13.1 couple with heart: woman, woman, medium-light skin tone, dark skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F469 1F3FB            ; fully-qualified     # 👩🏽‍❤️‍👩🏻 E13.1 couple with heart: woman, woman, medium skin tone, light skin tone
+1F469 1F3FD 200D 2764 200D 1F469 1F3FB                 ; minimally-qualified # 👩🏽‍❤‍👩🏻 E13.1 couple with heart: woman, woman, medium skin tone, light skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F469 1F3FC            ; fully-qualified     # 👩🏽‍❤️‍👩🏼 E13.1 couple with heart: woman, woman, medium skin tone, medium-light skin tone
+1F469 1F3FD 200D 2764 200D 1F469 1F3FC                 ; minimally-qualified # 👩🏽‍❤‍👩🏼 E13.1 couple with heart: woman, woman, medium skin tone, medium-light skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F469 1F3FD            ; fully-qualified     # 👩🏽‍❤️‍👩🏽 E13.1 couple with heart: woman, woman, medium skin tone
+1F469 1F3FD 200D 2764 200D 1F469 1F3FD                 ; minimally-qualified # 👩🏽‍❤‍👩🏽 E13.1 couple with heart: woman, woman, medium skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F469 1F3FE            ; fully-qualified     # 👩🏽‍❤️‍👩🏾 E13.1 couple with heart: woman, woman, medium skin tone, medium-dark skin tone
+1F469 1F3FD 200D 2764 200D 1F469 1F3FE                 ; minimally-qualified # 👩🏽‍❤‍👩🏾 E13.1 couple with heart: woman, woman, medium skin tone, medium-dark skin tone
+1F469 1F3FD 200D 2764 FE0F 200D 1F469 1F3FF            ; fully-qualified     # 👩🏽‍❤️‍👩🏿 E13.1 couple with heart: woman, woman, medium skin tone, dark skin tone
+1F469 1F3FD 200D 2764 200D 1F469 1F3FF                 ; minimally-qualified # 👩🏽‍❤‍👩🏿 E13.1 couple with heart: woman, woman, medium skin tone, dark skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F469 1F3FB            ; fully-qualified     # 👩🏾‍❤️‍👩🏻 E13.1 couple with heart: woman, woman, medium-dark skin tone, light skin tone
+1F469 1F3FE 200D 2764 200D 1F469 1F3FB                 ; minimally-qualified # 👩🏾‍❤‍👩🏻 E13.1 couple with heart: woman, woman, medium-dark skin tone, light skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F469 1F3FC            ; fully-qualified     # 👩🏾‍❤️‍👩🏼 E13.1 couple with heart: woman, woman, medium-dark skin tone, medium-light skin tone
+1F469 1F3FE 200D 2764 200D 1F469 1F3FC                 ; minimally-qualified # 👩🏾‍❤‍👩🏼 E13.1 couple with heart: woman, woman, medium-dark skin tone, medium-light skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F469 1F3FD            ; fully-qualified     # 👩🏾‍❤️‍👩🏽 E13.1 couple with heart: woman, woman, medium-dark skin tone, medium skin tone
+1F469 1F3FE 200D 2764 200D 1F469 1F3FD                 ; minimally-qualified # 👩🏾‍❤‍👩🏽 E13.1 couple with heart: woman, woman, medium-dark skin tone, medium skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F469 1F3FE            ; fully-qualified     # 👩🏾‍❤️‍👩🏾 E13.1 couple with heart: woman, woman, medium-dark skin tone
+1F469 1F3FE 200D 2764 200D 1F469 1F3FE                 ; minimally-qualified # 👩🏾‍❤‍👩🏾 E13.1 couple with heart: woman, woman, medium-dark skin tone
+1F469 1F3FE 200D 2764 FE0F 200D 1F469 1F3FF            ; fully-qualified     # 👩🏾‍❤️‍👩🏿 E13.1 couple with heart: woman, woman, medium-dark skin tone, dark skin tone
+1F469 1F3FE 200D 2764 200D 1F469 1F3FF                 ; minimally-qualified # 👩🏾‍❤‍👩🏿 E13.1 couple with heart: woman, woman, medium-dark skin tone, dark skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F469 1F3FB            ; fully-qualified     # 👩🏿‍❤️‍👩🏻 E13.1 couple with heart: woman, woman, dark skin tone, light skin tone
+1F469 1F3FF 200D 2764 200D 1F469 1F3FB                 ; minimally-qualified # 👩🏿‍❤‍👩🏻 E13.1 couple with heart: woman, woman, dark skin tone, light skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F469 1F3FC            ; fully-qualified     # 👩🏿‍❤️‍👩🏼 E13.1 couple with heart: woman, woman, dark skin tone, medium-light skin tone
+1F469 1F3FF 200D 2764 200D 1F469 1F3FC                 ; minimally-qualified # 👩🏿‍❤‍👩🏼 E13.1 couple with heart: woman, woman, dark skin tone, medium-light skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F469 1F3FD            ; fully-qualified     # 👩🏿‍❤️‍👩🏽 E13.1 couple with heart: woman, woman, dark skin tone, medium skin tone
+1F469 1F3FF 200D 2764 200D 1F469 1F3FD                 ; minimally-qualified # 👩🏿‍❤‍👩🏽 E13.1 couple with heart: woman, woman, dark skin tone, medium skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F469 1F3FE            ; fully-qualified     # 👩🏿‍❤️‍👩🏾 E13.1 couple with heart: woman, woman, dark skin tone, medium-dark skin tone
+1F469 1F3FF 200D 2764 200D 1F469 1F3FE                 ; minimally-qualified # 👩🏿‍❤‍👩🏾 E13.1 couple with heart: woman, woman, dark skin tone, medium-dark skin tone
+1F469 1F3FF 200D 2764 FE0F 200D 1F469 1F3FF            ; fully-qualified     # 👩🏿‍❤️‍👩🏿 E13.1 couple with heart: woman, woman, dark skin tone
+1F469 1F3FF 200D 2764 200D 1F469 1F3FF                 ; minimally-qualified # 👩🏿‍❤‍👩🏿 E13.1 couple with heart: woman, woman, dark skin tone
+1F468 200D 1F469 200D 1F466                            ; fully-qualified     # 👨‍👩‍👦 E2.0 family: man, woman, boy
+1F468 200D 1F469 200D 1F467                            ; fully-qualified     # 👨‍👩‍👧 E2.0 family: man, woman, girl
+1F468 200D 1F469 200D 1F467 200D 1F466                 ; fully-qualified     # 👨‍👩‍👧‍👦 E2.0 family: man, woman, girl, boy
+1F468 200D 1F469 200D 1F466 200D 1F466                 ; fully-qualified     # 👨‍👩‍👦‍👦 E2.0 family: man, woman, boy, boy
+1F468 200D 1F469 200D 1F467 200D 1F467                 ; fully-qualified     # 👨‍👩‍👧‍👧 E2.0 family: man, woman, girl, girl
+1F468 200D 1F468 200D 1F466                            ; fully-qualified     # 👨‍👨‍👦 E2.0 family: man, man, boy
+1F468 200D 1F468 200D 1F467                            ; fully-qualified     # 👨‍👨‍👧 E2.0 family: man, man, girl
+1F468 200D 1F468 200D 1F467 200D 1F466                 ; fully-qualified     # 👨‍👨‍👧‍👦 E2.0 family: man, man, girl, boy
+1F468 200D 1F468 200D 1F466 200D 1F466                 ; fully-qualified     # 👨‍👨‍👦‍👦 E2.0 family: man, man, boy, boy
+1F468 200D 1F468 200D 1F467 200D 1F467                 ; fully-qualified     # 👨‍👨‍👧‍👧 E2.0 family: man, man, girl, girl
+1F469 200D 1F469 200D 1F466                            ; fully-qualified     # 👩‍👩‍👦 E2.0 family: woman, woman, boy
+1F469 200D 1F469 200D 1F467                            ; fully-qualified     # 👩‍👩‍👧 E2.0 family: woman, woman, girl
+1F469 200D 1F469 200D 1F467 200D 1F466                 ; fully-qualified     # 👩‍👩‍👧‍👦 E2.0 family: woman, woman, girl, boy
+1F469 200D 1F469 200D 1F466 200D 1F466                 ; fully-qualified     # 👩‍👩‍👦‍👦 E2.0 family: woman, woman, boy, boy
+1F469 200D 1F469 200D 1F467 200D 1F467                 ; fully-qualified     # 👩‍👩‍👧‍👧 E2.0 family: woman, woman, girl, girl
+1F468 200D 1F466                                       ; fully-qualified     # 👨‍👦 E4.0 family: man, boy
+1F468 200D 1F466 200D 1F466                            ; fully-qualified     # 👨‍👦‍👦 E4.0 family: man, boy, boy
+1F468 200D 1F467                                       ; fully-qualified     # 👨‍👧 E4.0 family: man, girl
+1F468 200D 1F467 200D 1F466                            ; fully-qualified     # 👨‍👧‍👦 E4.0 family: man, girl, boy
+1F468 200D 1F467 200D 1F467                            ; fully-qualified     # 👨‍👧‍👧 E4.0 family: man, girl, girl
+1F469 200D 1F466                                       ; fully-qualified     # 👩‍👦 E4.0 family: woman, boy
+1F469 200D 1F466 200D 1F466                            ; fully-qualified     # 👩‍👦‍👦 E4.0 family: woman, boy, boy
+1F469 200D 1F467                                       ; fully-qualified     # 👩‍👧 E4.0 family: woman, girl
+1F469 200D 1F467 200D 1F466                            ; fully-qualified     # 👩‍👧‍👦 E4.0 family: woman, girl, boy
+1F469 200D 1F467 200D 1F467                            ; fully-qualified     # 👩‍👧‍👧 E4.0 family: woman, girl, girl
+
+# subgroup: person-symbol
+1F5E3 FE0F                                             ; fully-qualified     # 🗣️ E0.7 speaking head
+1F5E3                                                  ; unqualified         # 🗣 E0.7 speaking head
+1F464                                                  ; fully-qualified     # 👤 E0.6 bust in silhouette
+1F465                                                  ; fully-qualified     # 👥 E1.0 busts in silhouette
+1FAC2                                                  ; fully-qualified     # 🫂 E13.0 people hugging
+1F46A                                                  ; fully-qualified     # 👪 E0.6 family
+1F9D1 200D 1F9D1 200D 1F9D2                            ; fully-qualified     # 🧑‍🧑‍🧒 E15.1 family: adult, adult, child
+1F9D1 200D 1F9D1 200D 1F9D2 200D 1F9D2                 ; fully-qualified     # 🧑‍🧑‍🧒‍🧒 E15.1 family: adult, adult, child, child
+1F9D1 200D 1F9D2                                       ; fully-qualified     # 🧑‍🧒 E15.1 family: adult, child
+1F9D1 200D 1F9D2 200D 1F9D2                            ; fully-qualified     # 🧑‍🧒‍🧒 E15.1 family: adult, child, child
+1F463                                                  ; fully-qualified     # 👣 E0.6 footprints
+1FAC6                                                  ; fully-qualified     # 🫆 E16.0 fingerprint
+
+# People & Body subtotal:		3291
+# People & Body subtotal:		561	w/o modifiers
+
+# group: Component
+
+# subgroup: skin-tone
+1F3FB                                                  ; component           # 🏻 E1.0 light skin tone
+1F3FC                                                  ; component           # 🏼 E1.0 medium-light skin tone
+1F3FD                                                  ; component           # 🏽 E1.0 medium skin tone
+1F3FE                                                  ; component           # 🏾 E1.0 medium-dark skin tone
+1F3FF                                                  ; component           # 🏿 E1.0 dark skin tone
+
+# subgroup: hair-style
+1F9B0                                                  ; component           # 🦰 E11.0 red hair
+1F9B1                                                  ; component           # 🦱 E11.0 curly hair
+1F9B3                                                  ; component           # 🦳 E11.0 white hair
+1F9B2                                                  ; component           # 🦲 E11.0 bald
+
+# Component subtotal:		9
+# Component subtotal:		4	w/o modifiers
+
+# group: Animals & Nature
+
+# subgroup: animal-mammal
+1F435                                                  ; fully-qualified     # 🐵 E0.6 monkey face
+1F412                                                  ; fully-qualified     # 🐒 E0.6 monkey
+1F98D                                                  ; fully-qualified     # 🦍 E3.0 gorilla
+1F9A7                                                  ; fully-qualified     # 🦧 E12.0 orangutan
+1F436                                                  ; fully-qualified     # 🐶 E0.6 dog face
+1F415                                                  ; fully-qualified     # 🐕 E0.7 dog
+1F9AE                                                  ; fully-qualified     # 🦮 E12.0 guide dog
+1F415 200D 1F9BA                                       ; fully-qualified     # 🐕‍🦺 E12.0 service dog
+1F429                                                  ; fully-qualified     # 🐩 E0.6 poodle
+1F43A                                                  ; fully-qualified     # 🐺 E0.6 wolf
+1F98A                                                  ; fully-qualified     # 🦊 E3.0 fox
+1F99D                                                  ; fully-qualified     # 🦝 E11.0 raccoon
+1F431                                                  ; fully-qualified     # 🐱 E0.6 cat face
+1F408                                                  ; fully-qualified     # 🐈 E0.7 cat
+1F408 200D 2B1B                                        ; fully-qualified     # 🐈‍⬛ E13.0 black cat
+1F981                                                  ; fully-qualified     # 🦁 E1.0 lion
+1F42F                                                  ; fully-qualified     # 🐯 E0.6 tiger face
+1F405                                                  ; fully-qualified     # 🐅 E1.0 tiger
+1F406                                                  ; fully-qualified     # 🐆 E1.0 leopard
+1F434                                                  ; fully-qualified     # 🐴 E0.6 horse face
+1FACE                                                  ; fully-qualified     # 🫎 E15.0 moose
+1FACF                                                  ; fully-qualified     # 🫏 E15.0 donkey
+1F40E                                                  ; fully-qualified     # 🐎 E0.6 horse
+1F984                                                  ; fully-qualified     # 🦄 E1.0 unicorn
+1F993                                                  ; fully-qualified     # 🦓 E5.0 zebra
+1F98C                                                  ; fully-qualified     # 🦌 E3.0 deer
+1F9AC                                                  ; fully-qualified     # 🦬 E13.0 bison
+1F42E                                                  ; fully-qualified     # 🐮 E0.6 cow face
+1F402                                                  ; fully-qualified     # 🐂 E1.0 ox
+1F403                                                  ; fully-qualified     # 🐃 E1.0 water buffalo
+1F404                                                  ; fully-qualified     # 🐄 E1.0 cow
+1F437                                                  ; fully-qualified     # 🐷 E0.6 pig face
+1F416                                                  ; fully-qualified     # 🐖 E1.0 pig
+1F417                                                  ; fully-qualified     # 🐗 E0.6 boar
+1F43D                                                  ; fully-qualified     # 🐽 E0.6 pig nose
+1F40F                                                  ; fully-qualified     # 🐏 E1.0 ram
+1F411                                                  ; fully-qualified     # 🐑 E0.6 ewe
+1F410                                                  ; fully-qualified     # 🐐 E1.0 goat
+1F42A                                                  ; fully-qualified     # 🐪 E1.0 camel
+1F42B                                                  ; fully-qualified     # 🐫 E0.6 two-hump camel
+1F999                                                  ; fully-qualified     # 🦙 E11.0 llama
+1F992                                                  ; fully-qualified     # 🦒 E5.0 giraffe
+1F418                                                  ; fully-qualified     # 🐘 E0.6 elephant
+1F9A3                                                  ; fully-qualified     # 🦣 E13.0 mammoth
+1F98F                                                  ; fully-qualified     # 🦏 E3.0 rhinoceros
+1F99B                                                  ; fully-qualified     # 🦛 E11.0 hippopotamus
+1F42D                                                  ; fully-qualified     # 🐭 E0.6 mouse face
+1F401                                                  ; fully-qualified     # 🐁 E1.0 mouse
+1F400                                                  ; fully-qualified     # 🐀 E1.0 rat
+1F439                                                  ; fully-qualified     # 🐹 E0.6 hamster
+1F430                                                  ; fully-qualified     # 🐰 E0.6 rabbit face
+1F407                                                  ; fully-qualified     # 🐇 E1.0 rabbit
+1F43F FE0F                                             ; fully-qualified     # 🐿️ E0.7 chipmunk
+1F43F                                                  ; unqualified         # 🐿 E0.7 chipmunk
+1F9AB                                                  ; fully-qualified     # 🦫 E13.0 beaver
+1F994                                                  ; fully-qualified     # 🦔 E5.0 hedgehog
+1F987                                                  ; fully-qualified     # 🦇 E3.0 bat
+1F43B                                                  ; fully-qualified     # 🐻 E0.6 bear
+1F43B 200D 2744 FE0F                                   ; fully-qualified     # 🐻‍❄️ E13.0 polar bear
+1F43B 200D 2744                                        ; minimally-qualified # 🐻‍❄ E13.0 polar bear
+1F428                                                  ; fully-qualified     # 🐨 E0.6 koala
+1F43C                                                  ; fully-qualified     # 🐼 E0.6 panda
+1F9A5                                                  ; fully-qualified     # 🦥 E12.0 sloth
+1F9A6                                                  ; fully-qualified     # 🦦 E12.0 otter
+1F9A8                                                  ; fully-qualified     # 🦨 E12.0 skunk
+1F998                                                  ; fully-qualified     # 🦘 E11.0 kangaroo
+1F9A1                                                  ; fully-qualified     # 🦡 E11.0 badger
+1F43E                                                  ; fully-qualified     # 🐾 E0.6 paw prints
+
+# subgroup: animal-bird
+1F983                                                  ; fully-qualified     # 🦃 E1.0 turkey
+1F414                                                  ; fully-qualified     # 🐔 E0.6 chicken
+1F413                                                  ; fully-qualified     # 🐓 E1.0 rooster
+1F423                                                  ; fully-qualified     # 🐣 E0.6 hatching chick
+1F424                                                  ; fully-qualified     # 🐤 E0.6 baby chick
+1F425                                                  ; fully-qualified     # 🐥 E0.6 front-facing baby chick
+1F426                                                  ; fully-qualified     # 🐦 E0.6 bird
+1F427                                                  ; fully-qualified     # 🐧 E0.6 penguin
+1F54A FE0F                                             ; fully-qualified     # 🕊️ E0.7 dove
+1F54A                                                  ; unqualified         # 🕊 E0.7 dove
+1F985                                                  ; fully-qualified     # 🦅 E3.0 eagle
+1F986                                                  ; fully-qualified     # 🦆 E3.0 duck
+1F9A2                                                  ; fully-qualified     # 🦢 E11.0 swan
+1F989                                                  ; fully-qualified     # 🦉 E3.0 owl
+1F9A4                                                  ; fully-qualified     # 🦤 E13.0 dodo
+1FAB6                                                  ; fully-qualified     # 🪶 E13.0 feather
+1F9A9                                                  ; fully-qualified     # 🦩 E12.0 flamingo
+1F99A                                                  ; fully-qualified     # 🦚 E11.0 peacock
+1F99C                                                  ; fully-qualified     # 🦜 E11.0 parrot
+1FABD                                                  ; fully-qualified     # 🪽 E15.0 wing
+1F426 200D 2B1B                                        ; fully-qualified     # 🐦‍⬛ E15.0 black bird
+1FABF                                                  ; fully-qualified     # 🪿 E15.0 goose
+1F426 200D 1F525                                       ; fully-qualified     # 🐦‍🔥 E15.1 phoenix
+
+# subgroup: animal-amphibian
+1F438                                                  ; fully-qualified     # 🐸 E0.6 frog
+
+# subgroup: animal-reptile
+1F40A                                                  ; fully-qualified     # 🐊 E1.0 crocodile
+1F422                                                  ; fully-qualified     # 🐢 E0.6 turtle
+1F98E                                                  ; fully-qualified     # 🦎 E3.0 lizard
+1F40D                                                  ; fully-qualified     # 🐍 E0.6 snake
+1F432                                                  ; fully-qualified     # 🐲 E0.6 dragon face
+1F409                                                  ; fully-qualified     # 🐉 E1.0 dragon
+1F995                                                  ; fully-qualified     # 🦕 E5.0 sauropod
+1F996                                                  ; fully-qualified     # 🦖 E5.0 T-Rex
+
+# subgroup: animal-marine
+1F433                                                  ; fully-qualified     # 🐳 E0.6 spouting whale
+1F40B                                                  ; fully-qualified     # 🐋 E1.0 whale
+1F42C                                                  ; fully-qualified     # 🐬 E0.6 dolphin
+1F9AD                                                  ; fully-qualified     # 🦭 E13.0 seal
+1F41F                                                  ; fully-qualified     # 🐟 E0.6 fish
+1F420                                                  ; fully-qualified     # 🐠 E0.6 tropical fish
+1F421                                                  ; fully-qualified     # 🐡 E0.6 blowfish
+1F988                                                  ; fully-qualified     # 🦈 E3.0 shark
+1F419                                                  ; fully-qualified     # 🐙 E0.6 octopus
+1F41A                                                  ; fully-qualified     # 🐚 E0.6 spiral shell
+1FAB8                                                  ; fully-qualified     # 🪸 E14.0 coral
+1FABC                                                  ; fully-qualified     # 🪼 E15.0 jellyfish
+1F980                                                  ; fully-qualified     # 🦀 E1.0 crab
+1F99E                                                  ; fully-qualified     # 🦞 E11.0 lobster
+1F990                                                  ; fully-qualified     # 🦐 E3.0 shrimp
+1F991                                                  ; fully-qualified     # 🦑 E3.0 squid
+1F9AA                                                  ; fully-qualified     # 🦪 E12.0 oyster
+
+# subgroup: animal-bug
+1F40C                                                  ; fully-qualified     # 🐌 E0.6 snail
+1F98B                                                  ; fully-qualified     # 🦋 E3.0 butterfly
+1F41B                                                  ; fully-qualified     # 🐛 E0.6 bug
+1F41C                                                  ; fully-qualified     # 🐜 E0.6 ant
+1F41D                                                  ; fully-qualified     # 🐝 E0.6 honeybee
+1FAB2                                                  ; fully-qualified     # 🪲 E13.0 beetle
+1F41E                                                  ; fully-qualified     # 🐞 E0.6 lady beetle
+1F997                                                  ; fully-qualified     # 🦗 E5.0 cricket
+1FAB3                                                  ; fully-qualified     # 🪳 E13.0 cockroach
+1F577 FE0F                                             ; fully-qualified     # 🕷️ E0.7 spider
+1F577                                                  ; unqualified         # 🕷 E0.7 spider
+1F578 FE0F                                             ; fully-qualified     # 🕸️ E0.7 spider web
+1F578                                                  ; unqualified         # 🕸 E0.7 spider web
+1F982                                                  ; fully-qualified     # 🦂 E1.0 scorpion
+1F99F                                                  ; fully-qualified     # 🦟 E11.0 mosquito
+1FAB0                                                  ; fully-qualified     # 🪰 E13.0 fly
+1FAB1                                                  ; fully-qualified     # 🪱 E13.0 worm
+1F9A0                                                  ; fully-qualified     # 🦠 E11.0 microbe
+
+# subgroup: plant-flower
+1F490                                                  ; fully-qualified     # 💐 E0.6 bouquet
+1F338                                                  ; fully-qualified     # 🌸 E0.6 cherry blossom
+1F4AE                                                  ; fully-qualified     # 💮 E0.6 white flower
+1FAB7                                                  ; fully-qualified     # 🪷 E14.0 lotus
+1F3F5 FE0F                                             ; fully-qualified     # 🏵️ E0.7 rosette
+1F3F5                                                  ; unqualified         # 🏵 E0.7 rosette
+1F339                                                  ; fully-qualified     # 🌹 E0.6 rose
+1F940                                                  ; fully-qualified     # 🥀 E3.0 wilted flower
+1F33A                                                  ; fully-qualified     # 🌺 E0.6 hibiscus
+1F33B                                                  ; fully-qualified     # 🌻 E0.6 sunflower
+1F33C                                                  ; fully-qualified     # 🌼 E0.6 blossom
+1F337                                                  ; fully-qualified     # 🌷 E0.6 tulip
+1FABB                                                  ; fully-qualified     # 🪻 E15.0 hyacinth
+
+# subgroup: plant-other
+1F331                                                  ; fully-qualified     # 🌱 E0.6 seedling
+1FAB4                                                  ; fully-qualified     # 🪴 E13.0 potted plant
+1F332                                                  ; fully-qualified     # 🌲 E1.0 evergreen tree
+1F333                                                  ; fully-qualified     # 🌳 E1.0 deciduous tree
+1F334                                                  ; fully-qualified     # 🌴 E0.6 palm tree
+1F335                                                  ; fully-qualified     # 🌵 E0.6 cactus
+1F33E                                                  ; fully-qualified     # 🌾 E0.6 sheaf of rice
+1F33F                                                  ; fully-qualified     # 🌿 E0.6 herb
+2618 FE0F                                              ; fully-qualified     # ☘️ E1.0 shamrock
+2618                                                   ; unqualified         # ☘ E1.0 shamrock
+1F340                                                  ; fully-qualified     # 🍀 E0.6 four leaf clover
+1F341                                                  ; fully-qualified     # 🍁 E0.6 maple leaf
+1F342                                                  ; fully-qualified     # 🍂 E0.6 fallen leaf
+1F343                                                  ; fully-qualified     # 🍃 E0.6 leaf fluttering in wind
+1FAB9                                                  ; fully-qualified     # 🪹 E14.0 empty nest
+1FABA                                                  ; fully-qualified     # 🪺 E14.0 nest with eggs
+1F344                                                  ; fully-qualified     # 🍄 E0.6 mushroom
+1FABE                                                  ; fully-qualified     # 🪾 E16.0 leafless tree
+
+# Animals & Nature subtotal:		166
+# Animals & Nature subtotal:		166	w/o modifiers
+
+# group: Food & Drink
+
+# subgroup: food-fruit
+1F347                                                  ; fully-qualified     # 🍇 E0.6 grapes
+1F348                                                  ; fully-qualified     # 🍈 E0.6 melon
+1F349                                                  ; fully-qualified     # 🍉 E0.6 watermelon
+1F34A                                                  ; fully-qualified     # 🍊 E0.6 tangerine
+1F34B                                                  ; fully-qualified     # 🍋 E1.0 lemon
+1F34B 200D 1F7E9                                       ; fully-qualified     # 🍋‍🟩 E15.1 lime
+1F34C                                                  ; fully-qualified     # 🍌 E0.6 banana
+1F34D                                                  ; fully-qualified     # 🍍 E0.6 pineapple
+1F96D                                                  ; fully-qualified     # 🥭 E11.0 mango
+1F34E                                                  ; fully-qualified     # 🍎 E0.6 red apple
+1F34F                                                  ; fully-qualified     # 🍏 E0.6 green apple
+1F350                                                  ; fully-qualified     # 🍐 E1.0 pear
+1F351                                                  ; fully-qualified     # 🍑 E0.6 peach
+1F352                                                  ; fully-qualified     # 🍒 E0.6 cherries
+1F353                                                  ; fully-qualified     # 🍓 E0.6 strawberry
+1FAD0                                                  ; fully-qualified     # 🫐 E13.0 blueberries
+1F95D                                                  ; fully-qualified     # 🥝 E3.0 kiwi fruit
+1F345                                                  ; fully-qualified     # 🍅 E0.6 tomato
+1FAD2                                                  ; fully-qualified     # 🫒 E13.0 olive
+1F965                                                  ; fully-qualified     # 🥥 E5.0 coconut
+
+# subgroup: food-vegetable
+1F951                                                  ; fully-qualified     # 🥑 E3.0 avocado
+1F346                                                  ; fully-qualified     # 🍆 E0.6 eggplant
+1F954                                                  ; fully-qualified     # 🥔 E3.0 potato
+1F955                                                  ; fully-qualified     # 🥕 E3.0 carrot
+1F33D                                                  ; fully-qualified     # 🌽 E0.6 ear of corn
+1F336 FE0F                                             ; fully-qualified     # 🌶️ E0.7 hot pepper
+1F336                                                  ; unqualified         # 🌶 E0.7 hot pepper
+1FAD1                                                  ; fully-qualified     # 🫑 E13.0 bell pepper
+1F952                                                  ; fully-qualified     # 🥒 E3.0 cucumber
+1F96C                                                  ; fully-qualified     # 🥬 E11.0 leafy green
+1F966                                                  ; fully-qualified     # 🥦 E5.0 broccoli
+1F9C4                                                  ; fully-qualified     # 🧄 E12.0 garlic
+1F9C5                                                  ; fully-qualified     # 🧅 E12.0 onion
+1F95C                                                  ; fully-qualified     # 🥜 E3.0 peanuts
+1FAD8                                                  ; fully-qualified     # 🫘 E14.0 beans
+1F330                                                  ; fully-qualified     # 🌰 E0.6 chestnut
+1FADA                                                  ; fully-qualified     # 🫚 E15.0 ginger root
+1FADB                                                  ; fully-qualified     # 🫛 E15.0 pea pod
+1F344 200D 1F7EB                                       ; fully-qualified     # 🍄‍🟫 E15.1 brown mushroom
+1FADC                                                  ; fully-qualified     # 🫜 E16.0 root vegetable
+
+# subgroup: food-prepared
+1F35E                                                  ; fully-qualified     # 🍞 E0.6 bread
+1F950                                                  ; fully-qualified     # 🥐 E3.0 croissant
+1F956                                                  ; fully-qualified     # 🥖 E3.0 baguette bread
+1FAD3                                                  ; fully-qualified     # 🫓 E13.0 flatbread
+1F968                                                  ; fully-qualified     # 🥨 E5.0 pretzel
+1F96F                                                  ; fully-qualified     # 🥯 E11.0 bagel
+1F95E                                                  ; fully-qualified     # 🥞 E3.0 pancakes
+1F9C7                                                  ; fully-qualified     # 🧇 E12.0 waffle
+1F9C0                                                  ; fully-qualified     # 🧀 E1.0 cheese wedge
+1F356                                                  ; fully-qualified     # 🍖 E0.6 meat on bone
+1F357                                                  ; fully-qualified     # 🍗 E0.6 poultry leg
+1F969                                                  ; fully-qualified     # 🥩 E5.0 cut of meat
+1F953                                                  ; fully-qualified     # 🥓 E3.0 bacon
+1F354                                                  ; fully-qualified     # 🍔 E0.6 hamburger
+1F35F                                                  ; fully-qualified     # 🍟 E0.6 french fries
+1F355                                                  ; fully-qualified     # 🍕 E0.6 pizza
+1F32D                                                  ; fully-qualified     # 🌭 E1.0 hot dog
+1F96A                                                  ; fully-qualified     # 🥪 E5.0 sandwich
+1F32E                                                  ; fully-qualified     # 🌮 E1.0 taco
+1F32F                                                  ; fully-qualified     # 🌯 E1.0 burrito
+1FAD4                                                  ; fully-qualified     # 🫔 E13.0 tamale
+1F959                                                  ; fully-qualified     # 🥙 E3.0 stuffed flatbread
+1F9C6                                                  ; fully-qualified     # 🧆 E12.0 falafel
+1F95A                                                  ; fully-qualified     # 🥚 E3.0 egg
+1F373                                                  ; fully-qualified     # 🍳 E0.6 cooking
+1F958                                                  ; fully-qualified     # 🥘 E3.0 shallow pan of food
+1F372                                                  ; fully-qualified     # 🍲 E0.6 pot of food
+1FAD5                                                  ; fully-qualified     # 🫕 E13.0 fondue
+1F963                                                  ; fully-qualified     # 🥣 E5.0 bowl with spoon
+1F957                                                  ; fully-qualified     # 🥗 E3.0 green salad
+1F37F                                                  ; fully-qualified     # 🍿 E1.0 popcorn
+1F9C8                                                  ; fully-qualified     # 🧈 E12.0 butter
+1F9C2                                                  ; fully-qualified     # 🧂 E11.0 salt
+1F96B                                                  ; fully-qualified     # 🥫 E5.0 canned food
+
+# subgroup: food-asian
+1F371                                                  ; fully-qualified     # 🍱 E0.6 bento box
+1F358                                                  ; fully-qualified     # 🍘 E0.6 rice cracker
+1F359                                                  ; fully-qualified     # 🍙 E0.6 rice ball
+1F35A                                                  ; fully-qualified     # 🍚 E0.6 cooked rice
+1F35B                                                  ; fully-qualified     # 🍛 E0.6 curry rice
+1F35C                                                  ; fully-qualified     # 🍜 E0.6 steaming bowl
+1F35D                                                  ; fully-qualified     # 🍝 E0.6 spaghetti
+1F360                                                  ; fully-qualified     # 🍠 E0.6 roasted sweet potato
+1F362                                                  ; fully-qualified     # 🍢 E0.6 oden
+1F363                                                  ; fully-qualified     # 🍣 E0.6 sushi
+1F364                                                  ; fully-qualified     # 🍤 E0.6 fried shrimp
+1F365                                                  ; fully-qualified     # 🍥 E0.6 fish cake with swirl
+1F96E                                                  ; fully-qualified     # 🥮 E11.0 moon cake
+1F361                                                  ; fully-qualified     # 🍡 E0.6 dango
+1F95F                                                  ; fully-qualified     # 🥟 E5.0 dumpling
+1F960                                                  ; fully-qualified     # 🥠 E5.0 fortune cookie
+1F961                                                  ; fully-qualified     # 🥡 E5.0 takeout box
+
+# subgroup: food-sweet
+1F366                                                  ; fully-qualified     # 🍦 E0.6 soft ice cream
+1F367                                                  ; fully-qualified     # 🍧 E0.6 shaved ice
+1F368                                                  ; fully-qualified     # 🍨 E0.6 ice cream
+1F369                                                  ; fully-qualified     # 🍩 E0.6 doughnut
+1F36A                                                  ; fully-qualified     # 🍪 E0.6 cookie
+1F382                                                  ; fully-qualified     # 🎂 E0.6 birthday cake
+1F370                                                  ; fully-qualified     # 🍰 E0.6 shortcake
+1F9C1                                                  ; fully-qualified     # 🧁 E11.0 cupcake
+1F967                                                  ; fully-qualified     # 🥧 E5.0 pie
+1F36B                                                  ; fully-qualified     # 🍫 E0.6 chocolate bar
+1F36C                                                  ; fully-qualified     # 🍬 E0.6 candy
+1F36D                                                  ; fully-qualified     # 🍭 E0.6 lollipop
+1F36E                                                  ; fully-qualified     # 🍮 E0.6 custard
+1F36F                                                  ; fully-qualified     # 🍯 E0.6 honey pot
+
+# subgroup: drink
+1F37C                                                  ; fully-qualified     # 🍼 E1.0 baby bottle
+1F95B                                                  ; fully-qualified     # 🥛 E3.0 glass of milk
+2615                                                   ; fully-qualified     # ☕ E0.6 hot beverage
+1FAD6                                                  ; fully-qualified     # 🫖 E13.0 teapot
+1F375                                                  ; fully-qualified     # 🍵 E0.6 teacup without handle
+1F376                                                  ; fully-qualified     # 🍶 E0.6 sake
+1F37E                                                  ; fully-qualified     # 🍾 E1.0 bottle with popping cork
+1F377                                                  ; fully-qualified     # 🍷 E0.6 wine glass
+1F378                                                  ; fully-qualified     # 🍸 E0.6 cocktail glass
+1F379                                                  ; fully-qualified     # 🍹 E0.6 tropical drink
+1F37A                                                  ; fully-qualified     # 🍺 E0.6 beer mug
+1F37B                                                  ; fully-qualified     # 🍻 E0.6 clinking beer mugs
+1F942                                                  ; fully-qualified     # 🥂 E3.0 clinking glasses
+1F943                                                  ; fully-qualified     # 🥃 E3.0 tumbler glass
+1FAD7                                                  ; fully-qualified     # 🫗 E14.0 pouring liquid
+1F964                                                  ; fully-qualified     # 🥤 E5.0 cup with straw
+1F9CB                                                  ; fully-qualified     # 🧋 E13.0 bubble tea
+1F9C3                                                  ; fully-qualified     # 🧃 E12.0 beverage box
+1F9C9                                                  ; fully-qualified     # 🧉 E12.0 mate
+1F9CA                                                  ; fully-qualified     # 🧊 E12.0 ice
+
+# subgroup: dishware
+1F962                                                  ; fully-qualified     # 🥢 E5.0 chopsticks
+1F37D FE0F                                             ; fully-qualified     # 🍽️ E0.7 fork and knife with plate
+1F37D                                                  ; unqualified         # 🍽 E0.7 fork and knife with plate
+1F374                                                  ; fully-qualified     # 🍴 E0.6 fork and knife
+1F944                                                  ; fully-qualified     # 🥄 E3.0 spoon
+1F52A                                                  ; fully-qualified     # 🔪 E0.6 kitchen knife
+1FAD9                                                  ; fully-qualified     # 🫙 E14.0 jar
+1F3FA                                                  ; fully-qualified     # 🏺 E1.0 amphora
+
+# Food & Drink subtotal:		133
+# Food & Drink subtotal:		133	w/o modifiers
+
+# group: Travel & Places
+
+# subgroup: place-map
+1F30D                                                  ; fully-qualified     # 🌍 E0.7 globe showing Europe-Africa
+1F30E                                                  ; fully-qualified     # 🌎 E0.7 globe showing Americas
+1F30F                                                  ; fully-qualified     # 🌏 E0.6 globe showing Asia-Australia
+1F310                                                  ; fully-qualified     # 🌐 E1.0 globe with meridians
+1F5FA FE0F                                             ; fully-qualified     # 🗺️ E0.7 world map
+1F5FA                                                  ; unqualified         # 🗺 E0.7 world map
+1F5FE                                                  ; fully-qualified     # 🗾 E0.6 map of Japan
+1F9ED                                                  ; fully-qualified     # 🧭 E11.0 compass
+
+# subgroup: place-geographic
+1F3D4 FE0F                                             ; fully-qualified     # 🏔️ E0.7 snow-capped mountain
+1F3D4                                                  ; unqualified         # 🏔 E0.7 snow-capped mountain
+26F0 FE0F                                              ; fully-qualified     # ⛰️ E0.7 mountain
+26F0                                                   ; unqualified         # ⛰ E0.7 mountain
+1F30B                                                  ; fully-qualified     # 🌋 E0.6 volcano
+1F5FB                                                  ; fully-qualified     # 🗻 E0.6 mount fuji
+1F3D5 FE0F                                             ; fully-qualified     # 🏕️ E0.7 camping
+1F3D5                                                  ; unqualified         # 🏕 E0.7 camping
+1F3D6 FE0F                                             ; fully-qualified     # 🏖️ E0.7 beach with umbrella
+1F3D6                                                  ; unqualified         # 🏖 E0.7 beach with umbrella
+1F3DC FE0F                                             ; fully-qualified     # 🏜️ E0.7 desert
+1F3DC                                                  ; unqualified         # 🏜 E0.7 desert
+1F3DD FE0F                                             ; fully-qualified     # 🏝️ E0.7 desert island
+1F3DD                                                  ; unqualified         # 🏝 E0.7 desert island
+1F3DE FE0F                                             ; fully-qualified     # 🏞️ E0.7 national park
+1F3DE                                                  ; unqualified         # 🏞 E0.7 national park
+
+# subgroup: place-building
+1F3DF FE0F                                             ; fully-qualified     # 🏟️ E0.7 stadium
+1F3DF                                                  ; unqualified         # 🏟 E0.7 stadium
+1F3DB FE0F                                             ; fully-qualified     # 🏛️ E0.7 classical building
+1F3DB                                                  ; unqualified         # 🏛 E0.7 classical building
+1F3D7 FE0F                                             ; fully-qualified     # 🏗️ E0.7 building construction
+1F3D7                                                  ; unqualified         # 🏗 E0.7 building construction
+1F9F1                                                  ; fully-qualified     # 🧱 E11.0 brick
+1FAA8                                                  ; fully-qualified     # 🪨 E13.0 rock
+1FAB5                                                  ; fully-qualified     # 🪵 E13.0 wood
+1F6D6                                                  ; fully-qualified     # 🛖 E13.0 hut
+1F3D8 FE0F                                             ; fully-qualified     # 🏘️ E0.7 houses
+1F3D8                                                  ; unqualified         # 🏘 E0.7 houses
+1F3DA FE0F                                             ; fully-qualified     # 🏚️ E0.7 derelict house
+1F3DA                                                  ; unqualified         # 🏚 E0.7 derelict house
+1F3E0                                                  ; fully-qualified     # 🏠 E0.6 house
+1F3E1                                                  ; fully-qualified     # 🏡 E0.6 house with garden
+1F3E2                                                  ; fully-qualified     # 🏢 E0.6 office building
+1F3E3                                                  ; fully-qualified     # 🏣 E0.6 Japanese post office
+1F3E4                                                  ; fully-qualified     # 🏤 E1.0 post office
+1F3E5                                                  ; fully-qualified     # 🏥 E0.6 hospital
+1F3E6                                                  ; fully-qualified     # 🏦 E0.6 bank
+1F3E8                                                  ; fully-qualified     # 🏨 E0.6 hotel
+1F3E9                                                  ; fully-qualified     # 🏩 E0.6 love hotel
+1F3EA                                                  ; fully-qualified     # 🏪 E0.6 convenience store
+1F3EB                                                  ; fully-qualified     # 🏫 E0.6 school
+1F3EC                                                  ; fully-qualified     # 🏬 E0.6 department store
+1F3ED                                                  ; fully-qualified     # 🏭 E0.6 factory
+1F3EF                                                  ; fully-qualified     # 🏯 E0.6 Japanese castle
+1F3F0                                                  ; fully-qualified     # 🏰 E0.6 castle
+1F492                                                  ; fully-qualified     # 💒 E0.6 wedding
+1F5FC                                                  ; fully-qualified     # 🗼 E0.6 Tokyo tower
+1F5FD                                                  ; fully-qualified     # 🗽 E0.6 Statue of Liberty
+
+# subgroup: place-religious
+26EA                                                   ; fully-qualified     # ⛪ E0.6 church
+1F54C                                                  ; fully-qualified     # 🕌 E1.0 mosque
+1F6D5                                                  ; fully-qualified     # 🛕 E12.0 hindu temple
+1F54D                                                  ; fully-qualified     # 🕍 E1.0 synagogue
+26E9 FE0F                                              ; fully-qualified     # ⛩️ E0.7 shinto shrine
+26E9                                                   ; unqualified         # ⛩ E0.7 shinto shrine
+1F54B                                                  ; fully-qualified     # 🕋 E1.0 kaaba
+
+# subgroup: place-other
+26F2                                                   ; fully-qualified     # ⛲ E0.6 fountain
+26FA                                                   ; fully-qualified     # ⛺ E0.6 tent
+1F301                                                  ; fully-qualified     # 🌁 E0.6 foggy
+1F303                                                  ; fully-qualified     # 🌃 E0.6 night with stars
+1F3D9 FE0F                                             ; fully-qualified     # 🏙️ E0.7 cityscape
+1F3D9                                                  ; unqualified         # 🏙 E0.7 cityscape
+1F304                                                  ; fully-qualified     # 🌄 E0.6 sunrise over mountains
+1F305                                                  ; fully-qualified     # 🌅 E0.6 sunrise
+1F306                                                  ; fully-qualified     # 🌆 E0.6 cityscape at dusk
+1F307                                                  ; fully-qualified     # 🌇 E0.6 sunset
+1F309                                                  ; fully-qualified     # 🌉 E0.6 bridge at night
+2668 FE0F                                              ; fully-qualified     # ♨️ E0.6 hot springs
+2668                                                   ; unqualified         # ♨ E0.6 hot springs
+1F3A0                                                  ; fully-qualified     # 🎠 E0.6 carousel horse
+1F6DD                                                  ; fully-qualified     # 🛝 E14.0 playground slide
+1F3A1                                                  ; fully-qualified     # 🎡 E0.6 ferris wheel
+1F3A2                                                  ; fully-qualified     # 🎢 E0.6 roller coaster
+1F488                                                  ; fully-qualified     # 💈 E0.6 barber pole
+1F3AA                                                  ; fully-qualified     # 🎪 E0.6 circus tent
+
+# subgroup: transport-ground
+1F682                                                  ; fully-qualified     # 🚂 E1.0 locomotive
+1F683                                                  ; fully-qualified     # 🚃 E0.6 railway car
+1F684                                                  ; fully-qualified     # 🚄 E0.6 high-speed train
+1F685                                                  ; fully-qualified     # 🚅 E0.6 bullet train
+1F686                                                  ; fully-qualified     # 🚆 E1.0 train
+1F687                                                  ; fully-qualified     # 🚇 E0.6 metro
+1F688                                                  ; fully-qualified     # 🚈 E1.0 light rail
+1F689                                                  ; fully-qualified     # 🚉 E0.6 station
+1F68A                                                  ; fully-qualified     # 🚊 E1.0 tram
+1F69D                                                  ; fully-qualified     # 🚝 E1.0 monorail
+1F69E                                                  ; fully-qualified     # 🚞 E1.0 mountain railway
+1F68B                                                  ; fully-qualified     # 🚋 E1.0 tram car
+1F68C                                                  ; fully-qualified     # 🚌 E0.6 bus
+1F68D                                                  ; fully-qualified     # 🚍 E0.7 oncoming bus
+1F68E                                                  ; fully-qualified     # 🚎 E1.0 trolleybus
+1F690                                                  ; fully-qualified     # 🚐 E1.0 minibus
+1F691                                                  ; fully-qualified     # 🚑 E0.6 ambulance
+1F692                                                  ; fully-qualified     # 🚒 E0.6 fire engine
+1F693                                                  ; fully-qualified     # 🚓 E0.6 police car
+1F694                                                  ; fully-qualified     # 🚔 E0.7 oncoming police car
+1F695                                                  ; fully-qualified     # 🚕 E0.6 taxi
+1F696                                                  ; fully-qualified     # 🚖 E1.0 oncoming taxi
+1F697                                                  ; fully-qualified     # 🚗 E0.6 automobile
+1F698                                                  ; fully-qualified     # 🚘 E0.7 oncoming automobile
+1F699                                                  ; fully-qualified     # 🚙 E0.6 sport utility vehicle
+1F6FB                                                  ; fully-qualified     # 🛻 E13.0 pickup truck
+1F69A                                                  ; fully-qualified     # 🚚 E0.6 delivery truck
+1F69B                                                  ; fully-qualified     # 🚛 E1.0 articulated lorry
+1F69C                                                  ; fully-qualified     # 🚜 E1.0 tractor
+1F3CE FE0F                                             ; fully-qualified     # 🏎️ E0.7 racing car
+1F3CE                                                  ; unqualified         # 🏎 E0.7 racing car
+1F3CD FE0F                                             ; fully-qualified     # 🏍️ E0.7 motorcycle
+1F3CD                                                  ; unqualified         # 🏍 E0.7 motorcycle
+1F6F5                                                  ; fully-qualified     # 🛵 E3.0 motor scooter
+1F9BD                                                  ; fully-qualified     # 🦽 E12.0 manual wheelchair
+1F9BC                                                  ; fully-qualified     # 🦼 E12.0 motorized wheelchair
+1F6FA                                                  ; fully-qualified     # 🛺 E12.0 auto rickshaw
+1F6B2                                                  ; fully-qualified     # 🚲 E0.6 bicycle
+1F6F4                                                  ; fully-qualified     # 🛴 E3.0 kick scooter
+1F6F9                                                  ; fully-qualified     # 🛹 E11.0 skateboard
+1F6FC                                                  ; fully-qualified     # 🛼 E13.0 roller skate
+1F68F                                                  ; fully-qualified     # 🚏 E0.6 bus stop
+1F6E3 FE0F                                             ; fully-qualified     # 🛣️ E0.7 motorway
+1F6E3                                                  ; unqualified         # 🛣 E0.7 motorway
+1F6E4 FE0F                                             ; fully-qualified     # 🛤️ E0.7 railway track
+1F6E4                                                  ; unqualified         # 🛤 E0.7 railway track
+1F6E2 FE0F                                             ; fully-qualified     # 🛢️ E0.7 oil drum
+1F6E2                                                  ; unqualified         # 🛢 E0.7 oil drum
+26FD                                                   ; fully-qualified     # ⛽ E0.6 fuel pump
+1F6DE                                                  ; fully-qualified     # 🛞 E14.0 wheel
+1F6A8                                                  ; fully-qualified     # 🚨 E0.6 police car light
+1F6A5                                                  ; fully-qualified     # 🚥 E0.6 horizontal traffic light
+1F6A6                                                  ; fully-qualified     # 🚦 E1.0 vertical traffic light
+1F6D1                                                  ; fully-qualified     # 🛑 E3.0 stop sign
+1F6A7                                                  ; fully-qualified     # 🚧 E0.6 construction
+
+# subgroup: transport-water
+2693                                                   ; fully-qualified     # ⚓ E0.6 anchor
+1F6DF                                                  ; fully-qualified     # 🛟 E14.0 ring buoy
+26F5                                                   ; fully-qualified     # ⛵ E0.6 sailboat
+1F6F6                                                  ; fully-qualified     # 🛶 E3.0 canoe
+1F6A4                                                  ; fully-qualified     # 🚤 E0.6 speedboat
+1F6F3 FE0F                                             ; fully-qualified     # 🛳️ E0.7 passenger ship
+1F6F3                                                  ; unqualified         # 🛳 E0.7 passenger ship
+26F4 FE0F                                              ; fully-qualified     # ⛴️ E0.7 ferry
+26F4                                                   ; unqualified         # ⛴ E0.7 ferry
+1F6E5 FE0F                                             ; fully-qualified     # 🛥️ E0.7 motor boat
+1F6E5                                                  ; unqualified         # 🛥 E0.7 motor boat
+1F6A2                                                  ; fully-qualified     # 🚢 E0.6 ship
+
+# subgroup: transport-air
+2708 FE0F                                              ; fully-qualified     # ✈️ E0.6 airplane
+2708                                                   ; unqualified         # ✈ E0.6 airplane
+1F6E9 FE0F                                             ; fully-qualified     # 🛩️ E0.7 small airplane
+1F6E9                                                  ; unqualified         # 🛩 E0.7 small airplane
+1F6EB                                                  ; fully-qualified     # 🛫 E1.0 airplane departure
+1F6EC                                                  ; fully-qualified     # 🛬 E1.0 airplane arrival
+1FA82                                                  ; fully-qualified     # 🪂 E12.0 parachute
+1F4BA                                                  ; fully-qualified     # 💺 E0.6 seat
+1F681                                                  ; fully-qualified     # 🚁 E1.0 helicopter
+1F69F                                                  ; fully-qualified     # 🚟 E1.0 suspension railway
+1F6A0                                                  ; fully-qualified     # 🚠 E1.0 mountain cableway
+1F6A1                                                  ; fully-qualified     # 🚡 E1.0 aerial tramway
+1F6F0 FE0F                                             ; fully-qualified     # 🛰️ E0.7 satellite
+1F6F0                                                  ; unqualified         # 🛰 E0.7 satellite
+1F680                                                  ; fully-qualified     # 🚀 E0.6 rocket
+1F6F8                                                  ; fully-qualified     # 🛸 E5.0 flying saucer
+
+# subgroup: hotel
+1F6CE FE0F                                             ; fully-qualified     # 🛎️ E0.7 bellhop bell
+1F6CE                                                  ; unqualified         # 🛎 E0.7 bellhop bell
+1F9F3                                                  ; fully-qualified     # 🧳 E11.0 luggage
+
+# subgroup: time
+231B                                                   ; fully-qualified     # ⌛ E0.6 hourglass done
+23F3                                                   ; fully-qualified     # ⏳ E0.6 hourglass not done
+231A                                                   ; fully-qualified     # ⌚ E0.6 watch
+23F0                                                   ; fully-qualified     # ⏰ E0.6 alarm clock
+23F1 FE0F                                              ; fully-qualified     # ⏱️ E1.0 stopwatch
+23F1                                                   ; unqualified         # ⏱ E1.0 stopwatch
+23F2 FE0F                                              ; fully-qualified     # ⏲️ E1.0 timer clock
+23F2                                                   ; unqualified         # ⏲ E1.0 timer clock
+1F570 FE0F                                             ; fully-qualified     # 🕰️ E0.7 mantelpiece clock
+1F570                                                  ; unqualified         # 🕰 E0.7 mantelpiece clock
+1F55B                                                  ; fully-qualified     # 🕛 E0.6 twelve o’clock
+1F567                                                  ; fully-qualified     # 🕧 E0.7 twelve-thirty
+1F550                                                  ; fully-qualified     # 🕐 E0.6 one o’clock
+1F55C                                                  ; fully-qualified     # 🕜 E0.7 one-thirty
+1F551                                                  ; fully-qualified     # 🕑 E0.6 two o’clock
+1F55D                                                  ; fully-qualified     # 🕝 E0.7 two-thirty
+1F552                                                  ; fully-qualified     # 🕒 E0.6 three o’clock
+1F55E                                                  ; fully-qualified     # 🕞 E0.7 three-thirty
+1F553                                                  ; fully-qualified     # 🕓 E0.6 four o’clock
+1F55F                                                  ; fully-qualified     # 🕟 E0.7 four-thirty
+1F554                                                  ; fully-qualified     # 🕔 E0.6 five o’clock
+1F560                                                  ; fully-qualified     # 🕠 E0.7 five-thirty
+1F555                                                  ; fully-qualified     # 🕕 E0.6 six o’clock
+1F561                                                  ; fully-qualified     # 🕡 E0.7 six-thirty
+1F556                                                  ; fully-qualified     # 🕖 E0.6 seven o’clock
+1F562                                                  ; fully-qualified     # 🕢 E0.7 seven-thirty
+1F557                                                  ; fully-qualified     # 🕗 E0.6 eight o’clock
+1F563                                                  ; fully-qualified     # 🕣 E0.7 eight-thirty
+1F558                                                  ; fully-qualified     # 🕘 E0.6 nine o’clock
+1F564                                                  ; fully-qualified     # 🕤 E0.7 nine-thirty
+1F559                                                  ; fully-qualified     # 🕙 E0.6 ten o’clock
+1F565                                                  ; fully-qualified     # 🕥 E0.7 ten-thirty
+1F55A                                                  ; fully-qualified     # 🕚 E0.6 eleven o’clock
+1F566                                                  ; fully-qualified     # 🕦 E0.7 eleven-thirty
+
+# subgroup: sky & weather
+1F311                                                  ; fully-qualified     # 🌑 E0.6 new moon
+1F312                                                  ; fully-qualified     # 🌒 E1.0 waxing crescent moon
+1F313                                                  ; fully-qualified     # 🌓 E0.6 first quarter moon
+1F314                                                  ; fully-qualified     # 🌔 E0.6 waxing gibbous moon
+1F315                                                  ; fully-qualified     # 🌕 E0.6 full moon
+1F316                                                  ; fully-qualified     # 🌖 E1.0 waning gibbous moon
+1F317                                                  ; fully-qualified     # 🌗 E1.0 last quarter moon
+1F318                                                  ; fully-qualified     # 🌘 E1.0 waning crescent moon
+1F319                                                  ; fully-qualified     # 🌙 E0.6 crescent moon
+1F31A                                                  ; fully-qualified     # 🌚 E1.0 new moon face
+1F31B                                                  ; fully-qualified     # 🌛 E0.6 first quarter moon face
+1F31C                                                  ; fully-qualified     # 🌜 E0.7 last quarter moon face
+1F321 FE0F                                             ; fully-qualified     # 🌡️ E0.7 thermometer
+1F321                                                  ; unqualified         # 🌡 E0.7 thermometer
+2600 FE0F                                              ; fully-qualified     # ☀️ E0.6 sun
+2600                                                   ; unqualified         # ☀ E0.6 sun
+1F31D                                                  ; fully-qualified     # 🌝 E1.0 full moon face
+1F31E                                                  ; fully-qualified     # 🌞 E1.0 sun with face
+1FA90                                                  ; fully-qualified     # 🪐 E12.0 ringed planet
+2B50                                                   ; fully-qualified     # ⭐ E0.6 star
+1F31F                                                  ; fully-qualified     # 🌟 E0.6 glowing star
+1F320                                                  ; fully-qualified     # 🌠 E0.6 shooting star
+1F30C                                                  ; fully-qualified     # 🌌 E0.6 milky way
+2601 FE0F                                              ; fully-qualified     # ☁️ E0.6 cloud
+2601                                                   ; unqualified         # ☁ E0.6 cloud
+26C5                                                   ; fully-qualified     # ⛅ E0.6 sun behind cloud
+26C8 FE0F                                              ; fully-qualified     # ⛈️ E0.7 cloud with lightning and rain
+26C8                                                   ; unqualified         # ⛈ E0.7 cloud with lightning and rain
+1F324 FE0F                                             ; fully-qualified     # 🌤️ E0.7 sun behind small cloud
+1F324                                                  ; unqualified         # 🌤 E0.7 sun behind small cloud
+1F325 FE0F                                             ; fully-qualified     # 🌥️ E0.7 sun behind large cloud
+1F325                                                  ; unqualified         # 🌥 E0.7 sun behind large cloud
+1F326 FE0F                                             ; fully-qualified     # 🌦️ E0.7 sun behind rain cloud
+1F326                                                  ; unqualified         # 🌦 E0.7 sun behind rain cloud
+1F327 FE0F                                             ; fully-qualified     # 🌧️ E0.7 cloud with rain
+1F327                                                  ; unqualified         # 🌧 E0.7 cloud with rain
+1F328 FE0F                                             ; fully-qualified     # 🌨️ E0.7 cloud with snow
+1F328                                                  ; unqualified         # 🌨 E0.7 cloud with snow
+1F329 FE0F                                             ; fully-qualified     # 🌩️ E0.7 cloud with lightning
+1F329                                                  ; unqualified         # 🌩 E0.7 cloud with lightning
+1F32A FE0F                                             ; fully-qualified     # 🌪️ E0.7 tornado
+1F32A                                                  ; unqualified         # 🌪 E0.7 tornado
+1F32B FE0F                                             ; fully-qualified     # 🌫️ E0.7 fog
+1F32B                                                  ; unqualified         # 🌫 E0.7 fog
+1F32C FE0F                                             ; fully-qualified     # 🌬️ E0.7 wind face
+1F32C                                                  ; unqualified         # 🌬 E0.7 wind face
+1F300                                                  ; fully-qualified     # 🌀 E0.6 cyclone
+1F308                                                  ; fully-qualified     # 🌈 E0.6 rainbow
+1F302                                                  ; fully-qualified     # 🌂 E0.6 closed umbrella
+2602 FE0F                                              ; fully-qualified     # ☂️ E0.7 umbrella
+2602                                                   ; unqualified         # ☂ E0.7 umbrella
+2614                                                   ; fully-qualified     # ☔ E0.6 umbrella with rain drops
+26F1 FE0F                                              ; fully-qualified     # ⛱️ E0.7 umbrella on ground
+26F1                                                   ; unqualified         # ⛱ E0.7 umbrella on ground
+26A1                                                   ; fully-qualified     # ⚡ E0.6 high voltage
+2744 FE0F                                              ; fully-qualified     # ❄️ E0.6 snowflake
+2744                                                   ; unqualified         # ❄ E0.6 snowflake
+2603 FE0F                                              ; fully-qualified     # ☃️ E0.7 snowman
+2603                                                   ; unqualified         # ☃ E0.7 snowman
+26C4                                                   ; fully-qualified     # ⛄ E0.6 snowman without snow
+2604 FE0F                                              ; fully-qualified     # ☄️ E1.0 comet
+2604                                                   ; unqualified         # ☄ E1.0 comet
+1F525                                                  ; fully-qualified     # 🔥 E0.6 fire
+1F4A7                                                  ; fully-qualified     # 💧 E0.6 droplet
+1F30A                                                  ; fully-qualified     # 🌊 E0.6 water wave
+
+# Travel & Places subtotal:		267
+# Travel & Places subtotal:		267	w/o modifiers
+
+# group: Activities
+
+# subgroup: event
+1F383                                                  ; fully-qualified     # 🎃 E0.6 jack-o-lantern
+1F384                                                  ; fully-qualified     # 🎄 E0.6 Christmas tree
+1F386                                                  ; fully-qualified     # 🎆 E0.6 fireworks
+1F387                                                  ; fully-qualified     # 🎇 E0.6 sparkler
+1F9E8                                                  ; fully-qualified     # 🧨 E11.0 firecracker
+2728                                                   ; fully-qualified     # ✨ E0.6 sparkles
+1F388                                                  ; fully-qualified     # 🎈 E0.6 balloon
+1F389                                                  ; fully-qualified     # 🎉 E0.6 party popper
+1F38A                                                  ; fully-qualified     # 🎊 E0.6 confetti ball
+1F38B                                                  ; fully-qualified     # 🎋 E0.6 tanabata tree
+1F38D                                                  ; fully-qualified     # 🎍 E0.6 pine decoration
+1F38E                                                  ; fully-qualified     # 🎎 E0.6 Japanese dolls
+1F38F                                                  ; fully-qualified     # 🎏 E0.6 carp streamer
+1F390                                                  ; fully-qualified     # 🎐 E0.6 wind chime
+1F391                                                  ; fully-qualified     # 🎑 E0.6 moon viewing ceremony
+1F9E7                                                  ; fully-qualified     # 🧧 E11.0 red envelope
+1F380                                                  ; fully-qualified     # 🎀 E0.6 ribbon
+1F381                                                  ; fully-qualified     # 🎁 E0.6 wrapped gift
+1F397 FE0F                                             ; fully-qualified     # 🎗️ E0.7 reminder ribbon
+1F397                                                  ; unqualified         # 🎗 E0.7 reminder ribbon
+1F39F FE0F                                             ; fully-qualified     # 🎟️ E0.7 admission tickets
+1F39F                                                  ; unqualified         # 🎟 E0.7 admission tickets
+1F3AB                                                  ; fully-qualified     # 🎫 E0.6 ticket
+
+# subgroup: award-medal
+1F396 FE0F                                             ; fully-qualified     # 🎖️ E0.7 military medal
+1F396                                                  ; unqualified         # 🎖 E0.7 military medal
+1F3C6                                                  ; fully-qualified     # 🏆 E0.6 trophy
+1F3C5                                                  ; fully-qualified     # 🏅 E1.0 sports medal
+1F947                                                  ; fully-qualified     # 🥇 E3.0 1st place medal
+1F948                                                  ; fully-qualified     # 🥈 E3.0 2nd place medal
+1F949                                                  ; fully-qualified     # 🥉 E3.0 3rd place medal
+
+# subgroup: sport
+26BD                                                   ; fully-qualified     # ⚽ E0.6 soccer ball
+26BE                                                   ; fully-qualified     # ⚾ E0.6 baseball
+1F94E                                                  ; fully-qualified     # 🥎 E11.0 softball
+1F3C0                                                  ; fully-qualified     # 🏀 E0.6 basketball
+1F3D0                                                  ; fully-qualified     # 🏐 E1.0 volleyball
+1F3C8                                                  ; fully-qualified     # 🏈 E0.6 american football
+1F3C9                                                  ; fully-qualified     # 🏉 E1.0 rugby football
+1F3BE                                                  ; fully-qualified     # 🎾 E0.6 tennis
+1F94F                                                  ; fully-qualified     # 🥏 E11.0 flying disc
+1F3B3                                                  ; fully-qualified     # 🎳 E0.6 bowling
+1F3CF                                                  ; fully-qualified     # 🏏 E1.0 cricket game
+1F3D1                                                  ; fully-qualified     # 🏑 E1.0 field hockey
+1F3D2                                                  ; fully-qualified     # 🏒 E1.0 ice hockey
+1F94D                                                  ; fully-qualified     # 🥍 E11.0 lacrosse
+1F3D3                                                  ; fully-qualified     # 🏓 E1.0 ping pong
+1F3F8                                                  ; fully-qualified     # 🏸 E1.0 badminton
+1F94A                                                  ; fully-qualified     # 🥊 E3.0 boxing glove
+1F94B                                                  ; fully-qualified     # 🥋 E3.0 martial arts uniform
+1F945                                                  ; fully-qualified     # 🥅 E3.0 goal net
+26F3                                                   ; fully-qualified     # ⛳ E0.6 flag in hole
+26F8 FE0F                                              ; fully-qualified     # ⛸️ E0.7 ice skate
+26F8                                                   ; unqualified         # ⛸ E0.7 ice skate
+1F3A3                                                  ; fully-qualified     # 🎣 E0.6 fishing pole
+1F93F                                                  ; fully-qualified     # 🤿 E12.0 diving mask
+1F3BD                                                  ; fully-qualified     # 🎽 E0.6 running shirt
+1F3BF                                                  ; fully-qualified     # 🎿 E0.6 skis
+1F6F7                                                  ; fully-qualified     # 🛷 E5.0 sled
+1F94C                                                  ; fully-qualified     # 🥌 E5.0 curling stone
+
+# subgroup: game
+1F3AF                                                  ; fully-qualified     # 🎯 E0.6 bullseye
+1FA80                                                  ; fully-qualified     # 🪀 E12.0 yo-yo
+1FA81                                                  ; fully-qualified     # 🪁 E12.0 kite
+1F52B                                                  ; fully-qualified     # 🔫 E0.6 water pistol
+1F3B1                                                  ; fully-qualified     # 🎱 E0.6 pool 8 ball
+1F52E                                                  ; fully-qualified     # 🔮 E0.6 crystal ball
+1FA84                                                  ; fully-qualified     # 🪄 E13.0 magic wand
+1F3AE                                                  ; fully-qualified     # 🎮 E0.6 video game
+1F579 FE0F                                             ; fully-qualified     # 🕹️ E0.7 joystick
+1F579                                                  ; unqualified         # 🕹 E0.7 joystick
+1F3B0                                                  ; fully-qualified     # 🎰 E0.6 slot machine
+1F3B2                                                  ; fully-qualified     # 🎲 E0.6 game die
+1F9E9                                                  ; fully-qualified     # 🧩 E11.0 puzzle piece
+1F9F8                                                  ; fully-qualified     # 🧸 E11.0 teddy bear
+1FA85                                                  ; fully-qualified     # 🪅 E13.0 piñata
+1FAA9                                                  ; fully-qualified     # 🪩 E14.0 mirror ball
+1FA86                                                  ; fully-qualified     # 🪆 E13.0 nesting dolls
+2660 FE0F                                              ; fully-qualified     # ♠️ E0.6 spade suit
+2660                                                   ; unqualified         # ♠ E0.6 spade suit
+2665 FE0F                                              ; fully-qualified     # ♥️ E0.6 heart suit
+2665                                                   ; unqualified         # ♥ E0.6 heart suit
+2666 FE0F                                              ; fully-qualified     # ♦️ E0.6 diamond suit
+2666                                                   ; unqualified         # ♦ E0.6 diamond suit
+2663 FE0F                                              ; fully-qualified     # ♣️ E0.6 club suit
+2663                                                   ; unqualified         # ♣ E0.6 club suit
+265F FE0F                                              ; fully-qualified     # ♟️ E11.0 chess pawn
+265F                                                   ; unqualified         # ♟ E11.0 chess pawn
+1F0CF                                                  ; fully-qualified     # 🃏 E0.6 joker
+1F004                                                  ; fully-qualified     # 🀄 E0.6 mahjong red dragon
+1F3B4                                                  ; fully-qualified     # 🎴 E0.6 flower playing cards
+
+# subgroup: arts & crafts
+1F3AD                                                  ; fully-qualified     # 🎭 E0.6 performing arts
+1F5BC FE0F                                             ; fully-qualified     # 🖼️ E0.7 framed picture
+1F5BC                                                  ; unqualified         # 🖼 E0.7 framed picture
+1F3A8                                                  ; fully-qualified     # 🎨 E0.6 artist palette
+1F9F5                                                  ; fully-qualified     # 🧵 E11.0 thread
+1FAA1                                                  ; fully-qualified     # 🪡 E13.0 sewing needle
+1F9F6                                                  ; fully-qualified     # 🧶 E11.0 yarn
+1FAA2                                                  ; fully-qualified     # 🪢 E13.0 knot
+
+# Activities subtotal:		96
+# Activities subtotal:		96	w/o modifiers
+
+# group: Objects
+
+# subgroup: clothing
+1F453                                                  ; fully-qualified     # 👓 E0.6 glasses
+1F576 FE0F                                             ; fully-qualified     # 🕶️ E0.7 sunglasses
+1F576                                                  ; unqualified         # 🕶 E0.7 sunglasses
+1F97D                                                  ; fully-qualified     # 🥽 E11.0 goggles
+1F97C                                                  ; fully-qualified     # 🥼 E11.0 lab coat
+1F9BA                                                  ; fully-qualified     # 🦺 E12.0 safety vest
+1F454                                                  ; fully-qualified     # 👔 E0.6 necktie
+1F455                                                  ; fully-qualified     # 👕 E0.6 t-shirt
+1F456                                                  ; fully-qualified     # 👖 E0.6 jeans
+1F9E3                                                  ; fully-qualified     # 🧣 E5.0 scarf
+1F9E4                                                  ; fully-qualified     # 🧤 E5.0 gloves
+1F9E5                                                  ; fully-qualified     # 🧥 E5.0 coat
+1F9E6                                                  ; fully-qualified     # 🧦 E5.0 socks
+1F457                                                  ; fully-qualified     # 👗 E0.6 dress
+1F458                                                  ; fully-qualified     # 👘 E0.6 kimono
+1F97B                                                  ; fully-qualified     # 🥻 E12.0 sari
+1FA71                                                  ; fully-qualified     # 🩱 E12.0 one-piece swimsuit
+1FA72                                                  ; fully-qualified     # 🩲 E12.0 briefs
+1FA73                                                  ; fully-qualified     # 🩳 E12.0 shorts
+1F459                                                  ; fully-qualified     # 👙 E0.6 bikini
+1F45A                                                  ; fully-qualified     # 👚 E0.6 woman’s clothes
+1FAAD                                                  ; fully-qualified     # 🪭 E15.0 folding hand fan
+1F45B                                                  ; fully-qualified     # 👛 E0.6 purse
+1F45C                                                  ; fully-qualified     # 👜 E0.6 handbag
+1F45D                                                  ; fully-qualified     # 👝 E0.6 clutch bag
+1F6CD FE0F                                             ; fully-qualified     # 🛍️ E0.7 shopping bags
+1F6CD                                                  ; unqualified         # 🛍 E0.7 shopping bags
+1F392                                                  ; fully-qualified     # 🎒 E0.6 backpack
+1FA74                                                  ; fully-qualified     # 🩴 E13.0 thong sandal
+1F45E                                                  ; fully-qualified     # 👞 E0.6 man’s shoe
+1F45F                                                  ; fully-qualified     # 👟 E0.6 running shoe
+1F97E                                                  ; fully-qualified     # 🥾 E11.0 hiking boot
+1F97F                                                  ; fully-qualified     # 🥿 E11.0 flat shoe
+1F460                                                  ; fully-qualified     # 👠 E0.6 high-heeled shoe
+1F461                                                  ; fully-qualified     # 👡 E0.6 woman’s sandal
+1FA70                                                  ; fully-qualified     # 🩰 E12.0 ballet shoes
+1F462                                                  ; fully-qualified     # 👢 E0.6 woman’s boot
+1FAAE                                                  ; fully-qualified     # 🪮 E15.0 hair pick
+1F451                                                  ; fully-qualified     # 👑 E0.6 crown
+1F452                                                  ; fully-qualified     # 👒 E0.6 woman’s hat
+1F3A9                                                  ; fully-qualified     # 🎩 E0.6 top hat
+1F393                                                  ; fully-qualified     # 🎓 E0.6 graduation cap
+1F9E2                                                  ; fully-qualified     # 🧢 E5.0 billed cap
+1FA96                                                  ; fully-qualified     # 🪖 E13.0 military helmet
+26D1 FE0F                                              ; fully-qualified     # ⛑️ E0.7 rescue worker’s helmet
+26D1                                                   ; unqualified         # ⛑ E0.7 rescue worker’s helmet
+1F4FF                                                  ; fully-qualified     # 📿 E1.0 prayer beads
+1F484                                                  ; fully-qualified     # 💄 E0.6 lipstick
+1F48D                                                  ; fully-qualified     # 💍 E0.6 ring
+1F48E                                                  ; fully-qualified     # 💎 E0.6 gem stone
+
+# subgroup: sound
+1F507                                                  ; fully-qualified     # 🔇 E1.0 muted speaker
+1F508                                                  ; fully-qualified     # 🔈 E0.7 speaker low volume
+1F509                                                  ; fully-qualified     # 🔉 E1.0 speaker medium volume
+1F50A                                                  ; fully-qualified     # 🔊 E0.6 speaker high volume
+1F4E2                                                  ; fully-qualified     # 📢 E0.6 loudspeaker
+1F4E3                                                  ; fully-qualified     # 📣 E0.6 megaphone
+1F4EF                                                  ; fully-qualified     # 📯 E1.0 postal horn
+1F514                                                  ; fully-qualified     # 🔔 E0.6 bell
+1F515                                                  ; fully-qualified     # 🔕 E1.0 bell with slash
+
+# subgroup: music
+1F3BC                                                  ; fully-qualified     # 🎼 E0.6 musical score
+1F3B5                                                  ; fully-qualified     # 🎵 E0.6 musical note
+1F3B6                                                  ; fully-qualified     # 🎶 E0.6 musical notes
+1F399 FE0F                                             ; fully-qualified     # 🎙️ E0.7 studio microphone
+1F399                                                  ; unqualified         # 🎙 E0.7 studio microphone
+1F39A FE0F                                             ; fully-qualified     # 🎚️ E0.7 level slider
+1F39A                                                  ; unqualified         # 🎚 E0.7 level slider
+1F39B FE0F                                             ; fully-qualified     # 🎛️ E0.7 control knobs
+1F39B                                                  ; unqualified         # 🎛 E0.7 control knobs
+1F3A4                                                  ; fully-qualified     # 🎤 E0.6 microphone
+1F3A7                                                  ; fully-qualified     # 🎧 E0.6 headphone
+1F4FB                                                  ; fully-qualified     # 📻 E0.6 radio
+
+# subgroup: musical-instrument
+1F3B7                                                  ; fully-qualified     # 🎷 E0.6 saxophone
+1FA97                                                  ; fully-qualified     # 🪗 E13.0 accordion
+1F3B8                                                  ; fully-qualified     # 🎸 E0.6 guitar
+1F3B9                                                  ; fully-qualified     # 🎹 E0.6 musical keyboard
+1F3BA                                                  ; fully-qualified     # 🎺 E0.6 trumpet
+1F3BB                                                  ; fully-qualified     # 🎻 E0.6 violin
+1FA95                                                  ; fully-qualified     # 🪕 E12.0 banjo
+1F941                                                  ; fully-qualified     # 🥁 E3.0 drum
+1FA98                                                  ; fully-qualified     # 🪘 E13.0 long drum
+1FA87                                                  ; fully-qualified     # 🪇 E15.0 maracas
+1FA88                                                  ; fully-qualified     # 🪈 E15.0 flute
+1FA89                                                  ; fully-qualified     # 🪉 E16.0 harp
+
+# subgroup: phone
+1F4F1                                                  ; fully-qualified     # 📱 E0.6 mobile phone
+1F4F2                                                  ; fully-qualified     # 📲 E0.6 mobile phone with arrow
+260E FE0F                                              ; fully-qualified     # ☎️ E0.6 telephone
+260E                                                   ; unqualified         # ☎ E0.6 telephone
+1F4DE                                                  ; fully-qualified     # 📞 E0.6 telephone receiver
+1F4DF                                                  ; fully-qualified     # 📟 E0.6 pager
+1F4E0                                                  ; fully-qualified     # 📠 E0.6 fax machine
+
+# subgroup: computer
+1F50B                                                  ; fully-qualified     # 🔋 E0.6 battery
+1FAAB                                                  ; fully-qualified     # 🪫 E14.0 low battery
+1F50C                                                  ; fully-qualified     # 🔌 E0.6 electric plug
+1F4BB                                                  ; fully-qualified     # 💻 E0.6 laptop
+1F5A5 FE0F                                             ; fully-qualified     # 🖥️ E0.7 desktop computer
+1F5A5                                                  ; unqualified         # 🖥 E0.7 desktop computer
+1F5A8 FE0F                                             ; fully-qualified     # 🖨️ E0.7 printer
+1F5A8                                                  ; unqualified         # 🖨 E0.7 printer
+2328 FE0F                                              ; fully-qualified     # ⌨️ E1.0 keyboard
+2328                                                   ; unqualified         # ⌨ E1.0 keyboard
+1F5B1 FE0F                                             ; fully-qualified     # 🖱️ E0.7 computer mouse
+1F5B1                                                  ; unqualified         # 🖱 E0.7 computer mouse
+1F5B2 FE0F                                             ; fully-qualified     # 🖲️ E0.7 trackball
+1F5B2                                                  ; unqualified         # 🖲 E0.7 trackball
+1F4BD                                                  ; fully-qualified     # 💽 E0.6 computer disk
+1F4BE                                                  ; fully-qualified     # 💾 E0.6 floppy disk
+1F4BF                                                  ; fully-qualified     # 💿 E0.6 optical disk
+1F4C0                                                  ; fully-qualified     # 📀 E0.6 dvd
+1F9EE                                                  ; fully-qualified     # 🧮 E11.0 abacus
+
+# subgroup: light & video
+1F3A5                                                  ; fully-qualified     # 🎥 E0.6 movie camera
+1F39E FE0F                                             ; fully-qualified     # 🎞️ E0.7 film frames
+1F39E                                                  ; unqualified         # 🎞 E0.7 film frames
+1F4FD FE0F                                             ; fully-qualified     # 📽️ E0.7 film projector
+1F4FD                                                  ; unqualified         # 📽 E0.7 film projector
+1F3AC                                                  ; fully-qualified     # 🎬 E0.6 clapper board
+1F4FA                                                  ; fully-qualified     # 📺 E0.6 television
+1F4F7                                                  ; fully-qualified     # 📷 E0.6 camera
+1F4F8                                                  ; fully-qualified     # 📸 E1.0 camera with flash
+1F4F9                                                  ; fully-qualified     # 📹 E0.6 video camera
+1F4FC                                                  ; fully-qualified     # 📼 E0.6 videocassette
+1F50D                                                  ; fully-qualified     # 🔍 E0.6 magnifying glass tilted left
+1F50E                                                  ; fully-qualified     # 🔎 E0.6 magnifying glass tilted right
+1F56F FE0F                                             ; fully-qualified     # 🕯️ E0.7 candle
+1F56F                                                  ; unqualified         # 🕯 E0.7 candle
+1F4A1                                                  ; fully-qualified     # 💡 E0.6 light bulb
+1F526                                                  ; fully-qualified     # 🔦 E0.6 flashlight
+1F3EE                                                  ; fully-qualified     # 🏮 E0.6 red paper lantern
+1FA94                                                  ; fully-qualified     # 🪔 E12.0 diya lamp
+
+# subgroup: book-paper
+1F4D4                                                  ; fully-qualified     # 📔 E0.6 notebook with decorative cover
+1F4D5                                                  ; fully-qualified     # 📕 E0.6 closed book
+1F4D6                                                  ; fully-qualified     # 📖 E0.6 open book
+1F4D7                                                  ; fully-qualified     # 📗 E0.6 green book
+1F4D8                                                  ; fully-qualified     # 📘 E0.6 blue book
+1F4D9                                                  ; fully-qualified     # 📙 E0.6 orange book
+1F4DA                                                  ; fully-qualified     # 📚 E0.6 books
+1F4D3                                                  ; fully-qualified     # 📓 E0.6 notebook
+1F4D2                                                  ; fully-qualified     # 📒 E0.6 ledger
+1F4C3                                                  ; fully-qualified     # 📃 E0.6 page with curl
+1F4DC                                                  ; fully-qualified     # 📜 E0.6 scroll
+1F4C4                                                  ; fully-qualified     # 📄 E0.6 page facing up
+1F4F0                                                  ; fully-qualified     # 📰 E0.6 newspaper
+1F5DE FE0F                                             ; fully-qualified     # 🗞️ E0.7 rolled-up newspaper
+1F5DE                                                  ; unqualified         # 🗞 E0.7 rolled-up newspaper
+1F4D1                                                  ; fully-qualified     # 📑 E0.6 bookmark tabs
+1F516                                                  ; fully-qualified     # 🔖 E0.6 bookmark
+1F3F7 FE0F                                             ; fully-qualified     # 🏷️ E0.7 label
+1F3F7                                                  ; unqualified         # 🏷 E0.7 label
+
+# subgroup: money
+1F4B0                                                  ; fully-qualified     # 💰 E0.6 money bag
+1FA99                                                  ; fully-qualified     # 🪙 E13.0 coin
+1F4B4                                                  ; fully-qualified     # 💴 E0.6 yen banknote
+1F4B5                                                  ; fully-qualified     # 💵 E0.6 dollar banknote
+1F4B6                                                  ; fully-qualified     # 💶 E1.0 euro banknote
+1F4B7                                                  ; fully-qualified     # 💷 E1.0 pound banknote
+1F4B8                                                  ; fully-qualified     # 💸 E0.6 money with wings
+1F4B3                                                  ; fully-qualified     # 💳 E0.6 credit card
+1F9FE                                                  ; fully-qualified     # 🧾 E11.0 receipt
+1F4B9                                                  ; fully-qualified     # 💹 E0.6 chart increasing with yen
+
+# subgroup: mail
+2709 FE0F                                              ; fully-qualified     # ✉️ E0.6 envelope
+2709                                                   ; unqualified         # ✉ E0.6 envelope
+1F4E7                                                  ; fully-qualified     # 📧 E0.6 e-mail
+1F4E8                                                  ; fully-qualified     # 📨 E0.6 incoming envelope
+1F4E9                                                  ; fully-qualified     # 📩 E0.6 envelope with arrow
+1F4E4                                                  ; fully-qualified     # 📤 E0.6 outbox tray
+1F4E5                                                  ; fully-qualified     # 📥 E0.6 inbox tray
+1F4E6                                                  ; fully-qualified     # 📦 E0.6 package
+1F4EB                                                  ; fully-qualified     # 📫 E0.6 closed mailbox with raised flag
+1F4EA                                                  ; fully-qualified     # 📪 E0.6 closed mailbox with lowered flag
+1F4EC                                                  ; fully-qualified     # 📬 E0.7 open mailbox with raised flag
+1F4ED                                                  ; fully-qualified     # 📭 E0.7 open mailbox with lowered flag
+1F4EE                                                  ; fully-qualified     # 📮 E0.6 postbox
+1F5F3 FE0F                                             ; fully-qualified     # 🗳️ E0.7 ballot box with ballot
+1F5F3                                                  ; unqualified         # 🗳 E0.7 ballot box with ballot
+
+# subgroup: writing
+270F FE0F                                              ; fully-qualified     # ✏️ E0.6 pencil
+270F                                                   ; unqualified         # ✏ E0.6 pencil
+2712 FE0F                                              ; fully-qualified     # ✒️ E0.6 black nib
+2712                                                   ; unqualified         # ✒ E0.6 black nib
+1F58B FE0F                                             ; fully-qualified     # 🖋️ E0.7 fountain pen
+1F58B                                                  ; unqualified         # 🖋 E0.7 fountain pen
+1F58A FE0F                                             ; fully-qualified     # 🖊️ E0.7 pen
+1F58A                                                  ; unqualified         # 🖊 E0.7 pen
+1F58C FE0F                                             ; fully-qualified     # 🖌️ E0.7 paintbrush
+1F58C                                                  ; unqualified         # 🖌 E0.7 paintbrush
+1F58D FE0F                                             ; fully-qualified     # 🖍️ E0.7 crayon
+1F58D                                                  ; unqualified         # 🖍 E0.7 crayon
+1F4DD                                                  ; fully-qualified     # 📝 E0.6 memo
+
+# subgroup: office
+1F4BC                                                  ; fully-qualified     # 💼 E0.6 briefcase
+1F4C1                                                  ; fully-qualified     # 📁 E0.6 file folder
+1F4C2                                                  ; fully-qualified     # 📂 E0.6 open file folder
+1F5C2 FE0F                                             ; fully-qualified     # 🗂️ E0.7 card index dividers
+1F5C2                                                  ; unqualified         # 🗂 E0.7 card index dividers
+1F4C5                                                  ; fully-qualified     # 📅 E0.6 calendar
+1F4C6                                                  ; fully-qualified     # 📆 E0.6 tear-off calendar
+1F5D2 FE0F                                             ; fully-qualified     # 🗒️ E0.7 spiral notepad
+1F5D2                                                  ; unqualified         # 🗒 E0.7 spiral notepad
+1F5D3 FE0F                                             ; fully-qualified     # 🗓️ E0.7 spiral calendar
+1F5D3                                                  ; unqualified         # 🗓 E0.7 spiral calendar
+1F4C7                                                  ; fully-qualified     # 📇 E0.6 card index
+1F4C8                                                  ; fully-qualified     # 📈 E0.6 chart increasing
+1F4C9                                                  ; fully-qualified     # 📉 E0.6 chart decreasing
+1F4CA                                                  ; fully-qualified     # 📊 E0.6 bar chart
+1F4CB                                                  ; fully-qualified     # 📋 E0.6 clipboard
+1F4CC                                                  ; fully-qualified     # 📌 E0.6 pushpin
+1F4CD                                                  ; fully-qualified     # 📍 E0.6 round pushpin
+1F4CE                                                  ; fully-qualified     # 📎 E0.6 paperclip
+1F587 FE0F                                             ; fully-qualified     # 🖇️ E0.7 linked paperclips
+1F587                                                  ; unqualified         # 🖇 E0.7 linked paperclips
+1F4CF                                                  ; fully-qualified     # 📏 E0.6 straight ruler
+1F4D0                                                  ; fully-qualified     # 📐 E0.6 triangular ruler
+2702 FE0F                                              ; fully-qualified     # ✂️ E0.6 scissors
+2702                                                   ; unqualified         # ✂ E0.6 scissors
+1F5C3 FE0F                                             ; fully-qualified     # 🗃️ E0.7 card file box
+1F5C3                                                  ; unqualified         # 🗃 E0.7 card file box
+1F5C4 FE0F                                             ; fully-qualified     # 🗄️ E0.7 file cabinet
+1F5C4                                                  ; unqualified         # 🗄 E0.7 file cabinet
+1F5D1 FE0F                                             ; fully-qualified     # 🗑️ E0.7 wastebasket
+1F5D1                                                  ; unqualified         # 🗑 E0.7 wastebasket
+
+# subgroup: lock
+1F512                                                  ; fully-qualified     # 🔒 E0.6 locked
+1F513                                                  ; fully-qualified     # 🔓 E0.6 unlocked
+1F50F                                                  ; fully-qualified     # 🔏 E0.6 locked with pen
+1F510                                                  ; fully-qualified     # 🔐 E0.6 locked with key
+1F511                                                  ; fully-qualified     # 🔑 E0.6 key
+1F5DD FE0F                                             ; fully-qualified     # 🗝️ E0.7 old key
+1F5DD                                                  ; unqualified         # 🗝 E0.7 old key
+
+# subgroup: tool
+1F528                                                  ; fully-qualified     # 🔨 E0.6 hammer
+1FA93                                                  ; fully-qualified     # 🪓 E12.0 axe
+26CF FE0F                                              ; fully-qualified     # ⛏️ E0.7 pick
+26CF                                                   ; unqualified         # ⛏ E0.7 pick
+2692 FE0F                                              ; fully-qualified     # ⚒️ E1.0 hammer and pick
+2692                                                   ; unqualified         # ⚒ E1.0 hammer and pick
+1F6E0 FE0F                                             ; fully-qualified     # 🛠️ E0.7 hammer and wrench
+1F6E0                                                  ; unqualified         # 🛠 E0.7 hammer and wrench
+1F5E1 FE0F                                             ; fully-qualified     # 🗡️ E0.7 dagger
+1F5E1                                                  ; unqualified         # 🗡 E0.7 dagger
+2694 FE0F                                              ; fully-qualified     # ⚔️ E1.0 crossed swords
+2694                                                   ; unqualified         # ⚔ E1.0 crossed swords
+1F4A3                                                  ; fully-qualified     # 💣 E0.6 bomb
+1FA83                                                  ; fully-qualified     # 🪃 E13.0 boomerang
+1F3F9                                                  ; fully-qualified     # 🏹 E1.0 bow and arrow
+1F6E1 FE0F                                             ; fully-qualified     # 🛡️ E0.7 shield
+1F6E1                                                  ; unqualified         # 🛡 E0.7 shield
+1FA9A                                                  ; fully-qualified     # 🪚 E13.0 carpentry saw
+1F527                                                  ; fully-qualified     # 🔧 E0.6 wrench
+1FA9B                                                  ; fully-qualified     # 🪛 E13.0 screwdriver
+1F529                                                  ; fully-qualified     # 🔩 E0.6 nut and bolt
+2699 FE0F                                              ; fully-qualified     # ⚙️ E1.0 gear
+2699                                                   ; unqualified         # ⚙ E1.0 gear
+1F5DC FE0F                                             ; fully-qualified     # 🗜️ E0.7 clamp
+1F5DC                                                  ; unqualified         # 🗜 E0.7 clamp
+2696 FE0F                                              ; fully-qualified     # ⚖️ E1.0 balance scale
+2696                                                   ; unqualified         # ⚖ E1.0 balance scale
+1F9AF                                                  ; fully-qualified     # 🦯 E12.0 white cane
+1F517                                                  ; fully-qualified     # 🔗 E0.6 link
+26D3 FE0F 200D 1F4A5                                   ; fully-qualified     # ⛓️‍💥 E15.1 broken chain
+26D3 200D 1F4A5                                        ; unqualified         # ⛓‍💥 E15.1 broken chain
+26D3 FE0F                                              ; fully-qualified     # ⛓️ E0.7 chains
+26D3                                                   ; unqualified         # ⛓ E0.7 chains
+1FA9D                                                  ; fully-qualified     # 🪝 E13.0 hook
+1F9F0                                                  ; fully-qualified     # 🧰 E11.0 toolbox
+1F9F2                                                  ; fully-qualified     # 🧲 E11.0 magnet
+1FA9C                                                  ; fully-qualified     # 🪜 E13.0 ladder
+1FA8F                                                  ; fully-qualified     # 🪏 E16.0 shovel
+
+# subgroup: science
+2697 FE0F                                              ; fully-qualified     # ⚗️ E1.0 alembic
+2697                                                   ; unqualified         # ⚗ E1.0 alembic
+1F9EA                                                  ; fully-qualified     # 🧪 E11.0 test tube
+1F9EB                                                  ; fully-qualified     # 🧫 E11.0 petri dish
+1F9EC                                                  ; fully-qualified     # 🧬 E11.0 dna
+1F52C                                                  ; fully-qualified     # 🔬 E1.0 microscope
+1F52D                                                  ; fully-qualified     # 🔭 E1.0 telescope
+1F4E1                                                  ; fully-qualified     # 📡 E0.6 satellite antenna
+
+# subgroup: medical
+1F489                                                  ; fully-qualified     # 💉 E0.6 syringe
+1FA78                                                  ; fully-qualified     # 🩸 E12.0 drop of blood
+1F48A                                                  ; fully-qualified     # 💊 E0.6 pill
+1FA79                                                  ; fully-qualified     # 🩹 E12.0 adhesive bandage
+1FA7C                                                  ; fully-qualified     # 🩼 E14.0 crutch
+1FA7A                                                  ; fully-qualified     # 🩺 E12.0 stethoscope
+1FA7B                                                  ; fully-qualified     # 🩻 E14.0 x-ray
+
+# subgroup: household
+1F6AA                                                  ; fully-qualified     # 🚪 E0.6 door
+1F6D7                                                  ; fully-qualified     # 🛗 E13.0 elevator
+1FA9E                                                  ; fully-qualified     # 🪞 E13.0 mirror
+1FA9F                                                  ; fully-qualified     # 🪟 E13.0 window
+1F6CF FE0F                                             ; fully-qualified     # 🛏️ E0.7 bed
+1F6CF                                                  ; unqualified         # 🛏 E0.7 bed
+1F6CB FE0F                                             ; fully-qualified     # 🛋️ E0.7 couch and lamp
+1F6CB                                                  ; unqualified         # 🛋 E0.7 couch and lamp
+1FA91                                                  ; fully-qualified     # 🪑 E12.0 chair
+1F6BD                                                  ; fully-qualified     # 🚽 E0.6 toilet
+1FAA0                                                  ; fully-qualified     # 🪠 E13.0 plunger
+1F6BF                                                  ; fully-qualified     # 🚿 E1.0 shower
+1F6C1                                                  ; fully-qualified     # 🛁 E1.0 bathtub
+1FAA4                                                  ; fully-qualified     # 🪤 E13.0 mouse trap
+1FA92                                                  ; fully-qualified     # 🪒 E12.0 razor
+1F9F4                                                  ; fully-qualified     # 🧴 E11.0 lotion bottle
+1F9F7                                                  ; fully-qualified     # 🧷 E11.0 safety pin
+1F9F9                                                  ; fully-qualified     # 🧹 E11.0 broom
+1F9FA                                                  ; fully-qualified     # 🧺 E11.0 basket
+1F9FB                                                  ; fully-qualified     # 🧻 E11.0 roll of paper
+1FAA3                                                  ; fully-qualified     # 🪣 E13.0 bucket
+1F9FC                                                  ; fully-qualified     # 🧼 E11.0 soap
+1FAE7                                                  ; fully-qualified     # 🫧 E14.0 bubbles
+1FAA5                                                  ; fully-qualified     # 🪥 E13.0 toothbrush
+1F9FD                                                  ; fully-qualified     # 🧽 E11.0 sponge
+1F9EF                                                  ; fully-qualified     # 🧯 E11.0 fire extinguisher
+1F6D2                                                  ; fully-qualified     # 🛒 E3.0 shopping cart
+
+# subgroup: other-object
+1F6AC                                                  ; fully-qualified     # 🚬 E0.6 cigarette
+26B0 FE0F                                              ; fully-qualified     # ⚰️ E1.0 coffin
+26B0                                                   ; unqualified         # ⚰ E1.0 coffin
+1FAA6                                                  ; fully-qualified     # 🪦 E13.0 headstone
+26B1 FE0F                                              ; fully-qualified     # ⚱️ E1.0 funeral urn
+26B1                                                   ; unqualified         # ⚱ E1.0 funeral urn
+1F9FF                                                  ; fully-qualified     # 🧿 E11.0 nazar amulet
+1FAAC                                                  ; fully-qualified     # 🪬 E14.0 hamsa
+1F5FF                                                  ; fully-qualified     # 🗿 E0.6 moai
+1FAA7                                                  ; fully-qualified     # 🪧 E13.0 placard
+1FAAA                                                  ; fully-qualified     # 🪪 E14.0 identification card
+
+# Objects subtotal:		314
+# Objects subtotal:		314	w/o modifiers
+
+# group: Symbols
+
+# subgroup: transport-sign
+1F3E7                                                  ; fully-qualified     # 🏧 E0.6 ATM sign
+1F6AE                                                  ; fully-qualified     # 🚮 E1.0 litter in bin sign
+1F6B0                                                  ; fully-qualified     # 🚰 E1.0 potable water
+267F                                                   ; fully-qualified     # ♿ E0.6 wheelchair symbol
+1F6B9                                                  ; fully-qualified     # 🚹 E0.6 men’s room
+1F6BA                                                  ; fully-qualified     # 🚺 E0.6 women’s room
+1F6BB                                                  ; fully-qualified     # 🚻 E0.6 restroom
+1F6BC                                                  ; fully-qualified     # 🚼 E0.6 baby symbol
+1F6BE                                                  ; fully-qualified     # 🚾 E0.6 water closet
+1F6C2                                                  ; fully-qualified     # 🛂 E1.0 passport control
+1F6C3                                                  ; fully-qualified     # 🛃 E1.0 customs
+1F6C4                                                  ; fully-qualified     # 🛄 E1.0 baggage claim
+1F6C5                                                  ; fully-qualified     # 🛅 E1.0 left luggage
+
+# subgroup: warning
+26A0 FE0F                                              ; fully-qualified     # ⚠️ E0.6 warning
+26A0                                                   ; unqualified         # ⚠ E0.6 warning
+1F6B8                                                  ; fully-qualified     # 🚸 E1.0 children crossing
+26D4                                                   ; fully-qualified     # ⛔ E0.6 no entry
+1F6AB                                                  ; fully-qualified     # 🚫 E0.6 prohibited
+1F6B3                                                  ; fully-qualified     # 🚳 E1.0 no bicycles
+1F6AD                                                  ; fully-qualified     # 🚭 E0.6 no smoking
+1F6AF                                                  ; fully-qualified     # 🚯 E1.0 no littering
+1F6B1                                                  ; fully-qualified     # 🚱 E1.0 non-potable water
+1F6B7                                                  ; fully-qualified     # 🚷 E1.0 no pedestrians
+1F4F5                                                  ; fully-qualified     # 📵 E1.0 no mobile phones
+1F51E                                                  ; fully-qualified     # 🔞 E0.6 no one under eighteen
+2622 FE0F                                              ; fully-qualified     # ☢️ E1.0 radioactive
+2622                                                   ; unqualified         # ☢ E1.0 radioactive
+2623 FE0F                                              ; fully-qualified     # ☣️ E1.0 biohazard
+2623                                                   ; unqualified         # ☣ E1.0 biohazard
+
+# subgroup: arrow
+2B06 FE0F                                              ; fully-qualified     # ⬆️ E0.6 up arrow
+2B06                                                   ; unqualified         # ⬆ E0.6 up arrow
+2197 FE0F                                              ; fully-qualified     # ↗️ E0.6 up-right arrow
+2197                                                   ; unqualified         # ↗ E0.6 up-right arrow
+27A1 FE0F                                              ; fully-qualified     # ➡️ E0.6 right arrow
+27A1                                                   ; unqualified         # ➡ E0.6 right arrow
+2198 FE0F                                              ; fully-qualified     # ↘️ E0.6 down-right arrow
+2198                                                   ; unqualified         # ↘ E0.6 down-right arrow
+2B07 FE0F                                              ; fully-qualified     # ⬇️ E0.6 down arrow
+2B07                                                   ; unqualified         # ⬇ E0.6 down arrow
+2199 FE0F                                              ; fully-qualified     # ↙️ E0.6 down-left arrow
+2199                                                   ; unqualified         # ↙ E0.6 down-left arrow
+2B05 FE0F                                              ; fully-qualified     # ⬅️ E0.6 left arrow
+2B05                                                   ; unqualified         # ⬅ E0.6 left arrow
+2196 FE0F                                              ; fully-qualified     # ↖️ E0.6 up-left arrow
+2196                                                   ; unqualified         # ↖ E0.6 up-left arrow
+2195 FE0F                                              ; fully-qualified     # ↕️ E0.6 up-down arrow
+2195                                                   ; unqualified         # ↕ E0.6 up-down arrow
+2194 FE0F                                              ; fully-qualified     # ↔️ E0.6 left-right arrow
+2194                                                   ; unqualified         # ↔ E0.6 left-right arrow
+21A9 FE0F                                              ; fully-qualified     # ↩️ E0.6 right arrow curving left
+21A9                                                   ; unqualified         # ↩ E0.6 right arrow curving left
+21AA FE0F                                              ; fully-qualified     # ↪️ E0.6 left arrow curving right
+21AA                                                   ; unqualified         # ↪ E0.6 left arrow curving right
+2934 FE0F                                              ; fully-qualified     # ⤴️ E0.6 right arrow curving up
+2934                                                   ; unqualified         # ⤴ E0.6 right arrow curving up
+2935 FE0F                                              ; fully-qualified     # ⤵️ E0.6 right arrow curving down
+2935                                                   ; unqualified         # ⤵ E0.6 right arrow curving down
+1F503                                                  ; fully-qualified     # 🔃 E0.6 clockwise vertical arrows
+1F504                                                  ; fully-qualified     # 🔄 E1.0 counterclockwise arrows button
+1F519                                                  ; fully-qualified     # 🔙 E0.6 BACK arrow
+1F51A                                                  ; fully-qualified     # 🔚 E0.6 END arrow
+1F51B                                                  ; fully-qualified     # 🔛 E0.6 ON! arrow
+1F51C                                                  ; fully-qualified     # 🔜 E0.6 SOON arrow
+1F51D                                                  ; fully-qualified     # 🔝 E0.6 TOP arrow
+
+# subgroup: religion
+1F6D0                                                  ; fully-qualified     # 🛐 E1.0 place of worship
+269B FE0F                                              ; fully-qualified     # ⚛️ E1.0 atom symbol
+269B                                                   ; unqualified         # ⚛ E1.0 atom symbol
+1F549 FE0F                                             ; fully-qualified     # 🕉️ E0.7 om
+1F549                                                  ; unqualified         # 🕉 E0.7 om
+2721 FE0F                                              ; fully-qualified     # ✡️ E0.7 star of David
+2721                                                   ; unqualified         # ✡ E0.7 star of David
+2638 FE0F                                              ; fully-qualified     # ☸️ E0.7 wheel of dharma
+2638                                                   ; unqualified         # ☸ E0.7 wheel of dharma
+262F FE0F                                              ; fully-qualified     # ☯️ E0.7 yin yang
+262F                                                   ; unqualified         # ☯ E0.7 yin yang
+271D FE0F                                              ; fully-qualified     # ✝️ E0.7 latin cross
+271D                                                   ; unqualified         # ✝ E0.7 latin cross
+2626 FE0F                                              ; fully-qualified     # ☦️ E1.0 orthodox cross
+2626                                                   ; unqualified         # ☦ E1.0 orthodox cross
+262A FE0F                                              ; fully-qualified     # ☪️ E0.7 star and crescent
+262A                                                   ; unqualified         # ☪ E0.7 star and crescent
+262E FE0F                                              ; fully-qualified     # ☮️ E1.0 peace symbol
+262E                                                   ; unqualified         # ☮ E1.0 peace symbol
+1F54E                                                  ; fully-qualified     # 🕎 E1.0 menorah
+1F52F                                                  ; fully-qualified     # 🔯 E0.6 dotted six-pointed star
+1FAAF                                                  ; fully-qualified     # 🪯 E15.0 khanda
+
+# subgroup: zodiac
+2648                                                   ; fully-qualified     # ♈ E0.6 Aries
+2649                                                   ; fully-qualified     # ♉ E0.6 Taurus
+264A                                                   ; fully-qualified     # ♊ E0.6 Gemini
+264B                                                   ; fully-qualified     # ♋ E0.6 Cancer
+264C                                                   ; fully-qualified     # ♌ E0.6 Leo
+264D                                                   ; fully-qualified     # ♍ E0.6 Virgo
+264E                                                   ; fully-qualified     # ♎ E0.6 Libra
+264F                                                   ; fully-qualified     # ♏ E0.6 Scorpio
+2650                                                   ; fully-qualified     # ♐ E0.6 Sagittarius
+2651                                                   ; fully-qualified     # ♑ E0.6 Capricorn
+2652                                                   ; fully-qualified     # ♒ E0.6 Aquarius
+2653                                                   ; fully-qualified     # ♓ E0.6 Pisces
+26CE                                                   ; fully-qualified     # ⛎ E0.6 Ophiuchus
+
+# subgroup: av-symbol
+1F500                                                  ; fully-qualified     # 🔀 E1.0 shuffle tracks button
+1F501                                                  ; fully-qualified     # 🔁 E1.0 repeat button
+1F502                                                  ; fully-qualified     # 🔂 E1.0 repeat single button
+25B6 FE0F                                              ; fully-qualified     # ▶️ E0.6 play button
+25B6                                                   ; unqualified         # ▶ E0.6 play button
+23E9                                                   ; fully-qualified     # ⏩ E0.6 fast-forward button
+23ED FE0F                                              ; fully-qualified     # ⏭️ E0.7 next track button
+23ED                                                   ; unqualified         # ⏭ E0.7 next track button
+23EF FE0F                                              ; fully-qualified     # ⏯️ E1.0 play or pause button
+23EF                                                   ; unqualified         # ⏯ E1.0 play or pause button
+25C0 FE0F                                              ; fully-qualified     # ◀️ E0.6 reverse button
+25C0                                                   ; unqualified         # ◀ E0.6 reverse button
+23EA                                                   ; fully-qualified     # ⏪ E0.6 fast reverse button
+23EE FE0F                                              ; fully-qualified     # ⏮️ E0.7 last track button
+23EE                                                   ; unqualified         # ⏮ E0.7 last track button
+1F53C                                                  ; fully-qualified     # 🔼 E0.6 upwards button
+23EB                                                   ; fully-qualified     # ⏫ E0.6 fast up button
+1F53D                                                  ; fully-qualified     # 🔽 E0.6 downwards button
+23EC                                                   ; fully-qualified     # ⏬ E0.6 fast down button
+23F8 FE0F                                              ; fully-qualified     # ⏸️ E0.7 pause button
+23F8                                                   ; unqualified         # ⏸ E0.7 pause button
+23F9 FE0F                                              ; fully-qualified     # ⏹️ E0.7 stop button
+23F9                                                   ; unqualified         # ⏹ E0.7 stop button
+23FA FE0F                                              ; fully-qualified     # ⏺️ E0.7 record button
+23FA                                                   ; unqualified         # ⏺ E0.7 record button
+23CF FE0F                                              ; fully-qualified     # ⏏️ E1.0 eject button
+23CF                                                   ; unqualified         # ⏏ E1.0 eject button
+1F3A6                                                  ; fully-qualified     # 🎦 E0.6 cinema
+1F505                                                  ; fully-qualified     # 🔅 E1.0 dim button
+1F506                                                  ; fully-qualified     # 🔆 E1.0 bright button
+1F4F6                                                  ; fully-qualified     # 📶 E0.6 antenna bars
+1F6DC                                                  ; fully-qualified     # 🛜 E15.0 wireless
+1F4F3                                                  ; fully-qualified     # 📳 E0.6 vibration mode
+1F4F4                                                  ; fully-qualified     # 📴 E0.6 mobile phone off
+
+# subgroup: gender
+2640 FE0F                                              ; fully-qualified     # ♀️ E4.0 female sign
+2640                                                   ; unqualified         # ♀ E4.0 female sign
+2642 FE0F                                              ; fully-qualified     # ♂️ E4.0 male sign
+2642                                                   ; unqualified         # ♂ E4.0 male sign
+26A7 FE0F                                              ; fully-qualified     # ⚧️ E13.0 transgender symbol
+26A7                                                   ; unqualified         # ⚧ E13.0 transgender symbol
+
+# subgroup: math
+2716 FE0F                                              ; fully-qualified     # ✖️ E0.6 multiply
+2716                                                   ; unqualified         # ✖ E0.6 multiply
+2795                                                   ; fully-qualified     # ➕ E0.6 plus
+2796                                                   ; fully-qualified     # ➖ E0.6 minus
+2797                                                   ; fully-qualified     # ➗ E0.6 divide
+1F7F0                                                  ; fully-qualified     # 🟰 E14.0 heavy equals sign
+267E FE0F                                              ; fully-qualified     # ♾️ E11.0 infinity
+267E                                                   ; unqualified         # ♾ E11.0 infinity
+
+# subgroup: punctuation
+203C FE0F                                              ; fully-qualified     # ‼️ E0.6 double exclamation mark
+203C                                                   ; unqualified         # ‼ E0.6 double exclamation mark
+2049 FE0F                                              ; fully-qualified     # ⁉️ E0.6 exclamation question mark
+2049                                                   ; unqualified         # ⁉ E0.6 exclamation question mark
+2753                                                   ; fully-qualified     # ❓ E0.6 red question mark
+2754                                                   ; fully-qualified     # ❔ E0.6 white question mark
+2755                                                   ; fully-qualified     # ❕ E0.6 white exclamation mark
+2757                                                   ; fully-qualified     # ❗ E0.6 red exclamation mark
+3030 FE0F                                              ; fully-qualified     # 〰️ E0.6 wavy dash
+3030                                                   ; unqualified         # 〰 E0.6 wavy dash
+
+# subgroup: currency
+1F4B1                                                  ; fully-qualified     # 💱 E0.6 currency exchange
+1F4B2                                                  ; fully-qualified     # 💲 E0.6 heavy dollar sign
+
+# subgroup: other-symbol
+2695 FE0F                                              ; fully-qualified     # ⚕️ E4.0 medical symbol
+2695                                                   ; unqualified         # ⚕ E4.0 medical symbol
+267B FE0F                                              ; fully-qualified     # ♻️ E0.6 recycling symbol
+267B                                                   ; unqualified         # ♻ E0.6 recycling symbol
+269C FE0F                                              ; fully-qualified     # ⚜️ E1.0 fleur-de-lis
+269C                                                   ; unqualified         # ⚜ E1.0 fleur-de-lis
+1F531                                                  ; fully-qualified     # 🔱 E0.6 trident emblem
+1F4DB                                                  ; fully-qualified     # 📛 E0.6 name badge
+1F530                                                  ; fully-qualified     # 🔰 E0.6 Japanese symbol for beginner
+2B55                                                   ; fully-qualified     # ⭕ E0.6 hollow red circle
+2705                                                   ; fully-qualified     # ✅ E0.6 check mark button
+2611 FE0F                                              ; fully-qualified     # ☑️ E0.6 check box with check
+2611                                                   ; unqualified         # ☑ E0.6 check box with check
+2714 FE0F                                              ; fully-qualified     # ✔️ E0.6 check mark
+2714                                                   ; unqualified         # ✔ E0.6 check mark
+274C                                                   ; fully-qualified     # ❌ E0.6 cross mark
+274E                                                   ; fully-qualified     # ❎ E0.6 cross mark button
+27B0                                                   ; fully-qualified     # ➰ E0.6 curly loop
+27BF                                                   ; fully-qualified     # ➿ E1.0 double curly loop
+303D FE0F                                              ; fully-qualified     # 〽️ E0.6 part alternation mark
+303D                                                   ; unqualified         # 〽 E0.6 part alternation mark
+2733 FE0F                                              ; fully-qualified     # ✳️ E0.6 eight-spoked asterisk
+2733                                                   ; unqualified         # ✳ E0.6 eight-spoked asterisk
+2734 FE0F                                              ; fully-qualified     # ✴️ E0.6 eight-pointed star
+2734                                                   ; unqualified         # ✴ E0.6 eight-pointed star
+2747 FE0F                                              ; fully-qualified     # ❇️ E0.6 sparkle
+2747                                                   ; unqualified         # ❇ E0.6 sparkle
+00A9 FE0F                                              ; fully-qualified     # ©️ E0.6 copyright
+00A9                                                   ; unqualified         # © E0.6 copyright
+00AE FE0F                                              ; fully-qualified     # ®️ E0.6 registered
+00AE                                                   ; unqualified         # ® E0.6 registered
+2122 FE0F                                              ; fully-qualified     # ™️ E0.6 trade mark
+2122                                                   ; unqualified         # ™ E0.6 trade mark
+1FADF                                                  ; fully-qualified     # 🫟 E16.0 splatter
+
+# subgroup: keycap
+0023 FE0F 20E3                                         ; fully-qualified     # #️⃣ E0.6 keycap: #
+0023 20E3                                              ; unqualified         # #⃣ E0.6 keycap: #
+002A FE0F 20E3                                         ; fully-qualified     # *️⃣ E2.0 keycap: *
+002A 20E3                                              ; unqualified         # *⃣ E2.0 keycap: *
+0030 FE0F 20E3                                         ; fully-qualified     # 0️⃣ E0.6 keycap: 0
+0030 20E3                                              ; unqualified         # 0⃣ E0.6 keycap: 0
+0031 FE0F 20E3                                         ; fully-qualified     # 1️⃣ E0.6 keycap: 1
+0031 20E3                                              ; unqualified         # 1⃣ E0.6 keycap: 1
+0032 FE0F 20E3                                         ; fully-qualified     # 2️⃣ E0.6 keycap: 2
+0032 20E3                                              ; unqualified         # 2⃣ E0.6 keycap: 2
+0033 FE0F 20E3                                         ; fully-qualified     # 3️⃣ E0.6 keycap: 3
+0033 20E3                                              ; unqualified         # 3⃣ E0.6 keycap: 3
+0034 FE0F 20E3                                         ; fully-qualified     # 4️⃣ E0.6 keycap: 4
+0034 20E3                                              ; unqualified         # 4⃣ E0.6 keycap: 4
+0035 FE0F 20E3                                         ; fully-qualified     # 5️⃣ E0.6 keycap: 5
+0035 20E3                                              ; unqualified         # 5⃣ E0.6 keycap: 5
+0036 FE0F 20E3                                         ; fully-qualified     # 6️⃣ E0.6 keycap: 6
+0036 20E3                                              ; unqualified         # 6⃣ E0.6 keycap: 6
+0037 FE0F 20E3                                         ; fully-qualified     # 7️⃣ E0.6 keycap: 7
+0037 20E3                                              ; unqualified         # 7⃣ E0.6 keycap: 7
+0038 FE0F 20E3                                         ; fully-qualified     # 8️⃣ E0.6 keycap: 8
+0038 20E3                                              ; unqualified         # 8⃣ E0.6 keycap: 8
+0039 FE0F 20E3                                         ; fully-qualified     # 9️⃣ E0.6 keycap: 9
+0039 20E3                                              ; unqualified         # 9⃣ E0.6 keycap: 9
+1F51F                                                  ; fully-qualified     # 🔟 E0.6 keycap: 10
+
+# subgroup: alphanum
+1F520                                                  ; fully-qualified     # 🔠 E0.6 input latin uppercase
+1F521                                                  ; fully-qualified     # 🔡 E0.6 input latin lowercase
+1F522                                                  ; fully-qualified     # 🔢 E0.6 input numbers
+1F523                                                  ; fully-qualified     # 🔣 E0.6 input symbols
+1F524                                                  ; fully-qualified     # 🔤 E0.6 input latin letters
+1F170 FE0F                                             ; fully-qualified     # 🅰️ E0.6 A button (blood type)
+1F170                                                  ; unqualified         # 🅰 E0.6 A button (blood type)
+1F18E                                                  ; fully-qualified     # 🆎 E0.6 AB button (blood type)
+1F171 FE0F                                             ; fully-qualified     # 🅱️ E0.6 B button (blood type)
+1F171                                                  ; unqualified         # 🅱 E0.6 B button (blood type)
+1F191                                                  ; fully-qualified     # 🆑 E0.6 CL button
+1F192                                                  ; fully-qualified     # 🆒 E0.6 COOL button
+1F193                                                  ; fully-qualified     # 🆓 E0.6 FREE button
+2139 FE0F                                              ; fully-qualified     # ℹ️ E0.6 information
+2139                                                   ; unqualified         # ℹ E0.6 information
+1F194                                                  ; fully-qualified     # 🆔 E0.6 ID button
+24C2 FE0F                                              ; fully-qualified     # Ⓜ️ E0.6 circled M
+24C2                                                   ; unqualified         # Ⓜ E0.6 circled M
+1F195                                                  ; fully-qualified     # 🆕 E0.6 NEW button
+1F196                                                  ; fully-qualified     # 🆖 E0.6 NG button
+1F17E FE0F                                             ; fully-qualified     # 🅾️ E0.6 O button (blood type)
+1F17E                                                  ; unqualified         # 🅾 E0.6 O button (blood type)
+1F197                                                  ; fully-qualified     # 🆗 E0.6 OK button
+1F17F FE0F                                             ; fully-qualified     # 🅿️ E0.6 P button
+1F17F                                                  ; unqualified         # 🅿 E0.6 P button
+1F198                                                  ; fully-qualified     # 🆘 E0.6 SOS button
+1F199                                                  ; fully-qualified     # 🆙 E0.6 UP! button
+1F19A                                                  ; fully-qualified     # 🆚 E0.6 VS button
+1F201                                                  ; fully-qualified     # 🈁 E0.6 Japanese “here” button
+1F202 FE0F                                             ; fully-qualified     # 🈂️ E0.6 Japanese “service charge” button
+1F202                                                  ; unqualified         # 🈂 E0.6 Japanese “service charge” button
+1F237 FE0F                                             ; fully-qualified     # 🈷️ E0.6 Japanese “monthly amount” button
+1F237                                                  ; unqualified         # 🈷 E0.6 Japanese “monthly amount” button
+1F236                                                  ; fully-qualified     # 🈶 E0.6 Japanese “not free of charge” button
+1F22F                                                  ; fully-qualified     # 🈯 E0.6 Japanese “reserved” button
+1F250                                                  ; fully-qualified     # 🉐 E0.6 Japanese “bargain” button
+1F239                                                  ; fully-qualified     # 🈹 E0.6 Japanese “discount” button
+1F21A                                                  ; fully-qualified     # 🈚 E0.6 Japanese “free of charge” button
+1F232                                                  ; fully-qualified     # 🈲 E0.6 Japanese “prohibited” button
+1F251                                                  ; fully-qualified     # 🉑 E0.6 Japanese “acceptable” button
+1F238                                                  ; fully-qualified     # 🈸 E0.6 Japanese “application” button
+1F234                                                  ; fully-qualified     # 🈴 E0.6 Japanese “passing grade” button
+1F233                                                  ; fully-qualified     # 🈳 E0.6 Japanese “vacancy” button
+3297 FE0F                                              ; fully-qualified     # ㊗️ E0.6 Japanese “congratulations” button
+3297                                                   ; unqualified         # ㊗ E0.6 Japanese “congratulations” button
+3299 FE0F                                              ; fully-qualified     # ㊙️ E0.6 Japanese “secret” button
+3299                                                   ; unqualified         # ㊙ E0.6 Japanese “secret” button
+1F23A                                                  ; fully-qualified     # 🈺 E0.6 Japanese “open for business” button
+1F235                                                  ; fully-qualified     # 🈵 E0.6 Japanese “no vacancy” button
+
+# subgroup: geometric
+1F534                                                  ; fully-qualified     # 🔴 E0.6 red circle
+1F7E0                                                  ; fully-qualified     # 🟠 E12.0 orange circle
+1F7E1                                                  ; fully-qualified     # 🟡 E12.0 yellow circle
+1F7E2                                                  ; fully-qualified     # 🟢 E12.0 green circle
+1F535                                                  ; fully-qualified     # 🔵 E0.6 blue circle
+1F7E3                                                  ; fully-qualified     # 🟣 E12.0 purple circle
+1F7E4                                                  ; fully-qualified     # 🟤 E12.0 brown circle
+26AB                                                   ; fully-qualified     # ⚫ E0.6 black circle
+26AA                                                   ; fully-qualified     # ⚪ E0.6 white circle
+1F7E5                                                  ; fully-qualified     # 🟥 E12.0 red square
+1F7E7                                                  ; fully-qualified     # 🟧 E12.0 orange square
+1F7E8                                                  ; fully-qualified     # 🟨 E12.0 yellow square
+1F7E9                                                  ; fully-qualified     # 🟩 E12.0 green square
+1F7E6                                                  ; fully-qualified     # 🟦 E12.0 blue square
+1F7EA                                                  ; fully-qualified     # 🟪 E12.0 purple square
+1F7EB                                                  ; fully-qualified     # 🟫 E12.0 brown square
+2B1B                                                   ; fully-qualified     # ⬛ E0.6 black large square
+2B1C                                                   ; fully-qualified     # ⬜ E0.6 white large square
+25FC FE0F                                              ; fully-qualified     # ◼️ E0.6 black medium square
+25FC                                                   ; unqualified         # ◼ E0.6 black medium square
+25FB FE0F                                              ; fully-qualified     # ◻️ E0.6 white medium square
+25FB                                                   ; unqualified         # ◻ E0.6 white medium square
+25FE                                                   ; fully-qualified     # ◾ E0.6 black medium-small square
+25FD                                                   ; fully-qualified     # ◽ E0.6 white medium-small square
+25AA FE0F                                              ; fully-qualified     # ▪️ E0.6 black small square
+25AA                                                   ; unqualified         # ▪ E0.6 black small square
+25AB FE0F                                              ; fully-qualified     # ▫️ E0.6 white small square
+25AB                                                   ; unqualified         # ▫ E0.6 white small square
+1F536                                                  ; fully-qualified     # 🔶 E0.6 large orange diamond
+1F537                                                  ; fully-qualified     # 🔷 E0.6 large blue diamond
+1F538                                                  ; fully-qualified     # 🔸 E0.6 small orange diamond
+1F539                                                  ; fully-qualified     # 🔹 E0.6 small blue diamond
+1F53A                                                  ; fully-qualified     # 🔺 E0.6 red triangle pointed up
+1F53B                                                  ; fully-qualified     # 🔻 E0.6 red triangle pointed down
+1F4A0                                                  ; fully-qualified     # 💠 E0.6 diamond with a dot
+1F518                                                  ; fully-qualified     # 🔘 E0.6 radio button
+1F533                                                  ; fully-qualified     # 🔳 E0.6 white square button
+1F532                                                  ; fully-qualified     # 🔲 E0.6 black square button
+
+# Symbols subtotal:		305
+# Symbols subtotal:		305	w/o modifiers
+
+# group: Flags
+
+# subgroup: flag
+1F3C1                                                  ; fully-qualified     # 🏁 E0.6 chequered flag
+1F6A9                                                  ; fully-qualified     # 🚩 E0.6 triangular flag
+1F38C                                                  ; fully-qualified     # 🎌 E0.6 crossed flags
+1F3F4                                                  ; fully-qualified     # 🏴 E1.0 black flag
+1F3F3 FE0F                                             ; fully-qualified     # 🏳️ E0.7 white flag
+1F3F3                                                  ; unqualified         # 🏳 E0.7 white flag
+1F3F3 FE0F 200D 1F308                                  ; fully-qualified     # 🏳️‍🌈 E4.0 rainbow flag
+1F3F3 200D 1F308                                       ; unqualified         # 🏳‍🌈 E4.0 rainbow flag
+1F3F3 FE0F 200D 26A7 FE0F                              ; fully-qualified     # 🏳️‍⚧️ E13.0 transgender flag
+1F3F3 200D 26A7 FE0F                                   ; unqualified         # 🏳‍⚧️ E13.0 transgender flag
+1F3F3 FE0F 200D 26A7                                   ; minimally-qualified # 🏳️‍⚧ E13.0 transgender flag
+1F3F3 200D 26A7                                        ; unqualified         # 🏳‍⚧ E13.0 transgender flag
+1F3F4 200D 2620 FE0F                                   ; fully-qualified     # 🏴‍☠️ E11.0 pirate flag
+1F3F4 200D 2620                                        ; minimally-qualified # 🏴‍☠ E11.0 pirate flag
+
+# subgroup: country-flag
+1F1E6 1F1E8                                            ; fully-qualified     # 🇦🇨 E2.0 flag: Ascension Island
+1F1E6 1F1E9                                            ; fully-qualified     # 🇦🇩 E2.0 flag: Andorra
+1F1E6 1F1EA                                            ; fully-qualified     # 🇦🇪 E2.0 flag: United Arab Emirates
+1F1E6 1F1EB                                            ; fully-qualified     # 🇦🇫 E2.0 flag: Afghanistan
+1F1E6 1F1EC                                            ; fully-qualified     # 🇦🇬 E2.0 flag: Antigua & Barbuda
+1F1E6 1F1EE                                            ; fully-qualified     # 🇦🇮 E2.0 flag: Anguilla
+1F1E6 1F1F1                                            ; fully-qualified     # 🇦🇱 E2.0 flag: Albania
+1F1E6 1F1F2                                            ; fully-qualified     # 🇦🇲 E2.0 flag: Armenia
+1F1E6 1F1F4                                            ; fully-qualified     # 🇦🇴 E2.0 flag: Angola
+1F1E6 1F1F6                                            ; fully-qualified     # 🇦🇶 E2.0 flag: Antarctica
+1F1E6 1F1F7                                            ; fully-qualified     # 🇦🇷 E2.0 flag: Argentina
+1F1E6 1F1F8                                            ; fully-qualified     # 🇦🇸 E2.0 flag: American Samoa
+1F1E6 1F1F9                                            ; fully-qualified     # 🇦🇹 E2.0 flag: Austria
+1F1E6 1F1FA                                            ; fully-qualified     # 🇦🇺 E2.0 flag: Australia
+1F1E6 1F1FC                                            ; fully-qualified     # 🇦🇼 E2.0 flag: Aruba
+1F1E6 1F1FD                                            ; fully-qualified     # 🇦🇽 E2.0 flag: Åland Islands
+1F1E6 1F1FF                                            ; fully-qualified     # 🇦🇿 E2.0 flag: Azerbaijan
+1F1E7 1F1E6                                            ; fully-qualified     # 🇧🇦 E2.0 flag: Bosnia & Herzegovina
+1F1E7 1F1E7                                            ; fully-qualified     # 🇧🇧 E2.0 flag: Barbados
+1F1E7 1F1E9                                            ; fully-qualified     # 🇧🇩 E2.0 flag: Bangladesh
+1F1E7 1F1EA                                            ; fully-qualified     # 🇧🇪 E2.0 flag: Belgium
+1F1E7 1F1EB                                            ; fully-qualified     # 🇧🇫 E2.0 flag: Burkina Faso
+1F1E7 1F1EC                                            ; fully-qualified     # 🇧🇬 E2.0 flag: Bulgaria
+1F1E7 1F1ED                                            ; fully-qualified     # 🇧🇭 E2.0 flag: Bahrain
+1F1E7 1F1EE                                            ; fully-qualified     # 🇧🇮 E2.0 flag: Burundi
+1F1E7 1F1EF                                            ; fully-qualified     # 🇧🇯 E2.0 flag: Benin
+1F1E7 1F1F1                                            ; fully-qualified     # 🇧🇱 E2.0 flag: St. Barthélemy
+1F1E7 1F1F2                                            ; fully-qualified     # 🇧🇲 E2.0 flag: Bermuda
+1F1E7 1F1F3                                            ; fully-qualified     # 🇧🇳 E2.0 flag: Brunei
+1F1E7 1F1F4                                            ; fully-qualified     # 🇧🇴 E2.0 flag: Bolivia
+1F1E7 1F1F6                                            ; fully-qualified     # 🇧🇶 E2.0 flag: Caribbean Netherlands
+1F1E7 1F1F7                                            ; fully-qualified     # 🇧🇷 E2.0 flag: Brazil
+1F1E7 1F1F8                                            ; fully-qualified     # 🇧🇸 E2.0 flag: Bahamas
+1F1E7 1F1F9                                            ; fully-qualified     # 🇧🇹 E2.0 flag: Bhutan
+1F1E7 1F1FB                                            ; fully-qualified     # 🇧🇻 E2.0 flag: Bouvet Island
+1F1E7 1F1FC                                            ; fully-qualified     # 🇧🇼 E2.0 flag: Botswana
+1F1E7 1F1FE                                            ; fully-qualified     # 🇧🇾 E2.0 flag: Belarus
+1F1E7 1F1FF                                            ; fully-qualified     # 🇧🇿 E2.0 flag: Belize
+1F1E8 1F1E6                                            ; fully-qualified     # 🇨🇦 E2.0 flag: Canada
+1F1E8 1F1E8                                            ; fully-qualified     # 🇨🇨 E2.0 flag: Cocos (Keeling) Islands
+1F1E8 1F1E9                                            ; fully-qualified     # 🇨🇩 E2.0 flag: Congo - Kinshasa
+1F1E8 1F1EB                                            ; fully-qualified     # 🇨🇫 E2.0 flag: Central African Republic
+1F1E8 1F1EC                                            ; fully-qualified     # 🇨🇬 E2.0 flag: Congo - Brazzaville
+1F1E8 1F1ED                                            ; fully-qualified     # 🇨🇭 E2.0 flag: Switzerland
+1F1E8 1F1EE                                            ; fully-qualified     # 🇨🇮 E2.0 flag: Côte d’Ivoire
+1F1E8 1F1F0                                            ; fully-qualified     # 🇨🇰 E2.0 flag: Cook Islands
+1F1E8 1F1F1                                            ; fully-qualified     # 🇨🇱 E2.0 flag: Chile
+1F1E8 1F1F2                                            ; fully-qualified     # 🇨🇲 E2.0 flag: Cameroon
+1F1E8 1F1F3                                            ; fully-qualified     # 🇨🇳 E0.6 flag: China
+1F1E8 1F1F4                                            ; fully-qualified     # 🇨🇴 E2.0 flag: Colombia
+1F1E8 1F1F5                                            ; fully-qualified     # 🇨🇵 E2.0 flag: Clipperton Island
+1F1E8 1F1F6                                            ; fully-qualified     # 🇨🇶 E16.0 flag: Sark
+1F1E8 1F1F7                                            ; fully-qualified     # 🇨🇷 E2.0 flag: Costa Rica
+1F1E8 1F1FA                                            ; fully-qualified     # 🇨🇺 E2.0 flag: Cuba
+1F1E8 1F1FB                                            ; fully-qualified     # 🇨🇻 E2.0 flag: Cape Verde
+1F1E8 1F1FC                                            ; fully-qualified     # 🇨🇼 E2.0 flag: Curaçao
+1F1E8 1F1FD                                            ; fully-qualified     # 🇨🇽 E2.0 flag: Christmas Island
+1F1E8 1F1FE                                            ; fully-qualified     # 🇨🇾 E2.0 flag: Cyprus
+1F1E8 1F1FF                                            ; fully-qualified     # 🇨🇿 E2.0 flag: Czechia
+1F1E9 1F1EA                                            ; fully-qualified     # 🇩🇪 E0.6 flag: Germany
+1F1E9 1F1EC                                            ; fully-qualified     # 🇩🇬 E2.0 flag: Diego Garcia
+1F1E9 1F1EF                                            ; fully-qualified     # 🇩🇯 E2.0 flag: Djibouti
+1F1E9 1F1F0                                            ; fully-qualified     # 🇩🇰 E2.0 flag: Denmark
+1F1E9 1F1F2                                            ; fully-qualified     # 🇩🇲 E2.0 flag: Dominica
+1F1E9 1F1F4                                            ; fully-qualified     # 🇩🇴 E2.0 flag: Dominican Republic
+1F1E9 1F1FF                                            ; fully-qualified     # 🇩🇿 E2.0 flag: Algeria
+1F1EA 1F1E6                                            ; fully-qualified     # 🇪🇦 E2.0 flag: Ceuta & Melilla
+1F1EA 1F1E8                                            ; fully-qualified     # 🇪🇨 E2.0 flag: Ecuador
+1F1EA 1F1EA                                            ; fully-qualified     # 🇪🇪 E2.0 flag: Estonia
+1F1EA 1F1EC                                            ; fully-qualified     # 🇪🇬 E2.0 flag: Egypt
+1F1EA 1F1ED                                            ; fully-qualified     # 🇪🇭 E2.0 flag: Western Sahara
+1F1EA 1F1F7                                            ; fully-qualified     # 🇪🇷 E2.0 flag: Eritrea
+1F1EA 1F1F8                                            ; fully-qualified     # 🇪🇸 E0.6 flag: Spain
+1F1EA 1F1F9                                            ; fully-qualified     # 🇪🇹 E2.0 flag: Ethiopia
+1F1EA 1F1FA                                            ; fully-qualified     # 🇪🇺 E2.0 flag: European Union
+1F1EB 1F1EE                                            ; fully-qualified     # 🇫🇮 E2.0 flag: Finland
+1F1EB 1F1EF                                            ; fully-qualified     # 🇫🇯 E2.0 flag: Fiji
+1F1EB 1F1F0                                            ; fully-qualified     # 🇫🇰 E2.0 flag: Falkland Islands
+1F1EB 1F1F2                                            ; fully-qualified     # 🇫🇲 E2.0 flag: Micronesia
+1F1EB 1F1F4                                            ; fully-qualified     # 🇫🇴 E2.0 flag: Faroe Islands
+1F1EB 1F1F7                                            ; fully-qualified     # 🇫🇷 E0.6 flag: France
+1F1EC 1F1E6                                            ; fully-qualified     # 🇬🇦 E2.0 flag: Gabon
+1F1EC 1F1E7                                            ; fully-qualified     # 🇬🇧 E0.6 flag: United Kingdom
+1F1EC 1F1E9                                            ; fully-qualified     # 🇬🇩 E2.0 flag: Grenada
+1F1EC 1F1EA                                            ; fully-qualified     # 🇬🇪 E2.0 flag: Georgia
+1F1EC 1F1EB                                            ; fully-qualified     # 🇬🇫 E2.0 flag: French Guiana
+1F1EC 1F1EC                                            ; fully-qualified     # 🇬🇬 E2.0 flag: Guernsey
+1F1EC 1F1ED                                            ; fully-qualified     # 🇬🇭 E2.0 flag: Ghana
+1F1EC 1F1EE                                            ; fully-qualified     # 🇬🇮 E2.0 flag: Gibraltar
+1F1EC 1F1F1                                            ; fully-qualified     # 🇬🇱 E2.0 flag: Greenland
+1F1EC 1F1F2                                            ; fully-qualified     # 🇬🇲 E2.0 flag: Gambia
+1F1EC 1F1F3                                            ; fully-qualified     # 🇬🇳 E2.0 flag: Guinea
+1F1EC 1F1F5                                            ; fully-qualified     # 🇬🇵 E2.0 flag: Guadeloupe
+1F1EC 1F1F6                                            ; fully-qualified     # 🇬🇶 E2.0 flag: Equatorial Guinea
+1F1EC 1F1F7                                            ; fully-qualified     # 🇬🇷 E2.0 flag: Greece
+1F1EC 1F1F8                                            ; fully-qualified     # 🇬🇸 E2.0 flag: South Georgia & South Sandwich Islands
+1F1EC 1F1F9                                            ; fully-qualified     # 🇬🇹 E2.0 flag: Guatemala
+1F1EC 1F1FA                                            ; fully-qualified     # 🇬🇺 E2.0 flag: Guam
+1F1EC 1F1FC                                            ; fully-qualified     # 🇬🇼 E2.0 flag: Guinea-Bissau
+1F1EC 1F1FE                                            ; fully-qualified     # 🇬🇾 E2.0 flag: Guyana
+1F1ED 1F1F0                                            ; fully-qualified     # 🇭🇰 E2.0 flag: Hong Kong SAR China
+1F1ED 1F1F2                                            ; fully-qualified     # 🇭🇲 E2.0 flag: Heard & McDonald Islands
+1F1ED 1F1F3                                            ; fully-qualified     # 🇭🇳 E2.0 flag: Honduras
+1F1ED 1F1F7                                            ; fully-qualified     # 🇭🇷 E2.0 flag: Croatia
+1F1ED 1F1F9                                            ; fully-qualified     # 🇭🇹 E2.0 flag: Haiti
+1F1ED 1F1FA                                            ; fully-qualified     # 🇭🇺 E2.0 flag: Hungary
+1F1EE 1F1E8                                            ; fully-qualified     # 🇮🇨 E2.0 flag: Canary Islands
+1F1EE 1F1E9                                            ; fully-qualified     # 🇮🇩 E2.0 flag: Indonesia
+1F1EE 1F1EA                                            ; fully-qualified     # 🇮🇪 E2.0 flag: Ireland
+1F1EE 1F1F1                                            ; fully-qualified     # 🇮🇱 E2.0 flag: Israel
+1F1EE 1F1F2                                            ; fully-qualified     # 🇮🇲 E2.0 flag: Isle of Man
+1F1EE 1F1F3                                            ; fully-qualified     # 🇮🇳 E2.0 flag: India
+1F1EE 1F1F4                                            ; fully-qualified     # 🇮🇴 E2.0 flag: British Indian Ocean Territory
+1F1EE 1F1F6                                            ; fully-qualified     # 🇮🇶 E2.0 flag: Iraq
+1F1EE 1F1F7                                            ; fully-qualified     # 🇮🇷 E2.0 flag: Iran
+1F1EE 1F1F8                                            ; fully-qualified     # 🇮🇸 E2.0 flag: Iceland
+1F1EE 1F1F9                                            ; fully-qualified     # 🇮🇹 E0.6 flag: Italy
+1F1EF 1F1EA                                            ; fully-qualified     # 🇯🇪 E2.0 flag: Jersey
+1F1EF 1F1F2                                            ; fully-qualified     # 🇯🇲 E2.0 flag: Jamaica
+1F1EF 1F1F4                                            ; fully-qualified     # 🇯🇴 E2.0 flag: Jordan
+1F1EF 1F1F5                                            ; fully-qualified     # 🇯🇵 E0.6 flag: Japan
+1F1F0 1F1EA                                            ; fully-qualified     # 🇰🇪 E2.0 flag: Kenya
+1F1F0 1F1EC                                            ; fully-qualified     # 🇰🇬 E2.0 flag: Kyrgyzstan
+1F1F0 1F1ED                                            ; fully-qualified     # 🇰🇭 E2.0 flag: Cambodia
+1F1F0 1F1EE                                            ; fully-qualified     # 🇰🇮 E2.0 flag: Kiribati
+1F1F0 1F1F2                                            ; fully-qualified     # 🇰🇲 E2.0 flag: Comoros
+1F1F0 1F1F3                                            ; fully-qualified     # 🇰🇳 E2.0 flag: St. Kitts & Nevis
+1F1F0 1F1F5                                            ; fully-qualified     # 🇰🇵 E2.0 flag: North Korea
+1F1F0 1F1F7                                            ; fully-qualified     # 🇰🇷 E0.6 flag: South Korea
+1F1F0 1F1FC                                            ; fully-qualified     # 🇰🇼 E2.0 flag: Kuwait
+1F1F0 1F1FE                                            ; fully-qualified     # 🇰🇾 E2.0 flag: Cayman Islands
+1F1F0 1F1FF                                            ; fully-qualified     # 🇰🇿 E2.0 flag: Kazakhstan
+1F1F1 1F1E6                                            ; fully-qualified     # 🇱🇦 E2.0 flag: Laos
+1F1F1 1F1E7                                            ; fully-qualified     # 🇱🇧 E2.0 flag: Lebanon
+1F1F1 1F1E8                                            ; fully-qualified     # 🇱🇨 E2.0 flag: St. Lucia
+1F1F1 1F1EE                                            ; fully-qualified     # 🇱🇮 E2.0 flag: Liechtenstein
+1F1F1 1F1F0                                            ; fully-qualified     # 🇱🇰 E2.0 flag: Sri Lanka
+1F1F1 1F1F7                                            ; fully-qualified     # 🇱🇷 E2.0 flag: Liberia
+1F1F1 1F1F8                                            ; fully-qualified     # 🇱🇸 E2.0 flag: Lesotho
+1F1F1 1F1F9                                            ; fully-qualified     # 🇱🇹 E2.0 flag: Lithuania
+1F1F1 1F1FA                                            ; fully-qualified     # 🇱🇺 E2.0 flag: Luxembourg
+1F1F1 1F1FB                                            ; fully-qualified     # 🇱🇻 E2.0 flag: Latvia
+1F1F1 1F1FE                                            ; fully-qualified     # 🇱🇾 E2.0 flag: Libya
+1F1F2 1F1E6                                            ; fully-qualified     # 🇲🇦 E2.0 flag: Morocco
+1F1F2 1F1E8                                            ; fully-qualified     # 🇲🇨 E2.0 flag: Monaco
+1F1F2 1F1E9                                            ; fully-qualified     # 🇲🇩 E2.0 flag: Moldova
+1F1F2 1F1EA                                            ; fully-qualified     # 🇲🇪 E2.0 flag: Montenegro
+1F1F2 1F1EB                                            ; fully-qualified     # 🇲🇫 E2.0 flag: St. Martin
+1F1F2 1F1EC                                            ; fully-qualified     # 🇲🇬 E2.0 flag: Madagascar
+1F1F2 1F1ED                                            ; fully-qualified     # 🇲🇭 E2.0 flag: Marshall Islands
+1F1F2 1F1F0                                            ; fully-qualified     # 🇲🇰 E2.0 flag: North Macedonia
+1F1F2 1F1F1                                            ; fully-qualified     # 🇲🇱 E2.0 flag: Mali
+1F1F2 1F1F2                                            ; fully-qualified     # 🇲🇲 E2.0 flag: Myanmar (Burma)
+1F1F2 1F1F3                                            ; fully-qualified     # 🇲🇳 E2.0 flag: Mongolia
+1F1F2 1F1F4                                            ; fully-qualified     # 🇲🇴 E2.0 flag: Macao SAR China
+1F1F2 1F1F5                                            ; fully-qualified     # 🇲🇵 E2.0 flag: Northern Mariana Islands
+1F1F2 1F1F6                                            ; fully-qualified     # 🇲🇶 E2.0 flag: Martinique
+1F1F2 1F1F7                                            ; fully-qualified     # 🇲🇷 E2.0 flag: Mauritania
+1F1F2 1F1F8                                            ; fully-qualified     # 🇲🇸 E2.0 flag: Montserrat
+1F1F2 1F1F9                                            ; fully-qualified     # 🇲🇹 E2.0 flag: Malta
+1F1F2 1F1FA                                            ; fully-qualified     # 🇲🇺 E2.0 flag: Mauritius
+1F1F2 1F1FB                                            ; fully-qualified     # 🇲🇻 E2.0 flag: Maldives
+1F1F2 1F1FC                                            ; fully-qualified     # 🇲🇼 E2.0 flag: Malawi
+1F1F2 1F1FD                                            ; fully-qualified     # 🇲🇽 E2.0 flag: Mexico
+1F1F2 1F1FE                                            ; fully-qualified     # 🇲🇾 E2.0 flag: Malaysia
+1F1F2 1F1FF                                            ; fully-qualified     # 🇲🇿 E2.0 flag: Mozambique
+1F1F3 1F1E6                                            ; fully-qualified     # 🇳🇦 E2.0 flag: Namibia
+1F1F3 1F1E8                                            ; fully-qualified     # 🇳🇨 E2.0 flag: New Caledonia
+1F1F3 1F1EA                                            ; fully-qualified     # 🇳🇪 E2.0 flag: Niger
+1F1F3 1F1EB                                            ; fully-qualified     # 🇳🇫 E2.0 flag: Norfolk Island
+1F1F3 1F1EC                                            ; fully-qualified     # 🇳🇬 E2.0 flag: Nigeria
+1F1F3 1F1EE                                            ; fully-qualified     # 🇳🇮 E2.0 flag: Nicaragua
+1F1F3 1F1F1                                            ; fully-qualified     # 🇳🇱 E2.0 flag: Netherlands
+1F1F3 1F1F4                                            ; fully-qualified     # 🇳🇴 E2.0 flag: Norway
+1F1F3 1F1F5                                            ; fully-qualified     # 🇳🇵 E2.0 flag: Nepal
+1F1F3 1F1F7                                            ; fully-qualified     # 🇳🇷 E2.0 flag: Nauru
+1F1F3 1F1FA                                            ; fully-qualified     # 🇳🇺 E2.0 flag: Niue
+1F1F3 1F1FF                                            ; fully-qualified     # 🇳🇿 E2.0 flag: New Zealand
+1F1F4 1F1F2                                            ; fully-qualified     # 🇴🇲 E2.0 flag: Oman
+1F1F5 1F1E6                                            ; fully-qualified     # 🇵🇦 E2.0 flag: Panama
+1F1F5 1F1EA                                            ; fully-qualified     # 🇵🇪 E2.0 flag: Peru
+1F1F5 1F1EB                                            ; fully-qualified     # 🇵🇫 E2.0 flag: French Polynesia
+1F1F5 1F1EC                                            ; fully-qualified     # 🇵🇬 E2.0 flag: Papua New Guinea
+1F1F5 1F1ED                                            ; fully-qualified     # 🇵🇭 E2.0 flag: Philippines
+1F1F5 1F1F0                                            ; fully-qualified     # 🇵🇰 E2.0 flag: Pakistan
+1F1F5 1F1F1                                            ; fully-qualified     # 🇵🇱 E2.0 flag: Poland
+1F1F5 1F1F2                                            ; fully-qualified     # 🇵🇲 E2.0 flag: St. Pierre & Miquelon
+1F1F5 1F1F3                                            ; fully-qualified     # 🇵🇳 E2.0 flag: Pitcairn Islands
+1F1F5 1F1F7                                            ; fully-qualified     # 🇵🇷 E2.0 flag: Puerto Rico
+1F1F5 1F1F8                                            ; fully-qualified     # 🇵🇸 E2.0 flag: Palestinian Territories
+1F1F5 1F1F9                                            ; fully-qualified     # 🇵🇹 E2.0 flag: Portugal
+1F1F5 1F1FC                                            ; fully-qualified     # 🇵🇼 E2.0 flag: Palau
+1F1F5 1F1FE                                            ; fully-qualified     # 🇵🇾 E2.0 flag: Paraguay
+1F1F6 1F1E6                                            ; fully-qualified     # 🇶🇦 E2.0 flag: Qatar
+1F1F7 1F1EA                                            ; fully-qualified     # 🇷🇪 E2.0 flag: Réunion
+1F1F7 1F1F4                                            ; fully-qualified     # 🇷🇴 E2.0 flag: Romania
+1F1F7 1F1F8                                            ; fully-qualified     # 🇷🇸 E2.0 flag: Serbia
+1F1F7 1F1FA                                            ; fully-qualified     # 🇷🇺 E0.6 flag: Russia
+1F1F7 1F1FC                                            ; fully-qualified     # 🇷🇼 E2.0 flag: Rwanda
+1F1F8 1F1E6                                            ; fully-qualified     # 🇸🇦 E2.0 flag: Saudi Arabia
+1F1F8 1F1E7                                            ; fully-qualified     # 🇸🇧 E2.0 flag: Solomon Islands
+1F1F8 1F1E8                                            ; fully-qualified     # 🇸🇨 E2.0 flag: Seychelles
+1F1F8 1F1E9                                            ; fully-qualified     # 🇸🇩 E2.0 flag: Sudan
+1F1F8 1F1EA                                            ; fully-qualified     # 🇸🇪 E2.0 flag: Sweden
+1F1F8 1F1EC                                            ; fully-qualified     # 🇸🇬 E2.0 flag: Singapore
+1F1F8 1F1ED                                            ; fully-qualified     # 🇸🇭 E2.0 flag: St. Helena
+1F1F8 1F1EE                                            ; fully-qualified     # 🇸🇮 E2.0 flag: Slovenia
+1F1F8 1F1EF                                            ; fully-qualified     # 🇸🇯 E2.0 flag: Svalbard & Jan Mayen
+1F1F8 1F1F0                                            ; fully-qualified     # 🇸🇰 E2.0 flag: Slovakia
+1F1F8 1F1F1                                            ; fully-qualified     # 🇸🇱 E2.0 flag: Sierra Leone
+1F1F8 1F1F2                                            ; fully-qualified     # 🇸🇲 E2.0 flag: San Marino
+1F1F8 1F1F3                                            ; fully-qualified     # 🇸🇳 E2.0 flag: Senegal
+1F1F8 1F1F4                                            ; fully-qualified     # 🇸🇴 E2.0 flag: Somalia
+1F1F8 1F1F7                                            ; fully-qualified     # 🇸🇷 E2.0 flag: Suriname
+1F1F8 1F1F8                                            ; fully-qualified     # 🇸🇸 E2.0 flag: South Sudan
+1F1F8 1F1F9                                            ; fully-qualified     # 🇸🇹 E2.0 flag: São Tomé & Príncipe
+1F1F8 1F1FB                                            ; fully-qualified     # 🇸🇻 E2.0 flag: El Salvador
+1F1F8 1F1FD                                            ; fully-qualified     # 🇸🇽 E2.0 flag: Sint Maarten
+1F1F8 1F1FE                                            ; fully-qualified     # 🇸🇾 E2.0 flag: Syria
+1F1F8 1F1FF                                            ; fully-qualified     # 🇸🇿 E2.0 flag: Eswatini
+1F1F9 1F1E6                                            ; fully-qualified     # 🇹🇦 E2.0 flag: Tristan da Cunha
+1F1F9 1F1E8                                            ; fully-qualified     # 🇹🇨 E2.0 flag: Turks & Caicos Islands
+1F1F9 1F1E9                                            ; fully-qualified     # 🇹🇩 E2.0 flag: Chad
+1F1F9 1F1EB                                            ; fully-qualified     # 🇹🇫 E2.0 flag: French Southern Territories
+1F1F9 1F1EC                                            ; fully-qualified     # 🇹🇬 E2.0 flag: Togo
+1F1F9 1F1ED                                            ; fully-qualified     # 🇹🇭 E2.0 flag: Thailand
+1F1F9 1F1EF                                            ; fully-qualified     # 🇹🇯 E2.0 flag: Tajikistan
+1F1F9 1F1F0                                            ; fully-qualified     # 🇹🇰 E2.0 flag: Tokelau
+1F1F9 1F1F1                                            ; fully-qualified     # 🇹🇱 E2.0 flag: Timor-Leste
+1F1F9 1F1F2                                            ; fully-qualified     # 🇹🇲 E2.0 flag: Turkmenistan
+1F1F9 1F1F3                                            ; fully-qualified     # 🇹🇳 E2.0 flag: Tunisia
+1F1F9 1F1F4                                            ; fully-qualified     # 🇹🇴 E2.0 flag: Tonga
+1F1F9 1F1F7                                            ; fully-qualified     # 🇹🇷 E2.0 flag: Türkiye
+1F1F9 1F1F9                                            ; fully-qualified     # 🇹🇹 E2.0 flag: Trinidad & Tobago
+1F1F9 1F1FB                                            ; fully-qualified     # 🇹🇻 E2.0 flag: Tuvalu
+1F1F9 1F1FC                                            ; fully-qualified     # 🇹🇼 E2.0 flag: Taiwan
+1F1F9 1F1FF                                            ; fully-qualified     # 🇹🇿 E2.0 flag: Tanzania
+1F1FA 1F1E6                                            ; fully-qualified     # 🇺🇦 E2.0 flag: Ukraine
+1F1FA 1F1EC                                            ; fully-qualified     # 🇺🇬 E2.0 flag: Uganda
+1F1FA 1F1F2                                            ; fully-qualified     # 🇺🇲 E2.0 flag: U.S. Outlying Islands
+1F1FA 1F1F3                                            ; fully-qualified     # 🇺🇳 E4.0 flag: United Nations
+1F1FA 1F1F8                                            ; fully-qualified     # 🇺🇸 E0.6 flag: United States
+1F1FA 1F1FE                                            ; fully-qualified     # 🇺🇾 E2.0 flag: Uruguay
+1F1FA 1F1FF                                            ; fully-qualified     # 🇺🇿 E2.0 flag: Uzbekistan
+1F1FB 1F1E6                                            ; fully-qualified     # 🇻🇦 E2.0 flag: Vatican City
+1F1FB 1F1E8                                            ; fully-qualified     # 🇻🇨 E2.0 flag: St. Vincent & Grenadines
+1F1FB 1F1EA                                            ; fully-qualified     # 🇻🇪 E2.0 flag: Venezuela
+1F1FB 1F1EC                                            ; fully-qualified     # 🇻🇬 E2.0 flag: British Virgin Islands
+1F1FB 1F1EE                                            ; fully-qualified     # 🇻🇮 E2.0 flag: U.S. Virgin Islands
+1F1FB 1F1F3                                            ; fully-qualified     # 🇻🇳 E2.0 flag: Vietnam
+1F1FB 1F1FA                                            ; fully-qualified     # 🇻🇺 E2.0 flag: Vanuatu
+1F1FC 1F1EB                                            ; fully-qualified     # 🇼🇫 E2.0 flag: Wallis & Futuna
+1F1FC 1F1F8                                            ; fully-qualified     # 🇼🇸 E2.0 flag: Samoa
+1F1FD 1F1F0                                            ; fully-qualified     # 🇽🇰 E2.0 flag: Kosovo
+1F1FE 1F1EA                                            ; fully-qualified     # 🇾🇪 E2.0 flag: Yemen
+1F1FE 1F1F9                                            ; fully-qualified     # 🇾🇹 E2.0 flag: Mayotte
+1F1FF 1F1E6                                            ; fully-qualified     # 🇿🇦 E2.0 flag: South Africa
+1F1FF 1F1F2                                            ; fully-qualified     # 🇿🇲 E2.0 flag: Zambia
+1F1FF 1F1FC                                            ; fully-qualified     # 🇿🇼 E2.0 flag: Zimbabwe
+
+# subgroup: subdivision-flag
+1F3F4 E0067 E0062 E0065 E006E E0067 E007F              ; fully-qualified     # 🏴󠁧󠁢󠁥󠁮󠁧󠁿 E5.0 flag: England
+1F3F4 E0067 E0062 E0073 E0063 E0074 E007F              ; fully-qualified     # 🏴󠁧󠁢󠁳󠁣󠁴󠁿 E5.0 flag: Scotland
+1F3F4 E0067 E0062 E0077 E006C E0073 E007F              ; fully-qualified     # 🏴󠁧󠁢󠁷󠁬󠁳󠁿 E5.0 flag: Wales
+
+# Flags subtotal:		276
+# Flags subtotal:		276	w/o modifiers
+
+# Status Counts
+# fully-qualified : 3781
+# minimally-qualified : 1009
+# unqualified : 243
+# component : 9
+
+#EOF


### PR DESCRIPTION
Spike, and the premise it started from turned out to be wrong in a useful way.

The idea was that CLDR would give **better coverage** than the hand-maintained
catalog. It would not: the catalog is already complete through Emoji 16.0, all
3,781 fully-qualified emoji present. Coverage was never the problem.

What the spike did find is three defects the hand-maintained file was hiding.

## What was actually wrong

**163 entries are emoji Unicode has not released.** U+1FAEA "distorted face",
U+1FAEF "fight cloud", U+1FAC8 "hairy creature". They are draft candidates —
16.0 is the newest published `emoji-test.txt` (17.0 returns 404), none of them
appear in it at any qualification status, and no shipping font has them. They
draw as blank boxes wherever they land in the picker.

**No toned emoji was searchable.** All 2,030 skin-tone rows carried exactly one
keyword — `"waving hand: medium-dark skin tone"`. Search "wave" and you got 👋
but none of its six forms:

```
👋🏾  before: waving hand: medium-dark skin tone
     after:  waving hand medium dark skin tone bye cya g2g greetings gtg hello hey…
```

**Punctuation was baked into the tokens** — `"flag:"`, `"tone,"` — which matched
only because both clients happen to compare by prefix.

## Verified against the file it replaces

Running the search both clients implement over old and new:

| term | before | after | |
|---|---|---|---|
| `bff` | 0 | 90 | gained |
| `fairytale` | 0 | 66 | gained |
| `dating` | 8 | 90 | gained |
| `wave` | 5 | 25 | gained |
| `country` / `nation` / `banner` | 90 | 90 | held |

**Zero terms that returned results now return none.** Holding
`country`/`nation`/`banner` needed work — CLDR annotates each flag with its
country name and nothing else, so a naive port lost them (90 → 2). That is what
`tools/emoji-extras.tsv` is for; it is one line today, a category rule for flags.

All of the iOS suite's real-file assertions hold (`entries.count > 1_000`, every
browsable category non-empty, `search("heart")` non-empty), and the Android
suite is green.

## Vendored sources, and why

`tools/unicode/` carries the pinned `emoji-test.txt` and the two CLDR annotation
files — 1.4 MB, which is the part worth arguing about. Against that: the catalog
ships in both the APK and the IPA, F-Droid rebuilds what we ship from this tree
alone and compares it byte for byte, and a check that reaches the network fails
on someone else's outage and quietly changes meaning when upstream edits a file
in place. The repo already vendors whisper.cpp for the same reason. `--refresh`
is the only mode that goes out, and its diff is the record of what a version
bump actually changed.

`--check` now runs in CI on every push touching the shared assets or the
generator. Separately, **neither platform workflow ran when these assets
changed**, which was a pre-existing gap: the Android keyboard merges them into
its asset root, and `EmojiCatalogTests` asserts against the real catalog, so the
one suite checking the shipped file still parses never ran when that file was
edited. Both now trigger on it.

## EmojiSuggestions.TRIGGERS stays curated

Deliberately. The comment above it is right: CLDR's keywords are for a deliberate
search in the panel, and matched against ordinary prose they answer "the" with
an emoji. What the table could not catch on its own is a glyph nothing can draw,
so it is now held to the catalog — the 163 draft codepoints cannot come back
through the strip. Verified by putting one there and watching the test fail.

## Your call

`--skin-tones base` drops the toned rows: **3,781 → 1,906 entries, 301 KB → 101
KB**, and the People tab stops being six near-identical copies of every gesture.
But nothing can reach a toned emoji until the picker grows a tone selector, so
that is a UI change first. The default is `inline`, which preserves current
behaviour, and `--check` defaults to the same mode — a check that disagrees with
the committed file by default is worse than no check.

Not verified: the new catalog has not been render-checked on a device.
