### PR TITLE
Fix mid-text caps and spacing, and let a stable tag release

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,26 +1,32 @@
-name: Android beta release
+name: Android release
 
-# Pushing a tag like v0.1.0-beta.1 builds the signed full and fdroid release
-# APKs plus the full-flavor AAB (Play upload candidate), then publishes them as
-# a workflow artifact and a GitHub prerelease. Checksums and the signing
-# certificate fingerprint are attached so testers can verify what they install.
-# After the GitHub Release is published, the full AAB is uploaded to Google Play
-# Internal testing when PLAY_SERVICE_ACCOUNT_JSON is set. That step is skipped
-# if the secret is empty. fdroid artifacts and production are never uploaded.
+# Pushing a version tag builds the signed full and fdroid release APKs plus the
+# full-flavor AAB (Play upload candidate), then publishes them as a workflow
+# artifact and a GitHub Release. Checksums and the signing certificate
+# fingerprint are attached so testers can verify what they install. After the
+# GitHub Release is published, the full AAB is uploaded to Google Play Internal
+# testing when PLAY_SERVICE_ACCOUNT_JSON is set. That step is skipped if the
+# secret is empty. fdroid artifacts and production are never uploaded: every
+# track past Internal is promoted by hand in Console.
+#
+# Both tag shapes run the same build. Semver's own rule decides which is which:
+# a hyphen means a prerelease, so v0.1.0-beta.20 is published as a prerelease
+# and v0.1.0 is published as the latest release.
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+-beta*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 
 permissions:
   contents: write
 
 concurrency:
-  group: android-beta-${{ github.ref }}
+  group: android-release-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  beta:
+  release:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
@@ -31,7 +37,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
-          # The release notes step walks back to the previous beta tag, which
+          # The release notes step walks back to the previous release tag, which
           # needs the tags and the history connecting them. Only the commits
           # are needed, so skip fetching every blob in that history.
           fetch-depth: 0
@@ -170,25 +176,42 @@ jobs:
           # storage, and an APK is already a compressed archive.
           retention-days: 7
           compression-level: 0
-      - name: Publish beta GitHub Release
+      - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          # Semver: anything after a hyphen is a prerelease identifier. The tag
+          # patterns above admit only these two shapes, so the absence of one
+          # is the presence of the other.
+          case "$GITHUB_REF_NAME" in
+            *-*) release_kind=(--prerelease) ;;
+            *) release_kind=(--latest) ;;
+          esac
+
           # --generate-notes lists the pull requests merged since the previous
-          # beta. It will choose that starting point on its own, but naming the
-          # tag explicitly keeps the range right for a tag cut from anywhere
-          # other than the tip of main. An empty result is the first beta ever,
-          # where letting it pick means "everything", which is correct.
-          previous_tag="$(git describe --tags --abbrev=0 --match 'v*-beta*' "$GITHUB_REF_NAME^" 2>/dev/null || true)"
+          # release of the same kind. It will choose a starting point on its
+          # own, but naming the tag explicitly keeps the range right for a tag
+          # cut from anywhere other than the tip of main.
+          #
+          # A stable tag looks back to the previous stable one, so 0.2.0 covers
+          # everything since 0.1.0 rather than only what landed after the last
+          # beta of the 0.2.0 series. An empty result is the first release of
+          # that kind, where letting it pick means "everything" — which is what
+          # the first stable release should say.
+          case "$GITHUB_REF_NAME" in
+            *-*) match=(--match 'v*-*') ;;
+            *) match=(--match 'v*' --exclude 'v*-*') ;;
+          esac
+          previous_tag="$(git describe --tags --abbrev=0 "${match[@]}" "$GITHUB_REF_NAME^" 2>/dev/null || true)"
           notes_range=()
           if [ -n "$previous_tag" ]; then
             notes_range=(--notes-start-tag "$previous_tag")
           fi
 
           # --notes is prepended to the generated list, so the install
-          # instructions stay at the top where a beta tester looks first.
+          # instructions stay at the top where someone installing looks first.
           gh release create "$GITHUB_REF_NAME" \
             release-assets/vocaphone.apk \
             release-assets/vocaphone-fdroid.apk \
@@ -197,7 +220,7 @@ jobs:
             release-assets/SIGNING-CERTIFICATE-SHA256.txt \
             --repo "$GITHUB_REPOSITORY" \
             --title "vocaphone Android $GITHUB_REF_NAME" \
