### PR TITLE
ios: speed up model downloads and stop onboarding claiming Full Access

### DIFF
--- a/ios/VocaPhoneApp/App/OnboardingPresentation.swift
+++ b/ios/VocaPhoneApp/App/OnboardingPresentation.swift
@@ -129,15 +129,28 @@ enum OnboardingPresentation {
         )) / Double(SetupStep.allCases.count)
     }
 
-    /// The containing app cannot query the Full Access switch. It may advance
-    /// only after an already-ready keyboard proves access, or after the user
-    /// returns from the Settings trip and explicitly confirms the switch is on.
-    /// The keyboard-switch page then performs the real extension-side proof.
+    /// The containing app cannot query the Full Access switch: only the
+    /// extension's own write proves it, and the extension cannot write until it
+    /// has run. So this page advances on the strongest thing iOS does expose —
+    /// whether vocaphone is in the user's keyboard list — and the keyboard
+    /// switch page that follows performs the real Full Access proof.
+    ///
+    /// It deliberately no longer advances on the user's say-so after a trip to
+    /// Settings. Returning from Settings says nothing about what was changed
+    /// there, and offering a button that asserted Full Access was on let someone
+    /// who had granted nothing walk past it.
     static func canAdvanceFromKeyboardEnablement(
         status: SetupStatus,
         returnedFromSettings: Bool
     ) -> Bool {
-        status.isSatisfied(.keyboard) || returnedFromSettings
+        if status.isSatisfied(.keyboard) { return true }
+        guard let isInstalled = status.isKeyboardInstalled else {
+            // iOS did not publish the keyboard list. Trapping the user on this
+            // page would be worse than letting them through to the page that
+            // does hold out for proof.
+            return returnedFromSettings
+        }
+        return isInstalled
     }
 
     static func previousStage(before stage: OnboardingStage) -> OnboardingStage? {

--- a/ios/VocaPhoneApp/App/SetupStatus.swift
+++ b/ios/VocaPhoneApp/App/SetupStatus.swift
@@ -140,6 +140,11 @@ struct SetupStatus: Equatable, Sendable {
     var source = TranscriptionSourceStatus()
     var microphone: MicrophoneAccess = .undetermined
     var keyboard: KeyboardSetupState = .notAdded
+    /// Whether vocaphone appears in the user's keyboard list, kept as its own
+    /// tri-state because `keyboard` folds "not added" and "iOS did not say"
+    /// together. Guided setup needs them apart: the first is something to fix,
+    /// the second is something we simply cannot check.
+    var isKeyboardInstalled: Bool?
     var hasDictatedOnce = false
 
     func isSatisfied(_ step: SetupStep) -> Bool {

--- a/ios/VocaPhoneApp/App/SetupView.swift
+++ b/ios/VocaPhoneApp/App/SetupView.swift
@@ -415,10 +415,14 @@ struct SetupView: View {
                     symbol: "arrow.right",
                     action: advance
                 )
-            } else if keyboardSettingsRoundTripStarted {
+            } else if status.isKeyboardInstalled == true {
+                // Being in the keyboard list is observable; Full Access is not.
+                // Say only the part we actually checked — the next page is what
+                // proves the rest.
+                CompletionNotice("vocaphone is in your keyboard list")
                 VocaCard(padding: VocaMetrics.padding) {
                     Label(
-                        "iOS confirms Full Access only after vocaphone opens as the keyboard. The next step performs that check.",
+                        "Full Access cannot be checked from here. iOS confirms it only once vocaphone opens as the keyboard, which the next step walks you through.",
                         systemImage: "checkmark.shield"
                     )
                     .font(.subheadline)
@@ -427,18 +431,52 @@ struct SetupView: View {
                 }
 
                 VocaPrimaryButton(
-                    title: "Full Access is on — continue",
-                    symbol: "checkmark.shield",
+                    title: "Continue to keyboard switch",
+                    symbol: "arrow.right",
+                    action: advance
+                )
+            } else if status.isKeyboardInstalled == nil, keyboardSettingsRoundTripStarted {
+                // iOS did not publish the keyboard list, so there is nothing to
+                // check against. Blocking here would strand the user.
+                VocaCard(padding: VocaMetrics.padding) {
+                    Label(
+                        "iOS did not report your keyboard list, so this cannot be confirmed here. The next step verifies Full Access for real.",
+                        systemImage: "questionmark.circle"
+                    )
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+
+                VocaPrimaryButton(
+                    title: "Continue to keyboard switch",
+                    symbol: "arrow.right",
                     action: advance
                 )
             } else {
                 Button(action: {}) {
-                    Label("Enable Full Access before continuing", systemImage: "lock.fill")
+                    Label("Add the keyboard to continue", systemImage: "lock.fill")
                         .frame(maxWidth: .infinity, minHeight: VocaMetrics.minimumTarget)
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.large)
                 .disabled(true)
+
+                if keyboardSettingsRoundTripStarted {
+                    Text("vocaphone is not in your keyboard list yet. In Settings, use Add New Keyboard to add it, then turn on Allow Full Access.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    // iOS can publish the keyboard list a moment behind the
+                    // change. Without this the page would look like a dead end
+                    // to someone who has in fact just added the keyboard.
+                    Button("Check again") {
+                        Task { await refreshAfterForegroundReturn() }
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .frame(maxWidth: .infinity, minHeight: VocaMetrics.minimumTarget)
+                }
             }
         }
     }
@@ -496,14 +534,16 @@ struct SetupView: View {
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity)
 
-                if case .seenWithoutFullAccess = status.keyboard {
-                    Button("Full Access is still off — review Settings") {
-                        keyboardSettingsRoundTripStarted = false
-                        stage = .keyboard
-                    }
-                    .font(.subheadline.weight(.semibold))
-                    .frame(maxWidth: .infinity, minHeight: VocaMetrics.minimumTarget)
+                // Always offer the way back. This page waits on the extension
+                // running, and a keyboard that was never added — or was removed
+                // again — will never make that happen, so a state-specific
+                // escape hatch left those users watching a spinner forever.
+                Button(keyboardSwitchReviewLabel) {
+                    keyboardSettingsRoundTripStarted = false
+                    stage = .keyboard
                 }
+                .font(.subheadline.weight(.semibold))
+                .frame(maxWidth: .infinity, minHeight: VocaMetrics.minimumTarget)
             }
         }
     }
@@ -697,6 +737,18 @@ struct SetupView: View {
                 }
             }
         }
