### PR TITLE
Make the Android keyboard keep 120Hz

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ not load `gateway/.env` into the shell (that is the Compose bearer token).
 
 | Path | Owns |
 | --- | --- |
-| `android/` | Kotlin IME, foreground mic service, on-device engines, unit tests |
+| `android/` | Kotlin IME, foreground mic service, on-device engines, unit tests. Read [android/AGENTS.md](android/AGENTS.md) before changing the keyboard |
 | `ios/` | Swift app, keyboard extension, Live Activity, shared App Group state, tests |
 | `gateway/` | Pinned vocagateway checkout (not developed as a first-class tree here) |
 | `assets/keyboard/` | Shared word list, bigrams, emoji catalog (both keyboards) |
@@ -149,6 +149,12 @@ Develop against the **`full`** flavor (prebuilt sherpa-onnx JNI + whisper.cpp).
 | 16 KB pages | `just android ci` runs `tools/check-page-alignment.py` on the full debug APK |
 | Native | whisper.cpp via CMake/NDK from the submodule; do not vendor a second copy |
 | Secrets | Never commit `android/local.properties`, `*.keystore`, `*.jks`, `keystore.properties` |
+
+The IME hot path (pointer handling, preview overlay, `InputConnection`
+coalescing, dictionary scans, and the 120 Hz benchmark harness) is documented in
+[android/AGENTS.md](android/AGENTS.md). Read it before touching
+`ime/`. Never load the 10k-word list on the composition thread — not in
+production code, and not to make a test pass.
 
 There is **no** `connectedAndroidTest` recipe. Instrumented tests under
 `android/app/src/androidTest/` are not a CI gate. Keyboard, bubble, and
@@ -255,6 +261,9 @@ task is a release. See [docs/releasing.md](docs/releasing.md).
 - Follow [.github/pull_request_template.md](.github/pull_request_template.md).
   Docs-only: mark `just ios ci` / `just android ci` / device testing N/A and
   say so.
+- Stacked PRs: an Android follow-up branches off the open Android PR (for
+  example `android/predictive-text`), not off `main`, so review stays stacked.
+  If that base is rebased, rebase the follow-up onto it rather than merging.
 - Keep the diff focused. Update `docs/` when data flow, permissions, retention,
   or network behavior changes.
 - Do not add recordings, tokens, tailnet names, or signing files to "make CI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,9 @@ security issues privately via [SECURITY.md](SECURITY.md).
 Look for issues labeled `good first issue` or `help wanted` when those labels
 are available.
 