-            --prerelease \
+            "${release_kind[@]}" \
             --generate-notes \
             "${notes_range[@]}" \
             --notes "Release-signed APK covering every ABI (arm64-v8a, armeabi-v7a, x86_64) and all Android 13+ devices. Install with \`adb install vocaphone.apk\` or open the APK on the device. \`vocaphone.aab\` is the same full-flavor build as an Android App Bundle. This workflow uploads it to Google Play Internal testing when PLAY_SERVICE_ACCOUNT_JSON is set. SHA-256 checksum and signing-certificate fingerprint files are attached for verification. Android may still scan or restrict APKs installed outside an app store. \`vocaphone-fdroid.apk\` is the same release built without the prebuilt sherpa-onnx and ONNX Runtime libraries, published so F-Droid can verify its own rebuild against it; install \`vocaphone.apk\` unless you specifically want that variant."
@@ -205,6 +228,11 @@ jobs:
       # The action defaults to the production track, so tracks must be
       # internal. If that API name is missing, qa is the only other name
       # to try. Full-flavor AAB only; never fdroid, never production.
+      #
+      # A stable tag lands on Internal too. Play wants a closed test before
+      # production, and that promotion is a decision with a rollout percentage
+      # and a staged-release halt behind it, so it stays a Console action
+      # rather than a consequence of pushing a tag.
       - name: Upload vocaphone.aab to Play Internal testing
         if: ${{ env.PLAY_SERVICE_ACCOUNT_JSON_SET == 'true' }}
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5

--- a/android/README.md
+++ b/android/README.md
@@ -63,12 +63,19 @@ only in whether the prebuilt sherpa-onnx libraries are present; shared code asks
 `LocalModelCatalog.sherpaAvailable` rather than assuming either way, and the
 sherpa models are hidden from the picker when the library is absent.
 
-## GitHub beta releases
+## GitHub releases
 
-Pushing a tag such as `v0.1.0-beta.14` (or the latest prerelease tag) runs
-`.github/workflows/android-beta.yml`. Before tagging, bump `versionCode` and
-`versionName` in `app/build.gradle.kts`; the workflow refuses to publish when
-the tag and APK version do not match.
+Pushing a version tag runs `.github/workflows/android-release.yml`. Both shapes
+build identically and semver decides how each is published: a tag with a hyphen
+in it, such as `v0.1.0-beta.20`, becomes a GitHub prerelease, and a plain
+`v0.1.0` becomes the latest release. Generated notes span the previous tag of
+the same kind, so a stable tag summarizes everything since the last stable one
+rather than only what followed its own last beta.
+
+Before tagging, bump `versionCode` and `versionName` in `app/build.gradle.kts`;
+the workflow refuses to publish when the tag and APK version do not match. Both
+kinds upload to Play Internal testing and nothing promotes itself past that:
+closed testing, open testing and production are Console decisions.
 
 The repository needs these GitHub Actions secrets: `KEYSTORE_BASE64`,
 `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`, and
@@ -76,7 +83,7 @@ The repository needs these GitHub Actions secrets: `KEYSTORE_BASE64`,
 if it is empty). The workflow builds, tests, lints, verifies both APKs
 (package, version, cert) and the full AAB signing cert via `keytool`
 (package/version come from the matching full APK), and attaches these files
-to the prerelease:
+to the release:
 
 - `vocaphone.apk`
 - `vocaphone.aab`: full-flavor Android App Bundle. CI uploads it to Play

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -176,6 +176,17 @@ internal object KeyboardChrome {
             span.word.equals(word, ignoreCase = true)
     }
 
