### PR TITLE
Stop background upkeep taking the app down with it

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/VocaPhoneApplication.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/VocaPhoneApplication.kt
@@ -15,6 +15,7 @@ import com.vocahq.vocaphone.settings.SettingsRepository
 import com.vocahq.vocaphone.telemetry.Telemetry
 import com.vocahq.vocaphone.telemetry.TelemetryFlushScheduler
 import java.io.File
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -26,8 +27,6 @@ import kotlinx.coroutines.launch
  * rather than injected per component.
  */
 class AppContainer(context: Context) {
-
-    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     private val appContext = context.applicationContext
 
@@ -44,6 +43,27 @@ class AppContainer(context: Context) {
 
     /** App-private and bounded; it never contains transcript or gateway data. */
     val diagnostics = DiagnosticLog(context)
+
+    /**
+     * SupervisorJob keeps one failed job from cancelling its siblings. It does
+     * not stop an exception escaping a root `launch`, and an uncaught one there
+     * reaches the thread's default handler and takes the process down.
+     *
+     * Everything on this scope is upkeep or reporting -- model verification,
+     * expired-audio purging, exit reporting, telemetry -- and none of it is
+     * worth killing the app for. It also runs on every process start, which for
+     * this app includes every time the keyboard is raised, so a throw here is a
+     * crash the user meets again the moment they try to type. Record it where
+     * the bug report will show it and let the app carry on.
+     */
+    private val backgroundFailures = CoroutineExceptionHandler { _, _ ->
+        // No source: SOURCES names where a dictation came from, and this did
+        // not come from one. Anything else would be written out as "none".
+        diagnostics.recordError("background", null)
+    }
+
+    private val applicationScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.Default + backgroundFailures)
 
     /**
      * Why the previous process ended, written into [diagnostics] at start.

--- a/android/app/src/main/java/com/vocahq/vocaphone/data/DiagnosticLog.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/data/DiagnosticLog.kt
@@ -250,6 +250,11 @@ class DiagnosticLog(
             "audio_focus_lost",
             "audio_silenced",
             "audio_capture_lost",
+            // Upkeep on the application scope threw: model verification,
+            // expired-audio purging, exit reporting or telemetry. Coarse on
+            // purpose -- it says the app survived something it used to die on,
+            // and the exit that no longer happens is the rest of the story.
+            "background",
             "gateway",
             "insertion",
             "settings",

--- a/android/app/src/test/java/com/vocahq/vocaphone/data/DiagnosticLogTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/data/DiagnosticLogTest.kt
@@ -39,6 +39,27 @@ class DiagnosticLogTest {
     }
 
     /**
+     * The application scope's exception handler writes this and nothing else,
+     * so if the category ever falls out of the allowlist the log silently reads
+     * `value=unknown` and the one line explaining a survived crash is gone.
+     * `source` is deliberately absent: SOURCES names where a dictation came
+     * from, and background upkeep did not come from one.
+     */
+    @Test
+    fun `background upkeep failures survive the allowlist`() {
+        val directory = Files.createTempDirectory("vocaphone-diagnostics").toFile()
+        try {
+            val log = DiagnosticLog(directory.resolve("events.log"), nowMillis = { 7L })
+
+            log.recordError("background", null)
+
+            assertTrue(log.read().contains("event=error value=background source=none"))
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
+    /**
      * A microphone failure is only diagnosable after the fact if the log says
      * which one it was: the call or the screen recording that took the input is
      * gone by the time anyone reads this.


### PR DESCRIPTION
A release sweep of everything that landed since `v0.1.0-beta.17`. One thing was worth changing; the rest is recorded below so the next sweep does not redo it.

## The change

`AppContainer`'s scope is `SupervisorJob() + Dispatchers.Default` and nothing else. SupervisorJob keeps one failed job from cancelling its siblings — it does **not** stop an exception escaping a root `launch`, and an uncaught one there reaches the thread's default handler and kills the process.

Five things launch on that scope, and none of them is worth an app for:

| launch | unguarded work |
|---|---|
| `localModels.refresh()` | `migrateLegacyLayout()` |
| `history.purgeExpiredAudio()` | Room queries and file deletes |
| `processExits.report()` | the DataStore write behind `claimExitsUpTo` (only `recentExits()` is guarded) |
| `Telemetry` | four launches |
| `DictationController` | the whole controller |

Each runs on every process start, which for this app means every time the keyboard is raised after the last process was reclaimed. So a throw here is not a crash seen once — it is a crash met again the moment the user tries to type.

A `CoroutineExceptionHandler` on the scope records it and lets the app carry on. The failure is not swallowed: it lands in the diagnostic log, which is what this project already asks people to paste.

## The second half, which the first needed

`DiagnosticLog` answers to a closed vocabulary, and a category outside it is written as `unknown` with nothing failing — which [the file's own comment](https://github.com/VocaHQ/vocaphone/blob/main/android/app/src/main/java/com/vocahq/vocaphone/data/DiagnosticLog.kt) warns about: *"A mapper and an allowlist that drift turn every event into unknown and nothing fails."*

`background` had to be added to `ERROR_CATEGORIES`, or the handler would have logged `event=error value=unknown source=none` and told nobody anything — the same silent-degradation shape the sweep was looking for. There is no `source`, because `SOURCES` names where a dictation came from and background upkeep did not come from one. A test pins the rendered line so the category cannot drift back out.

The handler covers root `launch`es. The one `async` on a scope, in `SherpaIncrementalSession`, is awaited in `finish()` and is unaffected.

## What the sweep checked and found clean

- **16 KB page alignment** (#132) — all 24 shipped `.so` files in the release APK report `align 0x4000` under `llvm-readelf`, the locally compiled `libwhisper`/`libggml*` included. That work is correct.
- **Resources and assets in release** — `assets/emoji/catalog.tsv` (300 KB), `en.txt`, `en-bigrams.txt` and all 20 tone WAVs are present in the release APK. Release path-shortening renames `res/raw/*` to `res/1o.wav`, so grepping for `res/raw` there finds nothing and proves nothing; check `resources.txt` instead.
- **R8 exposure** — JSON is hand-rolled `org.json`, so there is no reflective serializer to keep. The one reflection-dependent dependency, sherpa-onnx JNI, already has its keep rule.
- **Swallowed failures** — no empty catch blocks; every `catch (_: …)` carries a comment saying why.
- **Manifest** — foreground service type, permissions and the IME/provider declarations all match what the code uses.
- **Release smoke test** — the release build walked through Speech, Language, Models, Keyboard, Dictation, History and back with no app-level exception; steady-state cold start 317 ms.
- **Gates** — unit tests pass on both `full` and `fdroid`; `lintVital` passes on both release variants.

## Honest limit

The handler prevents a crash that needs an IO or database failure to trigger, and I did not inject one to watch it work — the reasoning is standard coroutines semantics, and what is verified on-device is that the app still builds, installs and starts clean with it in place. The vocabulary half **is** directly tested.