### PR TITLE
fix: wait longer for one-shot gateway engines to finish

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/gateway/GatewayClient.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/gateway/GatewayClient.kt
@@ -78,7 +78,9 @@ class GatewayClient(
             .url(endpoint("v1", "sessions", sessionId.toString(), "finish"))
             .post(EMPTY_BODY)
             .build()
-        GatewaySession.from(execute(request, timeoutSeconds = 120).asJsonObject())
+        // One-shot local engines can spend several minutes loading or compiling
+        // a newly selected model before their first transcription completes.
+        GatewaySession.from(execute(request, timeoutSeconds = 540).asJsonObject())
     }
 
     suspend fun delete(sessionId: UUID) = withContext(Dispatchers.IO) {

--- a/ios/VocaPhoneApp/Networking/GatewayClient.swift
+++ b/ios/VocaPhoneApp/Networking/GatewayClient.swift
@@ -150,7 +150,9 @@ struct GatewayClient: Sendable {
     func finish(sessionID: UUID) async throws -> GatewaySession {
         var request = URLRequest(url: endpoint("v1/sessions/\(sessionID.uuidString.lowercased())/finish"))
         request.httpMethod = "POST"
-        request.timeoutInterval = 90
+        // One-shot local engines can spend several minutes loading or compiling
+        // a newly selected model before their first transcription completes.
+        request.timeoutInterval = 540
         return try await perform(request, as: GatewaySession.self)
     }
 


### PR DESCRIPTION
## Summary

Leftover client change from [vocaphone#40](https://github.com/VocaHQ/vocaphone/pull/40), which is now closed in favor of [vocagateway#26](https://github.com/VocaHQ/vocagateway/pull/26).

- Raise the iOS `/finish` timeout from 90s to 540s so one-shot local engines (VocaMac headless in particular) can load or compile a newly selected model on the first transcription.
- Raise the Android `/finish` timeout from 120s to 540s for the same reason. vocaphone#40 only touched iOS; Android would otherwise still time out first.

## Verification

- [ ] `just ios ci` — not run; timeout constant only
- [ ] `just android ci` — not run; timeout constant only
- [x] Gateway changes: [vocagateway#26](https://github.com/VocaHQ/vocagateway/pull/26)
- [ ] Physical-device test — not applicable; keyboard, microphone, background audio, and insertion are unchanged

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation unchanged; no data-flow, permission, retention, or network contract change beyond the HTTP client timeout