### PR TITLE
Tag issues with android or ios from the App dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,6 +9,8 @@ body:
       value: |
         Leave out recordings, transcripts, tokens, and private hostnames.
         Security issues go through SECURITY.md or a private advisory, not this form.
+  # Heading "App" and these option strings are parsed by
+  # .github/workflows/label-issue-app.yml to apply the android or ios label.
   - type: dropdown
     id: app
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,6 +9,8 @@ body:
       value: |
         VocaPhone stays on-device by default and does not need an account.
         Leave out tokens, recordings, transcripts, and private hostnames.
+  # Heading "App" and these option strings are parsed by
+  # .github/workflows/label-issue-app.yml to apply the android or ios label.
   - type: dropdown
     id: app
     attributes:

--- a/.github/workflows/label-issue-app.yml
+++ b/.github/workflows/label-issue-app.yml
@@ -1,0 +1,104 @@
+name: Label issues by app
+
+# Issue forms can attach static labels (bug, enhancement) but not labels that
+# depend on a dropdown. This reads the required App field and adds android or
+# ios so the issues list filters without opening each report.
+#
+# The parser keys off the "App" heading and the option strings in
+# .github/ISSUE_TEMPLATE/{bug_report,feature_request}.yml. Keep those in sync.
+on:
+  issues:
+    types: [opened, edited]
+  # Merging this file, or a manual run, tags already-open issues.
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/label-issue-app.yml'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'issues' }}
+
+jobs:
+  label:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Tag the selected app
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE: ${{ github.event_name == 'issues' && github.event.issue.number || '' }}
+        run: |
+          set -euo pipefail
+
+          ensure_label() {
+            local name="$1" color="$2" desc="$3"
+            if gh api --silent "repos/${REPO}/labels/${name}" >/dev/null 2>&1; then
+              return 0
+            fi
+            if gh label create "$name" --repo "$REPO" --color "$color" --description "$desc"; then
+              return 0
+            fi
+            # A parallel run may have created it first.
+            gh api --silent "repos/${REPO}/labels/${name}" >/dev/null 2>&1
+          }
+
+          app_from_body() {
+            awk '
+              { gsub(/\r/, "") }
+              /^### App[[:space:]]*$/ { in_app = 1; next }
+              in_app && /^### / { exit }
+              in_app && NF {
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+                print
+                exit
+              }
+            '
+          }
+
+          label_issue() {
+            local number="$1"
+            local body app want drop current
+
+            body=$(gh issue view "$number" --repo "$REPO" --json body --jq -r .body)
+            app=$(printf '%s\n' "$body" | app_from_body)
+
+            case "$app" in
+              "Android app") want=android; drop=ios ;;
+              "iOS app") want=ios; drop=android ;;
+              *)
+                echo "Issue #${number}: App field is '${app:-<empty>}', skipping"
+                return 0
+                ;;
+            esac
+
+            current=$(gh issue view "$number" --repo "$REPO" --json labels --jq '[.labels[].name] | join("\n")')
+
+            if ! printf '%s\n' "$current" | grep -Fxq "$want"; then
+              gh issue edit "$number" --repo "$REPO" --add-label "$want"
+            fi
+            if printf '%s\n' "$current" | grep -Fxq "$drop"; then
+              gh issue edit "$number" --repo "$REPO" --remove-label "$drop"
+            fi
+
+            echo "Issue #${number}: labeled ${want}"
+          }
+
+          ensure_label android 3DDC84 "Android app"
+          ensure_label ios 007AFF "iOS app"
+
+          if [ "$EVENT_NAME" = "issues" ]; then
+            label_issue "$ISSUE"
+            exit 0
+          fi
+
+          gh issue list --repo "$REPO" --state open --limit 1000 --json number --jq '.[].number' \
+            | while IFS= read -r number; do
+                label_issue "$number"
+              done


### PR DESCRIPTION
## Summary

Issue forms already ask Android vs iOS, but GitHub can only attach static labels from a template (`bug`, `enhancement`). The App answer never made it onto the issues list.

A small workflow reads that dropdown and applies `android` or `ios`. Editing the App field swaps the label. Merging this file (or a manual run under Actions → Label issues by app) tags already-open issues that used the current form. Older free-form reports without the App field are left alone.

Filter after merge:

- https://github.com/VocaHQ/vocaphone/issues?q=is%3Aissue+label%3Aios
- https://github.com/VocaHQ/vocaphone/issues?q=is%3Aissue+label%3Aandroid

## Verification

- [x] `just ios ci` — no iOS changes
- [x] `just android ci` — no Android changes
- [x] Gateway changes: none
- [x] Physical-device test: not applicable
- [x] `actionlint` on `.github/workflows/label-issue-app.yml`
- [x] Parser checked against current open issues: form-filed reports match `Android app` / `iOS app`; pre-form issues are skipped

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for data-flow, permission, retention, or network changes — none of those changed; workflow has `issues: write` only and does not check out the repo