### PR TITLE
Improve iOS onboarding and model downloads

### DIFF
--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		17A121351047369782528CA2 /* DictationBarComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FD84E65614D9F94D8EF0AC /* DictationBarComponents.swift */; };
 		18E5AC9EE6C8C0190F45D14B /* TranscriptStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DBF47C7F5E5B13752056CB /* TranscriptStyler.swift */; };
 		1935C96899E2437477303714 /* TranscriptionQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E2BF42CAC209DA12464566 /* TranscriptionQuality.swift */; };
+		1A5451979B0206365EE36D5E /* KeyboardHandoffPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46E8BCA13C319737A50B7CE9 /* KeyboardHandoffPresentation.swift */; };
 		1A55285B353E4AE5D1B6D967 /* KeyboardHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858088F81E12EC57E13F9492 /* KeyboardHaptics.swift */; };
 		1B6EE0F70EFC9078A48F7EB6 /* en.txt in Resources */ = {isa = PBXBuildFile; fileRef = B67629F24A2CF6C990BA991A /* en.txt */; };
 		1B72FBEA5D41DB51B82A1305 /* SetupStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA031D86C1DE3C2F8B047308 /* SetupStatusTests.swift */; };
@@ -152,6 +153,7 @@
 		77E93C2F64DEB6AAB50C09F0 /* TranscriptSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B121356A503DF83BFA0E0D0C /* TranscriptSanitizer.swift */; };
 		78D493F3552BE347D8931376 /* DictationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3489C985467C23EB6A90AD /* DictationBarView.swift */; };
 		79D51827CA805EB6D890699C /* SherpaLongAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */; };
+		7AE5598954918484EE8BB6B9 /* KeyboardHandoffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E5F9C1D93EF4EFB2AF5EA7 /* KeyboardHandoffView.swift */; };
 		7B0D3581B262BEB5AC561C23 /* TelemetryStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D9836F52892447650F0375 /* TelemetryStats.swift */; };
 		7E26A729562A6F474635AFEC /* TranscriptStylerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45A3914F898AD0570486806 /* TranscriptStylerTests.swift */; };
 		7E28776EDC2BD3E8A8AFCED9 /* TypingPrivacyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05735C847A47FF442B4FB21A /* TypingPrivacyTests.swift */; };
@@ -174,6 +176,7 @@
 		8A90D2390C756F9101AB251A /* SpeechAudioConditioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */; };
 		8D3596587AE7568FDB37C147 /* onnxruntime.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 796D6FA2FF5B98026FAA85AD /* onnxruntime.xcframework */; };
 		8DD5E5E2B734765883552523 /* DictationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3489C985467C23EB6A90AD /* DictationBarView.swift */; };
+		8F8E3C14AAC6A4F1DF144AD3 /* OnboardingPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D34E7E54437AFA69FDC2848 /* OnboardingPresentation.swift */; };
 		90F0433AE6FE139E90D62F9A /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */; };
 		9137DE19695E0CADB0EFBFB0 /* TranscriptRetention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6FFEA14B55E6F6C61FBAC /* TranscriptRetention.swift */; };
 		91C1D5BB9A998A47DFF79A52 /* DictationBarComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FD84E65614D9F94D8EF0AC /* DictationBarComponents.swift */; };
@@ -191,6 +194,7 @@
 		9C3766171C286926385A9F1E /* SpokenNumbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E590CFC53039DA367280B8CD /* SpokenNumbers.swift */; };
 		9C6AF2EE68EB7AA4D4CF0F61 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA135DE504590121F6D8843 /* DiagnosticLog.swift */; };
 		9EE31A21EE5F9D71A15404DA /* SpellChecking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4BE75828FCA9C70DFEDC96 /* SpellChecking.swift */; };
+		9F93D09F955DA7B5CC65F058 /* OnboardingPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8348F9E480C0343CD38657B /* OnboardingPresentationTests.swift */; };
 		A018E5851AAB98E42FBBB65A /* DictationPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCCE5FE1A8242B96B8CA9FD /* DictationPresentation.swift */; };
 		A0420E3166FF08AE5059A805 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9BB34E20645F3D8C78A0363 /* Telemetry.swift */; };
 		A0B8569F3B1A3F72EAC9C1DB /* TranscriptionQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E2BF42CAC209DA12464566 /* TranscriptionQuality.swift */; };
@@ -199,6 +203,7 @@
 		A568F548D639C064CDA86F0D /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */; };
 		A59723F937FABF80B8158883 /* RecordingSoundFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0187C986535C090BEE7EFD8 /* RecordingSoundFeedback.swift */; };
 		A5E6BD7DC01FF42503792DCB /* KeyboardGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FED099938C2E7D091FFE2BD /* KeyboardGeometryTests.swift */; };
+		A7216F1D388DBC1B95658666 /* SwipeBackCoach.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BAEF22ED143D3569B005C88 /* SwipeBackCoach.swift */; };
 		A794CD8D0B445E5118500EC3 /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
 		A79BA8A795F60838D96EDFAA /* VocaPhoneLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D3E1455AD292ED6DA1DFAC /* VocaPhoneLiveActivity.swift */; };
 		A86F678EFECCEA8BA246778C /* UsageReportingViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653FBC305F7EB4B9F7EB354B /* UsageReportingViews.swift */; };
@@ -209,10 +214,12 @@
 		ACDADCAF73BF41FE2355ED15 /* VocaPhoneKeyboard.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B7028AF4B134C7EDD726891E /* VocaPhoneKeyboard.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		AD2CCDE7DC189E63810890BB /* SwipeRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C4BD2142E9377F123A8848 /* SwipeRecognizer.swift */; };
 		AE4E1B1B8CB72567DEF58A40 /* TranscriptionQualityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCAE41267FF8113463CFFF96 /* TranscriptionQualityTests.swift */; };
+		AEF583A0E9B4984F72636A0A /* KeyboardHandoffPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46E8BCA13C319737A50B7CE9 /* KeyboardHandoffPresentation.swift */; };
 		B063AE9288450BE04769F7DD /* TypingCandidates.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAA4440B24071020CD693DB /* TypingCandidates.swift */; };
 		B0DF0FF5821BD7E8C839065C /* GatewayClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4211FAA8E574AEF57D788FA /* GatewayClient.swift */; };
 		B1D4DE96B74C3327DA6A0FAD /* SwipeTrailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */; };
 		B2406DA05AE90DDB7EED6246 /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
+		B4213158A69A8307967F0845 /* KeyboardHandoffPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75D17831C48C07141D7066C /* KeyboardHandoffPresentationTests.swift */; };
 		B4542386951D03680B5F6638 /* SpeechAudioConditioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */; };
 		B463A007E4ABBFF427073748 /* SessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */; };
 		B48D69BABE8D1FB3D9DE9504 /* LocalModelCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF28F6F60B7FDEA4EB183B6F /* LocalModelCatalogTests.swift */; };
@@ -220,6 +227,7 @@
 		B61F7C13B4B93422C9BA3680 /* DarwinNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3498C523755A678225152570 /* DarwinNotifications.swift */; };
 		B799AC1ACFA93756FA43069D /* TypingStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AA0EB543777294237739CF /* TypingStripView.swift */; };
 		B803C86D8A77C8A2D758DA0A /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C9B64B52A8D28D252CC3A5 /* AudioRecorder.swift */; };
+		B81AE1A8CE67BD8B31DBB97D /* OnboardingPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D34E7E54437AFA69FDC2848 /* OnboardingPresentation.swift */; };
 		BA66A26AC92DB96524E13AF5 /* TypingWordList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6743BB4173E2F719E3D8CB /* TypingWordList.swift */; };
 		BA7DED07F63C388ADD4EC07A /* KeyboardURLLauncher.m in Sources */ = {isa = PBXBuildFile; fileRef = 88548183D3F0AD213E2268E1 /* KeyboardURLLauncher.m */; };
 		BAEC1D5BFECB17B9B28BD780 /* TypingWordListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 867A5BD6049E4D6788DB704C /* TypingWordListTests.swift */; };
@@ -347,6 +355,7 @@
 		0AB84927D76F9C32C4BE1547 /* QuickDictationAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDictationAvailability.swift; sourceTree = "<group>"; };
 		0AC0739F69438AEC347C44A4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0B31528AA0DAB644EFBBE967 /* TypingCandidatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingCandidatesTests.swift; sourceTree = "<group>"; };
+		0BAEF22ED143D3569B005C88 /* SwipeBackCoach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeBackCoach.swift; sourceTree = "<group>"; };
 		0DFD83D2BCB84400E7981A4B /* SwipeTrailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeTrailTests.swift; sourceTree = "<group>"; };
 		11816AC1A2219D15E870CE3E /* EmojiCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCatalog.swift; sourceTree = "<group>"; };
 		136E505E4C5668F9ACCD30C5 /* EmojiSuggestions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiSuggestions.swift; sourceTree = "<group>"; };
@@ -359,6 +368,7 @@
 		2678D836274997421A54E901 /* AudioCaptureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCaptureTests.swift; sourceTree = "<group>"; };
 		27748467103CFAD3F6A2F603 /* TelemetryRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryRecord.swift; sourceTree = "<group>"; };
 		28ECEDA044D2B1021710F205 /* TranscriptHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptHistoryView.swift; sourceTree = "<group>"; };
+		2D34E7E54437AFA69FDC2848 /* OnboardingPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPresentation.swift; sourceTree = "<group>"; };
 		2E6C1FB17BFD787FDDCBBF82 /* SherpaOnnxBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SherpaOnnxBridge.h; sourceTree = "<group>"; };
 		32BFD71F9D14772A0C7330CD /* DictationBarLabelColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarLabelColorTests.swift; sourceTree = "<group>"; };
 		332854D2644CFCE5843E3F31 /* StopQuickDictationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopQuickDictationIntent.swift; sourceTree = "<group>"; };
@@ -378,6 +388,7 @@
 		406B0C287866B36EF3109238 /* LocalModelPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelPicker.swift; sourceTree = "<group>"; };
 		41C0A3D1DBF6BCF25C37CF24 /* EmojiSuggestionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiSuggestionsTests.swift; sourceTree = "<group>"; };
 		4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnedWords.swift; sourceTree = "<group>"; };
+		46E8BCA13C319737A50B7CE9 /* KeyboardHandoffPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHandoffPresentation.swift; sourceTree = "<group>"; };
 		473A608BF3F8827B3D3842B0 /* LocalModelCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelCatalog.swift; sourceTree = "<group>"; };
 		4871EA8AAF829D7979EC9587 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		48D9836F52892447650F0375 /* TelemetryStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryStats.swift; sourceTree = "<group>"; };
@@ -439,6 +450,7 @@
 		A45A3914F898AD0570486806 /* TranscriptStylerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptStylerTests.swift; sourceTree = "<group>"; };
 		A51A47686C093AFE92B89758 /* VocaPhoneKeyboard.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VocaPhoneKeyboard.entitlements; sourceTree = "<group>"; };
 		A59DB522E7DFDE3B3E009AFD /* SpeechAudioConditioningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechAudioConditioningTests.swift; sourceTree = "<group>"; };
+		A5E5F9C1D93EF4EFB2AF5EA7 /* KeyboardHandoffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHandoffView.swift; sourceTree = "<group>"; };
 		A8E2BF42CAC209DA12464566 /* TranscriptionQuality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionQuality.swift; sourceTree = "<group>"; };
 		A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardStatus.swift; sourceTree = "<group>"; };
 		A9711C18238B39EA2E842C0F /* BrandPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandPalette.swift; sourceTree = "<group>"; };
@@ -452,6 +464,7 @@
 		B6B395C37266816A19C38B59 /* SemanticPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticPaletteTests.swift; sourceTree = "<group>"; };
 		B7028AF4B134C7EDD726891E /* VocaPhoneKeyboard.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = VocaPhoneKeyboard.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		B71760E0F5AF9B1965E960E1 /* DesignSystemPreviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemPreviews.swift; sourceTree = "<group>"; };
+		B75D17831C48C07141D7066C /* KeyboardHandoffPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHandoffPresentationTests.swift; sourceTree = "<group>"; };
 		B854354D06D0111DEB123E7A /* SessionRecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRecordTests.swift; sourceTree = "<group>"; };
 		B87128326897BFA30E7B2038 /* KeyLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyLayout.swift; sourceTree = "<group>"; };
 		B8D81AEA9FD59906139F273D /* TelemetryFailureMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryFailureMapping.swift; sourceTree = "<group>"; };
@@ -495,6 +508,7 @@
 		F0DBF47C7F5E5B13752056CB /* TranscriptStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptStyler.swift; sourceTree = "<group>"; };
 		F2228242333B1BBC848C90DA /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		F72772F0CCE3BA274182C5F4 /* HomePresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePresentationTests.swift; sourceTree = "<group>"; };
+		F8348F9E480C0343CD38657B /* OnboardingPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPresentationTests.swift; sourceTree = "<group>"; };
 		FA83B914C241E5F8BF8F32AC /* DictationBarLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarLayoutTests.swift; sourceTree = "<group>"; };
 		FC2CD13AAF5FDF79DD5D0075 /* TypingFieldPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingFieldPolicy.swift; sourceTree = "<group>"; };
 		FCAE41267FF8113463CFFF96 /* TranscriptionQualityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionQualityTests.swift; sourceTree = "<group>"; };
@@ -731,11 +745,13 @@
 				7A53786C8D2346452C69A748 /* InsertionTargetTests.swift */,
 				EF0326EF6FB3E96C942C6065 /* KeyAlternativesTests.swift */,
 				7FED099938C2E7D091FFE2BD /* KeyboardGeometryTests.swift */,
+				B75D17831C48C07141D7066C /* KeyboardHandoffPresentationTests.swift */,
 				97639A09609D9E6E76153CDB /* KeyboardHapticsTests.swift */,
 				3EC2C1575D306E7683092FBA /* KeyGridLayoutTests.swift */,
 				C45D98EAFE18C689DC7551E9 /* LanguageMenuTests.swift */,
 				FF28F6F60B7FDEA4EB183B6F /* LocalModelCatalogTests.swift */,
 				EE41EF03C8A4F930315EFE77 /* ModelLanguageSupportTests.swift */,
+				F8348F9E480C0343CD38657B /* OnboardingPresentationTests.swift */,
 				7E9E5CE913B4FA5EF8EECD4E /* PairingPayloadTests.swift */,
 				7B5877B4AB653982A0433A37 /* ReliabilityFeatureTests.swift */,
 				B6B395C37266816A19C38B59 /* SemanticPaletteTests.swift */,
@@ -790,13 +806,17 @@
 				491DFC2F5F017E14BF64E308 /* DesignSystem.swift */,
 				17B4671FC8BBA4DD4FD5AA8C /* GatewaySetupView.swift */,
 				02C96151B8C8ECE035FF0D8F /* HomePresentation.swift */,
+				46E8BCA13C319737A50B7CE9 /* KeyboardHandoffPresentation.swift */,
+				A5E5F9C1D93EF4EFB2AF5EA7 /* KeyboardHandoffView.swift */,
 				D97C6225AC98D4FE053BDB13 /* KeyboardPreview.swift */,
 				406B0C287866B36EF3109238 /* LocalModelPicker.swift */,
+				2D34E7E54437AFA69FDC2848 /* OnboardingPresentation.swift */,
 				70B3F1DBA8332A13B095E4BA /* PairingScannerView.swift */,
 				87F5D76EB1E944F3A323006D /* SettingsView.swift */,
 				342F2B3B437269514C969C77 /* SetupStatus.swift */,
 				346B6558EE5557A35C916067 /* SetupView.swift */,
 				55A7126FEDA473D8C112A397 /* StartDictationIntent.swift */,
+				0BAEF22ED143D3569B005C88 /* SwipeBackCoach.swift */,
 				5A89F2BEC08F07614372D84D /* TranscriptHistoryModel.swift */,
 				28ECEDA044D2B1021710F205 /* TranscriptHistoryView.swift */,
 				5995603DDA33014FFA52B079 /* TranscriptionSourceStatus.swift */,
@@ -1079,6 +1099,8 @@
 				F37F68399E06B767B5D6ACC7 /* KeyGridView.swift in Sources */,
 				5C558BDC79705E089820562F /* KeyLayout.swift in Sources */,
 				400FC934DB32BD708B5D23A9 /* KeyView.swift in Sources */,
+				1A5451979B0206365EE36D5E /* KeyboardHandoffPresentation.swift in Sources */,
+				7AE5598954918484EE8BB6B9 /* KeyboardHandoffView.swift in Sources */,
 				98AE213452E133E22550785B /* KeyboardHaptics.swift in Sources */,
 				A568F548D639C064CDA86F0D /* KeyboardPreferences.swift in Sources */,
 				F7432B1674EF3B6924FB89B1 /* KeyboardPreview.swift in Sources */,
@@ -1093,6 +1115,7 @@
 				4FB8BA8E9E7B9332FDBCD80C /* LocalModelPicker.swift in Sources */,
 				8484AF469C29CC148B720447 /* LocalTranscriptionPreferences.swift in Sources */,
 				4FDB3D32A404C674AFAB948F /* ModelLanguageSupport.swift in Sources */,
+				B81AE1A8CE67BD8B31DBB97D /* OnboardingPresentation.swift in Sources */,
 				52D566C02915D934240601EA /* PairingPayload.swift in Sources */,
 				84EB79403F7CED013A82334F /* PairingScannerView.swift in Sources */,
 				D9D9DB4E8F749BCC02AD0B5B /* PreviewFixtures.swift in Sources */,
@@ -1114,6 +1137,7 @@
 				9C3766171C286926385A9F1E /* SpokenNumbers.swift in Sources */,
 				E9C82042A1155CC1E50BF2B6 /* StartDictationIntent.swift in Sources */,
 				108C096B9C0FB4861FC26437 /* StopQuickDictationIntent.swift in Sources */,
+				A7216F1D388DBC1B95658666 /* SwipeBackCoach.swift in Sources */,
 				AD2CCDE7DC189E63810890BB /* SwipeRecognizer.swift in Sources */,
 				81131D34DE3F3CBDBA61BE4E /* SwipeTrailView.swift in Sources */,
 				A0420E3166FF08AE5059A805 /* Telemetry.swift in Sources */,
@@ -1219,6 +1243,8 @@
 				966E2D9A6D13630E7A2122A6 /* KeyLayout.swift in Sources */,
 				BC36D829FEE2BEC0A6BC30C2 /* KeyView.swift in Sources */,
 				A5E6BD7DC01FF42503792DCB /* KeyboardGeometryTests.swift in Sources */,
+				AEF583A0E9B4984F72636A0A /* KeyboardHandoffPresentation.swift in Sources */,
+				B4213158A69A8307967F0845 /* KeyboardHandoffPresentationTests.swift in Sources */,
 				CFF7A7DC99B4880EB955D603 /* KeyboardHaptics.swift in Sources */,
 				4BF2126048D9E40C8999241D /* KeyboardHapticsTests.swift in Sources */,
 				90F0433AE6FE139E90D62F9A /* KeyboardPreferences.swift in Sources */,
