### PR TITLE
Follow-up: translation review notes and shift case cycling

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/core/ModelLanguageSupport.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/ModelLanguageSupport.kt
@@ -95,8 +95,8 @@ object ModelLanguageSupport {
     fun restriction(
         modelLanguages: Set<String>,
         detectsLanguageAutomatically: Boolean,
+        canTranslate: Boolean,
         onDevice: Boolean = false,
-        canTranslate: Boolean = false,
     ): String? {
         val owner = if (onDevice) "The on-device model" else "Your gateway's model"
         val coverage = if (modelLanguages.isEmpty()) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/ModelTranslationSupport.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/ModelTranslationSupport.kt
@@ -88,12 +88,40 @@ object ModelTranslationSupport {
         selected: TranscriptionLanguage,
         targets: Set<String>,
         onDevice: Boolean = true,
+        needsExplicitSource: Boolean = false,
+        sourceIsAutomatic: Boolean = false,
     ): String {
         if (!isSupported(targets)) {
             return if (onDevice) "Not supported by this model" else "Needs an on-device model"
         }
         val resolved = resolve(selected, targets)
-        return if (resolved == OFF) "Off" else resolved.displayName
+        if (resolved == OFF) return "Off"
+        if (needsExplicitSource && sourceIsAutomatic) {
+            return "${resolved.displayName} · set Language first"
+        }
+        return resolved.displayName
+    }
+
+    /**
+     * Whether a language row matches the search field.
+     *
+     * In translation mode the off row is labelled "Don't translate", not
+     * "Automatic". Matching [TranscriptionLanguage.AUTOMATIC.wireValue]
+     * (`"auto"`) made that row show up for the one word that describes the
+     * opposite of what it does.
+     */
+    fun matchesQuery(
+        query: String,
+        language: TranscriptionLanguage,
+        translating: Boolean,
+    ): Boolean {
+        if (query.isBlank()) return true
+        val label = if (translating && language == OFF) OFF_LABEL else language.displayName
+        if (label.contains(query, ignoreCase = true)) return true
+        if (translating && language == OFF) {
+            return "off".contains(query, ignoreCase = true)
+        }
+        return language.wireValue.contains(query, ignoreCase = true)
     }
 
     /**

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -239,6 +239,7 @@ class DictationController(
                         it,
                         record.language,
                         configuration.transcriptionQuality,
+                        configuration.translationTarget,
                     )
                 }
                 try {
@@ -313,6 +314,7 @@ class DictationController(
                     modelID,
                     configuration.effectiveLanguage.wireValue,
                     configuration.transcriptionQuality,
+                    configuration.translationTarget,
                 )
             }
         }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -58,6 +58,12 @@ internal sealed interface KeyboardCommand {
     data object DoubleSpacePeriod : KeyboardCommand
     data object FinishComposing : KeyboardCommand
     data object CycleSelectionCase : KeyboardCommand
+    /**
+     * Shift was pressed while Compose did not think there was a selection.
+     * The service still checks the live editor range: a stale `editorText`
+     * snapshot used to arm caps instead of cycling case.
+     */
+    data object ShiftTap : KeyboardCommand
 }
 
 /** Hold-delete starts on characters, then words, then the rest of the line. */
@@ -456,6 +462,7 @@ internal object KeyboardReducer {
                         shift = nextShift,
                         lastShiftTapMillis = if (nextShift == ShiftState.ONCE) nowMillis else null,
                     ),
+                    command = KeyboardCommand.ShiftTap,
                 )
             }
         }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -351,6 +351,39 @@ internal object CaseCycle {
         character.isLetterOrDigit() || character == '\''
 }
 
