### PR TITLE
Notice the keyboard being turned on without being told to look

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/ImeSetup.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/ImeSetup.kt
@@ -43,7 +43,8 @@ object ImeSetup {
 
     /**
      * The secure settings that change as someone turns the keyboard on and then
-     * chooses it, in the order guided setup asks for them.
+     * chooses it. Both are needed: the step is two system changes, and watching
+     * only the second leaves the checklist stuck on the first.
      *
      * Watching these is what makes the checklist notice. Coming back to the app
      * is not a reliable signal for either half: the picker is a system dialog

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/ImeSetup.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/ImeSetup.kt
@@ -3,6 +3,7 @@ package com.vocahq.vocaphone.ui
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.database.ContentObserver
 import android.os.Build
 import android.provider.Settings
 import android.view.inputmethod.InputMethodManager
@@ -38,6 +39,44 @@ object ImeSetup {
                 ) == component.flattenToString()
             },
         )
+    }
+
+    /**
+     * The secure settings that change as someone turns the keyboard on and then
+     * chooses it, in the order guided setup asks for them.
+     *
+     * Watching these is what makes the checklist notice. Coming back to the app
+     * is not a reliable signal for either half: the picker is a system dialog
+     * drawn over an activity that never leaves the resumed state, so nothing
+     * re-reads after it closes, and the settings screen commits its write
+     * asynchronously, so a read taken the moment the app resumes can still see
+     * the old value. Both leave the user staring at a step they have finished,
+     * with reopening the app as the only way out.
+     */
+    val WATCHED_SETTINGS = listOf(
+        Settings.Secure.ENABLED_INPUT_METHODS,
+        Settings.Secure.DEFAULT_INPUT_METHOD,
+    )
+
+    /**
+     * Registration is allowed to fail: these are secure settings, reading them
+     * directly is already restricted on Android 14, and a ROM that refuses the
+     * observer should cost the live update, not the onboarding screen.
+     */
+    fun watchSettings(context: Context, observer: ContentObserver) {
+        WATCHED_SETTINGS.forEach { name ->
+            runCatching {
+                context.contentResolver.registerContentObserver(
+                    Settings.Secure.getUriFor(name),
+                    false,
+                    observer,
+                )
+            }
+        }
+    }
+
+    fun stopWatchingSettings(context: Context, observer: ContentObserver) {
+        runCatching { context.contentResolver.unregisterContentObserver(observer) }
     }
 
     fun openSettings(context: Context) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
@@ -32,10 +32,10 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import kotlinx.coroutines.flow.filter
 import com.vocahq.vocaphone.R
 import com.vocahq.vocaphone.ui.theme.VocaPhoneTheme
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filter
 
 class MainActivity : ComponentActivity() {
     private val launchIntents = MutableStateFlow<Intent?>(null)

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
@@ -23,13 +23,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.painterResource
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.flow.filter
 import com.vocahq.vocaphone.R
 import com.vocahq.vocaphone.ui.theme.VocaPhoneTheme
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -92,6 +95,20 @@ fun VocaPhoneApp(
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    // The keyboard picker is a system dialog: it takes the window's focus
+    // without taking the activity out of the resumed state, so choosing a
+    // keyboard there produces no lifecycle event to read on. Getting focus back
+    // is the event it does produce. VocaPhoneViewModel watches the settings
+    // themselves, which is the mechanism that should carry this; this is here
+    // because a ROM is allowed to refuse that observer, and a stuck checklist
+    // is not a good way to find out.
+    val windowInfo = LocalWindowInfo.current
+    LaunchedEffect(windowInfo) {
+        snapshotFlow { windowInfo.isWindowFocused }
+            .filter { it }
+            .collect { viewModel.refreshSetup() }
     }
 
     var destination by remember { mutableStateOf(Destination.DICTATE) }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
@@ -1,9 +1,12 @@
 package com.vocahq.vocaphone.ui
 
 import android.app.Application
+import android.database.ContentObserver
 import android.media.AudioDeviceCallback
 import android.media.AudioDeviceInfo
 import android.media.AudioManager
+import android.os.Handler
+import android.os.Looper
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.vocahq.vocaphone.VocaPhoneApplication
@@ -117,8 +120,25 @@ class VocaPhoneViewModel(application: Application) : AndroidViewModel(applicatio
         override fun onAudioDevicesRemoved(removed: Array<out AudioDeviceInfo>?) = refreshMicrophones()
     }
 
+    /**
+     * Guided setup's keyboard step finishes outside the app, and neither half of
+     * it reliably brings the activity back through onResume. The picker is a
+     * system dialog drawn over an activity that stays resumed, so nothing
+     * re-reads once it closes; and the settings screen commits its write
+     * asynchronously, so a read taken on resume can still return the old value.
+     * Either way the checklist keeps asking for a step the user has just
+     * finished, and killing the app is the only way to move on.
+     *
+     * Watching the settings makes the state arrive rather than be sampled, so
+     * the step ticks while they are still looking at it.
+     */
+    private val imeSettingsObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
+        override fun onChange(selfChange: Boolean) = refreshSetup()
+    }
+
     init {
         audioManager?.registerAudioDeviceCallback(deviceCallback, null)
+        ImeSetup.watchSettings(application, imeSettingsObserver)
         container.telemetry.appFirstOpen()
         viewModelScope.launch {
             container.dictation.state.collect { state ->
@@ -131,6 +151,7 @@ class VocaPhoneViewModel(application: Application) : AndroidViewModel(applicatio
 
     override fun onCleared() {
         audioManager?.unregisterAudioDeviceCallback(deviceCallback)
+        ImeSetup.stopWatchingSettings(getApplication(), imeSettingsObserver)
         container.localModels.cancelDownload()
         localModelDownloadJob?.cancel()
         super.onCleared()

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/ImeSetupTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/ImeSetupTest.kt
@@ -1,0 +1,35 @@
+package com.vocahq.vocaphone.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImeSetupTest {
+
+    /**
+     * Guided setup's keyboard step is two separate system changes, and each one
+     * has its own setting. Watching only the second is the shape of the bug this
+     * list exists to prevent: the checklist would sit on "Turn on the VocaPhone
+     * keyboard" after it had been turned on, with no way forward but killing the
+     * app.
+     *
+     * The names rather than the URIs, because `Settings.Secure.getUriFor` needs
+     * a framework this test does not have — and because the names are the part
+     * that would be wrong.
+     */
+    @Test
+    fun bothHalvesOfTheKeyboardStepAreWatched() {
+        assertTrue(ImeSetup.WATCHED_SETTINGS.contains("enabled_input_methods"))
+        assertTrue(ImeSetup.WATCHED_SETTINGS.contains("default_input_method"))
+        assertEquals(2, ImeSetup.WATCHED_SETTINGS.size)
+    }
+
+    /** Turning it on comes first, so a partial registration still gets that far. */
+    @Test
+    fun theyAreInTheOrderSetupAsksForThem() {
+        assertEquals(
+            listOf("enabled_input_methods", "default_input_method"),
+            ImeSetup.WATCHED_SETTINGS,
+        )
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/ImeSetupTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/ImeSetupTest.kt
@@ -23,13 +23,4 @@ class ImeSetupTest {
         assertTrue(ImeSetup.WATCHED_SETTINGS.contains("default_input_method"))
         assertEquals(2, ImeSetup.WATCHED_SETTINGS.size)
     }
-
-    /** Turning it on comes first, so a partial registration still gets that far. */
-    @Test
-    fun theyAreInTheOrderSetupAsksForThem() {
-        assertEquals(
-            listOf("enabled_input_methods", "default_input_method"),
-            ImeSetup.WATCHED_SETTINGS,
-        )
-    }
 }


### PR DESCRIPTION
Testers keep getting stuck on the keyboard step of guided setup, and the way
out is to kill the app and open it again.

The step is finished outside the app, and the checklist only re-read it in
`onResume`. Neither half of the step reliably produces one.

**Choosing the keyboard is the worse half.** `showInputMethodPicker` puts up a
system dialog over an activity that stays `RESUMED` — it takes the *window's*
focus, not the activity's state. So when it closes there is no lifecycle event
at all, nothing re-reads, and the card goes on asking the user to choose the
keyboard they have just chosen.

**Turning it on ends the same way for a different reason.** That trip is a real
activity, so it does resume — but the settings write lands asynchronously, and a
read taken the instant the app comes back can still return the old value. That
is the half that makes this intermittent rather than constant, which is why it
reads as "sometimes".

It is not cosmetic. `isReadyToDictate` requires `ime.selected`, and the button
out of setup is `enabled = status.isReadyToDictate`, so a stale status leaves it
greyed out with nothing on screen to explain why.

## Reproduced

POCO F1, Android 14, app open on the keyboard card and untouched throughout:

```
adb shell ime enable com.vocahq.vocaphone/.ime...   card: unchanged
adb shell ime set    com.vocahq.vocaphone/.ime...   card: unchanged
```

Still offering **Enable keyboard** with the keyboard enabled *and* selected.

## The fix

The state arrives instead of being sampled. A `ContentObserver` on
`enabled_input_methods` and `default_input_method` covers both halves in both
directions, and it closes the race outright: the notification *is* the system
saying it has committed, so there is no longer a moment at which a read can be
early.

Same run again, each transition live, nothing touching the app in between:

| | card |
|---|---|
| `ime set <other>` | "Choose VocaPhone from the keyboard list." |
| `ime disable` | "Turn on the VocaPhone keyboard." |
| `ime enable` | "Choose VocaPhone from the keyboard list." |
| `ime set <vocaphone>` | "VocaPhone is the selected keyboard." |

Registration is wrapped. These are secure settings, reading them directly is
already restricted on Android 14 and the existing code says so, and a ROM that
refuses the observer should cost the live update rather than the onboarding
screen. That is also why the window-focus refresh is there: regaining focus is
the one event the picker dialog *does* produce, so it covers the dialog case on
its own if the observer never fires. The `onResume` read stays, because the
permission steps have nothing to watch.

## Verification

`just ci` — 406 test cases, no failures, lint clean, alignment check passes.

The device run above is the real check; the unit test pins the pair of setting
names, which is the part that would be wrong. It deliberately does not assert
the URIs, because `Settings.Secure.getUriFor` needs a framework the unit tests
do not have. Watching only `default_input_method` is the shape of bug worth
keeping out — everything would look fixed right until someone turned the
keyboard on.

## Not covered

The reproduction drives the settings with `adb` rather than through the system
UI, so what is verified is that the app notices the change. The two trips out to
Settings and to the picker were not walked by hand on the device.
