### PR TITLE
web: fix CodeQL incomplete URL substring sanitization in site test

### DIFF
--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -171,8 +171,9 @@ test("availability and install paths are honest", () => {
   // one. The hero is where most visitors decide, so an iPhone owner reaching
   // "see how it works" without ever being shown TestFlight is the bug.
   const hero = heroActions(html);
-  assert.ok(
-    hero.includes("https://testflight.apple.com/join/wd85wQ3W"),
+  assert.match(
+    hero,
+    /href="https:\/\/testflight\.apple\.com\/join\/wd85wQ3W"/,
     "hero is missing the TestFlight link",
   );
   // The Apple mark is filled, not stroked like the Android one beside it, and


### PR DESCRIPTION
Closes code scanning alert [#7](https://github.com/VocaHQ/vocaphone/security/code-scanning/7) (`js/incomplete-url-substring-sanitization`, high).

The hero assertion in `web/tests/site.test.mjs` checked the TestFlight link with `hero.includes("https://testflight.apple.com/join/wd85wQ3W")`. A bare substring check on a URL is the pattern CodeQL flags — the URL could sit anywhere in the string with arbitrary hosts around it.

Replaced it with `assert.match` on the anchored `href="…"` regex, which is the form the other three TestFlight assertions in the same file already use. Same coverage, stricter.

`npm test` in `web/`: 10/10 pass.