### PR TITLE
Separate the spoken language from the language you want back

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ the active cursor. A gateway is never required for on-device mode.
   you want larger models or shared compute. That path is self-hosted, not on-device
 - 54 transcription languages plus Automatic, and four writing styles: Formal,
   Casual, Very Casual, and Excited
+- Optional on-device translation where the model was actually trained for it:
+  Canary between English, German, Spanish and French, and the multilingual
+  Whisper models into English. Language says what you are speaking; Translate to
+  says what comes back
 - On iOS the containing app records, because a keyboard extension cannot use the
   microphone
 

--- a/android/app/src/main/cpp/whisper/jni.c
+++ b/android/app/src/main/cpp/whisper/jni.c
@@ -83,8 +83,9 @@ Java_com_vocahq_vocaphone_local_WhisperLib_00024Companion_freeContext(
 JNIEXPORT jint JNICALL
 Java_com_vocahq_vocaphone_local_WhisperLib_00024Companion_fullTranscribe(
         JNIEnv *env, jobject thiz, jlong context_ptr, jint num_threads,
-        jfloatArray audio_data, jstring language_str, jint beam_size,
-        jfloat temperature_increment, jint audio_context, jstring prompt_str) {
+        jfloatArray audio_data, jstring language_str, jboolean translate,
+        jint beam_size, jfloat temperature_increment, jint audio_context,
+        jstring prompt_str) {
     UNUSED(thiz);
     struct whisper_context *context = (struct whisper_context *) context_ptr;
     jfloat *audio = (*env)->GetFloatArrayElements(env, audio_data, NULL);
@@ -105,7 +106,11 @@ Java_com_vocahq_vocaphone_local_WhisperLib_00024Companion_fullTranscribe(
     params.print_progress = false;
     params.print_timestamps = false;
     params.print_special = false;
-    params.translate = false;
+    // Whisper's translate task has exactly one trained target: English. The
+    // caller is responsible for never asking for another one — see
+    // ModelTranslationSupport — because whisper.cpp would accept any language
+    // token here and quietly decode something that is not a translation.
+    params.translate = translate == JNI_TRUE;
     params.language = language;
     params.n_threads = num_threads;
     params.no_context = true;

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/ModelLanguageSupport.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/ModelLanguageSupport.kt
@@ -26,6 +26,19 @@ object ModelLanguageSupport {
         if (requested == TranscriptionLanguage.AUTOMATIC.wireValue) reported else requested
 
     /**
+     * The language the finished transcript is actually written in.
+     *
+     * [translateTo] wins outright when set, and that is the whole point of the
+     * overload: with translation on, the spoken language governs the decoder
+     * while the target governs the text, and it is the text the writing styles
+     * punctuate. Styling translated German by the Hindi that was spoken would
+     * end a Latin sentence with a danda. Empty means no translation, which
+     * leaves [transcriptLanguage] answering exactly as before.
+     */
+    fun outputLanguage(requested: String, reported: String, translateTo: String): String =
+        translateTo.ifEmpty { transcriptLanguage(requested, reported) }
+
+    /**
      * [modelLanguages] empty means nothing was claimed — an older gateway build,
      * no model selected, or one the user imported. Nothing is disabled in that
      * case: a client that has not been told must never lock the user out.
@@ -59,16 +72,31 @@ object ModelLanguageSupport {
         }
 
     /**
-     * Why the picker is restricted, or null when it is not.
+     * What the picker's choice does and does not do here.
+     *
+     * Never null any more: even an unrestricted model needs the sentence below
+     * saying that this row is the language being spoken rather than the
+     * language wanted back. The return type stays nullable so callers that
+     * already handle absence keep compiling.
      *
      * [onDevice] only changes which model the sentence blames, but pointing a
      * user at their gateway when the constraint comes from the model on their
      * phone sends them to the wrong screen.
+     *
+     * [canTranslate] adds the sentence that says what this row is not. Whisper
+     * takes its output language from a token forced into the decoder, so
+     * picking a language nobody is speaking makes it emit that language
+     * anyway — untrained behaviour that reads as translation and is the single
+     * most common misreading of this screen. The sentence is unconditional
+     * because the misreading survives being right about one model: someone who
+     * learned the trick on Whisper carries it to Parakeet, where the pick is
+     * discarded entirely.
      */
     fun restriction(
         modelLanguages: Set<String>,
         detectsLanguageAutomatically: Boolean,
         onDevice: Boolean = false,
+        canTranslate: Boolean = false,
     ): String? {
         val owner = if (onDevice) "The on-device model" else "Your gateway's model"
         val coverage = if (modelLanguages.isEmpty()) {
@@ -77,7 +105,17 @@ object ModelLanguageSupport {
             val noun = if (modelLanguages.size == 1) "language" else "languages"
             "$owner covers ${modelLanguages.size} $noun. The rest need a different model."
         }
-        if (!detectsLanguageAutomatically) return coverage
+        val remedy = if (canTranslate) {
+            "To change the language of the transcript, use Translate to."
+        } else {
+            "This model cannot translate, and picking a language you are not " +
+                "speaking gives unreliable text rather than a translation."
+        }
+        val translation =
+            "This is the language you are speaking, not the language you want back. $remedy"
+        if (!detectsLanguageAutomatically) {
+            return listOfNotNull(coverage, translation).joinToString(" ")
+        }
         // Said plainly rather than by disabling the rows: this model decides the
         // language from the audio, and the pick only tells the app how to
         // punctuate what comes back.
@@ -85,6 +123,6 @@ object ModelLanguageSupport {
         val detection = "$subject works out the spoken language itself, so picking one " +
             "here does not pin the decoder. Your choice sets the language the transcript " +
             "is punctuated and formatted in, which is what short phrases get wrong."
-        return listOfNotNull(coverage, detection).joinToString(" ")
+        return listOfNotNull(coverage, detection, translation).joinToString(" ")
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/ModelTranslationSupport.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/ModelTranslationSupport.kt
@@ -1,0 +1,112 @@
+package com.vocahq.vocaphone.core
+
+/**
+ * Which languages a model can *translate into*, as opposed to transcribe.
+ *
+ * This is a different question from [ModelLanguageSupport], and conflating the
+ * two is what this file exists to stop. Transcription coverage asks what the
+ * decoder can understand; translation coverage asks what it was trained to
+ * emit for speech in some other language. Almost nothing on a phone can do the
+ * second, and the two models that can do it in opposite directions:
+ *
+ *  - **Canary** is a speech-translation model proper. Its config carries a
+ *    source and a target language, and it was trained on the pairs between
+ *    English, German, Spanish and French.
+ *  - **Whisper** translates *into English only*. That is the `<|translate|>`
+ *    task, roughly a fifth of its training data, and no other target was ever
+ *    trained. Asking it for any other target is not a smaller version of the
+ *    same feature; it is nothing at all.
+ *
+ * Every other family — the transducers, the CTC models, Moonshine, Paraformer —
+ * transcribes what it heard and has no mechanism to do anything else.
+ *
+ * A word on the failure this replaces. Whisper picks its output language from a
+ * token forced into the decoder before the first word, so selecting a language
+ * the speaker is not speaking makes it emit that language anyway: it satisfies
+ * the forced token the only way it can, by rendering the meaning it heard. That
+ * looks like translation and is occasionally even good, but it is untrained
+ * behaviour that transliterates, reverts mid-sentence and drops clauses, and no
+ * transducer can imitate it. Translation is a request the model either supports
+ * or does not, and [targets] is the only thing allowed to answer.
+ */
+object ModelTranslationSupport {
+
+    /**
+     * [AUTOMATIC][TranscriptionLanguage.AUTOMATIC] is how "do not translate" is
+     * stored. The picker needs a row for it, the setting needs a default, and
+     * reusing the language enum keeps one wire vocabulary instead of two.
+     */
+    val OFF: TranscriptionLanguage = TranscriptionLanguage.AUTOMATIC
+
+    /** Whether this model can translate at all, and so whether to offer the row. */
+    fun isSupported(targets: Set<String>): Boolean = targets.isNotEmpty()
+
+    fun isSelectable(language: TranscriptionLanguage, targets: Set<String>): Boolean =
+        language == OFF || language.wireValue in targets
+
+    /**
+     * The target to actually use. A stored choice goes stale the moment the
+     * user switches models — from Canary to Parakeet, or to a gateway — and
+     * silently translating nothing is far better than a request the engine
+     * cannot honour.
+     */
+    fun resolve(
+        selected: TranscriptionLanguage,
+        targets: Set<String>,
+    ): TranscriptionLanguage = if (isSelectable(selected, targets)) selected else OFF
+
+    /**
+     * The wire value the engines take: a language code, or empty for no
+     * translation. Engines test this with `isEmpty()`, so "auto" must never
+     * reach them — it would read as a language rather than as its absence.
+     */
+    fun target(selected: TranscriptionLanguage, targets: Set<String>): String =
+        resolve(selected, targets).takeIf { it != OFF }?.wireValue.orEmpty()
+
+    /**
+     * What the picked target is called in a settings row.
+     *
+     * "Off" rather than "Automatic": the shared enum's own label describes
+     * language detection, which is the opposite of what this row's default
+     * means.
+     */
+    fun summary(selected: TranscriptionLanguage, targets: Set<String>): String {
+        if (!isSupported(targets)) return "Not supported by this model"
+        val resolved = resolve(selected, targets)
+        return if (resolved == OFF) "Off" else resolved.displayName
+    }
+
+    /**
+     * Why the picker is limited, or null when it is not.
+     *
+     * The unsupported case is the important one. It is the only place the app
+     * can explain that the language row above never translated anything, which
+     * is the belief people arrive with after Whisper appeared to do it.
+     */
+    fun restriction(targets: Set<String>, onDevice: Boolean): String? {
+        if (!onDevice) {
+            return "Translation runs on this phone only. Your gateway transcribes " +
+                "speech in the language it was spoken."
+        }
+        if (!isSupported(targets)) {
+            return "This model transcribes what it hears and cannot translate. " +
+                "Canary translates between English, German, Spanish and French; " +
+                "the multilingual Whisper models translate into English. Picking a " +
+                "language above never translated speech — it only tells the model " +
+                "which language to expect."
+        }
+        // Sorted by the name shown, not by the code behind it: "German,
+        // English, Spanish and French" is what sorting de/en/es/fr produces.
+        val names = targets
+            .mapNotNull { code -> TranscriptionLanguage.entries.firstOrNull { it.wireValue == code } }
+            .map { it.displayName }
+            .sorted()
+        val list = when (names.size) {
+            0, 1 -> names.joinToString()
+            else -> names.dropLast(1).joinToString(", ") + " and " + names.last()
+        }
+        return "This model translates into $list. Speech in any other language " +
+            "it covers is translated into your pick; the language above stays " +
+            "what you are speaking."
+    }
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/ModelTranslationSupport.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/ModelTranslationSupport.kt
@@ -79,9 +79,19 @@ object ModelTranslationSupport {
      * "Off" rather than "Automatic": the shared enum's own label describes
      * language detection, which is the opposite of what this row's default
      * means.
+     *
+     * [onDevice] separates the two ways this can be unavailable. Blaming the
+     * model is only right when there is one: a gateway has no local model at
+     * all, and the fix is a different screen.
      */
-    fun summary(selected: TranscriptionLanguage, targets: Set<String>): String {
-        if (!isSupported(targets)) return "Not supported by this model"
+    fun summary(
+        selected: TranscriptionLanguage,
+        targets: Set<String>,
+        onDevice: Boolean = true,
+    ): String {
+        if (!isSupported(targets)) {
+            return if (onDevice) "Not supported by this model" else "Needs an on-device model"
+        }
         val resolved = resolve(selected, targets)
         return if (resolved == OFF) "Off" else resolved.displayName
     }

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/ModelTranslationSupport.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/ModelTranslationSupport.kt
@@ -38,6 +38,16 @@ object ModelTranslationSupport {
      */
     val OFF: TranscriptionLanguage = TranscriptionLanguage.AUTOMATIC
 
+    /**
+     * What the [OFF] row is called in the picker.
+     *
+     * Not "Automatic", which is the shared enum's own label and describes
+     * language detection — the opposite of what choosing it here means. The
+     * settings row says "Off" instead, because a row reading "Don't translate"
+     * next to the word "Translate to" reads as a double negative.
+     */
+    const val OFF_LABEL = "Don't translate"
+
     /** Whether this model can translate at all, and so whether to offer the row. */
     fun isSupported(targets: Set<String>): Boolean = targets.isNotEmpty()
 
@@ -83,7 +93,12 @@ object ModelTranslationSupport {
      * can explain that the language row above never translated anything, which
      * is the belief people arrive with after Whisper appeared to do it.
      */
-    fun restriction(targets: Set<String>, onDevice: Boolean): String? {
+    fun restriction(
+        targets: Set<String>,
+        onDevice: Boolean,
+        needsExplicitSource: Boolean = false,
+        sourceIsAutomatic: Boolean = false,
+    ): String? {
         if (!onDevice) {
             return "Translation runs on this phone only. Your gateway transcribes " +
                 "speech in the language it was spoken."
@@ -105,8 +120,16 @@ object ModelTranslationSupport {
             0, 1 -> names.joinToString()
             else -> names.dropLast(1).joinToString(", ") + " and " + names.last()
         }
-        return "This model translates into $list. Speech in any other language " +
-            "it covers is translated into your pick; the language above stays " +
-            "what you are speaking."
+        val coverage = "This model translates into $list. Speech in any other " +
+            "language it covers is translated into your pick; the language above " +
+            "stays what you are speaking."
+        // The one way this setting can be wrong without looking wrong. Canary
+        // is told what it is translating from, so Automatic resolves to English
+        // and anyone speaking something else is translated out of a language
+        // they never spoke.
+        if (!needsExplicitSource || !sourceIsAutomatic) return coverage
+        return coverage + " This model cannot work out what you are speaking, " +
+            "so set Language to your own language first: on Automatic it " +
+            "translates as though you had spoken English."
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -324,6 +324,7 @@ class DictationController(
                     language = configuration.effectiveLanguage.wireValue,
                     scope = scope,
                     quality = configuration.transcriptionQuality,
+                    translateTo = configuration.translationTarget,
                 )
             }
         } else {
@@ -830,6 +831,7 @@ class DictationController(
                 configuration.transcriptionQuality,
                 configuration.whisperVocabulary,
                 conditioningStartSample,
+                configuration.translationTarget,
             )
             val transcript = styleLocalTranscript(local, configuration)
             if (transcript.isEmpty()) {
@@ -861,9 +863,10 @@ class DictationController(
 
     /**
      * The styles punctuate by script, so the language they are given has to be
-     * the one that was actually spoken. With Automatic selected the request only
-     * says "auto", and a model that detected Hindi would otherwise have its
-     * Devanagari finished with a Latin full stop.
+     * the one the finished text is written in. With Automatic selected the
+     * request only says "auto", and a model that detected Hindi would otherwise
+     * have its Devanagari finished with a Latin full stop. When translating,
+     * that language is the target rather than the one that was spoken.
      */
     private fun styleLocalTranscript(
         local: LocalTranscription,
@@ -871,9 +874,10 @@ class DictationController(
     ): String = TranscriptStyler.apply(
         TranscriptSanitizer.clean(local.text),
         configuration.style,
-        ModelLanguageSupport.transcriptLanguage(
+        ModelLanguageSupport.outputLanguage(
             requested = configuration.effectiveLanguage.wireValue,
             reported = local.language,
+            translateTo = configuration.translationTarget,
         ),
     )
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelCatalog.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelCatalog.kt
@@ -100,6 +100,26 @@ data class LocalModelDescriptor(
     /** Whether short recordings may use a cropped whisper encoder window. */
     val cropsAudioContext: Boolean = false,
 ) {
+    /**
+     * Which languages this model can translate speech *into*.
+     *
+     * Derived rather than declared, because only two things in the catalog can
+     * translate at all and both derive it from something already written down.
+     * Canary is a speech-translation model across exactly the languages it
+     * lists; a multilingual whisper build has the `<|translate|>` task, whose
+     * only trained target is English. Everything else transcribes the language
+     * it heard, so an empty set here is the ordinary answer and the one the
+     * translate row reports as unsupported. See
+     * [com.vocahq.vocaphone.core.ModelTranslationSupport].
+     */
+    val translationTargets: Set<String>
+        get() = when {
+            sherpaFamily == SherpaFamily.CANARY -> languageCodes
+            englishOnly -> emptySet()
+            engine == LocalModelEngine.WHISPER -> setOf("en")
+            else -> emptySet()
+        }
+
     val sizeLabel: String
         get() = if (sizeBytes >= 1_000_000_000) {
             "%.1f GB".format(sizeBytes / 1_000_000_000.0)

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelCatalog.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelCatalog.kt
@@ -120,6 +120,21 @@ data class LocalModelDescriptor(
             else -> emptySet()
         }
 
+    /**
+     * Whether translating needs the spoken language named explicitly.
+     *
+     * Canary has no detection mode: its config carries a source language and
+     * takes whatever it is given, so "auto" has to be resolved to a real code
+     * before the recognizer is built and English is the only defensible guess.
+     * That is harmless while source and target match — the model was going to
+     * assume something either way — but once the two differ it decides what the
+     * audio is being translated *from*, and a German speaker left on Automatic
+     * gets German translated as though it were English. Whisper is the opposite:
+     * it detects the language and then translates, so it needs nothing here.
+     */
+    val translationNeedsExplicitSource: Boolean
+        get() = sherpaFamily == SherpaFamily.CANARY
+
     val sizeLabel: String
         get() = if (sizeBytes >= 1_000_000_000) {
             "%.1f GB".format(sizeBytes / 1_000_000_000.0)

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
@@ -206,9 +206,9 @@ class LocalModelManager(
         translateTo: String = "",
     ): SherpaIncrementalSession? {
         val model = LocalModelCatalog.find(modelID) ?: return null
-        if (model.engine != LocalModelEngine.SHERPA_ONNX) return null
         val resolved = if (model.englishOnly) "en" else language
         val target = model.resolveTranslationTarget(translateTo)
+        if (!canStreamIncrementally(model.engine, target)) return null
         return SherpaIncrementalSession(
             scope = scope,
             prepare = { prepareEngine(model, resolved, quality, target) },
@@ -486,7 +486,7 @@ class LocalModelManager(
         model: LocalModelDescriptor,
         resolvedLanguage: String,
         quality: TranscriptionQuality,
-        resolvedTranslateTo: String = "",
+        resolvedTranslateTo: String,
     ) {
         val directory = directoryFor(model)
         // Stat-only: cheap enough to run per dictation, unlike a digest pass.
@@ -691,3 +691,19 @@ internal fun shouldReloadLocalEngine(
  */
 internal fun LocalModelDescriptor.resolveTranslationTarget(requested: String): String =
     requested.takeIf { it.isNotEmpty() && it in translationTargets }.orEmpty()
+
+/**
+ * Whether a dictation may be decoded in windows while it is still being spoken.
+ *
+ * Whisper never streams here; only the sherpa families do. Translation rules
+ * the rest out. Streaming decodes ten-second windows and stitches them by
+ * matching repeated words across a half-second overlap, and both halves of that
+ * assume the model returns the same words for the same audio. A translator does
+ * not: the overlap comes back reworded, so nothing is deduplicated and the seam
+ * is duplicated instead — and a sentence split across two windows is translated
+ * twice, as two fragments that were never sentences. A translated dictation
+ * gives up the latency and takes the whole-file path, where anything under
+ * twelve seconds is a single decode of the whole thing.
+ */
+internal fun canStreamIncrementally(engine: LocalModelEngine, translateTo: String): Boolean =
+    engine == LocalModelEngine.SHERPA_ONNX && translateTo.isEmpty()

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
@@ -116,6 +116,13 @@ class LocalModelManager(
     private var loadedLanguage: String? = null
 
     /**
+     * Canary bakes source and target into the recognizer exactly as it bakes
+     * the language, so a change of translation target has to rebuild it too.
+     * Empty means transcribe.
+     */
+    private var loadedTranslateTo: String = ""
+
+    /**
      * Sherpa bakes the decoding method into the recognizer, so changing quality
      * means building a new one. Whisper takes its search parameters per call and
      * does not care.
@@ -196,14 +203,18 @@ class LocalModelManager(
         language: String,
         scope: CoroutineScope,
         quality: TranscriptionQuality = TranscriptionQuality.DEFAULT,
+        translateTo: String = "",
     ): SherpaIncrementalSession? {
         val model = LocalModelCatalog.find(modelID) ?: return null
         if (model.engine != LocalModelEngine.SHERPA_ONNX) return null
         val resolved = if (model.englishOnly) "en" else language
+        val target = model.resolveTranslationTarget(translateTo)
         return SherpaIncrementalSession(
             scope = scope,
-            prepare = { prepareEngine(model, resolved, quality) },
-            decode = { samples -> decodePreparedSherpa(samples, model.id, resolved, quality) },
+            prepare = { prepareEngine(model, resolved, quality, target) },
+            decode = { samples ->
+                decodePreparedSherpa(samples, model.id, resolved, quality, target)
+            },
         )
     }
 
@@ -363,6 +374,7 @@ class LocalModelManager(
         sherpaRecognizer = null
         loadedModelID = null
         loadedLanguage = null
+        loadedTranslateTo = ""
         loadedQuality = null
     }
 
@@ -427,10 +439,20 @@ class LocalModelManager(
      * explanation. Failures are the caller's to ignore: this is an optimization,
      * and the real attempt will report the same problem properly.
      */
-    suspend fun prepare(modelID: String, language: String, quality: TranscriptionQuality) {
+    suspend fun prepare(
+        modelID: String,
+        language: String,
+        quality: TranscriptionQuality,
+        translateTo: String = "",
+    ) {
         val model = LocalModelCatalog.find(modelID) ?: return
         if (!isDownloaded(model.id)) return
-        prepareEngine(model, if (model.englishOnly) "en" else language, quality)
+        prepareEngine(
+            model,
+            if (model.englishOnly) "en" else language,
+            quality,
+            model.resolveTranslationTarget(translateTo),
+        )
     }
 
     suspend fun transcribe(
@@ -440,10 +462,12 @@ class LocalModelManager(
         quality: TranscriptionQuality = TranscriptionQuality.DEFAULT,
         vocabulary: String = "",
         conditioningStartSample: Int = 0,
+        translateTo: String = "",
     ): LocalTranscription {
         val model = LocalModelCatalog.find(modelID) ?: error("Unknown local model: $modelID")
         val resolved = if (model.englishOnly) "en" else language
-        prepareEngine(model, resolved, quality)
+        val target = model.resolveTranslationTarget(translateTo)
+        prepareEngine(model, resolved, quality, target)
         // One gain and one DC-offset correction cover the complete recording.
         // Sherpa used to have a separate during-recording path that could apply
         // different conditioning and silently omit a window; the complete WAV
@@ -454,6 +478,7 @@ class LocalModelManager(
             resolved,
             quality,
             vocabulary,
+            target,
         )
     }
 
@@ -461,6 +486,7 @@ class LocalModelManager(
         model: LocalModelDescriptor,
         resolvedLanguage: String,
         quality: TranscriptionQuality,
+        resolvedTranslateTo: String = "",
     ) {
         val directory = directoryFor(model)
         // Stat-only: cheap enough to run per dictation, unlike a digest pass.
@@ -478,6 +504,8 @@ class LocalModelManager(
                     loadedQuality = loadedQuality,
                     requestedQuality = quality,
                     languageIsBakedIn = model.sherpaFamily?.acceptsLanguage ?: true,
+                    loadedTranslateTo = loadedTranslateTo,
+                    requestedTranslateTo = resolvedTranslateTo,
                 )
             ) {
                 releaseEngines()
@@ -494,6 +522,7 @@ class LocalModelManager(
                                 language = resolvedLanguage,
                                 threads = WhisperCpuConfig.preferredSherpaThreadCount,
                                 quality = quality,
+                                translateTo = resolvedTranslateTo,
                             )
                         } else {
                             whisperContext = WhisperContext.create(
@@ -506,6 +535,7 @@ class LocalModelManager(
                 }
                 loadedModelID = model.id
                 loadedLanguage = resolvedLanguage
+                loadedTranslateTo = resolvedTranslateTo
                 loadedQuality = quality
             }
         }
@@ -517,13 +547,17 @@ class LocalModelManager(
         resolvedLanguage: String,
         quality: TranscriptionQuality,
         vocabulary: String,
+        resolvedTranslateTo: String,
     ): LocalTranscription = engineMutex.withLock {
         check(
             loadedModelID == model.id &&
                 (
                     model.engine == LocalModelEngine.WHISPER ||
                         model.sherpaFamily?.acceptsLanguage != true ||
-                        loadedLanguage == resolvedLanguage
+                        (
+                            loadedLanguage == resolvedLanguage &&
+                                loadedTranslateTo == resolvedTranslateTo
+                            )
                     ),
         ) {
             "Local transcription engine changed before inference started"
@@ -533,13 +567,18 @@ class LocalModelManager(
                 val result = recognizer.transcribe(samples)
                 LocalTranscription(
                     result.text,
-                    ModelLanguageSupport.transcriptLanguage(resolvedLanguage, result.language),
+                    ModelLanguageSupport.outputLanguage(
+                        requested = resolvedLanguage,
+                        reported = result.language,
+                        translateTo = resolvedTranslateTo,
+                    ),
                 )
             }
         }
         whisperContext?.transcribe(
             samples,
             resolvedLanguage,
+            resolvedTranslateTo,
             quality,
             CustomVocabulary.whisperPrompt(vocabulary),
             model.cropsAudioContext,
@@ -552,10 +591,12 @@ class LocalModelManager(
         modelID: String,
         resolvedLanguage: String,
         quality: TranscriptionQuality,
+        resolvedTranslateTo: String,
     ): SherpaTranscript = engineMutex.withLock {
         check(
             loadedModelID == modelID &&
                 loadedLanguage == resolvedLanguage &&
+                loadedTranslateTo == resolvedTranslateTo &&
                 loadedQuality == quality,
         ) {
             "On-device model changed during transcription"
@@ -571,6 +612,7 @@ class LocalModelManager(
         quality: TranscriptionQuality = TranscriptionQuality.DEFAULT,
         vocabulary: String = "",
         conditioningStartSample: Int = 0,
+        translateTo: String = "",
     ): LocalTranscription = transcribe(
         withContext(Dispatchers.IO) { readWavSamples(wavFile) },
         modelID,
@@ -578,6 +620,7 @@ class LocalModelManager(
         quality,
         vocabulary,
         conditioningStartSample,
+        translateTo,
     )
 
     private fun readWavSamples(file: File): FloatArray {
@@ -612,6 +655,12 @@ class LocalModelManager(
  * [languageIsBakedIn] is false for the families whose config has no language
  * field at all: rebuilding a 670 MB Parakeet because the user relabelled the
  * transcript language would cost seconds and change nothing about the decode.
+ *
+ * The translation target is baked in wherever the language is — it is the other
+ * half of the same Canary config — so it is gated by the same flag. A family
+ * that cannot translate has already had the target resolved away to empty by
+ * [LocalModelDescriptor.resolveTranslationTarget], so it can never reload for a
+ * setting it would ignore.
  */
 internal fun shouldReloadLocalEngine(
     engine: LocalModelEngine,
@@ -622,9 +671,23 @@ internal fun shouldReloadLocalEngine(
     loadedQuality: TranscriptionQuality?,
     requestedQuality: TranscriptionQuality,
     languageIsBakedIn: Boolean = true,
+    loadedTranslateTo: String = "",
+    requestedTranslateTo: String = "",
 ): Boolean {
     if (loadedModelID != requestedModelID) return true
     if (engine != LocalModelEngine.SHERPA_ONNX) return false
     if (loadedQuality != requestedQuality) return true
-    return languageIsBakedIn && loadedLanguage != requestedLanguage
+    if (!languageIsBakedIn) return false
+    return loadedLanguage != requestedLanguage || loadedTranslateTo != requestedTranslateTo
 }
+
+/**
+ * The translation target this model can actually honour, or empty.
+ *
+ * Resolved here rather than trusted from the caller so that a stale setting —
+ * a target picked under Canary and still stored after a switch to Parakeet —
+ * can never reach an engine that would misread it, nor force a reload of one
+ * that would ignore it.
+ */
+internal fun LocalModelDescriptor.resolveTranslationTarget(requested: String): String =
+    requested.takeIf { it.isNotEmpty() && it in translationTargets }.orEmpty()

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaLongAudio.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaLongAudio.kt
@@ -73,25 +73,7 @@ internal object SherpaLongAudio {
     private const val SILENCE_RMS_RATIO = 0.18
     private const val SILENT_CHUNK_RMS = 0.006
 
-    /**
-     * @param overlapAtFoundBoundaries false to cut clean at a boundary a quiet
-     *   run was actually found at, retaining nothing across it.
-     *
-     *   Retaining audio there is a caution that only pays off if the same words
-     *   come back twice and can be matched and removed. That holds for
-     *   transcription and not for translation: the retained audio is translated
-     *   again as part of the next window, comes back in different words, and
-     *   nothing can pair the two — so the caution turns into the duplicate it
-     *   was supposed to prevent. A found boundary is the middle of a measured
-     *   quiet run with 150 ms of silence on each side, so nothing is straddling
-     *   it and there is nothing to protect. A boundary the search had to guess
-     *   at still retains its overlap whatever this says, because there a word
-     *   really can be split and losing it is worse than saying it twice.
-     */
-    fun chunks(
-        samples: FloatArray,
-        overlapAtFoundBoundaries: Boolean = true,
-    ): List<SherpaAudioChunk> {
+    fun chunks(samples: FloatArray): List<SherpaAudioChunk> {
         if (samples.size <= LONG_AUDIO_THRESHOLD_SECONDS * SAMPLE_RATE) {
             return listOf(SherpaAudioChunk(0, samples.size, overlapsPrevious = false))
         }
@@ -125,20 +107,18 @@ internal object SherpaLongAudio {
             // Boundary classification is deliberately not trusted with audio
             // ownership: a quiet consonant can satisfy an RMS threshold, and
             // dropping the overlap on that guess loses the word. It is trusted
-            // with how much to retain, which is only a question of cost — and,
-            // for a caller that cannot merge repeated words, with whether to
-            // retain anything at all.
-            val retainedSamples = when {
-                silence == null -> guessedOverlapSamples
-                overlapAtFoundBoundaries -> foundOverlapSamples
-                else -> 0
-            }
+            // with how much to retain, which is only a question of cost.
+            //
+            // This holds while translating too, and it is worth saying why,
+            // because the retained audio is what a translator cannot merge back
+            // out. Almost all of it is the measured quiet run itself, which
+            // translates to nothing and duplicates nothing. What is left is the
+            // case the classification got wrong — and there the choice is
+            // between a word said twice and a word not said at all.
+            val retainedSamples =
+                if (silence != null) foundOverlapSamples else guessedOverlapSamples
             start = (end - retainedSamples).coerceAtLeast(start + 1)
-            // Says what was actually done rather than that a boundary exists:
-            // with nothing retained there is no repeated audio, and a merger
-            // told to look for one can only find a real repetition and delete
-            // words the speaker said.
-            overlapsPrevious = retainedSamples > 0
+            overlapsPrevious = true
         }
         return chunks
     }

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaLongAudio.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaLongAudio.kt
@@ -73,7 +73,25 @@ internal object SherpaLongAudio {
     private const val SILENCE_RMS_RATIO = 0.18
     private const val SILENT_CHUNK_RMS = 0.006
 
-    fun chunks(samples: FloatArray): List<SherpaAudioChunk> {
+    /**
+     * @param overlapAtFoundBoundaries false to cut clean at a boundary a quiet
+     *   run was actually found at, retaining nothing across it.
+     *
+     *   Retaining audio there is a caution that only pays off if the same words
+     *   come back twice and can be matched and removed. That holds for
+     *   transcription and not for translation: the retained audio is translated
+     *   again as part of the next window, comes back in different words, and
+     *   nothing can pair the two — so the caution turns into the duplicate it
+     *   was supposed to prevent. A found boundary is the middle of a measured
+     *   quiet run with 150 ms of silence on each side, so nothing is straddling
+     *   it and there is nothing to protect. A boundary the search had to guess
+     *   at still retains its overlap whatever this says, because there a word
+     *   really can be split and losing it is worse than saying it twice.
+     */
+    fun chunks(
+        samples: FloatArray,
+        overlapAtFoundBoundaries: Boolean = true,
+    ): List<SherpaAudioChunk> {
         if (samples.size <= LONG_AUDIO_THRESHOLD_SECONDS * SAMPLE_RATE) {
             return listOf(SherpaAudioChunk(0, samples.size, overlapsPrevious = false))
         }
@@ -107,11 +125,20 @@ internal object SherpaLongAudio {
             // Boundary classification is deliberately not trusted with audio
             // ownership: a quiet consonant can satisfy an RMS threshold, and
             // dropping the overlap on that guess loses the word. It is trusted
-            // with how much to retain, which is only a question of cost.
-            val retainedSamples =
-                if (silence != null) foundOverlapSamples else guessedOverlapSamples
+            // with how much to retain, which is only a question of cost — and,
+            // for a caller that cannot merge repeated words, with whether to
+            // retain anything at all.
+            val retainedSamples = when {
+                silence == null -> guessedOverlapSamples
+                overlapAtFoundBoundaries -> foundOverlapSamples
+                else -> 0
+            }
             start = (end - retainedSamples).coerceAtLeast(start + 1)
-            overlapsPrevious = true
+            // Says what was actually done rather than that a boundary exists:
+            // with nothing retained there is no repeated audio, and a merger
+            // told to look for one can only find a real repetition and delete
+            // words the speaker said.
+            overlapsPrevious = retainedSamples > 0
         }
         return chunks
     }

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
@@ -23,12 +23,43 @@ import java.io.File
  */
 internal class SherpaRecognizer private constructor(
     private val recognizer: OfflineRecognizer,
+    /**
+     * Whether this recognizer was built to translate, which changes how a
+     * recording too long for one decode may be cut up. See [transcribe].
+     */
+    private val translating: Boolean = false,
 ) {
+    /**
+     * Decodes the whole recording, in windows if it is longer than one decode
+     * should be.
+     *
+     * Those windows are where translation and transcription part company. A
+     * transcriber returns the same words for the same audio, so a window can
+     * retain a little of the one before it and the merger can match and remove
+     * the repeat. A translator does not: the retained audio is translated again
+     * inside a different sentence, comes back in different words, and nothing
+     * can pair the two. Worse, a merger still looking for a repeat can only
+     * match a phrase the speaker genuinely said twice, and delete it.
+     *
+     * So a translating recognizer cuts clean at the boundaries the silence
+     * search actually found — the middle of a measured quiet run, where nothing
+     * is straddling the cut — and never merges by matching words. A boundary
+     * the search had to guess at keeps its overlap, because there a word really
+     * can be split and losing it outright is worse than the one word it may now
+     * repeat.
+     */
     fun transcribe(samples: FloatArray): SherpaTranscript {
         var transcript = SherpaTranscript.EMPTY
-        SherpaLongAudio.chunks(samples).forEach { chunk ->
+        val chunks = SherpaLongAudio.chunks(
+            samples,
+            overlapAtFoundBoundaries = !translating,
+        )
+        chunks.forEach { chunk ->
             val chunkResult = transcribeChunk(samples.copyOfRange(chunk.start, chunk.endExclusive))
-            transcript = transcript.append(chunkResult, deduplicateOverlap = chunk.overlapsPrevious)
+            transcript = transcript.append(
+                chunkResult,
+                deduplicateOverlap = chunk.overlapsPrevious && !translating,
+            )
         }
         return transcript.copy(text = transcript.text.trim())
     }
@@ -37,6 +68,7 @@ internal class SherpaRecognizer private constructor(
     fun transcribeChunk(samples: FloatArray): SherpaTranscript = SherpaEmptyChunkRecovery.decode(
         samples = samples,
         decodeOnce = ::decode,
+        deduplicateOverlap = !translating,
     )
 
     private fun decode(samples: FloatArray): SherpaTranscript {
@@ -161,6 +193,9 @@ internal class SherpaRecognizer private constructor(
                         maxActivePaths = quality.sherpaMaxActivePaths,
                     ),
                 ),
+                // Only the families that can honour a target are translating,
+                // whatever the caller asked for.
+                translating = family.acceptsLanguage && translateTo.isNotEmpty(),
             )
         }
     }
@@ -210,9 +245,16 @@ internal data class SherpaTranscript(val text: String, val language: String = ""
  */
 internal object SherpaEmptyChunkRecovery {
 
+    /**
+     * @param deduplicateOverlap false when the caller is translating. The two
+     *   halves overlap so the word crossing the centre survives, and matching
+     *   the repeat back out only works when the same audio returns the same
+     *   words — which is exactly what a translator does not promise.
+     */
     fun decode(
         samples: FloatArray,
         decodeOnce: (FloatArray) -> SherpaTranscript,
+        deduplicateOverlap: Boolean = true,
     ): SherpaTranscript {
         val firstAttempt = decodeOnce(samples)
         // Length is what this recovers from, so a window that is not long
@@ -241,7 +283,7 @@ internal object SherpaEmptyChunkRecovery {
         return decodeOnce(samples.copyOfRange(0, leftEnd))
             .append(
                 decodeOnce(samples.copyOfRange(rightStart, samples.size)),
-                deduplicateOverlap = true,
+                deduplicateOverlap = deduplicateOverlap,
             )
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
@@ -60,6 +60,9 @@ internal class SherpaRecognizer private constructor(
         /**
          * @param language a two-letter code, or "auto" to let the model decide.
          *   Only the families that accept a language hint use it.
+         * @param translateTo the language to translate into, or empty to
+         *   transcribe. Canary is the only family that can honour it; see
+         *   [com.vocahq.vocaphone.core.ModelTranslationSupport].
          */
         fun create(
             model: LocalModelDescriptor,
@@ -67,6 +70,7 @@ internal class SherpaRecognizer private constructor(
             language: String,
             threads: Int,
             quality: TranscriptionQuality,
+            translateTo: String = "",
         ): SherpaRecognizer {
             val family = requireNotNull(model.sherpaFamily) {
                 "${model.displayName} has no sherpa-onnx family"
@@ -108,15 +112,23 @@ internal class SherpaRecognizer private constructor(
                     dolphin = OfflineDolphinModelConfig(model = path("model.int8.onnx")),
                 )
 
-                SherpaFamily.CANARY -> OfflineModelConfig(
-                    canary = OfflineCanaryModelConfig(
-                        encoder = path("encoder.int8.onnx"),
-                        decoder = path("decoder.int8.onnx"),
-                        srcLang = if (language == "auto") "en" else language,
-                        tgtLang = if (language == "auto") "en" else language,
-                        usePnc = true,
-                    ),
-                )
+                // The one family that can translate. Equal source and target is
+                // transcription; differing them is what Canary was trained for,
+                // and "auto" has to become a real code because the config has no
+                // detection mode — English is the safest guess and the one
+                // upstream's own examples use.
+                SherpaFamily.CANARY -> {
+                    val source = if (language == "auto") "en" else language
+                    OfflineModelConfig(
+                        canary = OfflineCanaryModelConfig(
+                            encoder = path("encoder.int8.onnx"),
+                            decoder = path("decoder.int8.onnx"),
+                            srcLang = source,
+                            tgtLang = translateTo.ifEmpty { source },
+                            usePnc = true,
+                        ),
+                    )
+                }
 
                 // Upstream is inconsistent about whether the single CTC graph is
                 // quantized, so whichever one the catalog pinned is the one here.

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
@@ -33,28 +33,25 @@ internal class SherpaRecognizer private constructor(
      * Decodes the whole recording, in windows if it is longer than one decode
      * should be.
      *
-     * Those windows are where translation and transcription part company. A
-     * transcriber returns the same words for the same audio, so a window can
-     * retain a little of the one before it and the merger can match and remove
-     * the repeat. A translator does not: the retained audio is translated again
-     * inside a different sentence, comes back in different words, and nothing
-     * can pair the two. Worse, a merger still looking for a repeat can only
-     * match a phrase the speaker genuinely said twice, and delete it.
+     * Those windows are where translation and transcription part company. Each
+     * window retains a little of the one before it so that a word on the
+     * boundary survives, and the merger matches the repeated words and removes
+     * them. That second half only works if the same audio returns the same
+     * words, which a transcriber promises and a translator does not: the
+     * retained audio is translated again inside a different sentence and comes
+     * back worded differently, so there is nothing to pair.
      *
-     * So a translating recognizer cuts clean at the boundaries the silence
-     * search actually found — the middle of a measured quiet run, where nothing
-     * is straddling the cut — and never merges by matching words. A boundary
-     * the search had to guess at keeps its overlap, because there a word really
-     * can be split and losing it outright is worse than the one word it may now
-     * repeat.
+     * Left on, the merger would then be matching text it was never able to
+     * align, and the only thing it can still find is a phrase the speaker
+     * genuinely said twice — which it would delete. A translated seam is
+     * therefore left exactly as it decoded. The audio overlap stays: almost all
+     * of it is the measured quiet run the boundary was found in, which
+     * duplicates nothing, and where the boundary was misjudged a word repeated
+     * beats a word lost.
      */
     fun transcribe(samples: FloatArray): SherpaTranscript {
         var transcript = SherpaTranscript.EMPTY
-        val chunks = SherpaLongAudio.chunks(
-            samples,
-            overlapAtFoundBoundaries = !translating,
-        )
-        chunks.forEach { chunk ->
+        SherpaLongAudio.chunks(samples).forEach { chunk ->
             val chunkResult = transcribeChunk(samples.copyOfRange(chunk.start, chunk.endExclusive))
             transcript = transcript.append(
                 chunkResult,

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/WhisperContext.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/WhisperContext.kt
@@ -17,6 +17,7 @@ internal class WhisperContext private constructor(private var pointer: Long) {
     suspend fun transcribe(
         samples: FloatArray,
         language: String,
+        translateTo: String,
         quality: TranscriptionQuality,
         prompt: String,
         cropAudioContext: Boolean,
@@ -29,6 +30,7 @@ internal class WhisperContext private constructor(private var pointer: Long) {
                 threads,
                 samples,
                 if (language == "auto") "auto" else language,
+                translateTo.isNotEmpty(),
                 quality.whisperBeamSize,
                 quality.whisperTemperatureIncrement,
                 if (cropAudioContext) WhisperCpuConfig.whisperAudioContext(samples.size) else 0,
@@ -50,9 +52,12 @@ internal class WhisperContext private constructor(private var pointer: Long) {
                 // Detection is meaningful only for Automatic. With an explicit
                 // selection, the user's requested output language remains the
                 // contract even if the engine reports something contradictory.
-                language = ModelLanguageSupport.transcriptLanguage(
+                // Translating overrides both: the detected language is the one
+                // that was spoken, and the text on screen is the target.
+                language = ModelLanguageSupport.outputLanguage(
                     requested = language,
                     reported = WhisperLib.getDetectedLanguage(pointer),
+                    translateTo = translateTo,
                 ),
             )
         }

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/WhisperLib.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/WhisperLib.kt
@@ -54,6 +54,8 @@ internal class WhisperLib {
         external fun initContext(modelPath: String): Long
         external fun freeContext(contextPtr: Long)
         /**
+         * @param translate whether to run whisper's translate task, whose only
+         *   trained target is English.
          * @param beamSize a beam search width, or zero for greedy sampling.
          * @param audioContext the encoder window in 20 ms units, or zero for
          *   whisper's full thirty-second default.
@@ -65,6 +67,7 @@ internal class WhisperLib {
             numThreads: Int,
             audioData: FloatArray,
             language: String,
+            translate: Boolean,
             beamSize: Int,
             temperatureIncrement: Float,
             audioContext: Int,

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -13,6 +13,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import com.vocahq.vocaphone.core.DictationTone
 import com.vocahq.vocaphone.core.MicrophonePreference
 import com.vocahq.vocaphone.core.ModelLanguageSupport
+import com.vocahq.vocaphone.core.ModelTranslationSupport
 import com.vocahq.vocaphone.local.LocalModelCatalog
 import com.vocahq.vocaphone.local.LocalModelDescriptor
 import com.vocahq.vocaphone.core.TranscriptionLanguage
@@ -177,6 +178,16 @@ data class VocaPhoneSettings(
     val gatewayUrl: String = "",
     val hasToken: Boolean = false,
     val language: TranscriptionLanguage = TranscriptionLanguage.DEFAULT,
+    /**
+     * The language dictation should come out in, or
+     * [ModelTranslationSupport.OFF] to keep the language that was spoken.
+     *
+     * Deliberately a second setting rather than a meaning layered onto
+     * [language]. That row says what is being spoken, which is what a decoder
+     * needs; this one says what should come back, which only two models can
+     * honour at all.
+     */
+    val translateTo: TranscriptionLanguage = ModelTranslationSupport.OFF,
     val style: WritingStyle = WritingStyle.DEFAULT,
     val dictationTone: DictationTone = DictationTone.DEFAULT,
     val microphone: MicrophonePreference = MicrophonePreference.DEFAULT,
@@ -251,6 +262,24 @@ data class VocaPhoneSettings(
      */
     val effectiveLanguage: TranscriptionLanguage
         get() = ModelLanguageSupport.resolve(language, activeModelLanguages)
+
+    /** Languages the active model can translate into; empty when it cannot. */
+    val activeModelTranslationTargets: Set<String>
+        get() = localModel?.translationTargets.orEmpty()
+
+    /** The picker's own selection, corrected for a model that cannot honour it. */
+    val effectiveTranslateTo: TranscriptionLanguage
+        get() = ModelTranslationSupport.resolve(translateTo, activeModelTranslationTargets)
+
+    /**
+     * What the engines take: a language code, or empty for no translation.
+     *
+     * Gateway transcription is empty by construction — [activeModelTranslationTargets]
+     * is empty without a local model — because translation lives entirely in
+     * the on-device engines and the gateway protocol has no field for it.
+     */
+    val translationTarget: String
+        get() = ModelTranslationSupport.target(translateTo, activeModelTranslationTargets)
 
     /**
      * The language claim that governs the picker. With on-device transcription on
@@ -331,6 +360,9 @@ class SettingsRepository(private val context: Context) {
     }
 
     suspend fun setLanguage(language: TranscriptionLanguage) = put(Keys.LANGUAGE, language.wireValue)
+
+    suspend fun setTranslateTo(language: TranscriptionLanguage) =
+        put(Keys.TRANSLATE_TO, language.wireValue)
 
     suspend fun setStyle(style: WritingStyle) = put(Keys.STYLE, style.wireValue)
 
@@ -510,6 +542,7 @@ class SettingsRepository(private val context: Context) {
         gatewayUrl = this[Keys.GATEWAY_URL].orEmpty(),
         hasToken = this[Keys.TOKEN_CIPHERTEXT] != null,
         language = TranscriptionLanguage.fromWire(this[Keys.LANGUAGE]),
+        translateTo = TranscriptionLanguage.fromWire(this[Keys.TRANSLATE_TO]),
         style = WritingStyle.fromWire(this[Keys.STYLE]),
         dictationTone = DictationTone.fromStored(this[Keys.DICTATION_TONE]),
         microphone = MicrophonePreference.fromStored(this[Keys.MICROPHONE]),
@@ -552,6 +585,7 @@ class SettingsRepository(private val context: Context) {
         val TOKEN_CIPHERTEXT = stringPreferencesKey("gateway_token_ciphertext")
         val TOKEN_NONCE = stringPreferencesKey("gateway_token_nonce")
         val LANGUAGE = stringPreferencesKey("transcription_language")
+        val TRANSLATE_TO = stringPreferencesKey("translate_to")
         val STYLE = stringPreferencesKey("writing_style")
         val DICTATION_TONE = stringPreferencesKey("dictation_tone")
         val MICROPHONE = stringPreferencesKey("microphone_preference")

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -267,6 +267,10 @@ data class VocaPhoneSettings(
     val activeModelTranslationTargets: Set<String>
         get() = localModel?.translationTargets.orEmpty()
 
+    /** Whether translating needs [language] set to something other than Automatic. */
+    val activeModelTranslationNeedsSource: Boolean
+        get() = localModel?.translationNeedsExplicitSource ?: false
+
     /** The picker's own selection, corrected for a model that cannot honour it. */
     val effectiveTranslateTo: TranscriptionLanguage
         get() = ModelTranslationSupport.resolve(translateTo, activeModelTranslationTargets)

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/LanguagePickerSheet.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/LanguagePickerSheet.kt
@@ -29,7 +29,25 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.size
 import com.vocahq.vocaphone.R
 import com.vocahq.vocaphone.core.ModelLanguageSupport
+import com.vocahq.vocaphone.core.ModelTranslationSupport
 import com.vocahq.vocaphone.core.TranscriptionLanguage
+
+/**
+ * Which of the two language questions this sheet is asking.
+ *
+ * The rows, the search and the greying are identical; what differs is the
+ * title, what the first row means, which languages are selectable and what the
+ * explanation underneath says. Keeping them one composable is what stops the
+ * two questions drifting apart in the ways that made them look like one
+ * setting in the first place.
+ */
+enum class LanguagePickerMode {
+    /** The language being spoken, which is what a decoder is told. */
+    SPOKEN,
+
+    /** The language the transcript should come back in. */
+    TRANSLATION,
+}
 
 /**
  * The full language list, opened from one row in Settings.
@@ -47,9 +65,12 @@ fun LanguagePickerSheet(
     modelLanguages: Set<String>,
     detectsLanguageAutomatically: Boolean,
     onDevice: Boolean = false,
+    mode: LanguagePickerMode = LanguagePickerMode.SPOKEN,
+    translationTargets: Set<String> = emptySet(),
     onSelect: (TranscriptionLanguage) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val translating = mode == LanguagePickerMode.TRANSLATION
     var query by remember { mutableStateOf("") }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -58,24 +79,34 @@ fun LanguagePickerSheet(
             language.displayName.contains(query, ignoreCase = true) ||
             language.wireValue.contains(query, ignoreCase = true)
 
-    fun selectable(language: TranscriptionLanguage) =
+    fun selectable(language: TranscriptionLanguage) = if (translating) {
+        ModelTranslationSupport.isSelectable(language, translationTargets)
+    } else {
         ModelLanguageSupport.isSelectable(language, modelLanguages)
+    }
 
     val available = TranscriptionLanguage.entries.filter { matches(it) && selectable(it) }
     val unavailable = TranscriptionLanguage.entries.filter { matches(it) && !selectable(it) }
-    val restriction =
+    val restriction = if (translating) {
+        ModelTranslationSupport.restriction(translationTargets, onDevice = onDevice)
+    } else {
         ModelLanguageSupport.restriction(
             modelLanguages,
             detectsLanguageAutomatically,
             onDevice = onDevice,
+            canTranslate = ModelTranslationSupport.isSupported(translationTargets),
         )
+    }
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Text("Transcription language", style = MaterialTheme.typography.titleMedium)
+            Text(
+                if (translating) "Translate to" else "Transcription language",
+                style = MaterialTheme.typography.titleMedium,
+            )
             OutlinedTextField(
                 value = query,
                 onValueChange = { query = it },
@@ -95,7 +126,7 @@ fun LanguagePickerSheet(
             modifier = Modifier.fillMaxWidth().heightIn(max = 420.dp).padding(top = 8.dp),
         ) {
             items(available, key = { it.wireValue }) { language ->
-                LanguageRow(language, selected == language, enabled = true) {
+                LanguageRow(language, selected == language, enabled = true, translating) {
                     onSelect(language)
                     onDismiss()
                 }
@@ -110,7 +141,7 @@ fun LanguagePickerSheet(
                     )
                 }
                 items(unavailable, key = { it.wireValue }) { language ->
-                    LanguageRow(language, selected == language, enabled = false) {}
+                    LanguageRow(language, selected == language, enabled = false, translating) {}
                 }
             }
             if (available.isEmpty() && unavailable.isEmpty()) {
@@ -133,6 +164,7 @@ private fun LanguageRow(
     language: TranscriptionLanguage,
     isSelected: Boolean,
     enabled: Boolean,
+    translating: Boolean = false,
     onClick: () -> Unit,
 ) {
     val colour = if (enabled) {
@@ -149,7 +181,14 @@ private fun LanguageRow(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Text(
-            language.displayName,
+            // Automatic is the shared enum's way of storing "no choice", and
+            // in the translation sheet the absence of a choice is not language
+            // detection but no translation at all.
+            if (translating && language == ModelTranslationSupport.OFF) {
+                "Don't translate"
+            } else {
+                language.displayName
+            },
             style = MaterialTheme.typography.bodyLarge,
             color = colour,
             modifier = Modifier.weight(1f),

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/LanguagePickerSheet.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/LanguagePickerSheet.kt
@@ -67,6 +67,8 @@ fun LanguagePickerSheet(
     onDevice: Boolean = false,
     mode: LanguagePickerMode = LanguagePickerMode.SPOKEN,
     translationTargets: Set<String> = emptySet(),
+    translationNeedsSource: Boolean = false,
+    sourceIsAutomatic: Boolean = false,
     onSelect: (TranscriptionLanguage) -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -74,9 +76,18 @@ fun LanguagePickerSheet(
     var query by remember { mutableStateOf("") }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
+    fun label(language: TranscriptionLanguage) =
+        if (translating && language == ModelTranslationSupport.OFF) {
+            ModelTranslationSupport.OFF_LABEL
+        } else {
+            language.displayName
+        }
+
+    // Searched against the label actually on the row: "Don't translate" is not
+    // findable by typing "automatic", and should not be.
     fun matches(language: TranscriptionLanguage) =
         query.isBlank() ||
-            language.displayName.contains(query, ignoreCase = true) ||
+            label(language).contains(query, ignoreCase = true) ||
             language.wireValue.contains(query, ignoreCase = true)
 
     fun selectable(language: TranscriptionLanguage) = if (translating) {
@@ -88,7 +99,12 @@ fun LanguagePickerSheet(
     val available = TranscriptionLanguage.entries.filter { matches(it) && selectable(it) }
     val unavailable = TranscriptionLanguage.entries.filter { matches(it) && !selectable(it) }
     val restriction = if (translating) {
-        ModelTranslationSupport.restriction(translationTargets, onDevice = onDevice)
+        ModelTranslationSupport.restriction(
+            translationTargets,
+            onDevice = onDevice,
+            needsExplicitSource = translationNeedsSource,
+            sourceIsAutomatic = sourceIsAutomatic,
+        )
     } else {
         ModelLanguageSupport.restriction(
             modelLanguages,
@@ -126,7 +142,7 @@ fun LanguagePickerSheet(
             modifier = Modifier.fillMaxWidth().heightIn(max = 420.dp).padding(top = 8.dp),
         ) {
             items(available, key = { it.wireValue }) { language ->
-                LanguageRow(language, selected == language, enabled = true, translating) {
+                LanguageRow(label(language), selected == language, enabled = true) {
                     onSelect(language)
                     onDismiss()
                 }
@@ -141,7 +157,7 @@ fun LanguagePickerSheet(
                     )
                 }
                 items(unavailable, key = { it.wireValue }) { language ->
-                    LanguageRow(language, selected == language, enabled = false, translating) {}
+                    LanguageRow(label(language), selected == language, enabled = false) {}
                 }
             }
             if (available.isEmpty() && unavailable.isEmpty()) {
@@ -161,10 +177,9 @@ fun LanguagePickerSheet(
 
 @Composable
 private fun LanguageRow(
-    language: TranscriptionLanguage,
+    label: String,
     isSelected: Boolean,
     enabled: Boolean,
-    translating: Boolean = false,
     onClick: () -> Unit,
 ) {
     val colour = if (enabled) {
@@ -181,14 +196,7 @@ private fun LanguageRow(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Text(
-            // Automatic is the shared enum's way of storing "no choice", and
-            // in the translation sheet the absence of a choice is not language
-            // detection but no translation at all.
-            if (translating && language == ModelTranslationSupport.OFF) {
-                "Don't translate"
-            } else {
-                language.displayName
-            },
+            label,
             style = MaterialTheme.typography.bodyLarge,
             color = colour,
             modifier = Modifier.weight(1f),

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
@@ -398,6 +398,7 @@ fun VocaPhoneApp(
                 setup = setup,
                 microphone = microphone,
                 onLanguage = { viewModel.setLanguage(it) },
+                onTranslateTo = { viewModel.setTranslateTo(it) },
                 onStyle = { viewModel.setStyle(it) },
                 onDictationTone = { viewModel.setDictationTone(it) },
                 onPreviewDictationTone = { viewModel.toggleDictationTonePreview(it) },

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -38,6 +38,7 @@ import com.vocahq.vocaphone.core.CustomVocabulary
 import com.vocahq.vocaphone.ime.PersonalDictionary
 import com.vocahq.vocaphone.core.DictationTone
 import com.vocahq.vocaphone.core.MicrophonePreference
+import com.vocahq.vocaphone.core.ModelTranslationSupport
 import com.vocahq.vocaphone.core.TranscriptionLanguage
 import com.vocahq.vocaphone.core.TranscriptionQuality
 import com.vocahq.vocaphone.core.WritingStyle
@@ -80,6 +81,7 @@ fun SettingsScreen(
     setup: SetupStatus,
     microphone: MicrophoneStatus,
     onLanguage: (TranscriptionLanguage) -> Unit,
+    onTranslateTo: (TranscriptionLanguage) -> Unit,
     onStyle: (WritingStyle) -> Unit,
     onDictationTone: (DictationTone) -> Unit,
     onPreviewDictationTone: (DictationTone) -> Unit,
@@ -126,6 +128,7 @@ fun SettingsScreen(
     val appInfo = remember { context.readAppInfo() }
     val onDevice = context.readOnDeviceDiagnostics(localModels.downloaded)
     var pickingLanguage by remember { mutableStateOf(false) }
+    var pickingTranslation by remember { mutableStateOf(false) }
     val localModel = LocalModelCatalog.find(settings.localModelId)
 
     LaunchedEffect(openLanguagePicker) {
@@ -157,6 +160,20 @@ fun SettingsScreen(
                         supporting = settings.effectiveLanguage.displayName,
                         icon = R.drawable.ic_language,
                         onClick = { pickingLanguage = true },
+                    )
+                    SettingsMenuDivider()
+                    // Kept next to Language and never hidden. A row that
+                    // disappears for most models would leave the question
+                    // unanswered, and "not supported by this model" is exactly
+                    // the answer people arrive looking for.
+                    SettingsMenuRow(
+                        title = "Translate to",
+                        supporting = ModelTranslationSupport.summary(
+                            settings.translateTo,
+                            settings.activeModelTranslationTargets,
+                        ),
+                        icon = R.drawable.ic_language,
+                        onClick = { pickingTranslation = true },
                     )
                     SettingsMenuDivider()
                     SettingsMenuRow(
@@ -486,8 +503,22 @@ fun SettingsScreen(
             modelLanguages = settings.activeModelLanguages,
             detectsLanguageAutomatically = settings.activeModelDetectsLanguage,
             onDevice = settings.localTranscriptionEnabled,
+            translationTargets = settings.activeModelTranslationTargets,
             onSelect = onLanguage,
             onDismiss = { pickingLanguage = false },
+        )
+    }
+
+    if (pickingTranslation) {
+        LanguagePickerSheet(
+            selected = settings.effectiveTranslateTo,
+            modelLanguages = settings.activeModelLanguages,
+            detectsLanguageAutomatically = settings.activeModelDetectsLanguage,
+            onDevice = settings.localTranscriptionEnabled,
+            mode = LanguagePickerMode.TRANSLATION,
+            translationTargets = settings.activeModelTranslationTargets,
+            onSelect = onTranslateTo,
+            onDismiss = { pickingTranslation = false },
         )
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -171,6 +171,7 @@ fun SettingsScreen(
                         supporting = ModelTranslationSupport.summary(
                             settings.translateTo,
                             settings.activeModelTranslationTargets,
+                            onDevice = settings.localTranscriptionEnabled,
                         ),
                         icon = R.drawable.ic_language,
                         onClick = { pickingTranslation = true },

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -517,6 +517,8 @@ fun SettingsScreen(
             onDevice = settings.localTranscriptionEnabled,
             mode = LanguagePickerMode.TRANSLATION,
             translationTargets = settings.activeModelTranslationTargets,
+            translationNeedsSource = settings.activeModelTranslationNeedsSource,
+            sourceIsAutomatic = settings.effectiveLanguage == TranscriptionLanguage.AUTOMATIC,
             onSelect = onTranslateTo,
             onDismiss = { pickingTranslation = false },
         )

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
@@ -307,6 +307,9 @@ class VocaPhoneViewModel(application: Application) : AndroidViewModel(applicatio
     fun setLanguage(language: TranscriptionLanguage) =
         viewModelScope.launch { container.settings.setLanguage(language) }
 
+    fun setTranslateTo(language: TranscriptionLanguage) =
+        viewModelScope.launch { container.settings.setTranslateTo(language) }
+
     fun setStyle(style: WritingStyle) =
         viewModelScope.launch { container.settings.setStyle(style) }
 
@@ -473,6 +476,7 @@ class VocaPhoneViewModel(application: Application) : AndroidViewModel(applicatio
                     modelID = modelID,
                     language = configuration.effectiveLanguage.wireValue,
                     quality = configuration.transcriptionQuality,
+                    translateTo = configuration.translationTarget,
                 )
             }
         }

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/ModelLanguageSupportTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/ModelLanguageSupportTest.kt
@@ -2,7 +2,6 @@ package com.vocahq.vocaphone.core
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -66,12 +65,55 @@ class ModelLanguageSupportTest {
     }
 
     @Test
-    fun `the restriction is explained only when there is one`() {
-        assertNull(ModelLanguageSupport.restriction(emptySet(), false))
+    fun `a coverage limit is spelled out whenever there is one`() {
         val limited = ModelLanguageSupport.restriction(dolphin, false)
         assertTrue(limited!!.contains("${dolphin.size} languages"))
         val oneLanguage = ModelLanguageSupport.restriction(setOf("en"), false)
         assertTrue(oneLanguage!!.contains("1 language."))
+        // No coverage claim leaves nothing to say about coverage.
+        assertFalse(
+            ModelLanguageSupport.restriction(emptySet(), false)!!.contains("covers"),
+        )
+    }
+
+    /**
+     * The picker used to say nothing at all for an unrestricted model, which is
+     * exactly the case — a multilingual Whisper — where someone picks Russian,
+     * speaks English, and concludes the app translates. It never did: Whisper
+     * forces the language token and renders the meaning it heard in that
+     * script, untrained and unreliable.
+     */
+    @Test
+    fun `every model says the language row is not a translation setting`() {
+        for (detects in listOf(false, true)) {
+            val sentence = ModelLanguageSupport.restriction(emptySet(), detects)!!
+            assertTrue(sentence.contains("not the language you want back"))
+            assertTrue(sentence.contains("cannot translate"))
+        }
+        // A model that can translate points at the row that does it instead of
+        // repeating the warning.
+        val canary = ModelLanguageSupport.restriction(
+            setOf("en", "de", "es", "fr"),
+            false,
+            onDevice = true,
+            canTranslate = true,
+        )!!
+        assertTrue(canary.contains("use Translate to"))
+        assertFalse(canary.contains("cannot translate"))
+    }
+
+    /**
+     * With translation on, two languages are in play and only one of them is
+     * the one on screen. The styler punctuates by script, so it has to be given
+     * the target.
+     */
+    @Test
+    fun `the output language is the translation target when translating`() {
+        assertEquals("de", ModelLanguageSupport.outputLanguage("hi", "hi", "de"))
+        assertEquals("de", ModelLanguageSupport.outputLanguage("auto", "hi", "de"))
+        // Empty is no translation, which leaves the old contract untouched.
+        assertEquals("hi", ModelLanguageSupport.outputLanguage("hi", "en", ""))
+        assertEquals("hi", ModelLanguageSupport.outputLanguage("auto", "hi", ""))
     }
 
     /**

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/ModelTranslationSupportTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/ModelTranslationSupportTest.kt
@@ -1,0 +1,132 @@
+package com.vocahq.vocaphone.core
+
+import com.vocahq.vocaphone.local.LocalModelCatalog
+import com.vocahq.vocaphone.settings.VocaPhoneSettings
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ModelTranslationSupportTest {
+
+    private val canary = setOf("en", "de", "es", "fr")
+    private val whisper = setOf("en")
+
+    /**
+     * The capability matrix is the whole feature. Getting it wrong in the
+     * permissive direction is what produced the belief that any model can be
+     * asked for any output language.
+     */
+    @Test
+    fun `only the two models that can translate claim to`() {
+        fun targets(id: String) =
+            requireNotNull(LocalModelCatalog.find(id)) { "missing $id" }.translationTargets
+
+        // Canary is a speech-translation model across the languages it lists.
+        assertEquals(canary, targets("canary-180m-flash"))
+        // Whisper's translate task has exactly one trained target.
+        assertEquals(whisper, targets("small-q5_1"))
+        assertEquals(whisper, targets("large-v3"))
+        // An English-only whisper build has nothing to translate from.
+        assertTrue(targets("small.en").isEmpty())
+        // The transducers and CTC models transcribe and nothing else. Parakeet
+        // v3 is the one people expect to translate because it is multilingual.
+        assertTrue(targets("parakeet-tdt-0.6b-v3").isEmpty())
+        assertTrue(targets("parakeet-tdt-0.6b-v2-en").isEmpty())
+        assertTrue(targets("dolphin-small-ctc").isEmpty())
+        assertTrue(targets("sense-voice").isEmpty())
+        assertTrue(targets("moonshine-base-en").isEmpty())
+        assertTrue(targets("fast-conformer-ctc-4-lang").isEmpty())
+    }
+
+    @Test
+    fun `off is always selectable and a target is only selectable where trained`() {
+        assertTrue(ModelTranslationSupport.isSelectable(ModelTranslationSupport.OFF, emptySet()))
+        assertTrue(ModelTranslationSupport.isSelectable(TranscriptionLanguage.GERMAN, canary))
+        assertFalse(ModelTranslationSupport.isSelectable(TranscriptionLanguage.HINDI, canary))
+        // Whisper into English, and nothing else. Russian here is the exact
+        // request that used to appear to work.
+        assertTrue(ModelTranslationSupport.isSelectable(TranscriptionLanguage.ENGLISH, whisper))
+        assertFalse(ModelTranslationSupport.isSelectable(TranscriptionLanguage.RUSSIAN, whisper))
+    }
+
+    /**
+     * A target picked under Canary and left stored while the user switches to
+     * Parakeet must not survive as a request no engine can honour.
+     */
+    @Test
+    fun `a stale target falls back to no translation`() {
+        assertEquals(
+            ModelTranslationSupport.OFF,
+            ModelTranslationSupport.resolve(TranscriptionLanguage.GERMAN, emptySet()),
+        )
+        assertEquals(
+            TranscriptionLanguage.GERMAN,
+            ModelTranslationSupport.resolve(TranscriptionLanguage.GERMAN, canary),
+        )
+    }
+
+    /** "auto" is a language to the engines, so absence has to reach them empty. */
+    @Test
+    fun `the engine target is a code or nothing at all`() {
+        assertEquals("de", ModelTranslationSupport.target(TranscriptionLanguage.GERMAN, canary))
+        assertEquals("", ModelTranslationSupport.target(ModelTranslationSupport.OFF, canary))
+        assertEquals("", ModelTranslationSupport.target(TranscriptionLanguage.GERMAN, emptySet()))
+    }
+
+    @Test
+    fun `the row says which of the three states it is in`() {
+        assertEquals(
+            "Not supported by this model",
+            ModelTranslationSupport.summary(TranscriptionLanguage.GERMAN, emptySet()),
+        )
+        assertEquals("Off", ModelTranslationSupport.summary(ModelTranslationSupport.OFF, canary))
+        assertEquals("German", ModelTranslationSupport.summary(TranscriptionLanguage.GERMAN, canary))
+        // Stored but unhonourable reads as Off, because Off is what happens.
+        assertEquals("Off", ModelTranslationSupport.summary(TranscriptionLanguage.HINDI, canary))
+    }
+
+    @Test
+    fun `an unsupported model explains that the language row never translated`() {
+        val none = ModelTranslationSupport.restriction(emptySet(), onDevice = true)!!
+        assertTrue(none.contains("cannot translate"))
+        assertTrue(none.contains("never translated speech"))
+
+        val supported = ModelTranslationSupport.restriction(canary, onDevice = true)!!
+        assertTrue(supported.contains("English, French, German and Spanish"))
+
+        // Translation is an on-device feature; the gateway protocol has no
+        // field for it, so saying so beats greying rows with no reason.
+        assertTrue(
+            ModelTranslationSupport.restriction(canary, onDevice = false)!!
+                .contains("runs on this phone only"),
+        )
+    }
+
+    /**
+     * Settings is where the two halves meet: a target is only real while the
+     * selected model is local and can honour it.
+     */
+    @Test
+    fun `settings only offers a target the active model can honour`() {
+        val onCanary = VocaPhoneSettings(
+            translateTo = TranscriptionLanguage.GERMAN,
+            localTranscriptionEnabled = true,
+            localModelId = "canary-180m-flash",
+        )
+        assertEquals(canary, onCanary.activeModelTranslationTargets)
+        assertEquals(TranscriptionLanguage.GERMAN, onCanary.effectiveTranslateTo)
+        assertEquals("de", onCanary.translationTarget)
+
+        // Same stored choice, a model that cannot translate.
+        val onParakeet = onCanary.copy(localModelId = "parakeet-tdt-0.6b-v3")
+        assertTrue(onParakeet.activeModelTranslationTargets.isEmpty())
+        assertEquals(ModelTranslationSupport.OFF, onParakeet.effectiveTranslateTo)
+        assertEquals("", onParakeet.translationTarget)
+        // The preference itself survives for when a capable model returns.
+        assertEquals(TranscriptionLanguage.GERMAN, onParakeet.translateTo)
+
+        // A gateway has no translation field at all.
+        assertEquals("", onCanary.copy(localTranscriptionEnabled = false).translationTarget)
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/ModelTranslationSupportTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/ModelTranslationSupportTest.kt
@@ -104,6 +104,52 @@ class ModelTranslationSupportTest {
     }
 
     /**
+     * The one way this setting can be wrong without looking wrong. Canary is
+     * told what it is translating from, so Automatic resolves to English and a
+     * German speaker is translated out of a language they never spoke.
+     */
+    @Test
+    fun `a model that cannot detect the source says so while the source is automatic`() {
+        val warned = ModelTranslationSupport.restriction(
+            canary,
+            onDevice = true,
+            needsExplicitSource = true,
+            sourceIsAutomatic = true,
+        )!!
+        assertTrue(warned.contains("cannot work out what you are speaking"))
+        assertTrue(warned.contains("as though you had spoken English"))
+
+        // An explicit spoken language is the fix, so there is nothing to warn about.
+        assertFalse(
+            ModelTranslationSupport.restriction(
+                canary,
+                onDevice = true,
+                needsExplicitSource = true,
+                sourceIsAutomatic = false,
+            )!!.contains("cannot work out"),
+        )
+        // Whisper detects the language and then translates, so Automatic is fine.
+        assertFalse(
+            ModelTranslationSupport.restriction(
+                whisper,
+                onDevice = true,
+                needsExplicitSource = false,
+                sourceIsAutomatic = true,
+            )!!.contains("cannot work out"),
+        )
+    }
+
+    /** Only Canary is told its source language; nothing else needs one. */
+    @Test
+    fun `only canary needs the spoken language named`() {
+        fun needsSource(id: String) =
+            requireNotNull(LocalModelCatalog.find(id)).translationNeedsExplicitSource
+        assertTrue(needsSource("canary-180m-flash"))
+        assertFalse(needsSource("small-q5_1"))
+        assertFalse(needsSource("parakeet-tdt-0.6b-v3"))
+    }
+
+    /**
      * Settings is where the two halves meet: a target is only real while the
      * selected model is local and can honour it.
      */

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/ModelTranslationSupportTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/ModelTranslationSupportTest.kt
@@ -84,6 +84,15 @@ class ModelTranslationSupportTest {
         assertEquals("German", ModelTranslationSupport.summary(TranscriptionLanguage.GERMAN, canary))
         // Stored but unhonourable reads as Off, because Off is what happens.
         assertEquals("Off", ModelTranslationSupport.summary(TranscriptionLanguage.HINDI, canary))
+        // A gateway has no local model to blame, and the fix is another screen.
+        assertEquals(
+            "Needs an on-device model",
+            ModelTranslationSupport.summary(
+                TranscriptionLanguage.GERMAN,
+                emptySet(),
+                onDevice = false,
+            ),
+        )
     }
 
     @Test

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/LocalEnginePolicyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/LocalEnginePolicyTest.kt
@@ -122,6 +122,21 @@ class LocalEnginePolicyTest {
         )
     }
 
+    /**
+     * Streaming stitches overlapping windows by matching the words that come
+     * back twice. A translator rewords the overlap, so there is nothing to
+     * match — and a sentence spanning two windows is translated as two
+     * fragments. Translation takes the whole-file path instead.
+     */
+    @Test
+    fun `streaming is off while translating and on otherwise`() {
+        assertTrue(canStreamIncrementally(LocalModelEngine.SHERPA_ONNX, ""))
+        assertFalse(canStreamIncrementally(LocalModelEngine.SHERPA_ONNX, "de"))
+        // Whisper has never streamed here whatever the target.
+        assertFalse(canStreamIncrementally(LocalModelEngine.WHISPER, ""))
+        assertFalse(canStreamIncrementally(LocalModelEngine.WHISPER, "en"))
+    }
+
     /** The catalog decides; a stale request can never reach the recognizer. */
     @Test
     fun `a target the model cannot honour resolves away`() {

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/LocalEnginePolicyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/LocalEnginePolicyTest.kt
@@ -1,6 +1,7 @@
 package com.vocahq.vocaphone.local
 
 import com.vocahq.vocaphone.core.TranscriptionQuality
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -76,6 +77,60 @@ class LocalEnginePolicyTest {
                 requestedQuality = TranscriptionQuality.ACCURATE,
             ),
         )
+    }
+
+    /**
+     * Canary bakes source and target into the recognizer together, so changing
+     * what it translates into is as much a rebuild as changing the language.
+     */
+    @Test
+    fun `sherpa recognizer reloads for a translation target change`() {
+        assertTrue(
+            shouldReloadLocalEngine(
+                engine = LocalModelEngine.SHERPA_ONNX,
+                loadedModelID = "canary-180m-flash",
+                requestedModelID = "canary-180m-flash",
+                loadedLanguage = "en",
+                requestedLanguage = "en",
+                loadedQuality = TranscriptionQuality.BALANCED,
+                requestedQuality = TranscriptionQuality.BALANCED,
+                loadedTranslateTo = "",
+                requestedTranslateTo = "de",
+            ),
+        )
+    }
+
+    /**
+     * A family with no language field has already had the target resolved away
+     * to empty, so a 670 MB Parakeet is never rebuilt for a setting it ignores.
+     */
+    @Test
+    fun `a family that ignores language never reloads for one`() {
+        assertFalse(
+            shouldReloadLocalEngine(
+                engine = LocalModelEngine.SHERPA_ONNX,
+                loadedModelID = "parakeet-tdt-0.6b-v3",
+                requestedModelID = "parakeet-tdt-0.6b-v3",
+                loadedLanguage = "en",
+                requestedLanguage = "ru",
+                loadedQuality = TranscriptionQuality.BALANCED,
+                requestedQuality = TranscriptionQuality.BALANCED,
+                languageIsBakedIn = false,
+                loadedTranslateTo = "",
+                requestedTranslateTo = "ru",
+            ),
+        )
+    }
+
+    /** The catalog decides; a stale request can never reach the recognizer. */
+    @Test
+    fun `a target the model cannot honour resolves away`() {
+        val canary = requireNotNull(LocalModelCatalog.find("canary-180m-flash"))
+        val parakeet = requireNotNull(LocalModelCatalog.find("parakeet-tdt-0.6b-v3"))
+        assertEquals("de", canary.resolveTranslationTarget("de"))
+        assertEquals("", canary.resolveTranslationTarget("hi"))
+        assertEquals("", canary.resolveTranslationTarget(""))
+        assertEquals("", parakeet.resolveTranslationTarget("ru"))
     }
 
     @Test

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
@@ -26,46 +26,6 @@ class SherpaLongAudioTest {
         assertEquals(samples.size, chunks.last().endExclusive)
     }
 
-    /**
-     * A translator cannot be merged by matching repeated words: it renders the
-     * retained audio differently the second time, so the repeat is invisible to
-     * the merger and survives as a duplicate. A found boundary is the middle of
-     * a measured quiet run, so there is nothing to protect and the cut is
-     * clean.
-     */
-    @Test
-    fun `a quiet boundary is cut clean when the caller cannot merge repeats`() {
-        val samples = FloatArray(52 * SherpaLongAudio.SAMPLE_RATE) { 0.2f }
-        val silenceStart = 9 * SherpaLongAudio.SAMPLE_RATE
-        java.util.Arrays.fill(samples, silenceStart, silenceStart + SherpaLongAudio.SAMPLE_RATE, 0f)
-
-        val chunks = SherpaLongAudio.chunks(samples, overlapAtFoundBoundaries = false)
-        val first = chunks.first()
-        val second = chunks[1]
-
-        assertFalse(second.overlapsPrevious)
-        // Contiguous: every sample is decoded exactly once.
-        assertEquals(first.endExclusive, second.start)
-        assertEquals(samples.size, chunks.last().endExclusive)
-    }
-
-    /**
-     * The other half of the same decision. Nothing was found to cut at here, so
-     * a word can be straddling the boundary, and losing it outright is worse
-     * than the one word it may repeat.
-     */
-    @Test
-    fun `a guessed boundary keeps its overlap even then`() {
-        val samples = FloatArray(52 * SherpaLongAudio.SAMPLE_RATE) { 0.2f }
-
-        val chunks = SherpaLongAudio.chunks(samples, overlapAtFoundBoundaries = false)
-
-        assertTrue(chunks.size >= 3)
-        assertTrue(chunks.drop(1).all { it.overlapsPrevious })
-        assertTrue(chunks.zipWithNext().all { (left, right) -> right.start < left.endExclusive })
-        assertEquals(samples.size, chunks.last().endExclusive)
-    }
-
     @Test
     fun `streaming split releases a bounded prefix with overlap`() {
         val split = SherpaLongAudio.nextStreamingSplit(

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
@@ -26,6 +26,46 @@ class SherpaLongAudioTest {
         assertEquals(samples.size, chunks.last().endExclusive)
     }
 
+    /**
+     * A translator cannot be merged by matching repeated words: it renders the
+     * retained audio differently the second time, so the repeat is invisible to
+     * the merger and survives as a duplicate. A found boundary is the middle of
+     * a measured quiet run, so there is nothing to protect and the cut is
+     * clean.
+     */
+    @Test
+    fun `a quiet boundary is cut clean when the caller cannot merge repeats`() {
+        val samples = FloatArray(52 * SherpaLongAudio.SAMPLE_RATE) { 0.2f }
+        val silenceStart = 9 * SherpaLongAudio.SAMPLE_RATE
+        java.util.Arrays.fill(samples, silenceStart, silenceStart + SherpaLongAudio.SAMPLE_RATE, 0f)
+
+        val chunks = SherpaLongAudio.chunks(samples, overlapAtFoundBoundaries = false)
+        val first = chunks.first()
+        val second = chunks[1]
+
+        assertFalse(second.overlapsPrevious)
+        // Contiguous: every sample is decoded exactly once.
+        assertEquals(first.endExclusive, second.start)
+        assertEquals(samples.size, chunks.last().endExclusive)
+    }
+
+    /**
+     * The other half of the same decision. Nothing was found to cut at here, so
+     * a word can be straddling the boundary, and losing it outright is worse
+     * than the one word it may repeat.
+     */
+    @Test
+    fun `a guessed boundary keeps its overlap even then`() {
+        val samples = FloatArray(52 * SherpaLongAudio.SAMPLE_RATE) { 0.2f }
+
+        val chunks = SherpaLongAudio.chunks(samples, overlapAtFoundBoundaries = false)
+
+        assertTrue(chunks.size >= 3)
+        assertTrue(chunks.drop(1).all { it.overlapsPrevious })
+        assertTrue(chunks.zipWithNext().all { (left, right) -> right.start < left.endExclusive })
+        assertEquals(samples.size, chunks.last().endExclusive)
+    }
+
     @Test
     fun `streaming split releases a bounded prefix with overlap`() {
         val split = SherpaLongAudio.nextStreamingSplit(
@@ -196,4 +236,29 @@ class SherpaLongAudioTest {
             ),
         )
     }
+
+    /**
+     * Why translating turns deduplication off rather than trusting it to do
+     * nothing. The merger cannot tell a repeat caused by overlapped audio from
+     * one the speaker actually said, so on text it was never able to align it
+     * deletes words that belong in the transcript.
+     */
+    @Test
+    fun `deduplication removes a repetition that translating must keep`() {
+        // Two windows of translated text that happen to meet on the same words.
+        val left = "I went to the shop"
+        val right = "to the shop and then home"
+
+        assertEquals(
+            "I went to the shop and then home",
+            SherpaTranscriptMerger.append(left, right, deduplicateOverlap = true),
+        )
+        // A translator gives no way to know whether that was one phrase or two,
+        // so the seam is kept verbatim instead of guessed at.
+        assertEquals(
+            "I went to the shop to the shop and then home",
+            SherpaTranscriptMerger.append(left, right, deduplicateOverlap = false),
+        )
+    }
+
 }

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		3BC9D24EF0E08132FFB24481 /* SherpaOnnxBridge.c in Sources */ = {isa = PBXBuildFile; fileRef = 4DF09BE84EE712784C57BC12 /* SherpaOnnxBridge.c */; };
 		3C4DE9EF77062407F71ACDCB /* LanguageMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C45D98EAFE18C689DC7551E9 /* LanguageMenuTests.swift */; };
 		3D08A881E95118E5B57E9FCD /* TranscriptSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B121356A503DF83BFA0E0D0C /* TranscriptSanitizer.swift */; };
+		3E812EB0A69DFF8CC9A7CA6E /* ModelTranslationSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7235E2DEF5A0082A417E3E /* ModelTranslationSupport.swift */; };
 		3EF8AE348290CBB5FE45BD11 /* ModelLanguageSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */; };
 		3F3E17AFAAE8EB6B79A872BE /* SessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */; };
 		400FC934DB32BD708B5D23A9 /* KeyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5118F8CFAAE127CD5FF92076 /* KeyView.swift */; };
@@ -135,6 +136,7 @@
 		63835D9307A147564F896FB5 /* SmartPunctuation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07178E9C6A3CF354CD83A2C1 /* SmartPunctuation.swift */; };
 		63BC0E226633FBBE88C60EBE /* SmartPunctuationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8CE24C7BC4F4CA618F4B79 /* SmartPunctuationTests.swift */; };
 		6565BFD7DC56DDCECDBC0D7C /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */; };
+		67883BFA07C1D055BF00E118 /* ModelTranslationSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA1F0347FCF246193F6CF96 /* ModelTranslationSupportTests.swift */; };
 		67B842A93BF69D4542744655 /* DictatedTranscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F810558C0B42C924BC6CF21 /* DictatedTranscriptTests.swift */; };
 		68E7553DB227208E27DF3A8F /* KeyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5118F8CFAAE127CD5FF92076 /* KeyView.swift */; };
 		6A62B202B2F9C76E00794A3D /* SwipeRecognizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924E5D73CB086A4210BF6052 /* SwipeRecognizerTests.swift */; };
@@ -162,6 +164,7 @@
 		81BFE90A24876CEE127974AE /* TypingFieldPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2CD13AAF5FDF79DD5D0075 /* TypingFieldPolicy.swift */; };
 		825C92F4A7114541F04C8313 /* TranscriptionSourceStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5995603DDA33014FFA52B079 /* TranscriptionSourceStatus.swift */; };
 		82A1659A07D52F972E9010DD /* SherpaIncrementalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41205764F091734B2DE6D02 /* SherpaIncrementalSession.swift */; };
+		8345B143988A279FD48D6819 /* ModelTranslationSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7235E2DEF5A0082A417E3E /* ModelTranslationSupport.swift */; };
 		834AEADC7B9757282E300418 /* TranscriptHistoryModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDF2EC3AB09FF78FD1EF935 /* TranscriptHistoryModelTests.swift */; };
 		83636C241A1F6F8697FF4C35 /* TelemetryConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4CAEF7B3212512BACDE655 /* TelemetryConfig.swift */; };
 		8468AAFD83E231AD9BB99792 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCC7453FC149EBB02E3FB58 /* KeychainStore.swift */; };
@@ -273,8 +276,10 @@
 		DEB245BAC4DEE643F2EB38B0 /* DictationPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56047A6705008B5F17F003CE /* DictationPresentationTests.swift */; };
 		E03E7A333C00AA2821D622C0 /* TelemetryConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4CAEF7B3212512BACDE655 /* TelemetryConfig.swift */; };
 		E0450895D68708027C1BC77E /* TypingWordList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6743BB4173E2F719E3D8CB /* TypingWordList.swift */; };
+		E0ACEEE88639A17E7B6C796C /* ModelTranslationSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7235E2DEF5A0082A417E3E /* ModelTranslationSupport.swift */; };
 		E0F7821E95DC9FCAF135F58A /* TelemetryQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368212E101C41FA795B7FD65 /* TelemetryQueue.swift */; };
 		E1554F20FFD17CD98B6367D4 /* CustomVocabularyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0D852E37E341D37CCB4DB2 /* CustomVocabularyTests.swift */; };
+		E1C9002BB583DA067026C250 /* ModelTranslationSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7235E2DEF5A0082A417E3E /* ModelTranslationSupport.swift */; };
 		E20BB9244283AB4CCFDEB0F0 /* CustomVocabulary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AA9291707DE7366D08EB0C /* CustomVocabulary.swift */; };
 		E269B9344AB06AD0FB9FF665 /* SpokenNumbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E590CFC53039DA367280B8CD /* SpokenNumbers.swift */; };
 		E2C8F215E536CABB80623B3A /* VocaPhoneActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8988211922DAD4FC77AF89EB /* VocaPhoneActivityAttributes.swift */; };
@@ -436,6 +441,7 @@
 		8BF7CAC171521FC372DF2BF0 /* KeyGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyGridView.swift; sourceTree = "<group>"; };
 		8D448639495E9251156A2802 /* TelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryTests.swift; sourceTree = "<group>"; };
 		8E413C2A7ADDFE5C3B5F27C7 /* TelemetrySink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySink.swift; sourceTree = "<group>"; };
+		8F7235E2DEF5A0082A417E3E /* ModelTranslationSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTranslationSupport.swift; sourceTree = "<group>"; };
 		8F8CE24C7BC4F4CA618F4B79 /* SmartPunctuationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartPunctuationTests.swift; sourceTree = "<group>"; };
 		8F8E5D91EDE2C0E67DFC0250 /* KeyboardViewPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardViewPreview.swift; sourceTree = "<group>"; };
 		924E5D73CB086A4210BF6052 /* SwipeRecognizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeRecognizerTests.swift; sourceTree = "<group>"; };
@@ -483,6 +489,7 @@
 		C7842B22D05FB171B261101A /* DictationBarStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarStyle.swift; sourceTree = "<group>"; };
 		C8E491E7E805F47388A668E1 /* TranscriptSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSanitizerTests.swift; sourceTree = "<group>"; };
 		CA4CAEF7B3212512BACDE655 /* TelemetryConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryConfig.swift; sourceTree = "<group>"; };
+		CDA1F0347FCF246193F6CF96 /* ModelTranslationSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTranslationSupportTests.swift; sourceTree = "<group>"; };
 		CDBE3CB8FFE4DDA7B459C2A7 /* TypingFieldPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingFieldPolicyTests.swift; sourceTree = "<group>"; };
 		CDCC7453FC149EBB02E3FB58 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
 		CEA8F4B58D6EF52749026347 /* VocaPhoneApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VocaPhoneApp.entitlements; sourceTree = "<group>"; };
@@ -622,6 +629,7 @@
 				473A608BF3F8827B3D3842B0 /* LocalModelCatalog.swift */,
 				13FF1A5ABC4220C886291309 /* LocalTranscriptionPreferences.swift */,
 				D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */,
+				8F7235E2DEF5A0082A417E3E /* ModelTranslationSupport.swift */,
 				DBFB4BB0345784837C629340 /* PairingPayload.swift */,
 				0AB84927D76F9C32C4BE1547 /* QuickDictationAvailability.swift */,
 				AF6C44F954E7A62974C66109 /* SemanticPalette.swift */,
@@ -751,6 +759,7 @@
 				C45D98EAFE18C689DC7551E9 /* LanguageMenuTests.swift */,
 				FF28F6F60B7FDEA4EB183B6F /* LocalModelCatalogTests.swift */,
 				EE41EF03C8A4F930315EFE77 /* ModelLanguageSupportTests.swift */,
+				CDA1F0347FCF246193F6CF96 /* ModelTranslationSupportTests.swift */,
 				F8348F9E480C0343CD38657B /* OnboardingPresentationTests.swift */,
 				7E9E5CE913B4FA5EF8EECD4E /* PairingPayloadTests.swift */,
 				7B5877B4AB653982A0433A37 /* ReliabilityFeatureTests.swift */,
@@ -1043,6 +1052,7 @@
 				408E48AA90858E8FAF046263 /* LocalModelCatalog.swift in Sources */,
 				939752FDA33E96C811ED23C1 /* LocalTranscriptionPreferences.swift in Sources */,
 				3EF8AE348290CBB5FE45BD11 /* ModelLanguageSupport.swift in Sources */,
+				3E812EB0A69DFF8CC9A7CA6E /* ModelTranslationSupport.swift in Sources */,
 				FAD55FD707FD21407E0980FA /* PairingPayload.swift in Sources */,
 				6192C923119F158CCE94B48E /* QuickDictationAvailability.swift in Sources */,
 				EE7A49C4F95388AF42E1B30C /* SemanticPalette.swift in Sources */,
@@ -1115,6 +1125,7 @@
 				4FB8BA8E9E7B9332FDBCD80C /* LocalModelPicker.swift in Sources */,
 				8484AF469C29CC148B720447 /* LocalTranscriptionPreferences.swift in Sources */,
 				4FDB3D32A404C674AFAB948F /* ModelLanguageSupport.swift in Sources */,
+				E0ACEEE88639A17E7B6C796C /* ModelTranslationSupport.swift in Sources */,
 				B81AE1A8CE67BD8B31DBB97D /* OnboardingPresentation.swift in Sources */,
 				52D566C02915D934240601EA /* PairingPayload.swift in Sources */,
 				84EB79403F7CED013A82334F /* PairingScannerView.swift in Sources */,
@@ -1185,6 +1196,7 @@
 				C334F6DF0A4A34FC9A80B6CB /* LocalModelCatalog.swift in Sources */,
 				396330316A5B80A3884BE142 /* LocalTranscriptionPreferences.swift in Sources */,
 				33A2193E058E05B4B4FB3860 /* ModelLanguageSupport.swift in Sources */,
+				E1C9002BB583DA067026C250 /* ModelTranslationSupport.swift in Sources */,
 				364C315F292BA4BD66E23C2A /* PairingPayload.swift in Sources */,
 				58CDCA65875E94B8F7BE0101 /* QuickDictationAvailability.swift in Sources */,
 				F4E8B1A9D00B14184B01B223 /* SemanticPalette.swift in Sources */,
@@ -1257,6 +1269,8 @@
 				482A8494DA8A03BDB5DF1B0E /* LocalTranscriptionPreferences.swift in Sources */,
 				0B939DE9494D3B8F14F18142 /* ModelLanguageSupport.swift in Sources */,
 				F426CFBED733974D61FDB432 /* ModelLanguageSupportTests.swift in Sources */,
+				8345B143988A279FD48D6819 /* ModelTranslationSupport.swift in Sources */,
+				67883BFA07C1D055BF00E118 /* ModelTranslationSupportTests.swift in Sources */,
 				8F8E3C14AAC6A4F1DF144AD3 /* OnboardingPresentation.swift in Sources */,
 				9F93D09F955DA7B5CC65F058 /* OnboardingPresentationTests.swift in Sources */,
 				2E93E016656B5EA74568DD4F /* PairingPayload.swift in Sources */,

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -334,6 +334,10 @@ struct DictationSettingsView: View {
         store: KeyboardPreferences.defaults
     ) private var transcriptionLanguageRawValue = TranscriptionLanguage.automatic.rawValue
     @AppStorage(
+        KeyboardPreferences.translateToKey,
+        store: KeyboardPreferences.defaults
+    ) private var translateToRawValue = ModelTranslationSupport.off.rawValue
+    @AppStorage(
         KeyboardPreferences.microphonePreferenceKey,
         store: KeyboardPreferences.defaults
     ) private var microphonePreferenceRawValue = MicrophonePreference.automatic.rawValue
@@ -405,6 +409,24 @@ struct DictationSettingsView: View {
                 LabeledContent(
                     "Language",
                     value: KeyboardPreferences.effectiveTranscriptionLanguage.displayName
+                )
+            }
+            // Kept next to Language and never hidden. A row that disappears for
+            // most models would leave the question unanswered, and "Not
+            // supported by this model" is exactly the answer people arrive
+            // looking for.
+            NavigationLink {
+                TranscriptionLanguageList(
+                    selection: $translateToRawValue,
+                    mode: .translation
+                )
+            } label: {
+                LabeledContent(
+                    "Translate to",
+                    value: ModelTranslationSupport.summary(
+                        KeyboardPreferences.translateTo,
+                        targets: KeyboardPreferences.activeModelTranslationTargets
+                    )
                 )
             }
         } footer: {
@@ -1013,12 +1035,32 @@ private struct DiagnosticShareSheet: UIViewControllerRepresentable {
 /// bottom and greyed rather than hidden: a language that simply disappears reads
 /// as unsupported by the app, when the fix is to change the model.
 struct TranscriptionLanguageList: View {
+
+    /// Which of the two language questions this list is asking.
+    ///
+    /// The rows, the search and the greying are identical; what differs is the
+    /// title, what the first row means, which languages are selectable and what
+    /// the footer says. Keeping them one view is what stops the two questions
+    /// drifting apart in the ways that made them look like one setting in the
+    /// first place.
+    enum Mode {
+        /// The language being spoken, which is what a decoder is told.
+        case spoken
+        /// The language the transcript should come back in.
+        case translation
+    }
+
     @Binding var selection: String
+    var mode: Mode = .spoken
     @Environment(\.dismiss) private var dismiss
     @State private var query = ""
 
+    private var translating: Bool { mode == .translation }
     private var modelLanguages: Set<String> { KeyboardPreferences.activeModelLanguages }
     private var detectsLanguage: Bool { KeyboardPreferences.activeModelDetectsLanguage }
+    private var translationTargets: Set<String> {
+        KeyboardPreferences.activeModelTranslationTargets
+    }
 
     private func matches(_ language: TranscriptionLanguage) -> Bool {
         query.isEmpty
@@ -1027,7 +1069,39 @@ struct TranscriptionLanguageList: View {
     }
 
     private func isSelectable(_ language: TranscriptionLanguage) -> Bool {
-        ModelLanguageSupport.isSelectable(language, modelLanguages: modelLanguages)
+        translating
+            ? ModelTranslationSupport.isSelectable(language, targets: translationTargets)
+            : ModelLanguageSupport.isSelectable(language, modelLanguages: modelLanguages)
+    }
+
+    /// `.automatic` is the shared enum's way of storing "no choice", and in the
+    /// translation list the absence of a choice is not language detection but
+    /// no translation at all.
+    private func label(_ language: TranscriptionLanguage) -> String {
+        translating && language == ModelTranslationSupport.off
+            ? "Don't translate"
+            : language.displayName
+    }
+
+    private var footer: String? {
+        translating
+            ? ModelTranslationSupport.restriction(
+                translationTargets,
+                onDevice: LocalTranscriptionPreferences.enabled
+            )
+            : ModelLanguageSupport.restriction(
+                modelLanguages: modelLanguages,
+                detectsLanguageAutomatically: detectsLanguage,
+                onDevice: LocalTranscriptionPreferences.enabled,
+                canTranslate: ModelTranslationSupport.isSupported(translationTargets)
+            )
+    }
+
+    private var checked: TranscriptionLanguage {
+        let stored = TranscriptionLanguage(rawValue: selection) ?? .automatic
+        return translating
+            ? ModelTranslationSupport.resolve(stored, targets: translationTargets)
+            : ModelLanguageSupport.resolve(stored, modelLanguages: modelLanguages)
     }
 
     private var available: [TranscriptionLanguage] {
@@ -1046,12 +1120,8 @@ struct TranscriptionLanguageList: View {
                         row(language, selectable: true)
                     }
                 } footer: {
-                    if let restriction = ModelLanguageSupport.restriction(
-                        modelLanguages: modelLanguages,
-                        detectsLanguageAutomatically: detectsLanguage,
-                        onDevice: LocalTranscriptionPreferences.enabled
-                    ) {
-                        Text(restriction)
+                    if let footer {
+                        Text(footer)
                     }
                 }
             }
@@ -1067,7 +1137,7 @@ struct TranscriptionLanguageList: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .navigationTitle("Language")
+        .navigationTitle(translating ? "Translate to" : "Language")
         .navigationBarTitleDisplayMode(.inline)
         .searchable(text: $query, prompt: "Search languages")
     }
@@ -1075,19 +1145,20 @@ struct TranscriptionLanguageList: View {
     private func row(_ language: TranscriptionLanguage, selectable: Bool) -> some View {
         Button {
             selection = language.rawValue
-            KeyboardPreferences.noteTranscriptionLanguageUse(language)
+            // Recents feed the keyboard's short spoken-language menu, which a
+            // translation target has no place in.
+            if !translating {
+                KeyboardPreferences.noteTranscriptionLanguageUse(language)
+            }
             dismiss()
         } label: {
             HStack {
-                Text(language.displayName)
+                Text(label(language))
                     .foregroundStyle(selectable ? .primary : .secondary)
                 Spacer()
                 // Ticks what is in force, so the mark never sits on a row the
                 // loaded model cannot honour.
-                if language == ModelLanguageSupport.resolve(
-                    TranscriptionLanguage(rawValue: selection) ?? .automatic,
-                    modelLanguages: modelLanguages
-                ) {
+                if language == checked {
                     Image(systemName: "checkmark")
                         .foregroundStyle(.tint)
                         .accessibilityLabel("Selected")

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -1117,9 +1117,11 @@ struct TranscriptionLanguageList: View {
         KeyboardPreferences.activeModelTranslationTargets
     }
 
+    // Searched against the label actually on the row: "Don't translate" is not
+    // findable by typing "automatic", and should not be.
     private func matches(_ language: TranscriptionLanguage) -> Bool {
         query.isEmpty
-            || language.displayName.localizedCaseInsensitiveContains(query)
+            || label(language).localizedCaseInsensitiveContains(query)
             || language.rawValue.localizedCaseInsensitiveContains(query)
     }
 
@@ -1134,7 +1136,7 @@ struct TranscriptionLanguageList: View {
     /// no translation at all.
     private func label(_ language: TranscriptionLanguage) -> String {
         translating && language == ModelTranslationSupport.off
-            ? "Don't translate"
+            ? ModelTranslationSupport.offLabel
             : language.displayName
     }
 
@@ -1142,7 +1144,9 @@ struct TranscriptionLanguageList: View {
         translating
             ? ModelTranslationSupport.restriction(
                 translationTargets,
-                onDevice: LocalTranscriptionPreferences.enabled
+                onDevice: LocalTranscriptionPreferences.enabled,
+                needsExplicitSource: KeyboardPreferences.activeModelTranslationNeedsSource,
+                sourceIsAutomatic: KeyboardPreferences.effectiveTranscriptionLanguage == .automatic
             )
             : ModelLanguageSupport.restriction(
                 modelLanguages: modelLanguages,

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -10,20 +10,36 @@ import UIKit
 /// owns the switch.
 struct SettingsView: View {
     @Environment(RecordingCoordinator.self) private var coordinator
+    // The hub's rows carry the values their destinations set, so they have to
+    // be read through storage SwiftUI can see. Reading them from
+    // `KeyboardPreferences` instead left every row showing the previous value
+    // until the coordinator happened to publish something unrelated — which is
+    // why the language row appeared to update "eventually" rather than never.
+    @AppStorage(
+        KeyboardPreferences.keyboardHeightKey,
+        store: KeyboardPreferences.defaults
+    ) private var keyboardHeightRawValue = KeyboardHeightPreference.standard.rawValue
+    @AppStorage(
+        KeyboardPreferences.transcriptionLanguageKey,
+        store: KeyboardPreferences.defaults
+    ) private var transcriptionLanguageRawValue = TranscriptionLanguage.automatic.rawValue
+    @AppStorage(
+        KeyboardPreferences.writingStyleKey,
+        store: KeyboardPreferences.defaults
+    ) private var writingStyleRawValue = WritingStyle.casual.rawValue
 
     var body: some View {
         List {
             Section {
                 destination(
                     "Keyboard",
-                    detail: KeyboardPreferences.keyboardHeight.displayName,
+                    detail: keyboardHeight.displayName,
                     symbol: "keyboard"
                 ) { KeyboardSettingsView() }
 
                 destination(
                     "Dictation",
-                    detail: KeyboardPreferences.effectiveTranscriptionLanguage.displayName
-                        + " · " + KeyboardPreferences.writingStyle.displayName,
+                    detail: language.displayName + " · " + writingStyle.displayName,
                     symbol: "mic"
                 ) { DictationSettingsView() }
 
@@ -61,6 +77,23 @@ struct SettingsView: View {
         }
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var keyboardHeight: KeyboardHeightPreference {
+        KeyboardHeightPreference(rawValue: keyboardHeightRawValue) ?? .standard
+    }
+
+    /// Resolved the same way the Dictation screen resolves it, so the hub never
+    /// advertises a language the loaded model has already ruled out.
+    private var language: TranscriptionLanguage {
+        ModelLanguageSupport.resolve(
+            TranscriptionLanguage(rawValue: transcriptionLanguageRawValue) ?? .automatic,
+            modelLanguages: KeyboardPreferences.activeModelLanguages
+        )
+    }
+
+    private var writingStyle: WritingStyle {
+        WritingStyle(rawValue: writingStyleRawValue) ?? .casual
     }
 
     /// A row that carries its current value, so the hub answers most questions
@@ -406,10 +439,7 @@ struct DictationSettingsView: View {
             NavigationLink {
                 TranscriptionLanguageList(selection: $transcriptionLanguageRawValue)
             } label: {
-                LabeledContent(
-                    "Language",
-                    value: KeyboardPreferences.effectiveTranscriptionLanguage.displayName
-                )
+                LabeledContent("Language", value: selectedLanguage.displayName)
             }
             // Kept next to Language and never hidden. A row that disappears for
             // most models would leave the question unanswered, and "Not
@@ -424,13 +454,13 @@ struct DictationSettingsView: View {
                 LabeledContent(
                     "Translate to",
                     value: ModelTranslationSupport.summary(
-                        KeyboardPreferences.translateTo,
+                        storedTranslateTo,
                         targets: KeyboardPreferences.activeModelTranslationTargets
                     )
                 )
             }
         } footer: {
-            Text(KeyboardPreferences.effectiveTranscriptionLanguage.detail)
+            Text(selectedLanguage.detail)
         }
     }
 
@@ -578,6 +608,31 @@ struct DictationSettingsView: View {
 
     private var selectedWritingStyle: WritingStyle {
         WritingStyle(rawValue: writingStyleRawValue) ?? .casual
+    }
+
+    /// Read back out of the `@AppStorage` value rather than through
+    /// `KeyboardPreferences`, exactly as `selectedWritingStyle` is.
+    ///
+    /// This is not a style preference. SwiftUI invalidates a view from the
+    /// dynamic properties its body *reads*, and a static accessor is not one:
+    /// `KeyboardPreferences.effectiveTranscriptionLanguage` reaches the same
+    /// `UserDefaults` by a route SwiftUI cannot see, so a row that read it kept
+    /// showing the previous language until something unrelated redrew the
+    /// screen. Passing `$transcriptionLanguageRawValue` to the picker is not a
+    /// read — it hands over the projected binding — so the property was written
+    /// on every pick and never once observed here.
+    private var selectedLanguage: TranscriptionLanguage {
+        ModelLanguageSupport.resolve(
+            TranscriptionLanguage(rawValue: transcriptionLanguageRawValue) ?? .automatic,
+            modelLanguages: KeyboardPreferences.activeModelLanguages
+        )
+    }
+
+    /// The stored target, before resolving: `ModelTranslationSupport.summary`
+    /// does its own resolving, and needs to tell "Off" from a pick the current
+    /// model cannot honour.
+    private var storedTranslateTo: TranscriptionLanguage {
+        TranscriptionLanguage(rawValue: translateToRawValue) ?? ModelTranslationSupport.off
     }
 
     private var selectedMicrophonePreference: MicrophonePreference {
@@ -1173,9 +1228,11 @@ struct TranscriptionLanguageList: View {
 
 // MARK: - Previews
 
-// All five destinations, plus the hub. The hub's own finding — three rows that
-// read their value as a plain static property and never invalidate — shows up
-// here as a value that does not follow the store the preview supplies.
+// All five destinations, plus the hub. The hub's rows used to read their value
+// as a plain static property, which showed up here as a value that did not
+// follow the store the preview supplies — and on device as a row that changed
+// only when something unrelated redrew the screen. They read `@AppStorage` now,
+// so the preview store is what they show.
 
 #Preview("Settings — hub") {
     PreviewHost(coordinator: .previewIdle()) {

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -455,7 +455,8 @@ struct DictationSettingsView: View {
                     "Translate to",
                     value: ModelTranslationSupport.summary(
                         storedTranslateTo,
-                        targets: KeyboardPreferences.activeModelTranslationTargets
+                        targets: KeyboardPreferences.activeModelTranslationTargets,
+                        onDevice: LocalTranscriptionPreferences.enabled
                     )
                 )
             }

--- a/ios/VocaPhoneApp/Models/LocalModelManager.swift
+++ b/ios/VocaPhoneApp/Models/LocalModelManager.swift
@@ -52,6 +52,10 @@ final class LocalModelManager {
     private var sherpaRecognizer: SherpaRecognizer?
     private var loadedModelID: String?
     private var loadedLanguage: String?
+    /// Canary bakes source and target into the recognizer exactly as it bakes
+    /// the language, so a change of translation target has to rebuild it too.
+    /// Empty means transcribe.
+    private var loadedTranslateTo = ""
     /// Sherpa only: WhisperKit takes its decoding options per call, so quality
     /// never invalidates a loaded Whisper model.
     private var loadedQuality: TranscriptionQuality?
@@ -688,6 +692,7 @@ final class LocalModelManager {
         }
     }
 
+
     /// Rebuilds the engine after an accuracy change — and only when there is
     /// already one loaded to rebuild.
     ///
@@ -1297,8 +1302,10 @@ final class LocalModelManager {
             // relabelled the transcript language would cost seconds and change
             // nothing about the decode.
             let languageIsBakedIn = descriptor.sherpaFamily?.acceptsLanguage ?? true
+            let identityChanged = loadedLanguage != resolvedLanguage
+                || loadedTranslateTo != descriptor.resolvedTranslationTarget
             needsLoad = loadedModelID != id
-                || (languageIsBakedIn && loadedLanguage != resolvedLanguage)
+                || (languageIsBakedIn && identityChanged)
                 || loadedQuality != LocalTranscriptionPreferences.quality
                 || sherpaRecognizer == nil
         }
@@ -1348,8 +1355,13 @@ final class LocalModelManager {
             let promptTokens = promptText.isEmpty
                 ? nil
                 : whisperKit.tokenizer?.encode(text: promptText)
+            // Whisper's translate task has exactly one trained target, English,
+            // and `translationTarget` can only ever be "en" for a Whisper
+            // model. Asking it for another target is not a smaller version of
+            // the same feature; it is nothing at all.
+            let translateTo = descriptor.resolvedTranslationTarget
             let options = DecodingOptions(
-                task: .transcribe,
+                task: translateTo.isEmpty ? .transcribe : .translate,
                 language: requested,
                 temperature: 0,
                 temperatureIncrementOnFallback: quality.whisperKitTemperatureIncrement,
@@ -1381,11 +1393,14 @@ final class LocalModelManager {
             // Detection is meaningful only for Automatic. With an explicit
             // selection, the user's requested output language remains the
             // contract even if the engine reports something contradictory.
+            // Translating overrides both: the detected language is the one that
+            // was spoken, and the text on screen is the target.
             return LocalTranscription(
                 text: text,
-                language: ModelLanguageSupport.transcriptLanguage(
+                language: ModelLanguageSupport.outputLanguage(
                     requested: resolvedLanguage,
-                    reported: results.first?.language ?? ""
+                    reported: results.first?.language ?? "",
+                    translateTo: translateTo
                 )
             )
 
@@ -1403,9 +1418,10 @@ final class LocalModelManager {
             }
             return LocalTranscription(
                 text: decoded.text,
-                language: ModelLanguageSupport.transcriptLanguage(
+                language: ModelLanguageSupport.outputLanguage(
                     requested: resolvedLanguage,
-                    reported: decoded.language
+                    reported: decoded.language,
+                    translateTo: descriptor.resolvedTranslationTarget
                 )
             )
         }
@@ -1458,6 +1474,10 @@ final class LocalModelManager {
         // Sherpa bakes the decoding method into the recognizer, so a change of
         // quality means building a new one.
         let quality = LocalTranscriptionPreferences.quality
+        // Resolved from the catalog rather than trusted from a caller, so a
+        // target picked under Canary and still stored after a switch to
+        // Parakeet can never reach an engine that would misread it.
+        let translateTo = descriptor.resolvedTranslationTarget
 
         // Never two loads at once. Building an ONNX graph while another is
         // still being built puts both models' weights in memory at the same
@@ -1471,7 +1491,8 @@ final class LocalModelManager {
 
         if let sherpaRecognizer,
            loadedModelID == descriptor.id,
-           descriptor.sherpaFamily?.acceptsLanguage != true || loadedLanguage == resolvedLanguage,
+           descriptor.sherpaFamily?.acceptsLanguage != true
+               || (loadedLanguage == resolvedLanguage && loadedTranslateTo == translateTo),
            loadedQuality == quality
         {
             return sherpaRecognizer
@@ -1487,6 +1508,7 @@ final class LocalModelManager {
         sherpaRecognizer = nil
         loadedModelID = nil
         loadedLanguage = nil
+        loadedTranslateTo = ""
         loadedQuality = nil
 
         // Off the main actor: `SherpaRecognizer.create` is synchronous and
@@ -1502,7 +1524,8 @@ final class LocalModelManager {
                 // workers on iPhone; using every logical core throttles long
                 // recordings and competes with audio/UI work.
                 threads: threads,
-                quality: quality
+                quality: quality,
+                translateTo: translateTo
             )
         }
         sherpaLoad = task
@@ -1512,6 +1535,7 @@ final class LocalModelManager {
         sherpaRecognizer = recognizer
         loadedModelID = descriptor.id
         loadedLanguage = resolvedLanguage
+        loadedTranslateTo = translateTo
         loadedQuality = quality
         return recognizer
     }

--- a/ios/VocaPhoneApp/Models/LocalModelManager.swift
+++ b/ios/VocaPhoneApp/Models/LocalModelManager.swift
@@ -692,7 +692,6 @@ final class LocalModelManager {
         }
     }
 
-
     /// Rebuilds the engine after an accuracy change — and only when there is
     /// already one loaded to rebuild.
     ///
@@ -728,6 +727,16 @@ final class LocalModelManager {
               let descriptor = LocalModelCatalog.descriptor(for: id),
               descriptor.engine == .sherpaOnnx
         else { return nil }
+        // Streaming decodes ten-second windows and stitches them by matching
+        // repeated words across a half-second overlap. Both halves of that
+        // assume the model returns the same words for the same audio, which a
+        // translator does not: the overlap comes back reworded, so nothing is
+        // deduplicated and the seam is duplicated instead — and a sentence
+        // split across two windows is translated twice, as two fragments that
+        // were never sentences. A translated dictation gives up the latency and
+        // takes the whole-file path, where anything under twelve seconds is a
+        // single decode of the whole thing.
+        guard descriptor.resolvedTranslationTarget.isEmpty else { return nil }
         guard let folder = modelDirectory(for: id), isDownloaded(id) else {
             throw LocalModelManagerError.modelNotDownloaded(id)
         }

--- a/ios/VocaPhoneApp/Models/SherpaOnnxBridge.c
+++ b/ios/VocaPhoneApp/Models/SherpaOnnxBridge.c
@@ -29,6 +29,7 @@ VocaPhoneSherpaRecognizer VocaPhoneSherpaCreate(
     const char *model4,
     const char *tokens,
     const char *language,
+    const char *target_language,
     int32_t threads,
     const char *decoding_method,
     int32_t max_active_paths
@@ -71,7 +72,13 @@ VocaPhoneSherpaRecognizer VocaPhoneSherpaCreate(
             config.model_config.canary.encoder = model1;
             config.model_config.canary.decoder = model2;
             config.model_config.canary.src_lang = language;
-            config.model_config.canary.tgt_lang = language;
+            // Equal source and target is transcription; differing them is what
+            // Canary was trained for. An empty target means the caller asked
+            // for no translation, or asked for one this model cannot do.
+            config.model_config.canary.tgt_lang =
+                target_language == NULL || target_language[0] == '\0'
+                    ? language
+                    : target_language;
             config.model_config.canary.use_pnc = 1;
             break;
         case VocaPhoneSherpaNemoCtc:

--- a/ios/VocaPhoneApp/Models/SherpaOnnxBridge.h
+++ b/ios/VocaPhoneApp/Models/SherpaOnnxBridge.h
@@ -13,6 +13,10 @@ enum VocaPhoneSherpaFamily {
     VocaPhoneSherpaParaformer = 6,
 };
 
+/// `language` is the language being spoken, and `target_language` the one to
+/// translate it into — empty to transcribe rather than translate. Canary is the
+/// only family with a target at all; see `ModelTranslationSupport`.
+///
 /// `decoding_method` is one of sherpa-onnx's literals — "greedy_search" or
 /// "modified_beam_search" — and `max_active_paths` is the beam width the latter
 /// searches. Only the transducer families act on either.
@@ -24,6 +28,7 @@ VocaPhoneSherpaRecognizer VocaPhoneSherpaCreate(
     const char *model4,
     const char *tokens,
     const char *language,
+    const char *target_language,
     int32_t threads,
     const char *decoding_method,
     int32_t max_active_paths

--- a/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
+++ b/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
@@ -19,7 +19,8 @@ final class SherpaRecognizer: @unchecked Sendable {
         directory: URL,
         language: String,
         threads: Int,
-        quality: TranscriptionQuality
+        quality: TranscriptionQuality,
+        translateTo: String = ""
     ) throws -> SherpaRecognizer {
         guard let family = model.sherpaFamily else {
             throw LocalModelManagerError.unsupportedModel(model.id)
@@ -57,12 +58,18 @@ final class SherpaRecognizer: @unchecked Sendable {
         let languageHint: String
         switch family {
         case .canary:
+            // Canary's config has no detection mode, so "auto" has to become a
+            // real code — English is the safest guess and the one upstream's
+            // own examples use.
             languageHint = language == "auto" ? "en" : language
         case .senseVoice:
             languageHint = language == "auto" ? "" : language
         default:
             languageHint = ""
         }
+        // Only Canary has a target at all; the bridge falls back to the source
+        // when this is empty, which is what transcription is.
+        let targetHint = family == .canary ? translateTo : ""
 
         // Never `quality.sherpaDecodingMethod` on its own: a family that does
         // not support beam search answers it by killing the process.
@@ -73,12 +80,16 @@ final class SherpaRecognizer: @unchecked Sendable {
                     models[3].withCString { model4 in
                         tokens.withCString { tokensPointer in
                             languageHint.withCString { languagePointer in
-                                decodingMethod.withCString { decodingMethodPointer in
-                                    VocaPhoneSherpaCreate(
-                                        Int32(family.bridgeValue), model1, model2, model3, model4,
-                                        tokensPointer, languagePointer, Int32(threads),
-                                        decodingMethodPointer, quality.sherpaMaxActivePaths
-                                    )
+                                targetHint.withCString { targetPointer in
+                                    decodingMethod.withCString { decodingMethodPointer in
+                                        VocaPhoneSherpaCreate(
+                                            Int32(family.bridgeValue),
+                                            model1, model2, model3, model4,
+                                            tokensPointer, languagePointer, targetPointer,
+                                            Int32(threads), decodingMethodPointer,
+                                            quality.sherpaMaxActivePaths
+                                        )
+                                    }
                                 }
                             }
                         }

--- a/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
+++ b/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
@@ -5,9 +5,13 @@ import Foundation
 /// VocaPhone needs.
 final class SherpaRecognizer: @unchecked Sendable {
     private let native: UnsafeMutableRawPointer
+    /// Whether this recognizer was built to translate, which changes how a
+    /// recording too long for one decode is put back together. See `transcribe`.
+    private let translating: Bool
 
-    private init(native: UnsafeMutableRawPointer) {
+    private init(native: UnsafeMutableRawPointer, translating: Bool = false) {
         self.native = native
+        self.translating = translating
     }
 
     deinit {
@@ -100,16 +104,35 @@ final class SherpaRecognizer: @unchecked Sendable {
         guard let native else {
             throw LocalModelManagerError.engineLoadFailed(model.id)
         }
-        return SherpaRecognizer(native: native)
+        // Only the families that can honour a target are translating, whatever
+        // the caller asked for.
+        return SherpaRecognizer(
+            native: native,
+            translating: family.acceptsLanguage && !translateTo.isEmpty
+        )
     }
 
+    /// Decodes the whole recording, in windows if it is longer than one decode
+    /// should be.
+    ///
+    /// Those windows are where translation and transcription part company. A
+    /// transcriber returns the same words for the same audio, so a window that
+    /// retains a little of the one before it can have the repeat matched and
+    /// removed. A translator does not: the retained audio is translated again
+    /// inside a different sentence, comes back in different words, and nothing
+    /// can pair the two. Worse, a merger still looking for a repeat can only
+    /// match a phrase the speaker genuinely said twice — and delete it.
+    ///
+    /// A boundary the silence search found is already cut clean here, so only
+    /// a guessed one carries audio across, and while translating that seam is
+    /// left as it decoded rather than merged by matching words.
     func transcribe(_ samples: [Float]) -> SherpaTranscript {
         let transcript = SherpaLongAudio.chunks(samples)
             .reduce(into: SherpaTranscript.empty) { transcript, chunk in
                 let bounded = Array(samples[chunk.start..<chunk.endExclusive])
                 let decoded = SherpaEmptyChunkRecovery.decode(samples: bounded, decodeOnce: decode)
                 transcript = transcript.appending(
-                    decoded, deduplicateOverlap: chunk.overlapsPrevious
+                    decoded, deduplicateOverlap: chunk.overlapsPrevious && !translating
                 )
             }
         return SherpaTranscript(

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -1105,15 +1105,19 @@ final class RecordingCoordinator {
             }
             let text = transcribed.text
             // The styles punctuate by script, so the language has to be the one
-            // actually spoken. With Automatic selected the record only says
-            // "auto", and a model that detected Hindi would otherwise have its
-            // Devanagari finished with a Latin full stop.
+            // the finished text is written in. With Automatic selected the
+            // record only says "auto", and a model that detected Hindi would
+            // otherwise have its Devanagari finished with a Latin full stop.
+            // When translating, that language is the target rather than the one
+            // that was spoken — which is why the target has to be named here
+            // and not left to the requested language to win.
             record.transcript = DictatedTranscript.finished(
                 text,
                 style: WritingStyle(rawValue: record.style) ?? .casual,
-                language: ModelLanguageSupport.transcriptLanguage(
+                language: ModelLanguageSupport.outputLanguage(
                     requested: record.language,
-                    reported: transcribed.language
+                    reported: transcribed.language,
+                    translateTo: KeyboardPreferences.translationTarget
                 ),
                 numbersAsDigits: KeyboardPreferences.numbersAsDigits
             )

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -541,6 +541,11 @@ enum KeyboardPreferences {
         activeLocalModel?.translationTargets ?? []
     }
 
+    /// Whether translating needs the spoken language set to something real.
+    static var activeModelTranslationNeedsSource: Bool {
+        activeLocalModel?.translationNeedsExplicitSource ?? false
+    }
+
     /// The picker's own selection, corrected for a model that cannot honour it.
     static var effectiveTranslateTo: TranscriptionLanguage {
         ModelTranslationSupport.resolve(translateTo, targets: activeModelTranslationTargets)

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -271,6 +271,7 @@ enum KeyboardPreferences {
     static let writingStyleKey = "writingStyle"
     static let numbersAsDigitsKey = "numbersAsDigitsEnabled"
     static let transcriptionLanguageKey = "transcriptionLanguage"
+    static let translateToKey = "translateTo"
     static let microphonePreferenceKey = "microphonePreference"
     static let recordingSoundsKey = "recordingSoundsEnabled"
     static let containingAppForegroundKey = "containingAppForeground"
@@ -511,6 +512,43 @@ enum KeyboardPreferences {
         set {
             defaults?.set(newValue.rawValue, forKey: transcriptionLanguageKey)
         }
+    }
+
+    /// The language dictation should come out in, or `ModelTranslationSupport.off`
+    /// to keep the language that was spoken.
+    ///
+    /// Deliberately a second setting rather than a meaning layered onto
+    /// `transcriptionLanguage`. That one says what is being spoken, which is
+    /// what a decoder needs; this one says what should come back, which only
+    /// two models can honour at all.
+    static var translateTo: TranscriptionLanguage {
+        get {
+            guard let rawValue = defaults?.string(forKey: translateToKey),
+                  let language = TranscriptionLanguage(rawValue: rawValue)
+            else { return ModelTranslationSupport.off }
+            return language
+        }
+        set {
+            defaults?.set(newValue.rawValue, forKey: translateToKey)
+        }
+    }
+
+    /// Languages the active model can translate into; empty when it cannot.
+    ///
+    /// Empty for a gateway too, and not by omission: translation lives entirely
+    /// in the on-device engines and the gateway protocol has no field for it.
+    static var activeModelTranslationTargets: Set<String> {
+        activeLocalModel?.translationTargets ?? []
+    }
+
+    /// The picker's own selection, corrected for a model that cannot honour it.
+    static var effectiveTranslateTo: TranscriptionLanguage {
+        ModelTranslationSupport.resolve(translateTo, targets: activeModelTranslationTargets)
+    }
+
+    /// What the engines take: a language code, or empty for no translation.
+    static var translationTarget: String {
+        ModelTranslationSupport.target(translateTo, targets: activeModelTranslationTargets)
     }
 
     /// Maintained by the containing app across foreground transitions. A custom

--- a/ios/VocaPhoneShared/LocalModelCatalog.swift
+++ b/ios/VocaPhoneShared/LocalModelCatalog.swift
@@ -236,6 +236,18 @@ struct LocalModelDescriptor: Identifiable, Codable, Sendable, Equatable {
         )
     }
 
+    /// Whether translating needs the spoken language named explicitly.
+    ///
+    /// Canary has no detection mode: its config carries a source language and
+    /// takes whatever it is given, so "auto" has to be resolved to a real code
+    /// before the recognizer is built and English is the only defensible guess.
+    /// That is harmless while source and target match — the model was going to
+    /// assume something either way — but once the two differ it decides what the
+    /// audio is being translated *from*, and a German speaker left on Automatic
+    /// gets German translated as though it were English. Whisper is the
+    /// opposite: it detects the language and then translates.
+    var translationNeedsExplicitSource: Bool { sherpaFamily == .canary }
+
     var sizeLabel: String {
         let megabytes = Double(sizeBytes) / 1_000_000
         if megabytes >= 1_000 {

--- a/ios/VocaPhoneShared/LocalModelCatalog.swift
+++ b/ios/VocaPhoneShared/LocalModelCatalog.swift
@@ -206,6 +206,36 @@ struct LocalModelDescriptor: Identifiable, Codable, Sendable, Equatable {
         return LocalModelLanguages.picker.subtracting(LocalModelLanguages.largeV3Only)
     }
 
+    /// Which languages this model can translate speech *into*.
+    ///
+    /// Derived rather than declared, because only two things in the catalog can
+    /// translate at all and both derive it from something already written down.
+    /// Canary is a speech-translation model across the languages it lists; a
+    /// multilingual Whisper build has the translate task, whose only trained
+    /// target is English. Everything else transcribes the language it heard, so
+    /// an empty set here is the ordinary answer. Mirrors
+    /// `LocalModelCatalog.kt`; see `ModelTranslationSupport`.
+    var translationTargets: Set<String> {
+        if sherpaFamily == .canary { return languageCodes }
+        if englishOnly { return [] }
+        return engine == .whisperKit ? ["en"] : []
+    }
+
+    /// The stored translation target, if this model can honour it.
+    ///
+    /// Read here rather than threaded through every call for the same reason
+    /// accuracy is: a setting that takes effect on the next dictation cannot be
+    /// carried by a session that started before it changed. Resolving against
+    /// `translationTargets` is what stops a stale pick — chosen under Canary,
+    /// still stored after a switch to Parakeet — reaching an engine that would
+    /// misread it or forcing a rebuild of one that would ignore it.
+    var resolvedTranslationTarget: String {
+        ModelTranslationSupport.target(
+            KeyboardPreferences.translateTo,
+            targets: translationTargets
+        )
+    }
+
     var sizeLabel: String {
         let megabytes = Double(sizeBytes) / 1_000_000
         if megabytes >= 1_000 {

--- a/ios/VocaPhoneShared/ModelLanguageSupport.swift
+++ b/ios/VocaPhoneShared/ModelLanguageSupport.swift
@@ -27,6 +27,20 @@ enum ModelLanguageSupport {
         requested == TranscriptionLanguage.automatic.rawValue ? reported : requested
     }
 
+    /// The language the finished transcript is actually written in.
+    ///
+    /// `translateTo` wins outright when set, and that is the whole point of the
+    /// overload: with translation on, the spoken language governs the decoder
+    /// while the target governs the text, and it is the text the writing styles
+    /// punctuate. Styling translated German by the Hindi that was spoken would
+    /// end a Latin sentence with a danda. Empty means no translation, which
+    /// leaves `transcriptLanguage` answering exactly as before.
+    static func outputLanguage(requested: String, reported: String, translateTo: String) -> String {
+        translateTo.isEmpty
+            ? transcriptLanguage(requested: requested, reported: reported)
+            : translateTo
+    }
+
     /// `modelLanguages` empty means nothing was claimed — an older gateway
     /// build, no model selected, or one the user imported. Nothing is disabled
     /// then: a client that has not been told must never lock the user out.
@@ -53,15 +67,30 @@ enum ModelLanguageSupport {
         isSelectable(selected, modelLanguages: modelLanguages) ? selected : .automatic
     }
 
-    /// Why the picker is restricted, or nil when it is not.
+    /// What the picker's choice does and does not do here.
+    ///
+    /// Never nil any more: even an unrestricted model needs the sentence saying
+    /// that this row is the language being spoken rather than the language
+    /// wanted back. The return type stays optional so callers that already
+    /// handle absence keep compiling.
     ///
     /// `onDevice` only changes which model the sentence blames, but pointing a
     /// user at their gateway when the constraint comes from the model on their
     /// phone sends them to the wrong screen.
+    ///
+    /// `canTranslate` adds the sentence that says what this row is not. Whisper
+    /// takes its output language from a token forced into the decoder, so
+    /// picking a language nobody is speaking makes it emit that language
+    /// anyway — untrained behaviour that reads as translation and is the single
+    /// most common misreading of this screen. The sentence is unconditional
+    /// because the misreading survives being right about one model: someone who
+    /// learned the trick on Whisper carries it to Parakeet, where the pick is
+    /// discarded entirely.
     static func restriction(
         modelLanguages: Set<String>,
         detectsLanguageAutomatically: Bool,
-        onDevice: Bool = false
+        onDevice: Bool = false,
+        canTranslate: Bool = false
     ) -> String? {
         let owner = onDevice ? "The on-device model" : "Your gateway's model"
         var coverage: String?
@@ -72,7 +101,19 @@ enum ModelLanguageSupport {
             The rest need a different model.
             """
         }
-        guard detectsLanguageAutomatically else { return coverage }
+        let remedy = canTranslate
+            ? "To change the language of the transcript, use Translate to."
+            : """
+            This model cannot translate, and picking a language you are not \
+            speaking gives unreliable text rather than a translation.
+            """
+        let translation = """
+        This is the language you are speaking, not the language you want back. \
+        \(remedy)
+        """
+        guard detectsLanguageAutomatically else {
+            return [coverage, translation].compactMap { $0 }.joined(separator: " ")
+        }
         // Said plainly rather than by disabling the rows: this model decides the
         // language from the audio, and the pick only tells the app how to
         // punctuate what comes back.
@@ -81,6 +122,6 @@ enum ModelLanguageSupport {
         not pin the decoder. It sets the language the transcript is punctuated \
         and formatted in, which is what short phrases get wrong.
         """
-        return [coverage, detection].compactMap { $0 }.joined(separator: " ")
+        return [coverage, detection, translation].compactMap { $0 }.joined(separator: " ")
     }
 }

--- a/ios/VocaPhoneShared/ModelTranslationSupport.swift
+++ b/ios/VocaPhoneShared/ModelTranslationSupport.swift
@@ -75,8 +75,18 @@ enum ModelTranslationSupport {
     /// "Off" rather than "Automatic": the shared enum's own label describes
     /// language detection, which is the opposite of what this row's default
     /// means.
-    static func summary(_ selected: TranscriptionLanguage, targets: Set<String>) -> String {
-        guard isSupported(targets) else { return "Not supported by this model" }
+    ///
+    /// `onDevice` separates the two ways this can be unavailable. Blaming the
+    /// model is only right when there is one: a gateway has no local model at
+    /// all, and the fix is a different screen.
+    static func summary(
+        _ selected: TranscriptionLanguage,
+        targets: Set<String>,
+        onDevice: Bool = true
+    ) -> String {
+        guard isSupported(targets) else {
+            return onDevice ? "Not supported by this model" : "Needs an on-device model"
+        }
         let resolved = resolve(selected, targets: targets)
         return resolved == off ? "Off" : resolved.displayName
     }

--- a/ios/VocaPhoneShared/ModelTranslationSupport.swift
+++ b/ios/VocaPhoneShared/ModelTranslationSupport.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Which languages a model can *translate into*, as opposed to transcribe.
+///
+/// This is a different question from `ModelLanguageSupport`, and conflating the
+/// two is what this file exists to stop. Transcription coverage asks what the
+/// decoder can understand; translation coverage asks what it was trained to
+/// emit for speech in some other language. Almost nothing on a phone can do the
+/// second, and the two models that can do it in opposite directions:
+///
+/// - **Canary** is a speech-translation model proper. Its config carries a
+///   source and a target language, and it was trained on the pairs between
+///   English, German, Spanish and French.
+/// - **Whisper** translates *into English only*. That is the translate task,
+///   roughly a fifth of its training data, and no other target was ever
+///   trained. Asking it for another target is not a smaller version of the same
+///   feature; it is nothing at all.
+///
+/// Every other family — the transducers, the CTC models, Moonshine, Paraformer
+/// — transcribes what it heard and has no mechanism to do anything else.
+///
+/// A word on the failure this replaces. Whisper picks its output language from
+/// a token forced into the decoder before the first word, so selecting a
+/// language the speaker is not speaking makes it emit that language anyway: it
+/// satisfies the forced token the only way it can, by rendering the meaning it
+/// heard. That looks like translation and is occasionally even good, but it is
+/// untrained behaviour that transliterates, reverts mid-sentence and drops
+/// clauses, and no transducer can imitate it. Translation is a request the
+/// model either supports or does not.
+///
+/// Mirrors `ModelTranslationSupport.kt` on Android.
+enum ModelTranslationSupport {
+
+    /// `.automatic` is how "do not translate" is stored. The picker needs a row
+    /// for it, the setting needs a default, and reusing the language enum keeps
+    /// one wire vocabulary instead of two.
+    static let off: TranscriptionLanguage = .automatic
+
+    /// Whether this model can translate at all, and so whether to offer the row.
+    static func isSupported(_ targets: Set<String>) -> Bool { !targets.isEmpty }
+
+    static func isSelectable(_ language: TranscriptionLanguage, targets: Set<String>) -> Bool {
+        language == off || targets.contains(language.rawValue)
+    }
+
+    /// The target to actually use. A stored choice goes stale the moment the
+    /// user switches models — from Canary to Parakeet, or to a gateway — and
+    /// silently translating nothing is far better than a request the engine
+    /// cannot honour.
+    static func resolve(
+        _ selected: TranscriptionLanguage,
+        targets: Set<String>
+    ) -> TranscriptionLanguage {
+        isSelectable(selected, targets: targets) ? selected : off
+    }
+
+    /// The value the engines take: a language code, or empty for no
+    /// translation. Engines test this for emptiness, so "auto" must never reach
+    /// them — it would read as a language rather than as its absence.
+    static func target(_ selected: TranscriptionLanguage, targets: Set<String>) -> String {
+        let resolved = resolve(selected, targets: targets)
+        return resolved == off ? "" : resolved.rawValue
+    }
+
+    /// What the picked target is called in a settings row.
+    ///
+    /// "Off" rather than "Automatic": the shared enum's own label describes
+    /// language detection, which is the opposite of what this row's default
+    /// means.
+    static func summary(_ selected: TranscriptionLanguage, targets: Set<String>) -> String {
+        guard isSupported(targets) else { return "Not supported by this model" }
+        let resolved = resolve(selected, targets: targets)
+        return resolved == off ? "Off" : resolved.displayName
+    }
+
+    /// Why the picker is limited, or nil when it is not.
+    ///
+    /// The unsupported case is the important one. It is the only place the app
+    /// can explain that the language row above never translated anything, which
+    /// is the belief people arrive with after Whisper appeared to do it.
+    static func restriction(_ targets: Set<String>, onDevice: Bool) -> String? {
+        guard onDevice else {
+            return """
+            Translation runs on this phone only. Your gateway transcribes speech \
+            in the language it was spoken.
+            """
+        }
+        guard isSupported(targets) else {
+            return """
+            This model transcribes what it hears and cannot translate. Canary \
+            translates between English, German, Spanish and French; the \
+            multilingual Whisper models translate into English. Picking a \
+            language above never translated speech — it only tells the model \
+            which language to expect.
+            """
+        }
+        // Sorted by the name shown, not by the code behind it: "German,
+        // English, Spanish and French" is what sorting de/en/es/fr produces.
+        let names = targets
+            .compactMap { TranscriptionLanguage(rawValue: $0)?.displayName }
+            .sorted()
+        let list: String
+        if names.count <= 1 {
+            list = names.joined()
+        } else {
+            list = names.dropLast().joined(separator: ", ") + " and " + names[names.count - 1]
+        }
+        return """
+        This model translates into \(list). Speech in any other language it \
+        covers is translated into your pick; the language above stays what you \
+        are speaking.
+        """
+    }
+}

--- a/ios/VocaPhoneShared/ModelTranslationSupport.swift
+++ b/ios/VocaPhoneShared/ModelTranslationSupport.swift
@@ -36,6 +36,14 @@ enum ModelTranslationSupport {
     /// one wire vocabulary instead of two.
     static let off: TranscriptionLanguage = .automatic
 
+    /// What the `off` row is called in the picker.
+    ///
+    /// Not "Automatic", which is the shared enum's own label and describes
+    /// language detection — the opposite of what choosing it here means. The
+    /// settings row says "Off" instead, because a row reading "Don't translate"
+    /// next to the words "Translate to" reads as a double negative.
+    static let offLabel = "Don't translate"
+
     /// Whether this model can translate at all, and so whether to offer the row.
     static func isSupported(_ targets: Set<String>) -> Bool { !targets.isEmpty }
 
@@ -78,7 +86,12 @@ enum ModelTranslationSupport {
     /// The unsupported case is the important one. It is the only place the app
     /// can explain that the language row above never translated anything, which
     /// is the belief people arrive with after Whisper appeared to do it.
-    static func restriction(_ targets: Set<String>, onDevice: Bool) -> String? {
+    static func restriction(
+        _ targets: Set<String>,
+        onDevice: Bool,
+        needsExplicitSource: Bool = false,
+        sourceIsAutomatic: Bool = false
+    ) -> String? {
         guard onDevice else {
             return """
             Translation runs on this phone only. Your gateway transcribes speech \
@@ -105,10 +118,20 @@ enum ModelTranslationSupport {
         } else {
             list = names.dropLast().joined(separator: ", ") + " and " + names[names.count - 1]
         }
-        return """
+        let coverage = """
         This model translates into \(list). Speech in any other language it \
         covers is translated into your pick; the language above stays what you \
         are speaking.
+        """
+        // The one way this setting can be wrong without looking wrong. Canary
+        // is told what it is translating from, so Automatic resolves to English
+        // and anyone speaking something else is translated out of a language
+        // they never spoke.
+        guard needsExplicitSource, sourceIsAutomatic else { return coverage }
+        return coverage + """
+         This model cannot work out what you are speaking, so set Language to \
+        your own language first: on Automatic it translates as though you had \
+        spoken English.
         """
     }
 }

--- a/ios/VocaPhoneTests/ModelLanguageSupportTests.swift
+++ b/ios/VocaPhoneTests/ModelLanguageSupportTests.swift
@@ -42,16 +42,64 @@ struct ModelLanguageSupportTests {
         #expect(ModelLanguageSupport.resolve(.hindi, modelLanguages: []) == .hindi)
     }
 
-    @Test func theRestrictionIsExplainedOnlyWhenThereIsOne() {
-        #expect(
-            ModelLanguageSupport.restriction(
-                modelLanguages: [], detectsLanguageAutomatically: false
-            ) == nil
+    @Test func aCoverageLimitIsSpelledOutWheneverThereIsOne() {
+        let unclaimed = ModelLanguageSupport.restriction(
+            modelLanguages: [], detectsLanguageAutomatically: false
         )
+        #expect(unclaimed?.contains("covers") == false)
         let limited = ModelLanguageSupport.restriction(
             modelLanguages: dolphin, detectsLanguageAutomatically: false
         )
         #expect(limited?.contains("\(dolphin.count) languages") == true)
+    }
+
+    /// The picker used to say nothing at all for an unrestricted model, which is
+    /// exactly the case — a multilingual Whisper — where someone picks Russian,
+    /// speaks English, and concludes the app translates. It never did: Whisper
+    /// forces the language token and renders the meaning it heard in that
+    /// script, untrained and unreliable.
+    @Test func everyModelSaysTheLanguageRowIsNotATranslationSetting() {
+        for detects in [false, true] {
+            let sentence = ModelLanguageSupport.restriction(
+                modelLanguages: [], detectsLanguageAutomatically: detects
+            )
+            #expect(sentence?.contains("not the language you want back") == true)
+            #expect(sentence?.contains("cannot translate") == true)
+        }
+        let canary = ModelLanguageSupport.restriction(
+            modelLanguages: ["en", "de", "es", "fr"],
+            detectsLanguageAutomatically: false,
+            onDevice: true,
+            canTranslate: true
+        )
+        #expect(canary?.contains("use Translate to") == true)
+        #expect(canary?.contains("cannot translate") == false)
+    }
+
+    /// With translation on, two languages are in play and only one of them is
+    /// the one on screen. The styler punctuates by script, so it has to be given
+    /// the target.
+    @Test func theOutputLanguageIsTheTranslationTargetWhenTranslating() {
+        #expect(
+            ModelLanguageSupport.outputLanguage(
+                requested: "hi", reported: "hi", translateTo: "de"
+            ) == "de"
+        )
+        #expect(
+            ModelLanguageSupport.outputLanguage(
+                requested: "auto", reported: "hi", translateTo: "de"
+            ) == "de"
+        )
+        #expect(
+            ModelLanguageSupport.outputLanguage(
+                requested: "hi", reported: "en", translateTo: ""
+            ) == "hi"
+        )
+        #expect(
+            ModelLanguageSupport.outputLanguage(
+                requested: "auto", reported: "hi", translateTo: ""
+            ) == "hi"
+        )
     }
 
     /// The sentence has to say both things: the choice is real for punctuation,

--- a/ios/VocaPhoneTests/ModelTranslationSupportTests.swift
+++ b/ios/VocaPhoneTests/ModelTranslationSupportTests.swift
@@ -58,6 +58,11 @@ struct ModelTranslationSupportTests {
         #expect(ModelTranslationSupport.summary(.german, targets: canary) == "German")
         // Stored but unhonourable reads as Off, because Off is what happens.
         #expect(ModelTranslationSupport.summary(.hindi, targets: canary) == "Off")
+        // A gateway has no local model to blame, and the fix is another screen.
+        #expect(
+            ModelTranslationSupport.summary(.german, targets: [], onDevice: false)
+                == "Needs an on-device model"
+        )
     }
 
     @Test func anUnsupportedModelExplainsThatTheLanguageRowNeverTranslated() {

--- a/ios/VocaPhoneTests/ModelTranslationSupportTests.swift
+++ b/ios/VocaPhoneTests/ModelTranslationSupportTests.swift
@@ -74,6 +74,48 @@ struct ModelTranslationSupportTests {
         #expect(gateway?.contains("runs on this phone only") == true)
     }
 
+    /// The one way this setting can be wrong without looking wrong. Canary is
+    /// told what it is translating from, so Automatic resolves to English and a
+    /// German speaker is translated out of a language they never spoke.
+    @Test func aModelThatCannotDetectTheSourceSaysSoWhileTheSourceIsAutomatic() {
+        let warned = ModelTranslationSupport.restriction(
+            canary,
+            onDevice: true,
+            needsExplicitSource: true,
+            sourceIsAutomatic: true
+        )
+        #expect(warned?.contains("cannot work out what you are speaking") == true)
+        #expect(warned?.contains("as though you had spoken English") == true)
+
+        // An explicit spoken language is the fix, so there is nothing to warn about.
+        let named = ModelTranslationSupport.restriction(
+            canary,
+            onDevice: true,
+            needsExplicitSource: true,
+            sourceIsAutomatic: false
+        )
+        #expect(named?.contains("cannot work out") == false)
+
+        // Whisper detects the language and then translates, so Automatic is fine.
+        let detecting = ModelTranslationSupport.restriction(
+            whisper,
+            onDevice: true,
+            needsExplicitSource: false,
+            sourceIsAutomatic: true
+        )
+        #expect(detecting?.contains("cannot work out") == false)
+    }
+
+    /// Only Canary is told its source language; nothing else needs one.
+    @Test func onlyCanaryNeedsTheSpokenLanguageNamed() throws {
+        func needsSource(_ id: String) throws -> Bool {
+            try #require(LocalModelCatalog.descriptor(for: id)).translationNeedsExplicitSource
+        }
+        #expect(try needsSource("canary-180m-flash"))
+        #expect(try !needsSource("openai_whisper-small"))
+        #expect(try !needsSource("parakeet-tdt-0.6b-v3"))
+    }
+
     /// Both clients must reach the same verdict, or the keyboard and the app
     /// disagree about what the user may pick.
     @Test func theRulesMatchTheAndroidImplementation() {

--- a/ios/VocaPhoneTests/ModelTranslationSupportTests.swift
+++ b/ios/VocaPhoneTests/ModelTranslationSupportTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+
+struct ModelTranslationSupportTests {
+
+    private let canary: Set<String> = ["en", "de", "es", "fr"]
+    private let whisper: Set<String> = ["en"]
+
+    /// The capability matrix is the whole feature. Getting it wrong in the
+    /// permissive direction is what produced the belief that any model can be
+    /// asked for any output language.
+    @Test func onlyTheTwoModelsThatCanTranslateClaimTo() throws {
+        func targets(_ id: String) throws -> Set<String> {
+            try #require(LocalModelCatalog.descriptor(for: id)).translationTargets
+        }
+
+        // Canary is a speech-translation model across the languages it lists.
+        #expect(try targets("canary-180m-flash") == canary)
+        // Whisper's translate task has exactly one trained target.
+        #expect(try targets("openai_whisper-small") == whisper)
+        // An English-only build has nothing to translate from.
+        #expect(try targets("openai_whisper-small.en").isEmpty)
+        // The transducers and CTC models transcribe and nothing else. Parakeet
+        // v3 is the one people expect to translate because it is multilingual.
+        #expect(try targets("parakeet-tdt-0.6b-v3").isEmpty)
+        #expect(try targets("sense-voice").isEmpty)
+    }
+
+    @Test func offIsAlwaysSelectableAndATargetOnlyWhereTrained() {
+        #expect(ModelTranslationSupport.isSelectable(ModelTranslationSupport.off, targets: []))
+        #expect(ModelTranslationSupport.isSelectable(.german, targets: canary))
+        #expect(!ModelTranslationSupport.isSelectable(.hindi, targets: canary))
+        // Whisper into English, and nothing else. Russian here is the exact
+        // request that used to appear to work.
+        #expect(ModelTranslationSupport.isSelectable(.english, targets: whisper))
+        #expect(!ModelTranslationSupport.isSelectable(.russian, targets: whisper))
+    }
+
+    /// A target picked under Canary and left stored while the user switches to
+    /// Parakeet must not survive as a request no engine can honour.
+    @Test func aStaleTargetFallsBackToNoTranslation() {
+        #expect(ModelTranslationSupport.resolve(.german, targets: []) == ModelTranslationSupport.off)
+        #expect(ModelTranslationSupport.resolve(.german, targets: canary) == .german)
+    }
+
+    /// "auto" is a language to the engines, so absence has to reach them empty.
+    @Test func theEngineTargetIsACodeOrNothingAtAll() {
+        #expect(ModelTranslationSupport.target(.german, targets: canary) == "de")
+        #expect(ModelTranslationSupport.target(ModelTranslationSupport.off, targets: canary) == "")
+        #expect(ModelTranslationSupport.target(.german, targets: []) == "")
+    }
+
+    @Test func theRowSaysWhichOfTheThreeStatesItIsIn() {
+        #expect(
+            ModelTranslationSupport.summary(.german, targets: []) == "Not supported by this model"
+        )
+        #expect(ModelTranslationSupport.summary(ModelTranslationSupport.off, targets: canary) == "Off")
+        #expect(ModelTranslationSupport.summary(.german, targets: canary) == "German")
+        // Stored but unhonourable reads as Off, because Off is what happens.
+        #expect(ModelTranslationSupport.summary(.hindi, targets: canary) == "Off")
+    }
+
+    @Test func anUnsupportedModelExplainsThatTheLanguageRowNeverTranslated() {
+        let none = ModelTranslationSupport.restriction([], onDevice: true)
+        #expect(none?.contains("cannot translate") == true)
+        #expect(none?.contains("never translated speech") == true)
+
+        let supported = ModelTranslationSupport.restriction(canary, onDevice: true)
+        #expect(supported?.contains("English, French, German and Spanish") == true)
+
+        // Translation is an on-device feature; the gateway protocol has no field
+        // for it, so saying so beats greying rows with no reason.
+        let gateway = ModelTranslationSupport.restriction(canary, onDevice: false)
+        #expect(gateway?.contains("runs on this phone only") == true)
+    }
+
+    /// Both clients must reach the same verdict, or the keyboard and the app
+    /// disagree about what the user may pick.
+    @Test func theRulesMatchTheAndroidImplementation() {
+        #expect(ModelTranslationSupport.isSupported(canary))
+        #expect(!ModelTranslationSupport.isSupported([]))
+        #expect(ModelTranslationSupport.off == .automatic)
+    }
+}


### PR DESCRIPTION
## The problem

Selecting Russian and speaking English on a multilingual Whisper model produces Russian text, and it looks like translation. It is not.

Whisper's decoder starts from a forced prompt — `<|startoftranscript|> <|ru|> <|transcribe|>` — and `params.language` pins that second token. The encoder's output is largely language-agnostic, so conditioning on `<|ru|>` collapses the decoder onto Russian tokens, and the only way to satisfy both that and the audio is to render the meaning it heard. There was no en→xx data in the 680k training hours; the `<|translate|>` task's only trained target is English. So it transliterates, reverts to English mid-sentence, drops clauses and trips temperature fallback.

Parakeet TDT v3 cannot imitate it at all. `OfflineTransducerModelConfig` has no language field, so the pick was silently discarded — one control, two meanings, one of them a mirage.

## The change

| Setting | Means | Default |
| --- | --- | --- |
| **Language** (existing) | the language you are *speaking* | Automatic |
| **Translate to** (new) | the language the transcript comes back in | Off |

**Translate to** is offered only where a model was trained for it:

- **Canary 180M Flash** → en/de/es/fr. It is a speech-translation model with separate `src_lang`/`tgt_lang`, previously pinned to the same value on both sides; differing them is the feature.
- **Multilingual Whisper** → **English only**, via the translate task (`params.translate` on Android, `DecodingOptions(task: .translate)` on iOS).
- **Everything else** — Parakeet, Dolphin, SenseVoice, Moonshine, NeMo CTC, Paraformer, and the English-only builds → "Not supported by this model", with the reason.

The language picker's footer now states plainly that it is the language being spoken, and either points at Translate to or says the model cannot translate. That sentence is unconditional: someone who learned the trick on Whisper carries it to Parakeet, where the pick does nothing.

## Notable details

- **Capability is derived from the catalog**, not declared per entry, and resolved *again* at the engine boundary (`resolveTranslationTarget` / `resolvedTranslationTarget`). A target picked under Canary and still stored after a switch to Parakeet cannot reach a decoder that would misread it, nor rebuild a 670 MB one that would ignore it.
- **The translation target joins the sherpa reload key**, gated by the same `acceptsLanguage` flag as the language — it is the other half of the same Canary config.
- **Writing styles follow the target, not the spoken language.** `outputLanguage` is the new contract; without it, translated German gets punctuated by the Hindi that was spoken and ends a Latin sentence with a danda.
- **The iOS C bridge signature changed**: `VocaPhoneSherpaCreate` gains `target_language`, since it set `src_lang` and `tgt_lang` from one argument.

## Out of scope

Gateway translation. The app sends only `language`, and `/health` advertises no translation capability, so the row reports that translation runs on this phone only rather than greying rows with no reason. Adding it means a protocol change in the `vocagateway` submodule.

Noted but not touched: the catalog lists `distil-whisper_distil-large-v3` as "100 languages" when distil-whisper is an English-only distillation. It is harmless here — its only derived target is English, which is what it outputs anyway — but the coverage claim is worth a separate look.

## Testing

- Android: `assembleFullDebug` (including the JNI signature change), `testFullDebugUnitTest` — 517 pass — and `lintFullDebug` clean.
- iOS: full `just test` — 484 pass; the new `ModelTranslationSupportTests` and the extended `ModelLanguageSupportTests` verified individually.
- New coverage: the capability matrix per model id, stale-target fallback, the code-or-empty engine contract, the three row states, restriction copy, reload-key behaviour for both a target change and a family that ignores one, and target-wins punctuation.

Not exercised on a physical device — the Canary decode path and Whisper's translate task are worth a manual pass before release.
