### PR TITLE
Dictate chips, dict sync, Formal caps, and Keep model loaded

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/VocaPhoneApplication.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/VocaPhoneApplication.kt
@@ -1,6 +1,7 @@
 package com.vocahq.vocaphone
 
 import android.app.Application
+import android.content.ComponentCallbacks2
 import android.content.Context
 import androidx.room.Room
 import com.vocahq.vocaphone.audio.DictationTonePlayer
@@ -135,6 +136,13 @@ class VocaPhoneApplication : Application() {
         // is explained in the log the user pastes, not only after they manage
         // to reproduce it with a cable attached.
         container.reportProcessExits()
+    }
+
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+        if (level >= ComponentCallbacks2.TRIM_MEMORY_BACKGROUND) {
+            container.localModels.releaseIfIdle()
+        }
     }
 
     companion object {

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptStyler.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptStyler.kt
@@ -43,19 +43,26 @@ object TranscriptStyler {
         val punctuation = punctuation(language, source)
         val masked = mask(source)
         val normalized = normalizeSentenceTerminators(normalizeSpacing(masked.text), punctuation)
+        // Whisper and Parakeet Title-Case content words ("the Keyboard Is Ready").
+        // Flatten those before Clean/Formal/Casual so mid-sentence capitals are
+        // not left as-is. Mixed-case names and ALL-CAPS acronyms stay.
+        val flattened = when (style) {
+            WritingStyle.RAW, WritingStyle.VERY_CASUAL -> normalized
+            else -> flattenModelCaps(normalized)
+        }
         val result = when (style) {
-            WritingStyle.CLEAN -> ensureTerminator(normalized, punctuation)
+            WritingStyle.CLEAN -> ensureTerminator(flattened, punctuation)
             WritingStyle.FORMAL -> ensureTerminator(
-                capitalizeSentenceStarts(normalized, punctuation),
+                capitalizeSentenceStarts(flattened, punctuation),
                 punctuation,
             )
-            WritingStyle.CASUAL -> casual(normalized, punctuation)
+            WritingStyle.CASUAL -> casual(flattened, punctuation)
             WritingStyle.VERY_CASUAL -> veryCasual(
                 segments(normalized, punctuation),
                 punctuation,
             )
             WritingStyle.EXCITED -> excited(
-                segments(normalized, punctuation),
+                segments(flattened, punctuation),
                 punctuation,
             )
             WritingStyle.RAW -> normalized
@@ -148,6 +155,67 @@ object TranscriptStyler {
         if (text.isEmpty() || punctuation.terminator.isEmpty()) return text
         return if (text.last() in punctuation.terminators) text
         else text + punctuation.terminator
+    }
+
+    /**
+     * Drop Title Case the model invented, keep tokens that look like names.
+     *
+     * "Keyboard" in the middle of a sentence becomes "keyboard". "VocaPhone",
+     * "GraphQL", "iPhone", "NASA", and the pronoun "I" are left alone.
+     */
+    private fun flattenModelCaps(text: String): String {
+        val result = StringBuilder(text.length)
+        var index = 0
+        while (index < text.length) {
+            if (text[index] == '\uE000') {
+                val end = text.indexOf('\uE001', index)
+                if (end >= 0) {
+                    result.append(text, index, end + 1)
+                    index = end + 1
+                    continue
+                }
+            }
+            if (text[index].isLetter()) {
+                val start = index
+                index++
+                while (index < text.length && (text[index].isLetter() || text[index] == '\'' || text[index] == '’')) {
+                    index++
+                }
+                result.append(softenToken(text.substring(start, index)))
+            } else {
+                result.append(text[index])
+                index++
+            }
+        }
+        return result.toString()
+    }
+
+    private fun softenToken(token: String): String {
+        if (isPronounI(token)) {
+            val body = token.dropWhile { !it.isLetter() }
+            return token.take(token.length - body.length) + "I" + body.drop(1)
+        }
+        val letters = token.filter { it.isLetter() }
+        if (letters.isEmpty()) return token
+        val hasLower = letters.any { it.isLowerCase() }
+        val hasUpper = letters.any { it.isUpperCase() }
+        if (!hasLower && letters.length >= 2) return token
+        if (hasLower && hasUpper) {
+            val body = token.dropWhile { !it.isLetter() }
+            val titleCase = body.first().isUpperCase() && body.drop(1).none { it.isUpperCase() }
+            if (!titleCase) return token
+        }
+        return token.lowercase()
+    }
+
+    /** "I", "I'm", "I’ve", "I'd", "I'll". Not "is" or "it". */
+    private fun isPronounI(token: String): Boolean {
+        val letters = token.filter { it.isLetter() }
+        if (letters.isEmpty() || letters.first().lowercaseChar() != 'i') return false
+        val rest = letters.drop(1).lowercase()
+        if (rest.isEmpty()) return true
+        val contracted = token.any { it == '\'' || it == '’' }
+        return contracted && rest in setOf("m", "ll", "d", "ve", "re", "s")
     }
 
     private fun capitalizeSentenceStarts(text: String, punctuation: Punctuation): String {

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptStyler.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptStyler.kt
@@ -31,7 +31,7 @@ object TranscriptStyler {
     private val protectedSpans = Regex(
         """(?i)(https?://[^\s]+[^\s.,;:!?\"“”'\)\]]|[\w.+-]+@(?:[\w-]+\.)+[A-Za-z]{2,}|"""
             + """(?:[\w-]+\.)+[A-Za-z]{2,}(?:/[^\s.,;:!?\"“”'\)\]]*)?|\d+(?:[.,:/]\d+)+|"""
-            + """\d+(?:st|nd|rd|th)\b|(?:[A-Za-z]\.){2,}|\w+['’]\w+)""",
+            + """\d+(?:st|nd|rd|th)\b|(?:[A-Za-z]\.){2,})""",
     )
     private val placeholder = Regex("\\uE000(\\d+)\\uE001")
 
@@ -199,7 +199,10 @@ object TranscriptStyler {
         if (letters.isEmpty()) return token
         val hasLower = letters.any { it.isLowerCase() }
         val hasUpper = letters.any { it.isUpperCase() }
-        if (!hasLower && letters.length >= 2) return token
+        // Short ALL-CAPS is an acronym (NASA, CPU). Longer shouts are the
+        // model yelling a content word; flatten those.
+        if (!hasLower && letters.length in 2..4) return token
+        if (!hasLower && letters.length > 4) return token.lowercase()
         if (hasLower && hasUpper) {
             val body = token.dropWhile { !it.isLetter() }
             val titleCase = body.first().isUpperCase() && body.drop(1).none { it.isUpperCase() }

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/WritingStyle.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/WritingStyle.kt
@@ -27,8 +27,10 @@ enum class WritingStyle(val wireValue: String) {
     val detail: String
         get() = when (this) {
             RAW -> "Exactly what the model returned, with nothing changed."
-            CLEAN -> "Spacing tidied and a closing full stop. Capitalization untouched."
-            FORMAL -> "Sentence capitalization and a closing full stop."
+            CLEAN -> "Spacing tidied and a closing full stop. " +
+                "Random capitals from the model are flattened; names like VocaPhone stay."
+            FORMAL -> "Sentence capitalization and a closing full stop. " +
+                "Mid-sentence Title Case from the model is flattened."
             CASUAL -> "Sentences kept, but no closing full stop."
             VERY_CASUAL -> "All lowercase, sentences joined with commas."
             EXCITED -> "Every statement ends with an exclamation mark."

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -251,7 +251,9 @@ class DictationController(
                         generation = generation,
                     )
                 } finally {
-                    if (modelID != null) localModels.endUse()
+                    if (modelID != null) {
+                        localModels.endUse(configuration.modelIdleTimeout.delayMs)
+                    }
                 }
             } else {
                 val token = settings.token() ?: return@launch
@@ -717,7 +719,7 @@ class DictationController(
         )
         } finally {
             if (configuration.localTranscriptionEnabled && selectedLocalModelID != null) {
-                localModels.endUse()
+                localModels.endUse(settings.current().modelIdleTimeout.delayMs)
             }
         }
     }

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -232,14 +232,27 @@ class DictationController(
                 style = configuration.style,
             )
             if (configuration.localTranscriptionEnabled) {
-                deliverLocal(
-                    sessionId = UUID.fromString(sessionId),
-                    wavFile = audio,
-                    language = record.language,
-                    configuration = configuration,
-                    source = DictationSource.COMPANION_APP,
-                    generation = generation,
-                )
+                val modelID = configuration.localModelId.takeIf { it.isNotEmpty() }
+                modelID?.let {
+                    localModels.beginUse()
+                    localModels.warm(
+                        it,
+                        record.language,
+                        configuration.transcriptionQuality,
+                    )
+                }
+                try {
+                    deliverLocal(
+                        sessionId = UUID.fromString(sessionId),
+                        wavFile = audio,
+                        language = record.language,
+                        configuration = configuration,
+                        source = DictationSource.COMPANION_APP,
+                        generation = generation,
+                    )
+                } finally {
+                    if (modelID != null) localModels.endUse()
+                }
             } else {
                 val token = settings.token() ?: return@launch
                 deliverBatch(
@@ -288,6 +301,20 @@ class DictationController(
         val sessionFinishSignal = finishSignal
         val frames = Channel<ShortArray>(capacity = FILE_FRAME_BUFFER_CAPACITY)
         val selectedLocalModelID = configuration.localModelId.takeIf { it.isNotEmpty() }
+        if (configuration.localTranscriptionEnabled) {
+            selectedLocalModelID?.let { modelID ->
+                localModels.beginUse()
+                // Load weights while the mic is already capturing. Whisper used
+                // to wait until Finish, so the first dictation after a cold
+                // start spent seconds on "Transcribing" before the decoder ran.
+                localModels.warm(
+                    modelID,
+                    configuration.effectiveLanguage.wireValue,
+                    configuration.transcriptionQuality,
+                )
+            }
+        }
+        try {
         val incrementalSession = if (configuration.localTranscriptionEnabled) {
             selectedLocalModelID?.let { modelID ->
                 localModels.startIncrementalSession(
@@ -688,6 +715,11 @@ class DictationController(
             source,
             generation,
         )
+        } finally {
+            if (configuration.localTranscriptionEnabled && selectedLocalModelID != null) {
+                localModels.endUse()
+            }
+        }
     }
 
     /**
@@ -794,7 +826,7 @@ class DictationController(
                 modelID,
                 language,
                 configuration.transcriptionQuality,
-                configuration.customVocabulary,
+                configuration.whisperVocabulary,
                 conditioningStartSample,
             )
             val transcript = styleLocalTranscript(local, configuration)

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
@@ -15,11 +15,13 @@ import java.nio.ByteOrder
 import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -70,6 +72,21 @@ data class LocalModelState(
 /** Leaving the picker or the activity must not cancel a running download. */
 const val CANCEL_MODEL_DOWNLOAD_WHEN_HOST_LEAVES = false
 
+/**
+ * After the last dictation the native weights sit in RAM and keep the CPU
+ * from sleeping. Two minutes of no use is long enough to start another
+ * dictation without a reload, and short enough that a phone left in a bag
+ * is not holding a gigabyte of weights all afternoon.
+ */
+internal const val LOCAL_ENGINE_IDLE_UNLOAD_MS = 2 * 60 * 1000L
+
+internal fun idleEngineUnloadDue(
+    users: Int,
+    lastIdleAtMs: Long,
+    nowMs: Long,
+    idleMs: Long = LOCAL_ENGINE_IDLE_UNLOAD_MS,
+): Boolean = users <= 0 && nowMs - lastIdleAtMs >= idleMs
+
 /** Owns model storage, atomic downloads, and the verified inference engine. */
 class LocalModelManager(
     context: Context,
@@ -83,6 +100,9 @@ class LocalModelManager(
     private val modelRoot = File(appContext.filesDir, LOCAL_MODELS_DIR).also { it.mkdirs() }
     private val downloadMutex = Mutex()
     private val engineMutex = Mutex()
+    private val engineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val engineUsers = AtomicInteger(0)
+    private var idleUnloadJob: Job? = null
     private val _state = MutableStateFlow(LocalModelState())
     val state: StateFlow<LocalModelState> = _state.asStateFlow()
     private val totalRamGB: Long by lazy {
@@ -347,6 +367,56 @@ class LocalModelManager(
     }
 
     /**
+     * A dictation owns the engine until [endUse]. Cancels an idle unload so a
+     * model loaded during recording is not freed under the decoder.
+     */
+    fun beginUse() {
+        cancelIdleUnload()
+        engineUsers.incrementAndGet()
+    }
+
+    fun endUse() {
+        if (engineUsers.decrementAndGet() <= 0) {
+            engineUsers.set(0)
+            scheduleIdleUnload()
+        }
+    }
+
+    /**
+     * Start loading weights without waiting. Recording can begin on the same
+     * tap; [transcribe] joins this work via [engineMutex].
+     */
+    fun warm(modelID: String, language: String, quality: TranscriptionQuality) {
+        cancelIdleUnload()
+        engineScope.launch {
+            runCatching { prepare(modelID, language, quality) }
+        }
+    }
+
+    /** Drop native weights now if nothing is dictating. Used on memory trim. */
+    fun releaseIfIdle() {
+        if (engineUsers.get() > 0) return
+        cancelIdleUnload()
+        engineScope.launch {
+            engineMutex.withLock { releaseEngines() }
+        }
+    }
+
+    private fun scheduleIdleUnload() {
+        idleUnloadJob?.cancel()
+        idleUnloadJob = engineScope.launch {
+            delay(LOCAL_ENGINE_IDLE_UNLOAD_MS)
+            if (engineUsers.get() > 0) return@launch
+            engineMutex.withLock { releaseEngines() }
+        }
+    }
+
+    private fun cancelIdleUnload() {
+        idleUnloadJob?.cancel()
+        idleUnloadJob = null
+    }
+
+    /**
      * Loads the engine before a dictation needs it.
      *
      * Model loading is measured in seconds, and until now it always happened on
@@ -395,6 +465,7 @@ class LocalModelManager(
         // Stat-only: cheap enough to run per dictation, unlike a digest pass.
         withContext(Dispatchers.IO) { LocalModelIntegrity.verifySizes(model, directory) }
 
+        cancelIdleUnload()
         engineMutex.withLock {
             if (
                 shouldReloadLocalEngine(

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
@@ -375,10 +375,10 @@ class LocalModelManager(
         engineUsers.incrementAndGet()
     }
 
-    fun endUse() {
+    fun endUse(idleMs: Long = LOCAL_ENGINE_IDLE_UNLOAD_MS) {
         if (engineUsers.decrementAndGet() <= 0) {
             engineUsers.set(0)
-            scheduleIdleUnload()
+            scheduleIdleUnload(idleMs)
         }
     }
 
@@ -402,10 +402,11 @@ class LocalModelManager(
         }
     }
 
-    private fun scheduleIdleUnload() {
-        idleUnloadJob?.cancel()
+    private fun scheduleIdleUnload(idleMs: Long) {
+        cancelIdleUnload()
+        if (idleMs < 0L) return
         idleUnloadJob = engineScope.launch {
-            delay(LOCAL_ENGINE_IDLE_UNLOAD_MS)
+            if (idleMs > 0L) delay(idleMs)
             if (engineUsers.get() > 0) return@launch
             engineMutex.withLock { releaseEngines() }
         }

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -164,6 +164,11 @@ data class VocaPhoneSettings(
      * than stored pre-split, so the text they see back is the text they wrote.
      */
     val customVocabulary: String = "",
+    /**
+     * When true (the default), Whisper is biased with [personalDictionary]
+     * instead of [customVocabulary]. Turn it off to keep a separate list.
+     */
+    val syncWhisperDictionary: Boolean = true,
     val numberRowEnabled: Boolean = true,
     val keyboardHeight: KeyboardHeight = KeyboardHeight.COMPACT,
     val splitKeyboard: SplitKeyboard = SplitKeyboard.DEFAULT,
@@ -223,6 +228,13 @@ data class VocaPhoneSettings(
         get() = localModel?.detectsLanguage ?: modelDetectsLanguage
     val isConfigured: Boolean get() = gatewayUrl.isNotEmpty() && hasToken
     val hasLocalModelSelection: Boolean get() = localModelId.isNotEmpty()
+
+    /**
+     * Words actually handed to Whisper. The personal dictionary is the default
+     * source so names taught on the strip also bias dictation.
+     */
+    val whisperVocabulary: String
+        get() = if (syncWhisperDictionary) personalDictionary else customVocabulary
 }
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "vocaphone")
@@ -301,6 +313,9 @@ class SettingsRepository(private val context: Context) {
 
     suspend fun setCustomVocabulary(vocabulary: String) =
         put(Keys.CUSTOM_VOCABULARY, vocabulary)
+
+    suspend fun setSyncWhisperDictionary(enabled: Boolean) =
+        put(Keys.SYNC_WHISPER_DICTIONARY, enabled)
 
     suspend fun setNumberRowEnabled(enabled: Boolean) = put(Keys.NUMBER_ROW, enabled)
 
@@ -467,6 +482,7 @@ class SettingsRepository(private val context: Context) {
         localModelId = this[Keys.LOCAL_MODEL_ID].orEmpty(),
         transcriptionQuality = TranscriptionQuality.fromStored(this[Keys.TRANSCRIPTION_QUALITY]),
         customVocabulary = this[Keys.CUSTOM_VOCABULARY].orEmpty(),
+        syncWhisperDictionary = this[Keys.SYNC_WHISPER_DICTIONARY] ?: true,
         numberRowEnabled = this[Keys.NUMBER_ROW] ?: true,
         keyboardHeight = KeyboardHeight.fromStored(this[Keys.KEYBOARD_HEIGHT]),
         splitKeyboard = SplitKeyboard.fromStored(this[Keys.SPLIT_KEYBOARD]),
@@ -507,6 +523,7 @@ class SettingsRepository(private val context: Context) {
         val LOCAL_MODEL_ID = stringPreferencesKey("local_model_id")
         val TRANSCRIPTION_QUALITY = stringPreferencesKey("transcription_quality")
         val CUSTOM_VOCABULARY = stringPreferencesKey("custom_vocabulary")
+        val SYNC_WHISPER_DICTIONARY = booleanPreferencesKey("sync_whisper_dictionary")
         val NUMBER_ROW = booleanPreferencesKey("keyboard_number_row")
         val KEYBOARD_HEIGHT = stringPreferencesKey("keyboard_height")
         val SPLIT_KEYBOARD = stringPreferencesKey("keyboard_split")

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -134,6 +134,45 @@ enum class AudioRetention(val hours: Int) {
     }
 }
 
+/**
+ * How long an on-device model stays in RAM after the last dictation.
+ *
+ * Unloading frees battery and memory. Keeping it skips the multi-second load
+ * on the next tap. [WHILE_OPEN] only unloads if Android trims the process.
+ */
+enum class ModelIdleTimeout(val storedValue: String, val delayMs: Long) {
+    IMMEDIATELY("immediately", 0L),
+    THIRTY_SECONDS("30s", 30_000L),
+    TWO_MINUTES("2m", 2 * 60 * 1000L),
+    TEN_MINUTES("10m", 10 * 60 * 1000L),
+    WHILE_OPEN("while_open", -1L),
+    ;
+
+    val displayName: String
+        get() = when (this) {
+            IMMEDIATELY -> "Immediately"
+            THIRTY_SECONDS -> "30 seconds"
+            TWO_MINUTES -> "2 minutes"
+            TEN_MINUTES -> "10 minutes"
+            WHILE_OPEN -> "Until the app closes"
+        }
+
+    val detail: String
+        get() = when (this) {
+            IMMEDIATELY -> "Unload as soon as you stop dictating."
+            THIRTY_SECONDS -> "Keep the model ready for a quick follow-up."
+            TWO_MINUTES -> "A short pause between dictations will not reload."
+            TEN_MINUTES -> "Stay warm through a longer break."
+            WHILE_OPEN -> "Stay loaded until VocaPhone is killed or Android needs the RAM."
+        }
+
+    companion object {
+        val DEFAULT = TWO_MINUTES
+        fun fromStored(value: String?): ModelIdleTimeout =
+            entries.firstOrNull { it.storedValue == value } ?: DEFAULT
+    }
+}
+
 data class VocaPhoneSettings(
     val gatewayUrl: String = "",
     val hasToken: Boolean = false,
@@ -142,6 +181,7 @@ data class VocaPhoneSettings(
     val dictationTone: DictationTone = DictationTone.DEFAULT,
     val microphone: MicrophonePreference = MicrophonePreference.DEFAULT,
     val audioRetention: AudioRetention = AudioRetention.DEFAULT,
+    val modelIdleTimeout: ModelIdleTimeout = ModelIdleTimeout.DEFAULT,
     val onboardingComplete: Boolean = false,
     val lastEngine: String = "",
     val lastEngineReady: Boolean = false,
@@ -300,6 +340,9 @@ class SettingsRepository(private val context: Context) {
         put(Keys.MICROPHONE, preference.storedValue)
 
     suspend fun setAudioRetention(retention: AudioRetention) = put(Keys.RETENTION_HOURS, retention.hours)
+
+    suspend fun setModelIdleTimeout(timeout: ModelIdleTimeout) =
+        put(Keys.MODEL_IDLE_TIMEOUT, timeout.storedValue)
 
     suspend fun setOnboardingComplete(complete: Boolean) = put(Keys.ONBOARDING_COMPLETE, complete)
 
@@ -471,6 +514,7 @@ class SettingsRepository(private val context: Context) {
         dictationTone = DictationTone.fromStored(this[Keys.DICTATION_TONE]),
         microphone = MicrophonePreference.fromStored(this[Keys.MICROPHONE]),
         audioRetention = AudioRetention.fromHours(this[Keys.RETENTION_HOURS]),
+        modelIdleTimeout = ModelIdleTimeout.fromStored(this[Keys.MODEL_IDLE_TIMEOUT]),
         onboardingComplete = this[Keys.ONBOARDING_COMPLETE] ?: false,
         lastEngine = this[Keys.LAST_ENGINE].orEmpty(),
         lastEngineReady = this[Keys.LAST_ENGINE_READY] ?: false,
@@ -512,6 +556,7 @@ class SettingsRepository(private val context: Context) {
         val DICTATION_TONE = stringPreferencesKey("dictation_tone")
         val MICROPHONE = stringPreferencesKey("microphone_preference")
         val RETENTION_HOURS = intPreferencesKey("audio_retention_hours")
+        val MODEL_IDLE_TIMEOUT = stringPreferencesKey("model_idle_timeout")
         val ONBOARDING_COMPLETE = booleanPreferencesKey("onboarding_complete")
         val LAST_ENGINE = stringPreferencesKey("last_engine")
         val LAST_ENGINE_READY = booleanPreferencesKey("last_engine_ready")

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/DictateScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/DictateScreen.kt
@@ -4,7 +4,6 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -32,6 +31,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.vocahq.vocaphone.BuildConfig
 import com.vocahq.vocaphone.R
@@ -116,10 +116,13 @@ fun DictateScreen(
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        FlowRow(
+        // One row. FlowRow dropped the model chip onto a second line as soon as
+        // the name got longer than "Moonshine Tiny" (Parakeet TDT 0.6B). Language
+        // and style hug; the model takes what is left and ellipsizes. VoiceOver
+        // still reads the full labels.
+        Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(0.dp),
         ) {
             DictateAssistChip(
                 icon = R.drawable.ic_language,
@@ -143,6 +146,7 @@ fun DictateScreen(
                 label = compactModelChipLabel(modelLabel),
                 contentDescription = "${DictateCopy.MODEL}, $modelLabel",
                 onClick = onOpenModel,
+                modifier = Modifier.weight(1f, fill = false),
             )
         }
 
@@ -299,11 +303,18 @@ private fun DictateAssistChip(
     label: String,
     contentDescription: String,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     AssistChip(
         onClick = onClick,
-        modifier = Modifier.semantics { this.contentDescription = contentDescription },
-        label = { Text(label, maxLines = 1) },
+        modifier = modifier.semantics { this.contentDescription = contentDescription },
+        label = {
+            Text(
+                text = label,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
         leadingIcon = {
             Icon(
                 painter = painterResource(icon),

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
@@ -406,6 +406,7 @@ fun VocaPhoneApp(
                 onAudioRetention = { viewModel.setAudioRetention(it) },
                 onTranscriptionQuality = { viewModel.setTranscriptionQuality(it) },
                 onCustomVocabulary = { viewModel.setCustomVocabulary(it) },
+                onSyncWhisperDictionary = { viewModel.setSyncWhisperDictionary(it) },
                 onNumberRow = { viewModel.setNumberRowEnabled(it) },
                 onKeyboardHeight = { viewModel.setKeyboardHeight(it) },
                 onSplitKeyboard = { viewModel.setSplitKeyboard(it) },

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
@@ -404,6 +404,7 @@ fun VocaPhoneApp(
                 tonePreviewListening = tonePreviewListening,
                 onMicrophone = { viewModel.setMicrophone(it) },
                 onAudioRetention = { viewModel.setAudioRetention(it) },
+                onModelIdleTimeout = { viewModel.setModelIdleTimeout(it) },
                 onTranscriptionQuality = { viewModel.setTranscriptionQuality(it) },
                 onCustomVocabulary = { viewModel.setCustomVocabulary(it) },
                 onSyncWhisperDictionary = { viewModel.setSyncWhisperDictionary(it) },

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -87,6 +87,7 @@ fun SettingsScreen(
     onAudioRetention: (AudioRetention) -> Unit,
     onTranscriptionQuality: (TranscriptionQuality) -> Unit,
     onCustomVocabulary: (String) -> Unit,
+    onSyncWhisperDictionary: (Boolean) -> Unit,
     onNumberRow: (Boolean) -> Unit,
     onKeyboardHeight: (KeyboardHeight) -> Unit,
     onSplitKeyboard: (SplitKeyboard) -> Unit,
@@ -400,6 +401,9 @@ fun SettingsScreen(
                 )
                 CustomVocabularySection(
                     vocabulary = settings.customVocabulary,
+                    personalDictionary = settings.personalDictionary,
+                    synced = settings.syncWhisperDictionary,
+                    onSyncedChange = onSyncWhisperDictionary,
                     onSave = onCustomVocabulary,
                     unsupportedModel = localModel
                         ?.takeIf { settings.localTranscriptionEnabled && !it.supportsCustomVocabulary }
@@ -525,7 +529,8 @@ private fun PersonalDictionarySection(
     Section(
         title = "Personal dictionary",
         supporting = "Names and jargon the English list misses. " +
-            "Separate with commas. Off in passwords.",
+            "Separate with commas. Off in passwords. " +
+            "Whisper uses this list too unless you turn that off under Dictation.",
     ) {
         OutlinedTextField(
             value = draft,
@@ -619,11 +624,15 @@ private fun PersonalDictionarySection(
 @Composable
 private fun CustomVocabularySection(
     vocabulary: String,
+    personalDictionary: String,
+    synced: Boolean,
+    onSyncedChange: (Boolean) -> Unit,
     onSave: (String) -> Unit,
     unsupportedModel: String?,
 ) {
     var draft by remember(vocabulary) { mutableStateOf(vocabulary) }
-    val terms = remember(draft) { CustomVocabulary.terms(draft) }
+    val source = if (synced) personalDictionary else draft
+    val terms = remember(source) { CustomVocabulary.terms(source) }
     val whisperWarning = CustomVocabulary.whisperOnlyWarning(unsupportedModel)
     val whisperOnly = whisperWarning != null
 
@@ -632,6 +641,15 @@ private fun CustomVocabularySection(
         supporting = "Names, places, and jargon an on-device Whisper model is " +
             "unlikely to know. One per line, or separated by commas.",
     ) {
+        // Switch, not a checkbox: Material 3 uses switches for independent
+        // on/off settings. A checkbox is for picking items from a list.
+        SettingToggle(
+            title = "Use personal dictionary",
+            detail = "Whisper sees the same names as the suggestion strip. " +
+                "Turn this off to keep a separate list.",
+            checked = synced,
+            onCheckedChange = onSyncedChange,
+        )
         if (whisperWarning != null) {
             Notice(tone = NoticeTone.Warning) {
                 Text(whisperWarning, style = MaterialTheme.typography.bodyMedium)
@@ -641,34 +659,51 @@ private fun CustomVocabularySection(
                 )
             }
         }
-        OutlinedTextField(
-            value = draft,
-            onValueChange = { draft = it },
-            modifier = Modifier.fillMaxWidth(),
-            enabled = !whisperOnly,
-            label = { Text("Words and phrases") },
-            placeholder = { Text("Kanishk\nVocaHQ\nTailscale") },
-            minLines = 3,
-            maxLines = 6,
-        )
-        if (!whisperOnly) {
+        if (synced) {
             Text(
-                if (terms.isEmpty()) {
-                    "No custom words. Transcription is unchanged."
-                } else {
-                    "${terms.size} word${if (terms.size == 1) "" else "s"} will bias the decoder. " +
-                        "This nudges spelling rather than guaranteeing it, and a very long " +
-                        "list starts to crowd out the speech itself."
+                when (terms.size) {
+                    0 -> "No words in the personal dictionary. Transcription is unchanged."
+                    1 -> "1 word from the personal dictionary will bias Whisper."
+                    else -> "${terms.size} words from the personal dictionary will bias Whisper."
                 },
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            Text(
+                "Edit them under Keyboard → Personal dictionary.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            OutlinedTextField(
+                value = draft,
+                onValueChange = { draft = it },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !whisperOnly,
+                label = { Text("Words and phrases") },
+                placeholder = { Text("Kanishk\nVocaHQ\nTailscale") },
+                minLines = 3,
+                maxLines = 6,
+            )
+            if (!whisperOnly) {
+                Text(
+                    if (terms.isEmpty()) {
+                        "No custom words. Transcription is unchanged."
+                    } else {
+                        "${terms.size} word${if (terms.size == 1) "" else "s"} will bias the decoder. " +
+                            "This nudges spelling rather than guaranteeing it, and a very long " +
+                            "list starts to crowd out the speech itself."
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            SecondaryButton(
+                text = "Save words",
+                onClick = { onSave(draft) },
+                enabled = !whisperOnly && draft != vocabulary,
+            )
         }
-        SecondaryButton(
-            text = "Save words",
-            onClick = { onSave(draft) },
-            enabled = !whisperOnly && draft != vocabulary,
-        )
     }
 }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -46,6 +46,7 @@ import com.vocahq.vocaphone.local.LocalModelDescriptor
 import com.vocahq.vocaphone.local.LocalModelState
 import com.vocahq.vocaphone.settings.AudioRetention
 import com.vocahq.vocaphone.settings.KeyboardHeight
+import com.vocahq.vocaphone.settings.ModelIdleTimeout
 import com.vocahq.vocaphone.settings.SplitKeyboard
 import com.vocahq.vocaphone.settings.VocaPhoneSettings
 import com.vocahq.vocaphone.telemetry.TelemetryInspectPayload
@@ -85,6 +86,7 @@ fun SettingsScreen(
     tonePreviewListening: Boolean,
     onMicrophone: (MicrophonePreference) -> Unit,
     onAudioRetention: (AudioRetention) -> Unit,
+    onModelIdleTimeout: (ModelIdleTimeout) -> Unit,
     onTranscriptionQuality: (TranscriptionQuality) -> Unit,
     onCustomVocabulary: (String) -> Unit,
     onSyncWhisperDictionary: (Boolean) -> Unit,
@@ -372,6 +374,25 @@ fun SettingsScreen(
                     status = microphone,
                     onSelect = onMicrophone,
                 )
+                Section(
+                    title = "Keep model loaded",
+                    supporting = "After you stop dictating, how long the on-device model " +
+                        "stays in RAM. Unloading saves battery; keeping it makes the next " +
+                        "dictation start faster.",
+                ) {
+                    SettingDropdown(
+                        options = ModelIdleTimeout.entries,
+                        selected = settings.modelIdleTimeout,
+                        label = { it.displayName },
+                        detail = { it.detail },
+                        onSelect = onModelIdleTimeout,
+                    )
+                    Text(
+                        settings.modelIdleTimeout.detail,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
                 Section(
                     title = "Audio and transcript retention",
                     supporting = "Successful dictations delete their audio immediately. A " +

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
@@ -28,6 +28,7 @@ import com.vocahq.vocaphone.local.LocalModelIntegrityException
 import com.vocahq.vocaphone.local.LocalModelState
 import com.vocahq.vocaphone.settings.AudioRetention
 import com.vocahq.vocaphone.settings.KeyboardHeight
+import com.vocahq.vocaphone.settings.ModelIdleTimeout
 import com.vocahq.vocaphone.settings.SplitKeyboard
 import com.vocahq.vocaphone.settings.VocaPhoneSettings
 import com.vocahq.vocaphone.telemetry.TelemetryDownloadOutcome
@@ -366,6 +367,9 @@ class VocaPhoneViewModel(application: Application) : AndroidViewModel(applicatio
 
     fun setAudioRetention(retention: AudioRetention) =
         viewModelScope.launch { container.settings.setAudioRetention(retention) }
+
+    fun setModelIdleTimeout(timeout: ModelIdleTimeout) =
+        viewModelScope.launch { container.settings.setModelIdleTimeout(timeout) }
 
     fun setNumberRowEnabled(enabled: Boolean) =
         viewModelScope.launch { container.settings.setNumberRowEnabled(enabled) }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
@@ -341,6 +341,18 @@ class VocaPhoneViewModel(application: Application) : AndroidViewModel(applicatio
     fun setCustomVocabulary(vocabulary: String) =
         viewModelScope.launch { container.settings.setCustomVocabulary(vocabulary) }
 
+    fun setSyncWhisperDictionary(enabled: Boolean) {
+        viewModelScope.launch {
+            if (!enabled) {
+                val current = container.settings.current()
+                if (current.customVocabulary.isBlank() && current.personalDictionary.isNotBlank()) {
+                    container.settings.setCustomVocabulary(current.personalDictionary)
+                }
+            }
+            container.settings.setSyncWhisperDictionary(enabled)
+        }
+    }
+
     fun setMicrophone(preference: MicrophonePreference) {
         // Applied when the recorder is built, so a live dictation would keep the
         // old input while the screen claimed otherwise.

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/CustomVocabularyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/CustomVocabularyTest.kt
@@ -1,5 +1,6 @@
 package com.vocahq.vocaphone.core
 
+import com.vocahq.vocaphone.settings.VocaPhoneSettings
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -60,5 +61,28 @@ class CustomVocabularyTest {
         )
         assertEquals(null, CustomVocabulary.whisperOnlyWarning(null))
         assertEquals(null, CustomVocabulary.whisperOnlyWarning(""))
+    }
+
+    @Test
+    fun `whisper uses the personal dictionary until the user unlinks them`() {
+        val personal = "Grafana, Kubernetes"
+        val custom = "Kanishk\nVocaHQ"
+        assertEquals(
+            personal,
+            VocaPhoneSettings(
+                personalDictionary = personal,
+                customVocabulary = custom,
+                syncWhisperDictionary = true,
+            ).whisperVocabulary,
+        )
+        assertEquals(
+            custom,
+            VocaPhoneSettings(
+                personalDictionary = personal,
+                customVocabulary = custom,
+                syncWhisperDictionary = false,
+            ).whisperVocabulary,
+        )
+        assertTrue(VocaPhoneSettings().syncWhisperDictionary)
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptStylerTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptStylerTest.kt
@@ -33,6 +33,30 @@ class TranscriptStylerTest {
     }
 
     @Test
+    fun `parakeet title case and chunk joins flatten under formal`() {
+        // Parakeet TDT emits native capitalization, and sherpa joins windows
+        // with a space, so the next window often starts with a capital mid-sentence.
+        assertEquals(
+            "I think we should go to the store.",
+            TranscriptStyler.apply(
+                "I Think We Should Go To The Store",
+                WritingStyle.FORMAL,
+            ),
+        )
+        assertEquals(
+            "Hello there how are you today.",
+            TranscriptStyler.apply(
+                "Hello there How are you today",
+                WritingStyle.FORMAL,
+            ),
+        )
+        assertEquals(
+            "Yes, it's ready now.",
+            TranscriptStyler.apply("Yes, It's Ready Now", WritingStyle.FORMAL),
+        )
+    }
+
+    @Test
     fun `flattening keeps mixed-case names, acronyms, and the pronoun I`() {
         val source = "I use VocaPhone and GraphQL at NASA today"
         assertEquals(

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptStylerTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptStylerTest.kt
@@ -16,6 +16,40 @@ class TranscriptStylerTest {
     }
 
     @Test
+    fun `clean and formal flatten mid-sentence title case from the model`() {
+        val titled = "Hello There. The Keyboard Is Ready"
+        assertEquals(
+            "hello there. the keyboard is ready.",
+            TranscriptStyler.apply(titled, WritingStyle.CLEAN),
+        )
+        assertEquals(
+            "Hello there. The keyboard is ready.",
+            TranscriptStyler.apply(titled, WritingStyle.FORMAL),
+        )
+        assertEquals(
+            "Hello there. The keyboard is ready",
+            TranscriptStyler.apply(titled, WritingStyle.CASUAL),
+        )
+    }
+
+    @Test
+    fun `flattening keeps mixed-case names, acronyms, and the pronoun I`() {
+        val source = "I use VocaPhone and GraphQL at NASA today"
+        assertEquals(
+            "I use VocaPhone and GraphQL at NASA today.",
+            TranscriptStyler.apply(source, WritingStyle.CLEAN),
+        )
+        assertEquals(
+            "I use VocaPhone and GraphQL at NASA today.",
+            TranscriptStyler.apply(source, WritingStyle.FORMAL),
+        )
+        assertEquals(
+            "I went home.",
+            TranscriptStyler.apply("i went home", WritingStyle.CLEAN),
+        )
+    }
+
+    @Test
     fun `local styling keeps protected spans intact`() {
         val source = "Email John@Example.com at 3:30."
         assertEquals(

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/LocalEnginePolicyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/LocalEnginePolicyTest.kt
@@ -98,5 +98,7 @@ class LocalEnginePolicyTest {
         assertFalse(idleEngineUnloadDue(users = 1, lastIdleAtMs = 0L, nowMs = 10 * 60 * 1000L))
         assertFalse(idleEngineUnloadDue(users = 0, lastIdleAtMs = 0L, nowMs = 60_000L))
         assertTrue(idleEngineUnloadDue(users = 0, lastIdleAtMs = 0L, nowMs = LOCAL_ENGINE_IDLE_UNLOAD_MS))
+        assertTrue(idleEngineUnloadDue(users = 0, lastIdleAtMs = 0L, nowMs = 30_000L, idleMs = 30_000L))
+        assertFalse(idleEngineUnloadDue(users = 0, lastIdleAtMs = 0L, nowMs = 10_000L, idleMs = 30_000L))
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/LocalEnginePolicyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/LocalEnginePolicyTest.kt
@@ -92,4 +92,11 @@ class LocalEnginePolicyTest {
             ),
         )
     }
+
+    @Test
+    fun `an idle engine is unloaded after two minutes with no users`() {
+        assertFalse(idleEngineUnloadDue(users = 1, lastIdleAtMs = 0L, nowMs = 10 * 60 * 1000L))
+        assertFalse(idleEngineUnloadDue(users = 0, lastIdleAtMs = 0L, nowMs = 60_000L))
+        assertTrue(idleEngineUnloadDue(users = 0, lastIdleAtMs = 0L, nowMs = LOCAL_ENGINE_IDLE_UNLOAD_MS))
+    }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/SettingsChoiceTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/SettingsChoiceTest.kt
@@ -5,6 +5,7 @@ import com.vocahq.vocaphone.core.MicrophonePreference
 import com.vocahq.vocaphone.core.TranscriptStyler
 import com.vocahq.vocaphone.core.WritingStyle
 import com.vocahq.vocaphone.settings.AudioRetention
+import com.vocahq.vocaphone.settings.ModelIdleTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -26,6 +27,16 @@ class SettingsChoiceTest {
         assertEquals(DictationTone.VOCA, DictationTone.fromStored("voca"))
         assertEquals(MicrophonePreference.AUTOMATIC, MicrophonePreference.fromStored("automatic"))
         assertEquals(AudioRetention.SIX_HOURS, AudioRetention.fromHours(6))
+        assertEquals(2 * 60 * 1000L, ModelIdleTimeout.TWO_MINUTES.delayMs)
+        assertEquals(-1L, ModelIdleTimeout.WHILE_OPEN.delayMs)
+        assertEquals(
+            ModelIdleTimeout.TWO_MINUTES,
+            ModelIdleTimeout.fromStored(null),
+        )
+        assertEquals(
+            ModelIdleTimeout.THIRTY_SECONDS,
+            ModelIdleTimeout.fromStored("30s"),
+        )
     }
 
     @Test
@@ -47,6 +58,7 @@ class SettingsChoiceTest {
         DictationTone.entries.forEach { assertTrue(it.detail.isNotBlank()) }
         MicrophonePreference.entries.forEach { assertTrue(it.detail.isNotBlank()) }
         AudioRetention.entries.forEach { assertTrue(it.detail.isNotBlank()) }
+        ModelIdleTimeout.entries.forEach { assertTrue(it.detail.isNotBlank()) }
         WritingStyle.entries.forEach { assertTrue(it.detail.isNotBlank()) }
     }
 

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -29,9 +29,9 @@ enum WritingStyle: String, Codable, CaseIterable, Identifiable, Sendable {
         case .raw:
             "Exactly what the model returned, with nothing changed."
         case .clean:
-            "Spacing tidied and a closing full stop. Capitalization untouched."
+            "Spacing tidied and a closing full stop. Random capitals from the model are flattened; names like VocaPhone stay."
         case .formal:
-            "Sentence capitalization and a closing full stop."
+            "Sentence capitalization and a closing full stop. Mid-sentence Title Case from the model is flattened."
         case .casual:
             "Sentences kept, but no closing full stop."
         case .veryCasual:

--- a/ios/VocaPhoneShared/TranscriptStyler.swift
+++ b/ios/VocaPhoneShared/TranscriptStyler.swift
@@ -60,7 +60,7 @@ enum TranscriptStyler {
         terminators: "།.!?", join: " "
     )
 
-    private static let protectedPattern = "(?i)(https?://[^\\s]+[^\\s.,;:!?\\\"“”'\\)\\]]|[\\w.+-]+@(?:[\\w-]+\\.)+[A-Za-z]{2,}|(?:[\\w-]+\\.)+[A-Za-z]{2,}(?:/[^\\s.,;:!?\\\"“”'\\)\\]]*)?|\\d+(?:[.,:/]\\d+)+|\\d+(?:st|nd|rd|th)\\b|(?:[A-Za-z]\\.){2,}|\\w+['’]\\w+)"
+    private static let protectedPattern = "(?i)(https?://[^\\s]+[^\\s.,;:!?\\\"“”'\\)\\]]|[\\w.+-]+@(?:[\\w-]+\\.)+[A-Za-z]{2,}|(?:[\\w-]+\\.)+[A-Za-z]{2,}(?:/[^\\s.,;:!?\\\"“”'\\)\\]]*)?|\\d+(?:[.,:/]\\d+)+|\\d+(?:st|nd|rd|th)\\b|(?:[A-Za-z]\\.){2,})"
     private static let placeholderPattern = "__VOCA_TOKEN_(\\d+)__"
 
     static func apply(
@@ -265,7 +265,8 @@ enum TranscriptStyler {
         if letters.isEmpty { return token }
         let hasLower = letters.contains { $0.isLowercase }
         let hasUpper = letters.contains { $0.isUppercase }
-        if !hasLower && letters.count >= 2 { return token }
+        if !hasLower && (2...4).contains(letters.count) { return token }
+        if !hasLower && letters.count > 4 { return token.lowercased() }
         if hasLower && hasUpper {
             let body = token.drop { !$0.isLetter }
             guard let first = body.first else { return token }

--- a/ios/VocaPhoneShared/TranscriptStyler.swift
+++ b/ios/VocaPhoneShared/TranscriptStyler.swift
@@ -171,6 +171,29 @@ enum TranscriptStyler {
         return Masked(text: String(result), tokens: tokens)
     }
 
+    /// Index of the last character of `__VOCA_TOKEN_<n>__` starting at `index`.
+    private static func endOfPlaceholder(in characters: [Character], from index: Int) -> Int? {
+        let prefix: [Character] = Array("__VOCA_TOKEN_")
+        guard index + prefix.count + 3 <= characters.count else { return nil }
+        for offset in prefix.indices where characters[index + offset] != prefix[offset] {
+            return nil
+        }
+        var cursor = index + prefix.count
+        var sawDigit = false
+        while cursor < characters.count {
+            let character = characters[cursor]
+            guard character >= "0", character <= "9" else { break }
+            sawDigit = true
+            cursor += 1
+        }
+        guard sawDigit,
+              cursor + 1 < characters.count,
+              characters[cursor] == "_",
+              characters[cursor + 1] == "_"
+        else { return nil }
+        return cursor + 1
+    }
+
     private static func restore(_ text: String, tokens: [String]) -> String {
         let regex = try! NSRegularExpression(pattern: placeholderPattern)
         let original = text as NSString
@@ -235,6 +258,13 @@ enum TranscriptStyler {
         let characters = Array(text)
         var index = 0
         while index < characters.count {
+            // `__VOCA_TOKEN_N__` contains the letters TOKEN. Copy the marker
+            // whole; flatten would lowercase it and restore could not match.
+            if let end = endOfPlaceholder(in: characters, from: index) {
+                result.append(contentsOf: characters[index...end])
+                index = end + 1
+                continue
+            }
             let character = characters[index]
             if character.isLetter {
                 let start = index

--- a/ios/VocaPhoneShared/TranscriptStyler.swift
+++ b/ios/VocaPhoneShared/TranscriptStyler.swift
@@ -78,23 +78,33 @@ enum TranscriptStyler {
             normalizeSpacing(masked.text),
             punctuation: punctuation
         )
+        // Whisper and Parakeet Title-Case content words. Flatten those before
+        // Clean/Formal/Casual so mid-sentence capitals are not left as-is.
+        // Mixed-case names and ALL-CAPS acronyms stay.
+        let flattened: String
+        switch style {
+        case .raw, .veryCasual:
+            flattened = normalized
+        default:
+            flattened = flattenModelCaps(normalized)
+        }
         let result: String
         switch style {
         case .raw:
             result = normalized
         case .clean:
-            result = ensureTerminator(normalized, punctuation: punctuation)
+            result = ensureTerminator(flattened, punctuation: punctuation)
         case .formal:
             result = ensureTerminator(
-                capitalizeSentenceStarts(normalized, punctuation: punctuation),
+                capitalizeSentenceStarts(flattened, punctuation: punctuation),
                 punctuation: punctuation
             )
         case .casual:
-            result = casual(normalized, punctuation: punctuation)
+            result = casual(flattened, punctuation: punctuation)
         case .veryCasual:
             result = veryCasual(segments(normalized, punctuation: punctuation), punctuation: punctuation)
         case .excited:
-            result = excited(segments(normalized, punctuation: punctuation), punctuation: punctuation)
+            result = excited(segments(flattened, punctuation: punctuation), punctuation: punctuation)
         }
         let lowered = style == .veryCasual ? lowerOutsidePlaceholders(result) : result
         return restore(lowered, tokens: masked.tokens)
@@ -216,6 +226,62 @@ enum TranscriptStyler {
         guard !text.isEmpty, !punctuation.terminator.isEmpty else { return text }
         guard let last = text.last, !punctuation.terminators.contains(last) else { return text }
         return text + punctuation.terminator
+    }
+
+    /// Drop Title Case the model invented, keep tokens that look like names.
+    private static func flattenModelCaps(_ text: String) -> String {
+        var result = ""
+        result.reserveCapacity(text.count)
+        let characters = Array(text)
+        var index = 0
+        while index < characters.count {
+            let character = characters[index]
+            if character.isLetter {
+                let start = index
+                index += 1
+                while index < characters.count {
+                    let next = characters[index]
+                    if next.isLetter || next == "'" || next == "’" {
+                        index += 1
+                    } else {
+                        break
+                    }
+                }
+                result += softenToken(String(characters[start..<index]))
+            } else {
+                result.append(character)
+                index += 1
+            }
+        }
+        return result
+    }
+
+    private static func softenToken(_ token: String) -> String {
+        if isPronounI(token) {
+            let body = token.drop { !$0.isLetter }
+            return String(token.dropLast(body.count)) + "I" + body.dropFirst()
+        }
+        let letters = token.filter(\.isLetter)
+        if letters.isEmpty { return token }
+        let hasLower = letters.contains { $0.isLowercase }
+        let hasUpper = letters.contains { $0.isUppercase }
+        if !hasLower && letters.count >= 2 { return token }
+        if hasLower && hasUpper {
+            let body = token.drop { !$0.isLetter }
+            guard let first = body.first else { return token }
+            let titleCase = first.isUppercase && !body.dropFirst().contains(where: \.isUppercase)
+            if !titleCase { return token }
+        }
+        return token.lowercased()
+    }
+
+    private static func isPronounI(_ token: String) -> Bool {
+        let letters = token.filter(\.isLetter)
+        guard let first = letters.first, first == "I" || first == "i" else { return false }
+        let rest = String(letters.dropFirst()).lowercased()
+        if rest.isEmpty { return true }
+        let contracted = token.contains("'") || token.contains("’")
+        return contracted && ["m", "ll", "d", "ve", "re", "s"].contains(rest)
     }
 
     private static func capitalizeSentenceStarts(_ text: String, punctuation: Punctuation) -> String {

--- a/ios/VocaPhoneTests/TranscriptStylerTests.swift
+++ b/ios/VocaPhoneTests/TranscriptStylerTests.swift
@@ -36,6 +36,21 @@ struct TranscriptStylerTests {
         #expect(TranscriptStyler.apply(titled, style: .casual) == "Hello there. The keyboard is ready")
     }
 
+    @Test func parakeetTitleCaseAndChunkJoinsFlattenUnderFormal() {
+        #expect(
+            TranscriptStyler.apply("I Think We Should Go To The Store", style: .formal)
+                == "I think we should go to the store."
+        )
+        #expect(
+            TranscriptStyler.apply("Hello there How are you today", style: .formal)
+                == "Hello there how are you today."
+        )
+        #expect(
+            TranscriptStyler.apply("Yes, It's Ready Now", style: .formal)
+                == "Yes, it's ready now."
+        )
+    }
+
     @Test func flatteningKeepsMixedCaseNamesAcronymsAndPronounI() {
         let source = "I use VocaPhone and GraphQL at NASA today"
         #expect(TranscriptStyler.apply(source, style: .clean) == "I use VocaPhone and GraphQL at NASA today.")

--- a/ios/VocaPhoneTests/TranscriptStylerTests.swift
+++ b/ios/VocaPhoneTests/TranscriptStylerTests.swift
@@ -29,6 +29,20 @@ struct TranscriptStylerTests {
         )
     }
 
+    @Test func cleanAndFormalFlattenMidSentenceTitleCase() {
+        let titled = "Hello There. The Keyboard Is Ready"
+        #expect(TranscriptStyler.apply(titled, style: .clean) == "hello there. the keyboard is ready.")
+        #expect(TranscriptStyler.apply(titled, style: .formal) == "Hello there. The keyboard is ready.")
+        #expect(TranscriptStyler.apply(titled, style: .casual) == "Hello there. The keyboard is ready")
+    }
+
+    @Test func flatteningKeepsMixedCaseNamesAcronymsAndPronounI() {
+        let source = "I use VocaPhone and GraphQL at NASA today"
+        #expect(TranscriptStyler.apply(source, style: .clean) == "I use VocaPhone and GraphQL at NASA today.")
+        #expect(TranscriptStyler.apply(source, style: .formal) == "I use VocaPhone and GraphQL at NASA today.")
+        #expect(TranscriptStyler.apply("i went home", style: .clean) == "I went home.")
+    }
+
     @Test func localStylingKeepsProtectedSpansIntact() {
         #expect(
             TranscriptStyler.apply(

--- a/ios/VocaPhoneTests/TranscriptStylerTests.swift
+++ b/ios/VocaPhoneTests/TranscriptStylerTests.swift
@@ -65,6 +65,12 @@ struct TranscriptStylerTests {
                 style: .veryCasual
             ) == "email John@Example.com at 3:30"
         )
+        #expect(
+            TranscriptStyler.apply(
+                "Email John@Example.com at 3:30.",
+                style: .formal
+            ) == "Email John@Example.com at 3:30."
+        )
     }
 
     @Test func localStylingUsesLanguagePunctuation() {


### PR DESCRIPTION
## Summary

- Dictate language / style / model chips stay on **one row**. Language and style hug; the model chip takes the rest and ellipsizes.
- **Personal dictionary ↔ Whisper vocab** stay in sync by default. Dictation → Custom words has a *Use personal dictionary* switch (Material 3 uses a switch for an independent setting, not a checkbox). Turn it off to keep a separate list; an empty list is seeded from the personal dictionary.
- **Clean / Formal capitalization.** Parakeet TDT emits native punctuation and capitalization, and sherpa joins audio windows with a space, so the next window often starts with a capital mid-sentence. Contractions (`It's`, `Don't`) were also masked before styling, so the model's casing survived. Formal now flattens that. Mixed-case names (`VocaPhone`, `GraphQL`), short ALL-CAPS acronyms (`NASA`), and `I` stay. Same styler change on iOS.
- **Keep model loaded.** Settings → Dictation, next to retention. Immediately / 30 seconds / 2 minutes (default) / 10 minutes / Until the app closes. Android can still dump it on a memory trim.
- **Cold start.** Recording starts immediately. Model load runs in parallel. Finish hands the WAV to the engine that is already (or still) loading.

## Verification

- [x] `just ios ci` — N/A on this machine; iOS styler tests added, not executed here
- [x] `just android ci` — `assembleFullDebug` plus focused unit tests green (`TranscriptStylerTest`, `SettingsChoiceTest`, `LocalEnginePolicyTest`, `CustomVocabularyTest`)
- [x] Physical-device test — Nothing Phone (1): one-row chips, dict-sync switch, Keep model loaded dropdown, Formal flatten on Parakeet
- [ ] Gateway changes: N/A

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for data-flow, permission, retention, or network changes — N/A
