### PR TITLE
Fix the dead layer keys and stop clipping dictation at both ends

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.vocahq.vocaphone"
         minSdk = 33
         targetSdk = 36
-        versionCode = 18
-        versionName = "0.1.0-beta.18"
+        versionCode = 19
+        versionName = "0.1.0-beta.19"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/audio/AudioCapture.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/audio/AudioCapture.kt
@@ -142,8 +142,20 @@ class AudioCapture(
         running.set(false)
         val recorder = record
         stopSilenceWatch(recorder)
-        // AudioRecord.read is blocking. Stop the recorder first so the read loop
-        // wakes immediately; joining before stop made Finish wait up to 500 ms.
+        // Give the read loop a moment to notice and drain what the hardware has
+        // already buffered, because `AudioRecord.stop` throws that away.
+        //
+        // Stopping first and joining afterwards is what cut the last syllable
+        // off a dictation: `read` is blocking, so stopping does wake it, but it
+        // wakes it into a stopped recorder with the tail still inside. A read
+        // returns within a frame while audio is flowing, so this join almost
+        // always completes well inside its bound; the hard stop below is what
+        // happens when the microphone has already stalled and there is nothing
+        // to wait for anyway.
+        val drained = thread
+            ?.takeIf { it !== Thread.currentThread() }
+            ?.let { runCatching { it.join(DRAIN_JOIN_MILLIS); !it.isAlive }.getOrDefault(false) }
+            ?: true
         recorder?.let {
             runCatching {
                 if (it.state == AudioRecord.STATE_INITIALIZED &&
@@ -153,7 +165,9 @@ class AudioCapture(
                 }
             }
         }
-        thread?.takeIf { it !== Thread.currentThread() }?.let { runCatching { it.join(500) } }
+        if (!drained) {
+            thread?.takeIf { it !== Thread.currentThread() }?.let { runCatching { it.join(500) } }
+        }
         thread = null
         recorder?.let {
             runCatching { it.release() }
@@ -405,6 +419,28 @@ class AudioCapture(
                 }
             }
         }
+        drainBufferedFrames(recorder)
+    }
+
+    /**
+     * Hands over whatever the hardware buffered while the loop was being asked
+     * to stop.
+     *
+     * `READ_NON_BLOCKING` so a microphone that has already gone quiet returns 0
+     * straight away rather than holding `stop` open for a frame that is never
+     * coming. Bounded because this runs while the user is waiting for their
+     * words: a tail worth keeping is milliseconds long, and anything larger is
+     * a backlog that the recording is better off without.
+     */
+    private fun drainBufferedFrames(recorder: AudioRecord) {
+        val samples = ShortArray(frameSamples)
+        repeat(MAX_DRAIN_FRAMES) {
+            val count = runCatching {
+                recorder.read(samples, 0, samples.size, AudioRecord.READ_NON_BLOCKING)
+            }.getOrDefault(0)
+            if (count <= 0) return
+            onFrame(samples, count)
+        }
     }
 
     private companion object {
@@ -416,5 +452,16 @@ class AudioCapture(
 
         /** Silence still present after this is another app, not a route change. */
         const val SILENCE_CONFIRMATION_MILLIS = 400L
+
+        /**
+         * How long `stop` waits for the read loop to hand back the tail. A
+         * blocking read returns within a frame while audio is flowing, so this
+         * is roughly two of them: enough for the common case, short enough that
+         * a stalled microphone does not hold up Finish.
+         */
+        const val DRAIN_JOIN_MILLIS = 250L
+
+        /** Two frames of tail. More than this is a backlog, not a last word. */
+        const val MAX_DRAIN_FRAMES = 2
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/audio/CueMuting.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/audio/CueMuting.kt
@@ -1,0 +1,38 @@
+package com.vocahq.vocaphone.audio
+
+/**
+ * Keeps the opening cue out of the recording without eating the opening of the
+ * sentence.
+ *
+ * The microphone is opened while the cue is still sounding, so that the cue
+ * plays over `AudioRecord`'s warm-up instead of in front of it, and the frames
+ * that overlap the cue are discarded rather than transcribed. That much is
+ * sound. What is not is telling the user the keyboard is listening while those
+ * frames are still going in the bin: anyone who starts talking on the cue --
+ * which is what a cue is for -- loses however much of it the cue still had left
+ * to run, up to 600 ms with the Lift tone.
+ *
+ * Losing it costs more than the words. The offline sherpa-onnx models are fed a
+ * whole utterance at a time, and a clip that begins part-way through the first
+ * syllable gives their decoder a bad first token to build the rest of the
+ * hypothesis on. A dictation that was merely missing a word came back with a
+ * worse version of everything after it too.
+ *
+ * So the wait comes back, minus the part of it the warm-up already paid for,
+ * and the user is told to speak only once what they say is being kept.
+ */
+internal object CueMuting {
+
+    /**
+     * How long to hold off announcing that the keyboard is listening.
+     *
+     * Zero once the cue has fallen quiet, which is the common case by the time
+     * the recorder has finished opening, and always zero for the Off tone.
+     */
+    fun waitMillis(cueQuietAtMillis: Long, nowMillis: Long): Long =
+        (cueQuietAtMillis - nowMillis).coerceAtLeast(0L)
+
+    /** Whether a frame captured at [frameAtMillis] is voice rather than cue. */
+    fun keepsFrame(frameAtMillis: Long, cueQuietAtMillis: Long): Boolean =
+        frameAtMillis >= cueQuietAtMillis
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager
 import android.os.SystemClock
 import androidx.core.content.ContextCompat
 import com.vocahq.vocaphone.audio.AudioCapture
+import com.vocahq.vocaphone.audio.CueMuting
 import com.vocahq.vocaphone.audio.CaptureFormat
 import com.vocahq.vocaphone.audio.DictationTonePlayer
 import com.vocahq.vocaphone.audio.MicrophoneInterruptedException
@@ -330,7 +331,7 @@ class DictationController(
             context = context,
             preference = configuration.microphone,
             onFrame = { samples, count ->
-                if (SystemClock.elapsedRealtime() >= cueQuietAt.get()) {
+                if (CueMuting.keepsFrame(SystemClock.elapsedRealtime(), cueQuietAt.get())) {
                     val frame = samples.copyOf(count)
                     if (frames.trySend(frame).isFailure) {
                         captureError.compareAndSet(
@@ -354,11 +355,11 @@ class DictationController(
             },
         )
         capture = recorder
-        // The cue sounds while AudioRecord warms up rather than before it, and
-        // onFrame drops whatever the microphone hears until it is done. Waiting
-        // the cue out first put its whole length in front of every dictation --
-        // 600 ms of it for Lift -- to buy the same guarantee.
-        cueQuietAt.set(announceListening(configuration.dictationTone))
+        // The cue sounds while AudioRecord warms up rather than before it, so
+        // most of its length costs nothing, and onFrame drops whatever the
+        // microphone hears until it falls quiet. See CueMuting for why the
+        // remainder is then waited out rather than announced through.
+        cueQuietAt.set(cues.startCue(configuration.dictationTone))
         if (!recorder.start()) {
             announceStopped(configuration.dictationTone)
             incrementalReference.getAndSet(null)?.cancel()
@@ -381,6 +382,12 @@ class DictationController(
             )
             return
         }
+
+        // Whatever the warm-up did not already cover. The haptic goes here
+        // rather than with the cue because it is the "speak now" signal, and
+        // now is when speaking starts being recorded.
+        delay(CueMuting.waitMillis(cueQuietAt.get(), SystemClock.elapsedRealtime()))
+        cues.haptic()
 
         val captureStartedAt = SystemClock.elapsedRealtime()
         _state.value = DictationState(
@@ -967,12 +974,6 @@ class DictationController(
             level = 0f,
             failure = DictationFailure(error.code, error.userMessage, error.recoverable),
         )
-    }
-
-    /** Taps the phone, sounds the cue, and reports when the cue falls quiet. */
-    private fun announceListening(tone: DictationTone): Long {
-        cues.haptic()
-        return cues.startCue(tone)
     }
 
     private fun announceStopped(tone: DictationTone) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardEditorConfig.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardEditorConfig.kt
@@ -101,3 +101,68 @@ internal data class KeyboardEditorConfig(
         }
     }
 }
+
+/**
+ * Enough of an editor to tell one apart from the next.
+ *
+ * `fieldId` alone would do for a single app, but it is only unique within a
+ * window, so the package comes with it. The input type and IME action are in
+ * here because they decide the layer, the return key and whether dictation is
+ * offered at all — a field that comes back having changed one of those is a
+ * different keyboard even if it is the same view.
+ */
+internal data class EditorIdentity(
+    val fieldId: Int,
+    val packageName: String?,
+    val inputType: Int,
+    val imeOptions: Int,
+) {
+    companion object {
+        fun of(info: EditorInfo?): EditorIdentity = EditorIdentity(
+            fieldId = info?.fieldId ?: 0,
+            packageName = info?.packageName,
+            inputType = info?.inputType ?: InputType.TYPE_NULL,
+            imeOptions = info?.imeOptions ?: EditorInfo.IME_ACTION_NONE,
+        )
+    }
+}
+
+/**
+ * Which `onStartInput` calls are a new editor and which are the same one being
+ * handed back.
+ *
+ * Apps restart input on the field the user is already typing in, and they do
+ * it constantly: `setText` from a `TextWatcher`, an input filter, emoji
+ * processing, a span update, a mention highlighter. Compose does it too —
+ * `TextInputServiceAndroid` restarts whenever the composing region changes
+ * while the selection does not, which is exactly what `finishComposingText`
+ * produces when the layer key is tapped mid-word.
+ *
+ * Treating those as new editors threw away everything the keyboard holds that
+ * the editor does not — the layer, caps lock, an open emoji panel — because
+ * all of it hangs off `KeyboardEditorConfig.sessionId`. Caps lock survived
+ * exactly one letter: committing it changed the app's text, the app restarted
+ * input, and shift went back to whatever the cursor's caps mode said. Tapping
+ * `?123` was worse, because finishing the composing region *is* the edit that
+ * causes the restart: the number layer appeared and the letters were back
+ * before the next frame, which reads as a dead key.
+ *
+ * The framework flags a restart with `restarting`, and that would be the
+ * obvious thing to branch on. This deliberately does not, because the flag is
+ * the IME's weakest input: it is decided by the app's process and the system
+ * server, an OEM framework is free to get it wrong, and every path that gets
+ * it wrong reintroduces the bug. The editor's own identity answers the same
+ * question without trusting anybody — two calls describing the same field are
+ * the same field.
+ *
+ * The pairing with `onFinishInput` is what makes that safe. Moving to another
+ * field always finishes the old input first (`InputMethodService.doStartInput`
+ * only skips `doFinishInput` when restarting), and finishing clears the stored
+ * identity, so a genuine field change still starts a new session even when two
+ * fields look alike — an unavoidable case, since a view with no id reports
+ * `fieldId` -1 like every other one.
+ */
+internal object EditorRestart {
+    fun keepsSession(previous: EditorIdentity?, next: EditorIdentity): Boolean =
+        previous == next
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -81,6 +81,7 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
     private var lastRecordedClip: String? = null
     private var lastImageSource: String? = null
     private var editorSession = 0
+    private var editorIdentity: EditorIdentity? = null
     private var editorConfig by mutableStateOf(KeyboardEditorConfig.empty())
     private var lastCandidatesStart = -1
     private var lastCandidatesEnd = -1
@@ -150,7 +151,10 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
     override fun onStartInput(attribute: EditorInfo?, restarting: Boolean) {
         super.onStartInput(attribute, restarting)
         currentInputType = attribute?.inputType ?: 0
-        editorSession += 1
+        val identity = EditorIdentity.of(attribute)
+        val sameEditor = EditorRestart.keepsSession(editorIdentity, identity)
+        editorIdentity = identity
+        if (!sameEditor) editorSession += 1
         lastCandidatesStart = -1
         lastCandidatesEnd = -1
         lastSelStart = attribute?.initialSelStart ?: -1
@@ -158,12 +162,25 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         val cursorCapsMode = runCatching {
             currentInputConnection?.getCursorCapsMode(currentInputType) ?: 0
         }.getOrDefault(0)
-        editorConfig = KeyboardEditorConfig.from(attribute, editorSession).let { config ->
+        val started = KeyboardEditorConfig.from(attribute, editorSession).let { config ->
             if (config.initialLayer == KeyboardLayer.LETTERS) {
                 config.copy(initialShift = KeyboardEditorConfig.shiftFromCapsMode(cursorCapsMode))
             } else {
                 config
             }
+        }
+        editorConfig = if (sameEditor) {
+            started.copy(
+                // The keyboard is still the one the user left, so leave its
+                // shift alone: a restart is not a reason to unlock caps.
+                shiftSync = editorConfig.shiftSync,
+                // The restart did drop the editor's composing region, so the
+                // half-typed word the strip was building there has to go with
+                // it, or the next letter commits the whole prefix again.
+                cursorSync = editorConfig.cursorSync + 1,
+            )
+        } else {
+            started
         }
         refreshEditorText()
     }
@@ -226,6 +243,7 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
     override fun onFinishInput() {
         cancelOwnedDictation("editor_finished")
         currentInputType = 0
+        editorIdentity = null
         editorSession += 1
         lastCandidatesStart = -1
         lastCandidatesEnd = -1

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -158,7 +158,24 @@ internal fun VocaPhoneKeyboard(
     onClearClipboardHistory: () -> Unit,
     onEmojiUsed: (String) -> Unit,
 ) {
-    var keyboardState by remember(editor.sessionId) {
+    // One set of state holders for the life of the composition, reset when the
+    // editor changes rather than rebuilt.
+    //
+    // These were all `remember(editor.sessionId)`, which built a *new*
+    // MutableState for every editor. The callbacks further down are remembered
+    // without keys so that forty keys can skip recomposition, and the Compose
+    // compiler memoizes the `::handleKey` reference handed to
+    // `rememberUpdatedState` along with them. So from the second editor onward
+    // the key handlers read and wrote the state objects belonging to the
+    // session they were built in, while the keyboard drew from the new ones.
+    //
+    // That is why this looked like "only the layer keys are broken". Tapping
+    // `?123` did run the reducer and did set the layer — on an orphaned state
+    // that nothing rendered, so no recomposition followed and the key looked
+    // dead. Letters were unaffected because a character reaches the editor
+    // through `onCommand`, which never goes near this state. Caps lock went the
+    // same way as the layer, for the same reason.
+    var keyboardState by remember {
         mutableStateOf(
             KeyboardState(
                 layer = editor.initialLayer,
@@ -166,10 +183,25 @@ internal fun VocaPhoneKeyboard(
             ),
         )
     }
-    var preferencePanel by remember(editor.sessionId) { mutableStateOf<PreferencePanel?>(null) }
-    var emojiCategory by remember(editor.sessionId) { mutableStateOf(EmojiCategory.SMILEYS) }
-    var swipeChoices by remember(editor.sessionId) { mutableStateOf<List<String>>(emptyList()) }
-    var swipeWord by remember(editor.sessionId) { mutableStateOf<String?>(null) }
+    var preferencePanel by remember { mutableStateOf<PreferencePanel?>(null) }
+    var emojiCategory by remember { mutableStateOf(EmojiCategory.SMILEYS) }
+    var swipeChoices by remember { mutableStateOf<List<String>>(emptyList()) }
+    var swipeWord by remember { mutableStateOf<String?>(null) }
+    var suggestionStrip by remember { mutableStateOf(SuggestionStrip(emptyList())) }
+
+    // The one place a new editor wipes the keyboard. Replacing the holders did
+    // this implicitly and broke the handlers that had closed over them.
+    LaunchedEffect(editor.sessionId) {
+        keyboardState = KeyboardState(
+            layer = editor.initialLayer,
+            shift = editor.initialShift,
+        )
+        preferencePanel = null
+        emojiCategory = EmojiCategory.SMILEYS
+        swipeChoices = emptyList()
+        swipeWord = null
+        suggestionStrip = SuggestionStrip(emptyList())
+    }
 
     LaunchedEffect(dictationState.phase, editor.dictationAllowed) {
         if (dictationState.phase != DictationPhase.IDLE || !editor.dictationAllowed) {
@@ -216,7 +248,6 @@ internal fun VocaPhoneKeyboard(
     // window would commit a suggestion for the word as it was a letter ago —
     // reachable in principle, sixteen milliseconds wide in practice, and the
     // same trade every keyboard that does this off the main thread makes.
-    var suggestionStrip by remember(editor.sessionId) { mutableStateOf(SuggestionStrip(emptyList())) }
     LaunchedEffect(
         composeWords,
         settings.correctionsEnabled,
@@ -1651,6 +1682,13 @@ private fun KeyboardRows(
     val trailColor = MaterialTheme.colorScheme.primary
     val currentOnSwipe = rememberUpdatedState(onSwipe)
 
+    // Only the swipe gesture clears this, and it is only installed on the
+    // letter layer, so a swipe that was still consuming when the layer changed
+    // would leave the flag raised with nothing left to lower it.
+    LaunchedEffect(swipeEnabled) {
+        if (!swipeEnabled) swipeConsumed.value = false
+    }
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -1700,7 +1738,17 @@ private fun KeyboardRows(
                                     editor = editor,
                                     keyHeight = keyHeight,
                                     showKeyHints = showKeyHints,
-                                    swipeConsumed = swipeConsumed,
+                                    // A swipe can only begin on a letter, so a
+                                    // letter is the only key whose own tap can
+                                    // be the tail of one. Handing the flag to
+                                    // shift or `?123` let a swipe that ended
+                                    // without a match swallow the next tap on
+                                    // them instead.
+                                    swipeConsumed = if (key.type == KeyboardKeyType.CHARACTER) {
+                                        swipeConsumed
+                                    } else {
+                                        null
+                                    },
                                     onPress = { onKey(key) },
                                     onHold = { heldMs -> onKeyHold(key, heldMs) },
                                     onCommitText = { text ->

--- a/android/app/src/test/java/com/vocahq/vocaphone/audio/CueMutingTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/audio/CueMutingTest.kt
@@ -1,0 +1,42 @@
+package com.vocahq.vocaphone.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CueMutingTest {
+
+    @Test
+    fun `a cue still sounding is waited out`() {
+        assertEquals(600L, CueMuting.waitMillis(cueQuietAtMillis = 1_600, nowMillis = 1_000))
+    }
+
+    @Test
+    fun `warm-up that outlasted the cue costs nothing`() {
+        assertEquals(0L, CueMuting.waitMillis(cueQuietAtMillis = 1_200, nowMillis = 1_400))
+    }
+
+    @Test
+    fun `the off tone never waits`() {
+        // startCue returns "now" for anything that did not sound.
+        assertEquals(0L, CueMuting.waitMillis(cueQuietAtMillis = 5_000, nowMillis = 5_000))
+    }
+
+    @Test
+    fun `frames under the cue are dropped and frames after it are kept`() {
+        assertFalse(CueMuting.keepsFrame(frameAtMillis = 999, cueQuietAtMillis = 1_000))
+        assertTrue(CueMuting.keepsFrame(frameAtMillis = 1_000, cueQuietAtMillis = 1_000))
+        assertTrue(CueMuting.keepsFrame(frameAtMillis = 1_001, cueQuietAtMillis = 1_000))
+    }
+
+    @Test
+    fun `no frame is dropped once the wait has been served`() {
+        // The invariant the fix rests on: the user is told to speak at
+        // `cueQuietAt`, and every frame from that mark on is kept.
+        val cueQuietAt = 2_000L
+        val announcedAt = cueQuietAt + CueMuting.waitMillis(cueQuietAt, cueQuietAt)
+
+        assertTrue(CueMuting.keepsFrame(announcedAt, cueQuietAt))
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardEditorConfigTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardEditorConfigTest.kt
@@ -109,4 +109,70 @@ class KeyboardEditorConfigTest {
         )
         assertEquals(ShiftState.OFF, KeyboardEditorConfig.shiftFromCapsMode(0))
     }
+
+    @Test
+    fun `restarting the same field keeps the session`() {
+        assertTrue(
+            EditorRestart.keepsSession(
+                previous = EditorIdentity.of(messageField()),
+                next = EditorIdentity.of(messageField()),
+            ),
+        )
+    }
+
+    @Test
+    fun `the same field is kept even when the framework forgets to say restarting`() {
+        // The whole point of comparing the editor rather than branching on the
+        // `restarting` flag: an app or an OEM framework that reports a restart
+        // as a fresh connection must not cost the user their layer.
+        val identity = EditorIdentity.of(messageField())
+
+        assertEquals(identity, EditorIdentity.of(messageField()))
+        assertTrue(EditorRestart.keepsSession(identity, EditorIdentity.of(messageField())))
+    }
+
+    @Test
+    fun `focusing a second field starts a new session`() {
+        val second = messageField().apply { fieldId = 202 }
+
+        assertFalse(
+            EditorRestart.keepsSession(
+                previous = EditorIdentity.of(messageField()),
+                next = EditorIdentity.of(second),
+            ),
+        )
+    }
+
+    @Test
+    fun `a field that changes input type under a restart starts over`() {
+        val password = messageField().apply {
+            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+        }
+
+        assertFalse(
+            EditorRestart.keepsSession(
+                previous = EditorIdentity.of(messageField()),
+                next = EditorIdentity.of(password),
+            ),
+        )
+    }
+
+    @Test
+    fun `a first connection is never a restart`() {
+        // onFinishInput clears the stored identity, so this is also the path a
+        // genuine focus change between two identical-looking fields takes.
+        assertFalse(
+            EditorRestart.keepsSession(
+                previous = null,
+                next = EditorIdentity.of(messageField()),
+            ),
+        )
+    }
+
+    private fun messageField() = EditorInfo().apply {
+        fieldId = 101
+        packageName = "com.example.chat"
+        inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
+        imeOptions = EditorInfo.IME_ACTION_SEND
+    }
 }

--- a/docs/play-store.md
+++ b/docs/play-store.md
@@ -26,8 +26,8 @@ Upload the full AAB only. Never upload the fdroid APK or an fdroid bundle to
 Play. The fdroid flavour drops prebuilt sherpa-onnx / ONNX Runtime so F-Droid
 can rebuild from source; Play testers should get the full catalog.
 
-Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 18,
-`versionName` `0.1.0-beta.18`. Keep that until the next Play-bound tag needs a
+Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 19,
+`versionName` `0.1.0-beta.19`. Keep that until the next Play-bound tag needs a
 bump; the beta workflow refuses to publish when the tag and APK version disagree.
 
 `dependenciesInfo.includeInApk` / `includeInBundle` stay `false` so AGP does

--- a/fastlane/metadata/android/en-US/changelogs/19.txt
+++ b/fastlane/metadata/android/en-US/changelogs/19.txt
@@ -1,0 +1,1 @@
+The 123, emoji and caps lock keys work again after you move between text fields. Dictation keeps the first word when you start speaking on the tone and the last one when you finish, which also restores on-device accuracy for the Parakeet and Canary models.

--- a/fdroid/com.vocahq.vocaphone.yml
+++ b/fdroid/com.vocahq.vocaphone.yml
@@ -40,9 +40,9 @@ Repo: https://github.com/VocaHQ/vocaphone.git
 Binaries: https://github.com/VocaHQ/vocaphone/releases/download/v%v/vocaphone-fdroid.apk
 
 Builds:
-  - versionName: 0.1.0-beta.18
-    versionCode: 18
-    commit: v0.1.0-beta.18
+  - versionName: 0.1.0-beta.19
+    versionCode: 19
+    commit: v0.1.0-beta.19
     subdir: android/app
     submodules: true
     gradle:
@@ -62,5 +62,5 @@ AllowedAPKSigningKeys: e6131446f8afeff13516f78036db9ea26aaa16e01b39f37182bf262cc
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 0.1.0-beta.18
-CurrentVersionCode: 18
+CurrentVersion: 0.1.0-beta.19
+CurrentVersionCode: 19


### PR DESCRIPTION
Two unrelated regressions from recent commits. `?123`, the emoji key and caps lock stopped responding after the first editor, and the sherpa-onnx models lost the start and end of what was said.

## The layer keys and caps lock

Every state holder in `VocaPhoneKeyboard` was `remember(editor.sessionId)`, so each editor built a **new** `MutableState`. The callbacks around them are remembered *without* keys — that is what lets forty keys skip recomposition (#133) — and the Compose compiler memoizes the `::handleKey` reference handed to `rememberUpdatedState` along with them. From the second editor onward the key handlers read and wrote the state objects from the session they were built in, while the keyboard drew from the new ones.

Caught on device:

```
recompose sessionId=23 layer=LETTERS     ← the keyboard is drawing LETTERS
keyGesture up pointerKey=shift up=true   ← the LETTERS shift key was tapped
handleKey id=shift ... curLayer=NUMBERS  ← the handler is on a different state
handleKey after-assign ...layer=NUMBERS  ← it writes, and no recompose follows
```

The tap was never the problem: the gesture returned `up=true`, the reducer produced the right answer, and the layer was set — on state nothing rendered. **Letters were unaffected because a character reaches the editor through `onCommand`, which never touches this state**, which is what made it look like only the layer keys were broken.

The holders now live for the whole composition and a new editor resets them in place.

While in there: an editor restarting input on the field the user is already in is not a new editor either. Apps do it constantly, and Compose does it whenever the composing region changes while the selection does not — exactly what finishing composing on a layer switch produces. Sessions key on the editor's identity now rather than on a counter bumped per `onStartInput`. This deliberately does not branch on the framework's `restarting` flag; on device that flag arrives `false` for cases that are plainly the same field.

## The clipped dictation and the accuracy drop

Same root cause for both, from #136.

**Head.** Cue muting opened the microphone under the opening cue and discarded the frames overlapping it — correct in itself — but announced `LISTENING` and fired the haptic immediately. Anyone who started talking on the cue, which is what a cue is for, lost whatever the cue still had left to run: up to 600 ms with Lift, in 100 ms frames.

That is also the accuracy report. The offline sherpa-onnx models are handed a whole utterance at a time, so a clip beginning part-way through the first syllable gives the decoder a bad first token to build the rest of the hypothesis on — a dictation missing a word came back with a worse version of everything after it too. The remainder of the cue is now waited out before the user is invited to speak, and the haptic moves with it, so the "speak now" signal and the first kept frame coincide.

**Tail.** `AudioCapture.stop()` called `AudioRecord.stop()` before joining the read loop, so whatever the hardware still held was discarded with it. The loop now drains what is buffered and `stop()` waits briefly for it, keeping the old hard stop for a microphone that has already stalled.

## Testing

- 423 unit tests, `assembleFullDebug testFullDebugUnitTest lintFullDebug` green.
- New: `CueMutingTest` (5), and 6 restart/identity cases in `KeyboardEditorConfigTest`.
- Verified on a POCO F1 against a release build — every layer switch now produces the matching recompose, across editor changes:

```
handleKey id=layer-?123    target=NUMBERS  curLayer=LETTERS  →  recompose layer=NUMBERS
handleKey id=emoji         target=EMOJI    curLayer=NUMBERS  →  recompose layer=EMOJI
handleKey id=emoji-letters target=LETTERS  curLayer=EMOJI    →  recompose layer=LETTERS
onStartInput restarting=true sameEditor=true session=7       →  session held, caps survives
```

The dictation head/tail fixes still want a listening check on device.