@@ -1231,6 +1257,8 @@
 				482A8494DA8A03BDB5DF1B0E /* LocalTranscriptionPreferences.swift in Sources */,
 				0B939DE9494D3B8F14F18142 /* ModelLanguageSupport.swift in Sources */,
 				F426CFBED733974D61FDB432 /* ModelLanguageSupportTests.swift in Sources */,
+				8F8E3C14AAC6A4F1DF144AD3 /* OnboardingPresentation.swift in Sources */,
+				9F93D09F955DA7B5CC65F058 /* OnboardingPresentationTests.swift in Sources */,
 				2E93E016656B5EA74568DD4F /* PairingPayload.swift in Sources */,
 				DCF552B58B7A7A12C517C17B /* PairingPayloadTests.swift in Sources */,
 				BCB8CA3BAACE6280D9ED4B22 /* QuickDictationAvailability.swift in Sources */,

--- a/ios/VocaPhoneApp/App/ContentView.swift
+++ b/ios/VocaPhoneApp/App/ContentView.swift
@@ -15,13 +15,17 @@ struct ContentView: View {
         KeyboardPreferences.setupCompletedKey,
         store: KeyboardPreferences.defaults
     ) private var setupCompleted = false
-    /// Deliberately not derived from `setupCompleted`: the cover opens once per
-    /// install, and leaving setup must not reopen it.
+    /// Presentation state only. `SetupView` stores the durable required page
+    /// that survives a Settings trip or process restart.
     @State private var isShowingSetup = false
     @AppStorage(
         KeyboardPreferences.firstDictationKey,
         store: KeyboardPreferences.defaults
     ) private var hasDictatedOnce = false
+    @AppStorage(
+        KeyboardPreferences.keyboardPracticeKey,
+        store: KeyboardPreferences.defaults
+    ) private var hasCompletedKeyboardPractice = false
     @State private var testText = ""
     @State private var isShowingSourceDetail = false
     @FocusState private var diagFocused: Bool
@@ -57,7 +61,12 @@ struct ContentView: View {
                 }
             }
             .task {
-                if !setupCompleted { isShowingSetup = true }
+                if OnboardingPresentation.requiresFirstRunCover(
+                    setupCompleted: setupCompleted,
+                    hasCompletedKeyboardPractice: hasCompletedKeyboardPractice
+                ) {
+                    isShowingSetup = true
+                }
                 coordinator.refreshSetupStatus()
                 await coordinator.recoverRecentSession()
                 coordinator.prepareQuickDictationIfEnabled()
@@ -70,21 +79,19 @@ struct ContentView: View {
             }
             .fullScreenCover(isPresented: $isShowingSetup) {
                 NavigationStack {
-                    SetupView()
+                    SetupView(mode: .onboarding)
                 }
             }
         }
         .overlay {
-            if showsKeyboardReturnGuide {
-                KeyboardReturnGuide(
-                    startedAt: coordinator.activeRecord?.createdAt ?? Date(),
-                    finish: coordinator.requestFinish,
-                    cancel: coordinator.cancel
-                )
+            if let record = keyboardHandoffRecord,
+               let presentation = KeyboardHandoffPresentation.make(record)
+            {
+                KeyboardHandoffView(record: record, presentation: presentation)
                 .transition(.opacity)
             }
         }
-        .animation(.easeInOut(duration: 0.2), value: showsKeyboardReturnGuide)
+        .animation(.easeInOut(duration: 0.2), value: keyboardHandoffRecord?.state)
     }
 
     // MARK: - Attention
@@ -395,13 +402,11 @@ struct ContentView: View {
         }
     }
 
-    private var showsKeyboardReturnGuide: Bool {
-        if coordinator.isKeyboardRecording { return true }
-#if DEBUG
-        return ProcessInfo.processInfo.arguments.contains("-previewKeyboardReturnGuide")
-#else
-        return false
-#endif
+    private var keyboardHandoffRecord: SessionRecord? {
+        guard let record = coordinator.activeRecord,
+              KeyboardHandoffPresentation.shouldPresent(record)
+        else { return nil }
+        return record
     }
 }
 
@@ -468,91 +473,6 @@ struct RecordingMeter: View {
         let level = CGFloat(coordinator.meterLevel)
         let position = CGFloat(index) / CGFloat(Self.barCount - 1)
         return Color.vocaRecording.opacity(level * (0.45 + 0.55 * sin(position * .pi)) > 0.06 ? 1 : 0.22)
-    }
-}
-
-private struct RecordingPulse: View {
-    @Environment(RecordingCoordinator.self) private var coordinator
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
-    private var level: CGFloat {
-        coordinator.isKeyboardRecording ? CGFloat(coordinator.meterLevel) : 0.42
-    }
-
-    var body: some View {
-        ZStack {
-            Circle()
-                .fill(Color.vocaRecording.opacity(0.12))
-                .frame(width: 108, height: 108)
-            Circle()
-                .fill(Color.vocaRecording)
-                .frame(width: 58 + responsiveLevel * 18, height: 58 + responsiveLevel * 18)
-                .animation(.linear(duration: 0.12), value: responsiveLevel)
-            Image(systemName: "mic.fill")
-                .font(.system(size: 30, weight: .semibold))
-                .foregroundStyle(.white)
-        }
-        .accessibilityHidden(true)
-    }
-
-    /// Reduce Motion stops the size following the microphone; the state stays
-    /// perfectly visible without it, which is the test the setting asks for.
-    private var responsiveLevel: CGFloat { reduceMotion ? 0.42 : level }
-}
-
-/// Shown while the keyboard is recording, to say the one thing that is not
-/// obvious: go back to where you were typing.
-///
-/// It used to draw a fake home bar with an arrow animating across it forever.
-/// The drawing was a picture of a gesture rather than the gesture, the loop ran
-/// for the whole recording, and between them they made a routine hand-off feel
-/// like an alert. What is left is the live state — a pulse that follows the
-/// input level, and a timer — plus one sentence of instruction.
-private struct KeyboardReturnGuide: View {
-    let startedAt: Date
-    let finish: () -> Void
-    let cancel: () -> Void
-
-    var body: some View {
-        ZStack {
-            Color.vocaCanvas
-                .ignoresSafeArea()
-
-            VStack(spacing: VocaMetrics.grouping + 4) {
-                Spacer()
-
-                RecordingPulse()
-
-                VStack(spacing: VocaMetrics.related) {
-                    Text("vocaphone is listening")
-                        .font(.title2.weight(.semibold))
-                    Text(startedAt, style: .timer)
-                        .font(.title3.monospacedDigit())
-                        .foregroundStyle(.secondary)
-                }
-
-                VStack(spacing: VocaMetrics.related - 2) {
-                    Text("Swipe right across the bottom edge to go back")
-                        .font(.headline)
-                    Text(
-                        "Recording continues in the background. When the keyboard "
-                            + "reappears, tap Finish — or use Finish in the Dynamic Island."
-                    )
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                }
-                .multilineTextAlignment(.center)
-
-                Spacer()
-
-                VStack(spacing: VocaMetrics.related) {
-                    VocaPrimaryButton(title: "Finish recording here instead", action: finish)
-                    Button("Cancel recording", role: .destructive, action: cancel)
-                        .font(.subheadline)
-                }
-            }
-            .padding(VocaMetrics.grouping + 4)
-        }
     }
 }
 

--- a/ios/VocaPhoneApp/App/KeyboardHandoffPresentation.swift
+++ b/ios/VocaPhoneApp/App/KeyboardHandoffPresentation.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// A full-screen explanation for an externally started dictation. It follows
+/// the persisted session, rather than only live recording, so finishing in
+/// vocaphone stays a continuous story through transcription and insertion.
+struct KeyboardHandoffPresentation: Equatable {
+    enum Kind: Equatable {
+        case recording
+        case processing
+        case ready
+        case recoverableFailure
+    }
+
+    enum PrimaryAction: Equatable {
+        case finish
+        case retry
+        case none
+    }
+
+    let kind: Kind
+    let title: String
+    let detail: String
+    let primaryAction: PrimaryAction
+    let primaryTitle: String?
+    let showsCancel: Bool
+
+    /// The handoff applies only to work that began in another app. A session
+    /// hosted by vocaphone's practice field has no app to return to.
+    static func shouldPresent(_ record: SessionRecord?) -> Bool {
+        guard let record,
+              record.sourceDocumentID != "in-app-test",
+              record.startedInContainingApp != true
+        else { return false }
+
+        return switch record.state {
+        case .recording, .finalizing, .uploading, .transcribing, .readyToInsert,
+             .targetContextChanged, .serverUnavailable, .uploadFailedRecoverable,
+             .transcriptionFailedRecoverable:
+            true
+        default:
+            false
+        }
+    }
+
+    static func make(_ record: SessionRecord) -> KeyboardHandoffPresentation? {
+        guard shouldPresent(record) else { return nil }
+
+        switch record.state {
+        case .recording:
+            return KeyboardHandoffPresentation(
+                kind: .recording,
+                title: "Recording",
+                detail: "Swipe back to the app where you were typing. Recording keeps going as you switch.",
+                primaryAction: .finish,
+                primaryTitle: "Finish & transcribe here",
+                showsCancel: true
+            )
+        case .finalizing:
+            return processing(title: "Finishing recording")
+        case .uploading:
+            switch record.processingLocation {
+            case .gateway:
+                return processing(title: "Sending to your gateway")
+            case .onDevice:
+                return processing(title: "Preparing on this iPhone")
+            case nil:
+                return processing(title: "Preparing transcript")
+            }
+        case .transcribing:
+            switch record.processingLocation {
+            case .gateway:
+                return processing(title: "Transcribing on your gateway")
+            case .onDevice:
+                return processing(title: "Transcribing on this iPhone")
+            case nil:
+                return processing(title: "Transcribing")
+            }
+        case .readyToInsert:
+            return KeyboardHandoffPresentation(
+                kind: .ready,
+                title: "Your text is ready",
+                detail: "Return to the keyboard and tap Insert.",
+                primaryAction: .none,
+                primaryTitle: nil,
+                showsCancel: true
+            )
+        case .targetContextChanged:
+            return KeyboardHandoffPresentation(
+                kind: .ready,
+                title: "Your text is ready",
+                detail: "Return to the keyboard. Go back to the original field you dictated for, or choose Insert in this field.",
+                primaryAction: .none,
+                primaryTitle: nil,
+                showsCancel: true
+            )
+        case .serverUnavailable, .uploadFailedRecoverable, .transcriptionFailedRecoverable:
+            return KeyboardHandoffPresentation(
+                kind: .recoverableFailure,
+                title: record.state == .serverUnavailable
+                    ? "Gateway unavailable"
+                    : "Transcription paused",
+                detail: record.error?.message ?? "Your recording is preserved. Return when you are ready to retry.",
+                primaryAction: record.canRetry ? .retry : .none,
+                primaryTitle: record.canRetry ? "Retry transcript" : nil,
+                showsCancel: true
+            )
+        default:
+            return nil
+        }
+    }
+
+    private static func processing(title: String) -> KeyboardHandoffPresentation {
+        KeyboardHandoffPresentation(
+            kind: .processing,
+            title: title,
+            detail: "You can return to the app where you were typing. The keyboard will update there.",
+            primaryAction: .none,
+            primaryTitle: nil,
+            showsCancel: true
+        )
+    }
+}

