### PR TITLE
fix(android): make app layouts responsive

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/AboutPage.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/AboutPage.kt
@@ -5,12 +5,12 @@ import android.content.ClipboardManager
 import android.content.Context
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -128,18 +129,38 @@ fun AboutPage(
                 onClick = { context.openHttpUrl(NEW_ISSUE_URL) },
                 filled = true,
             )
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                ABOUT_CONTACT_LINKS.forEach { link ->
-                    val icon = link.icon ?: return@forEach
-                    ContactColumnButton(
-                        label = link.label,
-                        icon = icon,
-                        onClick = { context.openHttpUrl(link.url) },
-                        modifier = Modifier.weight(1f),
-                    )
+            BoxWithConstraints(Modifier.fillMaxWidth()) {
+                val stacked = AdaptiveLayout.stackActions(
+                    maxWidth.value,
+                    LocalDensity.current.fontScale,
+                )
+                if (stacked) {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        ABOUT_CONTACT_LINKS.forEach { link ->
+                            val icon = link.icon ?: return@forEach
+                            ContactColumnButton(
+                                label = link.label,
+                                icon = icon,
+                                onClick = { context.openHttpUrl(link.url) },
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                    }
+                } else {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        ABOUT_CONTACT_LINKS.forEach { link ->
+                            val icon = link.icon ?: return@forEach
+                            ContactColumnButton(
+                                label = link.label,
+                                icon = icon,
+                                onClick = { context.openHttpUrl(link.url) },
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -209,11 +230,8 @@ fun AboutPage(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            SecondaryButton(
+        ResponsiveActionRow(
+            leading = { item -> SecondaryButton(
                 text = ABOUT_COPY_DIAGNOSTICS,
                 onClick = {
                     context.copyDiagnostics(
@@ -226,14 +244,14 @@ fun AboutPage(
                         ),
                     )
                 },
-                modifier = Modifier.weight(1f),
-            )
-            DestructiveButton(
+                modifier = item,
+            ) },
+            trailing = { item -> DestructiveButton(
                 text = ABOUT_CLEAR_EVENT_LOG,
                 onClick = onClearDiagnosticEvents,
-                modifier = Modifier.weight(1f),
-            )
-        }
+                modifier = item,
+            ) },
+        )
     }
 }
 
@@ -273,7 +291,7 @@ private fun ContactColumnButton(
     }
 }
 
-/** 48 dp, icon plus verb, matching the rest of the app's button height. */
+/** At least 48 dp, growing when enlarged text needs another line. */
 @Composable
 private fun AboutActionButton(
     label: String,
@@ -283,7 +301,7 @@ private fun AboutActionButton(
 ) {
     val modifier = Modifier
         .fillMaxWidth()
-        .height(48.dp)
+        .heightIn(min = 48.dp)
     val content: @Composable () -> Unit = {
         Icon(
             painter = painterResource(icon),

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/Components.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/Components.kt
@@ -3,13 +3,14 @@ package com.vocahq.vocaphone.ui
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -44,6 +45,7 @@ import androidx.annotation.DrawableRes
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
@@ -66,6 +68,28 @@ import com.vocahq.vocaphone.R
  */
 private val ButtonHeight = 48.dp
 
+/**
+ * Width decisions use the space a composable actually receives, not the device
+ * model or a global screen bucket. Dividing by font scale makes the same layout
+ * fold earlier when accessibility text needs more room.
+ */
+internal object AdaptiveLayout {
+    private fun effectiveWidth(widthDp: Float, fontScale: Float): Float =
+        widthDp / fontScale.coerceAtLeast(1f)
+
+    fun stackActions(widthDp: Float, fontScale: Float): Boolean =
+        effectiveWidth(widthDp, fontScale) < 360f
+
+    fun stackChecklistAction(widthDp: Float, fontScale: Float): Boolean =
+        effectiveWidth(widthDp, fontScale) < 400f
+
+    fun stackInfo(widthDp: Float, fontScale: Float): Boolean =
+        effectiveWidth(widthDp, fontScale) < 320f
+
+    fun modelGridColumns(widthDp: Float, fontScale: Float): Int =
+        if (effectiveWidth(widthDp, fontScale) < 400f) 1 else 2
+}
+
 @Composable
 fun PrimaryButton(
     text: String,
@@ -77,7 +101,7 @@ fun PrimaryButton(
     Button(
         onClick = onClick,
         enabled = enabled && !loading,
-        modifier = modifier.height(ButtonHeight),
+        modifier = modifier.heightIn(min = ButtonHeight),
     ) {
         ButtonLabel(text, loading)
     }
@@ -94,7 +118,7 @@ fun SecondaryButton(
     FilledTonalButton(
         onClick = onClick,
         enabled = enabled && !loading,
-        modifier = modifier.height(ButtonHeight),
+        modifier = modifier.heightIn(min = ButtonHeight),
     ) {
         ButtonLabel(text, loading)
     }
@@ -110,7 +134,7 @@ fun DestructiveButton(
     FilledTonalButton(
         onClick = onClick,
         enabled = enabled,
-        modifier = modifier.height(ButtonHeight),
+        modifier = modifier.heightIn(min = ButtonHeight),
         colors = ButtonDefaults.filledTonalButtonColors(
             containerColor = MaterialTheme.colorScheme.errorContainer,
             contentColor = MaterialTheme.colorScheme.onErrorContainer,
@@ -148,24 +172,67 @@ private fun ButtonLabel(text: String, loading: Boolean) {
     }
 }
 
-/** A label and its value on one line, for the About section. */
+/** A label and its value, stacked when narrow or enlarged text needs the room. */
 @Composable
 fun InfoRow(label: String, value: String, modifier: Modifier = Modifier) {
-    Row(
-        modifier = modifier.fillMaxWidth().padding(vertical = 2.dp),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        Text(
-            label,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Text(
-            value,
-            style = MaterialTheme.typography.bodyMedium,
-            textAlign = TextAlign.End,
-            modifier = Modifier.weight(1f),
-        )
+    BoxWithConstraints(modifier.fillMaxWidth().padding(vertical = 2.dp)) {
+        val stacked = AdaptiveLayout.stackInfo(maxWidth.value, LocalDensity.current.fontScale)
+        if (stacked) {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                InfoLabel(label)
+                Text(value, style = MaterialTheme.typography.bodyMedium)
+            }
+        } else {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                InfoLabel(label)
+                Text(
+                    value,
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.End,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun InfoLabel(label: String) {
+    Text(
+        label,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+/** Two actions share a row until either the available width or text scale says otherwise. */
+@Composable
+fun ResponsiveActionRow(
+    leading: @Composable (Modifier) -> Unit,
+    trailing: @Composable (Modifier) -> Unit,
+    modifier: Modifier = Modifier,
+    leadingWeight: Float = 1f,
+    trailingWeight: Float = 1f,
+) {
+    BoxWithConstraints(modifier.fillMaxWidth()) {
+        val stacked = AdaptiveLayout.stackActions(maxWidth.value, LocalDensity.current.fontScale)
+        if (stacked) {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                leading(Modifier.fillMaxWidth())
+                trailing(Modifier.fillMaxWidth())
+            }
+        } else {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                leading(Modifier.weight(leadingWeight))
+                trailing(Modifier.weight(trailingWeight))
+            }
+        }
     }
 }
 
@@ -210,6 +277,9 @@ val SectionSpacing = 28.dp
 
 /** The gap between page-level [SettingsCategory] blocks. */
 val CategorySpacing = 36.dp
+
+/** Keeps app pages readable on unfolded foldables and wide landscape phones. */
+val AppContentMaxWidth = 720.dp
 
 /**
  * A page-level heading. Settings used to be a flat stack of identically
@@ -322,8 +392,6 @@ fun SettingsMenuRow(
                 supporting,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
             )
         }
         Icon(
@@ -412,10 +480,47 @@ fun ChecklistRow(
     modifier: Modifier = Modifier,
     actionColor: Color = MaterialTheme.colorScheme.primary,
 ) {
-    Row(
-        modifier = modifier.fillMaxWidth().padding(vertical = 6.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
+    BoxWithConstraints(modifier.fillMaxWidth().padding(vertical = 6.dp)) {
+        val stacked = !satisfied && AdaptiveLayout.stackChecklistAction(
+            maxWidth.value,
+            LocalDensity.current.fontScale,
+        )
+        if (stacked) {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                ChecklistContent(title = title, detail = detail, satisfied = false)
+                TextButton(
+                    onClick = onAction,
+                    modifier = Modifier.align(Alignment.End),
+                    colors = ButtonDefaults.textButtonColors(contentColor = actionColor),
+                ) { Text(actionLabel) }
+            }
+        } else {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                ChecklistContent(
+                    title = title,
+                    detail = detail,
+                    satisfied = satisfied,
+                    modifier = Modifier.weight(1f),
+                )
+                if (!satisfied) {
+                    TextButton(
+                        onClick = onAction,
+                        colors = ButtonDefaults.textButtonColors(contentColor = actionColor),
+                    ) { Text(actionLabel) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChecklistContent(
+    title: String,
+    detail: String,
+    satisfied: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
         Icon(
             painter = painterResource(
                 if (satisfied) R.drawable.ic_step_done else R.drawable.ic_step_pending
@@ -436,14 +541,6 @@ fun ChecklistRow(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-        }
-        if (!satisfied) {
-            TextButton(
-                onClick = onAction,
-                colors = ButtonDefaults.textButtonColors(
-                    contentColor = actionColor,
-                ),
-            ) { Text(actionLabel) }
         }
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/DictateScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/DictateScreen.kt
@@ -3,12 +3,18 @@ package com.vocahq.vocaphone.ui
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.FilledTonalIconButton
@@ -113,131 +119,150 @@ fun DictateScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
+            .wrapContentWidth(Alignment.CenterHorizontally)
+            .widthIn(max = AppContentMaxWidth)
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        // One row. FlowRow dropped the model chip onto a second line as soon as
-        // the name got longer than "Moonshine Tiny" (Parakeet TDT 0.6B). Language
-        // and style hug; the model takes what is left and ellipsizes. VoiceOver
-        // still reads the full labels.
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            DictateAssistChip(
-                icon = R.drawable.ic_language,
-                label = settings.effectiveLanguage.displayName,
-                contentDescription = "${DictateCopy.LANGUAGE}, ${settings.effectiveLanguage.displayName}",
-                onClick = onOpenLanguage,
-            )
-            DictateAssistChip(
-                icon = R.drawable.ic_style,
-                label = settings.style.displayName,
-                contentDescription = "${DictateCopy.STYLE}, ${settings.style.displayName}",
-                onClick = onOpenStyle,
-            )
-            val modelLabel = dictateModelChipLabel(settings)
-            DictateAssistChip(
-                icon = if (settings.localTranscriptionEnabled) {
-                    R.drawable.ic_models
-                } else {
-                    R.drawable.ic_connection
-                },
-                label = compactModelChipLabel(modelLabel),
-                contentDescription = "${DictateCopy.MODEL}, $modelLabel",
-                onClick = onOpenModel,
-                modifier = Modifier.weight(1f, fill = false),
-            )
-        }
-
-        if (showDictateStatus(state.phase) || state.isRecording || state.phase == DictationPhase.FAILED) {
-            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                if (showDictateStatus(state.phase)) {
-                    Text(state.statusText, style = MaterialTheme.typography.bodyLarge)
-                }
-                if (state.isRecording) {
-                    LinearProgressIndicator(
-                        progress = { state.level.coerceIn(0f, 1f) },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    Text(
-                        "${state.recordedMillis / 1000}s" +
-                            (state.inputRouteLabel?.let { " · $it" } ?: "") +
-                            (if (state.streaming) " · streaming" else " · batch upload"),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    if (state.approachingLimit) {
-                        Text(
-                            "One minute left before the five-minute limit stops this recording.",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.error,
-                        )
-                    }
-                    if (state.partialTranscript.isNotEmpty()) {
-                        Text(
-                            state.partialTranscript,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-                if (state.phase == DictationPhase.FAILED) {
-                    Text(
-                        state.failure?.message.orEmpty(),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.error,
-                    )
-                }
-            }
-        }
-
-        SetupRepair(
-            status = setup,
-            onOpenGateway = onOpenGateway,
-        )
-
-        val fieldColors = TextFieldDefaults.colors(
-            focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-            disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-            focusedIndicatorColor = Color.Transparent,
-            unfocusedIndicatorColor = Color.Transparent,
-            disabledIndicatorColor = Color.Transparent,
-        )
-        Box(
+        BoxWithConstraints(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f),
         ) {
-            TextField(
-                value = scratchpad,
-                onValueChange = { scratchpad = it },
-                modifier = Modifier.fillMaxSize(),
-                placeholder = if (showScratchpadHint(scratchpad.text, state.phase)) {
-                    {
-                        Text(
-                            DictateCopy.HINT,
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                    }
-                } else {
-                    null
-                },
-                shape = MaterialTheme.shapes.large,
-                colors = fieldColors,
-            )
-            if (scratchpad.text.isNotEmpty()) {
-                FilledTonalIconButton(
-                    onClick = { scratchpad = TextFieldValue() },
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = 12.dp),
+            // Keep the scratchpad large on an ordinary phone, but let the whole
+            // content region scroll when landscape, setup repair, status text,
+            // or accessibility text would otherwise push actions off-screen.
+            val scratchpadHeight = (maxHeight - 64.dp).coerceAtLeast(180.dp)
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_delete),
-                        contentDescription = DictateCopy.CLEAR,
+                    DictateAssistChip(
+                        icon = R.drawable.ic_language,
+                        label = settings.effectiveLanguage.displayName,
+                        contentDescription = "${DictateCopy.LANGUAGE}, ${settings.effectiveLanguage.displayName}",
+                        onClick = onOpenLanguage,
                     )
+                    DictateAssistChip(
+                        icon = R.drawable.ic_style,
+                        label = settings.style.displayName,
+                        contentDescription = "${DictateCopy.STYLE}, ${settings.style.displayName}",
+                        onClick = onOpenStyle,
+                    )
+                    val modelLabel = dictateModelChipLabel(settings)
+                    DictateAssistChip(
+                        icon = if (settings.localTranscriptionEnabled) {
+                            R.drawable.ic_models
+                        } else {
+                            R.drawable.ic_connection
+                        },
+                        label = compactModelChipLabel(modelLabel),
+                        contentDescription = "${DictateCopy.MODEL}, $modelLabel",
+                        onClick = onOpenModel,
+                    )
+                }
+
+                if (
+                    showDictateStatus(state.phase) ||
+                    state.isRecording ||
+                    state.phase == DictationPhase.FAILED
+                ) {
+                    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        if (showDictateStatus(state.phase)) {
+                            Text(state.statusText, style = MaterialTheme.typography.bodyLarge)
+                        }
+                        if (state.isRecording) {
+                            LinearProgressIndicator(
+                                progress = { state.level.coerceIn(0f, 1f) },
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                            Text(
+                                "${state.recordedMillis / 1000}s" +
+                                    (state.inputRouteLabel?.let { " · $it" } ?: "") +
+                                    (if (state.streaming) " · streaming" else " · batch upload"),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            if (state.approachingLimit) {
+                                Text(
+                                    "One minute left before the five-minute limit stops this recording.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.error,
+                                )
+                            }
+                            if (state.partialTranscript.isNotEmpty()) {
+                                Text(
+                                    state.partialTranscript,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                        if (state.phase == DictationPhase.FAILED) {
+                            Text(
+                                state.failure?.message.orEmpty(),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                    }
+                }
+
+                SetupRepair(
+                    status = setup,
+                    onOpenGateway = onOpenGateway,
+                )
+
+                val fieldColors = TextFieldDefaults.colors(
+                    focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                    unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                    disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    disabledIndicatorColor = Color.Transparent,
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(scratchpadHeight),
+                ) {
+                    TextField(
+                        value = scratchpad,
+                        onValueChange = { scratchpad = it },
+                        modifier = Modifier.fillMaxSize(),
+                        placeholder = if (showScratchpadHint(scratchpad.text, state.phase)) {
+                            {
+                                Text(
+                                    DictateCopy.HINT,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                            }
+                        } else {
+                            null
+                        },
+                        shape = MaterialTheme.shapes.large,
+                        colors = fieldColors,
+                    )
+                    if (scratchpad.text.isNotEmpty()) {
+                        FilledTonalIconButton(
+                            onClick = { scratchpad = TextFieldValue() },
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .padding(bottom = 12.dp),
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_delete),
+                                contentDescription = DictateCopy.CLEAR,
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -265,29 +290,27 @@ private fun DictateActionRow(
     onDismiss: () -> Unit,
 ) {
     when {
-        state.isRecording -> Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            SecondaryButton("Cancel", onClick = onCancel, modifier = Modifier.weight(1f))
-            PrimaryButton("Finish", onClick = onFinish, modifier = Modifier.weight(2f))
-        }
+        state.isRecording -> ResponsiveActionRow(
+            leading = { item -> SecondaryButton("Cancel", onClick = onCancel, modifier = item) },
+            trailing = { item -> PrimaryButton("Finish", onClick = onFinish, modifier = item) },
+            trailingWeight = 2f,
+        )
         state.phase.isBusy -> SecondaryButton(
             "Cancel",
             onClick = onCancel,
             modifier = Modifier.fillMaxWidth(),
         )
-        state.canRetry -> Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            SecondaryButton("Dismiss", onClick = onDismiss, modifier = Modifier.weight(1f))
-            PrimaryButton(
-                text = "Retry",
-                onClick = { state.sessionId?.let { onRetry(it.toString()) } },
-                modifier = Modifier.weight(2f),
-            )
-        }
+        state.canRetry -> ResponsiveActionRow(
+            leading = { item -> SecondaryButton("Dismiss", onClick = onDismiss, modifier = item) },
+            trailing = { item ->
+                PrimaryButton(
+                    text = "Retry",
+                    onClick = { state.sessionId?.let { onRetry(it.toString()) } },
+                    modifier = item,
+                )
+            },
+            trailingWeight = 2f,
+        )
         else -> PrimaryButton(
             text = DictateCopy.DICTATE,
             onClick = onStart,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/GatewayScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/GatewayScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -90,10 +91,15 @@ fun GatewayScreen(
         }
     }
 
-    Column(modifier = modifier.fillMaxSize()) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         Column(
             modifier = Modifier
                 .weight(1f)
+                .widthIn(max = AppContentMaxWidth)
+                .fillMaxWidth()
                 .verticalScroll(rememberScrollState())
                 .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(SectionSpacing),
@@ -178,21 +184,21 @@ fun GatewayScreen(
 
                 // Saving is confirmed by the footer, which reports the connection
                 // test it kicks off rather than just that bytes hit the disk.
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    PrimaryButton(
+                ResponsiveActionRow(
+                    leading = { item -> PrimaryButton(
                         text = "Save",
                         onClick = submit,
                         enabled = url.isNotBlank() && (token.isNotBlank() || settings.hasToken),
-                        modifier = Modifier.weight(1f),
-                    )
-                    SecondaryButton(
+                        modifier = item,
+                    ) },
+                    trailing = { item -> SecondaryButton(
                         text = "Test connection",
                         onClick = onTest,
                         enabled = settings.isConfigured,
                         loading = testing,
-                        modifier = Modifier.weight(1f),
-                    )
-                }
+                        modifier = item,
+                    ) },
+                )
             }
 
             connection?.let { report ->
@@ -234,6 +240,7 @@ fun GatewayScreen(
             testing = testing,
             connection = connection,
             onDone = onDone,
+            modifier = Modifier.widthIn(max = AppContentMaxWidth),
         )
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/HistoryScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/HistoryScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Checkbox
@@ -18,6 +20,7 @@ import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -57,7 +60,12 @@ fun HistoryScreen(
         return
     }
 
-    LazyColumn(modifier = modifier.fillMaxSize()) {
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .wrapContentWidth(Alignment.CenterHorizontally)
+            .widthIn(max = AppContentMaxWidth),
+    ) {
         items(records, key = { it.sessionId }) { record ->
             HistoryRow(
                 record = record,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/LocalModelPicker.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/LocalModelPicker.kt
@@ -2,6 +2,7 @@ package com.vocahq.vocaphone.ui
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
@@ -34,6 +35,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -327,6 +329,7 @@ private fun ModelBusyBanner(state: LocalModelState, onCancelDownload: () -> Unit
                 Text(
                     "Loading ${state.preparing}… Please wait.",
                     style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f),
                 )
             }
             state.downloading != null -> {
@@ -341,6 +344,7 @@ private fun ModelBusyBanner(state: LocalModelState, onCancelDownload: () -> Unit
                         "Downloading $name",
                         style = MaterialTheme.typography.labelLarge,
                         color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.weight(1f),
                     )
                     TextButton(onClick = onCancelDownload) { Text("Cancel") }
                 }
@@ -428,49 +432,49 @@ private fun CompactRecommendedActions(
     onDownloadAndUse: (LocalModelDescriptor) -> Unit,
     onBrowse: () -> Unit,
 ) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        if (!downloaded) {
-            PrimaryButton(
-                text = SetupCopy.DOWNLOAD,
-                onClick = { onDownloadAndUse(model) },
-                enabled = !busy,
-                modifier = Modifier.weight(1f),
-            )
-        } else if (selected) {
-            Row(
-                modifier = Modifier.weight(1f),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_step_done),
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
+    ResponsiveActionRow(
+        leading = { item ->
+            if (!downloaded) {
+                PrimaryButton(
+                    text = SetupCopy.DOWNLOAD,
+                    onClick = { onDownloadAndUse(model) },
+                    enabled = !busy,
+                    modifier = item,
                 )
-                Text(
-                    "In use",
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.primary,
+            } else if (selected) {
+                Row(
+                    modifier = item,
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_step_done),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(
+                        "In use",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            } else {
+                SecondaryButton(
+                    text = "Use",
+                    onClick = { onSelect(model) },
+                    enabled = !busy,
+                    modifier = item,
                 )
             }
-        } else {
+        },
+        trailing = { item ->
             SecondaryButton(
-                text = "Use",
-                onClick = { onSelect(model) },
-                enabled = !busy,
-                modifier = Modifier.weight(1f),
+                text = SetupCopy.BROWSE_MODELS,
+                onClick = onBrowse,
+                modifier = item,
             )
-        }
-        SecondaryButton(
-            text = SetupCopy.BROWSE_MODELS,
-            onClick = onBrowse,
-            modifier = Modifier.weight(1f),
-        )
-    }
+        },
+    )
 }
 
 @Composable
@@ -604,27 +608,33 @@ private fun ModelPickGrid(
     selectedModelId: String,
     onInspect: (LocalModelDescriptor) -> Unit,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        picks.chunked(2).forEach { row ->
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(IntrinsicSize.Min),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                row.forEach { pick ->
-                    ModelTile(
-                        model = pick.model,
-                        selected = pick.model.id == selectedModelId,
-                        installed = pick.model.id in state.downloaded,
-                        downloading = state.downloading == pick.model.id,
-                        progress = state.progress,
-                        onClick = { onInspect(pick.model) },
-                        modifier = Modifier.weight(1f),
-                        roleLabel = pick.role.label,
-                    )
+    BoxWithConstraints(Modifier.fillMaxWidth()) {
+        val columns = AdaptiveLayout.modelGridColumns(
+            maxWidth.value,
+            LocalDensity.current.fontScale,
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            picks.chunked(columns).forEach { row ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(IntrinsicSize.Min),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    row.forEach { pick ->
+                        ModelTile(
+                            model = pick.model,
+                            selected = pick.model.id == selectedModelId,
+                            installed = pick.model.id in state.downloaded,
+                            downloading = state.downloading == pick.model.id,
+                            progress = state.progress,
+                            onClick = { onInspect(pick.model) },
+                            modifier = Modifier.weight(1f),
+                            roleLabel = pick.role.label,
+                        )
+                    }
+                    if (columns > 1 && row.size == 1) Spacer(Modifier.weight(1f))
                 }
-                if (row.size == 1) Spacer(Modifier.weight(1f))
             }
         }
     }
@@ -638,27 +648,33 @@ private fun ModelTileGrid(
     onInspect: (LocalModelDescriptor) -> Unit,
     elevated: Boolean = false,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        models.chunked(2).forEach { row ->
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(IntrinsicSize.Min),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                row.forEach { model ->
-                    ModelTile(
-                        model = model,
-                        selected = model.id == selectedModelId,
-                        installed = model.id in state.downloaded,
-                        downloading = state.downloading == model.id,
-                        progress = state.progress,
-                        onClick = { onInspect(model) },
-                        modifier = Modifier.weight(1f),
-                        elevated = elevated,
-                    )
+    BoxWithConstraints(Modifier.fillMaxWidth()) {
+        val columns = AdaptiveLayout.modelGridColumns(
+            maxWidth.value,
+            LocalDensity.current.fontScale,
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            models.chunked(columns).forEach { row ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(IntrinsicSize.Min),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    row.forEach { model ->
+                        ModelTile(
+                            model = model,
+                            selected = model.id == selectedModelId,
+                            installed = model.id in state.downloaded,
+                            downloading = state.downloading == model.id,
+                            progress = state.progress,
+                            onClick = { onInspect(model) },
+                            modifier = Modifier.weight(1f),
+                            elevated = elevated,
+                        )
+                    }
+                    if (columns > 1 && row.size == 1) Spacer(Modifier.weight(1f))
                 }
-                if (row.size == 1) Spacer(Modifier.weight(1f))
             }
         }
     }
@@ -826,6 +842,7 @@ private fun ModelActions(
                 "Loading model… Please wait.",
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.weight(1f),
             )
         }
         state.downloading == model.id -> Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -838,6 +855,7 @@ private fun ModelActions(
                     "Downloading",
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.weight(1f),
                 )
                 TextButton(onClick = onCancelDownload) { Text("Cancel") }
             }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -10,11 +10,12 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
@@ -143,6 +144,8 @@ fun SettingsScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
+            .wrapContentWidth(Alignment.CenterHorizontally)
+            .widthIn(max = AppContentMaxWidth)
             .verticalScroll(rememberScrollState())
             .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 16.dp),
         verticalArrangement = Arrangement.spacedBy(SectionSpacing),
@@ -607,11 +610,7 @@ private fun PersonalDictionarySection(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
+        val saveWords: @Composable (Modifier) -> Unit = { item ->
             SecondaryButton(
                 text = "Save words",
                 onClick = {
@@ -619,25 +618,36 @@ private fun PersonalDictionarySection(
                     onSave(draft)
                 },
                 enabled = PersonalDictionary.normalize(draft) != PersonalDictionary.normalize(words),
-                modifier = Modifier.weight(1f),
+                modifier = item,
             )
-            if (canUndo) {
-                SecondaryButton(
-                    text = "Undo",
-                    onClick = {
-                        val restored = lastCleared ?: return@SecondaryButton
-                        lastCleared = null
-                        draft = restored
-                        onSave(restored)
-                    },
-                    modifier = Modifier.weight(1f),
-                )
-            } else if (canClear) {
-                DestructiveTextButton(
-                    text = "Clear",
-                    onClick = { confirmClear = true },
-                )
-            }
+        }
+        when {
+            canUndo -> ResponsiveActionRow(
+                leading = saveWords,
+                trailing = { item ->
+                    SecondaryButton(
+                        text = "Undo",
+                        onClick = {
+                            val restored = lastCleared ?: return@SecondaryButton
+                            lastCleared = null
+                            draft = restored
+                            onSave(restored)
+                        },
+                        modifier = item,
+                    )
+                },
+            )
+            canClear -> ResponsiveActionRow(
+                leading = saveWords,
+                trailing = { item ->
+                    DestructiveTextButton(
+                        text = "Clear",
+                        onClick = { confirmClear = true },
+                        modifier = item,
+                    )
+                },
+            )
+            else -> saveWords(Modifier.fillMaxWidth())
         }
     }
     if (confirmClear) {
@@ -804,5 +814,3 @@ private fun TonePreviewMeter(active: Boolean, modifier: Modifier = Modifier) {
         }
     }
 }
-
-

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.LinearProgressIndicator
@@ -19,6 +20,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.vocahq.vocaphone.BuildConfig
@@ -84,10 +86,15 @@ fun SetupScreen(
     val askUsageReporting = BuildConfig.TELEMETRY && !settings.telemetryAsked
     var askingUsageReporting by remember { mutableStateOf(false) }
 
-    Column(modifier = modifier.fillMaxSize()) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         Column(
             modifier = Modifier
                 .weight(1f)
+                .widthIn(max = AppContentMaxWidth)
+                .fillMaxWidth()
                 .verticalScroll(rememberScrollState())
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(SectionSpacing),
@@ -143,6 +150,7 @@ fun SetupScreen(
 
         Column(
             modifier = Modifier
+                .widthIn(max = AppContentMaxWidth)
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
                 .padding(bottom = 16.dp),

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/UsageReporting.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/UsageReporting.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -156,21 +155,18 @@ fun UsageReportingDialog(
                 ) {
                     Text(UsageReportingCopy.SEE_WHAT_IS_SENT)
                 }
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    SecondaryButton(
+                ResponsiveActionRow(
+                    leading = { item -> SecondaryButton(
                         text = UsageReportingCopy.NOT_NOW,
                         onClick = { onDecision(false) },
-                        modifier = Modifier.weight(1f),
-                    )
-                    SecondaryButton(
+                        modifier = item,
+                    ) },
+                    trailing = { item -> SecondaryButton(
                         text = UsageReportingCopy.TURN_ON,
                         onClick = { onDecision(true) },
-                        modifier = Modifier.weight(1f),
-                    )
-                }
+                        modifier = item,
+                    ) },
+                )
                 Text(
                     UsageReportingCopy.CHANGE_LATER,
                     style = MaterialTheme.typography.bodySmall,

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/AdaptiveLayoutTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/AdaptiveLayoutTest.kt
@@ -1,0 +1,47 @@
+package com.vocahq.vocaphone.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AdaptiveLayoutTest {
+
+    @Test
+    fun `phone action pairs stack when their content area is narrow`() {
+        assertTrue(AdaptiveLayout.stackActions(widthDp = 320f, fontScale = 1f))
+        assertFalse(AdaptiveLayout.stackActions(widthDp = 379f, fontScale = 1f))
+    }
+
+    @Test
+    fun `large text folds action pairs before labels are squeezed`() {
+        assertTrue(AdaptiveLayout.stackActions(widthDp = 379f, fontScale = 1.2f))
+        assertFalse(AdaptiveLayout.stackActions(widthDp = 720f, fontScale = 1.5f))
+    }
+
+    @Test
+    fun `pixel width model content uses one readable column`() {
+        // Pixel 6a is about 411 dp wide; page padding leaves about 379 dp.
+        assertEquals(1, AdaptiveLayout.modelGridColumns(widthDp = 379f, fontScale = 1f))
+        assertEquals(2, AdaptiveLayout.modelGridColumns(widthDp = 411f, fontScale = 1f))
+    }
+
+    @Test
+    fun `model grid responds to accessibility text and wide screens`() {
+        assertEquals(1, AdaptiveLayout.modelGridColumns(widthDp = 500f, fontScale = 1.5f))
+        assertEquals(2, AdaptiveLayout.modelGridColumns(widthDp = 720f, fontScale = 1.5f))
+    }
+
+    @Test
+    fun `long checklist actions stack in inset cards on a pixel`() {
+        assertTrue(AdaptiveLayout.stackChecklistAction(widthDp = 347f, fontScale = 1f))
+        assertFalse(AdaptiveLayout.stackChecklistAction(widthDp = 480f, fontScale = 1f))
+    }
+
+    @Test
+    fun `diagnostic rows stack only when values lose useful width`() {
+        assertTrue(AdaptiveLayout.stackInfo(widthDp = 300f, fontScale = 1f))
+        assertFalse(AdaptiveLayout.stackInfo(widthDp = 379f, fontScale = 1f))
+        assertTrue(AdaptiveLayout.stackInfo(widthDp = 379f, fontScale = 1.3f))
+    }
+}


### PR DESCRIPTION
## Problem

Several Android screens force long labels, action pairs, and model cards into fixed horizontal layouts. On Pixel 6a-sized content, smaller phones, short landscape windows, or enlarged system text, controls can be squeezed, clipped, or pushed off-screen.

## Summary

- add width- and font-scale-aware layout decisions for paired actions, setup rows, diagnostics, and model grids
- wrap Dictate filter chips and make the Dictate content region scroll while keeping the main action reachable
- let buttons grow beyond their 48 dp minimum and stop truncating Settings summaries
- cap app-page content width on wide landscape phones and unfolded foldables
- add regression coverage for Pixel 6a content width, narrow phones, large text, and wide screens

## Verification

- [ ] `just ios ci` — N/A; Android-only change
- [x] `just android ci`
- [ ] Gateway changes — N/A; no gateway code or pin changes
- [ ] Physical-device test — not run; no Android device or emulator was attached

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [ ] Documentation updated — N/A; no data-flow, permission, retention, or network behavior changed