+/**
+ * How to apply a case cycle to a live selection.
+ *
+ * [restoreSelectionAfterFinish] is true when a composing span is still
+ * active. `finishComposingText` on several editors (Messages among them)
+ * drops the highlight, so the range has to be put back before `commitText`
+ * can replace it. Capturing the selected string *before* that finish is
+ * what keeps shift-to-cycle working after letters started going out as
+ * composing text.
+ */
+internal data class CaseCycleApply(
+    val next: String,
+    val start: Int,
+    val end: Int,
+    val restoreSelectionAfterFinish: Boolean,
+)
+
+internal fun planCaseCycle(
+    selected: String,
+    original: String?,
+    start: Int,
+    composingActive: Boolean,
+): CaseCycleApply? {
+    if (selected.none { it.isLetter() }) return null
+    val next = CaseCycle.next(selected, original ?: selected)
+    return CaseCycleApply(
+        next = next,
+        start = start,
+        end = start + next.length,
+        restoreSelectionAfterFinish = composingActive,
+    )
+}
+
 
 /** Pure keyboard-state reducer so behavior stays testable outside the IME process. */
 internal object KeyboardReducer {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -510,23 +510,31 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
 
     private fun cycleSelectionCase() {
         val connection = currentInputConnection ?: return
-        connection.finishComposingText()
         val selected = selectedText(connection)
-        if (selected.none { it.isLetter() }) return
         val start = selectionStart(connection) ?: return
         if (selected != caseCycleEmitted) {
             caseCycleOriginal = selected
         }
-        val next = CaseCycle.next(selected, caseCycleOriginal ?: selected)
+        val plan = planCaseCycle(
+            selected = selected,
+            original = caseCycleOriginal,
+            start = start,
+            composingActive = composingRegionActive,
+        ) ?: return
         connection.beginBatchEdit()
-        connection.commitText(next, 1)
-        connection.setSelection(start, start + next.length)
+        if (plan.restoreSelectionAfterFinish) {
+            connection.finishComposingText()
+            connection.setSelection(start, start + selected.length)
+        }
+        connection.commitText(plan.next, 1)
+        connection.setSelection(plan.start, plan.end)
         connection.endBatchEdit()
-        lastSelStart = start
-        lastSelEnd = start + next.length
-        caseCycleEmitted = next
+        composingRegionActive = false
+        lastSelStart = plan.start
+        lastSelEnd = plan.end
+        caseCycleEmitted = plan.next
         visibleEditorText.value = visibleEditorText.value.copy(
-            selected = next,
+            selected = plan.next,
             hasSelection = true,
         )
     }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -386,6 +386,15 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
                 composingRegionActive = false
             }
             KeyboardCommand.CycleSelectionCase -> cycleSelectionCase()
+            KeyboardCommand.ShiftTap -> {
+                if (cycleSelectionCase()) {
+                    // Compose already armed a capital from a stale snapshot.
+                    editorConfig = editorConfig.copy(
+                        initialShift = ShiftState.OFF,
+                        shiftSync = editorConfig.shiftSync + 1,
+                    )
+                }
+            }
         }
         // Composing lives in keyboard state; the strip does not need a
         // round-trip into the editor until a word is committed or the cursor
@@ -508,10 +517,10 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         }
     }
 
-    private fun cycleSelectionCase() {
-        val connection = currentInputConnection ?: return
+    private fun cycleSelectionCase(): Boolean {
+        val connection = currentInputConnection ?: return false
         val selected = selectedText(connection)
-        val start = selectionStart(connection) ?: return
+        val start = selectionStart(connection) ?: return false
         if (selected != caseCycleEmitted) {
             caseCycleOriginal = selected
         }
@@ -520,7 +529,7 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
             original = caseCycleOriginal,
             start = start,
             composingActive = composingRegionActive,
-        ) ?: return
+        ) ?: return false
         connection.beginBatchEdit()
         if (plan.restoreSelectionAfterFinish) {
             connection.finishComposingText()
@@ -537,9 +546,19 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
             selected = plan.next,
             hasSelection = true,
         )