+Coding-agent instructions (IME frame budget, `InputConnection`, benchmarks)
+live in [AGENTS.md](AGENTS.md) and [android/AGENTS.md](android/AGENTS.md).
+
 ## Development setup
 
 - Clone with submodules: `git clone --recurse-submodules …` (or

--- a/android/AGENTS.md
+++ b/android/AGENTS.md
@@ -1,0 +1,152 @@
+# Android agent notes
+
+Read this before changing the IME (`app/src/main/java/com/vocahq/vocaphone/ime/`).
+Human setup, flavors, and release tags: [README.md](README.md).
+
+The keyboard is a Compose `InputMethodService`. Users type on 120 Hz panels.
+A frame is **8.3 ms** (16.7 ms at 60 Hz). Work that blocks the IME main thread
+for a full frame reads as a stutter, not as lag.
+
+## Pointer and drawing
+
+A press must dirty **one key** and send **one write** to the editor.
+
+- Send letters, shift, layer, return, and delete on **pointer down**. Space
+  still commits on up so a cursor-swipe is not a space.
+- If the gesture becomes a swipe, undo **only the seed letter**
+  (`KeyboardReducer.undoLastCharacter`). Do not clear the whole composing word.
+- Accents: commit the letter on down; on long-press up, undo then commit the
+  variant. Same pattern FlorisBoard uses (`sendDown`, then cancel + replacement).
+- Preview is one in-tree overlay (`KeyPreviewLayer`) above the key grid. Do
+  **not** open a Compose `Popup` per tap. That is `WindowManager.addView` /
+  `removeView` on the down frame (often 5–20 ms) before the letter is sent.
+- Do not put `Modifier.shadow` on idle keys. Pressed state is a local color
+  change on that key.
+- Swipe trail is a sibling `Canvas` over a `SnapshotStateList`. Never store
+  trail points as `var` on the composable that builds the ~40 `KeyButton`s.
+- `KeyboardLayouts.rows()` allocates a new list. Remember it by
+  `(layer, returnKey, leadingPunctuation, numberRow)`. Rebuilding it on every
+  composing letter prevents Compose skip.
+- Per-key lambdas must be stable: `remember(key.id) { { currentOnKey.value(key) } }`
+  plus `rememberUpdatedState` at the parent. `{ onKey(key) }` inline in
+  `KeyboardRows` is a new object every pass and recomposes every key.
+- Do not read `swipeConsumed.value` (or other shared gesture flags) during
+  `KeyButton` composition. Gestures may read the `MutableState` on up.
+
+FlorisBoard (the Compose peer) uses one `pointerInteropFilter`, clones the
+`MotionEvent` into a `Channel(64)`, commits on down via `InputEventDispatcher`,
+and sets `key.isPressed` as `mutableStateOf` on the key object.
+AOSP / OpenBoard / HeliBoard / Simple Keyboard / AnySoftKeyboard use a View
+`KeyboardView`, an offscreen buffer, and `invalidateKey` dirty rects.
+Do not rewrite this IME in Views unless Compose pointer + skip still miss the
+frame after measurement.
+
+Known leftover: each special key still has its own `pointerInput`. Do not add
+more. A parent MotionEvent stream (Floris) is the next pointer cut.
+
+## InputConnection
+
+`getTextBeforeCursor` / `getTextAfterCursor` / `getCursorCapsMode` are
+**blocking Binder calls into the app being typed into**. Measured 7–16 ms per
+read on a POCO F1 typing into Messages — a whole 60 Hz frame, spent on the
+other app’s main thread.
+
+- Composing text lives in `KeyboardState.composing`. The strip uses that, not
+  a fresh editor read, while a word is in progress.
+- `handleCommand` skips `scheduleEditorTextRefresh()` for `SetComposingText`.
+  Other commands coalesce the read at 50 ms (`EDITOR_TEXT_REFRESH_DELAY_MS`).
+- Do not call `finishComposingText` when `composingRegionActive` is already
+  false. That is still an IPC.
+- Batch multi-call edits (`finishComposing` + `commitText`, double-space
+  period) with `beginBatchEdit` / `endBatchEdit`.
+- Keep `setComposingText` for letters so a suggestion can replace `hel` with
+  `hello `. FUTO maps composing to `commitText` internally because many apps
+  implement the composing API wrong, and they disabled it on Android 11- after
+  measuring lag in long documents. Do not drop composing here without measuring
+  Messages and Chrome on a phone.
+- FUTO’s `RichInputConnection` caches text-before-cursor and expected
+  selection, and backs off for ten minutes after a slow read (200 ms partial /
+  1000 ms full). That cache is the next IPC cut; the 50 ms coalesced read is
+  the reconcile, not the source of truth.
+
+## Suggestions and swipe
+
+- Load `en.txt`, bigrams, and the emoji catalog on `Dispatchers.Default` in
+  `onCreate`, never inside the first composition. The strip and emoji panel
+  already render empty.
+- `strip()` / `swipe()` / `similar()` run off the composition thread
+  (`LaunchedEffect` + `Dispatchers.Default`). Do not move them back into
+  `remember`.
+- `LaunchedEffect` cancellation is cooperative. Tight 10k-word loops must
+  take `shouldAbort` (checked every 128 words). Otherwise a cancelled job
+  still burns CPU and fights the 120 Hz thread for cores.
+- Do not key the strip effect on `editorText` while `composing` is nonempty.
+  That scheduled a second scan ~50 ms after every letter.
+- Swipe scoring of a messy path is **3.5 ms median / 5.5 ms p95** on a
+  Nothing Phone (1). That is most of a 120 Hz frame. It stays off the pointer
+  thread. Prefer `Channel.UNLIMITED` with ordered apply over `CONFLATED` so
+  two swipes in a row still commit in order.
+
+Word list, bigrams, emoji catalog: `assets/keyboard/` at the repo root, merged
+into the APK via `sourceSets` in `app/build.gradle.kts`. iOS reads the same
+files. Edits belong there, not in a platform-local copy.
+
+## Dictation vs keys
+
+`DictationState.level` updates at 10 Hz while recording. Collecting it at the
+IME root recomposes the whole keyboard, including keys. Isolate it in
+`DictationBar` / `MicButton` if you touch that path. The waveform
+`rememberInfiniteTransition` must only exist while `isRecording`.
+
+## Measuring
+
+FlorisBoard’s `benchmark` Gradle module is Macrobenchmark **app startup** plus
+baseline profiles. `FrameTimingMetric` on an Activity does **not** see IME
+frames (different window). Do not add that module to “prove” keystroke
+smoothness.
+
+This repo times the work a press actually does:
+
+```sh
+# Host JVM
+./gradlew :app:testFullDebugUnitTest -i \
+  --tests 'com.vocahq.vocaphone.ime.KeyboardHotPathTest' \
+  -Dvocaphone.benchmark=1
+
+# Phone
+./gradlew :app:connectedFullDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.keyboardBenchmark=true
+```
+
+`just keyboard-benchmark` runs the host pass and the device pass if a phone is
+attached. Logcat tag: `VocaPhoneBenchmark`. Opt-in, not a CI gate — phones
+differ. A 120 Hz budget is 8333 µs; report median and p95.
+
+On 2026-08-22, Nothing Phone (1) (`A063`, 120 Hz): `strip("hel")` 579 µs
+median, `swipe("tjhinl")` 3.5 ms median, reducer press 6.5 µs, Choreographer
+frame gap 8.35 ms median (one vsync). Treat those as a baseline, not a
+pass/fail.
+
+## Build and devices
+
+- JDK **21** exactly (F-Droid rebuilds on 21). `full` flavor for daily work;
+  every Gradle task name includes the flavor (`assembleFullDebug`,
+  `testFullDebugUnitTest`). `fdroid` flavor has no prebuilt sherpa-onnx.
+- `just build` / `just run` / `just ci` from `android/`.
+- WSL: USB debugging often shows up only on **Windows** `adb.exe`, not
+  `/usr/bin/adb`. If `adb devices` is empty, try
+  `/mnt/c/Users/<you>/platform-tools/adb.exe devices -l`. Copy APKs to a
+  Windows path (`/mnt/c/Users/.../Temp/`) before `adb.exe install`; `wslpath -w`
+  can mangle.
+- Pixel is the baseline device in the README. 120 Hz work should also be
+  felt on a 120 Hz panel (Nothing Phone 1 was used for the hot-path bench).
+
+## Where the hot path lives
+
+| File | Role |
+|---|---|
+| `ime/VocaPhoneKeyboard.kt` | Compose keyboard, gestures, preview, trail |
+| `ime/VocaPhoneInputMethodService.kt` | `InputConnection`, coalesced editor reads |
+| `ime/KeyboardModel.kt` | `KeyboardReducer`, composing, swipe undo |
+| `ime/SuggestionEngine.kt` | Dictionary, strip, swipe, `shouldAbort` |
+| `ime/LifecycleInputMethodService.kt` | ComposeView inside `InputMethodService` |

--- a/android/AGENTS.md
+++ b/android/AGENTS.md
@@ -16,7 +16,8 @@ A press must dirty **one key** and send **one write** to the editor.
 - If the gesture becomes a swipe, undo **only the seed letter**
   (`KeyboardReducer.undoLastCharacter`). Do not clear the whole composing word.
 - Accents: commit the letter on down; on long-press up, undo then commit the
-  variant. Same pattern FlorisBoard uses (`sendDown`, then cancel + replacement).
+  variant. That keeps the first glyph inside the 8.3 ms budget and still
+  lets a hold replace it.
 - Preview is one in-tree overlay (`KeyPreviewLayer`) above the key grid. Do
   **not** open a Compose `Popup` per tap. That is `WindowManager.addView` /
   `removeView` on the down frame (often 5–20 ms) before the letter is sent.
@@ -33,16 +34,12 @@ A press must dirty **one key** and send **one write** to the editor.
 - Do not read `swipeConsumed.value` (or other shared gesture flags) during
   `KeyButton` composition. Gestures may read the `MutableState` on up.
 
-FlorisBoard (the Compose peer) uses one `pointerInteropFilter`, clones the
-`MotionEvent` into a `Channel(64)`, commits on down via `InputEventDispatcher`,
-and sets `key.isPressed` as `mutableStateOf` on the key object.
-AOSP / OpenBoard / HeliBoard / Simple Keyboard / AnySoftKeyboard use a View
-`KeyboardView`, an offscreen buffer, and `invalidateKey` dirty rects.
-Do not rewrite this IME in Views unless Compose pointer + skip still miss the
-frame after measurement.
+Do not rewrite the IME in Views unless traces still show Compose pointer
+and skip missing the frame after measurement.
 
-Known leftover: each special key still has its own `pointerInput`. Do not add
-more. A parent MotionEvent stream (Floris) is the next pointer cut.
+Known leftover: each special key still has its own `pointerInput`. Do not
+add more. A single parent pointer stream is the next cut if Choreographer
+p95 climbs again.
 
 ## InputConnection
 
@@ -60,14 +57,10 @@ other app’s main thread.
 - Batch multi-call edits (`finishComposing` + `commitText`, double-space
   period) with `beginBatchEdit` / `endBatchEdit`.
 - Keep `setComposingText` for letters so a suggestion can replace `hel` with
-  `hello `. FUTO maps composing to `commitText` internally because many apps
-  implement the composing API wrong, and they disabled it on Android 11- after
-  measuring lag in long documents. Do not drop composing here without measuring
-  Messages and Chrome on a phone.
-- FUTO’s `RichInputConnection` caches text-before-cursor and expected
-  selection, and backs off for ten minutes after a slow read (200 ms partial /
-  1000 ms full). That cache is the next IPC cut; the 50 ms coalesced read is
-  the reconcile, not the source of truth.
+  `hello `. Do not switch letters to `commitText` without measuring Messages
+  and Chrome on a phone: composing is what makes the replacement cheap.
+- Caching text-before-cursor and expected selection locally is the next IPC
+  cut; the 50 ms coalesced read is the reconcile, not the source of truth.
 
 ## Suggestions and swipe
 
@@ -100,12 +93,8 @@ IME root recomposes the whole keyboard, including keys. Isolate it in
 
 ## Measuring
 
-FlorisBoard’s `benchmark` Gradle module is Macrobenchmark **app startup** plus
-baseline profiles. `FrameTimingMetric` on an Activity does **not** see IME
-frames (different window). Do not add that module to “prove” keystroke
-smoothness.
-
-This repo times the work a press actually does:
+Activity-level frame metrics never see IME presses (different window). Time
+the work a press actually does, on a 120 Hz phone:
 
 ```sh
 # Host JVM

--- a/android/app/src/androidTest/java/com/vocahq/vocaphone/ime/KeyboardHotPathBenchmark.kt
+++ b/android/app/src/androidTest/java/com/vocahq/vocaphone/ime/KeyboardHotPathBenchmark.kt
@@ -18,13 +18,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * On-device timing for the keyboard hot path.
+ * On-device timing for the keyboard hot path, after the 120 Hz pass.
  *
- * FlorisBoard's `benchmark` module measures companion-app *startup* with
- * Macrobenchmark, not keystroke frames. An IME draws in its own window, so
- * `FrameTimingMetric` on an Activity never sees a press. This harness times
- * the work a press actually does on the phone, plus Choreographer frame gaps
- * while Compose taps letter keys. Same opt-in shape as the Whisper bench:
+ * An IME draws in its own window, so Activity-level frame metrics never see
+ * a key press. This times the work a press actually does on the phone, plus
+ * Choreographer gaps while Compose taps letter keys. Opt in:
  *
  *     ./gradlew :app:connectedFullDebugAndroidTest \
  *       -Pandroid.testInstrumentationRunnerArguments.keyboardBenchmark=true

--- a/android/app/src/androidTest/java/com/vocahq/vocaphone/ime/KeyboardHotPathBenchmark.kt
+++ b/android/app/src/androidTest/java/com/vocahq/vocaphone/ime/KeyboardHotPathBenchmark.kt
@@ -1,0 +1,182 @@
+package com.vocahq.vocaphone.ime
+
+import android.os.SystemClock
+import android.util.Log
+import android.view.Choreographer
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vocahq.vocaphone.core.DictationState
+import com.vocahq.vocaphone.settings.VocaPhoneSettings
+import kotlin.system.measureNanoTime
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * On-device timing for the keyboard hot path.
+ *
+ * FlorisBoard's `benchmark` module measures companion-app *startup* with
+ * Macrobenchmark, not keystroke frames. An IME draws in its own window, so
+ * `FrameTimingMetric` on an Activity never sees a press. This harness times
+ * the work a press actually does on the phone, plus Choreographer frame gaps
+ * while Compose taps letter keys. Same opt-in shape as the Whisper bench:
+ *
+ *     ./gradlew :app:connectedFullDebugAndroidTest \
+ *       -Pandroid.testInstrumentationRunnerArguments.keyboardBenchmark=true
+ *
+ * Numbers go to logcat tag `VocaPhoneBenchmark`. A 120 Hz panel has 8.3 ms
+ * per frame; anything in p95 above that on the UI thread is a missed vsync.
+ */
+@RunWith(AndroidJUnit4::class)
+class KeyboardHotPathBenchmark {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val target = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun dictionaryAndReducerStayInsideAFrame() {
+        assumeEnabled()
+        val dictionary = SuggestionDictionary.load(target.assets)
+        val letter = KeyboardKey("character-h", "h", "h")
+
+        fun bench(label: String, iterations: Int = 80, warmup: Int = 20, block: () -> Unit) {
+            repeat(warmup) { block() }
+            val nanos = LongArray(iterations) { measureNanoTime(block) }
+            report(label, nanos)
+        }
+
+        log("120 Hz frame budget is 8333 us")
+        listOf("hel", "think", "teh", "recieve").forEach { composing ->
+            bench("strip(\"$composing\")") {
+                dictionary.strip(composing, "I ", "", correctionsEnabled = true)
+            }
+        }
+        listOf("tjhinl", "qwertyu").forEach { path ->
+            bench("swipe(\"$path\")", iterations = 24, warmup = 4) { dictionary.swipe(path) }
+        }
+        bench("reducer.press letter (compose)") {
+            KeyboardReducer.press(
+                KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF, composing = "hel"),
+                letter,
+                nowMillis = 1_000L,
+                composeWords = true,
+            )
+        }
+        bench("reducer.undoLastCharacter") {
+            KeyboardReducer.undoLastCharacter(
+                KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF, composing = "hell"),
+                composeWords = true,
+                restoreShift = ShiftState.ONCE,
+            )
+        }
+    }
+
+    @Test
+    fun composeLetterTapsReportFrameGaps() {
+        assumeEnabled()
+        composeRule.setContent {
+            VocaPhoneKeyboard(
+                dictationState = DictationState(),
+                editor = KeyboardEditorConfig.empty(),
+                settings = VocaPhoneSettings(swipeTypingEnabled = false),
+                isPreferenceWritePending = false,
+                clipboard = null,
+                editorText = EditorTextWindow(),
+                suggestions = null,
+                emojiCatalog = emptyList(),
+                onCommand = {},
+                onMicTap = {},
+                onMicLongPress = {},
+                onOpenSettings = {},
+                onLanguageSelected = {},
+                onStyleSelected = {},
+                onSuggestionPicked = { _, _ -> },
+                onSaveToDictionary = {},
+                onEmojiSuggestion = {},
+                onPasteClipboard = {},
+                onDismissClipboard = {},
+                onRemoveClipboardHistory = {},
+                onClearClipboardHistory = {},
+                onEmojiUsed = {},
+            )
+        }
+        composeRule.waitForIdle()
+
+        val sampler = FrameSampler()
+        composeRule.runOnUiThread { sampler.start() }
+        val letters = listOf("h", "e", "l", "l", "o", "t", "h", "e", "r", "e")
+        val tapNanos = LongArray(letters.size)
+        letters.forEachIndexed { index, letter ->
+            tapNanos[index] = measureNanoTime {
+                composeRule.onNodeWithContentDescription(letter).performTouchInput {
+                    down(center)
+                    up()
+                }
+                composeRule.waitForIdle()
+            }
+        }
+        // Let a couple of idle frames land so the last press is in the sample.
+        composeRule.runOnIdle { SystemClock.sleep(80) }
+        composeRule.runOnUiThread { sampler.stop() }
+
+        report("compose tap down+up+waitForIdle", tapNanos)
+        val frames = sampler.durationsNs
+        assumeTrue("Choreographer recorded frames", frames.isNotEmpty())
+        report("choreographer frame gap", frames.toLongArray())
+        // 8.3 ms is one 120 Hz vsync; counting "over 8.3 ms" catches jitter of
+        // a few tens of microseconds. A missed frame is two vsyncs, 16.7 ms.
+        val missed = frames.count { it > 16_667_000L }
+        log("frames=${frames.size} missed_vsync(>16.7ms)=$missed")
+    }
+
+    private fun assumeEnabled() {
+        assumeTrue(
+            "set -Pandroid.testInstrumentationRunnerArguments.keyboardBenchmark=true to run",
+            InstrumentationRegistry.getArguments().getString("keyboardBenchmark") == "true",
+        )
+    }
+
+    private class FrameSampler : Choreographer.FrameCallback {
+        private var last = 0L
+        val durationsNs = ArrayList<Long>(256)
+
+        fun start() {
+            last = 0L
+            durationsNs.clear()
+            Choreographer.getInstance().postFrameCallback(this)
+        }
+
+        fun stop() {
+            Choreographer.getInstance().removeFrameCallback(this)
+        }
+
+        override fun doFrame(frameTimeNanos: Long) {
+            if (last != 0L) durationsNs.add(frameTimeNanos - last)
+            last = frameTimeNanos
+            Choreographer.getInstance().postFrameCallback(this)
+        }
+    }
+
+    private companion object {
+        const val TAG = "VocaPhoneBenchmark"
+
+        fun report(label: String, nanos: LongArray) {
+            nanos.sort()
+            val median = nanos[nanos.size / 2] / 1_000.0
+            val p95 = nanos[(nanos.size * 95) / 100] / 1_000.0
+            log("%-40s median %7.1f us   p95 %7.1f us".format(label, median, p95))
+        }
+
+        fun log(line: String) {
+            println(line)
+            Log.i(TAG, line)
+        }
+    }
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -466,6 +466,43 @@ internal object KeyboardReducer {
         }
     }
 
+    /**
+     * Reverses the character committed on pointer down when the gesture turns
+     * into a swipe, or when a long-press replaces it with an accent.
+     *
+     * FlorisBoard and AOSP send the letter on down, then `sendCancel` if the
+     * pointer becomes a glide. Doing the same here means a swipe that started
+     * on "l" after "he" must drop only that "l", not the whole composing word.
+     */
+    fun undoLastCharacter(
+        state: KeyboardState,
+        composeWords: Boolean,
+        restoreShift: ShiftState? = null,
+    ): KeyboardReduction {
+        if (composeWords) {
+            if (state.composing.isEmpty()) return KeyboardReduction(state)
+            val next = state.composing.dropLast(1)
+            return KeyboardReduction(
+                state = state.copy(
+                    composing = next,
+                    shift = if (next.isEmpty()) restoreShift ?: state.shift else state.shift,
+                    lastWasSpace = false,
+                    capitalizeAfterSpace = false,
+                ),
+                command = KeyboardCommand.SetComposingText(next),
+            )
+        }
+        return KeyboardReduction(
+            state = state.copy(
+                composing = "",
+                shift = restoreShift ?: state.shift,
+                lastWasSpace = false,
+                capitalizeAfterSpace = false,
+            ),
+            command = KeyboardCommand.DeleteBackward,
+        )
+    }
+
     private fun spacePress(state: KeyboardState): KeyboardReduction {
         if (state.lastWasSpace) {
             val nextShift = if (state.shift == ShiftState.LOCKED) ShiftState.LOCKED else ShiftState.ONCE

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -470,9 +470,10 @@ internal object KeyboardReducer {
      * Reverses the character committed on pointer down when the gesture turns
      * into a swipe, or when a long-press replaces it with an accent.
      *
-     * FlorisBoard and AOSP send the letter on down, then `sendCancel` if the
-     * pointer becomes a glide. Doing the same here means a swipe that started
-     * on "l" after "he" must drop only that "l", not the whole composing word.
+     * Letters go out on down so the glyph is on screen inside the 8.3 ms
+     * 120 Hz budget (keyboard hot-path benchmark on a 120 Hz phone). A swipe
+     * that started on "l" after "he" must then drop only that "l", not the
+     * whole composing word, or the user loses "he" as well.
      */
     fun undoLastCharacter(
         state: KeyboardState,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
@@ -75,13 +75,21 @@ internal class SuggestionDictionary(
         return bigrams[previousWord.lowercase()].orEmpty().take(limit)
     }
 
-    fun correct(typed: String, limit: Int = 3): List<String> {
+    fun correct(
+        typed: String,
+        limit: Int = 3,
+        shouldAbort: () -> Boolean = { false },
+    ): List<String> {
         val lower = typed.lowercase()
         if (lower.length < 2 || isKnown(lower)) return emptyList()
-        return similar(typed, limit)
+        return similar(typed, limit, shouldAbort)
     }
 
-    fun similar(typed: String, limit: Int = 3): List<String> {
+    fun similar(
+        typed: String,
+        limit: Int = 3,
+        shouldAbort: () -> Boolean = { false },
+    ): List<String> {
         val lower = typed.lowercase()
         if (lower.length < 2) return emptyList()
         val neighbor = ArrayList<String>(limit)
@@ -93,6 +101,7 @@ internal class SuggestionDictionary(
         // One set of rows for the whole scan rather than three arrays per word.
         val scratch = SuggestionEngine.EditDistanceScratch(maxLen)
         for (index in words.indices) {
+            if ((index and 127) == 0 && shouldAbort()) return emptyList()
             val length = lengths[index]
             if (length < minLen || length > maxLen) continue
             if ((typedMask xor letterMasks[index]).countOneBits() > MAX_LETTER_DIFFERENCE) continue
@@ -119,13 +128,18 @@ internal class SuggestionDictionary(
         after: String,
         correctionsEnabled: Boolean,
         personalRaw: String = "",
+        shouldAbort: () -> Boolean = { false },
     ): SuggestionStrip {
         val token = composing.ifEmpty { SuggestionEngine.lastWordForEmoji(before).orEmpty() }
         val emojis = EmojiSuggestions.glyphs(token)
         if (composing.isNotEmpty()) {
             val personalHits = PersonalDictionary.completions(personalRaw, composing)
             val completions = complete(composing)
-            val corrections = if (correctionsEnabled) correct(composing) else emptyList()
+            val corrections = if (correctionsEnabled) {
+                correct(composing, shouldAbort = shouldAbort)
+            } else {
+                emptyList()
+            }
             val words = (personalHits + completions + corrections).distinct().take(3)
             val save = saveCandidate(
                 word = composing,
@@ -144,7 +158,7 @@ internal class SuggestionDictionary(
         if (correctionsEnabled) {
             val span = SuggestionEngine.wordSpan(before, after)
             if (span != null && span.word.length >= 2) {
-                val nearby = similar(span.word)
+                val nearby = similar(span.word, shouldAbort = shouldAbort)
                 if (nearby.isNotEmpty()) {
                     return SuggestionStrip(nearby, emojis, replacesWord = true, saveWord = save)
                 }
@@ -168,7 +182,11 @@ internal class SuggestionDictionary(
         return word
     }
 
-    fun swipe(path: String, limit: Int = 4): List<String> {
+    fun swipe(
+        path: String,
+        limit: Int = 4,
+        shouldAbort: () -> Boolean = { false },
+    ): List<String> {
         val keys = SuggestionEngine.collapseLetters(path)
         if (keys.length < 2) return emptyList()
         // The gesture's own sampled shape and length are the same for every
@@ -177,6 +195,7 @@ internal class SuggestionDictionary(
         val gesture = SuggestionEngine.SwipeGesture(keys)
         val scored = ArrayList<Pair<String, Float>>()
         for (rank in words.indices) {
+            if ((rank and 127) == 0 && shouldAbort()) return emptyList()
             val compact = collapsed[rank]
             val last = collapsedLength[rank] - 1
             if (last < 1) continue

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
@@ -471,11 +471,6 @@ internal object SuggestionEngine {
     }
 
     /**
-     * FlorisBoard / AnySoftKeyboard compare a swipe to the ideal line through
-     * the word's key centers, then rank by shape and path length. We do the
-     * same on the QWERTY grid instead of taking the first dictionary hit.
-     */
-    /**
      * One gesture's key path, with everything that depends only on the gesture
      * worked out once.
      *

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -96,6 +96,8 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
     private var lastSelEnd = -1
     private var caseCycleOriginal: String? = null
     private var caseCycleEmitted: String? = null
+    /** True while the editor still has a composing region we set. */
+    private var composingRegionActive = false
 
     private val editorTextRefresh = Runnable { refreshEditorText() }
 
@@ -172,6 +174,7 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         lastCandidatesEnd = -1
         lastSelStart = attribute?.initialSelStart ?: -1
         lastSelEnd = attribute?.initialSelEnd ?: -1
+        composingRegionActive = false
         val cursorCapsMode = runCatching {
             currentInputConnection?.getCursorCapsMode(currentInputType) ?: 0
         }.getOrDefault(0)
@@ -279,6 +282,7 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         lastSelEnd = -1
         caseCycleOriginal = null
         caseCycleEmitted = null
+        composingRegionActive = false
         mainHandler.removeCallbacks(editorTextRefresh)
         editorConfig = KeyboardEditorConfig.empty().copy(sessionId = editorSession)
         super.onFinishInput()
@@ -326,39 +330,69 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
     override fun currentTargetPackage(): String? = currentInputEditorInfo?.packageName
 
     private fun handleCommand(command: KeyboardCommand) {
+        val connection = currentInputConnection
         when (command) {
             is KeyboardCommand.CommitText -> {
-                currentInputConnection?.finishComposingText()
-                currentInputConnection?.commitText(command.text, 1)
+                if (connection == null) return
+                if (composingRegionActive) {
+                    connection.beginBatchEdit()
+                    connection.finishComposingText()
+                    connection.commitText(command.text, 1)
+                    connection.endBatchEdit()
+                } else {
+                    connection.commitText(command.text, 1)
+                }
+                composingRegionActive = false
             }
-            is KeyboardCommand.SetComposingText ->
-                currentInputConnection?.setComposingText(command.text, 1)
-            KeyboardCommand.FinishComposing -> currentInputConnection?.finishComposingText()
-            KeyboardCommand.DeleteBackward -> sendKey(KeyEvent.KEYCODE_DEL)
+            is KeyboardCommand.SetComposingText -> {
+                connection?.setComposingText(command.text, 1)
+                composingRegionActive = command.text.isNotEmpty()
+            }
+            KeyboardCommand.FinishComposing -> {
+                if (composingRegionActive) connection?.finishComposingText()
+                composingRegionActive = false
+            }
+            KeyboardCommand.DeleteBackward -> {
+                sendKey(KeyEvent.KEYCODE_DEL)
+                composingRegionActive = false
+            }
             is KeyboardCommand.DeleteSurrounding -> {
-                val connection = currentInputConnection ?: return
-                connection.finishComposingText()
+                if (connection == null) return
+                connection.beginBatchEdit()
+                if (composingRegionActive) connection.finishComposingText()
                 if (command.before > 0 || command.after > 0) {
                     connection.deleteSurroundingText(command.before, command.after)
                 }
+                connection.endBatchEdit()
+                composingRegionActive = false
             }
             KeyboardCommand.PerformEditorAction -> {
-                currentInputConnection?.finishComposingText()
+                if (composingRegionActive) connection?.finishComposingText()
+                composingRegionActive = false
                 performEditorAction()
             }
             is KeyboardCommand.MoveCursor -> {
-                currentInputConnection?.finishComposingText()
+                if (composingRegionActive) connection?.finishComposingText()
+                composingRegionActive = false
                 moveCursor(command.positions)
             }
             KeyboardCommand.DoubleSpacePeriod -> {
-                val connection = currentInputConnection ?: return
-                connection.finishComposingText()
+                if (connection == null) return
+                connection.beginBatchEdit()
+                if (composingRegionActive) connection.finishComposingText()
                 connection.deleteSurroundingText(1, 0)
                 connection.commitText(". ", 1)
+                connection.endBatchEdit()
+                composingRegionActive = false
             }
             KeyboardCommand.CycleSelectionCase -> cycleSelectionCase()
         }
-        scheduleEditorTextRefresh()
+        // Composing lives in keyboard state; the strip does not need a
+        // round-trip into the editor until a word is committed or the cursor
+        // moves.
+        if (command !is KeyboardCommand.SetComposingText) {
+            scheduleEditorTextRefresh()
+        }
     }
 
     private fun commitSuggestion(word: String, replaceWord: Boolean) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -54,15 +55,17 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
@@ -101,8 +104,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Popup
-import androidx.compose.ui.window.PopupProperties
+import androidx.compose.ui.layout.positionInWindow
 import com.vocahq.vocaphone.core.DictationPhase
 import com.vocahq.vocaphone.core.DictationState
 import com.vocahq.vocaphone.core.ModelLanguageSupport
@@ -190,6 +192,13 @@ internal fun VocaPhoneKeyboard(
     // Words saved this editor session, so the + chip vanishes before DataStore
     // has come back around. Reset with the editor; the persisted list is source of truth.
     var savedThisSession by remember { mutableStateOf(emptyList<String>()) }
+    // Shift before the letter that went out on pointer down, so a swipe can
+    // restore one-shot caps after undoing that letter.
+    var swipeSeedShift by remember { mutableStateOf<ShiftState?>(null) }
+    val keyPreview = remember { mutableStateOf<KeyPreview?>(null) }
+    val onKeyPreview = remember {
+        { preview: KeyPreview? -> keyPreview.value = preview }
+    }
 
     // The one place a new editor wipes the keyboard. Replacing the holders did
     // this implicitly and broke the handlers that had closed over them.
@@ -204,6 +213,8 @@ internal fun VocaPhoneKeyboard(
         swipeWord = null
         suggestionStrip = SuggestionStrip(emptyList())
         savedThisSession = emptyList()
+        swipeSeedShift = null
+        keyPreview.value = null
     }
 
     LaunchedEffect(dictationState.phase, editor.dictationAllowed) {
@@ -268,11 +279,15 @@ internal fun VocaPhoneKeyboard(
             PersonalDictionary.add(acc, word)
         }
     }
+    // Mid-word the strip is built from [keyboardState.composing]; surrounding
+    // editor text is only needed once the word is committed. Keying on
+    // editorText during a word ran a second scan ~50ms after every letter.
+    val stripEditorText = if (keyboardState.composing.isEmpty()) editorText else null
     LaunchedEffect(
         composeWords,
         settings.correctionsEnabled,
         keyboardState.composing,
-        editorText,
+        stripEditorText,
         suggestions,
         personalRaw,
     ) {
@@ -286,6 +301,7 @@ internal fun VocaPhoneKeyboard(
                     after = editorText.after,
                     correctionsEnabled = settings.correctionsEnabled,
                     personalRaw = personalRaw,
+                    shouldAbort = { !isActive },
                 )
             }
         }
@@ -359,6 +375,9 @@ internal fun VocaPhoneKeyboard(
         ) {
             clearSwipe()
         }
+        if (key.type == KeyboardKeyType.CHARACTER) {
+            swipeSeedShift = keyboardState.shift
+        }
         val reduction = KeyboardReducer.press(
             state = keyboardState,
             key = key,
@@ -368,6 +387,19 @@ internal fun VocaPhoneKeyboard(
         )
         keyboardState = reduction.state
         reduction.command?.let(onCommand)
+    }
+
+    fun undoSwipeSeed() {
+        val reduction = KeyboardReducer.undoLastCharacter(
+            state = keyboardState,
+            composeWords = composeWords,
+            restoreShift = swipeSeedShift,
+        )
+        swipeSeedShift = null
+        if (reduction.command == null && reduction.state == keyboardState) return
+        keyboardState = reduction.state
+        reduction.command?.let(onCommand)
+        onKeyPreview(null)
     }
 
     fun applySwipe(matches: List<String>, similar: List<String>) {
@@ -419,11 +451,12 @@ internal fun VocaPhoneKeyboard(
         val dictionary = suggestions ?: return@LaunchedEffect
         for (path in swipePaths) {
             val resolved = withContext(Dispatchers.Default) {
-                val matches = dictionary.swipe(path)
+                val abort = { !isActive }
+                val matches = dictionary.swipe(path, shouldAbort = abort)
                 matches to if (matches.isEmpty()) {
                     emptyList()
                 } else {
-                    dictionary.similar(matches.first())
+                    dictionary.similar(matches.first(), shouldAbort = abort)
                 }
             }
             latestApplySwipe(resolved.first, resolved.second)
@@ -441,6 +474,7 @@ internal fun VocaPhoneKeyboard(
     val latestKey by rememberUpdatedState<(KeyboardKey) -> Unit>(::handleKey)
     val latestDelete by rememberUpdatedState<(Long) -> Unit>(::handleDelete)
     val latestSwipe by rememberUpdatedState<(String) -> Unit>(::handleSwipe)
+    val latestUndoSwipe by rememberUpdatedState(::undoSwipeSeed)
     val latestCursorMove by rememberUpdatedState<(Int) -> Unit> { positions ->
         clearSwipe()
         keyboardState = keyboardState.copy(composing = "", lastWasSpace = false)
@@ -449,6 +483,7 @@ internal fun VocaPhoneKeyboard(
     val latestEmojiUsed by rememberUpdatedState(onEmojiUsed)
     val onKeyStable = remember { { key: KeyboardKey -> latestKey(key) } }
     val onSwipeStable = remember { { path: String -> latestSwipe(path) } }
+    val onUndoSwipeStable = remember { { latestUndoSwipe() } }
     val onCursorMoveStable = remember { { positions: Int -> latestCursorMove(positions) } }
     val onKeyHoldStable = remember {
         { key: KeyboardKey, heldMs: Long ->
@@ -471,6 +506,12 @@ internal fun VocaPhoneKeyboard(
                 val widthDp = maxWidth.value.roundToInt()
                 val splitKeys = SplitKeyboardLayout.shouldSplit(settings.splitKeyboard, widthDp)
                 val spacerFraction = SplitKeyboardLayout.spacerFraction(widthDp)
+                val hostCoords = remember { arrayOfNulls<LayoutCoordinates>(1) }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .onGloballyPositioned { hostCoords[0] = it },
+            ) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -622,13 +663,21 @@ internal fun VocaPhoneKeyboard(
                             onKey = onKeyStable,
                             onKeyHold = onKeyHoldStable,
                             onCursorMove = onCursorMoveStable,
+                            onPreview = onKeyPreview,
                         )
                     } else {
-                        val rows = KeyboardLayouts.rows(
+                        val rows = remember(
                             keyboardState.layer,
-                            editor,
-                            numberRow = settings.numberRowEnabled,
-                        )
+                            editor.returnKey,
+                            editor.leadingPunctuation,
+                            settings.numberRowEnabled,
+                        ) {
+                            KeyboardLayouts.rows(
+                                keyboardState.layer,
+                                editor,
+                                numberRow = settings.numberRowEnabled,
+                            )
+                        }
                         val fittedKeyHeight = if (rows.size <= 1) {
                             keyHeight
                         } else {
@@ -639,7 +688,7 @@ internal fun VocaPhoneKeyboard(
                             rows = rows,
                             shift = keyboardState.shift,
                             layer = keyboardState.layer,
-                            editor = editor,
+                            returnKey = editor.returnKey,
                             keyHeight = fittedKeyHeight,
                             numberKeyHints = settings.numberKeyHintsEnabled,
                             longPressSymbols = settings.longPressSymbolsEnabled,
@@ -649,6 +698,8 @@ internal fun VocaPhoneKeyboard(
                             swipeEnabled = settings.swipeTypingEnabled &&
                                 keyboardState.layer == KeyboardLayer.LETTERS,
                             onSwipe = onSwipeStable,
+                            onSwipeSeedUndo = onUndoSwipeStable,
+                            onPreview = onKeyPreview,
                             onKey = onKeyStable,
                             onKeyHold = onKeyHoldStable,
                             onCursorMove = onCursorMoveStable,
@@ -656,12 +707,118 @@ internal fun VocaPhoneKeyboard(
                     }
                 }
             }
+            KeyPreviewLayer(preview = keyPreview, hostCoords = hostCoords)
+            }
             }
         }
     }
 }
 
 private val RowGap = 5.dp
+private val KeyCorner = RoundedCornerShape(7.dp)
+private val PreviewCorner = RoundedCornerShape(9.dp)
+
+private data class KeyPreview(
+    val label: String,
+    val windowX: Float,
+    val windowY: Float,
+    val accents: List<String> = emptyList(),
+    val accentIndex: Int = -1,
+)
+
+@Composable
+private fun KeyPreviewLayer(
+    preview: MutableState<KeyPreview?>,
+    hostCoords: Array<LayoutCoordinates?>,
+) {
+    val density = LocalDensity.current
+    val current = preview.value ?: return
+    val host = hostCoords[0] ?: return
+    val local = host.windowToLocal(Offset(current.windowX, current.windowY))
+    val balloonHeightPx = with(density) { 52.dp.roundToPx() }
+    val simpleWidthPx = with(density) { 42.dp.roundToPx() }
+    val accent = current.accentIndex >= 0 && current.accents.isNotEmpty()
+    val widthPx = if (accent) {
+        with(density) { (current.accents.size * 36).dp.roundToPx() }
+    } else {
+        simpleWidthPx
+    }
+    Box(
+        modifier = Modifier.absoluteOffset {
+            IntOffset(
+                x = (local.x - widthPx / 2f).roundToInt(),
+                y = (local.y - balloonHeightPx - with(density) { 8.dp.roundToPx() }).roundToInt(),
+            )
+        },
+    ) {
+        if (accent) {
+            Row(
+                modifier = Modifier
+                    .clip(PreviewCorner)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                    .padding(horizontal = 6.dp, vertical = 4.dp),
+            ) {
+                current.accents.forEachIndexed { index, glyph ->
+                    Box(
+                        modifier = Modifier
+                            .padding(2.dp)
+                            .clip(RoundedCornerShape(6.dp))
+                            .background(
+                                if (index == current.accentIndex) {
+                                    MaterialTheme.colorScheme.primaryContainer
+                                } else {
+                                    Color.Transparent
+                                },
+                            )
+                            .padding(horizontal = 8.dp, vertical = 6.dp),
+                    ) {
+                        Text(
+                            glyph,
+                            fontSize = 20.sp,
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
+                }
+            }
+        } else {
+            Box(
+                modifier = Modifier
+                    .size(width = 42.dp, height = 52.dp)
+                    .clip(PreviewCorner)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    current.label,
+                    fontSize = 27.sp,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SwipeTrailLayer(
+    modifier: Modifier,
+    points: SnapshotStateList<Offset>,
+    color: Color,
+) {
+    val path = remember { Path() }
+    if (points.size < 2) return
+    Canvas(modifier) {
+        path.rewind()
+        path.moveTo(points[0].x, points[0].y)
+        for (index in 1 until points.size) {
+            path.lineTo(points[index].x, points[index].y)
+        }
+        drawPath(
+            path = path,
+            color = color,
+            style = Stroke(width = 5.dp.toPx(), cap = StrokeCap.Round, join = StrokeJoin.Round),
+        )
+    }
+}
 
 /** Material 3 icon-button minimum. Fits Compact's 48 dp dictation bar. */
 private val ToolbarControlSize = 48.dp
@@ -1759,6 +1916,7 @@ private fun EmojiLayer(
     onKey: (KeyboardKey) -> Unit,
     onKeyHold: (KeyboardKey, Long) -> Unit = { _, _ -> },
     onCursorMove: (Int) -> Unit,
+    onPreview: (KeyPreview?) -> Unit = {},
 ) {
     val bottomRow = KeyboardLayouts.rows(KeyboardLayer.EMOJI, editor)
     val glyphs = when (category) {
@@ -1778,10 +1936,11 @@ private fun EmojiLayer(
             rows = bottomRow,
             shift = shift,
             layer = layer,
-            editor = editor,
+            returnKey = editor.returnKey,
             keyHeight = keyHeight,
             split = split,
             spacerFraction = spacerFraction,
+            onPreview = onPreview,
             onKey = onKey,
             onKeyHold = onKeyHold,
             onCursorMove = onCursorMove,
@@ -1864,7 +2023,7 @@ private fun KeyboardRows(
     rows: List<KeyboardRow>,
     shift: ShiftState,
     layer: KeyboardLayer,
-    editor: KeyboardEditorConfig,
+    returnKey: ReturnKeyKind,
     keyHeight: Dp,
     numberKeyHints: Boolean = false,
     longPressSymbols: Boolean = false,
@@ -1873,16 +2032,26 @@ private fun KeyboardRows(
     spacerFraction: Float = SplitKeyboardLayout.MIN_SPACER_FRACTION,
     swipeEnabled: Boolean = false,
     onSwipe: (String) -> Unit = {},
+    onSwipeSeedUndo: () -> Unit = {},
+    onPreview: (KeyPreview?) -> Unit = {},
     onKey: (KeyboardKey) -> Unit,
     onKeyHold: (KeyboardKey, Long) -> Unit = { _, _ -> },
     onCursorMove: (Int) -> Unit,
 ) {
     val swipeConsumed = remember { mutableStateOf(false) }
     val keyBounds = remember { mutableMapOf<String, Pair<KeyboardKey, Rect>>() }
-    var parentCoords by remember { mutableStateOf<LayoutCoordinates?>(null) }
-    var trail by remember { mutableStateOf<List<Offset>>(emptyList()) }
+    val parentCoords = remember { arrayOfNulls<LayoutCoordinates>(1) }
+    val trail = remember { mutableStateListOf<Offset>() }
     val trailColor = MaterialTheme.colorScheme.primary
     val currentOnSwipe = rememberUpdatedState(onSwipe)
+    val currentOnUndo = rememberUpdatedState(onSwipeSeedUndo)
+    val currentOnPreview = rememberUpdatedState(onPreview)
+    val currentOnKey = rememberUpdatedState(onKey)
+    val currentOnKeyHold = rememberUpdatedState(onKeyHold)
+    val onPreviewStable = remember {
+        { preview: KeyPreview? -> currentOnPreview.value(preview) }
+    }
+    val onUndoStable = remember { { currentOnUndo.value() } }
 
     // Only the swipe gesture clears this, and it is only installed on the
     // letter layer, so a swipe that was still consuming when the layer changed
@@ -1894,14 +2063,16 @@ private fun KeyboardRows(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .onGloballyPositioned { parentCoords = it }
+            .onGloballyPositioned { parentCoords[0] = it }
             .then(
                 if (swipeEnabled) {
                     Modifier.swipeTypingGesture(
                         keyBounds = keyBounds,
-                        parentCoords = { parentCoords },
+                        parentCoords = { parentCoords[0] },
                         swipeConsumed = swipeConsumed,
-                        onTrail = { trail = it },
+                        trail = trail,
+                        onSwipeSeedUndo = { currentOnUndo.value() },
+                        onPreview = { currentOnPreview.value(it) },
                         onSwipe = { currentOnSwipe.value(it) },
                     )
                 } else {
@@ -1933,11 +2104,29 @@ private fun KeyboardRows(
                             is SplitItem.Gap -> Spacer(Modifier.weight(item.weight))
                             is SplitItem.Key -> {
                                 val key = item.key
+                                key(key.id) {
+                                val onPress = remember(key.id) {
+                                    { currentOnKey.value(key) }
+                                }
+                                val onHold = remember(key.id) {
+                                    { heldMs: Long -> currentOnKeyHold.value(key, heldMs) }
+                                }
+                                val onCommitText = remember(key.id) {
+                                    { text: String ->
+                                        currentOnKey.value(
+                                            KeyboardKey(
+                                                id = "variant-$text",
+                                                label = text,
+                                                output = text,
+                                            ),
+                                        )
+                                    }
+                                }
                                 KeyButton(
                                     key = key,
                                     shift = shift,
                                     layer = layer,
-                                    editor = editor,
+                                    returnKey = returnKey,
                                     keyHeight = keyHeight,
                                     numberKeyHints = numberKeyHints,
                                     longPressSymbols = longPressSymbols,
@@ -1953,17 +2142,11 @@ private fun KeyboardRows(
                                     } else {
                                         null
                                     },
-                                    onPress = { onKey(key) },
-                                    onHold = { heldMs -> onKeyHold(key, heldMs) },
-                                    onCommitText = { text ->
-                                        onKey(
-                                            KeyboardKey(
-                                                id = "variant-$text",
-                                                label = text,
-                                                output = text,
-                                            ),
-                                        )
-                                    },
+                                    onPress = onPress,
+                                    onHold = onHold,
+                                    onUndo = onUndoStable,
+                                    onCommitText = onCommitText,
+                                    onPreview = onPreviewStable,
                                     onCursorMove = onCursorMove,
                                     modifier = Modifier
                                         .weight(key.weight)
@@ -1977,6 +2160,7 @@ private fun KeyboardRows(
                                             )
                                         },
                                 )
+                                }
                             }
                         }
                     }
@@ -1984,19 +2168,11 @@ private fun KeyboardRows(
                 }
             }
         }
-        if (trail.size >= 2) {
-            Canvas(Modifier.matchParentSize()) {
-                val path = Path().apply {
-                    moveTo(trail.first().x, trail.first().y)
-                    trail.drop(1).forEach { lineTo(it.x, it.y) }
-                }
-                drawPath(
-                    path = path,
-                    color = trailColor,
-                    style = Stroke(width = 5.dp.toPx(), cap = StrokeCap.Round, join = StrokeJoin.Round),
-                )
-            }
-        }
+        SwipeTrailLayer(
+            modifier = Modifier.matchParentSize(),
+            points = trail,
+            color = trailColor,
+        )
     }
 }
 
@@ -2004,34 +2180,42 @@ private fun Modifier.swipeTypingGesture(
     keyBounds: Map<String, Pair<KeyboardKey, Rect>>,
     parentCoords: () -> LayoutCoordinates?,
     swipeConsumed: MutableState<Boolean>,
-    onTrail: (List<Offset>) -> Unit,
+    trail: SnapshotStateList<Offset>,
+    onSwipeSeedUndo: () -> Unit,
+    onPreview: (KeyPreview?) -> Unit,
     onSwipe: (String) -> Unit,
 ) = pointerInput(Unit) {
     awaitEachGesture {
         val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
         swipeConsumed.value = false
+        trail.clear()
         val start = hitLetter(keyBounds, parentCoords()?.localToRoot(down.position))
         if (start == null) return@awaitEachGesture
         val path = StringBuilder(start.output.lowercase())
         var lastId = start.id
-        val points = mutableListOf(down.position)
+        trail.add(down.position)
         while (true) {
             val event = awaitPointerEvent(PointerEventPass.Initial)
             val change = event.changes.firstOrNull { it.id == down.id } ?: break
-            points.add(change.position)
+            if (trail.size < 80) trail.add(change.position)
             val hit = hitLetter(keyBounds, parentCoords()?.localToRoot(change.position))
             if (hit != null && hit.id != lastId) {
-                swipeConsumed.value = true
+                if (!swipeConsumed.value) {
+                    // The letter already went out on down. Drop only that seed
+                    // so a swipe after "he" does not wipe the whole word.
+                    onSwipeSeedUndo()
+                    onPreview(null)
+                    swipeConsumed.value = true
+                }
                 path.append(hit.output.lowercase())
                 lastId = hit.id
             }
             if (swipeConsumed.value) {
                 change.consume()
-                onTrail(points.toList())
             }
             if (!change.pressed) break
         }
-        onTrail(emptyList())
+        trail.clear()
         if (swipeConsumed.value) onSwipe(path.toString())
     }
 }
@@ -2052,7 +2236,7 @@ private fun RowScope.KeyButton(
     key: KeyboardKey,
     shift: ShiftState,
     layer: KeyboardLayer,
-    editor: KeyboardEditorConfig,
+    returnKey: ReturnKeyKind,
     keyHeight: Dp,
     numberKeyHints: Boolean = false,
     longPressSymbols: Boolean = false,
@@ -2060,22 +2244,26 @@ private fun RowScope.KeyButton(
     swipeConsumed: MutableState<Boolean>? = null,
     onPress: () -> Unit,
     onHold: (Long) -> Unit = {},
+    onUndo: () -> Unit = {},
     onCommitText: (String) -> Unit,
+    onPreview: (KeyPreview?) -> Unit,
     onCursorMove: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val view = LocalView.current
-    val previewOffset = with(LocalDensity.current) { -(keyHeight + 8.dp).roundToPx() }
     val currentOnPress = rememberUpdatedState(onPress)
     val currentOnHold = rememberUpdatedState(onHold)
+    val currentOnUndo = rememberUpdatedState(onUndo)
     val currentOnCommitText = rememberUpdatedState(onCommitText)
     val currentOnCursorMove = rememberUpdatedState(onCursorMove)
+    val currentOnPreview = rememberUpdatedState(onPreview)
     var pressed by remember(key.id) { mutableStateOf(false) }
     var accentIndex by remember(key.id) { mutableStateOf(-1) }
+    val layout = remember(key.id) { arrayOfNulls<LayoutCoordinates>(1) }
     val accents = remember(key.id, shift, longPressSymbols, numberRow) {
         KeyAccents.forKey(key, shift, longPressSymbols, numberRow)
     }
-    val isReturnAction = key.type == KeyboardKeyType.RETURN && editor.returnKey != ReturnKeyKind.ENTER
+    val isReturnAction = key.type == KeyboardKeyType.RETURN && returnKey != ReturnKeyKind.ENTER
     val activeShift = key.type == KeyboardKeyType.SHIFT && shift != ShiftState.OFF
     val background = when {
         isReturnAction -> MaterialTheme.colorScheme.primary
@@ -2084,6 +2272,7 @@ private fun RowScope.KeyButton(
             MaterialTheme.colorScheme.surfaceContainerHighest
         else -> MaterialTheme.colorScheme.surfaceContainerHigh
     }
+    val pressedBackground = remember(background) { background.copy(alpha = 0.72f) }
     val foreground = when {
         isReturnAction -> MaterialTheme.colorScheme.onPrimary
         activeShift -> MaterialTheme.colorScheme.onPrimaryContainer
@@ -2098,44 +2287,83 @@ private fun RowScope.KeyButton(
     } else {
         key.label
     }
+    val publishPreview: (Boolean, Int) -> Unit = remember(key.id, previewLabel, accents) {
+        { show, index ->
+            if (!show || key.type != KeyboardKeyType.CHARACTER) {
+                currentOnPreview.value(null)
+            } else {
+                val coords = layout[0]
+                if (coords == null) {
+                    currentOnPreview.value(null)
+                } else {
+                    val pos = coords.positionInWindow()
+                    currentOnPreview.value(
+                        KeyPreview(
+                            label = previewLabel,
+                            windowX = pos.x + coords.size.width / 2f,
+                            windowY = pos.y,
+                            accents = accents,
+                            accentIndex = index,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+    val haptic = {
+        view.postOnAnimation {
+            view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+        }
+    }
     val gesture = when {
         key.type == KeyboardKeyType.SPACE -> Modifier.spacebarGesture(
             pointerKey = key.id,
             onTap = { currentOnPress.value() },
             onCursorMove = { currentOnCursorMove.value(it) },
             onPressedChange = { pressed = it },
-            onHaptic = { view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP) },
+            onHaptic = haptic,
         )
         key.type == KeyboardKeyType.CHARACTER && accents.isNotEmpty() -> Modifier.accentGesture(
             pointerKey = key.id,
             variantCount = accents.size,
             swipeConsumed = swipeConsumed,
             onTap = { currentOnPress.value() },
+            onUndo = { currentOnUndo.value() },
             onVariant = { index -> currentOnCommitText.value(accents[index]) },
-            onPressedChange = { pressed = it },
-            onAccentIndex = { accentIndex = it },
-            onHaptic = { view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP) },
+            onPressedChange = { isPressed ->
+                pressed = isPressed
+                if (!isPressed) currentOnPreview.value(null)
+            },
+            onAccentIndex = { index ->
+                accentIndex = index
+                publishPreview(true, index)
+            },
+            onHaptic = haptic,
         )
         else -> Modifier.keyGesture(
             pointerKey = key.id,
             repeat = key.type == KeyboardKeyType.DELETE,
-            swipeConsumed = swipeConsumed,
             onPress = { currentOnPress.value() },
             onHold = { currentOnHold.value(it) },
-            onPressedChange = { pressed = it },
-            onHaptic = { view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP) },
+            onPressedChange = { isPressed ->
+                pressed = isPressed
+                if (key.type == KeyboardKeyType.CHARACTER) {
+                    publishPreview(isPressed, -1)
+                }
+            },
+            onHaptic = haptic,
         )
     }
 
     Box(
         modifier = modifier
             .height(keyHeight)
-            .shadow(1.dp, RoundedCornerShape(7.dp))
-            .clip(RoundedCornerShape(7.dp))
-            .background(if (pressed) background.copy(alpha = 0.72f) else background)
+            .onGloballyPositioned { layout[0] = it }
+            .clip(KeyCorner)
+            .background(if (pressed) pressedBackground else background)
             .semantics {
                 role = Role.Button
-                contentDescription = keyDescription(key, previewLabel, editor.returnKey, shift)
+                contentDescription = keyDescription(key, previewLabel, returnKey, shift)
                 onClick {
                     currentOnPress.value()
                     true
@@ -2148,7 +2376,7 @@ private fun RowScope.KeyButton(
             key = key,
             displayLabel = previewLabel,
             shift = shift,
-            returnKey = editor.returnKey,
+            returnKey = returnKey,
             tint = foreground,
             hint = KeyAccents.hint(
                 key,
@@ -2157,53 +2385,6 @@ private fun RowScope.KeyButton(
                 numberRow = numberRow,
             ),
         )
-
-        if (pressed && swipeConsumed?.value != true && key.type == KeyboardKeyType.CHARACTER) {
-            Popup(
-                alignment = Alignment.TopCenter,
-                offset = IntOffset(0, previewOffset),
-                properties = PopupProperties(focusable = false, clippingEnabled = false),
-            ) {
-                if (accentIndex >= 0 && accents.isNotEmpty()) {
-                    Surface(
-                        shape = RoundedCornerShape(9.dp),
-                        color = MaterialTheme.colorScheme.surfaceContainerHighest,
-                        shadowElevation = 5.dp,
-                    ) {
-                        Row(Modifier.padding(horizontal = 6.dp, vertical = 4.dp)) {
-                            accents.forEachIndexed { index, glyph ->
-                                Box(
-                                    modifier = Modifier
-                                        .padding(2.dp)
-                                        .clip(RoundedCornerShape(6.dp))
-                                        .background(
-                                            if (index == accentIndex) {
-                                                MaterialTheme.colorScheme.primaryContainer
-                                            } else {
-                                                Color.Transparent
-                                            },
-                                        )
-                                        .padding(horizontal = 8.dp, vertical = 6.dp),
-                                ) {
-                                    Text(glyph, fontSize = 20.sp, color = foreground)
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    Surface(
-                        modifier = Modifier.size(width = 42.dp, height = 52.dp),
-                        shape = RoundedCornerShape(9.dp),
-                        color = MaterialTheme.colorScheme.surfaceContainerHighest,
-                        shadowElevation = 5.dp,
-                    ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Text(previewLabel, fontSize = 27.sp, color = foreground)
-                        }
-                    }
-                }
-            }
-        }
     }
 }
 
@@ -2214,7 +2395,6 @@ private fun Modifier.keyGesture(
     onHold: (Long) -> Unit = {},
     onPressedChange: (Boolean) -> Unit,
     onHaptic: () -> Unit,
-    swipeConsumed: MutableState<Boolean>? = null,
 ) = pointerInput(pointerKey, repeat) {
     coroutineScope {
         awaitEachGesture {
@@ -2223,7 +2403,7 @@ private fun Modifier.keyGesture(
             onPressedChange(true)
             onHaptic()
             val downAt = SystemClock.uptimeMillis()
-            if (repeat) onPress()
+            onPress()
             val repeatJob = if (repeat) {
                 launch {
                     delay(DeleteHold.REPEAT_DELAY_MS)
@@ -2236,10 +2416,9 @@ private fun Modifier.keyGesture(
             } else {
                 null
             }
-            val up = waitForUpOrCancellation()
+            waitForUpOrCancellation()
             repeatJob?.cancel()
             onPressedChange(false)
-            if (!repeat && up != null && swipeConsumed?.value != true) onPress()
         }
     }
 }
@@ -2287,6 +2466,7 @@ private fun Modifier.accentGesture(
     pointerKey: String,
     variantCount: Int,
     onTap: () -> Unit,
+    onUndo: () -> Unit,
     onVariant: (Int) -> Unit,
     onPressedChange: (Boolean) -> Unit,
     onAccentIndex: (Int) -> Unit,
@@ -2300,6 +2480,7 @@ private fun Modifier.accentGesture(
             down.consume()
             onPressedChange(true)
             onHaptic()
+            onTap()
             var showing = false
             var index = 0
             val hold = launch {
@@ -2328,12 +2509,9 @@ private fun Modifier.accentGesture(
             }
             hold.cancel()
             onPressedChange(false)
-            if (swipeConsumed?.value != true) {
-                if (showing) {
-                    onVariant(index)
-                } else {
-                    onTap()
-                }
+            if (swipeConsumed?.value != true && showing) {
+                onUndo()
+                onVariant(index)
             }
             onAccentIndex(-1)
         }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -117,6 +117,7 @@ import com.vocahq.vocaphone.ui.theme.VocaPhoneTheme
 import kotlin.math.PI
 import kotlin.math.sin
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -2332,11 +2333,13 @@ private fun RowScope.KeyButton(
             onVariant = { index -> currentOnCommitText.value(accents[index]) },
             onPressedChange = { isPressed ->
                 pressed = isPressed
-                if (!isPressed) currentOnPreview.value(null)
+                publishPreview(isPressed, if (isPressed) accentIndex else -1)
             },
             onAccentIndex = { index ->
                 accentIndex = index
-                publishPreview(true, index)
+                // Reset to -1 after lift used to call publishPreview(true, -1),
+                // which put the balloon back after the finger had already gone.
+                if (index >= 0) publishPreview(true, index)
             },
             onHaptic = haptic,
         )
@@ -2400,25 +2403,27 @@ private fun Modifier.keyGesture(
         awaitEachGesture {
             val down = awaitFirstDown(requireUnconsumed = false)
             down.consume()
-            onPressedChange(true)
             onHaptic()
             val downAt = SystemClock.uptimeMillis()
-            onPress()
-            val repeatJob = if (repeat) {
-                launch {
-                    delay(DeleteHold.REPEAT_DELAY_MS)
-                    while (isActive) {
-                        val heldMs = SystemClock.uptimeMillis() - downAt
-                        onHold(heldMs)
-                        delay(DeleteHold.interval(heldMs))
+            var repeatJob: Job? = null
+            try {
+                onPressedChange(true)
+                onPress()
+                if (repeat) {
+                    repeatJob = launch {
+                        delay(DeleteHold.REPEAT_DELAY_MS)
+                        while (isActive) {
+                            val heldMs = SystemClock.uptimeMillis() - downAt
+                            onHold(heldMs)
+                            delay(DeleteHold.interval(heldMs))
+                        }
                     }
                 }
-            } else {
-                null
+                waitForUpOrCancellation()
+            } finally {
+                repeatJob?.cancel()
+                onPressedChange(false)
             }
-            waitForUpOrCancellation()
-            repeatJob?.cancel()
-            onPressedChange(false)
         }
     }
 }
@@ -2478,42 +2483,46 @@ private fun Modifier.accentGesture(
         awaitEachGesture {
             val down = awaitFirstDown(requireUnconsumed = false)
             down.consume()
-            onPressedChange(true)
             onHaptic()
-            onTap()
             var showing = false
             var index = 0
-            val hold = launch {
-                delay(380L)
-                showing = true
-                onAccentIndex(0)
-                onHaptic()
-            }
-            while (true) {
-                val event = awaitPointerEvent()
-                val change = event.changes.firstOrNull { it.id == down.id } ?: break
-                if (!change.pressed) {
-                    change.consume()
-                    break
+            var hold: Job? = null
+            try {
+                onPressedChange(true)
+                onTap()
+                hold = launch {
+                    delay(380L)
+                    showing = true
+                    onAccentIndex(0)
+                    onHaptic()
                 }
-                if (showing) {
-                    val delta = change.position.x - down.position.x
-                    val next = (delta / step).toInt().coerceIn(0, variantCount - 1)
-                    if (next != index) {
-                        index = next
-                        onAccentIndex(index)
-                        onHaptic()
+                while (true) {
+                    val event = awaitPointerEvent()
+                    val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                    if (!change.pressed) {
+                        change.consume()
+                        break
                     }
+                    if (showing) {
+                        val delta = change.position.x - down.position.x
+                        val next = (delta / step).toInt().coerceIn(0, variantCount - 1)
+                        if (next != index) {
+                            index = next
+                            onAccentIndex(index)
+                            onHaptic()
+                        }
+                    }
+                    change.consume()
                 }
-                change.consume()
+            } finally {
+                hold?.cancel()
+                onPressedChange(false)
+                onAccentIndex(-1)
             }
-            hold.cancel()
-            onPressedChange(false)
             if (swipeConsumed?.value != true && showing) {
                 onUndo()
                 onVariant(index)
             }
-            onAccentIndex(-1)
         }
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -2479,6 +2479,7 @@ private fun Modifier.accentGesture(
     swipeConsumed: MutableState<Boolean>? = null,
 ) = pointerInput(pointerKey, variantCount) {
     val step = 28.dp.toPx()
+    val slopSquared = viewConfiguration.touchSlop.let { it * it }
     coroutineScope {
         awaitEachGesture {
             val down = awaitFirstDown(requireUnconsumed = false)
@@ -2487,11 +2488,21 @@ private fun Modifier.accentGesture(
             var showing = false
             var index = 0
             var hold: Job? = null
+            var leftKey = false
+            fun abortHold() {
+                leftKey = true
+                hold?.cancel()
+                if (showing) {
+                    showing = false
+                    onAccentIndex(-1)
+                }
+            }
             try {
                 onPressedChange(true)
                 onTap()
                 hold = launch {
                     delay(380L)
+                    if (leftKey || swipeConsumed?.value == true) return@launch
                     showing = true
                     onAccentIndex(0)
                     onHaptic()
@@ -2503,23 +2514,34 @@ private fun Modifier.accentGesture(
                         change.consume()
                         break
                     }
+                    if (swipeConsumed?.value == true) {
+                        abortHold()
+                        change.consume()
+                        break
+                    }
+                    val dx = change.position.x - down.position.x
+                    val dy = change.position.y - down.position.y
+                    if (!showing && !leftKey && dx * dx + dy * dy > slopSquared) {
+                        // Swipe or a flick off the key: do not let the 380 ms
+                        // hold pop the accent row over the trail.
+                        abortHold()
+                    }
                     if (showing) {
-                        val delta = change.position.x - down.position.x
-                        val next = (delta / step).toInt().coerceIn(0, variantCount - 1)
+                        val next = (dx / step).toInt().coerceIn(0, variantCount - 1)
                         if (next != index) {
                             index = next
                             onAccentIndex(index)
                             onHaptic()
                         }
+                        change.consume()
                     }
-                    change.consume()
                 }
             } finally {
                 hold?.cancel()
                 onPressedChange(false)
                 onAccentIndex(-1)
             }
-            if (swipeConsumed?.value != true && showing) {
+            if (swipeConsumed?.value != true && showing && !leftKey) {
                 onUndo()
                 onVariant(index)
             }

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -102,7 +102,7 @@ enum class KeyboardHeight(
 
     companion object {
         fun fromStored(value: String?): KeyboardHeight =
-            entries.firstOrNull { it.storedValue == value } ?: DEFAULT
+            entries.firstOrNull { it.storedValue == value } ?: COMPACT
     }
 }
 
@@ -164,8 +164,8 @@ data class VocaPhoneSettings(
      * than stored pre-split, so the text they see back is the text they wrote.
      */
     val customVocabulary: String = "",
-    val numberRowEnabled: Boolean = false,
-    val keyboardHeight: KeyboardHeight = KeyboardHeight.DEFAULT,
+    val numberRowEnabled: Boolean = true,
+    val keyboardHeight: KeyboardHeight = KeyboardHeight.COMPACT,
     val splitKeyboard: SplitKeyboard = SplitKeyboard.DEFAULT,
     val suggestionsEnabled: Boolean = true,
     val correctionsEnabled: Boolean = true,
@@ -471,7 +471,7 @@ class SettingsRepository(private val context: Context) {
         localModelId = this[Keys.LOCAL_MODEL_ID].orEmpty(),
         transcriptionQuality = TranscriptionQuality.fromStored(this[Keys.TRANSCRIPTION_QUALITY]),
         customVocabulary = this[Keys.CUSTOM_VOCABULARY].orEmpty(),
-        numberRowEnabled = this[Keys.NUMBER_ROW] ?: false,
+        numberRowEnabled = this[Keys.NUMBER_ROW] ?: true,
         keyboardHeight = KeyboardHeight.fromStored(this[Keys.KEYBOARD_HEIGHT]),
         splitKeyboard = SplitKeyboard.fromStored(this[Keys.SPLIT_KEYBOARD]),
         suggestionsEnabled = this[Keys.SUGGESTIONS] ?: true,

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardHotPathTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardHotPathTest.kt
@@ -1,0 +1,80 @@
+package com.vocahq.vocaphone.ime
+
+import java.io.File
+import kotlin.system.measureNanoTime
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+
+/**
+ * Wall-clock harness for the IME hot path on the host JVM.
+ *
+ * Frame timing has to be measured on a phone (see
+ * [com.vocahq.vocaphone.ime.KeyboardHotPathBenchmark]); this is the same
+ * dictionary and reducer work, so a change that blows the 8.3 ms 120 Hz budget
+ * here will show up before anyone flashes an APK. Opt in:
+ *
+ *     ./gradlew :app:testFullDebugUnitTest -i \
+ *       --tests '*KeyboardHotPathTest' -Dvocaphone.benchmark=1
+ */
+class KeyboardHotPathTest {
+
+    private val keyboardAssets: File?
+        get() = generateSequence(File("").absoluteFile) { it.parentFile }
+            .map { File(it, "assets/keyboard") }
+            .firstOrNull { File(it, "en.txt").isFile }
+
+    @Test
+    fun `report keystroke and swipe latency on the shipped dictionary`() {
+        assumeTrue(
+            "Timing harness; pass -Dvocaphone.benchmark=1 to run it",
+            System.getProperty("vocaphone.benchmark") != null,
+        )
+        val assets = keyboardAssets
+        assumeTrue("assets/keyboard is only present in the repository", assets != null)
+        val dictionary = SuggestionDictionary(
+            words = File(assets, "en.txt").readLines().map { it.trim() }.filter { it.isNotEmpty() },
+            bigrams = SuggestionDictionary.parseBigrams(
+                File(assets, "en-bigrams.txt").readLines(),
+            ),
+        )
+        val letter = KeyboardKey("character-h", "h", "h")
+
+        fun bench(label: String, iterations: Int = 200, block: () -> Unit) {
+            repeat(40) { block() }
+            val nanos = LongArray(iterations) { measureNanoTime(block) }
+            nanos.sort()
+            println(
+                "%-40s median %7.1f us   p95 %7.1f us".format(
+                    label,
+                    nanos[iterations / 2] / 1_000.0,
+                    nanos[(iterations * 95) / 100] / 1_000.0,
+                ),
+            )
+        }
+
+        println("120 Hz frame budget is 8333 us")
+        listOf("t", "th", "hel", "think", "teh", "recieve").forEach { composing ->
+            bench("strip(\"$composing\")") {
+                dictionary.strip(composing, "I ", "", correctionsEnabled = true)
+            }
+        }
+        listOf("tjhinl", "qwertyu", "hjelklo").forEach { path ->
+            bench("swipe(\"$path\")", iterations = 40) { dictionary.swipe(path) }
+        }
+        bench("reducer.press letter (compose)") {
+            KeyboardReducer.press(
+                KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF, composing = "hel"),
+                letter,
+                nowMillis = 1_000L,
+                composeWords = true,
+            )
+        }
+        bench("reducer.undoLastCharacter") {
+            KeyboardReducer.undoLastCharacter(
+                KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF, composing = "hell"),
+                composeWords = true,
+                restoreShift = ShiftState.ONCE,
+            )
+        }
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardReducerTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardReducerTest.kt
@@ -124,6 +124,73 @@ class KeyboardReducerTest {
     }
 
     @Test
+    fun `undo last composing letter drops one character`() {
+        val first = KeyboardReducer.press(
+            KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF),
+            character("h"),
+            nowMillis = 1_000,
+            composeWords = true,
+        )
+        val second = KeyboardReducer.press(
+            first.state,
+            character("i"),
+            nowMillis = 1_010,
+            composeWords = true,
+        )
+
+        val undo = KeyboardReducer.undoLastCharacter(second.state, composeWords = true)
+
+        assertEquals(KeyboardCommand.SetComposingText("h"), undo.command)
+        assertEquals("h", undo.state.composing)
+    }
+
+    @Test
+    fun `undo of the first letter restores one-shot shift`() {
+        val typed = KeyboardReducer.press(
+            KeyboardState(KeyboardLayer.LETTERS, ShiftState.ONCE),
+            character("h"),
+            nowMillis = 1_000,
+            composeWords = true,
+        )
+        assertEquals(ShiftState.OFF, typed.state.shift)
+
+        val undo = KeyboardReducer.undoLastCharacter(
+            typed.state,
+            composeWords = true,
+            restoreShift = ShiftState.ONCE,
+        )
+
+        assertEquals(ShiftState.ONCE, undo.state.shift)
+        assertEquals("", undo.state.composing)
+        assertEquals(KeyboardCommand.SetComposingText(""), undo.command)
+    }
+
+    @Test
+    fun `undo last committed letter deletes backward`() {
+        val typed = KeyboardReducer.press(
+            KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF),
+            character("h"),
+            nowMillis = 1_000,
+            composeWords = false,
+        )
+
+        val undo = KeyboardReducer.undoLastCharacter(typed.state, composeWords = false)
+
+        assertEquals(KeyboardCommand.DeleteBackward, undo.command)
+    }
+
+    @Test
+    fun `undo is a no-op when composing is already empty`() {
+        val undo = KeyboardReducer.undoLastCharacter(
+            KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF),
+            composeWords = true,
+        )
+
+        assertNull(undo.command)
+        assertEquals("", undo.state.composing)
+    }
+
+    @Test
     fun `delete while composing shortens the composing word`() {
         val typed = KeyboardReducer.press(
             KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF, composing = "hi"),

--- a/android/justfile
+++ b/android/justfile
@@ -78,6 +78,30 @@ permissions:
     done
     echo "Enable and select VocaPhone in Settings → Keyboard / Input method."
 
+# Time the IME hot path (dictionary, reducer). JVM always; phone if attached.
+#
+#     just keyboard-benchmark
+#     ANDROID_SERIAL=a775a5e9 just keyboard-benchmark
+[group('test')]
+keyboard-benchmark:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export ANDROID_HOME="$({{ just_executable() }} _sdk)"
+    echo "== host JVM =="
+    ./gradlew :app:testFullDebugUnitTest -i \
+        --tests 'com.vocahq.vocaphone.ime.KeyboardHotPathTest' \
+        -Dvocaphone.benchmark=1
+    if "{{ just_executable() }}" _serial >/dev/null 2>&1; then
+        echo "== device =="
+        ./gradlew :app:connectedFullDebugAndroidTest \
+            -Pandroid.testInstrumentationRunnerArguments.keyboardBenchmark=true
+    else
+        echo "No ready device; skip connected keyboardBenchmark."
+        echo "Plug in a phone and re-run, or install the androidTest APK and:"
+        echo "  adb shell am instrument -w -e keyboardBenchmark true \\"
+        echo "    com.vocahq.vocaphone.test/androidx.test.runner.AndroidJUnitRunner"
+    fi
+
 # Run the unit tests; pass a filter, e.g. `just test '*DictationTest'`.
 [group('test')]
 test *filter:


### PR DESCRIPTION
Android-only. Stacked on #180. 120 Hz keystroke pass after measuring the IME hot path on a Nothing Phone (1) (`A063`): letters go out on finger-down, the preview is one reused overlay, and the key grid no longer redraws on every press.

## Why

At 120 Hz the frame is 8.3 ms. Tracing a press showed the cost on **down**, before the letter was even sent: haptic + a new window for the preview + `.shadow` on ~40 keys, then `setComposingText` only on **up**. The preview was the frame the user felt; the glyph arrived later.

The dictionary was already off the composition thread, and editor reads were already coalesced at 50 ms. This slice is the remaining down-frame, plus the follow-up bugs that showed up while typing on the same phone.

## What changed

- Character, shift, layer, return, and delete fire on **down**. Space still waits for up so a cursor swipe is not a space.
- If the gesture becomes a swipe, only the seed letter is undone (`KeyboardReducer.undoLastCharacter`), not the whole composing word.
- One in-tree preview overlay, reused, no `WindowManager.addView`. Accent picker uses the same host.
- Swipe trail is a sibling `Canvas` over a `SnapshotStateList`. Pointer moves no longer recompose the keys.
- Keys drop `Modifier.shadow`. Pressed state is a local color change on that key.
- `KeyboardLayouts.rows()` is remembered. Per-key press lambdas are stable, so a composing update can skip the grid.
- `setComposingText` no longer schedules a `getTextBeforeCursor`. Multi-call commands (`commit` after composing, double-space) are `beginBatchEdit`.
- `similar` / `swipe` honor `shouldAbort` every 128 words so a cancelled `LaunchedEffect` actually stops the 10k walk.
- Unset DataStore keys now default to **compact** height and the **number row** on.
- Accent-key lift no longer republishes the letter balloon (`d` stuck over `e` after `hello world`).
- A swipe that starts on `e`/`a`/`o` (or any hold-variant key) cancels the 380 ms accent hold at touch slop, so the popup cannot eat the gesture.
- Agent notes: root `AGENTS.md` plus `android/AGENTS.md` record the 120 Hz IME rules (pointer, `InputConnection`, strip, how to measure).

## Benchmarks

Activity-level frame metrics never see IME presses (different window), so this times the work a press actually does. Opt-in, not a CI gate — phones differ.

Run from `android/`:

```sh
# Host JVM (dictionary + reducer)
./gradlew :app:testFullDebugUnitTest -i \
  --tests 'com.vocahq.vocaphone.ime.KeyboardHotPathTest' \
  -Dvocaphone.benchmark=1

# Phone (dictionary + reducer + Choreographer while tapping keys)
./gradlew :app:connectedFullDebugAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.keyboardBenchmark=true
```

Or `just keyboard-benchmark`. Logcat tag: `VocaPhoneBenchmark`.

Measured **2026-08-22** on a Nothing Phone (1) (`A063`, 120 Hz) with this branch, and on the host JVM for scale:

| Work | Host median | Phone median | Phone p95 | Share of 8.3 ms frame |
|---|---:|---:|---:|---|
| `strip("think")` (known word) | 2 µs | 47 µs | 55 µs | <1% |
| `strip("hel")` | 48 µs | 579 µs | 955 µs | 11% |
| `strip("teh")` (correction) | 50 µs | 609 µs | 643 µs | 8% |
| `strip("recieve")` | 99 µs | 810 µs | 843 µs | 10% |
| `swipe("qwertyu")` | 94 µs | 974 µs | 1.0 ms | 12% |
| `swipe("tjhinl")` | 131 µs | 3.5 ms | 5.5 ms | **66%** — stays on `Dispatchers.Default` |
| `KeyboardReducer.press` | 0.6 µs | 6.5 µs | 8.6 µs | <1% |
| `undoLastCharacter` | 0.4 µs | 5.8 µs | 6.3 µs | <1% |
| Choreographer frame gap (10 letter taps in Compose) | — | **8.35 ms** | 16.7 ms | locked to 120 Hz; 7/70 frames missed a vsync |

Takeaways:

- Dictionary strip and the reducer fit in a 120 Hz frame on this phone. Swipe scoring of a messy path is most of a frame, which is why it must not run on the pointer thread (it already doesn't).
- Compose Choreographer median is one 120 Hz vsync (8.35 ms). The 16.7 ms p95 is a missed vsync during first layout / test taps, not a steady hitch.
- `compose tap down+up+waitForIdle` (~59 ms) is the **test** waiting for idle after each tap, not key latency. Ignore it.
- This still does not measure `InputConnection` into Messages (previously 7–16 ms `getTextBeforeCursor` on a POCO F1). That IPC is now coalesced at 50 ms and skipped while composing.

## Out of scope

Still Compose. Per-key `pointerInput` remains for space/delete/accents. A parent pointer stream is the next cut if Choreographer p95 climbs. Dictation `level` at 10 Hz still recomposes the IME root while recording.

## Try it

1. Type at a normal pace: the letter should appear when the key goes down, not when it comes up. After `hello world`, no letter balloon should stay on the row above.
2. Hold `e` still for accents; swipe a word that **starts** on `e` and confirm the accent row does not appear.
3. Swipe a word that started on a letter: the first letter should not stick in front of the swipe result.
4. Fresh install (or unset DataStore keys): compact height and a number row without opening Settings.
5. Turn on **Long-press for symbols** and confirm hold-and-release still types the hint.

## Build the APK

From `android/`:

```sh
just build
```

That is `./gradlew assembleFullDebug`. The APK lands at:

`app/build/outputs/apk/full/debug/vocaphone-fullDebug.apk`

Install and launch on a connected device with `just run`.

## Tests

```sh
./gradlew :app:testFullDebugUnitTest --tests 'com.vocahq.vocaphone.ime.*'
```

Keyboard timings (opt-in, not CI): `just keyboard-benchmark`.
