### PR TITLE
docs: require Admin for App Store Connect API key

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -53,7 +53,7 @@ jobs:
           echo "APP_STORE_CONNECT_API_KEY, APP_STORE_CONNECT_API_KEY_ID, and"
           echo "APP_STORE_CONNECT_ISSUER_ID are not all set. Skipping the"
           echo "TestFlight upload. Create an App Store Connect API key with the"
-          echo "App Manager role (Users and Access → Integrations) and store"
+          echo "Admin role (Users and Access → Integrations) and store"
           echo "the .p8 body, Key ID, and Issuer ID as those three secrets."
           echo "See docs/releasing.md."
           if [[ "$GITHUB_REF" == refs/tags/ios/* ]]; then

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -127,7 +127,7 @@ iOS TestFlight (all three, or the macOS job never starts):
 | `APP_STORE_CONNECT_API_KEY_ID` | Key ID from Users and Access → Integrations |
 | `APP_STORE_CONNECT_ISSUER_ID` | Issuer ID on that same page |
 
-Create the key with the **App Manager** role so Xcode can mint a
+Create the key with the **Admin** role so Xcode can mint a
 cloud-managed Apple Distribution certificate and App Store profiles.
 
 `/build` on a pull request is unrelated: it makes an ad-hoc IPA for a

--- a/docs/testflight.md
+++ b/docs/testflight.md
@@ -142,7 +142,7 @@ Repository secrets (all three, or the macOS job never starts):
 | `APP_STORE_CONNECT_API_KEY_ID` | Key ID from Users and Access → Integrations |
 | `APP_STORE_CONNECT_ISSUER_ID` | Issuer ID on that same page |
 
-Create the key with the **App Manager** role so Xcode can mint a
+Create the key with the **Admin** role so Xcode can mint a
 cloud-managed Apple Distribution certificate and App Store profiles. An
 iOS-only drop without a tag is Actions → iOS TestFlight → Run workflow.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- The iOS TestFlight workflow archives unsigned, then asks Apple to mint an Apple Distribution cert and App Store profiles. That cloud-signing call needs an Admin team key. App Manager can upload a binary but cannot create those signing assets.
- The gate hint in `.github/workflows/ios-release.yml` and the secret setup notes in `docs/releasing.md` and `docs/testflight.md` said App Manager. They now say Admin.

## Verification

- [x] `just ios ci` (or note why not): docs and a skip-path echo only. No iOS code change.
- [x] `just android ci` (or note why not): no Android change.
- [x] Gateway changes: none
- [x] Physical-device test: not applicable

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for the API key role required by cloud signing

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b968fe2-77b9-4880-9396-b25398c8acc6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b968fe2-77b9-4880-9396-b25398c8acc6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

