### PR TITLE
fix(android): keep the typed word when a swipe follows it (#197)

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -192,6 +192,18 @@ internal object KeyboardChrome {
         stripReplacesWord: Boolean,
     ): Boolean = composing.isEmpty() && (swipeChoicesActive || stripReplacesWord)
 
+    /**
+     * What has to reach the editor before a swiped word is committed.
+     *
+     * A word typed but never spaced is still a composing region when the swipe
+     * resolves. Clearing that region (`setComposingText("")`) deleted the word
+     * from the editor, so the swiped word landed where it had been and read as
+     * a replacement. Commit the pending word instead and add the space the user
+     * never typed, so the swipe follows it.
+     */
+    fun swipePrefixCommand(composing: String): KeyboardCommand? =
+        if (composing.isEmpty()) null else KeyboardCommand.CommitText(" ")
+
     /** True only while the cursor is still sitting after the swiped word and its space. */
     fun swipeWordArmed(word: String?, before: CharSequence, after: CharSequence): Boolean {
         if (word.isNullOrEmpty()) return false

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -425,6 +425,8 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         // Leave composing alone so commitText replaces "hel" with "hello ".
         // Finishing first commits the stub, then this would insert in front of it.
         connection.commitText(SuggestionEngine.suggestionCommit(word, after), 1)
+        // `commitText` ends the composing region whether or not it replaced one.
+        composingRegionActive = false
         syncShiftFromCursor()
         scheduleEditorTextRefresh()
     }
@@ -447,6 +449,7 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         } else {
             connection.commitText(EmojiCommit.insertText(before, emoji), 1)
         }
