### PR TITLE
ci: build TestFlight archives with Xcode 26

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -77,6 +77,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Select Xcode 26
+        run: |
+          set -euo pipefail
+          # macos-15 still defaults to Xcode 16.4 / iOS 18.5. App Store
+          # Connect rejects that SDK on export.
+          app="$(ls -d /Applications/Xcode_26*.app | sort -V | tail -1)"
+          sudo xcode-select -s "$app"
+          xcodebuild -version
+
       - name: Install xcodegen
         run: brew install xcodegen
 

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -82,7 +82,7 @@ jobs:
           set -euo pipefail
           # macos-15 still defaults to Xcode 16.4 / iOS 18.5. App Store
           # Connect rejects that SDK on export.
-          app="$(ls -d /Applications/Xcode_26*.app | sort -V | tail -1)"
+          app="$(printf '%s\n' /Applications/Xcode_26*.app | sort -V | tail -1)"
           sudo xcode-select -s "$app"
           xcodebuild -version
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -67,7 +67,7 @@ git tag ios/v1.0.21
 git push origin ios/v1.0.21
 ```
 
-`.github/workflows/ios-release.yml` archives on `macos-15` and uploads to
+`.github/workflows/ios-release.yml` archives on `macos-15` with Xcode 26 and uploads to
 App Store Connect / TestFlight when the three API key secrets are set. It
 never submits for App Review and never assigns the build to a TestFlight
 group. Check TestFlight first: if this `CURRENT_PROJECT_VERSION` is already


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Attempt 2 of the `ios/v1.0.22` TestFlight run got past cloud signing with the Admin key, then Apple rejected the IPA: it was built with the iOS 18.5 SDK (Xcode 16.4, the macos-15 default). Uploads now need the iOS 26 SDK / Xcode 26.
- `ios-release.yml` now selects the newest `Xcode_26*.app` on the image before archive and export. `docs/releasing.md` mentions that.

## Verification

- [x] `just ios ci` (or note why not): workflow select-Xcode step only. No app code change.
- [x] `just android ci` (or note why not): no Android change.
- [x] Gateway changes: none
- [x] Physical-device test: not applicable

After merge, re-run the `ios/v1.0.22` TestFlight job. Build 22 still has not reached App Store Connect.

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] No privacy or data-flow change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b968fe2-77b9-4880-9396-b25398c8acc6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b968fe2-77b9-4880-9396-b25398c8acc6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