--- a/ios/VocaPhoneApp/App/KeyboardHandoffView.swift
+++ b/ios/VocaPhoneApp/App/KeyboardHandoffView.swift
@@ -1,0 +1,325 @@
+import SwiftUI
+
+/// The containing-app surface for a dictation started in another app. The
+/// keyboard cannot return the user to that app, so this view teaches the real
+/// system gesture once and then stays useful when the user finishes recording
+/// here instead.
+struct KeyboardHandoffView: View {
+    @Environment(RecordingCoordinator.self) private var coordinator
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    let record: SessionRecord
+    let presentation: KeyboardHandoffPresentation
+
+    var body: some View {
+        ZStack {
+            Color.vocaCanvas
+                .ignoresSafeArea()
+
+            if presentation.kind == .recording {
+                recordingHandoff
+            } else {
+                statusHandoff
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private var recordingHandoff: some View {
+        ScrollView {
+            VStack(spacing: VocaMetrics.section) {
+                header
+
+                VStack(spacing: VocaMetrics.related) {
+                    Text("Keep speaking")
+                        .font(.largeTitle.weight(.bold))
+                    Text("Swipe right across the bottom edge to return")
+                        .font(.title2.weight(.semibold))
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text("Recording continues while you switch apps.")
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity)
+
+                SwipeBackCoach(reduceMotion: reduceMotion, prominent: true)
+
+                VStack(spacing: VocaMetrics.related) {
+                    Button {
+                        perform(.finish)
+                    } label: {
+                        Label("Can't swipe back? Finish here instead", systemImage: "stop.fill")
+                            .font(.subheadline.weight(.semibold))
+                            .frame(minHeight: VocaMetrics.minimumTarget)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .accessibilityHint(primaryHint)
+
+                    Button("Cancel dictation", role: .destructive) {
+                        coordinator.cancel()
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .frame(minHeight: VocaMetrics.minimumTarget)
+                }
+            }
+            .frame(maxWidth: 560)
+            .padding(.horizontal, VocaMetrics.grouping)
+            .padding(.vertical, VocaMetrics.section)
+            .frame(maxWidth: .infinity, minHeight: 720)
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            realBottomEdgeCue
+        }
+    }
+
+    private var realBottomEdgeCue: some View {
+        VStack(spacing: 8) {
+            Label("Swipe at the real iPhone bottom edge", systemImage: "arrow.down")
+                .font(.headline)
+
+            HStack(spacing: VocaMetrics.related) {
+                Text("Then swipe right")
+                Rectangle()
+                    .fill(Color.brand)
+                    .frame(height: 3)
+                Image(systemName: "arrow.right")
+                    .font(.headline.weight(.bold))
+            }
+            .font(.subheadline.weight(.bold))
+        }
+        .foregroundStyle(Color.brand)
+        .padding(.horizontal, VocaMetrics.grouping)
+        .padding(.vertical, VocaMetrics.padding)
+        .background(Color.vocaSurface)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(Color.vocaBorder)
+                .frame(height: 1)
+        }
+        .allowsHitTesting(false)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("At the real bottom edge of this iPhone, swipe right.")
+    }
+
+    private var statusHandoff: some View {
+        ScrollView {
+            VStack(spacing: VocaMetrics.grouping) {
+                header
+                visual
+                instruction
+                actions
+            }
+            .frame(maxWidth: 520)
+            .padding(.horizontal, VocaMetrics.grouping)
+            .padding(.vertical, VocaMetrics.section)
+            .frame(maxWidth: .infinity, minHeight: 620)
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: VocaMetrics.related) {
+            Label(presentation.title, systemImage: symbolName)
+                .font(.headline)
+                .foregroundStyle(statusColor)
+            Spacer()
+            if presentation.kind == .recording {
+                Text(record.createdAt, style: .timer)
+                    .font(.headline.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel("Elapsed recording time")
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+
+    @ViewBuilder private var visual: some View {
+        switch presentation.kind {
+        case .recording:
+            VStack(spacing: VocaMetrics.padding) {
+                HandoffRecordingMark(level: coordinator.meterLevel, reduceMotion: reduceMotion)
+                RecordingMeter()
+                    .frame(maxWidth: 220)
+            }
+            .padding(.vertical, VocaMetrics.related)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Recording")
+            .accessibilityValue("Voice level \(Int(coordinator.meterLevel * 100)) percent")
+        case .processing:
+            ProgressView()
+                .controlSize(.large)
+                .tint(Color.vocaWarning)
+                .frame(height: 112)
+                .accessibilityLabel("Working")
+        case .ready:
+            Image(systemName: "text.badge.checkmark")
+                .font(.system(size: 56, weight: .semibold))
+                .foregroundStyle(Color.brand)
+                .frame(height: 112)
+                .accessibilityHidden(true)
+        case .recoverableFailure:
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 56, weight: .semibold))
+                .foregroundStyle(Color.vocaError)
+                .frame(height: 112)
+                .accessibilityHidden(true)
+        }
+    }
+
+    private var instruction: some View {
+        VocaCard(padding: VocaMetrics.padding) {
+            VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                Text(presentation.detail)
+                    .font(.title3.weight(.semibold))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if presentation.kind == .ready,
+                          let transcript = record.transcript?.trimmingCharacters(in: .whitespacesAndNewlines),
+                          !transcript.isEmpty
+                {
+                    Text(transcript)
+                        .font(.body)
+                        .lineLimit(3)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(VocaMetrics.related)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            Color.vocaRecessedSurface,
+                            in: RoundedRectangle(cornerRadius: VocaMetrics.fieldRadius, style: .continuous)
+                        )
+                        .accessibilityLabel("Transcript preview")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var actions: some View {
+        VStack(spacing: VocaMetrics.related) {
+            if let title = presentation.primaryTitle {
+                VocaPrimaryButton(title: title, symbol: primarySymbol) {
+                    perform(presentation.primaryAction)
+                }
+                .accessibilityHint(primaryHint)
+            }
+
+            if presentation.showsCancel {
+                Button("Cancel dictation", role: .destructive) {
+                    coordinator.cancel()
+                }
+                .font(.subheadline.weight(.semibold))
+                .frame(minHeight: VocaMetrics.minimumTarget)
+                .accessibilityHint("Discards this dictation.")
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var statusColor: Color {
+        switch presentation.kind {
+        case .recording: .vocaRecording
+        case .processing: .vocaWarning
+        case .ready: .brand
+        case .recoverableFailure: .vocaError
+        }
+    }
+
+    private var symbolName: String {
+        switch presentation.kind {
+        case .recording: "record.circle"
+        case .processing: "waveform"
+        case .ready: "checkmark.circle.fill"
+        case .recoverableFailure: "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var primarySymbol: String? {
+        switch presentation.primaryAction {
+        case .finish: "stop.fill"
+        case .retry: "arrow.clockwise"
+        case .none: nil
+        }
+    }
+
+    private var primaryHint: String {
+        switch presentation.primaryAction {
+        case .finish:
+            "Stops recording and starts speech to text. Return to the keyboard to insert the result."
+        case .retry:
+            "Sends the preserved recording again."
+        case .none:
+            ""
+        }
+    }
+
+    private func perform(_ action: KeyboardHandoffPresentation.PrimaryAction) {
+        switch action {
+        case .finish:
+            coordinator.requestFinish()
+        case .retry:
+            coordinator.retryPreservedRecording()
+        case .none:
+            break
+        }
+    }
+
+}
+
+private struct HandoffRecordingMark: View {
+    let level: Float
+    let reduceMotion: Bool
+
+    private var size: CGFloat {
+        reduceMotion ? 64 : 64 + CGFloat(level) * 18
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(Color.vocaRecording.opacity(0.12))
+                .frame(width: 116, height: 116)
+            Circle()
+                .fill(Color.vocaRecording)
+                .frame(width: size, height: size)
+                .animation(reduceMotion ? nil : .linear(duration: 0.12), value: level)
+            Image(systemName: "mic.fill")
+                .font(.system(size: 30, weight: .semibold))
+                .foregroundStyle(.white)
+        }
+    }
+}
+
+#if DEBUG
+
+#Preview("Handoff — recording") {
+    PreviewHost(
+        coordinator: .preview(
+            .recording,
+            startedInApp: false,
+            meterLevel: 0.46,
+            isRecording: true
+        )
+    ) {
+        let record = PreviewFixtures.record(state: .recording, startedInApp: false)
+        KeyboardHandoffView(
+            record: record,
+            presentation: KeyboardHandoffPresentation.make(record)!
+        )
+    }
+}
+
+#Preview("Handoff — ready") {
+    PreviewHost {
+        let record = PreviewFixtures.record(
+            state: .readyToInsert,
+            transcript: PreviewFixtures.shortTranscript,
+            startedInApp: false
+        )
+        KeyboardHandoffView(
+            record: record,
+            presentation: KeyboardHandoffPresentation.make(record)!
+        )
+    }
+}
+#endif

--- a/ios/VocaPhoneApp/App/LocalModelPicker.swift
+++ b/ios/VocaPhoneApp/App/LocalModelPicker.swift
@@ -19,7 +19,6 @@ struct LocalModelPicker: View {
     var previewSelectedModelID: String?
 #endif
 
-    @State private var downloadTask: Task<Void, Never>?
     @State private var modelLoadTask: Task<Void, Never>?
     @State private var modelLoadError: String?
     @State private var availableModelsExpanded = false
@@ -157,8 +156,7 @@ struct LocalModelPicker: View {
                     }
                     ProgressView(value: manager.progress)
                     Button("Cancel") {
-                        downloadTask?.cancel()
-                        downloadTask = nil
+                        manager.cancelDownload()
                     }
                     .buttonStyle(.bordered)
                 }
@@ -258,17 +256,8 @@ struct LocalModelPicker: View {
     }
 
     private func download(_ model: LocalModelDescriptor) {
-        downloadTask?.cancel()
-        downloadTask = Task { @MainActor in
-            do {
-                try await manager.download(model)
-            } catch is CancellationError {
-                // The picker shows cancellation as a normal action.
-            } catch {
-                // LocalModelManager publishes the actionable error.
-            }
+        manager.startDownload(model) {
             onChange()
-            downloadTask = nil
         }
     }
 

--- a/ios/VocaPhoneApp/App/OnboardingPresentation.swift
+++ b/ios/VocaPhoneApp/App/OnboardingPresentation.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+/// The focused moments in first-run setup. These are deliberately separate from
+/// `SetupStep`: Welcome and the handoff explanation teach the product but do not
+/// pretend to be operational requirements.
+enum OnboardingStage: String, CaseIterable, Identifiable, Sendable {
+    case welcome
+    case handoff
+    case source
+    case microphone
+    case keyboard
+    case keyboardSwitch
+    case practice
+    case complete
+
+    var id: String { rawValue }
+
+    var showsProofProgress: Bool {
+        switch self {
+        case .welcome, .handoff, .complete: false
+        default: true
+        }
+    }
+
+    var requiredStepNumber: Int? {
+        switch self {
+        case .source: 1
+        case .microphone: 2
+        case .keyboard: 3
+        case .keyboardSwitch: 4
+        case .practice: 5
+        case .welcome, .handoff, .complete: nil
+        }
+    }
+
+    static let requiredStepCount = 5
+}
+
+/// Pure onboarding decisions. Keeping these outside SwiftUI makes it impossible
+/// for one view branch to call setup complete while another still names a missing
+/// permission as required.
+enum OnboardingPresentation {
+    /// The first useful place to resume after the educational pages have been
+    /// seen. A successful transcript is not sufficient for `.complete`: the
+    /// stronger keyboard-practice proof says the keyboard inserted it too.
+    static func resumeStage(
+        status: SetupStatus,
+        hasCompletedKeyboardPractice: Bool
+    ) -> OnboardingStage {
+        if !status.isSatisfied(.source) { return .source }
+        if !status.isSatisfied(.microphone) { return .microphone }
+        if !status.isSatisfied(.keyboard) { return .keyboard }
+        if !hasCompletedKeyboardPractice { return .practice }
+        return .complete
+    }
+
+    static func initialStage(
+        setupCompleted: Bool,
+        persistedStage: OnboardingStage?,
+        status: SetupStatus,
+        hasCompletedKeyboardPractice: Bool
+    ) -> OnboardingStage {
+        if setupCompleted {
+            // Older builds set this flag when setup was merely dismissed. Use
+            // the absence of keyboard-practice proof to identify that state
+            // and migrate it to the first real missing requirement.
+            return hasCompletedKeyboardPractice
+                ? .complete
+                : resumeStage(
+                    status: status,
+                    hasCompletedKeyboardPractice: false
+                )
+        }
+
+        // The two teaching pages have no system proof to reconstruct, so keep
+        // their exact position. From the first operational page onward, live
+        // state is stronger than a stale saved page: Settings may have finished
+        // one or more requirements while vocaphone was suspended.
+        switch persistedStage ?? .welcome {
+        case .welcome: return .welcome
+        case .handoff: return .handoff
+        case .source, .microphone, .keyboard, .practice, .complete:
+            return resumeStage(
+                status: status,
+                hasCompletedKeyboardPractice: hasCompletedKeyboardPractice
+            )
+        case .keyboardSwitch:
+            if !status.isSatisfied(.source) || !status.isSatisfied(.microphone) {
+                return resumeStage(
+                    status: status,
+                    hasCompletedKeyboardPractice: hasCompletedKeyboardPractice
+                )
+            }
+            return status.isSatisfied(.keyboard) ? .practice : .keyboardSwitch
+        }
+    }
+
+    /// Existing builds used `setupCompleted` as “the intro was dismissed.” A
+    /// user who chose that escape hatch without proving keyboard insertion must
+    /// re-enter the now-mandatory flow once; completed users stay undisturbed.
+    static func requiresFirstRunCover(
+        setupCompleted: Bool,
+        hasCompletedKeyboardPractice: Bool
+    ) -> Bool {
+        !setupCompleted || !hasCompletedKeyboardPractice
+    }
+
+    /// Four proof-oriented units, preserving the original progress contract
+    /// while making the final unit the actual keyboard exercise.
+    static func completedProofCount(
+        status: SetupStatus,
+        hasCompletedKeyboardPractice: Bool
+    ) -> Int {
+        [
+            status.isSatisfied(.source),
+            status.isSatisfied(.microphone),
+            status.isSatisfied(.keyboard),
+            hasCompletedKeyboardPractice,
+        ].filter { $0 }.count
+    }
+
+    static func progress(
+        status: SetupStatus,
+        hasCompletedKeyboardPractice: Bool
+    ) -> Double {
+        Double(completedProofCount(
+            status: status,
+            hasCompletedKeyboardPractice: hasCompletedKeyboardPractice
+        )) / Double(SetupStep.allCases.count)
+    }
+
+    /// The containing app cannot query the Full Access switch. It may advance
+    /// only after an already-ready keyboard proves access, or after the user
+    /// returns from the Settings trip and explicitly confirms the switch is on.
+    /// The keyboard-switch page then performs the real extension-side proof.
+    static func canAdvanceFromKeyboardEnablement(
+        status: SetupStatus,
+        returnedFromSettings: Bool
+    ) -> Bool {
+        status.isSatisfied(.keyboard) || returnedFromSettings
+    }
+
+    static func previousStage(before stage: OnboardingStage) -> OnboardingStage? {
+        switch stage {
+        case .welcome: nil
+        case .handoff: .welcome
+        case .source: .handoff
+        case .microphone: .source
+        case .keyboard: .microphone
+        case .keyboardSwitch: .keyboard
+        case .practice: .keyboardSwitch
+        case .complete: .practice
+        }
+    }
+
+    static func nextStage(after stage: OnboardingStage) -> OnboardingStage? {
+        switch stage {
+        case .welcome: .handoff
+        case .handoff: .source
+        case .source: .microphone
+        case .microphone: .keyboard
+        case .keyboard: .keyboardSwitch
+        case .keyboardSwitch: .practice
+        case .practice: .complete
+        case .complete: nil
+        }
+    }
+}

--- a/ios/VocaPhoneApp/App/Previews/PreviewFixtures.swift
+++ b/ios/VocaPhoneApp/App/Previews/PreviewFixtures.swift
@@ -309,7 +309,10 @@ enum PreviewFixtures {
     static func registerAppGroupDefaults(hasDictatedOnce: Bool = true) {
         KeyboardPreferences.defaults?.register(defaults: [
             KeyboardPreferences.setupCompletedKey: true,
+            KeyboardPreferences.onboardingStageKey: OnboardingStage.complete.rawValue,
             KeyboardPreferences.firstDictationKey: hasDictatedOnce,
+            KeyboardPreferences.keyboardPracticeKey: hasDictatedOnce,
+            KeyboardPreferences.keyboardPracticeMigrationKey: true,
             KeyboardPreferences.keyboardHeightKey: KeyboardHeightPreference.standard.rawValue,
             KeyboardPreferences.writingStyleKey: WritingStyle.casual.rawValue,
             KeyboardPreferences.transcriptionLanguageKey: TranscriptionLanguage.automatic.rawValue,

--- a/ios/VocaPhoneApp/App/SetupView.swift
+++ b/ios/VocaPhoneApp/App/SetupView.swift
@@ -1,55 +1,98 @@
 import SwiftUI
 import UIKit
 
-/// Guided setup.
-///
-/// The dominant failure mode for this app is an unfinished setup spread across
-/// iOS Settings, a self-hosted gateway and two permission prompts — none of
-/// which the app can complete on the user's behalf. So every step says what the
-/// access is for and carries the button that starts it.
-///
-/// None of those steps report back when they are finished, and the keyboard one
-/// completes while this screen is still on top, so the state is re-read from
-/// three angles: on return to the foreground, on a keyboard switch, and on a
-/// short poll while the keyboard step is outstanding.
+/// Whether setup is being shown as the first-run experience or reopened from
+/// Settings. A configured user should see a useful status overview, never an
+/// unexpected replay of the welcome lesson.
+enum SetupViewMode {
+    case onboarding
+    case review
+}
+
+/// Focused iOS setup. Each page owns one action and reconciles against the real
+/// state from `SetupStatus`; no Continue button can manufacture a permission,
+/// model, keyboard, or transcript that has not actually worked.
 struct SetupView: View {
     @Environment(RecordingCoordinator.self) private var coordinator
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    let mode: SetupViewMode
+
     @AppStorage(
         KeyboardPreferences.setupCompletedKey,
         store: KeyboardPreferences.defaults
     ) private var setupCompleted = false
     @AppStorage(
+        KeyboardPreferences.onboardingStageKey,
+        store: KeyboardPreferences.defaults
+    ) private var persistedStageRaw = OnboardingStage.welcome.rawValue
+    @AppStorage(
+        KeyboardPreferences.keyboardPracticeKey,
+        store: KeyboardPreferences.defaults
+    ) private var hasCompletedKeyboardPractice = false
+    @AppStorage(
         LocalTranscriptionPreferences.enabledKey,
         store: UserDefaults(suiteName: AppConfiguration.appGroupIdentifier)
     ) private var localTranscriptionEnabled = false
+
+    @State private var stage = OnboardingStage.welcome
+    @State private var isShowingFlow: Bool
+    @State private var hasInitialized = false
     @State private var keyboardProbeText = ""
-    @State private var typingProbeText = ""
-    /// Seeded from the stored flag and then owned by the view, so answering the
-    /// usage-reporting step removes it immediately instead of leaving it on
-    /// screen already-answered until the next redraw.
+    @State private var practiceText = ""
+    @FocusState private var keyboardProbeFocused: Bool
+    @FocusState private var practiceFocused: Bool
     @State private var hasAskedAboutReporting = UserDefaultsTelemetryPreferences().hasBeenAsked
+    @State private var hasCopiedSettingsPath = false
+    @AppStorage(
+        KeyboardPreferences.keyboardSettingsRoundTripKey,
+        store: KeyboardPreferences.defaults
+    ) private var keyboardSettingsRoundTripStarted = false
+
     private let telemetryPreferences = UserDefaultsTelemetryPreferences()
 
+    init(mode: SetupViewMode = .review) {
+        self.mode = mode
+        _isShowingFlow = State(initialValue: mode == .onboarding)
+    }
+
     private var status: SetupStatus { coordinator.setupStatus }
+    private var proofCount: Int {
+        OnboardingPresentation.completedProofCount(
+            status: status,
+            hasCompletedKeyboardPractice: hasCompletedKeyboardPractice
+        )
+    }
+    private var proofProgress: Double {
+        OnboardingPresentation.progress(
+            status: status,
+            hasCompletedKeyboardPractice: hasCompletedKeyboardPractice
+        )
+    }
 
     var body: some View {
-        List {
-            introSection
-            sourceSection
-            stepsSection
-            usageReportingSection
-            finishSection
-            privacySection
+        Group {
+            if isShowingFlow {
+                onboardingBody
+            } else {
+                overviewBody
+            }
         }
-        .navigationTitle("Set up vocaphone")
+        .background(Color.vocaCanvas)
+        .navigationTitle(isShowingFlow ? "Set up vocaphone" : "Guided setup")
         .navigationBarTitleDisplayMode(.inline)
+        .interactiveDismissDisabled(mode == .onboarding && requiresMandatorySetup)
+        .toolbar { toolbarContent }
         .task {
+            // Establish the saved page immediately. A slow gateway health
+            // check must not make a relaunch look as though setup restarted.
             coordinator.refreshSetupStatus()
+            initializeIfNeeded()
             await coordinator.refreshGatewayHealth()
         }
-        .task(id: status.isSatisfied(.keyboard)) {
+        .task(id: keyboardWatchID) {
             await watchForTheKeyboard()
         }
         .onReceive(
@@ -57,260 +100,530 @@ struct SetupView: View {
                 for: UITextInputMode.currentInputModeDidChangeNotification
             )
         ) { _ in
-            // Switching into the vocaphone keyboard happens without the app
-            // ever leaving the foreground. This is the only signal iOS gives
-            // for it, and it lands before the poll would notice.
             coordinator.refreshSetupStatus()
         }
         .onChange(of: scenePhase) { previousPhase, currentPhase in
-            // Every step here is finished somewhere else — iOS Settings, a
-            // permission alert, the keyboard itself — so returning is the only
-            // reliable moment to re-read them.
             guard previousPhase != .active, currentPhase == .active else { return }
-            coordinator.refreshSetupStatus()
-            Task { await coordinator.refreshGatewayHealth() }
+            Task { await refreshAfterForegroundReturn() }
         }
         .onChange(of: localTranscriptionEnabled) { _, _ in
             coordinator.refreshSetupStatus()
         }
+        .onChange(of: hasCompletedKeyboardPractice) { _, complete in
+            guard complete, stage == .practice else { return }
+            UIAccessibility.post(
+                notification: .announcement,
+                argument: "Your words were inserted through the vocaphone keyboard."
+            )
+        }
+        .onChange(of: stage) { _, newStage in
+            guard mode == .onboarding, requiresMandatorySetup else { return }
+            persistedStageRaw = newStage.rawValue
+        }
     }
 
-    // MARK: - Sections
+    // MARK: - First-run flow
 
-    private var introSection: some View {
-        Section {
-            VStack(alignment: .leading, spacing: VocaMetrics.related) {
-                BrandMark(size: 36)
-                    .padding(.bottom, 2)
-                Text("Dictate into any app")
-                    .font(.title3.weight(.semibold))
-                Text(
-                    "vocaphone records on this iPhone and turns it into text either "
-                        + "here on the phone or on a gateway you run yourself. Nothing "
-                        + "goes to a third-party transcription service. Four steps and "
-                        + "you are done."
+    private var onboardingBody: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: VocaMetrics.grouping) {
+                if stage.showsProofProgress { progressHeader }
+
+                stageBody
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .id(stage)
+                    .transition(.asymmetric(
+                        insertion: .move(edge: .trailing).combined(with: .opacity),
+                        removal: .move(edge: .leading).combined(with: .opacity)
+                    ))
+
+                if stage != .complete {
+                    Label("Required once to use dictation", systemImage: "checkmark.shield")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity)
+                        .accessibilityLabel("These setup steps are required once to use dictation.")
+                }
+            }
+            .padding(.horizontal, VocaMetrics.padding)
+            .padding(.vertical, VocaMetrics.grouping)
+            .frame(maxWidth: 620)
+            .frame(maxWidth: .infinity)
+        }
+        .scrollDismissesKeyboard(.interactively)
+    }
+
+    private var progressHeader: some View {
+        VStack(alignment: .leading, spacing: VocaMetrics.related) {
+            HStack {
+                Label("Required setup", systemImage: "checkmark.shield")
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                Text("Step \(stage.requiredStepNumber ?? 1) of \(OnboardingStage.requiredStepCount)")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            ProgressView(
+                value: Double(stage.requiredStepNumber ?? 1),
+                total: Double(OnboardingStage.requiredStepCount)
+            )
+                .accessibilityLabel("Setup progress")
+                .accessibilityValue(
+                    "Step \(stage.requiredStepNumber ?? 1) of \(OnboardingStage.requiredStepCount)"
+                )
+            HStack(spacing: 6) {
+                ForEach(1...OnboardingStage.requiredStepCount, id: \.self) { number in
+                    Capsule()
+                        .fill(number <= (stage.requiredStepNumber ?? 1) ? Color.brand : Color.vocaBorder)
+                        .frame(maxWidth: .infinity, minHeight: 5, maxHeight: 5)
+                }
+            }
+            .accessibilityHidden(true)
+        }
+        .padding(VocaMetrics.padding)
+        .background(
+            Color.vocaSurface,
+            in: RoundedRectangle(cornerRadius: VocaMetrics.cardRadius, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VocaMetrics.cardRadius, style: .continuous)
+                .strokeBorder(Color.vocaBorder, lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder private var stageBody: some View {
+        switch stage {
+        case .welcome:
+            welcomeStage
+        case .handoff:
+            handoffStage
+        case .source:
+            sourceStage
+        case .microphone:
+            microphoneStage
+        case .keyboard:
+            keyboardStage
+        case .keyboardSwitch:
+            keyboardSwitchStage
+        case .practice:
+            practiceStage
+        case .complete:
+            completionStage
+        }
+    }
+
+    private var welcomeStage: some View {
+        OnboardingPage {
+            OnboardingWelcomeVisual(reduceMotion: reduceMotion)
+            Text("Dictate into any app")
+                .font(.largeTitle.weight(.bold))
+            Text(
+                "Speak naturally, then place the finished text at your cursor with the vocaphone keyboard."
+            )
+            .font(.body)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            OnboardingFactRow(symbol: "lock", text: "Choose on-device speech to text or your own gateway.")
+            OnboardingFactRow(symbol: "text.cursor", text: "Insert text directly where you are typing.")
+            OnboardingFactRow(symbol: "keyboard", text: "Keep a familiar keyboard for everyday typing.")
+
+            VocaPrimaryButton(title: "See how it works", symbol: "arrow.right", action: advance)
+        }
+    }
+
+    private var handoffStage: some View {
+        OnboardingPage {
+            SwipeBackCoach(reduceMotion: reduceMotion, compact: true)
+            Text("The keyboard and app work together")
+                .font(.title.weight(.bold))
+            Text(
+                "Tap Dictate in the keyboard. vocaphone opens and records, then you swipe back to finish and insert from the keyboard."
+            )
+            .font(.body)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            VocaCard(padding: VocaMetrics.padding) {
+                Label(
+                    "iOS keyboards cannot use the microphone directly, so recording happens in vocaphone.",
+                    systemImage: "info.circle"
                 )
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             }
-            .padding(.vertical, VocaMetrics.tight)
-            .accessibilityElement(children: .combine)
 
-            VStack(alignment: .leading, spacing: VocaMetrics.related) {
-                Text("\(status.completedStepCount) of \(status.stepCount) steps done")
-                    .font(.subheadline.weight(.semibold))
-                // No completion colour of its own: the app's tint *is* the
-                // "this is fine" colour now, so switching to a second green at
-                // 100% only said that two greens exist.
-                ProgressView(value: status.progress)
-            }
-            .padding(.vertical, 2)
-            .accessibilityElement(children: .combine)
+            VocaPrimaryButton(title: "Set up dictation", symbol: "arrow.right", action: advance)
         }
     }
 
-    // MARK: - Step 1: a choice, not two requirements
-
-    /// Both routes are real and either one finishes the step, so they are
-    /// presented as a segmented choice with the selected one's own setup below
-    /// it. The previous screen showed the gateway as the step and the on-device
-    /// model as a smaller alternative underneath, which read as "the gateway is
-    /// required and this is a workaround".
-    @ViewBuilder private var sourceSection: some View {
-        Section {
-            SetupStepLabel(
-                step: .source,
-                detail: status.detail(for: .source),
-                isComplete: status.isSatisfied(.source)
-            )
-
-            Picker("Speech to text", selection: $localTranscriptionEnabled) {
-                Text("On this iPhone").tag(true)
-                Text("Your gateway").tag(false)
-            }
-            .pickerStyle(.segmented)
-
-            Text(status.source.boundaryDetail)
-                .font(.footnote)
+    private var sourceStage: some View {
+        OnboardingPage {
+            Image(systemName: "waveform.badge.magnifyingglass")
+                .font(.system(size: 48, weight: .medium))
+                .foregroundStyle(Color.brand)
+                .accessibilityHidden(true)
+            Text("Choose where speech becomes text")
+                .font(.title.weight(.bold))
+            Text("Both routes are private by design. Choose the one you want to use first.")
+                .font(.body)
                 .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
 
-            if !localTranscriptionEnabled {
+            SourceChoiceCard(
+                title: "On this iPhone",
+                detail: "Audio and the speech-to-text model stay on this iPhone after the model is downloaded.",
+                symbol: "iphone",
+                isSelected: localTranscriptionEnabled
+            ) {
+                localTranscriptionEnabled = true
+            }
+
+            SourceChoiceCard(
+                title: "Your gateway",
+                detail: "Audio goes to the gateway you configured. It runs the speech-to-text model and returns text.",
+                symbol: "server.rack",
+                isSelected: !localTranscriptionEnabled
+            ) {
+                localTranscriptionEnabled = false
+            }
+
+            if localTranscriptionEnabled {
+                NavigationLink {
+                    OnDeviceModelSetupView()
+                } label: {
+                    Label(
+                        status.source.isReady ? "Review speech-to-text model" : "Choose a speech-to-text model",
+                        systemImage: "arrow.down.circle"
+                    )
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+            } else {
                 NavigationLink {
                     GatewaySetupView()
                 } label: {
-                    Label("Pair or configure your gateway", systemImage: "server.rack")
+                    Label(
+                        status.source.isReady ? "Review your gateway" : "Pair or configure your gateway",
+                        systemImage: "arrow.right"
+                    )
+                    .frame(maxWidth: .infinity)
                 }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
             }
-        } header: {
-            Text("Transcription source")
-        }
 
-        // The picker brings its own sections — installed models, available
-        // models, and its status line — so it sits beside this one rather than
-        // inside it.
-        if localTranscriptionEnabled {
-            LocalModelPicker(manager: coordinator.localModels) {
-                coordinator.refreshSetupStatus()
-            }
-        }
-    }
-
-    private var stepsSection: some View {
-        Section {
-            microphoneStep
-            keyboardStep
-            firstDictationStep
-            typingStep
-        } footer: {
-            Text(
-                "Full Access is used only to share session state with vocaphone and to "
-                    + "reach the gateway you configured. The keyboard never sees what you "
-                    + "type in other apps."
-            )
-        }
-    }
-
-    @ViewBuilder private var microphoneStep: some View {
-        SetupStepLabel(
-            step: .microphone,
-            detail: status.detail(for: .microphone),
-            isComplete: status.isSatisfied(.microphone)
-        )
-        switch status.microphone {
-        case .undetermined:
-            stepAction("Allow microphone access") {
-                coordinator.requestMicrophonePermission()
-            }
-        case .denied:
-            // iOS shows its permission alert only once, so re-prompting here
-            // would do nothing at all.
-            stepAction("Open iOS Settings", action: openSystemSettings)
-        case .granted:
-            EmptyView()
-        }
-    }
-
-    @ViewBuilder private var keyboardStep: some View {
-        SetupStepLabel(
-            step: .keyboard,
-            detail: status.detail(for: .keyboard),
-            isComplete: status.isSatisfied(.keyboard)
-        )
-
-        if !status.isSatisfied(.keyboard) {
-            // Not labelled as a deep link to Keyboard settings, because iOS
-            // offers none: this URL opens vocaphone's own settings pane, and the
-            // path below is the part that actually gets the user there.
-            stepAction("Open iOS Settings", action: openSystemSettings)
-
-            VStack(alignment: .leading, spacing: VocaMetrics.related - 2) {
-                Text(AppConfiguration.fullAccessSettingsPath)
+            if status.isSatisfied(.source) {
+                CompletionNotice("Speech-to-text is ready")
+                VocaPrimaryButton(title: "Continue", symbol: "arrow.right", action: advance)
+            } else {
+                Text(status.detail(for: .source))
                     .font(.footnote)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
-                    .textSelection(.enabled)
-                // Two switches, named, because that screen is genuinely
-                // confusing the first time: one adds the keyboard and the other
-                // is a second tap *inside* it.
-                VStack(alignment: .leading, spacing: 2) {
-                    Label("Add “vocaphone” under Keyboards", systemImage: "1.circle")
-                    Label("Tap it, then turn on “Allow Full Access”", systemImage: "2.circle")
-                }
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-
-                // The app is only told the keyboard exists once the extension
-                // actually runs, and it only runs when it is switched to. A
-                // field right here is the shortest path to that.
-                TextField("Tap here, then hold 🌐 and pick vocaphone", text: $keyboardProbeText)
-                    .textInputAutocapitalization(.never)
-                Text("Switching to vocaphone here ticks this step automatically.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
             }
-            .padding(.leading, 32)
-            .padding(.vertical, 2)
         }
     }
 
-    @ViewBuilder private var firstDictationStep: some View {
-        SetupStepLabel(
-            step: .firstDictation,
-            detail: status.detail(for: .firstDictation),
-            isComplete: status.isSatisfied(.firstDictation)
-        )
+    @ViewBuilder private var microphoneStage: some View {
+        OnboardingPage {
+            Image(systemName: status.microphone == .granted ? "mic.badge.checkmark" : "mic")
+                .font(.system(size: 50, weight: .medium))
+                .foregroundStyle(status.microphone == .granted ? Color.brand : Color.vocaRecording)
+                .accessibilityHidden(true)
+            Text("Allow recording on this iPhone")
+                .font(.title.weight(.bold))
+            Text(
+                "vocaphone records in the app because iOS keyboards cannot access the microphone. Your selected route decides where the recording is processed."
+            )
+            .font(.body)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
 
-        if coordinator.isRecording {
-            RecordingMeter()
-                .padding(.leading, 32)
-            stepAction("Finish and transcribe") { coordinator.requestFinish() }
-            stepAction("Cancel", role: .destructive) { coordinator.cancel() }
-        } else if !status.isSatisfied(.firstDictation) {
-            stepAction("Start test recording") { coordinator.startInAppTest() }
-                .disabled(!canRunTestDictation)
-            if !canRunTestDictation {
-                Text("Finish the transcription source and microphone steps first.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                    .padding(.leading, 32)
-            }
-        }
-
-        if let message = coordinator.message, coordinator.activeRecord != nil {
-            Text(message)
-                .font(.footnote)
-                .foregroundStyle(coordinator.hasError ? Color.vocaError : .secondary)
-                .padding(.leading, 32)
-        }
-    }
-
-    /// The product's second half had no moment in onboarding at all: someone
-    /// could finish setup without ever learning the keyboard completes and
-    /// corrects. Optional, and last, because dictation is still the headline.
-    @ViewBuilder private var typingStep: some View {
-        if status.isSatisfied(.keyboard) {
-            VStack(alignment: .leading, spacing: VocaMetrics.related - 2) {
-                Text("Try typing")
-                    .font(.subheadline.weight(.semibold))
-                Text(
-                    "Switch to the vocaphone keyboard here and type a few words. "
-                        + "Suggestions appear in the row above the keys; tap one to "
-                        + "use it, or keep typing to ignore them."
+            switch status.microphone {
+            case .granted:
+                CompletionNotice("Microphone ready")
+                VocaPrimaryButton(title: "Continue", symbol: "arrow.right", action: advance)
+            case .undetermined:
+                VocaPrimaryButton(
+                    title: "Allow microphone access",
+                    symbol: "mic.fill",
+                    action: coordinator.requestMicrophonePermission
                 )
-                .font(.footnote)
+            case .denied:
+                VocaCard {
+                    VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                        Text("Microphone access is off")
+                            .font(.headline)
+                        Text(
+                            "iOS shows its permission prompt only once. Turn the Microphone setting back on for vocaphone, then return here."
+                        )
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    }
+                }
+                VocaPrimaryButton(title: "Open vocaphone Settings", symbol: "gear", action: openSystemSettings)
+            }
+        }
+    }
+
+    private var keyboardStage: some View {
+        OnboardingPage {
+            Image(systemName: "keyboard")
+                .font(.system(size: 48, weight: .medium))
+                .foregroundStyle(Color.brand)
+                .accessibilityHidden(true)
+            Text("Enable the vocaphone keyboard")
+                .font(.title.weight(.bold))
+            Text(
+                "Add vocaphone, then turn on Full Access. The next screen will show you how to switch to it."
+            )
+            .font(.body)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            VStack(spacing: VocaMetrics.related) {
+                SettingsReferenceCard(
+                    number: 1,
+                    title: "Add the keyboard",
+                    detail: "Settings → General → Keyboard → Keyboards → Add New Keyboard → vocaphone",
+                    symbol: "keyboard"
+                )
+                SettingsReferenceCard(
+                    number: 2,
+                    title: "Allow Full Access",
+                    detail: "Tap vocaphone in the Keyboards list, then turn on Allow Full Access.",
+                    symbol: "checkmark.shield"
+                )
+            }
+
+            VocaPrimaryButton(title: "Open vocaphone Settings", symbol: "gear", action: openSystemSettings)
+            Button(action: copySettingsPath) {
+                Label(
+                    hasCopiedSettingsPath ? "Settings path copied" : "Copy Settings path",
+                    systemImage: hasCopiedSettingsPath ? "checkmark" : "doc.on.doc"
+                )
+            }
+            .font(.subheadline.weight(.semibold))
+            .frame(maxWidth: .infinity, minHeight: VocaMetrics.minimumTarget)
+
+            if status.isSatisfied(.keyboard) {
+                CompletionNotice("Full Access is already verified")
+                VocaPrimaryButton(
+                    title: "Continue to keyboard switch",
+                    symbol: "arrow.right",
+                    action: advance
+                )
+            } else if keyboardSettingsRoundTripStarted {
+                VocaCard(padding: VocaMetrics.padding) {
+                    Label(
+                        "iOS confirms Full Access only after vocaphone opens as the keyboard. The next step performs that check.",
+                        systemImage: "checkmark.shield"
+                    )
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+
+                VocaPrimaryButton(
+                    title: "Full Access is on — continue",
+                    symbol: "checkmark.shield",
+                    action: advance
+                )
+            } else {
+                Button(action: {}) {
+                    Label("Enable Full Access before continuing", systemImage: "lock.fill")
+                        .frame(maxWidth: .infinity, minHeight: VocaMetrics.minimumTarget)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .disabled(true)
+            }
+        }
+    }
+
+    private var keyboardSwitchStage: some View {
+        OnboardingPage {
+            Text("Switch to vocaphone")
+                .font(.title.weight(.bold))
+            Text("Tap the field, hold the globe, then choose vocaphone. This confirms Full Access automatically.")
+                .font(.body)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
-                TextField("Type a sentence", text: $typingProbeText)
-                    .textFieldStyle(.roundedBorder)
+
+            KeyboardSwitchCoach(reduceMotion: reduceMotion)
+
+            VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                Label("Try it now", systemImage: "hand.tap")
+                    .font(.headline)
+
+                TextField("Tap here to show the keyboard", text: $keyboardProbeText, axis: .vertical)
+                    .textInputAutocapitalization(.never)
+                    .textFieldStyle(.plain)
+                    .padding(VocaMetrics.padding)
+                    .background(
+                        Color.vocaSurface,
+                        in: RoundedRectangle(cornerRadius: VocaMetrics.fieldRadius, style: .continuous)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VocaMetrics.fieldRadius, style: .continuous)
+                            .strokeBorder(keyboardProbeFocused ? Color.brand : Color.vocaBorder, lineWidth: 2)
+                    )
+                    .focused($keyboardProbeFocused)
+
+                Button {
+                    keyboardProbeFocused = true
+                } label: {
+                    Label("Open the keyboard", systemImage: "keyboard")
+                        .frame(maxWidth: .infinity, minHeight: VocaMetrics.minimumTarget)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
             }
-            .padding(.vertical, 2)
+            .padding(VocaMetrics.padding)
+            .background(
+                Color.vocaRecessedSurface,
+                in: RoundedRectangle(cornerRadius: VocaMetrics.cardRadius, style: .continuous)
+            )
+
+            if status.isSatisfied(.keyboard) {
+                CompletionNotice("vocaphone opened with Full Access")
+                VocaPrimaryButton(title: "Continue to test dictation", symbol: "arrow.right", action: advance)
+            } else {
+                Label("Waiting for vocaphone to open", systemImage: "circle.dotted")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity)
+
+                if case .seenWithoutFullAccess = status.keyboard {
+                    Button("Full Access is still off — review Settings") {
+                        keyboardSettingsRoundTripStarted = false
+                        stage = .keyboard
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .frame(maxWidth: .infinity, minHeight: VocaMetrics.minimumTarget)
+                }
+            }
         }
     }
 
-    /// Indented to sit under its step's text rather than its checkmark, so a
-    /// button reads as belonging to the line above it.
-    private func stepAction(
-        _ title: String,
-        role: ButtonRole? = nil,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(title, role: role, action: action)
-            .padding(.leading, 32)
+    @ViewBuilder private var practiceStage: some View {
+        OnboardingPage {
+            Text("Make your first dictation")
+                .font(.title.weight(.bold))
+            Text(
+                "Use the real field and keyboard below. The Dictate button appears after you switch to vocaphone."
+            )
+            .font(.body)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            DictationPracticeCoach(reduceMotion: reduceMotion)
+
+            VStack(alignment: .leading, spacing: VocaMetrics.padding) {
+                Label("Now do it yourself", systemImage: "hand.tap")
+                    .font(.headline)
+
+                TextField("Your dictated words will appear here", text: $practiceText, axis: .vertical)
+                    .lineLimit(3...6)
+                    .textFieldStyle(.plain)
+                    .padding(VocaMetrics.padding)
+                    .background(
+                        Color.vocaSurface,
+                        in: RoundedRectangle(cornerRadius: VocaMetrics.fieldRadius, style: .continuous)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VocaMetrics.fieldRadius, style: .continuous)
+                            .strokeBorder(practiceFocused ? Color.brand : Color.vocaBorder, lineWidth: 2)
+                    )
+                    .focused($practiceFocused)
+
+                if hasCompletedKeyboardPractice {
+                    CompletionNotice("Your words were inserted successfully")
+                } else if coordinator.isDictatingIntoContainingApp {
+                    VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                        HStack {
+                            Label("Speak now", systemImage: "record.circle")
+                                .font(.headline)
+                                .foregroundStyle(Color.vocaRecording)
+                            Spacer()
+                            RecordingMeter()
+                                .frame(width: 108)
+                        }
+                        Text("When you finish speaking, return to the keyboard and tap Finish.")
+                            .font(.subheadline.weight(.semibold))
+                    }
+                } else if let record = coordinator.activeRecord,
+                          [.finalizing, .uploading, .transcribing, .readyToInsert, .inserting].contains(record.state)
+                {
+                    VocaStatusLine(
+                        status: record.state == .readyToInsert ? .ready : .working,
+                        title: practiceStateTitle(for: record),
+                        detail: practiceStateDetail(for: record)
+                    )
+                } else {
+                    VStack(alignment: .leading, spacing: 6) {
+                        PracticeDirection(number: 1, text: "Tap the field to show the keyboard")
+                        PracticeDirection(number: 2, text: "Choose vocaphone with the globe")
+                        PracticeDirection(number: 3, text: "Tap Dictate and say a short sentence")
+                    }
+                    VocaPrimaryButton(title: "Start in the field", symbol: "keyboard") {
+                        practiceFocused = true
+                    }
+                }
+            }
+            .padding(VocaMetrics.padding)
+            .background(
+                Color.vocaRecessedSurface,
+                in: RoundedRectangle(cornerRadius: VocaMetrics.cardRadius, style: .continuous)
+            )
+
+            if hasCompletedKeyboardPractice {
+                VocaPrimaryButton(title: "Continue", symbol: "arrow.right", action: advance)
+            }
+        }
     }
 
-    /// Asked last, and only once the checklist is done: requesting a favour of
-    /// someone still deciding whether the app is worth their time is how you get
-    /// a reflexive no.
-    @ViewBuilder
-    private var usageReportingSection: some View {
+    @ViewBuilder private var completionStage: some View {
+        OnboardingPage {
+            HStack(alignment: .top, spacing: VocaMetrics.padding) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 48, weight: .medium))
+                    .foregroundStyle(Color.brand)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                    Text("You're ready to dictate")
+                        .font(.title.weight(.bold))
+                    Text("Your first keyboard dictation was inserted successfully.")
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .accessibilityElement(children: .combine)
+
+            VocaCard(padding: VocaMetrics.padding) {
+                VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                    Text("In any app")
+                        .font(.headline)
+                    OnboardingFactRow(symbol: "globe", text: "Choose vocaphone with the globe key.")
+                    OnboardingFactRow(symbol: "mic.fill", text: "Tap Dictate and speak.")
+                    OnboardingFactRow(
+                        symbol: "arrow.right",
+                        text: "Swipe back, then tap Finish and Insert."
+                    )
+                }
+            }
+
+            usageReportingSection
+            VocaPrimaryButton(title: "Start using vocaphone", symbol: "arrow.right", action: finishSetup)
+        }
+    }
+
+    @ViewBuilder private var usageReportingSection: some View {
         if status.isReadyToDictate && !hasAskedAboutReporting {
             UsageReportingSetupSection { enabled in
-                // The answer and the fact of having asked are recorded
-                // separately: "declined" and "not asked yet" have to stay
-                // distinguishable, or a no becomes a question repeated on every
-                // trip through guided setup.
                 Task { await Telemetry.shared.setEnabled(enabled) }
                 telemetryPreferences.hasBeenAsked = true
                 hasAskedAboutReporting = true
@@ -318,153 +631,818 @@ struct SetupView: View {
         }
     }
 
-    private var finishSection: some View {
-        Section {
-            Button(action: leaveSetup) {
-                Text("Start dictating")
-                    .frame(maxWidth: .infinity)
-            }
-            .brandProminentButton()
-            .controlSize(.large)
-            .disabled(!status.isReadyToDictate)
-            .listRowBackground(Color.clear)
-            .listRowSeparator(.hidden)
+    // MARK: - Review
 
-            if !status.isReadyToDictate {
-                // Leaving has to stay possible: a gateway may be something the
-                // user can only stand up later, and trapping them on this
-                // screen until then helps nobody.
-                Button(action: leaveSetup) {
-                    Text("Skip for now")
-                        .frame(maxWidth: .infinity)
+    private var overviewBody: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: VocaMetrics.grouping) {
+                VocaCard {
+                    VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                        VocaStatusLine(
+                            status: status.isReadyToDictate ? .ready : .attention,
+                            title: status.isReadyToDictate ? "Ready to dictate" : "Setup needs attention",
+                            detail: status.isReadyToDictate
+                                ? "vocaphone will keep checking these requirements when it returns to the foreground."
+                                : status.attentionDetail
+                        )
+                        ProgressView(value: proofProgress)
+                        Text("\(proofCount) of \(SetupStep.allCases.count) steps proven")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
                 }
-                .listRowBackground(Color.clear)
-                .listRowSeparator(.hidden)
+
+                VStack(spacing: VocaMetrics.related) {
+                    ForEach(SetupStep.allCases) { step in
+                        SetupReviewCard(
+                            step: step,
+                            detail: reviewDetail(for: step),
+                            isComplete: isCompleteForReview(step)
+                        )
+                    }
+                }
+
+                if hasCompletedKeyboardPractice {
+                    CompletionNotice("Keyboard practice completed")
+                }
+
+                VocaPrimaryButton(
+                    title: status.isReadyToDictate && hasCompletedKeyboardPractice
+                        ? "Practice again"
+                        : "Continue setup",
+                    symbol: "arrow.right"
+                ) {
+                    stage = OnboardingPresentation.resumeStage(
+                        status: status,
+                        hasCompletedKeyboardPractice: hasCompletedKeyboardPractice
+                    )
+                    withAnimation(.easeInOut(duration: 0.2)) { isShowingFlow = true }
+                }
             }
-        } footer: {
-            if status.isReadyToDictate {
-                Text(
-                    status.isComplete
-                        ? "Everything is ready. You can reopen this screen from Settings."
-                        : "Dictation will work. The test recording is optional, but it is "
-                            + "the only thing that proves the whole chain end to end."
-                )
-            } else {
-                Text(
-                    "Still to do: "
-                        + status.remainingSteps.map(\.label).joined(separator: ", ")
-                        + ". vocaphone will remind you on the main screen."
-                )
+            .padding(VocaMetrics.padding)
+            .frame(maxWidth: 620)
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    // MARK: - Actions and state
+
+    @ToolbarContentBuilder private var toolbarContent: some ToolbarContent {
+        if isShowingFlow, let previous = OnboardingPresentation.previousStage(before: stage) {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) { stage = previous }
+                } label: {
+                    Label("Back", systemImage: "chevron.left")
+                }
             }
         }
     }
 
-    /// A closing note, so it is a footer rather than a paragraph in a cell.
-    private var privacySection: some View {
-        Section {
-        } footer: {
-            Text(
-                "Audio stays on this phone until transcription succeeds. A gateway "
-                    + "deletes successfully transcribed audio by default. No third-party "
-                    + "transcription or analytics service is involved. If you turn on "
-                    + "usage reporting, counters go to a server VocaHQ self-hosts — never "
-                    + "your speech, your text, or your gateway's address."
-            )
+    private var keyboardWatchID: String {
+        "\(isShowingFlow)-\(stage.rawValue)-\(status.isSatisfied(.keyboard))"
+    }
+
+    private var requiresMandatorySetup: Bool {
+        OnboardingPresentation.requiresFirstRunCover(
+            setupCompleted: setupCompleted,
+            hasCompletedKeyboardPractice: hasCompletedKeyboardPractice
+        )
+    }
+
+    private func initializeIfNeeded() {
+        guard !hasInitialized else { return }
+        hasInitialized = true
+        stage = OnboardingPresentation.initialStage(
+            setupCompleted: setupCompleted,
+            persistedStage: OnboardingStage(rawValue: persistedStageRaw),
+            status: status,
+            hasCompletedKeyboardPractice: hasCompletedKeyboardPractice
+        )
+    }
+
+    private func advance() {
+        switch stage {
+        case .source:
+            guard status.isSatisfied(.source) else { return }
+        case .microphone:
+            guard status.isSatisfied(.microphone) else { return }
+        case .keyboardSwitch:
+            guard status.isSatisfied(.keyboard) else { return }
+        case .keyboard:
+            guard OnboardingPresentation.canAdvanceFromKeyboardEnablement(
+                status: status,
+                returnedFromSettings: keyboardSettingsRoundTripStarted
+            ) else { return }
+        case .practice:
+            guard hasCompletedKeyboardPractice else { return }
+        case .complete:
+            finishSetup()
+            return
+        case .welcome, .handoff:
+            break
         }
+        guard let next = OnboardingPresentation.nextStage(after: stage) else { return }
+        if stage == .keyboard {
+            keyboardSettingsRoundTripStarted = false
+        }
+        withAnimation(.snappy(duration: 0.32)) { stage = next }
+        UIAccessibility.post(notification: .screenChanged, argument: nil)
     }
 
-    // MARK: - Actions
-
-    private var canRunTestDictation: Bool {
-        status.isSatisfied(.source) && status.isSatisfied(.microphone)
+    private func finishSetup() {
+        guard status.isReadyToDictate, hasCompletedKeyboardPractice else { return }
+        setupCompleted = true
+        persistedStageRaw = OnboardingStage.complete.rawValue
+        keyboardSettingsRoundTripStarted = false
+        Telemetry.shared.setupFinished()
+        dismiss()
     }
 
-    /// The keyboard writes its status from another process into a file nothing
-    /// can observe, and it does so while this app is still in the foreground —
-    /// so waiting for a scene-phase change leaves the step stuck on screen
-    /// long after it is actually done. Re-reading it costs one small file read,
-    /// and only runs while the step is outstanding and this screen is up.
+    private func refresh() async {
+        coordinator.refreshSetupStatus()
+        await coordinator.refreshGatewayHealth()
+    }
+
+    private func refreshAfterForegroundReturn() async {
+        coordinator.refreshSetupStatus()
+
+        // iOS can publish a changed permission or keyboard list just after the
+        // app becomes active. Re-read briefly so the first return updates in
+        // place instead of requiring another trip through Settings.
+        for delay in [180, 420, 800] {
+            try? await Task.sleep(for: .milliseconds(delay))
+            guard !Task.isCancelled else { return }
+            coordinator.refreshSetupStatus()
+        }
+
+        await coordinator.refreshGatewayHealth()
+    }
+
     private func watchForTheKeyboard() async {
-        guard !status.isSatisfied(.keyboard) else { return }
+        guard isShowingFlow, stage == .keyboardSwitch, !status.isSatisfied(.keyboard) else { return }
         while !Task.isCancelled {
             try? await Task.sleep(for: .milliseconds(400))
             coordinator.refreshSetupStatus()
         }
     }
 
-    private func leaveSetup() {
-        setupCompleted = true
-        if status.isReadyToDictate { Telemetry.shared.setupFinished() }
-        dismiss()
-    }
-
     private func openSystemSettings() {
         guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        if stage == .keyboard {
+            keyboardSettingsRoundTripStarted = true
+        }
         UIApplication.shared.open(url)
+    }
+
+    private func copySettingsPath() {
+        UIPasteboard.general.string = AppConfiguration.fullAccessSettingsPath
+        hasCopiedSettingsPath = true
+    }
+
+    private func isCompleteForReview(_ step: SetupStep) -> Bool {
+        step == .firstDictation ? hasCompletedKeyboardPractice : status.isSatisfied(step)
+    }
+
+    private func reviewDetail(for step: SetupStep) -> String {
+        if step == .firstDictation {
+            return hasCompletedKeyboardPractice
+                ? "A transcript was inserted through the vocaphone keyboard."
+                : "Try a real keyboard dictation to prove the full loop."
+        }
+        return status.detail(for: step)
+    }
+
+    private func practiceStateTitle(for record: SessionRecord) -> String {
+        switch record.state {
+        case .finalizing: "Finishing recording"
+        case .uploading:
+            record.processingLocation == .gateway ? "Sending to your gateway" : "Preparing on this iPhone"
+        case .transcribing:
+            record.processingLocation == .gateway ? "Transcribing on your gateway" : "Transcribing on this iPhone"
+        case .readyToInsert: "Your text is ready"
+        case .inserting: "Inserting text"
+        default: record.state.displayName
+        }
+    }
+
+    private func practiceStateDetail(for record: SessionRecord) -> String? {
+        switch record.state {
+        case .readyToInsert: "Tap Insert in the keyboard to place your words in the field above."
+        case .inserting: "Placing your words at the cursor."
+        default: record.processingLocation == .onDevice
+            ? "The speech-to-text model is running on this iPhone."
+            : record.processingLocation == .gateway
+                ? "Your gateway is running its speech-to-text model."
+                : nil
+        }
     }
 }
 
-/// One checklist line: state, what the step is, and where it currently stands.
-struct SetupStepLabel: View {
-    let step: SetupStep
-    let detail: String
-    let isComplete: Bool
+// MARK: - Focused setup components
+
+private struct OnboardingPage<Content: View>: View {
+    @ViewBuilder let content: Content
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 12) {
-            Image(systemName: isComplete ? "checkmark.circle.fill" : "circle")
-                .foregroundStyle(isComplete ? Color.brand : .secondary)
-                .accessibilityHidden(true)
-            VStack(alignment: .leading, spacing: 3) {
-                Text(step.title)
-                    .font(.subheadline.weight(.semibold))
+        VStack(alignment: .leading, spacing: VocaMetrics.grouping) {
+            content
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(VocaMetrics.grouping)
+        .background(
+            Color.vocaSurface,
+            in: RoundedRectangle(cornerRadius: VocaMetrics.heroRadius, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VocaMetrics.heroRadius, style: .continuous)
+                .strokeBorder(Color.vocaBorder, lineWidth: 1)
+        )
+    }
+}
+
+private struct OnboardingFactRow: View {
+    let symbol: String
+    let text: String
+
+    var body: some View {
+        Label {
+            Text(text)
+                .font(.subheadline)
+                .fixedSize(horizontal: false, vertical: true)
+        } icon: {
+            Image(systemName: symbol)
+                .foregroundStyle(Color.brand)
+        }
+    }
+}
+
+private struct CompletionNotice: View {
+    let text: String
+
+    init(_ text: String) { self.text = text }
+
+    var body: some View {
+        Label(text, systemImage: "checkmark.circle.fill")
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(Color.brand)
+            .accessibilityElement(children: .combine)
+    }
+}
+
+private struct SourceChoiceCard: View {
+    let title: String
+    let detail: String
+    let symbol: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(alignment: .top, spacing: VocaMetrics.padding) {
+                Image(systemName: symbol)
+                    .font(.title3)
+                    .foregroundStyle(isSelected ? Color.brand : .secondary)
+                    .frame(width: 26)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Text(detail)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 0)
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isSelected ? Color.brand : .secondary)
+                    .accessibilityHidden(true)
+            }
+            .padding(VocaMetrics.padding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                isSelected ? Color.brand.opacity(0.08) : Color.vocaRecessedSurface,
+                in: RoundedRectangle(cornerRadius: VocaMetrics.cardRadius, style: .continuous)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VocaMetrics.cardRadius, style: .continuous)
+                    .strokeBorder(isSelected ? Color.brand : Color.vocaBorder, lineWidth: isSelected ? 2 : 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+    }
+}
+
+private struct SettingsReferenceCard: View {
+    let number: Int
+    let title: String
+    let detail: String
+    let symbol: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: VocaMetrics.padding) {
+            Text("\(number)")
+                .font(.headline.monospacedDigit())
+                .foregroundStyle(Color.onBrand)
+                .frame(width: 28, height: 28)
+                .background(Color.brand, in: Circle())
+            VStack(alignment: .leading, spacing: 4) {
+                Label(title, systemImage: symbol)
+                    .font(.headline)
                 Text(detail)
                     .font(.footnote)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
-        .padding(.vertical, 2)
+        .padding(VocaMetrics.padding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            Color.vocaRecessedSurface,
+            in: RoundedRectangle(cornerRadius: VocaMetrics.cardRadius, style: .continuous)
+        )
         .accessibilityElement(children: .combine)
-        .accessibilityValue(isComplete ? "Done" : "Not done")
+    }
+}
+
+private struct SetupReviewCard: View {
+    let step: SetupStep
+    let detail: String
+    let isComplete: Bool
+
+    var body: some View {
+        VocaCard {
+            HStack(alignment: .top, spacing: VocaMetrics.related + 2) {
+                Image(systemName: isComplete ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isComplete ? Color.brand : .secondary)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(step.title)
+                        .font(.headline)
+                    Text(detail)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityValue(isComplete ? "Done" : "Needs attention")
+    }
+}
+
+private struct OnDeviceModelSetupView: View {
+    @Environment(RecordingCoordinator.self) private var coordinator
+
+    var body: some View {
+        List {
+            LocalModelPicker(manager: coordinator.localModels) {
+                coordinator.refreshSetupStatus()
+            }
+        }
+        .navigationTitle("Speech-to-text model")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { coordinator.refreshSetupStatus() }
+    }
+}
+
+private struct OnboardingWelcomeVisual: View {
+    let reduceMotion: Bool
+    @State private var textAppeared = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VocaMetrics.related) {
+            HStack(spacing: 4) {
+                ForEach(0..<12, id: \.self) { index in
+                    Capsule()
+                        .fill(Color.brand.opacity(textAppeared ? 0.35 : 0.85))
+                        .frame(width: 4, height: CGFloat(8 + (index % 5) * 5))
+                }
+            }
+            Text("Meet me by the station at six.")
+                .font(.body)
+                .foregroundStyle(textAppeared ? Color.vocaPrimaryText : .clear)
+            Rectangle()
+                .fill(Color.brand)
+                .frame(width: 2, height: 20)
+                .opacity(textAppeared ? 1 : 0)
+        }
+        .padding(VocaMetrics.padding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            Color.vocaRecessedSurface,
+            in: RoundedRectangle(cornerRadius: VocaMetrics.cardRadius, style: .continuous)
+        )
+        .task {
+            guard !reduceMotion else {
+                textAppeared = true
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(320))
+            withAnimation(.easeInOut(duration: 0.2)) { textAppeared = true }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("A short waveform becomes text at the cursor.")
+    }
+}
+
+private struct KeyboardSwitchCoach: View {
+    private enum Step: Int, CaseIterable, Identifiable {
+        case field
+        case globe
+        case vocaphone
+
+        var id: Int { rawValue }
+
+        var number: Int { rawValue + 1 }
+
+        var title: String {
+            switch self {
+            case .field: "Tap the text field"
+            case .globe: "Touch and hold the globe"
+            case .vocaphone: "Choose vocaphone"
+            }
+        }
+
+        var detail: String {
+            switch self {
+            case .field: "The keyboard appears at the bottom of the screen."
+            case .globe: "Keep holding until the keyboard list opens."
+            case .vocaphone: "Slide to vocaphone, then lift your finger."
+            }
+        }
+    }
+
+    let reduceMotion: Bool
+
+    @State private var step = Step.field
+    @State private var replayID = 0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VocaMetrics.padding) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(step.title)
+                    .font(.title3.weight(.bold))
+                    .contentTransition(.opacity)
+                Spacer()
+                Button {
+                    replayID += 1
+                } label: {
+                    Label("Replay", systemImage: "arrow.clockwise")
+                        .labelStyle(.iconOnly)
+                        .frame(width: VocaMetrics.minimumTarget, height: VocaMetrics.minimumTarget)
+                }
+                .accessibilityLabel("Replay keyboard switch demonstration")
+            }
+
+            Text(step.detail)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .contentTransition(.opacity)
+
+            GeometryReader { proxy in
+                let width = proxy.size.width
+                let height = proxy.size.height
+
+                ZStack {
+                    RoundedRectangle(cornerRadius: 28, style: .continuous)
+                        .fill(Color.vocaSurface)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                                .strokeBorder(Color.vocaBorder, lineWidth: 2)
+                        )
+
+                    VStack(spacing: 0) {
+                        HStack(spacing: 5) {
+                            Text(step == .field ? "Tap to type" : "Cursor is ready")
+                                .font(.subheadline)
+                                .foregroundStyle(step == .field ? .secondary : Color.vocaPrimaryText)
+                            Rectangle()
+                                .fill(Color.brand)
+                                .frame(width: 2, height: 20)
+                                .opacity(step == .field ? 0 : 1)
+                            Spacer()
+                        }
+                        .padding(.horizontal, VocaMetrics.padding)
+                        .frame(height: 52)
+                        .background(
+                            step == .field ? Color.brand.opacity(0.1) : Color.vocaRecessedSurface,
+                            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .strokeBorder(step == .field ? Color.brand : Color.vocaBorder, lineWidth: 2)
+                        )
+                        .padding(VocaMetrics.padding)
+
+                        Spacer(minLength: 8)
+                        simulatedKeyboard
+                    }
+
+                    if step != .field {
+                        keyboardMenu
+                            .frame(width: min(width * 0.58, 220))
+                            .offset(x: -width * 0.12, y: height * 0.05)
+                            .transition(.scale(scale: 0.86, anchor: .bottomLeading).combined(with: .opacity))
+                    }
+
+                    gestureMarker
+                        .offset(markerOffset(width: width, height: height))
+                }
+                .contentShape(Rectangle())
+                .onTapGesture(perform: advanceDemo)
+            }
+            .frame(height: 250)
+
+            HStack(spacing: 8) {
+                ForEach(Step.allCases) { candidate in
+                    Capsule()
+                        .fill(candidate == step ? Color.brand : Color.vocaBorder)
+                        .frame(width: candidate == step ? 30 : 8, height: 8)
+                        .animation(.snappy(duration: 0.25), value: step)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .accessibilityHidden(true)
+        }
+        .padding(VocaMetrics.padding)
+        .background(
+            Color.vocaRecessedSurface,
+            in: RoundedRectangle(cornerRadius: VocaMetrics.cardRadius, style: .continuous)
+        )
+        .task(id: replayID) {
+            guard !reduceMotion else {
+                step = .vocaphone
+                return
+            }
+            step = .field
+            for candidate in [Step.globe, .vocaphone] {
+                try? await Task.sleep(for: .milliseconds(candidate == .globe ? 900 : 1_150))
+                guard !Task.isCancelled else { return }
+                withAnimation(.snappy(duration: 0.42)) { step = candidate }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Step \(step.number) of 3. \(step.title). \(step.detail)")
+        .accessibilityAction(named: "Next step", advanceDemo)
+    }
+
+    private var simulatedKeyboard: some View {
+        VStack(spacing: 7) {
+            ForEach(0..<2, id: \.self) { row in
+                HStack(spacing: 6) {
+                    ForEach(0..<(row == 0 ? 8 : 7), id: \.self) { _ in
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .fill(Color.vocaSurface)
+                            .frame(height: 28)
+                    }
+                }
+            }
+            HStack(spacing: 8) {
+                Image(systemName: "globe")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(step == .globe ? Color.onBrand : Color.vocaPrimaryText)
+                    .frame(width: 48, height: 38)
+                    .background(
+                        step == .globe ? Color.brand : Color.vocaSurface,
+                        in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    )
+                    .scaleEffect(step == .globe ? 1.12 : 1)
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.vocaSurface)
+                    .overlay(Text("space").font(.caption).foregroundStyle(.secondary))
+                    .frame(maxWidth: .infinity, minHeight: 38)
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.vocaSurface)
+                    .frame(width: 54, height: 38)
+            }
+        }
+        .padding(10)
+        .background(Color.vocaBorder.opacity(0.65))
+    }
+
+    private var keyboardMenu: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Label("English", systemImage: "keyboard")
+                .foregroundStyle(.secondary)
+                .padding(12)
+            Label("vocaphone", systemImage: step == .vocaphone ? "checkmark" : "keyboard")
+                .fontWeight(.semibold)
+                .foregroundStyle(step == .vocaphone ? Color.onBrand : Color.vocaPrimaryText)
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(step == .vocaphone ? Color.brand : Color.vocaSurface)
+        }
+        .font(.subheadline)
+        .background(
+            Color.vocaSurface,
+            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Color.vocaBorder, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.16), radius: 12, y: 5)
+    }
+
+    private var gestureMarker: some View {
+        ZStack {
+            Circle()
+                .fill(Color.brand.opacity(0.18))
+                .frame(width: 64, height: 64)
+            Circle()
+                .fill(Color.brand)
+                .frame(width: 44, height: 44)
+            Image(systemName: step == .globe ? "hand.tap.fill" : "hand.point.up.left.fill")
+                .foregroundStyle(Color.onBrand)
+        }
+        .shadow(color: .black.opacity(0.14), radius: 8, y: 3)
+        .allowsHitTesting(false)
+    }
+
+    private func markerOffset(width: CGFloat, height: CGFloat) -> CGSize {
+        switch step {
+        case .field:
+            CGSize(width: width * 0.24, height: -height * 0.31)
+        case .globe:
+            CGSize(width: -width * 0.37, height: height * 0.34)
+        case .vocaphone:
+            CGSize(width: -width * 0.03, height: height * 0.03)
+        }
+    }
+
+    private func advanceDemo() {
+        let next = Step(rawValue: (step.rawValue + 1) % Step.allCases.count) ?? .field
+        withAnimation(.snappy(duration: 0.36)) { step = next }
+    }
+}
+
+private struct PracticeDirection: View {
+    let number: Int
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: VocaMetrics.related) {
+            Text("\(number)")
+                .font(.caption.weight(.bold).monospacedDigit())
+                .foregroundStyle(Color.onBrand)
+                .frame(width: 24, height: 24)
+                .background(Color.brand, in: Circle())
+            Text(text)
+                .font(.subheadline.weight(.semibold))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct DictationPracticeCoach: View {
+    private enum Phase: Int, CaseIterable, Identifiable {
+        case field
+        case keyboard
+        case dictate
+        case finish
+
+        var id: Int { rawValue }
+        var number: Int { rawValue + 1 }
+
+        var title: String {
+            switch self {
+            case .field: "Tap the real field below"
+            case .keyboard: "Choose vocaphone"
+            case .dictate: "Tap Dictate in the keyboard"
+            case .finish: "Speak, return, then finish"
+            }
+        }
+
+        var detail: String {
+            switch self {
+            case .field: "This opens the actual iOS keyboard."
+            case .keyboard: "Hold the globe and select vocaphone if it is not already visible."
+            case .dictate: "The Dictate button exists inside the vocaphone keyboard—not on this screen."
+            case .finish: "Swipe back, tap Finish, then Insert to put your words in the field."
+            }
+        }
+
+        var symbol: String {
+            switch self {
+            case .field: "text.cursor"
+            case .keyboard: "globe"
+            case .dictate: "mic.fill"
+            case .finish: "checkmark.circle.fill"
+            }
+        }
+    }
+
+    let reduceMotion: Bool
+
+    @State private var phase = Phase.field
+    @State private var replayID = 0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VocaMetrics.padding) {
+            HStack(alignment: .firstTextBaseline) {
+                Label("Follow these steps below", systemImage: "keyboard")
+                    .font(.headline)
+                Spacer()
+                Button {
+                    replayID += 1
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .frame(width: VocaMetrics.minimumTarget, height: VocaMetrics.minimumTarget)
+                }
+                .accessibilityLabel("Replay dictation demonstration")
+            }
+
+            HStack(alignment: .top, spacing: VocaMetrics.padding) {
+                ZStack {
+                    Circle()
+                        .fill(Color.brand)
+                        .frame(width: 54, height: 54)
+                    Image(systemName: phase.symbol)
+                        .font(.title3.weight(.bold))
+                        .foregroundStyle(Color.onBrand)
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Step \(phase.number) of \(Phase.allCases.count)")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(Color.brand)
+                    Text(phase.title)
+                        .font(.title3.weight(.bold))
+                        .contentTransition(.opacity)
+                    Text(phase.detail)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .contentTransition(.opacity)
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 126, alignment: .topLeading)
+            .padding(VocaMetrics.padding)
+            .background(
+                Color.vocaSurface,
+                in: RoundedRectangle(cornerRadius: VocaMetrics.cardRadius, style: .continuous)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VocaMetrics.cardRadius, style: .continuous)
+                    .strokeBorder(Color.brand.opacity(0.45), lineWidth: 2)
+            )
+
+            HStack(spacing: 8) {
+                ForEach(Phase.allCases) { candidate in
+                    Capsule()
+                        .fill(candidate == phase ? Color.brand : Color.vocaBorder)
+                        .frame(width: candidate == phase ? 30 : 8, height: 8)
+                        .animation(.snappy(duration: 0.25), value: phase)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .accessibilityHidden(true)
+
+            Label(
+                "All taps happen in the field or keyboard below—this card only shows the order.",
+                systemImage: "arrow.down"
+            )
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(VocaMetrics.padding)
+        .background(
+            Color.vocaRecessedSurface,
+            in: RoundedRectangle(cornerRadius: VocaMetrics.cardRadius, style: .continuous)
+        )
+        .task(id: replayID) {
+            guard !reduceMotion else {
+                phase = .dictate
+                return
+            }
+            phase = .field
+            for candidate in [Phase.keyboard, .dictate, .finish] {
+                try? await Task.sleep(for: .milliseconds(1_350))
+                guard !Task.isCancelled else { return }
+                withAnimation(.snappy(duration: 0.42)) { phase = candidate }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Step \(phase.number) of 4. \(phase.title). \(phase.detail)")
     }
 }
 
 #if DEBUG
 
-// MARK: - Previews
-
-// Guided setup is four steps that each complete somewhere else — iOS Settings,
-// a permission alert, the keyboard itself — so reaching a particular
-// combination on a device means undoing real system state. These are the
-// combinations that change what the screen says.
-
-#Preview("Setup — nothing done yet") {
+#Preview("Onboarding — welcome") {
     PreviewHost(
-        coordinator: RecordingCoordinator(
-            preview: nil,
-            setupStatus: PreviewFixtures.setupFresh
-        ),
-        store: PreviewFixtures.gatewayUnpairedStore
+        coordinator: RecordingCoordinator(preview: nil, setupStatus: PreviewFixtures.setupFresh),
+        hasDictatedOnce: false
     ) {
-        NavigationStack { SetupView() }
+        NavigationStack { SetupView(mode: .onboarding) }
     }
 }
 
-#Preview("Setup — microphone declined") {
-    PreviewHost(
-        coordinator: RecordingCoordinator(
-            preview: nil,
-            setupStatus: PreviewFixtures.setupMicrophoneDenied
-        )
-    ) {
-        NavigationStack { SetupView() }
-    }
-}
-
-/// The most common stuck point: listed under Keyboards, never granted Full
-/// Access, so the extension has never reached the shared container.
-#Preview("Setup — keyboard needs Full Access") {
+#Preview("Onboarding — keyboard") {
     PreviewHost(
         coordinator: RecordingCoordinator(
             preview: nil,
@@ -472,87 +1450,19 @@ struct SetupStepLabel: View {
             models: LocalModelManager(preview: [PreviewFixtures.firstModelID])
         )
     ) {
-        NavigationStack { SetupView() }
+        NavigationStack { SetupView(mode: .review) }
     }
 }
 
-#Preview("Setup — keyboard has gone silent") {
-    PreviewHost(
-        coordinator: RecordingCoordinator(
-            preview: nil,
-            setupStatus: PreviewFixtures.setupKeyboardSilent
-        )
-    ) {
-        NavigationStack { SetupView() }
-    }
-}
-
-/// Dictation works and only the optional trial run is outstanding — the state
-/// that must *not* warn on the home screen.
-#Preview("Setup — ready, test dictation left") {
-    PreviewHost(
-        coordinator: RecordingCoordinator(
-            preview: nil,
-            setupStatus: PreviewFixtures.setupReadyToDictate
-        )
-    ) {
-        NavigationStack { SetupView() }
-    }
-}
-
-#Preview("Setup — recording the test dictation") {
-    PreviewHost(
-        coordinator: .preview(
-            .recording,
-            setupStatus: PreviewFixtures.setupReadyToDictate,
-            message: "Listening…",
-            meterLevel: 0.55,
-            isRecording: true
-        )
-    ) {
-        NavigationStack { SetupView() }
-    }
-}
-
-#Preview("Setup — complete") {
-    PreviewHost(
-        coordinator: RecordingCoordinator(
-            preview: nil,
-            setupStatus: PreviewFixtures.setupComplete
-        )
-    ) {
-        NavigationStack { SetupView() }
-    }
-}
-
-/// The five hardcoded `padding(.leading, 32)` indents in this file are the
-/// reason this matrix exists: at `.accessibility5` they eat a third of the
-/// width, and right to left they land on the wrong side.
-#Preview("Setup — matrix", traits: .sizeThatFitsLayout) {
+#Preview("Onboarding — matrix", traits: .sizeThatFitsLayout) {
     PreviewMatrix(
         coordinator: RecordingCoordinator(
             preview: nil,
-            setupStatus: PreviewFixtures.setupFresh
-        ),
-        store: PreviewFixtures.gatewayUnpairedStore
+            setupStatus: PreviewFixtures.setupKeyboardNeedsFullAccess,
+            models: LocalModelManager(preview: [PreviewFixtures.firstModelID])
+        )
     ) {
-        NavigationStack { SetupView() }
-    }
-}
-
-#Preview("Setup step label — done and not done", traits: .sizeThatFitsLayout) {
-    PreviewHost {
-        VStack(alignment: .leading, spacing: VocaMetrics.grouping) {
-            ForEach(SetupStep.allCases) { step in
-                SetupStepLabel(
-                    step: step,
-                    detail: PreviewFixtures.setupKeyboardNeedsFullAccess.detail(for: step),
-                    isComplete: PreviewFixtures.setupKeyboardNeedsFullAccess.isSatisfied(step)
-                )
-            }
-        }
-        .padding()
-        .frame(width: 380)
+        NavigationStack { SetupView(mode: .review) }
     }
 }
 #endif

--- a/ios/VocaPhoneApp/App/SwipeBackCoach.swift
+++ b/ios/VocaPhoneApp/App/SwipeBackCoach.swift
@@ -49,7 +49,7 @@ struct SwipeBackCoach: View {
                             .foregroundStyle(Color.onBrand)
                     }
                     .offset(x: -width * 0.31 + progress * width * 0.52, y: -26)
-                    .opacity(reduceMotion ? 0 : 1 - progress * 0.45)
+                    .opacity(reduceMotion ? 0 : 1 - Double(progress) * 0.45)
 
                     Capsule()
                         .fill(Color.vocaPrimaryText.opacity(0.72))

--- a/ios/VocaPhoneApp/App/SwipeBackCoach.swift
+++ b/ios/VocaPhoneApp/App/SwipeBackCoach.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+
+/// A replayable explanation of iOS's previous-app gesture. This is deliberately
+/// a demonstration, not a fake navigation control: the user still swipes the
+/// real home indicator at the bottom edge of the device.
+struct SwipeBackCoach: View {
+    let reduceMotion: Bool
+    var compact = false
+    var prominent = false
+
+    @State private var progress: CGFloat = 0
+    @State private var replayID = 0
+    @State private var interactionGeneration = 0
+    @State private var dragBaseline: CGFloat?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VocaMetrics.related) {
+            GeometryReader { proxy in
+                let width = proxy.size.width
+
+                ZStack(alignment: .bottom) {
+                    destinationCard
+                        .padding(.horizontal, 4)
+                        .opacity(0.45 + progress * 0.55)
+
+                    vocaphoneCard
+                        .padding(.horizontal, 10)
+                        .scaleEffect(1 - progress * 0.035)
+                        .offset(x: progress * width * 0.72, y: -8)
+                        .shadow(
+                            color: .black.opacity(0.08 + progress * 0.08),
+                            radius: 8,
+                            x: -3,
+                            y: 3
+                        )
+
+                    Capsule()
+                        .fill(Color.brand.opacity(0.24))
+                        .frame(width: 44 + progress * 74, height: 8)
+                        .offset(x: -width * 0.22 + progress * width * 0.24, y: -16)
+
+                    ZStack {
+                        Circle()
+                            .fill(Color.brand)
+                            .frame(width: prominent ? 48 : 32, height: prominent ? 48 : 32)
+                            .shadow(color: .black.opacity(0.18), radius: 5, y: 2)
+                        Image(systemName: "hand.point.up.left.fill")
+                            .font((prominent ? Font.body : Font.caption).weight(.bold))
+                            .foregroundStyle(Color.onBrand)
+                    }
+                    .offset(x: -width * 0.31 + progress * width * 0.52, y: -26)
+                    .opacity(reduceMotion ? 0 : 1 - progress * 0.45)
+
+                    Capsule()
+                        .fill(Color.vocaPrimaryText.opacity(0.72))
+                        .frame(width: 82, height: 4)
+                        .padding(.bottom, 4)
+                }
+                .clipped()
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture(minimumDistance: 10)
+                        .onChanged { value in
+                            guard !reduceMotion,
+                                  abs(value.translation.width) > abs(value.translation.height)
+                            else { return }
+                            if dragBaseline == nil {
+                                interactionGeneration += 1
+                                dragBaseline = progress
+                            }
+                            let baseline = dragBaseline ?? progress
+                            progress = min(max(
+                                baseline + value.translation.width / max(width * 0.72, 1),
+                                0
+                            ), 1)
+                        }
+                        .onEnded { _ in
+                            guard dragBaseline != nil else { return }
+                            dragBaseline = nil
+                            withAnimation(.snappy(duration: 0.3)) {
+                                progress = progress >= 0.45 ? 1 : 0
+                            }
+                        }
+                )
+            }
+            .frame(height: prominent ? 258 : compact ? 150 : 174)
+            .allowsHitTesting(!prominent)
+
+            if prominent {
+                Label(
+                    "Preview only — do not swipe here",
+                    systemImage: "play.rectangle"
+                )
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .center)
+            } else {
+                HStack(spacing: 8) {
+                    instruction(number: 1, title: "Touch the home bar")
+                    Image(systemName: "arrow.right")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+                    instruction(number: 2, title: "Swipe right")
+                }
+            }
+
+            if !prominent {
+                HStack {
+                    Label(
+                        progress < 0.5 ? "Try the swipe in this demo" : "The previous app appears",
+                        systemImage: progress < 0.5 ? "hand.point.up.left" : "text.cursor"
+                    )
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.brand)
+                    .contentTransition(.symbolEffect(.replace))
+
+                    Spacer()
+
+                    Button("Replay swipe", action: replay)
+                        .font(.caption.weight(.semibold))
+                }
+            }
+        }
+        .task(id: replayID) {
+            await play(expectedGeneration: interactionGeneration)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            prominent
+                ? "Animation preview. Use the real iPhone home indicator at the bottom of the screen to return to the app where you were typing."
+                : "Interactive demonstration. Swipe right along the home indicator to return to the app where you were typing."
+        )
+        .accessibilityAction(named: "Replay swipe", replay)
+    }
+
+    private var destinationCard: some View {
+        RoundedRectangle(cornerRadius: VocaMetrics.cardRadius, style: .continuous)
+            .fill(Color.vocaRecessedSurface)
+            .overlay(alignment: .topLeading) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Label("Where you were typing", systemImage: "text.cursor")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Color.brand)
+                    HStack(spacing: 3) {
+                        Text("Your cursor is still here")
+                            .font(.caption)
+                        Rectangle()
+                            .fill(Color.brand)
+                            .frame(width: 2, height: 15)
+                    }
+                }
+                .padding(12)
+            }
+            .frame(height: prominent ? 232 : compact ? 132 : 156)
+    }
+
+    private var vocaphoneCard: some View {
+        RoundedRectangle(cornerRadius: VocaMetrics.cardRadius, style: .continuous)
+            .fill(Color.vocaSurface)
+            .overlay(
+                RoundedRectangle(cornerRadius: VocaMetrics.cardRadius, style: .continuous)
+                    .strokeBorder(Color.vocaBorder, lineWidth: 1)
+            )
+            .overlay(alignment: .topLeading) {
+                VStack(alignment: .leading, spacing: 10) {
+                    Label("vocaphone is recording", systemImage: "mic.fill")
+                        .font((prominent ? Font.subheadline : Font.caption).weight(.semibold))
+                        .foregroundStyle(Color.vocaRecording)
+                    HStack(spacing: 4) {
+                        ForEach(0..<8, id: \.self) { index in
+                            Capsule()
+                                .fill(Color.vocaRecording.opacity(0.55))
+                                .frame(width: 3, height: CGFloat(7 + (index % 4) * 4))
+                        }
+                    }
+                }
+                .padding(12)
+            }
+            .frame(height: prominent ? 194 : compact ? 112 : 136)
+    }
+
+    private func instruction(number: Int, title: String) -> some View {
+        HStack(spacing: 5) {
+            Text("\(number)")
+                .font(.caption2.weight(.bold).monospacedDigit())
+                .foregroundStyle(Color.onBrand)
+                .frame(width: 20, height: 20)
+                .background(Color.brand, in: Circle())
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @MainActor
+    private func replay() {
+        interactionGeneration += 1
+        replayID += 1
+    }
+
+    private func play(expectedGeneration: Int) async {
+        if reduceMotion {
+            progress = 1
+            return
+        }
+
+        progress = 0
+        try? await Task.sleep(for: .milliseconds(380))
+        guard !Task.isCancelled, expectedGeneration == interactionGeneration else { return }
+        withAnimation(.smooth(duration: 0.9)) { progress = 1 }
+    }
+}
+
+#if DEBUG
+
+#Preview("Swipe back coach") {
+    SwipeBackCoach(reduceMotion: false)
+        .padding()
+        .background(Color.vocaCanvas)
+}
+#endif

--- a/ios/VocaPhoneApp/App/VocaPhoneApp.swift
+++ b/ios/VocaPhoneApp/App/VocaPhoneApp.swift
@@ -1,7 +1,62 @@
 import SwiftUI
+import UIKit
+
+/// UIKit delivers the completion handler for a background `URLSession` here.
+/// The session delegate calls it only after all queued download events have
+/// been handed back to the app.
+final class ModelDownloadBackgroundEvents: @unchecked Sendable {
+    static let shared = ModelDownloadBackgroundEvents()
+
+    private final class HandlerBox: @unchecked Sendable {
+        let handler: () -> Void
+
+        init(_ handler: @escaping () -> Void) {
+            self.handler = handler
+        }
+    }
+
+    private let lock = NSLock()
+    private var handlers: [String: HandlerBox] = [:]
+
+    private init() {}
+
+    func register(identifier: String, completion: @escaping () -> Void) {
+        lock.lock()
+        handlers[identifier] = HandlerBox(completion)
+        lock.unlock()
+    }
+
+    func finish(identifier: String) {
+        lock.lock()
+        let handler = handlers.removeValue(forKey: identifier)
+        lock.unlock()
+        guard let handler else { return }
+        DispatchQueue.main.async {
+            handler.handler()
+        }
+    }
+}
+
+final class VocaPhoneAppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        handleEventsForBackgroundURLSession identifier: String,
+        completionHandler: @escaping () -> Void
+    ) {
+        guard identifier == LocalModelManager.backgroundDownloadSessionIdentifier else {
+            completionHandler()
+            return
+        }
+        ModelDownloadBackgroundEvents.shared.register(
+            identifier: identifier,
+            completion: completionHandler
+        )
+    }
+}
 
 @main
 struct VocaPhoneApp: App {
+    @UIApplicationDelegateAdaptor(VocaPhoneAppDelegate.self) private var appDelegate
     @Environment(\.scenePhase) private var scenePhase
     @State private var coordinator = RecordingCoordinator()
 

--- a/ios/VocaPhoneApp/Models/LocalModelManager.swift
+++ b/ios/VocaPhoneApp/Models/LocalModelManager.swift
@@ -6,6 +6,14 @@ import Observation
 @MainActor
 @Observable
 final class LocalModelManager {
+    /// A background `URLSession` is identified by the containing app, not by a
+    /// particular SwiftUI screen. Keeping this stable lets iOS own the active
+    /// transfer while VocaPhone is suspended and reconnect the session when the
+    /// app is awakened for background events.
+    nonisolated static var backgroundDownloadSessionIdentifier: String {
+        "\(Bundle.main.bundleIdentifier ?? "com.vocahq.vocaphone").model-downloads"
+    }
+
     private(set) var downloadedModelIDs: Set<String> = []
     private(set) var downloadingModelID: String?
     private(set) var progress: Double = 0
@@ -49,6 +57,33 @@ final class LocalModelManager {
     /// The sherpa load currently running, so a second request waits for it
     /// instead of building a second ONNX graph beside the first.
     private var sherpaLoad: Task<SherpaRecognizer, Error>?
+    /// Download ownership belongs to the manager rather than the picker view.
+    /// SwiftUI is free to recreate either onboarding or Settings while a model
+    /// is downloading; a view-local task handle made their Cancel buttons lose
+    /// the operation they were meant to stop.
+    @ObservationIgnored private var modelDownloadTask: Task<Void, Never>?
+
+    private static let backgroundDownloadDelegate = FileDownloadDelegate()
+    private static let backgroundDownloadSession: URLSession = {
+        let configuration = URLSessionConfiguration.background(
+            withIdentifier: backgroundDownloadSessionIdentifier
+        )
+        configuration.waitsForConnectivity = true
+        configuration.timeoutIntervalForRequest = 15 * 60
+        configuration.timeoutIntervalForResource = 24 * 60 * 60
+        configuration.sessionSendsLaunchEvents = true
+        configuration.isDiscretionary = false
+        // Model downloads are explicitly user-initiated. Low Data Mode and an
+        // expensive connection should not silently pause a download the user
+        // has already chosen to make.
+        configuration.allowsExpensiveNetworkAccess = true
+        configuration.allowsConstrainedNetworkAccess = true
+        return URLSession(
+            configuration: configuration,
+            delegate: backgroundDownloadDelegate,
+            delegateQueue: nil
+        )
+    }()
     private var modelsDirectory: URL? {
         FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
             .first?
@@ -62,6 +97,9 @@ final class LocalModelManager {
     }
 
     init() {
+        // Recreate the session at launch so iOS can reconnect any background
+        // events belonging to the stable identifier above.
+        _ = Self.backgroundDownloadSession
         refresh()
     }
 
@@ -188,27 +226,31 @@ final class LocalModelManager {
     /// every byte cross back through the main actor before it could be written.
     private final class FileDownloadDelegate: NSObject, URLSessionDownloadDelegate,
         @unchecked Sendable {
-        private let progressHandler: @Sendable (Int64) -> Void
-        private let lock = NSLock()
-        private var task: URLSessionDownloadTask?
-        private var continuation: CheckedContinuation<(URL, URLResponse), Error>?
-        private var lastReportedBytes: Int64 = 0
-
-        init(progressHandler: @escaping @Sendable (Int64) -> Void) {
-            self.progressHandler = progressHandler
+        private struct Transfer {
+            let task: URLSessionDownloadTask
+            let continuation: CheckedContinuation<(URL, URLResponse), Error>
+            let progressHandler: @Sendable (Int64) -> Void
+            var lastReportedBytes: Int64 = 0
         }
+
+        private let lock = NSLock()
+        private var transfers: [Int: Transfer] = [:]
 
         func start(
             session: URLSession,
-            request: URLRequest
+            request: URLRequest,
+            progressHandler: @escaping @Sendable (Int64) -> Void
         ) async throws -> (URL, URLResponse) {
             try await withTaskCancellationHandler(operation: {
                 try await withCheckedThrowingContinuation {
                     (continuation: CheckedContinuation<(URL, URLResponse), Error>) in
                     lock.lock()
-                    self.continuation = continuation
                     let task = session.downloadTask(with: request)
-                    self.task = task
+                    transfers[task.taskIdentifier] = Transfer(
+                        task: task,
+                        continuation: continuation,
+                        progressHandler: progressHandler
+                    )
                     let isCancelled = Task.isCancelled
                     lock.unlock()
 
@@ -225,9 +267,9 @@ final class LocalModelManager {
 
         func cancel() {
             lock.lock()
-            let task = self.task
+            let tasks = transfers.values.map(\.task)
             lock.unlock()
-            task?.cancel()
+            tasks.forEach { $0.cancel() }
         }
 
         func urlSession(
@@ -237,7 +279,7 @@ final class LocalModelManager {
             totalBytesWritten: Int64,
             totalBytesExpectedToWrite: Int64
         ) {
-            report(totalBytesWritten)
+            report(totalBytesWritten, taskIdentifier: downloadTask.taskIdentifier)
         }
 
         func urlSession(
@@ -245,14 +287,25 @@ final class LocalModelManager {
             downloadTask: URLSessionDownloadTask,
             didFinishDownloadingTo location: URL
         ) {
-            report(downloadTask.countOfBytesReceived)
+            let taskIdentifier = downloadTask.taskIdentifier
+            guard isTracking(taskIdentifier) else {
+                // A transfer may finish after iOS relaunched the process. Its
+                // original continuation no longer exists, so ignore this
+                // system-owned temporary file rather than allowing the stale
+                // callback to complete a newer model file.
+                return
+            }
+            report(downloadTask.countOfBytesReceived, taskIdentifier: taskIdentifier)
             let persistentLocation = FileManager.default.temporaryDirectory
                 .appendingPathComponent("vocaphone-download-\(UUID().uuidString)")
             do {
                 try FileManager.default.moveItem(at: location, to: persistentLocation)
-                finish(.success((persistentLocation, downloadTask.response ?? URLResponse())))
+                finish(
+                    taskIdentifier: taskIdentifier,
+                    result: .success((persistentLocation, downloadTask.response ?? URLResponse()))
+                )
             } catch {
-                finish(.failure(error))
+                finish(taskIdentifier: taskIdentifier, result: .failure(error))
             }
         }
 
@@ -262,27 +315,43 @@ final class LocalModelManager {
             didCompleteWithError error: Error?
         ) {
             guard let error else { return }
-            finish(.failure(error))
+            finish(taskIdentifier: task.taskIdentifier, result: .failure(error))
         }
 
-        private func report(_ totalBytesWritten: Int64) {
+        func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+            guard let identifier = session.configuration.identifier else { return }
+            ModelDownloadBackgroundEvents.shared.finish(identifier: identifier)
+        }
+
+        private func isTracking(_ taskIdentifier: Int) -> Bool {
             lock.lock()
-            let shouldReport = totalBytesWritten > lastReportedBytes
-            lastReportedBytes = max(lastReportedBytes, totalBytesWritten)
+            let isTracking = transfers[taskIdentifier] != nil
+            lock.unlock()
+            return isTracking
+        }
+
+        private func report(_ totalBytesWritten: Int64, taskIdentifier: Int) {
+            lock.lock()
+            guard var transfer = transfers[taskIdentifier] else {
+                lock.unlock()
+                return
+            }
+            let shouldReport = totalBytesWritten > transfer.lastReportedBytes
+            transfer.lastReportedBytes = max(transfer.lastReportedBytes, totalBytesWritten)
+            transfers[taskIdentifier] = transfer
+            let progressHandler = transfer.progressHandler
             lock.unlock()
             if shouldReport { progressHandler(totalBytesWritten) }
         }
 
-        private func finish(_ result: Result<(URL, URLResponse), Error>) {
+        private func finish(
+            taskIdentifier: Int,
+            result: Result<(URL, URLResponse), Error>
+        ) {
             lock.lock()
-            guard let continuation else {
-                lock.unlock()
-                return
-            }
-            self.continuation = nil
-            task = nil
+            let transfer = transfers.removeValue(forKey: taskIdentifier)
             lock.unlock()
-            continuation.resume(with: result)
+            transfer?.continuation.resume(with: result)
         }
     }
 
@@ -589,6 +658,37 @@ final class LocalModelManager {
         }
     }
 
+    /// Starts a model download whose lifetime is independent of the SwiftUI
+    /// view that initiated it. Both onboarding and Settings use this entry
+    /// point, so navigating, backgrounding, or a view refresh cannot detach the
+    /// Cancel button from the active operation.
+    func startDownload(
+        _ descriptor: LocalModelDescriptor,
+        onCompletion: @escaping @MainActor () -> Void = {}
+    ) {
+        guard !isInert, modelDownloadTask == nil, downloadingModelID == nil else { return }
+        modelDownloadTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.modelDownloadTask = nil
+                onCompletion()
+            }
+            do {
+                try await self.download(descriptor)
+            } catch {
+                // `download` publishes either the actionable error or the
+                // normal cancellation message used by both picker surfaces.
+            }
+        }
+    }
+
+    func cancelDownload() {
+        guard modelDownloadTask != nil || downloadingModelID != nil else { return }
+        message = "Canceling model download…"
+        Self.backgroundDownloadDelegate.cancel()
+        modelDownloadTask?.cancel()
+    }
+
     /// A failed download that failed its integrity check is worth telling apart
     /// from one that simply could not finish: the first means a pinned digest no
     /// longer matches what the host serves, which is a supply-chain signal
@@ -733,7 +833,7 @@ final class LocalModelManager {
         for attempt in 1...maxAttempts {
             try Task.checkCancellation()
             let generation = await progressTracker.beginFile(expectedBytes: expectedBytes)
-            let delegate = FileDownloadDelegate { [weak self] bytesWritten in
+            let progressHandler: @Sendable (Int64) -> Void = { [weak self] bytesWritten in
                 Task { @MainActor [weak self] in
                     guard let value = await progressTracker.updateFile(
                         bytesWritten: bytesWritten,
@@ -742,29 +842,15 @@ final class LocalModelManager {
                     self?.progress = value
                 }
             }
-            let configuration = URLSessionConfiguration.default
-            configuration.waitsForConnectivity = true
-            configuration.timeoutIntervalForRequest = 15 * 60
-            configuration.timeoutIntervalForResource = 24 * 60 * 60
-            // Model downloads are explicitly user-initiated. Do not let Low
-            // Data Mode or the system's expensive-network policy silently defer
-            // or suspend a multi-hundred-megabyte download.
-            configuration.allowsExpensiveNetworkAccess = true
-            configuration.allowsConstrainedNetworkAccess = true
-            let session = URLSession(
-                configuration: configuration,
-                delegate: delegate,
-                delegateQueue: nil
-            )
 
             do {
                 var request = URLRequest(url: url)
                 request.timeoutInterval = 15 * 60
-                let (temporaryFile, response) = try await delegate.start(
-                    session: session,
-                    request: request
+                let (temporaryFile, response) = try await Self.backgroundDownloadDelegate.start(
+                    session: Self.backgroundDownloadSession,
+                    request: request,
+                    progressHandler: progressHandler
                 )
-                defer { session.invalidateAndCancel() }
                 try Task.checkCancellation()
                 guard let httpResponse = response as? HTTPURLResponse,
                       200..<300 ~= httpResponse.statusCode
@@ -779,7 +865,6 @@ final class LocalModelManager {
                 progress = await progressTracker.completeFile(generation: generation)
                 return target
             } catch {
-                session.invalidateAndCancel()
                 progress = await progressTracker.resetFile(generation: generation)
                 guard attempt < maxAttempts, isRetryableDownloadError(error) else {
                     throw error

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -286,6 +286,7 @@ final class RecordingCoordinator {
     }
 
     init() {
+        KeyboardPreferences.migrateKeyboardPracticeIfNeeded()
         localModels = LocalModelManager()
         // A process exit can leave an otherwise valid-looking availability
         // marker behind. The new app process is not warm until it arms audio.

--- a/ios/VocaPhoneApp/Telemetry/UsageReportingViews.swift
+++ b/ios/VocaPhoneApp/Telemetry/UsageReportingViews.swift
@@ -1,39 +1,109 @@
 import SwiftUI
 
-/// The onboarding step that asks.
-///
-/// Deliberately placed at the end of guided setup, after the user has a working
-/// transcript rather than while they are still deciding whether the app is worth
-/// their time. Both buttons carry the same weight: no greyed-out decline, and
-/// nothing that makes saying no look like a mistake. The controls are on this
-/// screen rather than behind a link, because a notice whose switch lives
-/// somewhere else is not a choice.
+/// The optional onboarding choice shown after dictation is already working.
+/// This is a card rather than a `Section`: setup lives in a ScrollView, and a
+/// list-only section there loses its hierarchy and shrinks the decision buttons
+/// to their labels. Both choices remain equally prominent and full width.
 struct UsageReportingSetupSection: View {
     let onDecision: (Bool) -> Void
 
     @State private var isShowingPayload = false
+    @State private var isShowingDetails = false
 
     var body: some View {
-        Section {
-            Button(UsageReportingCopy.turnOn) { onDecision(true) }
-                .brandProminentButton()
-                .listRowSeparator(.hidden)
+        VocaCard(padding: VocaMetrics.padding) {
+            VStack(alignment: .leading, spacing: VocaMetrics.padding) {
+                HStack(alignment: .firstTextBaseline) {
+                    Label(UsageReportingCopy.title, systemImage: "wrench.and.screwdriver.fill")
+                        .font(.title3.weight(.bold))
+                    Spacer(minLength: VocaMetrics.related)
+                    Text("Optional")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(Color.brand)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(
+                            Color.brand.opacity(0.12),
+                            in: Capsule()
+                        )
+                }
 
-            Button(UsageReportingCopy.notNow) { onDecision(false) }
-                .listRowSeparator(.hidden)
+                Text("Share anonymous setup and dictation reliability counters with VocaHQ.")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
 
-            Button(UsageReportingCopy.seeWhatIsSent) { isShowingPayload = true }
-                .font(.subheadline)
-        } header: {
-            Text(UsageReportingCopy.title)
-        } footer: {
-            VStack(alignment: .leading, spacing: VocaMetrics.related) {
-                Text(UsageReportingCopy.whatIsSent)
-                Text(UsageReportingCopy.whatIsNeverSent)
-                Text(UsageReportingCopy.changeLater)
+                Label(
+                    "Never your audio, transcripts, typed text, gateway address, or an identifier.",
+                    systemImage: "lock.shield.fill"
+                )
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Color.brand)
+                .fixedSize(horizontal: false, vertical: true)
+
+                ViewThatFits(in: .horizontal) {
+                    HStack(spacing: VocaMetrics.related) {
+                        decisionButton(
+                            UsageReportingCopy.turnOn,
+                            symbol: "checkmark",
+                            enabled: true
+                        )
+                        decisionButton(
+                            UsageReportingCopy.notNow,
+                            symbol: "xmark",
+                            enabled: false
+                        )
+                    }
+
+                    VStack(spacing: VocaMetrics.related) {
+                        decisionButton(
+                            UsageReportingCopy.turnOn,
+                            symbol: "checkmark",
+                            enabled: true
+                        )
+                        decisionButton(
+                            UsageReportingCopy.notNow,
+                            symbol: "xmark",
+                            enabled: false
+                        )
+                    }
+                }
+
+                DisclosureGroup("Privacy details", isExpanded: $isShowingDetails) {
+                    VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                        Text(UsageReportingCopy.whatIsSent)
+                        Text(UsageReportingCopy.whatIsNeverSent)
+                        Text(UsageReportingCopy.changeLater)
+                    }
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .padding(.top, VocaMetrics.related)
+                }
+                .font(.subheadline.weight(.semibold))
+
+                Button { isShowingPayload = true } label: {
+                    Label(UsageReportingCopy.seeWhatIsSent, systemImage: "doc.text.magnifyingglass")
+                        .frame(maxWidth: .infinity, minHeight: VocaMetrics.minimumTarget)
+                }
+                .font(.subheadline.weight(.semibold))
             }
         }
         .sheet(isPresented: $isShowingPayload) { PendingPayloadSheet() }
+    }
+
+    private func decisionButton(
+        _ title: String,
+        symbol: String,
+        enabled: Bool
+    ) -> some View {
+        Button {
+            onDecision(enabled)
+        } label: {
+            Label(title, systemImage: symbol)
+                .frame(maxWidth: .infinity, minHeight: VocaMetrics.minimumTarget)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.large)
     }
 }
 

--- a/ios/VocaPhoneKeyboard/DictationPresentation.swift
+++ b/ios/VocaPhoneKeyboard/DictationPresentation.swift
@@ -320,23 +320,24 @@ extension DictationBarModel {
     }
 
     private static func waitingForField(_ context: DictationContext) -> DictationBarModel {
-        DictationBarModel(
-            title: "Waiting for the original field",
-            body: .message(
-                quoted(context.transcript) ?? "Return to that field, or insert it here."
-            ),
+        let detail = quoted(context.transcript).map {
+            $0 + " This is a different text field from the one where you started."
+        } ?? "Go back to the field you dictated for, or insert the text in this field."
+        return DictationBarModel(
+            title: "Your text is ready",
+            body: .message(detail),
             accent: .working,
             pulse: .steady,
             primary: DictationButton(
-                title: "Insert here",
+                title: "Insert in this field",
                 symbol: "text.badge.plus",
                 action: .insertHere,
-                hint: "Inserts the waiting transcript into this field instead."
+                hint: "Inserts the waiting transcript at the cursor in this field."
             ),
             secondaries: [.cancel],
             showsElapsedTime: false,
             isExpanded: true,
-            announcement: "Waiting for the field this was dictated for"
+            announcement: "Text ready in a different field. Return to the original field or insert in this field."
         )
     }
 

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -711,6 +711,14 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             try store.save(record)
             try record.transition(to: .completed)
             try store.save(record)
+            // A keyboard-started dictation inside vocaphone's own field is the
+            // one onboarding exercise that proves the whole loop: Dictate,
+            // record, transcribe and direct insertion. Do not set this for
+            // keyboard sessions started in another app or for the app's
+            // diagnostic microphone test.
+            if record.startedInContainingApp == true, record.sourceDocumentID != "in-app-test" {
+                KeyboardPreferences.hasCompletedKeyboardPractice = true
+            }
             DiagnosticLog.record(.insertionCompleted)
             activeSessionID = nil
             sessionTargetDocumentID = nil

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -251,7 +251,22 @@ enum KeyboardPreferences {
     static let recordingSoundsKey = "recordingSoundsEnabled"
     static let containingAppForegroundKey = "containingAppForeground"
     static let setupCompletedKey = "setupCompleted"
+    /// The exact first-run page to restore if iOS terminates the app while the
+    /// user is in Settings. Setup is mandatory, so a relaunch must continue the
+    /// task instead of replaying Welcome or falling through to Home.
+    static let onboardingStageKey = "onboardingStage"
+    /// Set before onboarding opens iOS Settings for the keyboard. Unlike view
+    /// state, this survives iOS reclaiming the app while Settings is in front,
+    /// so the first return can reveal the confirmation action immediately.
+    static let keyboardSettingsRoundTripKey = "keyboardSettingsRoundTripStarted"
     static let firstDictationKey = "hasCompletedFirstDictation"
+    /// Separate from the first transcript milestone: this proves the user has
+    /// seen a transcript make the complete trip through the keyboard and into a
+    /// field hosted by vocaphone.
+    static let keyboardPracticeKey = "hasCompletedKeyboardPractice"
+    /// Lets an upgrade distinguish an existing first transcript from a new user
+    /// completing a diagnostic microphone test after this key was introduced.
+    static let keyboardPracticeMigrationKey = "hasMigratedKeyboardPractice"
     static let modelLanguagesKey = "gatewayModelLanguages"
     static let modelDetectsLanguageKey = "gatewayModelDetectsLanguage"
     static let recentLanguagesKey = "recentTranscriptionLanguages"
@@ -483,9 +498,8 @@ enum KeyboardPreferences {
         set { defaults?.set(newValue, forKey: containingAppForegroundKey) }
     }
 
-    /// Set when the user leaves guided setup, so it opens once rather than on
-    /// every launch. Whether setup is actually finished is re-derived from the
-    /// system each time; this only records that the screen has been seen.
+    /// Set only after every required setup proof and the real keyboard practice
+    /// insertion have succeeded. It is no longer a dismiss/seen flag.
     static var setupCompleted: Bool {
         get { defaults?.bool(forKey: setupCompletedKey) ?? false }
         set { defaults?.set(newValue, forKey: setupCompletedKey) }
@@ -496,6 +510,24 @@ enum KeyboardPreferences {
     static var hasCompletedFirstDictation: Bool {
         get { defaults?.bool(forKey: firstDictationKey) ?? false }
         set { defaults?.set(newValue, forKey: firstDictationKey) }
+    }
+
+    /// A successful keyboard insertion into vocaphone's own practice field.
+    /// This powers the stronger onboarding confirmation without changing the
+    /// existing first-transcript activation milestone.
+    static var hasCompletedKeyboardPractice: Bool {
+        get { defaults?.bool(forKey: keyboardPracticeKey) ?? false }
+        set { defaults?.set(newValue, forKey: keyboardPracticeKey) }
+    }
+
+    /// Existing users already proved a working transcript before the guided
+    /// keyboard exercise existed. Preserve that experience on upgrade, but run
+    /// the migration once so a later in-app diagnostic recording cannot satisfy
+    /// the new keyboard-practice proof by accident.
+    static func migrateKeyboardPracticeIfNeeded() {
+        guard defaults?.bool(forKey: keyboardPracticeMigrationKey) != true else { return }
+        defaults?.set(hasCompletedFirstDictation, forKey: keyboardPracticeKey)
+        defaults?.set(true, forKey: keyboardPracticeMigrationKey)
     }
 
     static var microphonePreference: MicrophonePreference {

--- a/ios/VocaPhoneTests/DictationPresentationTests.swift
+++ b/ios/VocaPhoneTests/DictationPresentationTests.swift
@@ -140,8 +140,16 @@ struct DictationPresentationTests {
 
     @Test func aStrandedTranscriptCanBeRedirectedToTheCurrentField() {
         let model = Self.model(.targetContextChanged, transcript: "Redirect me")
+        #expect(model.title == "Your text is ready")
         #expect(model.primary.action == .insertHere)
-        #expect(model.body == .message("“Redirect me”"))
+        #expect(model.primary.title == "Insert in this field")
+        #expect(model.body == .message(
+            "“Redirect me” This is a different text field from the one where you started."
+        ))
+        #expect(
+            model.announcement
+                == "Text ready in a different field. Return to the original field or insert in this field."
+        )
     }
 
     @Test func elapsedTimeReadsAsMinutesAndSeconds() {

--- a/ios/VocaPhoneTests/KeyboardHandoffPresentationTests.swift
+++ b/ios/VocaPhoneTests/KeyboardHandoffPresentationTests.swift
@@ -1,0 +1,79 @@
+import Testing
+
+@MainActor
+struct KeyboardHandoffPresentationTests {
+    private func record(
+        state: SessionState,
+        startedInContainingApp: Bool? = false,
+        sourceDocumentID: String? = nil,
+        processingLocation: SessionProcessingLocation? = .gateway,
+        transcript: String? = nil
+    ) -> SessionRecord {
+        var record = SessionRecord(
+            state: state,
+            sourceDocumentID: sourceDocumentID
+        )
+        record.startedInContainingApp = startedInContainingApp
+        record.processingLocation = processingLocation
+        record.transcript = transcript
+        return record
+    }
+
+    @Test func externalRecordingShowsTheRealReturnGestureAndFinishAction() {
+        let presentation = KeyboardHandoffPresentation.make(record(state: .recording))
+
+        #expect(presentation?.kind == .recording)
+        #expect(presentation?.title == "Recording")
+        #expect(presentation?.primaryAction == .finish)
+        #expect(presentation?.primaryTitle == "Finish & transcribe here")
+        #expect(presentation?.detail.contains("Swipe back") == true)
+    }
+
+    @Test func processingKeepsTheHandoffStoryAndNamesTheConfirmedRoute() {
+        let presentation = KeyboardHandoffPresentation.make(
+            record(state: .transcribing, processingLocation: .onDevice)
+        )
+
+        #expect(presentation?.kind == .processing)
+        #expect(presentation?.title == "Transcribing on this iPhone")
+        #expect(presentation?.primaryAction == KeyboardHandoffPresentation.PrimaryAction.none)
+    }
+
+    @Test func aReadyTranscriptExplainsTheDifferentFieldChoice() {
+        let presentation = KeyboardHandoffPresentation.make(
+            record(
+                state: .targetContextChanged,
+                transcript: "A preserved transcript"
+            )
+        )
+
+        #expect(presentation?.kind == .ready)
+        #expect(presentation?.title == "Your text is ready")
+        #expect(presentation?.detail.contains("original") == true)
+        #expect(presentation?.detail.contains("Insert in this field") == true)
+    }
+
+    @Test func inAppPracticeNeverShowsTheExternalHandoff() {
+        #expect(!KeyboardHandoffPresentation.shouldPresent(
+            record(state: .recording, startedInContainingApp: true)
+        ))
+        #expect(!KeyboardHandoffPresentation.shouldPresent(
+            record(state: .recording, sourceDocumentID: "in-app-test")
+        ))
+    }
+
+    @Test func recoverableFailurePreservesTheRetryPath() {
+        var failedRecord = record(state: .uploadFailedRecoverable)
+        failedRecord.error = SessionFailure(
+            code: "timeout",
+            message: "The gateway did not answer in time.",
+            recoverable: true
+        )
+        let presentation = KeyboardHandoffPresentation.make(failedRecord)
+
+        #expect(presentation?.kind == .recoverableFailure)
+        #expect(presentation?.primaryAction == .retry)
+        #expect(presentation?.primaryTitle == "Retry transcript")
+        #expect(presentation?.detail == "The gateway did not answer in time.")
+    }
+}

--- a/ios/VocaPhoneTests/OnboardingPresentationTests.swift
+++ b/ios/VocaPhoneTests/OnboardingPresentationTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+
+@MainActor
+struct OnboardingPresentationTests {
+    private var readyGateway: TranscriptionSourceStatus {
+        var source = TranscriptionSourceStatus()
+        source.selected = .gateway
+        source.gatewayAddress = "https://dictation.example.com"
+        source.isGatewayReady = true
+        return source
+    }
+
+    private var readyToDictate: SetupStatus {
+        SetupStatus(
+            source: readyGateway,
+            microphone: .granted,
+            keyboard: .ready(lastSeenAt: Date()),
+            hasDictatedOnce: false
+        )
+    }
+
+    @Test func aFreshInstallStartsWithTheProductExplanation() {
+        #expect(
+            OnboardingPresentation.initialStage(
+                setupCompleted: false,
+                persistedStage: nil,
+                status: SetupStatus(),
+                hasCompletedKeyboardPractice: false
+            ) == .welcome
+        )
+    }
+
+    @Test func relaunchKeepsAnUnfinishedTeachingPage() {
+        #expect(
+            OnboardingPresentation.initialStage(
+                setupCompleted: false,
+                persistedStage: .handoff,
+                status: SetupStatus(),
+                hasCompletedKeyboardPractice: false
+            ) == .handoff
+        )
+    }
+
+    @Test func relaunchAfterSettingsUsesLiveProofInsteadOfReplayingWelcome() {
+        var keyboardMissing = readyToDictate
+        keyboardMissing.keyboard = .addedButNeverRun
+
+        #expect(
+            OnboardingPresentation.initialStage(
+                setupCompleted: false,
+                persistedStage: .keyboard,
+                status: keyboardMissing,
+                hasCompletedKeyboardPractice: false
+            ) == .keyboard
+        )
+        #expect(
+            OnboardingPresentation.initialStage(
+                setupCompleted: false,
+                persistedStage: .keyboard,
+                status: readyToDictate,
+                hasCompletedKeyboardPractice: false
+            ) == .practice
+        )
+    }
+
+    @Test func keyboardEnableAndSwitchAreSeparateResumableSteps() {
+        var keyboardMissing = readyToDictate
+        keyboardMissing.keyboard = .addedButNeverRun
+
+        #expect(OnboardingPresentation.nextStage(after: .keyboard) == .keyboardSwitch)
+        #expect(OnboardingPresentation.previousStage(before: .practice) == .keyboardSwitch)
+        #expect(
+            OnboardingPresentation.initialStage(
+                setupCompleted: false,
+                persistedStage: .keyboardSwitch,
+                status: keyboardMissing,
+                hasCompletedKeyboardPractice: false
+            ) == .keyboardSwitch
+        )
+        #expect(OnboardingStage.keyboard.requiredStepNumber == 3)
+        #expect(OnboardingStage.keyboardSwitch.requiredStepNumber == 4)
+        #expect(OnboardingStage.practice.requiredStepNumber == 5)
+    }
+
+    @Test func keyboardEnablementCannotAdvanceBeforeTheSettingsRoundTrip() {
+        var keyboardMissing = readyToDictate
+        keyboardMissing.keyboard = .addedButNeverRun
+
+        #expect(!OnboardingPresentation.canAdvanceFromKeyboardEnablement(
+            status: keyboardMissing,
+            returnedFromSettings: false
+        ))
+        #expect(OnboardingPresentation.canAdvanceFromKeyboardEnablement(
+            status: keyboardMissing,
+            returnedFromSettings: true
+        ))
+        #expect(OnboardingPresentation.canAdvanceFromKeyboardEnablement(
+            status: readyToDictate,
+            returnedFromSettings: false
+        ))
+    }
+
+    @Test func oldSetupLaterStateReentersMandatoryPractice() {
+        #expect(OnboardingPresentation.requiresFirstRunCover(
+            setupCompleted: true,
+            hasCompletedKeyboardPractice: false
+        ))
+        #expect(
+            OnboardingPresentation.initialStage(
+                setupCompleted: true,
+                persistedStage: .complete,
+                status: readyToDictate,
+                hasCompletedKeyboardPractice: false
+            ) == .practice
+        )
+        #expect(!OnboardingPresentation.requiresFirstRunCover(
+            setupCompleted: true,
+            hasCompletedKeyboardPractice: true
+        ))
+    }
+
+    @Test func aReturningUserResumesAtTheFirstMissingProof() {
+        var missingKeyboard = readyToDictate
+        missingKeyboard.keyboard = .addedButNeverRun
+
+        #expect(
+            OnboardingPresentation.resumeStage(
+                status: missingKeyboard,
+                hasCompletedKeyboardPractice: false
+            ) == .keyboard
+        )
+        #expect(
+            OnboardingPresentation.resumeStage(
+                status: readyToDictate,
+                hasCompletedKeyboardPractice: false
+            ) == .practice
+        )
+    }
+
+    @Test func completionRequiresTheKeyboardPracticeProof() {
+        #expect(
+            OnboardingPresentation.resumeStage(
+                status: readyToDictate,
+                hasCompletedKeyboardPractice: true
+            ) == .complete
+        )
+        #expect(
+            OnboardingPresentation.completedProofCount(
+                status: readyToDictate,
+                hasCompletedKeyboardPractice: false
+            ) == 3
+        )
+        #expect(
+            OnboardingPresentation.progress(
+                status: readyToDictate,
+                hasCompletedKeyboardPractice: true
+            ) == 1
+        )
+    }
+
+    @Test func educationalPagesDoNotPretendToBeSystemProofs() {
+        #expect(!OnboardingStage.welcome.showsProofProgress)
+        #expect(!OnboardingStage.handoff.showsProofProgress)
+        #expect(OnboardingStage.source.showsProofProgress)
+        #expect(!OnboardingStage.complete.showsProofProgress)
+    }
+}

--- a/ios/VocaPhoneTests/SetupStatusTests.swift
+++ b/ios/VocaPhoneTests/SetupStatusTests.swift
@@ -98,7 +98,7 @@ struct SetupStatusTests {
     @Test func theKeyboardListMatchesEntriesCarryingLayoutOptions() {
         let entries = [
             "en_US@sw=QWERTY;hw=Automatic",
-            "com.vocahq.vocaphone.keyboard@sw=QWERTY;hw=Automatic",
+            "\(AppConfiguration.keyboardBundleIdentifier)@sw=QWERTY;hw=Automatic",
         ]
 
         #expect(InstalledKeyboards.includesVocaPhone(entries) == true)

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -166,6 +166,10 @@ targets:
       # Guided setup decides what the app claims is done, and every signal it
       # reads can be undone from iOS Settings. The model behind it is pure.
       - path: VocaPhoneApp/App/SetupStatus.swift
+      - path: VocaPhoneApp/App/OnboardingPresentation.swift
+      # The external-dictation screen stays truthful through recording,
+      # processing, a ready transcript, and recoverable failures.
+      - path: VocaPhoneApp/App/KeyboardHandoffPresentation.swift
       # Which transcription route is selected, whether it is ready, and what the
       # interface is allowed to claim about where audio goes.
       - path: VocaPhoneApp/App/TranscriptionSourceStatus.swift


### PR DESCRIPTION
## Problem

The iOS setup flow was dense, could restart after a Settings round trip, and did not clearly teach keyboard switching, real dictation, or the bottom-edge return gesture. Model downloads also stopped when the app was suspended, and Cancel could lose its task when SwiftUI recreated the picker.

## Summary

- replace first-run setup with a mandatory, resumable, interactive onboarding flow
- separate keyboard enablement, keyboard switching, and real dictation practice
- add clearer cross-app handoff and different-field transcript recovery states
- keep model downloads running through an iOS background URL session
- move download cancellation into the shared model manager so onboarding and Settings behave consistently
- add presentation tests and previews

## Verification

- 469 iOS tests passed across 54 suites
- simulator build passed with production bundle and App Group configuration
- signed iPhone 14 Pro build succeeded
- onboarding, Full Access, keyboard switching, practice insertion, and handoff were exercised on device