+    /**
+     * What the shift key becomes when the service re-reads the caps mode at the
+     * cursor, after a commit or a tap somewhere else in the field.
+     *
+     * Caps lock is the user's and the editor never asks for it, so a locked
+     * keyboard ignores the answer. Everything else takes it, which is how a tap
+     * into the middle of a word turns off a pending capital.
+     */
+    fun shiftAfterCursorSync(current: ShiftState, atCursor: ShiftState): ShiftState =
+        if (current == ShiftState.LOCKED) ShiftState.LOCKED else atCursor
+
     fun swipeAlternatives(
         committed: String,
         swipeMatches: List<String>,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
@@ -539,4 +539,17 @@ internal object SuggestionEngine {
 
     private fun isWordChar(character: Char): Boolean =
         character.isLetterOrDigit() || character == '\''
+
+    /**
+     * A picked suggestion carries its own trailing space so the next word can
+     * follow straight on. At the end of the text that is what everyone wants;
+     * mid-text it is not, because the space that already separates this word
+     * from the next one is still sitting there and the field ends up with two.
+     *
+     * The space belongs before another word and nowhere else, so it is dropped
+     * whenever the cursor is about to land in front of anything that is not a
+     * word character: existing whitespace, a comma, a closing bracket.
+     */
+    fun suggestionCommit(word: String, textAfterCursor: CharSequence): String =
+        if (textAfterCursor.isEmpty() || isWordChar(textAfterCursor[0])) "$word " else word
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -230,6 +230,15 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         if (userMove) {
             currentInputConnection?.finishComposingText()
             editorConfig = editorConfig.copy(cursorSync = editorConfig.cursorSync + 1)
+            // A tap somewhere else is a new sentence position, so the pending
+            // shift has to be re-read there. Without this the ONCE armed at the
+            // start of the field, or by the last ". ", follows the cursor into
+            // the middle of an existing word and capitalizes inside it.
+            //
+            // Only for a plain cursor. Once there is a selection the shift key
+            // cycles its case instead of arming a capital, and "in a word" has
+            // no answer for a span that covers several.
+            if (newSelStart == newSelEnd) syncShiftFromCursor()
         }
         // Selecting text is rare and the shift key changes meaning once there
         // is a selection, so that one reads straight away. Typing conflates.
@@ -333,22 +342,25 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
 
     private fun commitSuggestion(word: String, replaceWord: Boolean) {
         val connection = currentInputConnection ?: return
+        var after = runCatching {
+            connection.getTextAfterCursor(32, 0)?.toString().orEmpty()
+        }.getOrDefault("")
         if (replaceWord) {
             connection.finishComposingText()
             val before = runCatching {
                 connection.getTextBeforeCursor(32, 0)?.toString().orEmpty()
             }.getOrDefault("")
-            val after = runCatching {
-                connection.getTextAfterCursor(32, 0)?.toString().orEmpty()
-            }.getOrDefault("")
             val span = SuggestionEngine.replaceableWord(before, after)
             if (span != null) {
                 connection.deleteSurroundingText(span.beforeLength, span.afterLength)
+                // What the commit lands in front of is what survives the
+                // delete, not what was there when the suggestion was picked.
+                after = after.substring(span.afterLength)
             }
         }
         // Leave composing alone so commitText replaces "hel" with "hello ".
         // Finishing first commits the stub, then this would insert in front of it.
-        connection.commitText("$word ", 1)
+        connection.commitText(SuggestionEngine.suggestionCommit(word, after), 1)
         syncShiftFromCursor()
         scheduleEditorTextRefresh()
     }
@@ -489,6 +501,13 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         visibleEditorText.value = EditorTextWindow(before, after, selected)
     }
 
+    /**
+     * Re-reads the platform's caps mode for wherever the cursor is now.
+     *
+     * `getCursorCapsMode` is position-aware: mid-word it answers 0 even when
+     * the field asks for sentence capitalization, which is exactly the check
+     * the keyboard's own shift state cannot make for itself.
+     */
     private fun syncShiftFromCursor() {
         if (editorConfig.initialLayer != KeyboardLayer.LETTERS) return
         val capsMode = runCatching {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -210,12 +210,24 @@ internal fun VocaPhoneKeyboard(
     }
     LaunchedEffect(editor.shiftSync) {
         if (editor.shiftSync > 0) {
-            keyboardState = keyboardState.copy(shift = editor.initialShift)
+            keyboardState = keyboardState.copy(
+                shift = KeyboardChrome.shiftAfterCursorSync(
+                    current = keyboardState.shift,
+                    atCursor = editor.initialShift,
+                ),
+            )
         }
     }
     LaunchedEffect(editor.cursorSync) {
         if (editor.cursorSync > 0) {
-            keyboardState = keyboardState.copy(composing = "")
+            // Both flags describe the character the cursor was sitting after,
+            // and it is no longer sitting there. Left set, the next space
+            // capitalizes because of a period somewhere else in the field.
+            keyboardState = keyboardState.copy(
+                composing = "",
+                capitalizeAfterSpace = false,
+                lastWasSpace = false,
+            )
         }
     }
     LaunchedEffect(settings.asciiEmojiEnabled, emojiCategory) {

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardChromeTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardChromeTest.kt
@@ -158,4 +158,37 @@ class KeyboardChromeTest {
             ),
         )
     }
+
+    @Test
+    fun `a cursor move inside a word drops the pending capital`() {
+        assertEquals(
+            ShiftState.OFF,
+            KeyboardChrome.shiftAfterCursorSync(
+                current = ShiftState.ONCE,
+                atCursor = ShiftState.OFF,
+            ),
+        )
+    }
+
+    @Test
+    fun `a cursor move at a sentence start arms one capital`() {
+        assertEquals(
+            ShiftState.ONCE,
+            KeyboardChrome.shiftAfterCursorSync(
+                current = ShiftState.OFF,
+                atCursor = ShiftState.ONCE,
+            ),
+        )
+    }
+
+    @Test
+    fun `caps lock survives a cursor move`() {
+        assertEquals(
+            ShiftState.LOCKED,
+            KeyboardChrome.shiftAfterCursorSync(
+                current = ShiftState.LOCKED,
+                atCursor = ShiftState.OFF,
+            ),
+        )
+    }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
@@ -235,4 +235,28 @@ class SuggestionEngineTest {
         assertEquals(6, span?.beforeLength)
         assertEquals(0, span?.afterLength)
     }
+
+    @Test
+    fun `a picked suggestion keeps its trailing space at the end of the text`() {
+        assertEquals("hello ", SuggestionEngine.suggestionCommit("hello", ""))
+    }
+
+    @Test
+    fun `a picked suggestion spaces itself from a word that follows`() {
+        assertEquals("hello ", SuggestionEngine.suggestionCommit("hello", "world"))
+    }
+
+    @Test
+    fun `a picked suggestion drops the space the text after it already has`() {
+        // Editing "hel|lo world": the word span takes "hello" out and the
+        // commit lands in front of " world", which is already separated.
+        assertEquals("hello", SuggestionEngine.suggestionCommit("hello", " world"))
+        assertEquals("hello", SuggestionEngine.suggestionCommit("hello", "\nrest"))
+    }
+
+    @Test
+    fun `a picked suggestion does not push punctuation away from its word`() {
+        assertEquals("hello", SuggestionEngine.suggestionCommit("hello", ", world"))
+        assertEquals("hello", SuggestionEngine.suggestionCommit("hello", "."))
+    }
 }

--- a/docs/play-store.md
+++ b/docs/play-store.md
@@ -1,14 +1,15 @@
 # Preparing Google Play (maintainers)
 
-How to take a VocaPhone Android beta tag from GitHub Releases into Play Console.
+How to take a VocaPhone Android tag from GitHub Releases into Play Console.
 This is Console and listing work. The app is not listed on Play until that work
 is finished; there is no store URL to publish yet.
 
-Beta tags attach a signed full-flavor AAB as `vocaphone.aab`. When
-`PLAY_SERVICE_ACCOUNT_JSON` is set, the beta tag workflow uploads that AAB to
+Version tags attach a signed full-flavor AAB as `vocaphone.aab`. When
+`PLAY_SERVICE_ACCOUNT_JSON` is set, the tag workflow uploads that AAB to
 Internal testing after the GitHub Release is published. The step is skipped if
 the secret is empty, so testers still get the GitHub APKs if Play is unset or
-fails. This tag workflow never uploads to production.
+fails. Stable tags go to Internal too: this tag workflow never uploads to
+production, and never to a wider track than Internal.
 
 The Play Developer API account is
 `vocaphone-play-upload@level-approach-506001-h1.iam.gserviceaccount.com`.
@@ -19,7 +20,7 @@ It can view this app and release it to testing tracks only.
 | Artifact | Flavor | Use |
 | --- | --- | --- |
 | `vocaphone.aab` | `full` | Play Internal testing (CI when the secret is set) |
-| `vocaphone.apk` | `full` | Sideload / GitHub beta |
+| `vocaphone.apk` | `full` | Sideload / GitHub Release |
 | `vocaphone-fdroid.apk` | `fdroid` | F-Droid rebuild verification only |
 
 Upload the full AAB only. Never upload the fdroid APK or an fdroid bundle to
@@ -28,7 +29,7 @@ can rebuild from source; Play testers should get the full catalog.
 
 Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 20,
 `versionName` `0.1.0-beta.20`. Keep that until the next Play-bound tag needs a
-bump; the beta workflow refuses to publish when the tag and APK version disagree.
+bump; the release workflow refuses to publish when the tag and APK version disagree.
 
 `dependenciesInfo.includeInApk` / `includeInBundle` stay `false` so AGP does
 not embed Play dependency metadata. Do not turn those back on.
@@ -37,8 +38,8 @@ not embed Play dependency metadata. Do not turn those back on.
 
 The GitHub release keystore already signs `vocaphone.apk`, `vocaphone-fdroid.apk`,
 and `vocaphone.aab`. The public certificate SHA-256 is published with every
-beta release in `SIGNING-CERTIFICATE-SHA256.txt` (pinned in
-`.github/workflows/android-beta.yml`).
+release in `SIGNING-CERTIFICATE-SHA256.txt` (pinned in
+`.github/workflows/android-release.yml`).
 
 In Play Console, use Play App Signing:
 
@@ -53,9 +54,11 @@ purpose.
 
 ## Track order
 
-The beta tag workflow uses the Play API track name `internal`. If that name is
-missing, `qa` is the only other name to try. Wider testing and production stay
-in Console. This tag workflow never uploads to production.
+The tag workflow uses the Play API track name `internal`, for prerelease and
+stable tags alike. If that name is missing, `qa` is the only other name to try.
+Closed testing, open testing and production stay in Console. Promotion carries a
+rollout percentage and a staged-release halt behind it, which is a decision
+rather than a consequence of pushing a tag.
 
 ## Permissions (Console justification notes)
 
@@ -113,7 +116,7 @@ PY
 4. Data safety form (no analytics; on-device default; gateway optional)
 5. Content rating questionnaire
 6. Closed testing track before production
-7. Confirm Internal testing received `vocaphone.aab` from the beta tag workflow
+7. Confirm Internal testing received `vocaphone.aab` from the tag workflow
    (upload by hand from the matching GitHub Release if the secret was unset)
 8. Confirm listing copy and graphics in Fastlane match what you paste into Console
 
@@ -127,10 +130,10 @@ export KEYSTORE_FILE=… KEYSTORE_PASSWORD=… KEY_ALIAS=… KEY_PASSWORD=…
 ```
 
 Output under `app/build/outputs/bundle/fullRelease/`. Prefer the CI artifact
-from a beta tag so the signing certificate matches the published fingerprint.
+from a version tag so the signing certificate matches the published fingerprint.
 
 ## Related docs
 
-- [Android client](../android/README.md): build flavors, beta tags, keyboard setup
+- [Android client](../android/README.md): build flavors, version tags, keyboard setup
 - [TestFlight](testflight.md): iOS counterpart
 - [Privacy](privacy.md): data flow and threat model


### PR DESCRIPTION
Closes #143. Closes #144.

### Auto-capitalization inside a word (#143)

Shift was only re-read from the cursor after a commit, never after a move. Tap into the middle of a word with a capital armed — from the field's own `initialCapsMode`, or from the last `". "` — and the next letter came out uppercase mid-word.

`getCursorCapsMode` is position-aware and answers 0 inside a word, which is the check the keyboard's own shift state cannot make for itself. `onUpdateSelection` now asks it on a plain cursor move. Two things it deliberately does not do: it skips the sync while text is selected, where the shift key cycles case instead of arming a capital, and a caps lock the user set survives, since the editor never asks for LOCKED and the answer would otherwise switch it off under their hands. `capitalizeAfterSpace` and `lastWasSpace` are also cleared on a move — both described a character the cursor has left, and a stale one capitalized after a period elsewhere in the field.

### Doubled space while editing (#144)

`commitSuggestion` committed `"$word "` unconditionally. Mid-text the word span deletion leaves the separating space in place, so `hel|lo world` came back as `hello  world`.

The space now goes in only ahead of another word — dropped in front of whitespace or punctuation, kept at the end of the text so typing flows on. The following text is also read *after* the replaced span is deleted, not before, since that is what the commit actually lands in front of.

### A `v0.1.0` tag can now release

`android-beta.yml` matched `'v[0-9]+.[0-9]+.[0-9]+-beta*'` only, so tagging `v0.1.0` would have built nothing — no APK, no AAB, no Release, no Play upload, and no failure either. Renamed to `android-release.yml` and widened to both tag shapes, with semver deciding the rest:

| | prerelease tag | stable tag |
| --- | --- | --- |
| Example | `v0.1.0-beta.20` | `v0.1.0` |
| GitHub Release | `--prerelease` | `--latest` |
| Notes back to | previous prerelease | previous **stable** |
| Play track | Internal | Internal |

Notes spanning the previous tag *of the same kind* means 0.2.0 covers everything since 0.1.0, rather than only what followed its own last beta. For the first stable tag there is no previous stable, so `--generate-notes` covers everything, which is what a first release should say.

Stable stays on Internal on purpose. Play wants a closed test before production, and promotion carries a rollout percentage and a staged-release halt behind it — a decision, not a consequence of pushing a tag. The workflow still never uploads production or the fdroid artifact.

`android/README.md` and `docs/play-store.md` follow the rename and the new behaviour.

### Checks

`testFullDebugUnitTest` and `lintFullRelease` pass. Seven new cases cover the spacing rule and the shift-sync rule including the caps-lock carve-out. The tag classification and `git describe` ranges were run against this repo's real tags: `v0.1.0-beta.19` → prerelease from `v0.1.0-beta.18`, `v0.1.0` → latest with no previous stable.

Not in scope: #151 (swipe accuracy and the main-thread scan behind the dropped-gesture delay).