+    }
+
+    /// Names the reason this page is still waiting, so the way back to the
+    /// Settings instructions describes the user's actual situation.
+    private var keyboardSwitchReviewLabel: String {
+        if status.isKeyboardInstalled == false {
+            return "vocaphone is not in your keyboard list — review Settings"
+        }
+        if case .seenWithoutFullAccess = status.keyboard {
+            return "Full Access is still off — review Settings"
+        }
+        return "Not working? Review the Settings steps"
     }
 
     private var keyboardWatchID: String {

--- a/ios/VocaPhoneApp/App/VocaPhoneApp.swift
+++ b/ios/VocaPhoneApp/App/VocaPhoneApp.swift
@@ -78,6 +78,12 @@ struct VocaPhoneApp: App {
                         // reliably has something to send. A deferred background
                         // task would usually wake to an empty queue.
                         Task { await Telemetry.shared.flush() }
+                        if phase == .background {
+                            // Hands any in-flight model download to the
+                            // background session, which is the only one the
+                            // system keeps running once we are suspended.
+                            LocalModelManager.enterBackground()
+                        }
                         return
                     }
                     Task {

--- a/ios/VocaPhoneApp/Models/LocalModelManager.swift
+++ b/ios/VocaPhoneApp/Models/LocalModelManager.swift
@@ -1,6 +1,7 @@
 import AVFAudio
 import Foundation
 import Observation
+import UIKit
 @preconcurrency import WhisperKit
 
 @MainActor
@@ -63,7 +64,39 @@ final class LocalModelManager {
     /// the operation they were meant to stop.
     @ObservationIgnored private var modelDownloadTask: Task<Void, Never>?
 
-    private static let backgroundDownloadDelegate = FileDownloadDelegate()
+    /// Downloads run on a foreground session while the app is in front, and are
+    /// handed to the background session only when the user leaves. Routing every
+    /// byte through `nsurlsessiond` costs real throughput, and the app is in
+    /// front for very nearly every download.
+    private static let downloadDelegate = FileDownloadDelegate()
+
+    /// How many of a model's small files are fetched side by side.
+    static let maxParallelTransfers = 4
+
+    /// Files at or above this size are fetched one at a time rather than
+    /// alongside their siblings, so the handful of very large weights in a model
+    /// never compete with each other for the link.
+    private static let largeFileThreshold: Int64 = 32 * 1024 * 1024
+
+    private static let foregroundDownloadSession: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.waitsForConnectivity = true
+        configuration.timeoutIntervalForRequest = 15 * 60
+        configuration.timeoutIntervalForResource = 24 * 60 * 60
+        configuration.allowsExpensiveNetworkAccess = true
+        configuration.allowsConstrainedNetworkAccess = true
+        configuration.httpMaximumConnectionsPerHost = maxParallelTransfers
+        // Model files are verified and stored by hand. Nothing this large has
+        // any business entering the shared URL cache on the way past.
+        configuration.urlCache = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        return URLSession(
+            configuration: configuration,
+            delegate: downloadDelegate,
+            delegateQueue: nil
+        )
+    }()
+
     private static let backgroundDownloadSession: URLSession = {
         let configuration = URLSessionConfiguration.background(
             withIdentifier: backgroundDownloadSessionIdentifier
@@ -80,10 +113,61 @@ final class LocalModelManager {
         configuration.allowsConstrainedNetworkAccess = true
         return URLSession(
             configuration: configuration,
-            delegate: backgroundDownloadDelegate,
+            delegate: downloadDelegate,
             delegateQueue: nil
         )
     }()
+
+    /// Holds the app awake just long enough to hand every in-flight transfer to
+    /// the background session. Without it the process can suspend mid-handoff
+    /// and the download is lost rather than continued.
+    private final class BackgroundAssertion: @unchecked Sendable {
+        private let lock = NSLock()
+        private var identifier: UIBackgroundTaskIdentifier = .invalid
+
+        @MainActor
+        func begin() {
+            let identifier = UIApplication.shared.beginBackgroundTask(
+                withName: "model-download-handoff"
+            ) { [weak self] in
+                self?.end()
+            }
+            lock.lock()
+            self.identifier = identifier
+            lock.unlock()
+        }
+
+        func end() {
+            lock.lock()
+            let identifier = self.identifier
+            self.identifier = .invalid
+            lock.unlock()
+            guard identifier != .invalid else { return }
+            Task { @MainActor in
+                UIApplication.shared.endBackgroundTask(identifier)
+            }
+        }
+    }
+
+    /// Moves anything in flight onto the background session so leaving the app
+    /// does not kill a half-finished 1.5 GB download. Called from the scene
+    /// phase hook in `VocaPhoneApp`.
+    ///
+    /// There is deliberately no move back on return to the foreground: undoing
+    /// it means cancelling a live task and hoping for resume data, and a
+    /// transfer that cannot produce any would restart from zero.
+    @MainActor
+    static func enterBackground() {
+        // This runs on every trip to the home screen, so do not take a
+        // background assertion unless there is actually a transfer to hand over.
+        guard downloadDelegate.hasTransfers else { return }
+        let assertion = BackgroundAssertion()
+        assertion.begin()
+        downloadDelegate.migrate(to: backgroundDownloadSession) {
+            assertion.end()
+        }
+    }
+
     private var modelsDirectory: URL? {
         FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
             .first?
@@ -161,15 +245,13 @@ final class LocalModelManager {
         case missing
     }
 
-    /// Tracks bytes across tokenizer and model files so the picker can show
-    /// meaningful progress rather than waiting for a whole multi-hundred-MB
-    /// file to finish.
+    /// Tracks bytes across every transfer in flight so the picker shows real
+    /// movement rather than a step per finished file. A unit is one file, or one
+    /// byte range within a large file, and several run at once.
     private actor DownloadProgress {
         let totalBytes: Int64
-        var completedBytes: Int64 = 0
-        private var activeFileBytes: Int64 = 0
-        private var activeFileExpectedBytes: Int64 = 0
-        private var activeFileGeneration = 0
+        private var completedBytes: Int64 = 0
+        private var inFlight: [UUID: Int64] = [:]
 
         init(totalBytes: Int64) {
             self.totalBytes = totalBytes
@@ -180,43 +262,34 @@ final class LocalModelManager {
             return fraction
         }
 
-        func beginFile(expectedBytes: Int64) -> Int {
-            activeFileGeneration += 1
-            activeFileBytes = 0
-            activeFileExpectedBytes = max(0, expectedBytes)
-            return activeFileGeneration
+        func begin(_ unit: UUID) {
+            inFlight[unit] = 0
         }
 
-        func updateFile(bytesWritten: Int64, generation: Int) -> Double? {
-            guard generation == activeFileGeneration else { return nil }
-            activeFileBytes = min(
-                max(0, bytesWritten),
-                activeFileExpectedBytes
-            )
+        /// Returns nil for a unit that has already finished or been abandoned,
+        /// so a late delegate callback cannot resurrect its bytes.
+        func update(_ unit: UUID, bytesWritten: Int64, expectedBytes: Int64) -> Double? {
+            guard inFlight[unit] != nil else { return nil }
+            inFlight[unit] = min(max(0, bytesWritten), max(0, expectedBytes))
             return fraction
         }
 
-        func completeFile(generation: Int) -> Double {
-            guard generation == activeFileGeneration else { return fraction }
-            completedBytes += activeFileExpectedBytes
-            activeFileBytes = 0
-            activeFileExpectedBytes = 0
+        func complete(_ unit: UUID, bytes: Int64) -> Double {
+            inFlight.removeValue(forKey: unit)
+            completedBytes += max(0, bytes)
             return fraction
         }
 
-        func resetFile(generation: Int) -> Double {
-            guard generation == activeFileGeneration else { return fraction }
-            activeFileBytes = 0
-            activeFileExpectedBytes = 0
+        /// A retry restarts the unit, so its bytes go back to zero.
+        func reset(_ unit: UUID) -> Double {
+            if inFlight[unit] != nil { inFlight[unit] = 0 }
             return fraction
         }
 
         private var fraction: Double {
             guard totalBytes > 0 else { return 0 }
-            return min(
-                1,
-                Double(completedBytes + activeFileBytes) / Double(totalBytes)
-            )
+            let active = inFlight.values.reduce(Int64(0), +)
+            return min(1, Double(completedBytes + active) / Double(totalBytes))
         }
     }
 
@@ -224,30 +297,60 @@ final class LocalModelManager {
     /// delivering one byte at a time through an AsyncBytes data task. This is
     /// important for multi-hundred-megabyte Core ML weights: the old path made
     /// every byte cross back through the main actor before it could be written.
+    ///
+    /// One delegate serves both sessions, so transfers are keyed by a token
+    /// carried in `taskDescription`. `taskIdentifier` is only unique within a
+    /// single session and would collide across the two.
     private final class FileDownloadDelegate: NSObject, URLSessionDownloadDelegate,
         @unchecked Sendable {
+        /// Progress is forwarded at most this often, and only once a meaningful
+        /// slice of the unit has landed. `didWriteData` fires per network chunk;
+        /// forwarding every one of them put tens of thousands of hops on the
+        /// main actor over a single gigabyte-scale file and re-rendered the
+        /// picker each time.
+        private static let progressInterval: TimeInterval = 0.1
+
         private struct Transfer {
-            let task: URLSessionDownloadTask
+            var task: URLSessionDownloadTask
+            let request: URLRequest
+            let expectedBytes: Int64
             let continuation: CheckedContinuation<(URL, URLResponse), Error>
             let progressHandler: @Sendable (Int64) -> Void
             var lastReportedBytes: Int64 = 0
+            var lastReportedAt: TimeInterval = 0
+            /// Set while a task is cancelled only so it can be restarted on the
+            /// other session. Its cancellation must not fail the continuation.
+            var isMigrating = false
+
+            /// At most a couple of hundred updates per unit, never more often
+            /// than once a megabyte.
+            var progressThreshold: Int64 {
+                max(1_048_576, expectedBytes / 200)
+            }
         }
 
         private let lock = NSLock()
-        private var transfers: [Int: Transfer] = [:]
+        private var transfers: [String: Transfer] = [:]
 
         func start(
             session: URLSession,
             request: URLRequest,
+            expectedBytes: Int64,
+            resumeData: Data?,
             progressHandler: @escaping @Sendable (Int64) -> Void
         ) async throws -> (URL, URLResponse) {
-            try await withTaskCancellationHandler(operation: {
+            let token = UUID().uuidString
+            return try await withTaskCancellationHandler(operation: {
                 try await withCheckedThrowingContinuation {
                     (continuation: CheckedContinuation<(URL, URLResponse), Error>) in
                     lock.lock()
-                    let task = session.downloadTask(with: request)
-                    transfers[task.taskIdentifier] = Transfer(
+                    let task = resumeData.map(session.downloadTask(withResumeData:))
+                        ?? session.downloadTask(with: request)
+                    task.taskDescription = token
+                    transfers[token] = Transfer(
                         task: task,
+                        request: request,
+                        expectedBytes: expectedBytes,
                         continuation: continuation,
                         progressHandler: progressHandler
                     )
@@ -261,15 +364,81 @@ final class LocalModelManager {
                     }
                 }
             }, onCancel: { [weak self] in
-                self?.cancel()
+                self?.cancel(token: token)
             })
         }
 
+        var hasTransfers: Bool {
+            lock.lock()
+            let hasTransfers = !transfers.isEmpty
+            lock.unlock()
+            return hasTransfers
+        }
+
+        /// Cancels every transfer. Used by the picker's Cancel button, which
+        /// stops the whole model rather than one file.
         func cancel() {
             lock.lock()
             let tasks = transfers.values.map(\.task)
             lock.unlock()
             tasks.forEach { $0.cancel() }
+        }
+
+        private func cancel(token: String) {
+            lock.lock()
+            let task = transfers[token]?.task
+            lock.unlock()
+            task?.cancel()
+        }
+
+        /// Cancels every in-flight transfer for its resume data and restarts it
+        /// on `session`, keeping the awaiting continuation intact. A transfer
+        /// that cannot produce resume data restarts from the beginning rather
+        /// than being dropped: losing bytes beats losing the download.
+        func migrate(to session: URLSession, completion: @escaping @Sendable () -> Void) {
+            lock.lock()
+            var pending: [String: URLSessionDownloadTask] = [:]
+            for (token, transfer) in transfers where !transfer.isMigrating {
+                transfers[token]?.isMigrating = true
+                pending[token] = transfer.task
+            }
+            lock.unlock()
+
+            guard !pending.isEmpty else {
+                completion()
+                return
+            }
+
+            let group = DispatchGroup()
+            for (token, task) in pending {
+                group.enter()
+                task.cancel(byProducingResumeData: { [weak self] resumeData in
+                    self?.restart(token: token, on: session, resumeData: resumeData)
+                    group.leave()
+                })
+            }
+            group.notify(queue: .main) { completion() }
+        }
+
+        private func restart(token: String, on session: URLSession, resumeData: Data?) {
+            lock.lock()
+            guard var transfer = transfers[token] else {
+                lock.unlock()
+                return
+            }
+            let task = resumeData.map(session.downloadTask(withResumeData:))
+                ?? session.downloadTask(with: transfer.request)
+            task.taskDescription = token
+            transfer.task = task
+            transfer.isMigrating = false
+            // Without resume data the new task counts from zero again, so a
+            // high-water mark carried over from the old one would suppress every
+            // report until it caught up.
+            transfer.lastReportedBytes = 0
+            transfer.lastReportedAt = 0
+            transfers[token] = transfer
+            lock.unlock()
+            task.resume()
         }
 
         func urlSession(
@@ -279,7 +448,7 @@ final class LocalModelManager {
             totalBytesWritten: Int64,
             totalBytesExpectedToWrite: Int64
         ) {
-            report(totalBytesWritten, taskIdentifier: downloadTask.taskIdentifier)
+            report(totalBytesWritten, token: downloadTask.taskDescription)
         }
 
         func urlSession(
@@ -287,25 +456,23 @@ final class LocalModelManager {
             downloadTask: URLSessionDownloadTask,
             didFinishDownloadingTo location: URL
         ) {
-            let taskIdentifier = downloadTask.taskIdentifier
-            guard isTracking(taskIdentifier) else {
+            guard let token = downloadTask.taskDescription, isTracking(token) else {
                 // A transfer may finish after iOS relaunched the process. Its
                 // original continuation no longer exists, so ignore this
                 // system-owned temporary file rather than allowing the stale
                 // callback to complete a newer model file.
                 return
             }
-            report(downloadTask.countOfBytesReceived, taskIdentifier: taskIdentifier)
             let persistentLocation = FileManager.default.temporaryDirectory
                 .appendingPathComponent("vocaphone-download-\(UUID().uuidString)")
             do {
                 try FileManager.default.moveItem(at: location, to: persistentLocation)
                 finish(
-                    taskIdentifier: taskIdentifier,
+                    token: token,
                     result: .success((persistentLocation, downloadTask.response ?? URLResponse()))
                 )
             } catch {
-                finish(taskIdentifier: taskIdentifier, result: .failure(error))
+                finish(token: token, result: .failure(error))
             }
         }
 
@@ -314,8 +481,16 @@ final class LocalModelManager {
             task: URLSessionTask,
             didCompleteWithError error: Error?
         ) {
-            guard let error else { return }
-            finish(taskIdentifier: task.taskIdentifier, result: .failure(error))
+            guard let error, let token = task.taskDescription else { return }
+            lock.lock()
+            let transfer = transfers[token]
+            lock.unlock()
+            // A migration cancels the task on purpose, and URLSession does not
+            // promise whether this callback or the resume-data handler runs
+            // first. Both orderings have to be ignored: still migrating, or
+            // already replaced by the task `restart` put in its place.
+            guard let transfer, transfer.task === task, !transfer.isMigrating else { return }
+            finish(token: token, result: .failure(error))
         }
 
         func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
@@ -323,33 +498,40 @@ final class LocalModelManager {
             ModelDownloadBackgroundEvents.shared.finish(identifier: identifier)
         }
 
-        private func isTracking(_ taskIdentifier: Int) -> Bool {
+        private func isTracking(_ token: String) -> Bool {
             lock.lock()
-            let isTracking = transfers[taskIdentifier] != nil
+            let isTracking = transfers[token] != nil
             lock.unlock()
             return isTracking
         }
 
-        private func report(_ totalBytesWritten: Int64, taskIdentifier: Int) {
+        private func report(_ totalBytesWritten: Int64, token: String?) {
+            guard let token else { return }
+            let now = Date().timeIntervalSinceReferenceDate
             lock.lock()
-            guard var transfer = transfers[taskIdentifier] else {
+            guard var transfer = transfers[token] else {
                 lock.unlock()
                 return
             }
-            let shouldReport = totalBytesWritten > transfer.lastReportedBytes
-            transfer.lastReportedBytes = max(transfer.lastReportedBytes, totalBytesWritten)
-            transfers[taskIdentifier] = transfer
+            let shouldReport =
+                totalBytesWritten - transfer.lastReportedBytes >= transfer.progressThreshold
+                && now - transfer.lastReportedAt >= Self.progressInterval
+            if shouldReport {
+                transfer.lastReportedBytes = totalBytesWritten
+                transfer.lastReportedAt = now
+                transfers[token] = transfer
+            }
             let progressHandler = transfer.progressHandler
             lock.unlock()
             if shouldReport { progressHandler(totalBytesWritten) }
         }
 
         private func finish(
-            taskIdentifier: Int,
+            token: String,
             result: Result<(URL, URLResponse), Error>
         ) {
             lock.lock()
-            let transfer = transfers.removeValue(forKey: taskIdentifier)
+            let transfer = transfers.removeValue(forKey: token)
             lock.unlock()
             transfer?.continuation.resume(with: result)
         }
@@ -685,7 +867,7 @@ final class LocalModelManager {
     func cancelDownload() {
         guard modelDownloadTask != nil || downloadingModelID != nil else { return }
         message = "Canceling model download…"
-        Self.backgroundDownloadDelegate.cancel()
+        Self.downloadDelegate.cancel()
         modelDownloadTask?.cancel()
     }
 
@@ -745,7 +927,7 @@ final class LocalModelManager {
                 progressTracker: progressTracker
             )
         }
-        try LocalModelIntegrity.verifyDigests(
+        try await Self.verifyDigests(
             in: staging, files: tokenizer.files, modelIdentifier: repository
         )
         if fileManager.fileExists(atPath: destination.path) {
@@ -773,40 +955,145 @@ final class LocalModelManager {
         try fileManager.createDirectory(at: stagingModel, withIntermediateDirectories: true)
         defer { try? fileManager.removeItem(at: stagingRoot) }
 
-        for file in files {
-            try Task.checkCancellation()
-            guard isSafeRelativePath(file.path) else {
-                throw LocalModelManagerError.integrityFileMissing(file.path)
-            }
-
-            let destination = stagingModel.appendingPathComponent(file.path)
-            message = "Downloading \(descriptor.displayName)…"
-            let url = try fileURL(
-                repository: repository,
-                revision: revision,
-                path: [pathPrefix, file.path].compactMap { $0 }.joined(separator: "/")
-            )
-            let temporaryFile = try await downloadFile(
-                from: url,
-                to: destination,
-                keepingPartialExtension: true,
-                expectedBytes: file.size,
-                progressTracker: progressTracker
-            )
-            try LocalModelIntegrity.verify(file: temporaryFile, against: file)
-            try fileManager.moveItem(at: temporaryFile, to: destination)
-
+        for file in files where !isSafeRelativePath(file.path) {
+            throw LocalModelManagerError.integrityFileMissing(file.path)
         }
 
-        try LocalModelIntegrity.verifyDigests(
-            in: stagingModel, files: files, modelIdentifier: descriptor.id
+        message = "Downloading \(descriptor.displayName)…"
+
+        // Every model in the catalog is one to three very large weights beside a
+        // dozen or more tiny descriptors. Fetching the small ones several at a
+        // time stops each of them paying a fresh TLS handshake and a Hugging
+        // Face redirect in turn, which is most of what they cost. The large ones
+        // stay sequential: splitting a single stream into parallel byte ranges
+        // measured no reliable gain and sometimes lost, which does not justify
+        // the reassembly pass or giving up resume on a retry.
+        let large = files.filter { $0.size >= Self.largeFileThreshold }
+        let small = files.filter { $0.size < Self.largeFileThreshold }
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            var pending = small.makeIterator()
+            var inFlight = 0
+            while inFlight < Self.maxParallelTransfers, let file = pending.next() {
+                group.addTask {
+                    try await self.downloadAndVerify(
+                        file,
+                        modelIdentifier: descriptor.id,
+                        repository: repository,
+                        revision: revision,
+                        pathPrefix: pathPrefix,
+                        into: stagingModel,
+                        progressTracker: progressTracker
+                    )
+                }
+                inFlight += 1
+            }
+            while inFlight > 0 {
+                try await group.next()
+                inFlight -= 1
+                guard let file = pending.next() else { continue }
+                group.addTask {
+                    try await self.downloadAndVerify(
+                        file,
+                        modelIdentifier: descriptor.id,
+                        repository: repository,
+                        revision: revision,
+                        pathPrefix: pathPrefix,
+                        into: stagingModel,
+                        progressTracker: progressTracker
+                    )
+                }
+                inFlight += 1
+            }
+        }
+
+        for file in large {
+            try Task.checkCancellation()
+            try await downloadAndVerify(
+                file,
+                modelIdentifier: descriptor.id,
+                repository: repository,
+                revision: revision,
+                pathPrefix: pathPrefix,
+                into: stagingModel,
+                progressTracker: progressTracker
+            )
+        }
+
+        // Every file was hashed as it landed, so all that is left is confirming
+        // the set is complete and recording the marker the cheap launch path
+        // reads. The whole-directory digest pass that used to run here hashed
+        // every byte of the model a second time, on the main actor.
+        try LocalModelIntegrity.verifySizes(
+            in: stagingModel, files: files, requiringMarker: false
         )
+        try LocalModelIntegrity.writeMarker(
+            LocalModelIntegrity.fingerprint(of: files), in: stagingModel
+        )
+
         let finalFolder = root.appendingPathComponent(descriptor.id, isDirectory: true)
         if fileManager.fileExists(atPath: finalFolder.path) {
             try fileManager.removeItem(at: finalFolder)
         }
         try fileManager.moveItem(at: stagingModel, to: finalFolder)
         return finalFolder
+    }
+
+    /// Fetches one manifest file into the staging folder and checks its digest
+    /// before committing it under its real name.
+    private func downloadAndVerify(
+        _ file: LocalModelIntegrity.ManifestFile,
+        modelIdentifier: String,
+        repository: String,
+        revision: String,
+        pathPrefix: String?,
+        into stagingModel: URL,
+        progressTracker: DownloadProgress
+    ) async throws {
+        let url = try fileURL(
+            repository: repository,
+            revision: revision,
+            path: [pathPrefix, file.path].compactMap { $0 }.joined(separator: "/")
+        )
+        let destination = stagingModel.appendingPathComponent(file.path)
+        let temporaryFile = try await downloadFile(
+            from: url,
+            to: destination,
+            keepingPartialExtension: true,
+            expectedBytes: file.size,
+            progressTracker: progressTracker
+        )
+        try await Self.verify(
+            file: temporaryFile, against: file, modelIdentifier: modelIdentifier
+        )
+        try FileManager.default.moveItem(at: temporaryFile, to: destination)
+    }
+
+    /// Digest work is CPU-bound file I/O over hundreds of megabytes. On the main
+    /// actor it froze the picker at the end of a large download, which reads as
+    /// a stalled progress bar rather than as verification.
+    private nonisolated static func verify(
+        file url: URL,
+        against expectedFile: LocalModelIntegrity.ManifestFile,
+        modelIdentifier: String?
+    ) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            try LocalModelIntegrity.verify(
+                file: url, against: expectedFile, modelIdentifier: modelIdentifier
+            )
+        }.value
+    }
+
+    private nonisolated static func verifyDigests(
+        in directory: URL,
+        files: [LocalModelIntegrity.ManifestFile],
+        modelIdentifier: String?
+    ) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            try LocalModelIntegrity.verifyDigests(
+                in: directory, files: files, modelIdentifier: modelIdentifier
+            )
+        }.value
     }
 
     /// Downloads one file into place, creating intermediate directories. When
@@ -829,26 +1116,48 @@ final class LocalModelManager {
             : destination
         try? fileManager.removeItem(at: target)
 
+        let file = try await downloadUnit(
+            from: url,
+            expectedBytes: expectedBytes,
+            progressTracker: progressTracker
+        )
+        try fileManager.moveItem(at: file, to: target)
+        return target
+    }
+
+    /// One file transfer with its own retry budget. Returns a temporary file
+    /// the caller owns.
+    private func downloadUnit(
+        from url: URL,
+        expectedBytes: Int64,
+        progressTracker: DownloadProgress
+    ) async throws -> URL {
+        let fileManager = FileManager.default
+        let unit = UUID()
+        await progressTracker.begin(unit)
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 15 * 60
+
+        let progressHandler: @Sendable (Int64) -> Void = { [weak self] bytesWritten in
+            Task { @MainActor [weak self] in
+                guard let value = await progressTracker.update(
+                    unit, bytesWritten: bytesWritten, expectedBytes: expectedBytes
+                ) else { return }
+                self?.publish(value)
+            }
+        }
+
         let maxAttempts = 3
+        var resumeData: Data?
         for attempt in 1...maxAttempts {
             try Task.checkCancellation()
-            let generation = await progressTracker.beginFile(expectedBytes: expectedBytes)
-            let progressHandler: @Sendable (Int64) -> Void = { [weak self] bytesWritten in
-                Task { @MainActor [weak self] in
-                    guard let value = await progressTracker.updateFile(
-                        bytesWritten: bytesWritten,
-                        generation: generation
-                    ) else { return }
-                    self?.progress = value
-                }
-            }
-
             do {
-                var request = URLRequest(url: url)
-                request.timeoutInterval = 15 * 60
-                let (temporaryFile, response) = try await Self.backgroundDownloadDelegate.start(
-                    session: Self.backgroundDownloadSession,
+                let (temporaryFile, response) = try await Self.downloadDelegate.start(
+                    session: Self.foregroundDownloadSession,
                     request: request,
+                    expectedBytes: expectedBytes,
+                    resumeData: resumeData,
                     progressHandler: progressHandler
                 )
                 try Task.checkCancellation()
@@ -861,23 +1170,35 @@ final class LocalModelManager {
                         statusCode: (response as? HTTPURLResponse)?.statusCode
                     )
                 }
-                try fileManager.moveItem(at: temporaryFile, to: target)
-                progress = await progressTracker.completeFile(generation: generation)
-                return target
+                progress = await progressTracker.complete(unit, bytes: expectedBytes)
+                return temporaryFile
             } catch {
-                progress = await progressTracker.resetFile(generation: generation)
+                progress = await progressTracker.reset(unit)
                 guard attempt < maxAttempts, isRetryableDownloadError(error) else {
+                    _ = await progressTracker.complete(unit, bytes: 0)
                     throw error
                 }
+                // A dropped connection at 90% of a 1.27 GB weight used to cost
+                // the whole file. Resume data picks it up where it stopped.
+                resumeData = (error as NSError)
+                    .userInfo[NSURLSessionDownloadTaskResumeData] as? Data
                 message = "Network interruption. Retrying \(url.lastPathComponent)…"
                 try await Task.sleep(nanoseconds: UInt64(attempt) * 750_000_000)
             }
         }
 
+        _ = await progressTracker.complete(unit, bytes: 0)
         throw LocalModelManagerError.downloadFailed(
             path: url.lastPathComponent,
             statusCode: nil
         )
+    }
+
+    /// Several transfers report at once and their main-actor hops can land out
+    /// of order, which must not make the bar jump backwards mid-download.
+    private func publish(_ value: Double) {
+        guard value > progress else { return }
+        progress = value
     }
 
     private func isRetryableDownloadError(_ error: Error) -> Bool {

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -116,13 +116,15 @@ final class RecordingCoordinator {
     /// permission can be revoked from Settings while the app is suspended.
     func refreshSetupStatus() {
         guard !isInert else { return }
+        let isKeyboardInstalled = InstalledKeyboards.includesVocaPhone()
         let refreshed = SetupStatus(
             source: transcriptionSource,
             microphone: microphoneAccess,
             keyboard: KeyboardSetupState.resolve(
                 try? store.loadKeyboardStatus(),
-                isInstalled: InstalledKeyboards.includesVocaPhone()
+                isInstalled: isKeyboardInstalled
             ),
+            isKeyboardInstalled: isKeyboardInstalled,
             hasDictatedOnce: KeyboardPreferences.hasCompletedFirstDictation
         )
         // Guided setup re-reads this several times a second while it waits for

--- a/ios/VocaPhoneTests/OnboardingPresentationTests.swift
+++ b/ios/VocaPhoneTests/OnboardingPresentationTests.swift
@@ -83,21 +83,53 @@ struct OnboardingPresentationTests {
         #expect(OnboardingStage.practice.requiredStepNumber == 5)
     }
 
-    @Test func keyboardEnablementCannotAdvanceBeforeTheSettingsRoundTrip() {
-        var keyboardMissing = readyToDictate
-        keyboardMissing.keyboard = .addedButNeverRun
+    /// The reported bug: opening Settings, changing nothing, and swiping back
+    /// used to be enough to walk past a button that claimed Full Access was on.
+    @Test func returningFromSettingsWithoutAddingTheKeyboardCannotAdvance() {
+        var notAdded = readyToDictate
+        notAdded.keyboard = .notAdded
+        notAdded.isKeyboardInstalled = false
 
         #expect(!OnboardingPresentation.canAdvanceFromKeyboardEnablement(
-            status: keyboardMissing,
+            status: notAdded,
             returnedFromSettings: false
         ))
-        #expect(OnboardingPresentation.canAdvanceFromKeyboardEnablement(
-            status: keyboardMissing,
+        #expect(!OnboardingPresentation.canAdvanceFromKeyboardEnablement(
+            status: notAdded,
             returnedFromSettings: true
+        ))
+    }
+
+    @Test func aKeyboardInTheListAdvancesWithoutTheSettingsRoundTrip() {
+        var added = readyToDictate
+        added.keyboard = .addedButNeverRun
+        added.isKeyboardInstalled = true
+
+        #expect(OnboardingPresentation.canAdvanceFromKeyboardEnablement(
+            status: added,
+            returnedFromSettings: false
         ))
         #expect(OnboardingPresentation.canAdvanceFromKeyboardEnablement(
             status: readyToDictate,
             returnedFromSettings: false
+        ))
+    }
+
+    /// iOS publishes the keyboard list under an undocumented key. If it ever
+    /// stops, setup must not trap the user on this page — the switch page still
+    /// refuses to move on without the extension's own proof.
+    @Test func anUnreadableKeyboardListFallsBackToTheSettingsRoundTrip() {
+        var unknown = readyToDictate
+        unknown.keyboard = .notAdded
+        unknown.isKeyboardInstalled = nil
+
+        #expect(!OnboardingPresentation.canAdvanceFromKeyboardEnablement(
+            status: unknown,
+            returnedFromSettings: false
+        ))
+        #expect(OnboardingPresentation.canAdvanceFromKeyboardEnablement(
+            status: unknown,
+            returnedFromSettings: true
         ))
     }
 


### PR DESCRIPTION
## Model downloads

On-device model downloads were far slower than the same work on Android. Four causes, all in `LocalModelManager`:

**Background `URLSession` for everything.** Every byte crossed `nsurlsessiond`, which the system schedules and throttles even with `isDiscretionary = false`. Downloads now run on a foreground `URLSessionConfiguration.default` session while the app is in front. `enterBackground()` hands anything in flight to the background session via `cancel(byProducingResumeData:)` plus restart, under a `UIBackgroundTask` assertion so the handoff completes before suspension. One delegate serves both sessions, keyed by a token in `taskDescription` — `taskIdentifier` is only unique within a session and would have collided.

There is deliberately no move back on returning to the foreground: undoing it means cancelling a live task and hoping for resume data, and a transfer that cannot produce any would restart from zero.

**Every byte hashed twice, on the main thread.** `downloadModel` verified each file's digest and then ran a whole-directory `verifyDigests` that hashed all of them again, both synchronously on the main actor. For `openai_whisper-medium` that is 3 GB of SHA-256 on the main thread, with the progress bar pinned at 100% throughout — which reads as a stalled download rather than as verification. Files are now hashed once, in a detached task, and the tail is a size check plus the marker write.

**Progress flooded the main actor.** `didWriteData` forwarded every network chunk through a fresh `Task { @MainActor }`, writing an `@Observable` property and re-rendering the picker each time — tens of thousands of hops over a gigabyte-scale file. Now throttled to one report per 100 ms and per ~0.5% of the file.

**Serial small files.** A model is 12–17 tiny descriptor files beside one to three large weights; the small ones were fetched one at a time, each paying its own TLS handshake and Hugging Face redirect. They now go four at a time.

**No resume.** A retryable failure at 90% of a 1.27 GB weight restarted from zero. Retries now use resume data.

### Considered and rejected

Splitting large weights into parallel byte ranges. Hugging Face supports it (`accept-ranges: bytes`, serves `206`), but measured throughput did not justify it: one 192 MB run went 49.5 s parallel vs 44.1 s serial, and three alternating 32 MB rounds won twice and lost once. Inconclusive, against the certain cost of a full extra read/write reassembly pass and losing resume on chunk retries. `largeFileThreshold` is the split point if this is worth revisiting on a faster link.

## Onboarding

Returning from iOS Settings without changing anything surfaced a button reading **"Full Access is on — continue"**, and `canAdvanceFromKeyboardEnablement` was `status.isSatisfied(.keyboard) || returnedFromSettings`. The flag was set by tapping "Open vocaphone Settings" and cleared by nothing but the return, so the app asserted a permission it had never observed.

The containing app cannot read the Full Access switch — only the extension's own write to the shared container proves it, and the extension cannot write until it has run, so a hard gate here would deadlock the page that makes it run. The page now advances on what iOS does expose: whether vocaphone is in the keyboard list. `SetupStatus` carries that as its own tri-state, because `KeyboardSetupState.resolve` folds "not added" and "iOS did not say" together and guided setup needs them apart.

- In the list → advance, with copy claiming only what was checked.
- Not in the list → blocked, with a "Check again" re-read so a briefly stale `AppleKeyboards` value is never a dead end.
- List unreadable → falls back to the old round-trip behaviour rather than stranding the user; the switch page still holds out for real proof.

Also fixed: `keyboardSwitchStage` only offered its way back for `seenWithoutFullAccess`, so a user who never added the keyboard — or removed it — sat on "Waiting for vocaphone to open" forever, since that page waits on the extension running. The escape is now always present and labelled for the actual state.

`.source`, `.microphone` and `.practice` only show Continue when genuinely satisfied, `finishSetup()` guards on `isReadyToDictate && hasCompletedKeyboardPractice`, and the cover is `interactiveDismissDisabled` with no skip path. Nothing reaches practice or completion without the extension reporting Full Access.

## Testing

Build clean, 471 tests pass. Three new tests in `OnboardingPresentationTests` replace the one that asserted the old behaviour, covering the reported case (return from Settings, keyboard not added, cannot advance), the installed case, and the unreadable-list fallback.

`LocalModelManager.swift` is only in the `VocaPhoneApp` target, so the suite does not cover the download changes. **Not yet verified on device** — worth exercising a real download and a mid-download backgrounding on hardware, since resume data can come back nil and that path restarts the file.