### PR TITLE
Deploy a website preview for every pull request that touches it

### DIFF
--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -1,0 +1,146 @@
+name: Website preview
+
+# Deploys web/ to a Cloudflare Pages preview on every pull request that
+# touches it, and comments the URL. GitHub Pages cannot do this: it serves one
+# site per repository and this one's slot is production on vocaphone.vocahq.com,
+# so a preview deployed there would replace the live site rather than sit
+# beside it.
+#
+# The preview is not a merge gate. quality-web.yml runs npm run check and is
+# what has to pass; this only shows you the thing.
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'web/**'
+      - '.github/workflows/web-preview.yml'
+
+permissions:
+  contents: read
+  # Lets the URL comment be posted and updated in place.
+  pull-requests: write
+
+concurrency:
+  # One preview per pull request. A superseded push is a preview nobody will
+  # look at, so let the newer one cancel it.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    # A fork pull request gets no secrets at all, so the deploy below cannot
+    # work there and would only fail loudly on someone else's contribution.
+    # Skipping keeps their pull request green; a maintainer sees the preview
+    # after pushing the branch to this repository.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !github.event.pull_request.draft
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # The same gate the deploy job on main runs. Publishing a preview of a
+      # site that fails its own checks wastes the reviewer's time.
+      - name: Check site
+        working-directory: web
+        run: npm run check
+
+      # Secrets are unreadable from a step-level if:, so this turns their
+      # presence into something the steps below can branch on.
+      - name: Note whether Cloudflare is configured
+        id: cloudflare
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          if [ -n "$CLOUDFLARE_API_TOKEN" ] && [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo 'configured=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'configured=false' >> "$GITHUB_OUTPUT"
+            echo 'CLOUDFLARE_API_TOKEN or CLOUDFLARE_ACCOUNT_ID is unset, so no preview was deployed.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Deploy the preview
+        id: deploy
+        if: steps.cloudflare.outputs.configured == 'true'
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # web/ is uploaded whole, exactly as pages.yml hands it to GitHub
+          # Pages, so the preview is the same file tree production serves.
+          #
+          # --branch is what Cloudflare keys a preview deployment on. It must
+          # not be the production branch name, or this would deploy over the
+          # Pages project's production alias.
+          command: >-
+            pages deploy web
+            --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT || 'vocaphone-web' }}
+            --branch=pr-${{ github.event.pull_request.number }}
+
+      - name: Comment the preview URL
+        if: steps.cloudflare.outputs.configured == 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          # The per-deployment URL, which points at this exact commit and stays
+          # reachable after later pushes. wrangler also prints an alias URL for
+          # the branch; that one always shows the newest deploy.
+          PREVIEW_URL: ${{ steps.deploy.outputs.deployment-url }}
+          COMMIT: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const marker = '<!-- vocaphone-web-preview -->';
+            const url = process.env.PREVIEW_URL;
+            if (!url) {
+              core.warning('wrangler reported no deployment URL, so there is nothing to comment.');
+              return;
+            }
+            const short = process.env.COMMIT.slice(0, 7);
+            const body = [
+              marker,
+              `**Website preview:** ${url}`,
+              '',
+              `Built from \`${short}\`. Every push to this pull request deploys a new one and updates this comment.`,
+            ].join('\n');
+            // Same swallow-the-failure reasoning as report-size: a comment is
+            // not worth failing a run that already produced the preview, and
+            // the URL is in the job summary either way.
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                per_page: 100,
+              });
+              const existing = comments.find(c => c.body && c.body.startsWith(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  body,
+                });
+              }
+            } catch (err) {
+              core.warning(`Could not post the preview comment: ${err.message}`);
+            }
+
+      - name: Record the preview in the job summary
+        if: steps.cloudflare.outputs.configured == 'true'
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.deployment-url }}
+        run: |
+          set -euo pipefail
+          printf 'Website preview: %s\n' "${PREVIEW_URL:-not reported by wrangler}" >> "$GITHUB_STEP_SUMMARY"

--- a/web/README.md
+++ b/web/README.md
@@ -31,6 +31,36 @@ this directory (see `.github/workflows/pages.yml`). Set Pages source to
 `/`, `/iphone/`, `/iphone/device-setup/`, and `/privacy/` must resolve as HTML
 routes.
 
