### PR TITLE
Publish only the files a visitor should get

### DIFF
--- a/.github/actions/stage-site/action.yml
+++ b/.github/actions/stage-site/action.yml
@@ -1,0 +1,59 @@
+name: Stage the publishable site
+description: >
+  Copies web/ to a staging directory with the files that exist for developers
+  rather than visitors removed, and reports the path to upload.
+
+  Everything in web/ is published by default and this removes named exceptions,
+  rather than listing what to publish. A missed exception is a stray file on
+  the site; a missed inclusion is a 404 on a page someone is looking at, and
+  the first is the better failure to have.
+
+inputs:
+  source:
+    description: Directory holding the site as it lives in the repository.
+    required: false
+    default: web
+
+outputs:
+  path:
+    description: Directory to upload, holding only what visitors should get.
+    value: ${{ steps.stage.outputs.path }}
+
+runs:
+  using: composite
+  steps:
+    - id: stage
+      shell: bash
+      env:
+        SOURCE: ${{ inputs.source }}
+        # Kept deliberately: CNAME is how Pages knows the custom domain, and
+        # robots.txt and sitemap.xml are for crawlers rather than readers, so
+        # "nothing links to it" is not a reason to drop them.
+        #
+        # tests/ is the site's own check suite, and package.json exists to
+        # carry the two npm scripts that run it and a local server.
+        # .htmlvalidate.json configures an editor's HTML linting; nothing in
+        # this repository reads it. Pages already withheld that one, so listing
+        # it changes nothing there and covers anywhere else this is uploaded.
+        NOT_PUBLISHED: 'README.md package.json tests .htmlvalidate.json'
+      run: |
+        set -euo pipefail
+        staged="$RUNNER_TEMP/site"
+        rm -rf "$staged"
+        cp -R "$SOURCE" "$staged"
+        for entry in $NOT_PUBLISHED; do
+          # Guard the path rather than the loop: an entry that has already been
+          # renamed away should not quietly stop this from staging the rest.
+          if [ -e "$staged/$entry" ]; then
+            rm -rf "${staged:?}/$entry"
+          else
+            echo "::warning::$SOURCE/$entry is listed as not published but does not exist"
+          fi
+        done
+        echo "path=$staged" >> "$GITHUB_OUTPUT"
+        {
+          echo 'Staged for publishing:'
+          echo '```'
+          (cd "$staged" && find . -type f | sort | sed 's|^\./||')
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,11 +35,18 @@ jobs:
         working-directory: web
         run: npm run check
 
+      # web/ also holds the check suite and the package.json carrying its npm
+      # scripts. Uploading the directory as it stands published those, so
+      # README.md, package.json and tests/ were all reachable on the live site.
+      - name: Stage the publishable site
+        id: site
+        uses: ./.github/actions/stage-site
+
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: web
+          path: ${{ steps.site.outputs.path }}
 
       - id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/web/README.md
+++ b/web/README.md
@@ -25,8 +25,17 @@ this directory (see `.github/workflows/pages.yml`). Set Pages source to
 
 - Site directory: `web`
 - Check command: `npm run check`
-- Publish directory: `web`
+- Publish directory: `web`, minus the files that exist for developers rather
+  than visitors
 - Canonical URL expected by metadata: `https://vocaphone.vocahq.com/`
+
+`.github/actions/stage-site` drops `README.md`, `package.json`, `tests/` and
+`.htmlvalidate.json` before the upload; the first three used to be reachable on
+the live site. It removes named exceptions rather than listing what to publish,
+so a new asset ships by default: a stray file on the site is a better failure
+than a 404 on a page someone is reading. `CNAME`, `robots.txt` and `sitemap.xml`
+stay — Pages needs the first for the custom domain and crawlers want the others,
+so "nothing links to it" does not decide this.
 
 `/`, `/iphone/`, `/iphone/device-setup/`, and `/privacy/` must resolve as HTML
 routes.


### PR DESCRIPTION
`pages.yml` uploaded `web/` as it stands, so files that exist for developers were served to visitors. All three answered 200 on the live site:

- `https://vocaphone.vocahq.com/README.md`
- `https://vocaphone.vocahq.com/package.json`
- `https://vocaphone.vocahq.com/tests/site.test.mjs`

Untidy rather than dangerous — nothing secret is in them — but they are not part of the site.

### Exclusion, not inclusion

The staging step removes a named list and publishes everything else, rather than enumerating what to publish. A missed exception is a stray file on the site; a missed inclusion is a 404 on a page someone is reading, so new assets ship by default.

Dropped: `README.md`, `package.json`, `tests/`, `.htmlvalidate.json`. Kept: `CNAME`, `robots.txt`, `sitemap.xml` — Pages needs the first for the custom domain and the other two are for crawlers, so "nothing links to it" is the wrong test for them.

`.htmlvalidate.json` I only found by running the staging locally and listing the result; it is a dotfile, so it was invisible to a plain `ls`. Pages already withheld it (404 today), and nothing in the repository reads it, but listing it costs nothing and covers wherever else this gets uploaded.

### Why a composite action

The Cloudflare preview in #156 uploads `web/` the same way and has to stage identically to be a preview of what actually ships. A list of what-not-to-publish kept in two workflows is a list that drifts apart. **#156 should adopt this once one of them merges** — say the word and I'll wire it up.

### Verified

Ran the staging logic locally and listed the result. What would be published:

```
CNAME  favicon.ico  index.html  robots.txt  script.js
site.webmanifest  sitemap.xml  styles.css
assets/  (10 files)
iphone/index.html  iphone/device-setup/index.html  privacy/index.html
```

All four routes `web/README.md` requires — `/`, `/privacy/`, `/iphone/`, `/iphone/device-setup/` — are present, and no developer-only file is. Grepped the pages, `script.js` and `site.webmanifest` first: nothing references any of the removed files. `actionlint` clean, `npm run check` 18/18.

The removed URLs will start returning 404 after this deploys, which is the point.