+        composingRegionActive = false
         recordEmojiRecent(emoji)
         syncShiftFromCursor()
         scheduleEditorTextRefresh()

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -409,9 +409,7 @@ internal fun VocaPhoneKeyboard(
 
     fun applySwipe(matches: List<String>, similar: List<String>) {
         if (matches.isEmpty()) return
-        if (keyboardState.composing.isNotEmpty()) {
-            onCommand(KeyboardCommand.SetComposingText(""))
-        }
+        KeyboardChrome.swipePrefixCommand(keyboardState.composing)?.let(onCommand)
         val capitalize = keyboardState.shift != ShiftState.OFF
         fun cased(word: String) = if (capitalize) word.replaceFirstChar { it.uppercase() } else word
         val chosen = cased(matches.first())

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SwipeCommitTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SwipeCommitTest.kt
@@ -1,0 +1,153 @@
+package com.vocahq.vocaphone.ime
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * What a swipe leaves in the editor, replayed end to end.
+ *
+ * A swipe is not one command: the seed letter goes out on pointer down, the
+ * gesture takes it back, and the resolved word is committed a frame or more
+ * later, on top of whatever composing region is still open. The bug that
+ * motivated this file (#197) only showed up in that sequence — every step in it
+ * was correct on its own — so the test keeps the sequence rather than the
+ * steps.
+ */
+class SwipeCommitTest {
+
+    @Test
+    fun `a swipe after a word that was never spaced keeps that word`() {
+        val editor = FakeEditor()
+        var state = KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF)
+
+        state = editor.type(state, "h", "i")
+        assertEquals("hi", editor.text)
+
+        // The swipe starts on "w": the letter is committed on pointer down so
+        // it is on screen inside the frame, then the gesture undoes it.
+        state = editor.type(state, "w")
+        state = editor.undoSeed(state)
+        assertEquals("hi", editor.text)
+
+        editor.swipe(state, "world")
+
+        assertEquals("hi world ", editor.text)
+    }
+
+    @Test
+    fun `a swipe after a spaced word reads the same as one after an unspaced word`() {
+        val editor = FakeEditor()
+        var state = KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF)
+
+        state = editor.type(state, "h", "i")
+        state = editor.space(state)
+        state = editor.type(state, "w")
+        state = editor.undoSeed(state)
+        assertEquals("hi ", editor.text)
+
+        editor.swipe(state, "world")
+
+        assertEquals("hi world ", editor.text)
+    }
+
+    @Test
+    fun `a swipe into an empty field commits the word and its space`() {
+        val editor = FakeEditor()
+        var state = KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF)
+
+        state = editor.type(state, "w")
+        state = editor.undoSeed(state)
+
+        editor.swipe(state, "world")
+
+        assertEquals("world ", editor.text)
+    }
+
+    @Test
+    fun `two swipes in a row are two words`() {
+        val editor = FakeEditor()
+        var state = KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF)
+
+        state = editor.type(state, "h")
+        state = editor.undoSeed(state)
+        state = editor.swipe(state, "hello")
+
+        state = editor.type(state, "w")
+        state = editor.undoSeed(state)
+        editor.swipe(state, "world")
+
+        assertEquals("hello world ", editor.text)
+    }
+
+    /**
+     * The editor side of the `InputConnection` contract, held to the part the
+     * keyboard uses: a composing region that `setComposingText` rewrites and
+     * that any commit ends. `apply` mirrors `VocaPhoneInputMethodService.
+     * handleCommand`, including its `finishComposingText` before a commit —
+     * that is what makes a commit land *after* the composing word instead of
+     * replacing it.
+     */
+    private class FakeEditor {
+        private val buffer = StringBuilder()
+        private var composingStart = -1
+
+        val text: String get() = buffer.toString()
+
+        fun apply(command: KeyboardCommand) {
+            when (command) {
+                is KeyboardCommand.SetComposingText -> {
+                    if (composingStart < 0) composingStart = buffer.length
+                    buffer.setLength(composingStart)
+                    buffer.append(command.text)
+                    if (command.text.isEmpty()) composingStart = -1
+                }
+                is KeyboardCommand.CommitText -> {
+                    composingStart = -1
+                    buffer.append(command.text)
+                }
+                KeyboardCommand.FinishComposing -> composingStart = -1
+                else -> throw IllegalArgumentException("unexpected $command")
+            }
+        }
+
+        fun type(state: KeyboardState, vararg letters: String): KeyboardState {
+            var next = state
+            letters.forEach { letter ->
+                val reduction = KeyboardReducer.press(
+                    state = next,
+                    key = KeyboardKey(id = "character-$letter", label = letter, output = letter),
+                    nowMillis = 1_000,
+                    composeWords = true,
+                )
+                next = reduction.state
+                reduction.command?.let(::apply)
+            }
+            return next
+        }
+
+        fun space(state: KeyboardState): KeyboardState {
+            val reduction = KeyboardReducer.press(
+                state = state,
+                key = KeyboardKey(id = "space", label = "Space", type = KeyboardKeyType.SPACE),
+                nowMillis = 1_000,
+                composeWords = true,
+            )
+            reduction.command?.let(::apply)
+            return reduction.state
+        }
+
+        fun undoSeed(state: KeyboardState): KeyboardState {
+            val reduction = KeyboardReducer.undoLastCharacter(state, composeWords = true)
+            reduction.command?.let(::apply)
+            return reduction.state
+        }
+
+        /** `VocaPhoneKeyboard.applySwipe` plus the service's `commitSuggestion`. */
+        fun swipe(state: KeyboardState, word: String): KeyboardState {
+            KeyboardChrome.swipePrefixCommand(state.composing)?.let(::apply)
+            composingStart = -1
+            buffer.append(SuggestionEngine.suggestionCommit(word, textAfterCursor = ""))
+            return state.copy(composing = "", lastWasSpace = true, capitalizeAfterSpace = false)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #197.

## The bug

Type a word, then swipe the next one without pressing space: the first word is gone and the swiped word sits where it was.

A word that was typed but never spaced is still a **composing region** in the editor. `applySwipe` sent `setComposingText("")` to get that region out of the way before committing the swiped word — but that *deletes* the region's text. Pressing space first commits the region, which is why only the unspaced path was broken.

## The fix

`KeyboardChrome.swipePrefixCommand(composing)` returns `CommitText(" ")` when a word is pending and `null` otherwise. `handleCommand`'s `CommitText` already batches `finishComposingText()` + `commitText(" ")`, so the pending word survives and gets the space the user never typed — the same single batch edit the clear was, no extra binder round trip on the swipe path.

Also clears `composingRegionActive` in `commitSuggestion` / `commitEmojiSuggestion`. Both end the composing region but left the flag set, which cost a redundant `finishComposingText` IPC on the next command.

## Test

`SwipeCommitTest` replays the whole gesture — seed letter on pointer down, seed undo, word committed a frame later — against a fake editor held to the `InputConnection` composing semantics. It covers the reported case, the spaced case, an empty field, and two swipes in a row. Each step was correct on its own, so the test keeps the sequence rather than the steps.

Verified the test fails on the old `setComposingText("")` behaviour and passes on the fix. `just ci` (assemble + unit tests + lint + page alignment) is green.