+## Pull request previews
+
+A pull request touching `web/` deploys the site to a Cloudflare Pages preview
+and comments the URL, updating that comment on every push
+(`.github/workflows/web-preview.yml`).
+
+Cloudflare rather than GitHub Pages because Pages serves one site per
+repository, and this repository's is production on the custom domain. A
+preview deployed there would replace the live site instead of sitting beside
+it.
+
+One-time setup:
+
+1. Create a Cloudflare Pages project. Any name works; the workflow defaults to
+   `vocaphone-web` and reads the repository variable `CLOUDFLARE_PAGES_PROJECT`
+   if you pick another. Choose direct upload, not a git connection: the
+   workflow uploads the directory itself, so a second connection would deploy
+   the same commits twice.
+2. Add repository secrets `CLOUDFLARE_API_TOKEN` (a token with the
+   **Cloudflare Pages: Edit** permission) and `CLOUDFLARE_ACCOUNT_ID`.
+
+Until both secrets exist the workflow still runs `npm run check` and then says
+in the job summary that it skipped the deploy, so an unconfigured repository
+does not fail its pull requests. Pull requests from forks skip the deploy for
+the same reason they cannot upload: a fork's token is given no secrets.
+
+Previews are deployed under the branch name `pr-<number>`, which keeps them off
+the Pages project's production alias. They are not a merge gate — `npm run
+check` in `quality-web.yml` is.
+
 The Android product images are the original 576×1280 screenshots from
 [VocaPhone PR #70](https://github.com/VocaHQ/vocaphone/pull/70). The website
 frames them with CSS and does not load media from GitHub at runtime.


### PR DESCRIPTION
A pull request touching `web/` now deploys the site to a Cloudflare Pages preview and comments the URL, updating that comment on each push.

### Why not GitHub Pages

Pages serves one site per repository, and this repository's is production on `vocaphone.vocahq.com` via `actions/deploy-pages`. A preview deployed there would *replace* the live site rather than sit beside it, so previews need somewhere else to live. Cloudflare Pages' free tier does per-branch preview deployments, which is the shape wanted here.

I considered two alternatives before this. Uploading `web/` as a workflow artifact needs no account, but the site uses root-absolute paths (`href="/iphone/"`), so a downloaded copy has to be served rather than opened — not much better than checking the branch out. A second repository on Pages gives real URLs but costs an extra repo, a PAT stored here, and a cleanup job.

### Shape

- Runs `npm run check` first. Publishing a preview of a site failing its own checks wastes the reviewer's time.
- Uploads `web/` whole, exactly as `pages.yml` hands it to Pages, so the preview is the tree production would serve.
- Deploys under branch `pr-<number>`, which keeps previews off the project's production alias.
- Comments via the same marker-and-upsert pattern `report-size` uses, and swallows a comment failure the same way — the URL is in the job summary regardless.
- **Not a merge gate.** `quality-web.yml` still owns the required check. This only shows you the thing.

### Degrades quietly

Secrets can't be read from a step-level `if:`, so the workflow turns their presence into an output and branches on that. With `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` unset it still runs the site check and notes the skip in the job summary rather than failing. Fork pull requests skip the deploy too, since a fork's token is given no secrets and the step could only fail loudly on someone else's contribution.

### Setup needed before it does anything

Documented in `web/README.md`: create a Cloudflare Pages project (direct upload, not a git connection, or the same commits deploy twice), then add the two secrets. The project name defaults to `vocaphone-web` and reads the repository variable `CLOUDFLARE_PAGES_PROJECT` if you want another.

Until then this PR is inert — worth merging anyway, since the skip path is what runs.

### Checks

`actionlint` 1.7.12 clean across all workflows (the version CI pins). `npm run check` 18/18. `wrangler-action` is SHA-pinned to v4.0.0 with the version in a trailing comment, matching every other action here; its `deployment-url` output is confirmed against the action's own `action.yml`.

### Unrelated thing I noticed

`pages.yml` uploads `web/` whole, so `web/README.md`, `web/package.json` and `web/tests/` are live on the production site right now — all three return 200 on `vocaphone.vocahq.com`. Harmless but untidy, and the preview inherits it by design (it mirrors production). Happy to filter the publish set in a separate PR if you want it cleaned up.
