### PR TITLE
fix(android): long-press symbol no longer keeps the number

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -508,20 +508,23 @@ internal object KeyboardReducer {
 
     /**
      * Reverses the character committed on pointer down when the gesture turns
-     * into a swipe, or when a long-press replaces it with an accent.
+     * into a swipe, or when a long-press replaces it with an accent or symbol.
      *
      * Letters go out on down so the glyph is on screen inside the 8.3 ms
      * 120 Hz budget (keyboard hot-path benchmark on a 120 Hz phone). A swipe
      * that started on "l" after "he" must then drop only that "l", not the
      * whole composing word, or the user loses "he" as well.
+     *
+     * Digits and punctuation skip composing ([characterPress] uses
+     * [KeyboardCommand.CommitText]), so a hold on `2` for `@` has to delete
+     * that committed `2` instead of no-op'ing on empty composing.
      */
     fun undoLastCharacter(
         state: KeyboardState,
         composeWords: Boolean,
         restoreShift: ShiftState? = null,
     ): KeyboardReduction {
-        if (composeWords) {
-            if (state.composing.isEmpty()) return KeyboardReduction(state)
+        if (composeWords && state.composing.isNotEmpty()) {
             val next = state.composing.dropLast(1)
             return KeyboardReduction(
                 state = state.copy(

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -103,7 +103,7 @@ enum class KeyboardHeight(
 
     companion object {
         fun fromStored(value: String?): KeyboardHeight =
-            entries.firstOrNull { it.storedValue == value } ?: COMPACT
+            entries.firstOrNull { it.storedValue == value } ?: DEFAULT
     }
 }
 
@@ -221,7 +221,7 @@ data class VocaPhoneSettings(
      */
     val syncWhisperDictionary: Boolean = true,
     val numberRowEnabled: Boolean = true,
-    val keyboardHeight: KeyboardHeight = KeyboardHeight.COMPACT,
+    val keyboardHeight: KeyboardHeight = KeyboardHeight.DEFAULT,
     val splitKeyboard: SplitKeyboard = SplitKeyboard.DEFAULT,
     val suggestionsEnabled: Boolean = true,
     val correctionsEnabled: Boolean = true,

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardReducerTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardReducerTest.kt
@@ -193,14 +193,26 @@ class KeyboardReducerTest {
     }
 
     @Test
-    fun `undo is a no-op when composing is already empty`() {
-        val undo = KeyboardReducer.undoLastCharacter(
-            KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF),
+    fun `undo of a committed digit deletes backward`() {
+        val typed = KeyboardReducer.press(
+            KeyboardState(KeyboardLayer.NUMBERS, ShiftState.OFF),
+            character("2"),
+            nowMillis = 1_000,
             composeWords = true,
         )
+        assertEquals(KeyboardCommand.CommitText("2"), typed.command)
+        assertEquals("", typed.state.composing)
 
-        assertNull(undo.command)
-        assertEquals("", undo.state.composing)
+        val undo = KeyboardReducer.undoLastCharacter(typed.state, composeWords = true)
+        assertEquals(KeyboardCommand.DeleteBackward, undo.command)
+
+        val symbol = KeyboardReducer.press(
+            undo.state,
+            character("@"),
+            nowMillis = 1_400,
+            composeWords = true,
+        )
+        assertEquals(KeyboardCommand.CommitText("@"), symbol.command)
     }
 
     @Test

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/SettingsChoiceTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/SettingsChoiceTest.kt
@@ -5,7 +5,9 @@ import com.vocahq.vocaphone.core.MicrophonePreference
 import com.vocahq.vocaphone.core.TranscriptStyler
 import com.vocahq.vocaphone.core.WritingStyle
 import com.vocahq.vocaphone.settings.AudioRetention
+import com.vocahq.vocaphone.settings.KeyboardHeight
 import com.vocahq.vocaphone.settings.ModelIdleTimeout
+import com.vocahq.vocaphone.settings.VocaPhoneSettings
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -51,6 +53,9 @@ class SettingsChoiceTest {
         assertEquals(AudioRetention.SIX_HOURS, AudioRetention.DEFAULT)
         assertEquals(3, AudioRetention.entries.size)
         assertEquals(5, MicrophonePreference.entries.size)
+        assertEquals(KeyboardHeight.DEFAULT, KeyboardHeight.fromStored(null))
+        assertEquals(KeyboardHeight.DEFAULT, VocaPhoneSettings().keyboardHeight)
+        assertEquals(48, KeyboardHeight.DEFAULT.keyHeightDp)
     }
 
     @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Long-press on a number key was typing the number and then the symbol. Hold 2 and you got `2@` instead of `@`. Digits commit on pointer down (they are not composing text), and the hold undo treated empty composing as nothing to do. Undo now deletes that committed character before the symbol is inserted.

Also, a fresh install was landing on Compact height. The Default step is 48 dp and that is what we meant to ship. Anyone who already chose Compact keeps Compact.

## Verification

- [ ] `just ios ci` — N/A. Linux host, no iOS files changed.
- [x] Android unit tests: `./gradlew testFullDebugUnitTest` (531 tests, 0 failures). Includes `undo of a committed digit deletes backward` and the Default height fallback. Full `just android ci` (assemble, lint, 16 KB page check) was not run here; Quality (Android) on this PR covers that.
- [ ] Gateway changes: N/A, pin unchanged
- [ ] Physical-device test: IME long-press cannot run here. On a phone: enable the number row, long-press 2, confirm only `@` is inserted. Clear the height preference (or a fresh install) and check Settings → Keyboard shows Default.

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation: N/A, no data-flow, permission, retention, or network change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-124e6190-0e69-420e-8014-83d65992e0e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-124e6190-0e69-420e-8014-83d65992e0e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

