### PR TITLE
Stop swipe typing dropping gestures and losing the right word

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,26 +1,32 @@
-name: Android beta release
+name: Android release
 
-# Pushing a tag like v0.1.0-beta.1 builds the signed full and fdroid release
-# APKs plus the full-flavor AAB (Play upload candidate), then publishes them as
-# a workflow artifact and a GitHub prerelease. Checksums and the signing
-# certificate fingerprint are attached so testers can verify what they install.
-# After the GitHub Release is published, the full AAB is uploaded to Google Play
-# Internal testing when PLAY_SERVICE_ACCOUNT_JSON is set. That step is skipped
-# if the secret is empty. fdroid artifacts and production are never uploaded.
+# Pushing a version tag builds the signed full and fdroid release APKs plus the
+# full-flavor AAB (Play upload candidate), then publishes them as a workflow
+# artifact and a GitHub Release. Checksums and the signing certificate
+# fingerprint are attached so testers can verify what they install. After the
+# GitHub Release is published, the full AAB is uploaded to Google Play Internal
+# testing when PLAY_SERVICE_ACCOUNT_JSON is set. That step is skipped if the
+# secret is empty. fdroid artifacts and production are never uploaded: every
+# track past Internal is promoted by hand in Console.
+#
+# Both tag shapes run the same build. Semver's own rule decides which is which:
+# a hyphen means a prerelease, so v0.1.0-beta.20 is published as a prerelease
+# and v0.1.0 is published as the latest release.
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+-beta*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 
 permissions:
   contents: write
 
 concurrency:
-  group: android-beta-${{ github.ref }}
+  group: android-release-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  beta:
+  release:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
@@ -31,7 +37,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
-          # The release notes step walks back to the previous beta tag, which
+          # The release notes step walks back to the previous release tag, which
           # needs the tags and the history connecting them. Only the commits
           # are needed, so skip fetching every blob in that history.
           fetch-depth: 0
@@ -170,25 +176,42 @@ jobs:
           # storage, and an APK is already a compressed archive.
           retention-days: 7
           compression-level: 0
-      - name: Publish beta GitHub Release
+      - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          # Semver: anything after a hyphen is a prerelease identifier. The tag
+          # patterns above admit only these two shapes, so the absence of one
+          # is the presence of the other.
+          case "$GITHUB_REF_NAME" in
+            *-*) release_kind=(--prerelease) ;;
+            *) release_kind=(--latest) ;;
+          esac
+
           # --generate-notes lists the pull requests merged since the previous
-          # beta. It will choose that starting point on its own, but naming the
-          # tag explicitly keeps the range right for a tag cut from anywhere
-          # other than the tip of main. An empty result is the first beta ever,
-          # where letting it pick means "everything", which is correct.
-          previous_tag="$(git describe --tags --abbrev=0 --match 'v*-beta*' "$GITHUB_REF_NAME^" 2>/dev/null || true)"
+          # release of the same kind. It will choose a starting point on its
+          # own, but naming the tag explicitly keeps the range right for a tag
+          # cut from anywhere other than the tip of main.
+          #
+          # A stable tag looks back to the previous stable one, so 0.2.0 covers
+          # everything since 0.1.0 rather than only what landed after the last
+          # beta of the 0.2.0 series. An empty result is the first release of
+          # that kind, where letting it pick means "everything" — which is what
+          # the first stable release should say.
+          case "$GITHUB_REF_NAME" in
+            *-*) match=(--match 'v*-*') ;;
+            *) match=(--match 'v*' --exclude 'v*-*') ;;
+          esac
+          previous_tag="$(git describe --tags --abbrev=0 "${match[@]}" "$GITHUB_REF_NAME^" 2>/dev/null || true)"
           notes_range=()
           if [ -n "$previous_tag" ]; then
             notes_range=(--notes-start-tag "$previous_tag")
           fi
 
           # --notes is prepended to the generated list, so the install
-          # instructions stay at the top where a beta tester looks first.
+          # instructions stay at the top where someone installing looks first.
           gh release create "$GITHUB_REF_NAME" \
             release-assets/vocaphone.apk \
             release-assets/vocaphone-fdroid.apk \
@@ -197,7 +220,7 @@ jobs:
             release-assets/SIGNING-CERTIFICATE-SHA256.txt \
             --repo "$GITHUB_REPOSITORY" \
             --title "vocaphone Android $GITHUB_REF_NAME" \
