### PR TITLE
Prepare 0.1.0-beta.18

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.vocahq.vocaphone"
         minSdk = 33
         targetSdk = 36
-        versionCode = 17
-        versionName = "0.1.0-beta.17"
+        versionCode = 18
+        versionName = "0.1.0-beta.18"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/docs/play-store.md
+++ b/docs/play-store.md
@@ -26,8 +26,8 @@ Upload the full AAB only. Never upload the fdroid APK or an fdroid bundle to
 Play. The fdroid flavour drops prebuilt sherpa-onnx / ONNX Runtime so F-Droid
 can rebuild from source; Play testers should get the full catalog.
 
-Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 17,
-`versionName` `0.1.0-beta.17`. Keep that until the next Play-bound tag needs a
+Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 18,
+`versionName` `0.1.0-beta.18`. Keep that until the next Play-bound tag needs a
 bump; the beta workflow refuses to publish when the tag and APK version disagree.
 
 `dependenciesInfo.includeInApk` / `includeInBundle` stay `false` so AGP does

--- a/fastlane/metadata/android/en-US/changelogs/18.txt
+++ b/fastlane/metadata/android/en-US/changelogs/18.txt
@@ -1,0 +1,1 @@
+Dictation plays a start and stop tone. Pick one under Settings, Dictation, or set it to Off. The keyboard no longer stutters while you type and its emoji list now covers the full Unicode catalog. On-device transcription works on phones that use 16 KB memory pages.

--- a/fdroid/com.vocahq.vocaphone.yml
+++ b/fdroid/com.vocahq.vocaphone.yml
@@ -40,9 +40,9 @@ Repo: https://github.com/VocaHQ/vocaphone.git
 Binaries: https://github.com/VocaHQ/vocaphone/releases/download/v%v/vocaphone-fdroid.apk
 
 Builds:
-  - versionName: 0.1.0-beta.17
-    versionCode: 17
-    commit: v0.1.0-beta.17
+  - versionName: 0.1.0-beta.18
+    versionCode: 18
+    commit: v0.1.0-beta.18
     subdir: android/app
     submodules: true
     gradle:
@@ -62,5 +62,5 @@ AllowedAPKSigningKeys: e6131446f8afeff13516f78036db9ea26aaa16e01b39f37182bf262cc
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 0.1.0-beta.17
-CurrentVersionCode: 17
+CurrentVersion: 0.1.0-beta.18
+CurrentVersionCode: 18


### PR DESCRIPTION
Android goes to `versionCode` 18 / `0.1.0-beta.18` so the next tag matches `versionName`. This does not create a tag — `v0.1.0-beta.18` gets pushed after this merges.

## What landed since beta.17

| | |
|---|---|
| #126 | Dictation tone picker — ten start/stop pairs, Voca by default, Off is a real choice |
| #136 | Those tones made audible, and taken off the critical path of starting dictation |
| #137 | Background upkeep no longer takes the app down with it |
| #132 | 16 KB page support, and a record of why a killed process died |
| #133 | Keyboard stops stuttering while you type |
| #134 | Emoji catalog generated from Unicode and CLDR |
| #135 | Keyboard notices being turned on without being told to look |

## The four files

Same set the beta.17 bump touched:

- `android/app/build.gradle.kts` — `versionCode` and `versionName`
- `fdroid/com.vocahq.vocaphone.yml` — build entry, `commit:` tag, `CurrentVersion`, `CurrentVersionCode`
- `docs/play-store.md` — the "current tree on main" line
- `fastlane/metadata/android/en-US/changelogs/18.txt` — new, 265 characters

## Checked rather than assumed

The beta workflow compares `v$versionName` from `aapt dump badging` against the tag and fails the release if they disagree, so the built APK was read back:

```
package: name='com.vocahq.vocaphone' versionCode='18' versionName='0.1.0-beta.18'
```

That is what `v0.1.0-beta.18` will be compared against.

The tree was swept for other mentions of the old version. The only one left is in `android/app/src/full/jniLibs/README.md` — "up to and including 1.23.2, what we shipped through 0.1.0-beta.17" — which is history about which ONNX Runtime shipped when, and is correct as it stands.