### PR TITLE
Add Android personal dictionary, letter-key symbols, and fuzzier emoji

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -154,7 +154,9 @@ Typing extras, all local to the phone:
   Suggestions and swipe are English only; there is no language pack to download.
 - Clipboard chip (tap to paste, long press to dismiss) and optional clip history
 - Emoji categories, recents, and optional ASCII emoticons
-- Long-press letters for accents, long-press 1-0 for symbols, double-space for a period
+- Long-press letters for accents, long-press 1-0 for symbols, optional long-press
+  on letters for punctuation and digits, double-space for a period
+- Personal dictionary (Settings → Keyboard), also addable from a + chip on the strip
 - The globe key is gone; Android's keyboard switcher still changes IMEs
 
 Suggestions may read about 32 characters around the cursor. The clipboard chip

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/EmojiSuggestions.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/EmojiSuggestions.kt
@@ -7,19 +7,69 @@ package com.vocahq.vocaphone.ime
  * exist for a deliberate search in the emoji panel. Matched against ordinary
  * prose they answer "the" with 🤣, "dog" with 💩, and "clock" with 🏫.
  *
- * Exact whole words only. A prefix match would put an emoji on the strip
- * while the user is still two letters into a different word.
+ * Exact whole words first. A unique, almost-finished prefix (`pizz` → pizza)
+ * and a unique one-letter insert or delete (`piza` → pizza) are the only
+ * fuzzy paths, and only when they collapse to a single glyph. Substitution
+ * is out: `read` is one edit from `dead`, and offering 💀 for "read" is
+ * the strip crying wolf.
  */
 internal object EmojiSuggestions {
     const val MINIMUM_LENGTH = 2
+
+    /** Prefix and insert/delete matching start here. Three letters are too ambiguous. */
+    const val FUZZY_MIN_LENGTH = 4
+
+    /**
+     * How much of the trigger may still be untyped for a prefix to count.
+     * `pizz` (one short of pizza) is a finish; `read` (three short of reading)
+     * is just the word "read".
+     */
+    const val PREFIX_SLACK = 2
 
     fun glyph(word: String): String? = glyphs(word).firstOrNull()
 
     fun glyphs(word: String): List<String> {
         val key = word.lowercase()
         if (key.length < MINIMUM_LENGTH) return emptyList()
-        val primary = TRIGGERS[key] ?: return emptyList()
+        val primary = resolvePrimary(key) ?: return emptyList()
         return (listOf(primary) + EXTRAS[primary].orEmpty()).distinct()
+    }
+
+    private fun resolvePrimary(key: String): String? {
+        TRIGGERS[key]?.let { return it }
+        if (key.length < FUZZY_MIN_LENGTH) return null
+
+        val prefixGlyphs = LinkedHashSet<String>()
+        for ((trigger, glyph) in TRIGGERS) {
+            if (
+                trigger.length > key.length &&
+                trigger.startsWith(key) &&
+                key.length >= trigger.length - PREFIX_SLACK
+            ) {
+                prefixGlyphs.add(glyph)
+                if (prefixGlyphs.size > 1) return null
+            }
+        }
+        if (prefixGlyphs.size == 1) return prefixGlyphs.first()
+        if (prefixGlyphs.isNotEmpty()) return null
+
+        val fuzzyGlyphs = LinkedHashSet<String>()
+        val scratch = SuggestionEngine.EditDistanceScratch(key.length + 1)
+        for ((trigger, glyph) in TRIGGERS) {
+            if (kotlin.math.abs(trigger.length - key.length) != 1) continue
+            // A leading extra letter is how "they" becomes "hey". Trailing or
+            // mid-word inserts are typos of the trigger itself (`piza` / `pizza`).
+            if (isLeadingExtraLetter(key, trigger)) continue
+            if (SuggestionEngine.editDistance(key, trigger, max = 1, scratch = scratch) != 1) continue
+            fuzzyGlyphs.add(glyph)
+            if (fuzzyGlyphs.size > 1) return null
+        }
+        return fuzzyGlyphs.singleOrNull()
+    }
+
+    private fun isLeadingExtraLetter(left: String, right: String): Boolean {
+        val (shorter, longer) = if (left.length < right.length) left to right else right to left
+        return longer.length == shorter.length + 1 && longer.endsWith(shorter)
     }
 
     internal val TRIGGERS: Map<String, String> = mapOf(

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyAccents.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyAccents.kt
@@ -3,6 +3,22 @@ package com.vocahq.vocaphone.ime
 import java.util.Locale
 
 internal object KeyAccents {
+    /**
+     * Gboard / AOSP letter → symbol map. Hold-and-release types the hint;
+     * accents stay in the same popup behind it.
+     */
+    private val letterSymbols = mapOf(
+        "q" to "1", "w" to "2", "e" to "3", "r" to "4", "t" to "5",
+        "y" to "6", "u" to "7", "i" to "8", "o" to "9", "p" to "0",
+        "a" to "@", "s" to "#", "d" to "$", "f" to "_", "g" to "&",
+        "h" to "-", "j" to "+", "k" to "(", "l" to ")",
+        "z" to "*", "x" to "\"", "c" to "'", "v" to ":", "b" to ";",
+        "n" to "!", "m" to "?",
+    )
+
+    /** q-p duplicate the number row. Hide those hints when 1-0 are already showing. */
+    private val digitLetters = setOf("q", "w", "e", "r", "t", "y", "u", "i", "o", "p")
+
     private val variants = mapOf(
         "a" to listOf("à", "á", "â", "ä", "æ", "ã", "å", "ā"),
         "c" to listOf("ç", "ć", "č"),
@@ -36,19 +52,54 @@ internal object KeyAccents {
         "0" to listOf(")"),
     )
 
-    fun forKey(key: KeyboardKey, shift: ShiftState): List<String> {
+    fun forKey(
+        key: KeyboardKey,
+        shift: ShiftState,
+        longPressSymbols: Boolean = false,
+        numberRow: Boolean = false,
+    ): List<String> {
         if (key.type != KeyboardKeyType.CHARACTER) return emptyList()
         val base = key.output.lowercase(Locale.ROOT)
-        val options = variants[base] ?: return emptyList()
-        if (shift == ShiftState.OFF) return options
-        return options.map { it.uppercase(Locale.ROOT) }
+        val accents = variants[base].orEmpty()
+        val symbol = letterSymbol(base, longPressSymbols, numberRow)
+        if (symbol == null && accents.isEmpty()) return emptyList()
+        val shiftedAccents = if (shift == ShiftState.OFF) {
+            accents
+        } else {
+            accents.map { it.uppercase(Locale.ROOT) }
+        }
+        // The hinted symbol does not follow shift: long-press e is 3, not #,
+        // whether or not caps is on. Accents still capitalise.
+        return (listOfNotNull(symbol) + shiftedAccents).distinct()
     }
 
-    /** Light corner mark on 1-0, matching the long-press symbol. */
-    fun hint(key: KeyboardKey): String? {
+    /**
+     * Light corner mark. Digits keep `!` on `1` when number-key hints are on.
+     * Letters show the Gboard symbol only when long-press-for-symbols is on,
+     * and q-p hide `1`-`0` while the number row is already there.
+     */
+    fun hint(
+        key: KeyboardKey,
+        numberKeyHints: Boolean = true,
+        longPressSymbols: Boolean = false,
+        numberRow: Boolean = false,
+    ): String? {
         if (key.type != KeyboardKeyType.CHARACTER) return null
-        val digit = key.output
-        if (digit.length != 1 || !digit[0].isDigit()) return null
-        return variants[digit]?.firstOrNull()
+        val base = key.output
+        if (base.length != 1) return null
+        if (base[0].isDigit()) {
+            return if (numberKeyHints) variants[base]?.firstOrNull() else null
+        }
+        return letterSymbol(base.lowercase(Locale.ROOT), longPressSymbols, numberRow)
+    }
+
+    private fun letterSymbol(
+        base: String,
+        longPressSymbols: Boolean,
+        numberRow: Boolean,
+    ): String? {
+        if (!longPressSymbols) return null
+        if (numberRow && base in digitLetters) return null
+        return letterSymbols[base]
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -127,6 +127,8 @@ internal data class ClipboardChip(
 internal data class SuggestionItem(
     val text: String,
     val isEmoji: Boolean = false,
+    /** Tapping this chip saves [text] to the personal dictionary. */
+    val savesWord: Boolean = false,
 )
 
 /** What the single Gboard-style toolbar row should show. */
@@ -222,9 +224,14 @@ internal data class SuggestionStrip(
     val words: List<String>,
     val emojis: List<String> = emptyList(),
     val replacesWord: Boolean = false,
+    val saveWord: String? = null,
 ) {
     val items: List<SuggestionItem>
-        get() = words.map { SuggestionItem(it) } + emojis.map { SuggestionItem(it, isEmoji = true) }
+        get() = buildList {
+            saveWord?.let { add(SuggestionItem(it, savesWord = true)) }
+            addAll(words.map { SuggestionItem(it) })
+            addAll(emojis.map { SuggestionItem(it, isEmoji = true) })
+        }
 }
 
 /**

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/PersonalDictionary.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/PersonalDictionary.kt
@@ -1,0 +1,69 @@
+package com.vocahq.vocaphone.ime
+
+import java.util.Locale
+
+/**
+ * Words this user taught the suggestion strip: names, project names, anything
+ * the shipped English list misses.
+ *
+ * Separate from [com.vocahq.vocaphone.core.CustomVocabulary], which only biases
+ * Whisper. These words complete on the strip. Nothing here is logged or sent.
+ *
+ * The stored text is what the settings field shows. Parsing matches that
+ * field's contract: split on newlines and commas, keep the first spelling of
+ * a duplicate, cap the list so a pasted dump cannot grow without bound.
+ */
+internal object PersonalDictionary {
+    const val CAPACITY = 2_000
+    const val MIN_LENGTH = 3
+
+    fun terms(raw: String?): List<String> {
+        if (raw.isNullOrBlank()) return emptyList()
+        val seen = mutableSetOf<String>()
+        return raw.split('\n', ',')
+            .map { it.trim() }
+            .filter { isSavable(it) && seen.add(it.lowercase(Locale.ROOT)) }
+            .take(CAPACITY)
+    }
+
+    fun normalize(raw: String?): String = terms(raw).joinToString("\n")
+
+    fun contains(raw: String?, word: String): Boolean {
+        val key = word.lowercase(Locale.ROOT)
+        if (key.isEmpty()) return false
+        return terms(raw).any { it.lowercase(Locale.ROOT) == key }
+    }
+
+    fun completions(raw: String?, prefix: String, limit: Int = 3): List<String> {
+        if (prefix.isEmpty() || limit <= 0) return emptyList()
+        val lower = prefix.lowercase(Locale.ROOT)
+        return terms(raw)
+            .filter { it.length > lower.length && it.lowercase(Locale.ROOT).startsWith(lower) }
+            .take(limit)
+            .map { present(prefix, it) }
+    }
+
+    fun add(raw: String?, word: String): String {
+        val cleaned = word.trim()
+        if (!isSavable(cleaned)) return normalize(raw)
+        val existing = terms(raw).filter { !it.equals(cleaned, ignoreCase = true) }
+        return (listOf(cleaned) + existing).take(CAPACITY).joinToString("\n")
+    }
+
+    fun isSavable(word: String): Boolean {
+        val trimmed = word.trim()
+        return trimmed.length >= MIN_LENGTH &&
+            trimmed.any { it.isLetter() } &&
+            trimmed.all { it.isLetter() || it == '\'' }
+    }
+
+    /**
+     * Keep the stored spelling when the user typed in lowercase — that capital
+     * letter is why they saved the word. Honour caps lock / a leading capital
+     * the same way the word list does.
+     */
+    fun present(prefix: String, stored: String): String {
+        if (prefix.all { !it.isLetter() || it.isLowerCase() }) return stored
+        return SuggestionEngine.matchCase(prefix, stored)
+    }
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/PersonalDictionary.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/PersonalDictionary.kt
@@ -9,13 +9,14 @@ import java.util.Locale
  * Separate from [com.vocahq.vocaphone.core.CustomVocabulary], which only biases
  * Whisper. These words complete on the strip. Nothing here is logged or sent.
  *
- * The stored text is what the settings field shows. Parsing matches that
- * field's contract: split on newlines and commas, keep the first spelling of
- * a duplicate, cap the list so a pasted dump cannot grow without bound.
+ * The stored text is what the settings field shows. Parsing accepts commas
+ * or new lines; saving always writes a comma-separated list, which is how
+ * the field is meant to be edited.
  */
 internal object PersonalDictionary {
     const val CAPACITY = 2_000
     const val MIN_LENGTH = 3
+    private const val SEPARATOR = ", "
 
     fun terms(raw: String?): List<String> {
         if (raw.isNullOrBlank()) return emptyList()
@@ -26,7 +27,7 @@ internal object PersonalDictionary {
             .take(CAPACITY)
     }
 
-    fun normalize(raw: String?): String = terms(raw).joinToString("\n")
+    fun normalize(raw: String?): String = terms(raw).joinToString(SEPARATOR)
 
     fun contains(raw: String?, word: String): Boolean {
         val key = word.lowercase(Locale.ROOT)
@@ -47,7 +48,7 @@ internal object PersonalDictionary {
         val cleaned = word.trim()
         if (!isSavable(cleaned)) return normalize(raw)
         val existing = terms(raw).filter { !it.equals(cleaned, ignoreCase = true) }
-        return (listOf(cleaned) + existing).take(CAPACITY).joinToString("\n")
+        return (listOf(cleaned) + existing).take(CAPACITY).joinToString(SEPARATOR)
     }
 
     fun isSavable(word: String): Boolean {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
@@ -118,24 +118,54 @@ internal class SuggestionDictionary(
         before: String,
         after: String,
         correctionsEnabled: Boolean,
+        personalRaw: String = "",
     ): SuggestionStrip {
         val token = composing.ifEmpty { SuggestionEngine.lastWordForEmoji(before).orEmpty() }
         val emojis = EmojiSuggestions.glyphs(token)
         if (composing.isNotEmpty()) {
+            val personalHits = PersonalDictionary.completions(personalRaw, composing)
             val completions = complete(composing)
             val corrections = if (correctionsEnabled) correct(composing) else emptyList()
-            return SuggestionStrip((completions + corrections).distinct().take(3), emojis)
+            val words = (personalHits + completions + corrections).distinct().take(3)
+            val save = saveCandidate(
+                word = composing,
+                personalRaw = personalRaw,
+                // Still typing a known word: hello/help already fill the strip.
+                hasCompletions = personalHits.isNotEmpty() || completions.isNotEmpty(),
+            )
+            return SuggestionStrip(words, emojis, saveWord = save)
         }
+        val finished = SuggestionEngine.lastTypedWord(before)
+        val save = saveCandidate(
+            word = finished.orEmpty(),
+            personalRaw = personalRaw,
+            hasCompletions = false,
+        )
         if (correctionsEnabled) {
             val span = SuggestionEngine.wordSpan(before, after)
             if (span != null && span.word.length >= 2) {
                 val nearby = similar(span.word)
                 if (nearby.isNotEmpty()) {
-                    return SuggestionStrip(nearby, emojis, replacesWord = true)
+                    return SuggestionStrip(nearby, emojis, replacesWord = true, saveWord = save)
                 }
             }
         }
-        return SuggestionStrip(next(SuggestionEngine.lastWord(before).orEmpty()), emojis)
+        return SuggestionStrip(
+            next(SuggestionEngine.lastWord(before).orEmpty()),
+            emojis,
+            saveWord = save,
+        )
+    }
+
+    private fun saveCandidate(
+        word: String,
+        personalRaw: String,
+        hasCompletions: Boolean,
+    ): String? {
+        if (hasCompletions) return null
+        if (!PersonalDictionary.isSavable(word)) return null
+        if (isKnown(word) || PersonalDictionary.contains(personalRaw, word)) return null
+        return word
     }
 
     fun swipe(path: String, limit: Int = 4): List<String> {
@@ -233,6 +263,24 @@ internal object SuggestionEngine {
         val word = trimmed.substring(start).replace("'", "").lowercase()
         return word.takeIf { it.any(Char::isLetter) }
     }
+
+    /**
+     * The last token as the user typed it, for adding to the personal
+     * dictionary. [lastWord] strips apostrophes and case for bigram lookup;
+     * saving "obrien" when they wrote "O'Brien" would miss the point.
+     */
+    fun lastTypedWord(textBeforeCursor: CharSequence): String? {
+        var end = textBeforeCursor.length
+        while (end > 0 && !isTypedWordChar(textBeforeCursor[end - 1])) end--
+        if (end == 0) return null
+        var start = end
+        while (start > 0 && isTypedWordChar(textBeforeCursor[start - 1])) start--
+        val word = textBeforeCursor.subSequence(start, end).toString()
+        return word.takeIf { it.any(Char::isLetter) }
+    }
+
+    private fun isTypedWordChar(character: Char): Boolean =
+        character.isLetter() || character == '\''
 
     /** Last word even when a space or period is already sitting after it. */
     fun lastWordForEmoji(textBeforeCursor: CharSequence): String? {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -151,6 +151,7 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
             onLanguageSelected = ::setLanguage,
             onStyleSelected = ::setStyle,
             onSuggestionPicked = ::commitSuggestion,
+            onSaveToDictionary = ::addPersonalWord,
             onEmojiSuggestion = ::commitEmojiSuggestion,
             onPasteClipboard = { pasteClipboard(it) },
             onDismissClipboard = ::dismissClipboard,
@@ -463,6 +464,14 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
 
     private fun recordEmojiRecent(emoji: String) {
         persistPreference { container.settings.recordEmojiRecent(emoji) }
+    }
+
+    private fun addPersonalWord(word: String) {
+        // Not persistPreference: that gate drops a write while another is in
+        // flight, and two + chips in a row would lose the first word.
+        scope.launch {
+            container.settings.addPersonalWord(word)
+        }
     }
 
     private fun cycleSelectionCase() {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -149,6 +149,7 @@ internal fun VocaPhoneKeyboard(
     onLanguageSelected: (TranscriptionLanguage) -> Unit,
     onStyleSelected: (WritingStyle) -> Unit,
     onSuggestionPicked: (String, Boolean) -> Unit,
+    onSaveToDictionary: (String) -> Unit,
     onEmojiSuggestion: (String) -> Unit,
     onPasteClipboard: (String) -> Unit,
     onDismissClipboard: () -> Unit,
@@ -186,6 +187,9 @@ internal fun VocaPhoneKeyboard(
     var swipeChoices by remember { mutableStateOf<List<String>>(emptyList()) }
     var swipeWord by remember { mutableStateOf<String?>(null) }
     var suggestionStrip by remember { mutableStateOf(SuggestionStrip(emptyList())) }
+    // Words saved this editor session, so the + chip vanishes before DataStore
+    // has come back around. Reset with the editor; the persisted list is source of truth.
+    var savedThisSession by remember { mutableStateOf(emptyList<String>()) }
 
     // The one place a new editor wipes the keyboard. Replacing the holders did
     // this implicitly and broke the handlers that had closed over them.
@@ -199,6 +203,7 @@ internal fun VocaPhoneKeyboard(
         swipeChoices = emptyList()
         swipeWord = null
         suggestionStrip = SuggestionStrip(emptyList())
+        savedThisSession = emptyList()
     }
 
     LaunchedEffect(dictationState.phase, editor.dictationAllowed) {
@@ -258,12 +263,18 @@ internal fun VocaPhoneKeyboard(
     // window would commit a suggestion for the word as it was a letter ago —
     // reachable in principle, sixteen milliseconds wide in practice, and the
     // same trade every keyboard that does this off the main thread makes.
+    val personalRaw = remember(settings.personalDictionary, savedThisSession) {
+        savedThisSession.fold(settings.personalDictionary) { acc, word ->
+            PersonalDictionary.add(acc, word)
+        }
+    }
     LaunchedEffect(
         composeWords,
         settings.correctionsEnabled,
         keyboardState.composing,
         editorText,
         suggestions,
+        personalRaw,
     ) {
         suggestionStrip = if (!composeWords || suggestions == null) {
             SuggestionStrip(emptyList())
@@ -274,6 +285,7 @@ internal fun VocaPhoneKeyboard(
                     before = editorText.before,
                     after = editorText.after,
                     correctionsEnabled = settings.correctionsEnabled,
+                    personalRaw = personalRaw,
                 )
             }
         }
@@ -520,6 +532,18 @@ internal fun VocaPhoneKeyboard(
                                 lastWasSpace = false,
                             )
                             onEmojiSuggestion(item.text)
+                        } else if (item.savesWord) {
+                            savedThisSession = savedThisSession + item.text
+                            onSaveToDictionary(item.text)
+                            if (keyboardState.composing.isNotEmpty()) {
+                                clearSwipe()
+                                keyboardState = keyboardState.copy(
+                                    composing = "",
+                                    lastWasSpace = true,
+                                    capitalizeAfterSpace = false,
+                                )
+                                onSuggestionPicked(item.text, false)
+                            }
                         } else {
                             val replace = KeyboardChrome.suggestionReplacesWord(
                                 composing = keyboardState.composing,
@@ -617,7 +641,9 @@ internal fun VocaPhoneKeyboard(
                             layer = keyboardState.layer,
                             editor = editor,
                             keyHeight = fittedKeyHeight,
-                            showKeyHints = settings.numberKeyHintsEnabled,
+                            numberKeyHints = settings.numberKeyHintsEnabled,
+                            longPressSymbols = settings.longPressSymbolsEnabled,
+                            numberRow = settings.numberRowEnabled,
                             split = splitKeys,
                             spacerFraction = spacerFraction,
                             swipeEnabled = settings.swipeTypingEnabled &&
@@ -1604,10 +1630,15 @@ private fun RowScope.SuggestionStripRow(
     if (suggestions.size <= 3) {
         suggestions.forEach { item ->
             SuggestionChip(
-                label = item.text,
+                label = if (item.savesWord) "+ ${item.text}" else item.text,
                 emoji = item.isEmoji,
                 onClick = { onSuggestion(item) },
                 modifier = Modifier.weight(1f),
+                contentDescription = if (item.savesWord) {
+                    "Add ${item.text} to dictionary"
+                } else {
+                    item.text
+                },
             )
         }
         return
@@ -1639,10 +1670,15 @@ private fun RowScope.SuggestionStripRow(
         ) {
             suggestions.forEach { item ->
                 SuggestionChip(
-                    label = item.text,
+                    label = if (item.savesWord) "+ ${item.text}" else item.text,
                     emoji = item.isEmoji,
                     onClick = { onSuggestion(item) },
                     modifier = Modifier.widthIn(min = if (item.isEmoji) 44.dp else 68.dp),
+                    contentDescription = if (item.savesWord) {
+                        "Add ${item.text} to dictionary"
+                    } else {
+                        item.text
+                    },
                 )
             }
         }
@@ -1655,13 +1691,14 @@ private fun SuggestionChip(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     emoji: Boolean = false,
+    contentDescription: String = label,
 ) {
     Surface(
         modifier = modifier
             .height(32.dp)
             .semantics {
                 role = Role.Button
-                contentDescription = label
+                this.contentDescription = contentDescription
             },
         shape = RoundedCornerShape(10.dp),
         color = MaterialTheme.colorScheme.surfaceContainerHigh,
@@ -1829,7 +1866,9 @@ private fun KeyboardRows(
     layer: KeyboardLayer,
     editor: KeyboardEditorConfig,
     keyHeight: Dp,
-    showKeyHints: Boolean = false,
+    numberKeyHints: Boolean = false,
+    longPressSymbols: Boolean = false,
+    numberRow: Boolean = false,
     split: Boolean = false,
     spacerFraction: Float = SplitKeyboardLayout.MIN_SPACER_FRACTION,
     swipeEnabled: Boolean = false,
@@ -1900,7 +1939,9 @@ private fun KeyboardRows(
                                     layer = layer,
                                     editor = editor,
                                     keyHeight = keyHeight,
-                                    showKeyHints = showKeyHints,
+                                    numberKeyHints = numberKeyHints,
+                                    longPressSymbols = longPressSymbols,
+                                    numberRow = numberRow,
                                     // A swipe can only begin on a letter, so a
                                     // letter is the only key whose own tap can
                                     // be the tail of one. Handing the flag to
@@ -2013,7 +2054,9 @@ private fun RowScope.KeyButton(
     layer: KeyboardLayer,
     editor: KeyboardEditorConfig,
     keyHeight: Dp,
-    showKeyHints: Boolean = false,
+    numberKeyHints: Boolean = false,
+    longPressSymbols: Boolean = false,
+    numberRow: Boolean = false,
     swipeConsumed: MutableState<Boolean>? = null,
     onPress: () -> Unit,
     onHold: (Long) -> Unit = {},
@@ -2029,7 +2072,9 @@ private fun RowScope.KeyButton(
     val currentOnCursorMove = rememberUpdatedState(onCursorMove)
     var pressed by remember(key.id) { mutableStateOf(false) }
     var accentIndex by remember(key.id) { mutableStateOf(-1) }
-    val accents = remember(key.id, shift) { KeyAccents.forKey(key, shift) }
+    val accents = remember(key.id, shift, longPressSymbols, numberRow) {
+        KeyAccents.forKey(key, shift, longPressSymbols, numberRow)
+    }
     val isReturnAction = key.type == KeyboardKeyType.RETURN && editor.returnKey != ReturnKeyKind.ENTER
     val activeShift = key.type == KeyboardKeyType.SHIFT && shift != ShiftState.OFF
     val background = when {
@@ -2105,7 +2150,12 @@ private fun RowScope.KeyButton(
             shift = shift,
             returnKey = editor.returnKey,
             tint = foreground,
-            hint = if (showKeyHints) KeyAccents.hint(key) else null,
+            hint = KeyAccents.hint(
+                key,
+                numberKeyHints = numberKeyHints,
+                longPressSymbols = longPressSymbols,
+                numberRow = numberRow,
+            ),
         )
 
         if (pressed && swipeConsumed?.value != true && key.type == KeyboardKeyType.CHARACTER) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -336,7 +336,7 @@ class SettingsRepository(private val context: Context) {
                 .map { it.trim() }
                 .filter { it.isNotEmpty() && !it.equals(cleaned, ignoreCase = true) }
             preferences[Keys.PERSONAL_DICTIONARY] =
-                (listOf(cleaned) + existing).take(2_000).joinToString("\n")
+                (listOf(cleaned) + existing).take(2_000).joinToString(", ")
         }
     }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -170,6 +170,12 @@ data class VocaPhoneSettings(
     val suggestionsEnabled: Boolean = true,
     val correctionsEnabled: Boolean = true,
     val numberKeyHintsEnabled: Boolean = true,
+    val longPressSymbolsEnabled: Boolean = false,
+    /**
+     * Words the suggestion strip should complete, as the user typed or pasted
+     * them. Newlines or commas; the keyboard parses the text on read.
+     */
+    val personalDictionary: String = "",
     val asciiEmojiEnabled: Boolean = true,
     val swipeTypingEnabled: Boolean = true,
     val clipboardChipEnabled: Boolean = true,
@@ -312,6 +318,28 @@ class SettingsRepository(private val context: Context) {
 
     suspend fun setNumberKeyHintsEnabled(enabled: Boolean) = put(Keys.NUMBER_KEY_HINTS, enabled)
 
+    suspend fun setLongPressSymbolsEnabled(enabled: Boolean) = put(Keys.LONG_PRESS_SYMBOLS, enabled)
+
+    suspend fun setPersonalDictionary(words: String) = put(Keys.PERSONAL_DICTIONARY, words)
+
+    /**
+     * Appends one word in a single DataStore edit so two rapid strip taps
+     * cannot drop the first. The keyboard only hands over words it already
+     * treated as savable.
+     */
+    suspend fun addPersonalWord(word: String) {
+        val cleaned = word.trim()
+        if (cleaned.length < 3) return
+        context.dataStore.edit { preferences ->
+            val current = preferences[Keys.PERSONAL_DICTIONARY].orEmpty()
+            val existing = current.split('\n', ',')
+                .map { it.trim() }
+                .filter { it.isNotEmpty() && !it.equals(cleaned, ignoreCase = true) }
+            preferences[Keys.PERSONAL_DICTIONARY] =
+                (listOf(cleaned) + existing).take(2_000).joinToString("\n")
+        }
+    }
+
     suspend fun setAsciiEmojiEnabled(enabled: Boolean) = put(Keys.ASCII_EMOJI, enabled)
 
     suspend fun setSwipeTypingEnabled(enabled: Boolean) = put(Keys.SWIPE_TYPING, enabled)
@@ -449,6 +477,8 @@ class SettingsRepository(private val context: Context) {
         suggestionsEnabled = this[Keys.SUGGESTIONS] ?: true,
         correctionsEnabled = this[Keys.CORRECTIONS] ?: true,
         numberKeyHintsEnabled = this[Keys.NUMBER_KEY_HINTS] ?: true,
+        longPressSymbolsEnabled = this[Keys.LONG_PRESS_SYMBOLS] ?: false,
+        personalDictionary = this[Keys.PERSONAL_DICTIONARY].orEmpty(),
         asciiEmojiEnabled = this[Keys.ASCII_EMOJI] ?: true,
         swipeTypingEnabled = this[Keys.SWIPE_TYPING] ?: true,
         clipboardChipEnabled = this[Keys.CLIPBOARD_CHIP] ?: true,
@@ -487,6 +517,8 @@ class SettingsRepository(private val context: Context) {
         val SUGGESTIONS = booleanPreferencesKey("keyboard_suggestions")
         val CORRECTIONS = booleanPreferencesKey("keyboard_corrections")
         val NUMBER_KEY_HINTS = booleanPreferencesKey("keyboard_number_key_hints")
+        val LONG_PRESS_SYMBOLS = booleanPreferencesKey("keyboard_long_press_symbols")
+        val PERSONAL_DICTIONARY = stringPreferencesKey("keyboard_personal_dictionary")
         val ASCII_EMOJI = booleanPreferencesKey("keyboard_ascii_emoji")
         val SWIPE_TYPING = booleanPreferencesKey("keyboard_swipe_typing")
         val CLIPBOARD_CHIP = booleanPreferencesKey("keyboard_clipboard_chip")

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
@@ -418,7 +418,6 @@ fun VocaPhoneApp(
                 onSwipeTyping = { viewModel.setSwipeTypingEnabled(it) },
                 onClipboardChip = { viewModel.setClipboardChipEnabled(it) },
                 onClipboardHistory = { viewModel.setClipboardHistoryEnabled(it) },
-                onClearClipboardHistory = { viewModel.clearClipboardHistory() },
                 localModels = localModels,
                 onLocalTranscriptionEnabled = viewModel::setLocalTranscriptionEnabled,
                 onLocalModel = viewModel::setLocalModel,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
@@ -412,6 +412,8 @@ fun VocaPhoneApp(
                 onSuggestions = { viewModel.setSuggestionsEnabled(it) },
                 onCorrections = { viewModel.setCorrectionsEnabled(it) },
                 onNumberKeyHints = { viewModel.setNumberKeyHintsEnabled(it) },
+                onLongPressSymbols = { viewModel.setLongPressSymbolsEnabled(it) },
+                onPersonalDictionary = { viewModel.setPersonalDictionary(it) },
                 onAsciiEmoji = { viewModel.setAsciiEmojiEnabled(it) },
                 onSwipeTyping = { viewModel.setSwipeTypingEnabled(it) },
                 onClipboardChip = { viewModel.setClipboardChipEnabled(it) },

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -516,7 +516,7 @@ private fun PersonalDictionarySection(
     words: String,
     onSave: (String) -> Unit,
 ) {
-    var draft by remember(words) { mutableStateOf(words) }
+    var draft by remember(words) { mutableStateOf(PersonalDictionary.normalize(words)) }
     var lastCleared by remember { mutableStateOf<String?>(null) }
     var confirmClear by remember { mutableStateOf(false) }
     val terms = remember(draft) { PersonalDictionary.terms(draft) }
@@ -531,7 +531,6 @@ private fun PersonalDictionarySection(
             value = draft,
             onValueChange = { draft = it },
             modifier = Modifier.fillMaxWidth(),
-            label = { Text("Words") },
             placeholder = { Text("Grafana, GraphQL, Kubernetes, Docker") },
             minLines = 3,
             maxLines = 8,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.vocahq.vocaphone.R
 import com.vocahq.vocaphone.core.CustomVocabulary
+import com.vocahq.vocaphone.ime.PersonalDictionary
 import com.vocahq.vocaphone.core.DictationTone
 import com.vocahq.vocaphone.core.MicrophonePreference
 import com.vocahq.vocaphone.core.TranscriptionLanguage
@@ -88,6 +89,8 @@ fun SettingsScreen(
     onSuggestions: (Boolean) -> Unit,
     onCorrections: (Boolean) -> Unit,
     onNumberKeyHints: (Boolean) -> Unit,
+    onLongPressSymbols: (Boolean) -> Unit,
+    onPersonalDictionary: (String) -> Unit,
     onAsciiEmoji: (Boolean) -> Unit,
     onSwipeTyping: (Boolean) -> Unit,
     onClipboardChip: (Boolean) -> Unit,
@@ -277,6 +280,14 @@ fun SettingsScreen(
                         onCheckedChange = onNumberKeyHints,
                     )
                     SettingToggle(
+                        title = "Long-press for symbols",
+                        detail = "Show a punctuation or digit on each letter key. " +
+                            "Hold the key to type it; slide for accents. Off by default " +
+                            "so a hold on E still types è.",
+                        checked = settings.longPressSymbolsEnabled,
+                        onCheckedChange = onLongPressSymbols,
+                    )
+                    SettingToggle(
                         title = "Text emoticons",
                         detail = "Add an ASCII category to the emoji panel, like :) and ¯\\_(ツ)_/¯.",
                         checked = settings.asciiEmojiEnabled,
@@ -290,6 +301,10 @@ fun SettingsScreen(
                         onCheckedChange = onSwipeTyping,
                     )
                 }
+                PersonalDictionarySection(
+                    words = settings.personalDictionary,
+                    onSave = onPersonalDictionary,
+                )
                 Section("Clipboard") {
                     SettingToggle(
                         title = "Clipboard chip",
@@ -495,6 +510,54 @@ private fun MicrophoneSection(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+    }
+}
+
+@Composable
+private fun PersonalDictionarySection(
+    words: String,
+    onSave: (String) -> Unit,
+) {
+    var draft by remember(words) { mutableStateOf(words) }
+    val terms = remember(draft) { PersonalDictionary.terms(draft) }
+    Section(
+        title = "Personal dictionary",
+        supporting = "Words the suggestion strip should know: names, project " +
+            "names, anything the English list misses. One per line, or separated " +
+            "by commas. Off in passwords.",
+    ) {
+        OutlinedTextField(
+            value = draft,
+            onValueChange = { draft = it },
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("Words") },
+            placeholder = { Text("Kanishk\nVocaPhone\nvocahq") },
+            minLines = 3,
+            maxLines = 8,
+        )
+        Text(
+            if (terms.isEmpty()) {
+                "No personal words. Completions come from the shipped English list."
+            } else {
+                "${terms.size} word${if (terms.size == 1) "" else "s"} will complete on the strip."
+            },
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        SecondaryButton(
+            text = "Save words",
+            onClick = { onSave(draft) },
+            enabled = PersonalDictionary.normalize(draft) != PersonalDictionary.normalize(words),
+        )
+        if (words.isNotBlank()) {
+            DestructiveButton(
+                "Clear personal dictionary",
+                onClick = {
+                    draft = ""
+                    onSave("")
+                },
+            )
+        }
     }
 }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -524,9 +524,8 @@ private fun PersonalDictionarySection(
     val canClear = words.isNotBlank()
     Section(
         title = "Personal dictionary",
-        supporting = "Words the suggestion strip should know: names, project " +
-            "names, anything the English list misses. Comma-separated, or one " +
-            "per line. Off in passwords.",
+        supporting = "Names and jargon the English list misses. " +
+            "Separate with commas. Off in passwords.",
     ) {
         OutlinedTextField(
             value = draft,
@@ -538,10 +537,10 @@ private fun PersonalDictionarySection(
             maxLines = 8,
         )
         Text(
-            if (terms.isEmpty()) {
-                "No personal words. Completions come from the shipped English list."
-            } else {
-                "${terms.size} word${if (terms.size == 1) "" else "s"} will complete on the strip."
+            when (terms.size) {
+                0 -> "None saved."
+                1 -> "1 word."
+                else -> "${terms.size} words."
             },
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -587,9 +586,9 @@ private fun PersonalDictionarySection(
             text = {
                 Text(
                     if (count == 1) {
-                        "This removes 1 word from this phone. You can undo from this screen."
+                        "This removes 1 word from this phone."
                     } else {
-                        "This removes $count words from this phone. You can undo from this screen."
+                        "This removes $count words from this phone."
                     },
                 )
             },

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalContext
@@ -98,7 +99,6 @@ fun SettingsScreen(
     onSwipeTyping: (Boolean) -> Unit,
     onClipboardChip: (Boolean) -> Unit,
     onClipboardHistory: (Boolean) -> Unit,
-    onClearClipboardHistory: () -> Unit,
     localModels: LocalModelState,
     onLocalTranscriptionEnabled: (Boolean) -> Unit,
     onLocalModel: (LocalModelDescriptor) -> Unit,
@@ -319,16 +319,11 @@ fun SettingsScreen(
                     SettingToggle(
                         title = "Clipboard history",
                         detail = "Save recent text and images on this phone. Open them " +
-                            "from the keyboard menu. Off in passwords.",
+                            "from the keyboard menu, where you can paste or delete them. " +
+                            "Off in passwords.",
                         checked = settings.clipboardHistoryEnabled,
                         onCheckedChange = onClipboardHistory,
                     )
-                    if (settings.clipboardHistory.isNotEmpty()) {
-                        DestructiveButton(
-                            "Clear clipboard history (${settings.clipboardHistory.size})",
-                            onClick = onClearClipboardHistory,
-                        )
-                    }
                 }
             }
 
@@ -530,15 +525,15 @@ private fun PersonalDictionarySection(
     Section(
         title = "Personal dictionary",
         supporting = "Words the suggestion strip should know: names, project " +
-            "names, anything the English list misses. One per line, or separated " +
-            "by commas. Off in passwords.",
+            "names, anything the English list misses. Comma-separated, or one " +
+            "per line. Off in passwords.",
     ) {
         OutlinedTextField(
             value = draft,
             onValueChange = { draft = it },
             modifier = Modifier.fillMaxWidth(),
             label = { Text("Words") },
-            placeholder = { Text("One per line") },
+            placeholder = { Text("Grafana, GraphQL, Kubernetes, Docker") },
             minLines = 3,
             maxLines = 8,
         )
@@ -554,8 +549,8 @@ private fun PersonalDictionarySection(
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            val shareRow = canClear || canUndo
             SecondaryButton(
                 text = "Save words",
                 onClick = {
@@ -563,7 +558,7 @@ private fun PersonalDictionarySection(
                     onSave(draft)
                 },
                 enabled = PersonalDictionary.normalize(draft) != PersonalDictionary.normalize(words),
-                modifier = if (shareRow) Modifier.weight(1f) else Modifier.fillMaxWidth(),
+                modifier = Modifier.weight(1f),
             )
             if (canUndo) {
                 SecondaryButton(
@@ -577,10 +572,9 @@ private fun PersonalDictionarySection(
                     modifier = Modifier.weight(1f),
                 )
             } else if (canClear) {
-                DestructiveButton(
+                DestructiveTextButton(
                     text = "Clear",
                     onClick = { confirmClear = true },
-                    modifier = Modifier.weight(1f),
                 )
             }
         }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -10,15 +10,18 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -519,7 +522,11 @@ private fun PersonalDictionarySection(
     onSave: (String) -> Unit,
 ) {
     var draft by remember(words) { mutableStateOf(words) }
+    var lastCleared by remember { mutableStateOf<String?>(null) }
+    var confirmClear by remember { mutableStateOf(false) }
     val terms = remember(draft) { PersonalDictionary.terms(draft) }
+    val canUndo = lastCleared != null && words.isBlank()
+    val canClear = words.isNotBlank()
     Section(
         title = "Personal dictionary",
         supporting = "Words the suggestion strip should know: names, project " +
@@ -531,7 +538,7 @@ private fun PersonalDictionarySection(
             onValueChange = { draft = it },
             modifier = Modifier.fillMaxWidth(),
             label = { Text("Words") },
-            placeholder = { Text("Kanishk\nVocaPhone\nvocahq") },
+            placeholder = { Text("One per line") },
             minLines = 3,
             maxLines = 8,
         )
@@ -544,20 +551,71 @@ private fun PersonalDictionarySection(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        SecondaryButton(
-            text = "Save words",
-            onClick = { onSave(draft) },
-            enabled = PersonalDictionary.normalize(draft) != PersonalDictionary.normalize(words),
-        )
-        if (words.isNotBlank()) {
-            DestructiveButton(
-                "Clear personal dictionary",
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            val shareRow = canClear || canUndo
+            SecondaryButton(
+                text = "Save words",
                 onClick = {
-                    draft = ""
-                    onSave("")
+                    lastCleared = null
+                    onSave(draft)
                 },
+                enabled = PersonalDictionary.normalize(draft) != PersonalDictionary.normalize(words),
+                modifier = if (shareRow) Modifier.weight(1f) else Modifier.fillMaxWidth(),
             )
+            if (canUndo) {
+                SecondaryButton(
+                    text = "Undo",
+                    onClick = {
+                        val restored = lastCleared ?: return@SecondaryButton
+                        lastCleared = null
+                        draft = restored
+                        onSave(restored)
+                    },
+                    modifier = Modifier.weight(1f),
+                )
+            } else if (canClear) {
+                DestructiveButton(
+                    text = "Clear",
+                    onClick = { confirmClear = true },
+                    modifier = Modifier.weight(1f),
+                )
+            }
         }
+    }
+    if (confirmClear) {
+        val count = PersonalDictionary.terms(words).size
+        AlertDialog(
+            onDismissRequest = { confirmClear = false },
+            title = { Text("Clear personal dictionary?") },
+            text = {
+                Text(
+                    if (count == 1) {
+                        "This removes 1 word from this phone. You can undo from this screen."
+                    } else {
+                        "This removes $count words from this phone. You can undo from this screen."
+                    },
+                )
+            },
+            confirmButton = {
+                DestructiveTextButton(
+                    text = "Clear",
+                    onClick = {
+                        lastCleared = words
+                        confirmClear = false
+                        draft = ""
+                        onSave("")
+                    },
+                )
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmClear = false }) {
+                    Text("Cancel")
+                }
+            },
+        )
     }
 }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
@@ -373,6 +373,16 @@ class VocaPhoneViewModel(application: Application) : AndroidViewModel(applicatio
     fun setNumberKeyHintsEnabled(enabled: Boolean) =
         viewModelScope.launch { container.settings.setNumberKeyHintsEnabled(enabled) }
 
+    fun setLongPressSymbolsEnabled(enabled: Boolean) =
+        viewModelScope.launch { container.settings.setLongPressSymbolsEnabled(enabled) }
+
+    fun setPersonalDictionary(words: String) =
+        viewModelScope.launch {
+            container.settings.setPersonalDictionary(
+                com.vocahq.vocaphone.ime.PersonalDictionary.normalize(words),
+            )
+        }
+
     fun setAsciiEmojiEnabled(enabled: Boolean) =
         viewModelScope.launch { container.settings.setAsciiEmojiEnabled(enabled) }
 

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/EmojiSuggestionsTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/EmojiSuggestionsTest.kt
@@ -35,6 +35,43 @@ class EmojiSuggestionsTest {
     }
 
     @Test
+    fun uniqueAlmostFinishedPrefixOffersTheGlyph() {
+        assertEquals("🍕", EmojiSuggestions.glyph("pizz"))
+        assertEquals("☕", EmojiSuggestions.glyph("coffe"))
+        assertEquals(listOf("😢", "😭", "😞"), EmojiSuggestions.glyphs("unhap"))
+    }
+
+    @Test
+    fun shortOrAmbiguousPrefixesOfferNothing() {
+        assertNull(EmojiSuggestions.glyph("hap"))
+        assertNull(EmojiSuggestions.glyph("co"))
+        // "read" is a real word, three letters short of "reading". Offering 📚
+        // here is the same failure as matching catalog keywords.
+        assertNull(EmojiSuggestions.glyph("read"))
+    }
+
+    @Test
+    fun uniqueInsertOrDeleteOffersTheGlyph() {
+        assertEquals("🍕", EmojiSuggestions.glyph("piza"))
+        assertEquals("☕", EmojiSuggestions.glyph("cofee"))
+        assertEquals("😊", EmojiSuggestions.glyph("happpy"))
+    }
+
+    @Test
+    fun substitutionDoesNotOfferANearbyTrigger() {
+        // "read" is one substitution from "dead". That must not become 💀.
+        assertNull(EmojiSuggestions.glyph("read"))
+        assertEquals("💀", EmojiSuggestions.glyph("dead"))
+    }
+
+    @Test
+    fun aLeadingExtraLetterDoesNotTurnAParticleIntoATrigger() {
+        // "they" is "t" + "hey". Offering 👋 there is the strip crying wolf.
+        assertNull(EmojiSuggestions.glyph("they"))
+        assertEquals("👋", EmojiSuggestions.glyph("hey"))
+    }
+
+    @Test
     fun ordinaryProseGetsNothing() {
         for (word in listOf(
             "the", "and", "is", "was", "of", "to", "it", "that", "this", "with",

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyAccentsTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyAccentsTest.kt
@@ -39,4 +39,44 @@ class KeyAccentsTest {
         assertEquals(")", KeyAccents.hint(KeyboardKey(id = "0", label = "0", output = "0")))
         assertEquals(null, KeyAccents.hint(KeyboardKey(id = "e", label = "e", output = "e")))
     }
+
+    @Test
+    fun letterKeysShowGboardSymbolsWhenEnabled() {
+        val e = KeyboardKey(id = "e", label = "e", output = "e")
+        val a = KeyboardKey(id = "a", label = "a", output = "a")
+        val q = KeyboardKey(id = "q", label = "q", output = "q")
+        assertEquals("3", KeyAccents.hint(e, longPressSymbols = true))
+        assertEquals("@", KeyAccents.hint(a, longPressSymbols = true))
+        assertEquals("1", KeyAccents.hint(q, longPressSymbols = true, numberRow = false))
+        assertEquals(null, KeyAccents.hint(q, longPressSymbols = true, numberRow = true))
+        assertEquals("@", KeyAccents.hint(a, longPressSymbols = true, numberRow = true))
+        assertEquals(null, KeyAccents.hint(e, longPressSymbols = false))
+    }
+
+    @Test
+    fun longPressSymbolsSitInFrontOfAccents() {
+        val e = KeyboardKey(id = "e", label = "e", output = "e")
+        val off = KeyAccents.forKey(e, ShiftState.OFF)
+        assertEquals("è", off.first())
+        assertTrue("3" !in off)
+
+        val on = KeyAccents.forKey(e, ShiftState.OFF, longPressSymbols = true)
+        assertEquals("3", on.first())
+        assertTrue("è" in on)
+
+        val shifted = KeyAccents.forKey(e, ShiftState.ONCE, longPressSymbols = true)
+        assertEquals("3", shifted.first())
+        assertTrue("È" in shifted)
+    }
+
+    @Test
+    fun qLongPressesToOneOnlyWithoutANumberRow() {
+        val q = KeyboardKey(id = "q", label = "q", output = "q")
+        assertTrue(KeyAccents.forKey(q, ShiftState.OFF).isEmpty())
+        assertEquals(listOf("1"), KeyAccents.forKey(q, ShiftState.OFF, longPressSymbols = true))
+        assertTrue(
+            KeyAccents.forKey(q, ShiftState.OFF, longPressSymbols = true, numberRow = true)
+                .isEmpty(),
+        )
+    }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/PersonalDictionaryTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/PersonalDictionaryTest.kt
@@ -1,0 +1,49 @@
+package com.vocahq.vocaphone.ime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PersonalDictionaryTest {
+
+    @Test
+    fun parsesCommasAndNewlinesAndKeepsTheFirstSpelling() {
+        val terms = PersonalDictionary.terms("Kanishk, vocahq\nKanishk\nVocaPhone")
+        assertEquals(listOf("Kanishk", "vocahq", "VocaPhone"), terms)
+    }
+
+    @Test
+    fun completionsPreferSavedSpellingForLowercasePrefixes() {
+        val raw = "Kanishk\nVocaPhone"
+        assertEquals(listOf("Kanishk"), PersonalDictionary.completions(raw, "kan"))
+        assertEquals(listOf("KANISHK"), PersonalDictionary.completions(raw, "KAN"))
+        assertTrue(PersonalDictionary.completions(raw, "zzz").isEmpty())
+        assertTrue(PersonalDictionary.completions(raw, "kanishk").isEmpty())
+    }
+
+    @Test
+    fun addPutsTheNewWordFirstAndDropsDuplicates() {
+        val added = PersonalDictionary.add("vocahq\nKanishk", "VocaPhone")
+        assertEquals("VocaPhone\nvocahq\nKanishk", added)
+        assertEquals(
+            "kanishk\nvocahq",
+            PersonalDictionary.add("vocahq\nKanishk", "kanishk"),
+        )
+    }
+
+    @Test
+    fun rejectsShortAndNonWordTokens() {
+        assertFalse(PersonalDictionary.isSavable("ab"))
+        assertFalse(PersonalDictionary.isSavable("hel2"))
+        assertFalse(PersonalDictionary.isSavable("@kanishk"))
+        assertTrue(PersonalDictionary.isSavable("O'Brien"))
+        assertEquals("", PersonalDictionary.add("", "ok"))
+    }
+
+    @Test
+    fun containsIsCaseInsensitive() {
+        assertTrue(PersonalDictionary.contains("Kanishk", "kanishk"))
+        assertFalse(PersonalDictionary.contains("Kanishk", "kan"))
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/PersonalDictionaryTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/PersonalDictionaryTest.kt
@@ -25,11 +25,20 @@ class PersonalDictionaryTest {
     @Test
     fun addPutsTheNewWordFirstAndDropsDuplicates() {
         val added = PersonalDictionary.add("vocahq\nKanishk", "VocaPhone")
-        assertEquals("VocaPhone\nvocahq\nKanishk", added)
+        assertEquals("VocaPhone, vocahq, Kanishk", added)
         assertEquals(
-            "kanishk\nvocahq",
+            "kanishk, vocahq",
             PersonalDictionary.add("vocahq\nKanishk", "kanishk"),
         )
+    }
+
+    @Test
+    fun normalizeWritesACommaSeparatedList() {
+        assertEquals(
+            "Kanishk, vocahq, VocaPhone",
+            PersonalDictionary.normalize("Kanishk, vocahq\nVocaPhone"),
+        )
+        assertEquals("", PersonalDictionary.normalize("  \n , "))
     }
 
     @Test

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
@@ -132,6 +132,76 @@ class SuggestionEngineTest {
     }
 
     @Test
+    fun lastTypedWordKeepsCaseAndApostrophes() {
+        assertEquals("O'Brien", SuggestionEngine.lastTypedWord("Hello O'Brien "))
+        assertEquals("Kanishk", SuggestionEngine.lastTypedWord("Kanishk."))
+        assertEquals("kanishk", SuggestionEngine.lastTypedWord("I am kanishk"))
+        assertEquals(null, SuggestionEngine.lastTypedWord("   "))
+    }
+
+    @Test
+    fun `strip completes personal words ahead of the shipped list`() {
+        val strip = dictionary.strip(
+            composing = "kan",
+            before = "",
+            after = "",
+            correctionsEnabled = false,
+            personalRaw = "Kanishk\nVocaPhone",
+        )
+        assertEquals("Kanishk", strip.words.first())
+        assertEquals(null, strip.saveWord)
+    }
+
+    @Test
+    fun `strip offers to save an unknown word`() {
+        val strip = dictionary.strip(
+            composing = "kanishk",
+            before = "",
+            after = "",
+            correctionsEnabled = false,
+        )
+        assertEquals("kanishk", strip.saveWord)
+        assertTrue(strip.items.first().savesWord)
+        assertEquals("kanishk", strip.items.first().text)
+    }
+
+    @Test
+    fun `strip does not offer to save a prefix of a known word`() {
+        val strip = dictionary.strip(
+            composing = "hel",
+            before = "",
+            after = "",
+            correctionsEnabled = false,
+        )
+        assertEquals(null, strip.saveWord)
+        assertTrue(strip.words.isNotEmpty())
+    }
+
+    @Test
+    fun `strip offers to save a finished unknown word`() {
+        val strip = dictionary.strip(
+            composing = "",
+            before = "Thanks Kanishk ",
+            after = "",
+            correctionsEnabled = false,
+            personalRaw = "",
+        )
+        assertEquals("Kanishk", strip.saveWord)
+    }
+
+    @Test
+    fun `strip does not offer to save a word already in the personal dictionary`() {
+        val strip = dictionary.strip(
+            composing = "kanishk",
+            before = "",
+            after = "",
+            correctionsEnabled = false,
+            personalRaw = "Kanishk",
+        )
+        assertEquals(null, strip.saveWord)
+    }
+
+    @Test
     fun `strip does not offer emoji for a prefix of a trigger`() {
         val strip = dictionary.strip(
             composing = "hap",


### PR DESCRIPTION
Android-only typing upgrades. The suggestion strip was a 10k English list, a static bigram table, and exact emoji triggers. This makes it learn names, reach punctuation without leaving the letters plane, and catch near-miss emoji without pointing CLDR at ordinary prose.

## Personal dictionary

Settings → Keyboard. Paste `Grafana, GraphQL, Kubernetes, Docker` (commas; new lines still parse). Those words complete first on the strip, with the spelling you saved.

Unknown words get a `+ kanishk` chip. Tap to save; if you were still composing, it also commits. Prefixes of known words (`hel` → hello) do not get a chip.

Clear sits next to Save as text, asks first, and leaves Undo on that row for the last list. Clipboard history is still toggled here; wiping it stays on the keyboard clipboard panel.

Empty field shows the Grafana example without a tap. Save writes a comma-separated list, not one word per line.

## Long-press for symbols

Off by default, so a hold on E still types `è`. When on, letter keys show the Gboard/AOSP hint (`e`→`3`, `a`→`@`, `n`→`!`) and hold-and-release types it. Accents stay in the same popup behind the symbol. With the number row on, `q`–`p` do not duplicate `1`–`0`.

## Fuzzier emoji

Still the curated table, not `catalog.tsv`. Exact trigger first (`lol` → 😂). Unique almost-finished prefix (`pizz` → 🍕), at least 4 letters and at most 2 short of the trigger. Unique one-letter insert or delete (`piza` → 🍕). Substitutions and a leading extra letter are out (`read` ↛ 💀, `they` ↛ 👋).

## Out of scope

iOS is unchanged. CLDR keywords still only power the emoji panel search. Next-word prediction is still the static bigram table.

## Try it

1. Settings → Keyboard: turn on **Long-press for symbols**. Paste a few names into **Personal dictionary**.
2. Type `pizz`, `piza`, and an unknown name on the IME.
3. Hold `e` with the toggle off (accents) vs on (`3`, then slide for `è`).
4. Clear the dictionary, confirm, Undo.

## Build the APK

From `android/`:

```sh
just build
```

That is `./gradlew assembleFullDebug`. The APK lands at:

`app/build/outputs/apk/full/debug/vocaphone-fullDebug.apk`

Install and launch on a connected device with `just run`.

## Tests

`./gradlew :app:testFullDebugUnitTest --tests 'com.vocahq.vocaphone.ime.*'`