-            --prerelease \
+            "${release_kind[@]}" \
             --generate-notes \
             "${notes_range[@]}" \
             --notes "Release-signed APK covering every ABI (arm64-v8a, armeabi-v7a, x86_64) and all Android 13+ devices. Install with \`adb install vocaphone.apk\` or open the APK on the device. \`vocaphone.aab\` is the same full-flavor build as an Android App Bundle. This workflow uploads it to Google Play Internal testing when PLAY_SERVICE_ACCOUNT_JSON is set. SHA-256 checksum and signing-certificate fingerprint files are attached for verification. Android may still scan or restrict APKs installed outside an app store. \`vocaphone-fdroid.apk\` is the same release built without the prebuilt sherpa-onnx and ONNX Runtime libraries, published so F-Droid can verify its own rebuild against it; install \`vocaphone.apk\` unless you specifically want that variant."
@@ -205,6 +228,11 @@ jobs:
       # The action defaults to the production track, so tracks must be
       # internal. If that API name is missing, qa is the only other name
       # to try. Full-flavor AAB only; never fdroid, never production.
+      #
+      # A stable tag lands on Internal too. Play wants a closed test before
+      # production, and that promotion is a decision with a rollout percentage
+      # and a staged-release halt behind it, so it stays a Console action
+      # rather than a consequence of pushing a tag.
       - name: Upload vocaphone.aab to Play Internal testing
         if: ${{ env.PLAY_SERVICE_ACCOUNT_JSON_SET == 'true' }}
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5

--- a/android/README.md
+++ b/android/README.md
@@ -63,12 +63,19 @@ only in whether the prebuilt sherpa-onnx libraries are present; shared code asks
 `LocalModelCatalog.sherpaAvailable` rather than assuming either way, and the
 sherpa models are hidden from the picker when the library is absent.
 
-## GitHub beta releases
+## GitHub releases
 
-Pushing a tag such as `v0.1.0-beta.14` (or the latest prerelease tag) runs
-`.github/workflows/android-beta.yml`. Before tagging, bump `versionCode` and
-`versionName` in `app/build.gradle.kts`; the workflow refuses to publish when
-the tag and APK version do not match.
+Pushing a version tag runs `.github/workflows/android-release.yml`. Both shapes
+build identically and semver decides how each is published: a tag with a hyphen
+in it, such as `v0.1.0-beta.20`, becomes a GitHub prerelease, and a plain
+`v0.1.0` becomes the latest release. Generated notes span the previous tag of
+the same kind, so a stable tag summarizes everything since the last stable one
+rather than only what followed its own last beta.
+
+Before tagging, bump `versionCode` and `versionName` in `app/build.gradle.kts`;
+the workflow refuses to publish when the tag and APK version do not match. Both
+kinds upload to Play Internal testing and nothing promotes itself past that:
+closed testing, open testing and production are Console decisions.
 
 The repository needs these GitHub Actions secrets: `KEYSTORE_BASE64`,
 `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`, and
@@ -76,7 +83,7 @@ The repository needs these GitHub Actions secrets: `KEYSTORE_BASE64`,
 if it is empty). The workflow builds, tests, lints, verifies both APKs
 (package, version, cert) and the full AAB signing cert via `keytool`
 (package/version come from the matching full APK), and attaches these files
-to the prerelease:
+to the release:
 
 - `vocaphone.apk`
 - `vocaphone.aab`: full-flavor Android App Bundle. CI uploads it to Play

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -176,6 +176,17 @@ internal object KeyboardChrome {
             span.word.equals(word, ignoreCase = true)
     }
 