+        return true
     }
 
     private fun selectedText(connection: InputConnection): String {
+        val surrounding = runCatching {
+            connection.getSurroundingText(1024, 1024, 0)
+        }.getOrNull()
+        if (surrounding != null) {
+            val text = surrounding.text.toString()
+            val start = minOf(surrounding.selectionStart, surrounding.selectionEnd).coerceAtLeast(0)
+            val end = maxOf(surrounding.selectionStart, surrounding.selectionEnd).coerceAtMost(text.length)
+            if (start < end) return text.substring(start, end)
+        }
         val live = runCatching {
             connection.getSelectedText(0)?.toString()
         }.getOrNull()
@@ -555,6 +574,13 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
     }
 
     private fun selectionStart(connection: InputConnection): Int? {
+        val surrounding = runCatching {
+            connection.getSurroundingText(1024, 1024, 0)
+        }.getOrNull()
+        if (surrounding != null) {
+            val start = minOf(surrounding.selectionStart, surrounding.selectionEnd)
+            if (start >= 0) return start
+        }
         val extracted = runCatching {
             connection.getExtractedText(ExtractedTextRequest(), 0)
         }.getOrNull()

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -365,6 +365,8 @@ internal fun VocaPhoneKeyboard(
         onCommand(command)
     }
 
+    val currentEditorText = rememberUpdatedState(editorText)
+
     fun handleKey(key: KeyboardKey) {
         if (key.type == KeyboardKeyType.DELETE) {
             handleDelete(0L)
@@ -380,12 +382,13 @@ internal fun VocaPhoneKeyboard(
         if (key.type == KeyboardKeyType.CHARACTER) {
             swipeSeedShift = keyboardState.shift
         }
+        val text = currentEditorText.value
         val reduction = KeyboardReducer.press(
             state = keyboardState,
             key = key,
             nowMillis = SystemClock.uptimeMillis(),
             composeWords = composeWords,
-            hasSelection = editorText.hasSelection || editorText.selected.any { it.isLetter() },
+            hasSelection = text.hasSelection || text.selected.any { it.isLetter() },
         )
         keyboardState = reduction.state
         reduction.command?.let(onCommand)

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -108,6 +108,7 @@ import androidx.compose.ui.layout.positionInWindow
 import com.vocahq.vocaphone.core.DictationPhase
 import com.vocahq.vocaphone.core.DictationState
 import com.vocahq.vocaphone.core.ModelLanguageSupport
+import com.vocahq.vocaphone.core.ModelTranslationSupport
 import com.vocahq.vocaphone.core.TranscriptionLanguage
 import com.vocahq.vocaphone.core.WritingStyle
 import com.vocahq.vocaphone.settings.ClipboardHistory
@@ -1330,6 +1331,7 @@ private fun LanguagePreferencePanel(
     val restriction = ModelLanguageSupport.restriction(
         settings.activeModelLanguages,
         settings.activeModelDetectsLanguage,
+        canTranslate = ModelTranslationSupport.isSupported(settings.activeModelTranslationTargets),
         onDevice = settings.localTranscriptionEnabled,
     )
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelCatalog.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelCatalog.kt
@@ -115,7 +115,7 @@ data class LocalModelDescriptor(
     val translationTargets: Set<String>
         get() = when {
             sherpaFamily == SherpaFamily.CANARY -> languageCodes
-            englishOnly -> emptySet()
+            englishOnly || "distil" in id -> emptySet()
             engine == LocalModelEngine.WHISPER -> setOf("en")
             else -> emptySet()
         }

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
@@ -207,7 +207,7 @@ class LocalModelManager(
     ): SherpaIncrementalSession? {
         val model = LocalModelCatalog.find(modelID) ?: return null
         val resolved = if (model.englishOnly) "en" else language
-        val target = model.resolveTranslationTarget(translateTo)
+        val target = model.resolveTranslationTarget(translateTo, resolved)
         if (!canStreamIncrementally(model.engine, target)) return null
         return SherpaIncrementalSession(
             scope = scope,
@@ -398,10 +398,15 @@ class LocalModelManager(
      * Start loading weights without waiting. Recording can begin on the same
      * tap; [transcribe] joins this work via [engineMutex].
      */
-    fun warm(modelID: String, language: String, quality: TranscriptionQuality) {
+    fun warm(
+        modelID: String,
+        language: String,
+        quality: TranscriptionQuality,
+        translateTo: String,
+    ) {
         cancelIdleUnload()
         engineScope.launch {
-            runCatching { prepare(modelID, language, quality) }
+            runCatching { prepare(modelID, language, quality, translateTo) }
         }
     }
 
@@ -443,15 +448,16 @@ class LocalModelManager(
         modelID: String,
         language: String,
         quality: TranscriptionQuality,
-        translateTo: String = "",
+        translateTo: String,
     ) {
         val model = LocalModelCatalog.find(modelID) ?: return
         if (!isDownloaded(model.id)) return
+        val spoken = if (model.englishOnly) "en" else language
         prepareEngine(
             model,
-            if (model.englishOnly) "en" else language,
+            spoken,
             quality,
-            model.resolveTranslationTarget(translateTo),
+            model.resolveTranslationTarget(translateTo, spoken),
         )
     }
 
@@ -466,7 +472,7 @@ class LocalModelManager(
     ): LocalTranscription {
         val model = LocalModelCatalog.find(modelID) ?: error("Unknown local model: $modelID")
         val resolved = if (model.englishOnly) "en" else language
-        val target = model.resolveTranslationTarget(translateTo)
+        val target = model.resolveTranslationTarget(translateTo, resolved)
         prepareEngine(model, resolved, quality, target)
         // One gain and one DC-offset correction cover the complete recording.
         // Sherpa used to have a separate during-recording path that could apply
@@ -689,8 +695,23 @@ internal fun shouldReloadLocalEngine(
  * can never reach an engine that would misread it, nor force a reload of one
  * that would ignore it.
  */
-internal fun LocalModelDescriptor.resolveTranslationTarget(requested: String): String =
-    requested.takeIf { it.isNotEmpty() && it in translationTargets }.orEmpty()
+internal fun LocalModelDescriptor.resolveTranslationTarget(
+    requested: String,
+    spokenLanguage: String? = null,
+): String {
+    val target = requested.takeIf { it.isNotEmpty() && it in translationTargets }.orEmpty()
+    if (target.isEmpty()) return ""
+    // Canary has no detection. Automatic is resolved to English before the
+    // recognizer is built, so a target with no spoken language named is a
+    // translation out of English, not out of whatever was actually said.
+    if (spokenLanguage != null &&
+        translationNeedsExplicitSource &&
+        (spokenLanguage.isEmpty() || spokenLanguage == "auto")
+    ) {
+        return ""
+    }
+    return target
+}
 
 /**
  * Whether a dictation may be decoded in windows while it is still being spoken.

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/LanguagePickerSheet.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/LanguagePickerSheet.kt
@@ -83,12 +83,8 @@ fun LanguagePickerSheet(
             language.displayName
         }
 
-    // Searched against the label actually on the row: "Don't translate" is not
-    // findable by typing "automatic", and should not be.
     fun matches(language: TranscriptionLanguage) =
-        query.isBlank() ||
-            label(language).contains(query, ignoreCase = true) ||
-            language.wireValue.contains(query, ignoreCase = true)
+        ModelTranslationSupport.matchesQuery(query, language, translating)
 
     fun selectable(language: TranscriptionLanguage) = if (translating) {
         ModelTranslationSupport.isSelectable(language, translationTargets)

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -172,6 +172,9 @@ fun SettingsScreen(
                             settings.translateTo,
                             settings.activeModelTranslationTargets,
                             onDevice = settings.localTranscriptionEnabled,
+                            needsExplicitSource = localModel?.translationNeedsExplicitSource == true,
+                            sourceIsAutomatic = settings.effectiveLanguage ==
+                                TranscriptionLanguage.AUTOMATIC,
                         ),
                         icon = R.drawable.ic_language,
                         onClick = { pickingTranslation = true },

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/ModelLanguageSupportTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/ModelLanguageSupportTest.kt
@@ -66,13 +66,13 @@ class ModelLanguageSupportTest {
 
     @Test
     fun `a coverage limit is spelled out whenever there is one`() {
-        val limited = ModelLanguageSupport.restriction(dolphin, false)
+        val limited = ModelLanguageSupport.restriction(dolphin, false, canTranslate = false)
         assertTrue(limited!!.contains("${dolphin.size} languages"))
-        val oneLanguage = ModelLanguageSupport.restriction(setOf("en"), false)
+        val oneLanguage = ModelLanguageSupport.restriction(setOf("en"), false, canTranslate = false)
         assertTrue(oneLanguage!!.contains("1 language."))
         // No coverage claim leaves nothing to say about coverage.
         assertFalse(
-            ModelLanguageSupport.restriction(emptySet(), false)!!.contains("covers"),
+            ModelLanguageSupport.restriction(emptySet(), false, canTranslate = false)!!.contains("covers"),
         )
     }
 
@@ -86,7 +86,7 @@ class ModelLanguageSupportTest {
     @Test
     fun `every model says the language row is not a translation setting`() {
         for (detects in listOf(false, true)) {
-            val sentence = ModelLanguageSupport.restriction(emptySet(), detects)!!
+            val sentence = ModelLanguageSupport.restriction(emptySet(), detects, canTranslate = false)!!
             assertTrue(sentence.contains("not the language you want back"))
             assertTrue(sentence.contains("cannot translate"))
         }
@@ -95,8 +95,8 @@ class ModelLanguageSupportTest {
         val canary = ModelLanguageSupport.restriction(
             setOf("en", "de", "es", "fr"),
             false,
-            onDevice = true,
             canTranslate = true,
+            onDevice = true,
         )!!
         assertTrue(canary.contains("use Translate to"))
         assertFalse(canary.contains("cannot translate"))
@@ -123,15 +123,15 @@ class ModelLanguageSupportTest {
      */
     @Test
     fun `an auto-detecting model says what picking a language does`() {
-        val detected = ModelLanguageSupport.restriction(dolphin, true)!!
+        val detected = ModelLanguageSupport.restriction(dolphin, true, canTranslate = false)!!
         assertTrue(detected.contains("${dolphin.size} languages"))
         assertTrue(detected.contains("does not pin the decoder"))
         assertTrue(detected.contains("punctuated"))
         // With no coverage claim there is still the detection half to explain.
-        val unclaimed = ModelLanguageSupport.restriction(emptySet(), true)!!
+        val unclaimed = ModelLanguageSupport.restriction(emptySet(), true, canTranslate = false)!!
         assertTrue(unclaimed.contains("does not pin the decoder"))
         assertTrue(
-            ModelLanguageSupport.restriction(dolphin, true, onDevice = true)!!
+            ModelLanguageSupport.restriction(dolphin, true, canTranslate = false, onDevice = true)!!
                 .contains("The on-device model"),
         )
     }

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/ModelTranslationSupportTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/ModelTranslationSupportTest.kt
@@ -184,4 +184,65 @@ class ModelTranslationSupportTest {
         // A gateway has no translation field at all.
         assertEquals("", onCanary.copy(localTranscriptionEnabled = false).translationTarget)
     }
+
+    @Test
+    fun `canary on automatic is labelled as needing a spoken language`() {
+        assertEquals(
+            "German · set Language first",
+            ModelTranslationSupport.summary(
+                TranscriptionLanguage.GERMAN,
+                canary,
+                needsExplicitSource = true,
+                sourceIsAutomatic = true,
+            ),
+        )
+        assertEquals(
+            "German",
+            ModelTranslationSupport.summary(
+                TranscriptionLanguage.GERMAN,
+                canary,
+                needsExplicitSource = true,
+                sourceIsAutomatic = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `translation search does not find don't translate by typing automatic`() {
+        assertFalse(
+            ModelTranslationSupport.matchesQuery(
+                "automatic",
+                ModelTranslationSupport.OFF,
+                translating = true,
+            ),
+        )
+        assertFalse(
+            ModelTranslationSupport.matchesQuery(
+                "auto",
+                ModelTranslationSupport.OFF,
+                translating = true,
+            ),
+        )
+        assertTrue(
+            ModelTranslationSupport.matchesQuery(
+                "don't",
+                ModelTranslationSupport.OFF,
+                translating = true,
+            ),
+        )
+        assertTrue(
+            ModelTranslationSupport.matchesQuery(
+                "off",
+                ModelTranslationSupport.OFF,
+                translating = true,
+            ),
+        )
+        assertTrue(
+            ModelTranslationSupport.matchesQuery(
+                "auto",
+                TranscriptionLanguage.AUTOMATIC,
+                translating = false,
+            ),
+        )
+    }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/CaseCycleTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/CaseCycleTest.kt
@@ -1,6 +1,8 @@
 package com.vocahq.vocaphone.ime
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CaseCycleTest {
@@ -53,5 +55,30 @@ class CaseCycleTest {
     fun `text with no letters is left alone`() {
         assertEquals("123", CaseCycle.next("123"))
         assertEquals("", CaseCycle.next(""))
+    }
+
+    @Test
+    fun `a composing span must restore the selection after finish`() {
+        val plan = planCaseCycle(
+            selected = "hello",
+            original = "hello",
+            start = 4,
+            composingActive = true,
+        )!!
+        assertEquals("Hello", plan.next)
+        assertEquals(4, plan.start)
+        assertEquals(9, plan.end)
+        assertTrue(plan.restoreSelectionAfterFinish)
+    }
+
+    @Test
+    fun `no composing span does not finish composing first`() {
+        val plan = planCaseCycle(
+            selected = "hello",
+            original = "hello",
+            start = 0,
+            composingActive = false,
+        )!!
+        assertFalse(plan.restoreSelectionAfterFinish)
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardReducerTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardReducerTest.kt
@@ -32,12 +32,25 @@ class KeyboardReducerTest {
     }
 
     @Test
+    fun `shift without a selection still notifies the service`() {
+        val result = KeyboardReducer.press(
+            KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF),
+            shiftKey(),
+            nowMillis = 1_000,
+        )
+
+        assertEquals(KeyboardCommand.ShiftTap, result.command)
+        assertEquals(ShiftState.ONCE, result.state.shift)
+    }
+
+    @Test
     fun `double tapping shift enables caps lock`() {
         val first = KeyboardReducer.press(
             KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF),
             shiftKey(),
             nowMillis = 1_000,
         )
+        assertEquals(KeyboardCommand.ShiftTap, first.command)
         val second = KeyboardReducer.press(first.state, shiftKey(), nowMillis = 1_250)
         val letter = KeyboardReducer.press(second.state, character("p"), nowMillis = 1_300)
 

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/LocalEnginePolicyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/LocalEnginePolicyTest.kt
@@ -146,6 +146,9 @@ class LocalEnginePolicyTest {
         assertEquals("", canary.resolveTranslationTarget("hi"))
         assertEquals("", canary.resolveTranslationTarget(""))
         assertEquals("", parakeet.resolveTranslationTarget("ru"))
+        // Named Automatic is English-as-source, not a translation.
+        assertEquals("", canary.resolveTranslationTarget("de", spokenLanguage = "auto"))
+        assertEquals("de", canary.resolveTranslationTarget("de", spokenLanguage = "de"))
     }
 
     @Test

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -456,7 +456,10 @@ struct DictationSettingsView: View {
                     value: ModelTranslationSupport.summary(
                         storedTranslateTo,
                         targets: KeyboardPreferences.activeModelTranslationTargets,
-                        onDevice: LocalTranscriptionPreferences.enabled
+                        onDevice: LocalTranscriptionPreferences.enabled,
+                        needsExplicitSource: KeyboardPreferences.activeModelTranslationNeedsSource,
+                        sourceIsAutomatic: KeyboardPreferences.effectiveTranscriptionLanguage
+                            == .automatic
                     )
                 )
             }
@@ -1121,9 +1124,7 @@ struct TranscriptionLanguageList: View {
     // Searched against the label actually on the row: "Don't translate" is not
     // findable by typing "automatic", and should not be.
     private func matches(_ language: TranscriptionLanguage) -> Bool {
-        query.isEmpty
-            || label(language).localizedCaseInsensitiveContains(query)
-            || language.rawValue.localizedCaseInsensitiveContains(query)
+        ModelTranslationSupport.matchesQuery(query, language: language, translating: translating)
     }
 
     private func isSelectable(_ language: TranscriptionLanguage) -> Bool {

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -1153,8 +1153,8 @@ struct TranscriptionLanguageList: View {
             : ModelLanguageSupport.restriction(
                 modelLanguages: modelLanguages,
                 detectsLanguageAutomatically: detectsLanguage,
-                onDevice: LocalTranscriptionPreferences.enabled,
-                canTranslate: ModelTranslationSupport.isSupported(translationTargets)
+                canTranslate: ModelTranslationSupport.isSupported(translationTargets),
+                onDevice: LocalTranscriptionPreferences.enabled
             )
     }
 

--- a/ios/VocaPhoneShared/LocalModelCatalog.swift
+++ b/ios/VocaPhoneShared/LocalModelCatalog.swift
@@ -217,7 +217,7 @@ struct LocalModelDescriptor: Identifiable, Codable, Sendable, Equatable {
     /// `LocalModelCatalog.kt`; see `ModelTranslationSupport`.
     var translationTargets: Set<String> {
         if sherpaFamily == .canary { return languageCodes }
-        if englishOnly { return [] }
+        if englishOnly || id.contains("distil") { return [] }
         return engine == .whisperKit ? ["en"] : []
     }
 
@@ -230,10 +230,16 @@ struct LocalModelDescriptor: Identifiable, Codable, Sendable, Equatable {
     /// still stored after a switch to Parakeet — reaching an engine that would
     /// misread it or forcing a rebuild of one that would ignore it.
     var resolvedTranslationTarget: String {
-        ModelTranslationSupport.target(
+        let target = ModelTranslationSupport.target(
             KeyboardPreferences.translateTo,
             targets: translationTargets
         )
+        if translationNeedsExplicitSource,
+           KeyboardPreferences.effectiveTranscriptionLanguage == .automatic
+        {
+            return ""
+        }
+        return target
     }
 
     /// Whether translating needs the spoken language named explicitly.

--- a/ios/VocaPhoneShared/ModelLanguageSupport.swift
+++ b/ios/VocaPhoneShared/ModelLanguageSupport.swift
@@ -89,8 +89,8 @@ enum ModelLanguageSupport {
     static func restriction(
         modelLanguages: Set<String>,
         detectsLanguageAutomatically: Bool,
-        onDevice: Bool = false,
-        canTranslate: Bool = false
+        canTranslate: Bool,
+        onDevice: Bool = false
     ) -> String? {
         let owner = onDevice ? "The on-device model" : "Your gateway's model"
         var coverage: String?

--- a/ios/VocaPhoneShared/ModelTranslationSupport.swift
+++ b/ios/VocaPhoneShared/ModelTranslationSupport.swift
@@ -82,13 +82,39 @@ enum ModelTranslationSupport {
     static func summary(
         _ selected: TranscriptionLanguage,
         targets: Set<String>,
-        onDevice: Bool = true
+        onDevice: Bool = true,
+        needsExplicitSource: Bool = false,
+        sourceIsAutomatic: Bool = false
     ) -> String {
         guard isSupported(targets) else {
             return onDevice ? "Not supported by this model" : "Needs an on-device model"
         }
         let resolved = resolve(selected, targets: targets)
-        return resolved == off ? "Off" : resolved.displayName
+        if resolved == off { return "Off" }
+        if needsExplicitSource && sourceIsAutomatic {
+            return "\(resolved.displayName) · set Language first"
+        }
+        return resolved.displayName
+    }
+
+    /// Whether a language row matches the search field.
+    ///
+    /// In translation mode the off row is labelled "Don't translate", not
+    /// "Automatic". Matching `.automatic`'s raw value (`"auto"`) made that
+    /// row show up for the one word that describes the opposite of what it
+    /// does.
+    static func matchesQuery(
+        _ query: String,
+        language: TranscriptionLanguage,
+        translating: Bool
+    ) -> Bool {
+        if query.isEmpty { return true }
+        let rowLabel = translating && language == off ? offLabel : language.displayName
+        if rowLabel.localizedCaseInsensitiveContains(query) { return true }
+        if translating && language == off {
+            return "off".localizedCaseInsensitiveContains(query)
+        }
+        return language.rawValue.localizedCaseInsensitiveContains(query)
     }
 
     /// Why the picker is limited, or nil when it is not.

--- a/ios/VocaPhoneTests/ModelLanguageSupportTests.swift
+++ b/ios/VocaPhoneTests/ModelLanguageSupportTests.swift
@@ -44,11 +44,11 @@ struct ModelLanguageSupportTests {
 
     @Test func aCoverageLimitIsSpelledOutWheneverThereIsOne() {
         let unclaimed = ModelLanguageSupport.restriction(
-            modelLanguages: [], detectsLanguageAutomatically: false
+            modelLanguages: [], detectsLanguageAutomatically: false, canTranslate: false
         )
         #expect(unclaimed?.contains("covers") == false)
         let limited = ModelLanguageSupport.restriction(
-            modelLanguages: dolphin, detectsLanguageAutomatically: false
+            modelLanguages: dolphin, detectsLanguageAutomatically: false, canTranslate: false
         )
         #expect(limited?.contains("\(dolphin.count) languages") == true)
     }
@@ -61,7 +61,7 @@ struct ModelLanguageSupportTests {
     @Test func everyModelSaysTheLanguageRowIsNotATranslationSetting() {
         for detects in [false, true] {
             let sentence = ModelLanguageSupport.restriction(
-                modelLanguages: [], detectsLanguageAutomatically: detects
+                modelLanguages: [], detectsLanguageAutomatically: detects, canTranslate: false
             )
             #expect(sentence?.contains("not the language you want back") == true)
             #expect(sentence?.contains("cannot translate") == true)
@@ -69,8 +69,8 @@ struct ModelLanguageSupportTests {
         let canary = ModelLanguageSupport.restriction(
             modelLanguages: ["en", "de", "es", "fr"],
             detectsLanguageAutomatically: false,
-            onDevice: true,
-            canTranslate: true
+            canTranslate: true,
+            onDevice: true
         )
         #expect(canary?.contains("use Translate to") == true)
         #expect(canary?.contains("cannot translate") == false)
@@ -107,17 +107,20 @@ struct ModelLanguageSupportTests {
     /// picker starts lying about what the model does.
     @Test func anAutoDetectingModelSaysWhatPickingALanguageDoes() {
         let detected = ModelLanguageSupport.restriction(
-            modelLanguages: dolphin, detectsLanguageAutomatically: true
+            modelLanguages: dolphin, detectsLanguageAutomatically: true, canTranslate: false
         )
         #expect(detected?.contains("\(dolphin.count) languages") == true)
         #expect(detected?.contains("does not pin the decoder") == true)
         #expect(detected?.contains("punctuated") == true)
         let unclaimed = ModelLanguageSupport.restriction(
-            modelLanguages: [], detectsLanguageAutomatically: true
+            modelLanguages: [], detectsLanguageAutomatically: true, canTranslate: false
         )
         #expect(unclaimed?.contains("does not pin the decoder") == true)
         let local = ModelLanguageSupport.restriction(
-            modelLanguages: dolphin, detectsLanguageAutomatically: true, onDevice: true
+            modelLanguages: dolphin,
+            detectsLanguageAutomatically: true,
+            canTranslate: false,
+            onDevice: true
         )
         #expect(local?.contains("The on-device model") == true)
     }

--- a/ios/VocaPhoneTests/ModelTranslationSupportTests.swift
+++ b/ios/VocaPhoneTests/ModelTranslationSupportTests.swift
@@ -24,6 +24,10 @@ struct ModelTranslationSupportTests {
         // v3 is the one people expect to translate because it is multilingual.
         #expect(try targets("parakeet-tdt-0.6b-v3").isEmpty)
         #expect(try targets("sense-voice").isEmpty)
+        // Distil-whisper is an English-only distillation; the catalog still
+        // says "100 languages", but it has no translate task.
+        #expect(try targets("distil-whisper_distil-large-v3").isEmpty)
+        #expect(try targets("distil-whisper_distil-large-v3_turbo").isEmpty)
     }
 
     @Test func offIsAlwaysSelectableAndATargetOnlyWhereTrained() {
@@ -119,6 +123,56 @@ struct ModelTranslationSupportTests {
         #expect(try needsSource("canary-180m-flash"))
         #expect(try !needsSource("openai_whisper-small"))
         #expect(try !needsSource("parakeet-tdt-0.6b-v3"))
+    }
+
+    @Test func canaryOnAutomaticIsLabelledAsNeedingASpokenLanguage() {
+        #expect(
+            ModelTranslationSupport.summary(
+                .german,
+                targets: canary,
+                needsExplicitSource: true,
+                sourceIsAutomatic: true
+            ) == "German · set Language first"
+        )
+        #expect(
+            ModelTranslationSupport.summary(
+                .german,
+                targets: canary,
+                needsExplicitSource: true,
+                sourceIsAutomatic: false
+            ) == "German"
+        )
+    }
+
+    @Test func translationSearchDoesNotFindDontTranslateByTypingAutomatic() {
+        #expect(
+            !ModelTranslationSupport.matchesQuery(
+                "automatic",
+                language: ModelTranslationSupport.off,
+                translating: true
+            )
+        )
+        #expect(
+            !ModelTranslationSupport.matchesQuery(
+                "auto",
+                language: ModelTranslationSupport.off,
+                translating: true
+            )
+        )
+        #expect(
+            ModelTranslationSupport.matchesQuery(
+                "don't",
+                language: ModelTranslationSupport.off,
+                translating: true
+            )
+        )
+        #expect(
+            ModelTranslationSupport.matchesQuery(
+                "off",
+                language: ModelTranslationSupport.off,
+                translating: true
+            )
+        )
     }
 
     /// Both clients must reach the same verdict, or the keyboard and the app


### PR DESCRIPTION
## Summary

Follow-up to #186 (now on `main`).

- Canary is warmed with the translation target. `warm()` was preparing it as transcribe (`tgtLang == srcLang`) at the start of every dictation, then `transcribe` rebuilt it on Finish.
- `ModelLanguageSupport.restriction(canTranslate)` is required. The IME language panel now passes it, so Canary and multilingual Whisper no longer claim they cannot translate.
- Distil-whisper is out of `translationTargets`. Those catalog entries still say "100 languages" with `englishOnly: false`; they have no translate task.
- Translate-to search no longer matches `"auto"` for Don't translate. `"off"` and `"don't"` still find it.
- Canary left on Automatic: the Translate to row reads `German · set Language first`, and the engine does not send a target until Language is an explicit code.
- Shift on a selection cycles Title / UPPER / lower / original again. After letters started going out as composing text, `finishComposingText` dropped the highlight before the selected string was read. The range is captured first and put back.

## Verification

- [x] `just ios ci` — N/A (Linux host; iOS files updated in lockstep, not compiled here)
- [x] Android unit tests: `ModelLanguageSupportTest`, `ModelTranslationSupportTest`, `LocalEnginePolicyTest`, `CaseCycleTest`, `KeyboardReducerTest`
- [ ] Gateway changes: N/A
- [ ] Physical-device test for shift-on-selection: not re-run on the phone this turn. Please select a word in a field and tap Shift (Title → UPPER → lower → original). That path broke after the 120 Hz composing change.

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] No data-flow / permission / network documentation change
