### PR TITLE
Let the app labeler read the issue body

### DIFF
--- a/.github/workflows/label-issue-app.yml
+++ b/.github/workflows/label-issue-app.yml
@@ -66,7 +66,7 @@ jobs:
             local number="$1"
             local body app want drop current
 
-            body=$(gh issue view "$number" --repo "$REPO" --json body --jq -r .body)
+            body=$(gh issue view "$number" --repo "$REPO" --json body --jq .body)
             app=$(printf '%s\n' "$body" | app_from_body)
 
             case "$app" in


### PR DESCRIPTION
## Summary

The merge run of Label issues by app failed with `accepts 1 arg(s), received 2`. `gh issue view --jq -r .body` is invalid: `--jq` already prints a raw string, and `-r` is then a second positional argument.

This drops `-r` so new issues get `android` / `ios`. Open form-filed issues were tagged from here in the meantime.

## Verification

- [x] `just ios ci` — no iOS changes
- [x] `just android ci` — no Android changes
- [x] Gateway changes: none
- [x] Physical-device test: not applicable
- [x] `gh issue view 149 --json body --jq -r .body` reproduces the error
- [x] `gh issue view 149 --json body --jq .body` returns the App field

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for data-flow, permission, retention, or network changes — n/a