+    /**
+     * What the shift key becomes when the service re-reads the caps mode at the
+     * cursor, after a commit or a tap somewhere else in the field.
+     *
+     * Caps lock is the user's and the editor never asks for it, so a locked
+     * keyboard ignores the answer. Everything else takes it, which is how a tap
+     * into the middle of a word turns off a pending capital.
+     */
+    fun shiftAfterCursorSync(current: ShiftState, atCursor: ShiftState): ShiftState =
+        if (current == ShiftState.LOCKED) ShiftState.LOCKED else atCursor
+
     fun swipeAlternatives(
         committed: String,
         swipeMatches: List<String>,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
@@ -539,4 +539,17 @@ internal object SuggestionEngine {
 
     private fun isWordChar(character: Char): Boolean =
         character.isLetterOrDigit() || character == '\''
+
+    /**
+     * A picked suggestion carries its own trailing space so the next word can
+     * follow straight on. At the end of the text that is what everyone wants;
+     * mid-text it is not, because the space that already separates this word
+     * from the next one is still sitting there and the field ends up with two.
+     *
+     * The space belongs before another word and nowhere else, so it is dropped
+     * whenever the cursor is about to land in front of anything that is not a
+     * word character: existing whitespace, a comma, a closing bracket.
+     */
+    fun suggestionCommit(word: String, textAfterCursor: CharSequence): String =
+        if (textAfterCursor.isEmpty() || isWordChar(textAfterCursor[0])) "$word " else word
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
@@ -151,8 +151,11 @@ internal class SuggestionDictionary(
             val last = collapsedLength[rank] - 1
             if (last < 1) continue
             if (!gesture.endsAreReachable(compact[0], compact[last])) continue
-            if (!SuggestionEngine.isSubsequence(compact, keys)) continue
-            scored.add(words[rank] to gesture.score(compact, rank))
+            // Exact first: it is the cheaper test, it rejects most of the list,
+            // and whether it succeeded is itself part of the score below.
+            val exact = SuggestionEngine.isSubsequence(compact, keys)
+            if (!exact && !SuggestionEngine.isReachableSubsequence(compact, keys)) continue
+            scored.add(words[rank] to gesture.score(compact, rank, approximate = !exact))
         }
         return scored
             .sortedByDescending { it.second }
@@ -400,14 +403,6 @@ internal object SuggestionEngine {
         }
     }
 
-    internal fun isSubsequence(word: String, path: String): Boolean {
-        var index = 0
-        for (character in path) {
-            if (index < word.length && character == word[index]) index++
-        }
-        return index == word.length
-    }
-
     /**
      * FlorisBoard / AnySoftKeyboard compare a swipe to the ideal line through
      * the word's key centers, then rank by shape and path length. We do the
@@ -437,14 +432,15 @@ internal object SuggestionEngine {
         fun endsAreReachable(first: Char, last: Char): Boolean =
             letterBit(first) and firstMask != 0 && letterBit(last) and lastMask != 0
 
-        fun score(compactWord: String, frequencyRank: Int): Float {
+        fun score(compactWord: String, frequencyRank: Int, approximate: Boolean): Float {
             val shape = shapeDistance(compactWord)
             val lengthGap = kotlin.math.abs(length - pathLength(compactWord))
             val endPenalty =
                 (if (compactWord.first() == keys.first()) 0f else 0.7f) +
                     (if (compactWord.last() == keys.last()) 0f else 0.7f)
             val frequency = 1f / (1f + frequencyRank / 400f)
-            return frequency * 2f - shape * 3f - lengthGap * 0.35f - endPenalty
+            val nearby = if (approximate) NEARBY_KEY_PENALTY else 0f
+            return frequency * 2f - shape * 3f - lengthGap * 0.35f - endPenalty - nearby
         }
 
         private fun shapeDistance(word: String): Float {
@@ -513,6 +509,18 @@ internal object SuggestionEngine {
 
     private const val SAMPLE_POINTS = 16
 
+    /**
+     * How much worse a word is for having been matched through a neighbouring
+     * key rather than the one the finger crossed.
+     *
+     * It has to be large enough that a word which really was spelled out beats
+     * a shape-alike that was not, and small enough that a genuinely wobbly
+     * swipe still finds its word. Simulated over the shipped list against noisy
+     * paths, anything from roughly 1 to 1.5 sits on the same plateau; 1.5 is
+     * the end of it that keeps the exactly-spelled word in front.
+     */
+    private const val NEARBY_KEY_PENALTY = 1.5f
+
     private val QWERTY: Map<Char, KeyXY> = buildMap {
         fun row(y: Float, startX: Float, letters: String) {
             letters.forEachIndexed { index, letter -> put(letter, KeyXY(startX + index, y)) }
@@ -535,6 +543,60 @@ internal object SuggestionEngine {
             .filter { (other, point) -> other != letter && origin.distanceTo(point) < 1.55f }
             .map { it.key }
             .toSet()
+    }
+
+    /**
+     * For each letter, the keys a finger aiming at it could plausibly have
+     * crossed instead: the key itself and its neighbours, as one bitmap.
+     *
+     * Declared after [NEARBY] for the same source-order reason it is.
+     */
+    private val REACH: IntArray = IntArray(26) { offset ->
+        val letter = 'a' + offset
+        letterBits(NEARBY[letter].orEmpty() + letter)
+    }
+
+    private fun reachMask(letter: Char): Int {
+        val offset = letter - 'a'
+        return if (offset in 0..25) REACH[offset] else 0
+    }
+
+    /** Whether every letter of [word] appears in [path], in order. */
+    internal fun isSubsequence(word: String, path: String): Boolean {
+        var index = 0
+        for (character in path) {
+            if (index < word.length && character == word[index]) index++
+        }
+        return index == word.length
+    }
+
+    /**
+     * Whether a swipe could have spelled [word], allowing for a finger that
+     * clipped the key next to the one it was aiming at.
+     *
+     * The exact version of this test threw the right word away outright. A
+     * corner apex landing a quarter of a key off — which is most of them —
+     * leaves that letter missing from the crossed keys, and one missing letter
+     * eliminated the candidate no matter how well the rest of the gesture fit.
+     * Simulated against noisy paths for the shipped word list, that cost about
+     * a fifth of swipes at a quarter-key wobble and half of them at a third.
+     *
+     * Neighbours are admitted here and nowhere else: a letter may be met by a
+     * key beside it, but every letter must still be met, in order. Letting a
+     * letter go unmatched entirely was measurably worse, because the noise it
+     * admits outranks the word more often than it rescues it.
+     *
+     * A word that only matches this way is scored below one whose keys were
+     * all actually crossed — see [NEARBY_KEY_PENALTY]. Without that, a word
+     * sharing the gesture's shape but not its letters wins on shape alone.
+     */
+    internal fun isReachableSubsequence(word: String, path: String): Boolean {
+        var index = 0
+        for (character in path) {
+            if (index == word.length) break
+            if (letterBit(character) and reachMask(word[index]) != 0) index++
+        }
+        return index == word.length
     }
 
     private fun isWordChar(character: Char): Boolean =

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -230,6 +230,15 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         if (userMove) {
             currentInputConnection?.finishComposingText()
             editorConfig = editorConfig.copy(cursorSync = editorConfig.cursorSync + 1)
+            // A tap somewhere else is a new sentence position, so the pending
+            // shift has to be re-read there. Without this the ONCE armed at the
+            // start of the field, or by the last ". ", follows the cursor into
+            // the middle of an existing word and capitalizes inside it.
+            //
+            // Only for a plain cursor. Once there is a selection the shift key
+            // cycles its case instead of arming a capital, and "in a word" has
+            // no answer for a span that covers several.
+            if (newSelStart == newSelEnd) syncShiftFromCursor()
         }
         // Selecting text is rare and the shift key changes meaning once there
         // is a selection, so that one reads straight away. Typing conflates.
@@ -333,22 +342,25 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
 
     private fun commitSuggestion(word: String, replaceWord: Boolean) {
         val connection = currentInputConnection ?: return
+        var after = runCatching {
+            connection.getTextAfterCursor(32, 0)?.toString().orEmpty()
+        }.getOrDefault("")
         if (replaceWord) {
             connection.finishComposingText()
             val before = runCatching {
                 connection.getTextBeforeCursor(32, 0)?.toString().orEmpty()
             }.getOrDefault("")
-            val after = runCatching {
-                connection.getTextAfterCursor(32, 0)?.toString().orEmpty()
-            }.getOrDefault("")
             val span = SuggestionEngine.replaceableWord(before, after)
             if (span != null) {
                 connection.deleteSurroundingText(span.beforeLength, span.afterLength)
+                // What the commit lands in front of is what survives the
+                // delete, not what was there when the suggestion was picked.
+                after = after.substring(span.afterLength)
             }
         }
         // Leave composing alone so commitText replaces "hel" with "hello ".
         // Finishing first commits the stub, then this would insert in front of it.
-        connection.commitText("$word ", 1)
+        connection.commitText(SuggestionEngine.suggestionCommit(word, after), 1)
         syncShiftFromCursor()
         scheduleEditorTextRefresh()
     }
@@ -489,6 +501,13 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         visibleEditorText.value = EditorTextWindow(before, after, selected)
     }
 
+    /**
+     * Re-reads the platform's caps mode for wherever the cursor is now.
+     *
+     * `getCursorCapsMode` is position-aware: mid-word it answers 0 even when
+     * the field asks for sentence capitalization, which is exactly the check
+     * the keyboard's own shift state cannot make for itself.
+     */
     private fun syncShiftFromCursor() {
         if (editorConfig.initialLayer != KeyboardLayer.LETTERS) return
         val capsMode = runCatching {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -210,12 +210,24 @@ internal fun VocaPhoneKeyboard(
     }
     LaunchedEffect(editor.shiftSync) {
         if (editor.shiftSync > 0) {
-            keyboardState = keyboardState.copy(shift = editor.initialShift)
+            keyboardState = keyboardState.copy(
+                shift = KeyboardChrome.shiftAfterCursorSync(
+                    current = keyboardState.shift,
+                    atCursor = editor.initialShift,
+                ),
+            )
         }
     }
     LaunchedEffect(editor.cursorSync) {
         if (editor.cursorSync > 0) {
-            keyboardState = keyboardState.copy(composing = "")
+            // Both flags describe the character the cursor was sitting after,
+            // and it is no longer sitting there. Left set, the next space
+            // capitalizes because of a period somewhere else in the field.
+            keyboardState = keyboardState.copy(
+                composing = "",
+                capitalizeAfterSpace = false,
+                lastWasSpace = false,
+            )
         }
     }
     LaunchedEffect(settings.asciiEmojiEnabled, emojiCategory) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -118,6 +118,7 @@ import com.vocahq.vocaphone.ui.theme.VocaPhoneTheme
 import kotlin.math.PI
 import kotlin.math.sin
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -367,8 +368,7 @@ internal fun VocaPhoneKeyboard(
         reduction.command?.let(onCommand)
     }
 
-    fun handleSwipe(path: String) {
-        val matches = suggestions?.swipe(path).orEmpty()
+    fun applySwipe(matches: List<String>, similar: List<String>) {
         if (matches.isEmpty()) return
         if (keyboardState.composing.isNotEmpty()) {
             onCommand(KeyboardCommand.SetComposingText(""))
@@ -380,7 +380,7 @@ internal fun VocaPhoneKeyboard(
         swipeChoices = KeyboardChrome.swipeAlternatives(
             committed = chosen,
             swipeMatches = matches.map(::cased),
-            similar = suggestions?.similar(matches.first()).orEmpty().map(::cased),
+            similar = similar.map(::cased),
         )
         keyboardState = keyboardState.copy(
             composing = "",
@@ -389,6 +389,43 @@ internal fun VocaPhoneKeyboard(
             shift = if (keyboardState.shift == ShiftState.LOCKED) ShiftState.LOCKED else ShiftState.OFF,
         )
         onSuggestionPicked(chosen, false)
+    }
+
+    // Finished gestures, handed over rather than resolved in place.
+    //
+    // Matching a swipe walks the whole word list twice, and it used to do that
+    // on the thread delivering the pointer events. The keyboard stopped reading
+    // the screen for as long as it took, so a second swipe started during that
+    // window went nowhere at all: no letters, no feedback, the gesture simply
+    // swallowed. That is the "hidden cooldown" it felt like from the outside.
+    //
+    // A channel with one consumer keeps that work off this thread while still
+    // applying results in the order the gestures were made, so swiping two
+    // words in quick succession still writes them down in that order.
+    val swipePaths = remember { Channel<String>(Channel.UNLIMITED) }
+
+    fun handleSwipe(path: String) {
+        swipePaths.trySend(path)
+    }
+
+    // The consumer below outlives the composition that started it, so it has to
+    // reach the current `applySwipe` rather than the one it closed over: that
+    // one still holds the `onCommand` and `onSuggestionPicked` it was handed.
+    val latestApplySwipe by rememberUpdatedState<(List<String>, List<String>) -> Unit>(::applySwipe)
+
+    LaunchedEffect(suggestions) {
+        val dictionary = suggestions ?: return@LaunchedEffect
+        for (path in swipePaths) {
+            val resolved = withContext(Dispatchers.Default) {
+                val matches = dictionary.swipe(path)
+                matches to if (matches.isEmpty()) {
+                    emptyList()
+                } else {
+                    dictionary.similar(matches.first())
+                }
+            }
+            latestApplySwipe(resolved.first, resolved.second)
+        }
     }
 
     // Callbacks with an identity that survives recomposition.

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardChromeTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardChromeTest.kt
@@ -158,4 +158,37 @@ class KeyboardChromeTest {
             ),
         )
     }
+
+    @Test
+    fun `a cursor move inside a word drops the pending capital`() {
+        assertEquals(
+            ShiftState.OFF,
+            KeyboardChrome.shiftAfterCursorSync(
+                current = ShiftState.ONCE,
+                atCursor = ShiftState.OFF,
+            ),
+        )
+    }
+
+    @Test
+    fun `a cursor move at a sentence start arms one capital`() {
+        assertEquals(
+            ShiftState.ONCE,
+            KeyboardChrome.shiftAfterCursorSync(
+                current = ShiftState.OFF,
+                atCursor = ShiftState.ONCE,
+            ),
+        )
+    }
+
+    @Test
+    fun `caps lock survives a cursor move`() {
+        assertEquals(
+            ShiftState.LOCKED,
+            KeyboardChrome.shiftAfterCursorSync(
+                current = ShiftState.LOCKED,
+                atCursor = ShiftState.OFF,
+            ),
+        )
+    }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
@@ -235,4 +235,28 @@ class SuggestionEngineTest {
         assertEquals(6, span?.beforeLength)
         assertEquals(0, span?.afterLength)
     }
+
+    @Test
+    fun `a picked suggestion keeps its trailing space at the end of the text`() {
+        assertEquals("hello ", SuggestionEngine.suggestionCommit("hello", ""))
+    }
+
+    @Test
+    fun `a picked suggestion spaces itself from a word that follows`() {
+        assertEquals("hello ", SuggestionEngine.suggestionCommit("hello", "world"))
+    }
+
+    @Test
+    fun `a picked suggestion drops the space the text after it already has`() {
+        // Editing "hel|lo world": the word span takes "hello" out and the
+        // commit lands in front of " world", which is already separated.
+        assertEquals("hello", SuggestionEngine.suggestionCommit("hello", " world"))
+        assertEquals("hello", SuggestionEngine.suggestionCommit("hello", "\nrest"))
+    }
+
+    @Test
+    fun `a picked suggestion does not push punctuation away from its word`() {
+        assertEquals("hello", SuggestionEngine.suggestionCommit("hello", ", world"))
+        assertEquals("hello", SuggestionEngine.suggestionCommit("hello", "."))
+    }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
@@ -1,6 +1,7 @@
 package com.vocahq.vocaphone.ime
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -179,15 +180,58 @@ class SuggestionEngineTest {
         assertEquals(0, SuggestionEngine.lineBefore(""))
     }
 
+    /**
+     * The winner is asserted rather than the whole list. Admitting words whose
+     * letters the finger only came near widened what a path can return — that
+     * is the point of it, since those extra words fill the strip the user
+     * picks from — so only the ranking is a promise here.
+     */
     @Test
     fun `swipe matches a path across letter keys`() {
-        assertEquals(listOf("the"), dictionary.swipe("the"))
-        assertEquals(listOf("the"), dictionary.swipe("tghe"))
-        assertEquals(listOf("hello"), dictionary.swipe("hjkello"))
-        assertEquals(listOf("hello"), dictionary.swipe("helo"))
-        assertEquals(listOf("book"), dictionary.swipe("bok"))
+        assertEquals("the", dictionary.swipe("the").first())
+        assertEquals("the", dictionary.swipe("tghe").first())
+        assertEquals("hello", dictionary.swipe("hjkello").first())
+        assertEquals("hello", dictionary.swipe("helo").first())
+        assertEquals("book", dictionary.swipe("bok").first())
         assertTrue(dictionary.swipe("qz").isEmpty())
         assertTrue(dictionary.swipe("h").isEmpty())
+    }
+
+    @Test
+    fun `a word whose keys were all crossed outranks a shape-alike that was not`() {
+        // j-o-e-l traces almost the same line as this h-e-l-l-o path and is
+        // reachable from it one key at a time, but "hello" is the word the
+        // finger actually spelled and has to stay in front of it.
+        val words = SuggestionDictionary(
+            words = listOf("joel", "hello"),
+            bigrams = emptyMap(),
+        )
+        assertEquals("hello", words.swipe("hjkello").first())
+    }
+
+    @Test
+    fun `a swipe that started off its first key still finds its word`() {
+        // A recorded h-e-l-l-o path whose start landed a little high, on "u"
+        // rather than "h", so "h" is nowhere in the keys the finger crossed.
+        // Requiring every letter exactly threw "hello" out over that one miss,
+        // while it is plainly still the best answer for the gesture.
+        val words = SuggestionDictionary(
+            words = listOf("hello", "help", "held", "book"),
+            bigrams = emptyMap(),
+        )
+        assertFalse(SuggestionEngine.isSubsequence("helo", "uytrertyuiklo"))
+        assertEquals("hello", words.swipe("uytrertyuiklo").first())
+    }
+
+    @Test
+    fun `a reachable subsequence still needs every letter in order`() {
+        assertTrue(SuggestionEngine.isReachableSubsequence("helo", "hjkelo"))
+        // "k" stands in for "l" and "p" for "o": both are neighbours.
+        assertTrue(SuggestionEngine.isReachableSubsequence("helo", "hgerkp"))
+        // "z" is nowhere near "l", so the word is not spelled here.
+        assertFalse(SuggestionEngine.isReachableSubsequence("helo", "hgerzo"))
+        // Right letters, wrong order.
+        assertFalse(SuggestionEngine.isReachableSubsequence("helo", "hole"))
     }
 
     /**

--- a/docs/play-store.md
+++ b/docs/play-store.md
@@ -1,14 +1,15 @@
 # Preparing Google Play (maintainers)
 
-How to take a VocaPhone Android beta tag from GitHub Releases into Play Console.
+How to take a VocaPhone Android tag from GitHub Releases into Play Console.
 This is Console and listing work. The app is not listed on Play until that work
 is finished; there is no store URL to publish yet.
 
-Beta tags attach a signed full-flavor AAB as `vocaphone.aab`. When
-`PLAY_SERVICE_ACCOUNT_JSON` is set, the beta tag workflow uploads that AAB to
+Version tags attach a signed full-flavor AAB as `vocaphone.aab`. When
+`PLAY_SERVICE_ACCOUNT_JSON` is set, the tag workflow uploads that AAB to
 Internal testing after the GitHub Release is published. The step is skipped if
 the secret is empty, so testers still get the GitHub APKs if Play is unset or
-fails. This tag workflow never uploads to production.
+fails. Stable tags go to Internal too: this tag workflow never uploads to
+production, and never to a wider track than Internal.
 
 The Play Developer API account is
 `vocaphone-play-upload@level-approach-506001-h1.iam.gserviceaccount.com`.
@@ -19,7 +20,7 @@ It can view this app and release it to testing tracks only.
 | Artifact | Flavor | Use |
 | --- | --- | --- |
 | `vocaphone.aab` | `full` | Play Internal testing (CI when the secret is set) |
-| `vocaphone.apk` | `full` | Sideload / GitHub beta |
+| `vocaphone.apk` | `full` | Sideload / GitHub Release |
 | `vocaphone-fdroid.apk` | `fdroid` | F-Droid rebuild verification only |
 
 Upload the full AAB only. Never upload the fdroid APK or an fdroid bundle to
@@ -28,7 +29,7 @@ can rebuild from source; Play testers should get the full catalog.
 
 Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 20,
 `versionName` `0.1.0-beta.20`. Keep that until the next Play-bound tag needs a
-bump; the beta workflow refuses to publish when the tag and APK version disagree.
+bump; the release workflow refuses to publish when the tag and APK version disagree.
 
 `dependenciesInfo.includeInApk` / `includeInBundle` stay `false` so AGP does
 not embed Play dependency metadata. Do not turn those back on.
@@ -37,8 +38,8 @@ not embed Play dependency metadata. Do not turn those back on.
 
 The GitHub release keystore already signs `vocaphone.apk`, `vocaphone-fdroid.apk`,
 and `vocaphone.aab`. The public certificate SHA-256 is published with every
-beta release in `SIGNING-CERTIFICATE-SHA256.txt` (pinned in
-`.github/workflows/android-beta.yml`).
+release in `SIGNING-CERTIFICATE-SHA256.txt` (pinned in
+`.github/workflows/android-release.yml`).
 
 In Play Console, use Play App Signing:
 
@@ -53,9 +54,11 @@ purpose.
 
 ## Track order
 
-The beta tag workflow uses the Play API track name `internal`. If that name is
-missing, `qa` is the only other name to try. Wider testing and production stay
-in Console. This tag workflow never uploads to production.
+The tag workflow uses the Play API track name `internal`, for prerelease and
+stable tags alike. If that name is missing, `qa` is the only other name to try.
+Closed testing, open testing and production stay in Console. Promotion carries a
+rollout percentage and a staged-release halt behind it, which is a decision
+rather than a consequence of pushing a tag.
 
 ## Permissions (Console justification notes)
 
@@ -113,7 +116,7 @@ PY
 4. Data safety form (no analytics; on-device default; gateway optional)
 5. Content rating questionnaire
 6. Closed testing track before production
-7. Confirm Internal testing received `vocaphone.aab` from the beta tag workflow
+7. Confirm Internal testing received `vocaphone.aab` from the tag workflow
    (upload by hand from the matching GitHub Release if the secret was unset)
 8. Confirm listing copy and graphics in Fastlane match what you paste into Console
 
@@ -127,10 +130,10 @@ export KEYSTORE_FILE=… KEYSTORE_PASSWORD=… KEY_ALIAS=… KEY_PASSWORD=…
 ```
 
 Output under `app/build/outputs/bundle/fullRelease/`. Prefer the CI artifact
-from a beta tag so the signing certificate matches the published fingerprint.
+from a version tag so the signing certificate matches the published fingerprint.
 
 ## Related docs
 
-- [Android client](../android/README.md): build flavors, beta tags, keyboard setup
+- [Android client](../android/README.md): build flavors, version tags, keyboard setup
 - [TestFlight](testflight.md): iOS counterpart
 - [Privacy](privacy.md): data flow and threat model


### PR DESCRIPTION
Closes #151.

Targets `main`, but it branched off #152 and carries that commit too, so its diff shows both until #152 lands. **Merge #152 first.** (It was based on #152 originally; the workflows all filter `pull_request: branches: [main]`, so nothing ran at all until the base moved.)

### The dropped gestures

`SuggestionDictionary.swipe()` walks the whole ~10k word list, and `similar()` walks it again; both ran synchronously inside the pointer handler. The keyboard stopped reading the screen for as long as that took, so a swipe begun in that window was discarded with no letters and no feedback — the "hidden cooldown" in the report.

Finished gestures now go through a `Channel` to a single background consumer. One consumer rather than a job per gesture, because results have to be applied in the order the gestures were made — swiping two words in a row has to write them down in that order. The consumer reaches `applySwipe` through `rememberUpdatedState`, since it outlives the composition that started it and would otherwise keep calling that composition's `onCommand`.

### The wrong word

The candidate filter required every letter of a word to appear among the keys the finger crossed. A corner apex landing a quarter of a key wide — which is most of them — leaves that letter out of the crossed keys, and the word was then eliminated no matter how well the rest of the gesture fit it.

A letter may now be met by a **neighbouring** key. On its own that made things worse in a specific way worth naming: `hello` started returning `joel`, a word tracing nearly the same line while sharing almost none of the letters. So a word matched through neighbours now scores below one whose keys were all genuinely crossed. Both halves are needed; either alone is a regression.

I picked the penalty by simulation rather than by feel. Per-substitution scaling was clearly worse than a flat one — a real wobbly swipe legitimately needs several neighbours, and scaling punishes exactly the case being rescued. Flat 1.0 and 1.5 sit on the same plateau; 1.5 is the end of it that keeps the exactly-spelled word in front, which is what this issue is about.

### Measured

Simulated finger paths (bezier-bowed strokes, corner apexes jittered by a gaussian) over the shipped word list, 220 common words × 8 swipes each. Correct word ranked first / within the top three, where the strip puts it one tap away:

| wobble | before | after |
| --- | --- | --- |
| 0.20 key | 95.6% / 96.5% | **97.8% / 99.5%** |
| 0.30 key | 65.2% / 66.8% | **85.3% / 94.4%** |
| 0.40 key | 37.9% / 39.7% | **68.2% / 82.9%** |

### Checks

`clean testFullDebugUnitTest lintFullRelease assembleFullDebug` passes. Four new cases, including one built from a recorded path where the old filter threw `hello` away over a single missed key, and one pinning `hello` ahead of `joel`.

One existing assertion changed meaning: `swipe("hjkello")` returned exactly `[hello]` and now returns `[hello, help, book]`. Admitting near-miss words widens what a path returns — that is the point, since those extra words are what fills the strip — so that test now pins the ranking rather than the whole list. The real-dictionary probes it sits next to are untouched and still pass as they were.