### PR TITLE
fix(android): long-press inserts only the chosen symbol

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyAccents.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyAccents.kt
@@ -4,8 +4,11 @@ import java.util.Locale
 
 internal object KeyAccents {
     /**
-     * Gboard / AOSP letter → symbol map. Hold-and-release types the hint;
+     * Letter → first row of the `?123` page. Hold-and-release types the hint;
      * accents stay in the same popup behind it.
+     *
+     * q-p are `1`-`0`. a-l and z-m follow the two punctuation rows under
+     * those digits (`@#$…` then `*"'…`).
      */
     private val letterSymbols = mapOf(
         "q" to "1", "w" to "2", "e" to "3", "r" to "4", "t" to "5",
@@ -16,8 +19,14 @@ internal object KeyAccents {
         "n" to "!", "m" to "?",
     )
 
-    /** q-p duplicate the number row. Hide those hints when 1-0 are already showing. */
-    private val digitLetters = setOf("q", "w", "e", "r", "t", "y", "u", "i", "o", "p")
+    /**
+     * When the number row already shows `1`-`0`, q-p would be blank if they
+     * kept those digits. They take the first row of the `#+=` page instead.
+     */
+    private val qwertySymbolsWhenNumberRow = mapOf(
+        "q" to "[", "w" to "]", "e" to "{", "r" to "}", "t" to "#",
+        "y" to "%", "u" to "^", "i" to "*", "o" to "+", "p" to "=",
+    )
 
     private val variants = mapOf(
         "a" to listOf("à", "á", "â", "ä", "æ", "ã", "å", "ā"),
@@ -75,8 +84,9 @@ internal object KeyAccents {
 
     /**
      * Light corner mark. Digits keep `!` on `1` when number-key hints are on.
-     * Letters show the Gboard symbol only when long-press-for-symbols is on,
-     * and q-p hide `1`-`0` while the number row is already there.
+     * Letters show a `?123` / `#+=` symbol when long-press-for-symbols is on.
+     * q-p show `1`-`0` unless the number row is already there, then the
+     * first `#+=` row (`[]{}#%^*+=`).
      */
     fun hint(
         key: KeyboardKey,
@@ -99,7 +109,7 @@ internal object KeyAccents {
         numberRow: Boolean,
     ): String? {
         if (!longPressSymbols) return null
-        if (numberRow && base in digitLetters) return null
+        if (numberRow) qwertySymbolsWhenNumberRow[base]?.let { return it }
         return letterSymbols[base]
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -1,6 +1,7 @@
 package com.vocahq.vocaphone.ime
 
 import java.util.Locale
+import kotlin.math.floor
 
 internal enum class KeyboardLayer {
     LETTERS,
@@ -70,6 +71,31 @@ internal sealed interface KeyboardCommand {
      * snapshot used to arm caps instead of cycling case.
      */
     data object ShiftTap : KeyboardCommand
+}
+
+/**
+ * Long-press accent row: hold still this long, then slide to pick a variant.
+ *
+ * The row grows to the right of the key and is shifted so every cell stays
+ * on the keyboard. Swipe typing uses the same hold time so a slide after
+ * the popup is up does not become a swipe.
+ */
+internal object AccentPicker {
+    const val HOLD_MS = 380L
+    const val CELL_DP = 36
+
+    fun rowLeft(centerX: Float, count: Int, cellPx: Float, parentWidth: Float): Float {
+        val width = count * cellPx
+        if (count <= 0 || cellPx <= 0f) return 0f
+        if (width >= parentWidth) return 0f
+        val preferred = centerX - cellPx / 2f
+        return preferred.coerceIn(0f, parentWidth - width)
+    }
+
+    fun indexAt(x: Float, rowLeft: Float, cellPx: Float, count: Int): Int {
+        if (count <= 0 || cellPx <= 0f) return 0
+        return floor((x - rowLeft) / cellPx).toInt().coerceIn(0, count - 1)
+    }
 }
 
 /** Hold-delete starts on characters, then words, then the rest of the line. */
@@ -575,8 +601,8 @@ internal object KeyboardReducer {
      * on pointer down.
      *
      * A composing letter is rewritten in place (`hel` + hold `l` for `ł`
-     * becomes `heł`). A committed digit or symbol is deleted and replaced
-     * in one batch so the editor cannot keep both.
+     * becomes `heł`). A digit or a letter-key symbol (`a` for `@`) is
+     * deleted and replaced in one batch so the editor cannot keep both.
      */
     fun replaceLastCharacter(
         state: KeyboardState,
@@ -594,14 +620,14 @@ internal object KeyboardReducer {
             ),
             composeWords,
         )
-        val command = when (undone.command) {
-            is KeyboardCommand.SetComposingText -> typed.command
-            is KeyboardCommand.DeleteSurrounding,
-            KeyboardCommand.DeleteBackward,
-            -> KeyboardCommand.ReplaceLastCommitted(
-                (typed.command as? KeyboardCommand.CommitText)?.text ?: replacement,
-            )
-            else -> typed.command
+        // Accents stay in the composing region (`e` → `é`). A symbol is
+        // CommitText, and finishing composing first would keep the letter
+        // (`a` then `@`). Batch-delete the seed and insert the symbol.
+        val command = when (val typedCommand = typed.command) {
+            is KeyboardCommand.SetComposingText -> typedCommand
+            is KeyboardCommand.CommitText ->
+                KeyboardCommand.ReplaceLastCommitted(typedCommand.text)
+            else -> typedCommand
         }
         return KeyboardReduction(state = typed.state, command = command)
     }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -53,6 +53,12 @@ internal sealed interface KeyboardCommand {
     data class SetComposingText(val text: String) : KeyboardCommand
     data object DeleteBackward : KeyboardCommand
     data class DeleteSurrounding(val before: Int, val after: Int) : KeyboardCommand
+    /**
+     * Drop the character that went out on pointer down and insert [text]
+     * in the same batch. [DeleteBackward] is a key event, so a following
+     * [CommitText] can land first and leave `2@` from a hold on `2`.
+     */
+    data class ReplaceLastCommitted(val text: String) : KeyboardCommand
     data object PerformEditorAction : KeyboardCommand
     data class MoveCursor(val positions: Int) : KeyboardCommand
     data object DoubleSpacePeriod : KeyboardCommand
@@ -530,6 +536,11 @@ internal object KeyboardReducer {
      * Digits and punctuation skip composing ([characterPress] uses
      * [KeyboardCommand.CommitText]), so a hold on `2` for `@` has to delete
      * that committed `2` instead of no-op'ing on empty composing.
+     *
+     * The delete is [KeyboardCommand.DeleteSurrounding], not
+     * [KeyboardCommand.DeleteBackward]. Backward-delete is a `KEYCODE_DEL`
+     * key event in the IME; the editor can apply it after the following
+     * commit, so a hold on `2` typed `2@`.
      */
     fun undoLastCharacter(
         state: KeyboardState,
@@ -555,8 +566,44 @@ internal object KeyboardReducer {
                 lastWasSpace = false,
                 capitalizeAfterSpace = false,
             ),
-            command = KeyboardCommand.DeleteBackward,
+            command = KeyboardCommand.DeleteSurrounding(1, 0),
         )
+    }
+
+    /**
+     * Long-press replacement after the seed character has already gone out
+     * on pointer down.
+     *
+     * A composing letter is rewritten in place (`hel` + hold `l` for `ł`
+     * becomes `heł`). A committed digit or symbol is deleted and replaced
+     * in one batch so the editor cannot keep both.
+     */
+    fun replaceLastCharacter(
+        state: KeyboardState,
+        replacement: String,
+        composeWords: Boolean,
+        restoreShift: ShiftState? = null,
+    ): KeyboardReduction {
+        val undone = undoLastCharacter(state, composeWords, restoreShift)
+        val typed = characterPress(
+            undone.state,
+            KeyboardKey(
+                id = "variant-$replacement",
+                label = replacement,
+                output = replacement,
+            ),
+            composeWords,
+        )
+        val command = when (undone.command) {
+            is KeyboardCommand.SetComposingText -> typed.command
+            is KeyboardCommand.DeleteSurrounding,
+            KeyboardCommand.DeleteBackward,
+            -> KeyboardCommand.ReplaceLastCommitted(
+                (typed.command as? KeyboardCommand.CommitText)?.text ?: replacement,
+            )
+            else -> typed.command
+        }
+        return KeyboardReduction(state = typed.state, command = command)
     }
 
     private fun spacePress(state: KeyboardState): KeyboardReduction {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -376,6 +376,15 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
                 composingRegionActive = false
                 moveCursor(command.positions)
             }
+            is KeyboardCommand.ReplaceLastCommitted -> {
+                if (connection == null) return
+                connection.beginBatchEdit()
+                if (composingRegionActive) connection.finishComposingText()
+                connection.deleteSurroundingText(1, 0)
+                connection.commitText(command.text, 1)
+                connection.endBatchEdit()
+                composingRegionActive = false
+            }
             KeyboardCommand.DoubleSpacePeriod -> {
                 if (connection == null) return
                 connection.beginBatchEdit()

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -407,6 +407,19 @@ internal fun VocaPhoneKeyboard(
         onKeyPreview(null)
     }
 
+    fun commitLongPressVariant(text: String) {
+        val reduction = KeyboardReducer.replaceLastCharacter(
+            state = keyboardState,
+            replacement = text,
+            composeWords = composeWords,
+            restoreShift = swipeSeedShift,
+        )
+        swipeSeedShift = null
+        keyboardState = reduction.state
+        reduction.command?.let(onCommand)
+        onKeyPreview(null)
+    }
+
     fun applySwipe(matches: List<String>, similar: List<String>) {
         if (matches.isEmpty()) return
         KeyboardChrome.swipePrefixCommand(keyboardState.composing)?.let(onCommand)
@@ -478,6 +491,7 @@ internal fun VocaPhoneKeyboard(
     val latestDelete by rememberUpdatedState<(Long) -> Unit>(::handleDelete)
     val latestSwipe by rememberUpdatedState<(String) -> Unit>(::handleSwipe)
     val latestUndoSwipe by rememberUpdatedState(::undoSwipeSeed)
+    val latestLongPressVariant by rememberUpdatedState(::commitLongPressVariant)
     val latestCursorMove by rememberUpdatedState<(Int) -> Unit> { positions ->
         clearSwipe()
         keyboardState = keyboardState.copy(composing = "", lastWasSpace = false)
@@ -487,6 +501,7 @@ internal fun VocaPhoneKeyboard(
     val onKeyStable = remember { { key: KeyboardKey -> latestKey(key) } }
     val onSwipeStable = remember { { path: String -> latestSwipe(path) } }
     val onUndoSwipeStable = remember { { latestUndoSwipe() } }
+    val onLongPressVariantStable = remember { { text: String -> latestLongPressVariant(text) } }
     val onCursorMoveStable = remember { { positions: Int -> latestCursorMove(positions) } }
     val onKeyHoldStable = remember {
         { key: KeyboardKey, heldMs: Long ->
@@ -667,6 +682,7 @@ internal fun VocaPhoneKeyboard(
                             onKeyHold = onKeyHoldStable,
                             onCursorMove = onCursorMoveStable,
                             onPreview = onKeyPreview,
+                            onLongPressVariant = onLongPressVariantStable,
                         )
                     } else {
                         val rows = remember(
@@ -702,6 +718,7 @@ internal fun VocaPhoneKeyboard(
                                 keyboardState.layer == KeyboardLayer.LETTERS,
                             onSwipe = onSwipeStable,
                             onSwipeSeedUndo = onUndoSwipeStable,
+                            onLongPressVariant = onLongPressVariantStable,
                             onPreview = onKeyPreview,
                             onKey = onKeyStable,
                             onKeyHold = onKeyHoldStable,
@@ -1917,6 +1934,7 @@ private fun EmojiLayer(
     onKeyHold: (KeyboardKey, Long) -> Unit = { _, _ -> },
     onCursorMove: (Int) -> Unit,
     onPreview: (KeyPreview?) -> Unit = {},
+    onLongPressVariant: (String) -> Unit = {},
 ) {
     val bottomRow = KeyboardLayouts.rows(KeyboardLayer.EMOJI, editor)
     val glyphs = when (category) {
@@ -1944,6 +1962,7 @@ private fun EmojiLayer(
             onKey = onKey,
             onKeyHold = onKeyHold,
             onCursorMove = onCursorMove,
+            onLongPressVariant = onLongPressVariant,
         )
     }
 }
@@ -2033,6 +2052,7 @@ private fun KeyboardRows(
     swipeEnabled: Boolean = false,
     onSwipe: (String) -> Unit = {},
     onSwipeSeedUndo: () -> Unit = {},
+    onLongPressVariant: (String) -> Unit = {},
     onPreview: (KeyPreview?) -> Unit = {},
     onKey: (KeyboardKey) -> Unit,
     onKeyHold: (KeyboardKey, Long) -> Unit = { _, _ -> },
@@ -2045,13 +2065,13 @@ private fun KeyboardRows(
     val trailColor = MaterialTheme.colorScheme.primary
     val currentOnSwipe = rememberUpdatedState(onSwipe)
     val currentOnUndo = rememberUpdatedState(onSwipeSeedUndo)
+    val currentOnLongPressVariant = rememberUpdatedState(onLongPressVariant)
     val currentOnPreview = rememberUpdatedState(onPreview)
     val currentOnKey = rememberUpdatedState(onKey)
     val currentOnKeyHold = rememberUpdatedState(onKeyHold)
     val onPreviewStable = remember {
         { preview: KeyPreview? -> currentOnPreview.value(preview) }
     }
-    val onUndoStable = remember { { currentOnUndo.value() } }
 
     // Only the swipe gesture clears this, and it is only installed on the
     // letter layer, so a swipe that was still consuming when the layer changed
@@ -2112,15 +2132,7 @@ private fun KeyboardRows(
                                     { heldMs: Long -> currentOnKeyHold.value(key, heldMs) }
                                 }
                                 val onCommitText = remember(key.id) {
-                                    { text: String ->
-                                        currentOnKey.value(
-                                            KeyboardKey(
-                                                id = "variant-$text",
-                                                label = text,
-                                                output = text,
-                                            ),
-                                        )
-                                    }
+                                    { text: String -> currentOnLongPressVariant.value(text) }
                                 }
                                 KeyButton(
                                     key = key,
@@ -2144,7 +2156,6 @@ private fun KeyboardRows(
                                     },
                                     onPress = onPress,
                                     onHold = onHold,
-                                    onUndo = onUndoStable,
                                     onCommitText = onCommitText,
                                     onPreview = onPreviewStable,
                                     onCursorMove = onCursorMove,
@@ -2244,7 +2255,6 @@ private fun RowScope.KeyButton(
     swipeConsumed: MutableState<Boolean>? = null,
     onPress: () -> Unit,
     onHold: (Long) -> Unit = {},
-    onUndo: () -> Unit = {},
     onCommitText: (String) -> Unit,
     onPreview: (KeyPreview?) -> Unit,
     onCursorMove: (Int) -> Unit,
@@ -2253,7 +2263,6 @@ private fun RowScope.KeyButton(
     val view = LocalView.current
     val currentOnPress = rememberUpdatedState(onPress)
     val currentOnHold = rememberUpdatedState(onHold)
-    val currentOnUndo = rememberUpdatedState(onUndo)
     val currentOnCommitText = rememberUpdatedState(onCommitText)
     val currentOnCursorMove = rememberUpdatedState(onCursorMove)
     val currentOnPreview = rememberUpdatedState(onPreview)
@@ -2328,7 +2337,6 @@ private fun RowScope.KeyButton(
             variantCount = accents.size,
             swipeConsumed = swipeConsumed,
             onTap = { currentOnPress.value() },
-            onUndo = { currentOnUndo.value() },
             onVariant = { index -> currentOnCommitText.value(accents[index]) },
             onPressedChange = { isPressed ->
                 pressed = isPressed
@@ -2470,7 +2478,6 @@ private fun Modifier.accentGesture(
     pointerKey: String,
     variantCount: Int,
     onTap: () -> Unit,
-    onUndo: () -> Unit,
     onVariant: (Int) -> Unit,
     onPressedChange: (Boolean) -> Unit,
     onAccentIndex: (Int) -> Unit,
@@ -2541,7 +2548,6 @@ private fun Modifier.accentGesture(
                 onAccentIndex(-1)
             }
             if (swipeConsumed?.value != true && showing && !leftKey) {
-                onUndo()
                 onVariant(index)
             }
         }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -757,16 +757,22 @@ private fun KeyPreviewLayer(
     val local = host.windowToLocal(Offset(current.windowX, current.windowY))
     val balloonHeightPx = with(density) { 52.dp.roundToPx() }
     val simpleWidthPx = with(density) { 42.dp.roundToPx() }
+    val cellPx = with(density) { AccentPicker.CELL_DP.dp.toPx() }
     val accent = current.accentIndex >= 0 && current.accents.isNotEmpty()
-    val widthPx = if (accent) {
-        with(density) { (current.accents.size * 36).dp.roundToPx() }
+    val leftPx = if (accent) {
+        AccentPicker.rowLeft(
+            centerX = local.x,
+            count = current.accents.size,
+            cellPx = cellPx,
+            parentWidth = host.size.width.toFloat(),
+        )
     } else {
-        simpleWidthPx
+        local.x - simpleWidthPx / 2f
     }
     Box(
         modifier = Modifier.absoluteOffset {
             IntOffset(
-                x = (local.x - widthPx / 2f).roundToInt(),
+                x = leftPx.roundToInt(),
                 y = (local.y - balloonHeightPx - with(density) { 8.dp.roundToPx() }).roundToInt(),
             )
         },
@@ -776,12 +782,12 @@ private fun KeyPreviewLayer(
                 modifier = Modifier
                     .clip(PreviewCorner)
                     .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-                    .padding(horizontal = 6.dp, vertical = 4.dp),
+                    .padding(vertical = 4.dp),
             ) {
                 current.accents.forEachIndexed { index, glyph ->
                     Box(
                         modifier = Modifier
-                            .padding(2.dp)
+                            .width(AccentPicker.CELL_DP.dp)
                             .clip(RoundedCornerShape(6.dp))
                             .background(
                                 if (index == current.accentIndex) {
@@ -790,7 +796,8 @@ private fun KeyPreviewLayer(
                                     Color.Transparent
                                 },
                             )
-                            .padding(horizontal = 8.dp, vertical = 6.dp),
+                            .padding(vertical = 6.dp),
+                        contentAlignment = Alignment.Center,
                     ) {
                         Text(
                             glyph,
@@ -2200,6 +2207,7 @@ private fun Modifier.swipeTypingGesture(
         val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
         swipeConsumed.value = false
         trail.clear()
+        val downAt = SystemClock.uptimeMillis()
         val start = hitLetter(keyBounds, parentCoords()?.localToRoot(down.position))
         if (start == null) return@awaitEachGesture
         val path = StringBuilder(start.output.lowercase())
@@ -2208,9 +2216,14 @@ private fun Modifier.swipeTypingGesture(
         while (true) {
             val event = awaitPointerEvent(PointerEventPass.Initial)
             val change = event.changes.firstOrNull { it.id == down.id } ?: break
-            if (trail.size < 80) trail.add(change.position)
             val hit = hitLetter(keyBounds, parentCoords()?.localToRoot(change.position))
             if (hit != null && hit.id != lastId) {
+                if (SystemClock.uptimeMillis() - downAt >= AccentPicker.HOLD_MS) {
+                    // Finger stayed long enough for the accent row. Sliding
+                    // now picks a variant; it is not a swipe.
+                    if (!change.pressed) break
+                    continue
+                }
                 if (!swipeConsumed.value) {
                     // The letter already went out on down. Drop only that seed
                     // so a swipe after "he" does not wipe the whole word.
@@ -2222,6 +2235,7 @@ private fun Modifier.swipeTypingGesture(
                 lastId = hit.id
             }
             if (swipeConsumed.value) {
+                if (trail.size < 80) trail.add(change.position)
                 change.consume()
             }
             if (!change.pressed) break
@@ -2336,6 +2350,13 @@ private fun RowScope.KeyButton(
             pointerKey = key.id,
             variantCount = accents.size,
             swipeConsumed = swipeConsumed,
+            keyLayout = layout,
+            parentWidthPx = { view.width.toFloat() },
+            windowOriginX = {
+                val loc = IntArray(2)
+                view.getLocationInWindow(loc)
+                loc[0].toFloat()
+            },
             onTap = { currentOnPress.value() },
             onVariant = { index -> currentOnCommitText.value(accents[index]) },
             onPressedChange = { isPressed ->
@@ -2483,8 +2504,11 @@ private fun Modifier.accentGesture(
     onAccentIndex: (Int) -> Unit,
     onHaptic: () -> Unit,
     swipeConsumed: MutableState<Boolean>? = null,
+    keyLayout: Array<LayoutCoordinates?>,
+    parentWidthPx: () -> Float,
+    windowOriginX: () -> Float,
 ) = pointerInput(pointerKey, variantCount) {
-    val step = 28.dp.toPx()
+    val cellPx = AccentPicker.CELL_DP.dp.toPx()
     val slopSquared = viewConfiguration.touchSlop.let { it * it }
     coroutineScope {
         awaitEachGesture {
@@ -2503,11 +2527,31 @@ private fun Modifier.accentGesture(
                     onAccentIndex(-1)
                 }
             }
+            fun indexFor(position: Offset): Int {
+                val coords = keyLayout[0] ?: return AccentPicker.indexAt(
+                    x = position.x,
+                    rowLeft = 0f,
+                    cellPx = cellPx,
+                    count = variantCount,
+                )
+                val origin = windowOriginX()
+                val fingerX = coords.localToWindow(position).x - origin
+                val centerX = coords.localToWindow(
+                    Offset(coords.size.width / 2f, 0f),
+                ).x - origin
+                val left = AccentPicker.rowLeft(
+                    centerX = centerX,
+                    count = variantCount,
+                    cellPx = cellPx,
+                    parentWidth = parentWidthPx(),
+                )
+                return AccentPicker.indexAt(fingerX, left, cellPx, variantCount)
+            }
             try {
                 onPressedChange(true)
                 onTap()
                 hold = launch {
-                    delay(380L)
+                    delay(AccentPicker.HOLD_MS)
                     if (leftKey || swipeConsumed?.value == true) return@launch
                     showing = true
                     onAccentIndex(0)
@@ -2528,12 +2572,12 @@ private fun Modifier.accentGesture(
                     val dx = change.position.x - down.position.x
                     val dy = change.position.y - down.position.y
                     if (!showing && !leftKey && dx * dx + dy * dy > slopSquared) {
-                        // Swipe or a flick off the key: do not let the 380 ms
-                        // hold pop the accent row over the trail.
+                        // Swipe or a flick off the key: do not let the hold
+                        // pop the accent row over the trail.
                         abortHold()
                     }
                     if (showing) {
-                        val next = (dx / step).toInt().coerceIn(0, variantCount - 1)
+                        val next = indexFor(change.position)
                         if (next != index) {
                             index = next
                             onAccentIndex(index)

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/AccentPickerTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/AccentPickerTest.kt
@@ -1,0 +1,49 @@
+package com.vocahq.vocaphone.ime
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AccentPickerTest {
+
+    @Test
+    fun `row grows right of the key when it fits`() {
+        val left = AccentPicker.rowLeft(
+            centerX = 200f,
+            count = 4,
+            cellPx = 50f,
+            parentWidth = 1000f,
+        )
+        assertEquals(175f, left)
+    }
+
+    @Test
+    fun `row shifts right when the key is against the left edge`() {
+        val left = AccentPicker.rowLeft(
+            centerX = 10f,
+            count = 9,
+            cellPx = 50f,
+            parentWidth = 1080f,
+        )
+        assertEquals(0f, left)
+    }
+
+    @Test
+    fun `row shifts left when the key is against the right edge`() {
+        val left = AccentPicker.rowLeft(
+            centerX = 1040f,
+            count = 9,
+            cellPx = 50f,
+            parentWidth = 1080f,
+        )
+        assertEquals(1080f - 450f, left)
+    }
+
+    @Test
+    fun `index follows the finger along the row`() {
+        val left = 100f
+        assertEquals(0, AccentPicker.indexAt(110f, left, 50f, 9))
+        assertEquals(1, AccentPicker.indexAt(160f, left, 50f, 9))
+        assertEquals(8, AccentPicker.indexAt(900f, left, 50f, 9))
+        assertEquals(0, AccentPicker.indexAt(0f, left, 50f, 9))
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyAccentsTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyAccentsTest.kt
@@ -48,7 +48,7 @@ class KeyAccentsTest {
         assertEquals("3", KeyAccents.hint(e, longPressSymbols = true))
         assertEquals("@", KeyAccents.hint(a, longPressSymbols = true))
         assertEquals("1", KeyAccents.hint(q, longPressSymbols = true, numberRow = false))
-        assertEquals(null, KeyAccents.hint(q, longPressSymbols = true, numberRow = true))
+        assertEquals("[", KeyAccents.hint(q, longPressSymbols = true, numberRow = true))
         assertEquals("@", KeyAccents.hint(a, longPressSymbols = true, numberRow = true))
         assertEquals(null, KeyAccents.hint(e, longPressSymbols = false))
     }
@@ -70,13 +70,32 @@ class KeyAccentsTest {
     }
 
     @Test
-    fun qLongPressesToOneOnlyWithoutANumberRow() {
+    fun qLongPressesToOneWithoutANumberRowAndBracketWithOne() {
         val q = KeyboardKey(id = "q", label = "q", output = "q")
         assertTrue(KeyAccents.forKey(q, ShiftState.OFF).isEmpty())
         assertEquals(listOf("1"), KeyAccents.forKey(q, ShiftState.OFF, longPressSymbols = true))
-        assertTrue(
-            KeyAccents.forKey(q, ShiftState.OFF, longPressSymbols = true, numberRow = true)
-                .isEmpty(),
+        assertEquals(
+            listOf("["),
+            KeyAccents.forKey(q, ShiftState.OFF, longPressSymbols = true, numberRow = true),
         )
+    }
+
+    @Test
+    fun qwertyMirrorsTheSymbolsPageWhenTheNumberRowIsShowing() {
+        val expected = mapOf(
+            "q" to "[", "w" to "]", "e" to "{", "r" to "}", "t" to "#",
+            "y" to "%", "u" to "^", "i" to "*", "o" to "+", "p" to "=",
+        )
+        expected.forEach { (letter, symbol) ->
+            val key = KeyboardKey(id = letter, label = letter, output = letter)
+            assertEquals(
+                symbol,
+                KeyAccents.hint(key, longPressSymbols = true, numberRow = true),
+            )
+            assertTrue(
+                "$letter should long-press to $symbol",
+                symbol in KeyAccents.forKey(key, ShiftState.OFF, longPressSymbols = true, numberRow = true),
+            )
+        }
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardReducerTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardReducerTest.kt
@@ -232,6 +232,25 @@ class KeyboardReducerTest {
     }
 
     @Test
+    fun `long-press on a composing letter for a symbol replaces in one batch`() {
+        val typed = KeyboardReducer.press(
+            KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF),
+            character("a"),
+            nowMillis = 1_000,
+            composeWords = true,
+        )
+        assertEquals(KeyboardCommand.SetComposingText("a"), typed.command)
+
+        val replaced = KeyboardReducer.replaceLastCharacter(
+            typed.state,
+            replacement = "@",
+            composeWords = true,
+        )
+        assertEquals(KeyboardCommand.ReplaceLastCommitted("@"), replaced.command)
+        assertEquals("", replaced.state.composing)
+    }
+
+    @Test
     fun `delete while composing shortens the composing word`() {
         val typed = KeyboardReducer.press(
             KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF, composing = "hi"),

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardReducerTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardReducerTest.kt
@@ -179,7 +179,7 @@ class KeyboardReducerTest {
     }
 
     @Test
-    fun `undo last committed letter deletes backward`() {
+    fun `undo last committed letter deletes surrounding`() {
         val typed = KeyboardReducer.press(
             KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF),
             character("h"),
@@ -189,13 +189,13 @@ class KeyboardReducerTest {
 
         val undo = KeyboardReducer.undoLastCharacter(typed.state, composeWords = false)
 
-        assertEquals(KeyboardCommand.DeleteBackward, undo.command)
+        assertEquals(KeyboardCommand.DeleteSurrounding(1, 0), undo.command)
     }
 
     @Test
-    fun `undo of a committed digit deletes backward`() {
+    fun `long-press on a digit replaces it in one batch`() {
         val typed = KeyboardReducer.press(
-            KeyboardState(KeyboardLayer.NUMBERS, ShiftState.OFF),
+            KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF),
             character("2"),
             nowMillis = 1_000,
             composeWords = true,
@@ -203,16 +203,32 @@ class KeyboardReducerTest {
         assertEquals(KeyboardCommand.CommitText("2"), typed.command)
         assertEquals("", typed.state.composing)
 
-        val undo = KeyboardReducer.undoLastCharacter(typed.state, composeWords = true)
-        assertEquals(KeyboardCommand.DeleteBackward, undo.command)
-
-        val symbol = KeyboardReducer.press(
-            undo.state,
-            character("@"),
-            nowMillis = 1_400,
+        val replaced = KeyboardReducer.replaceLastCharacter(
+            typed.state,
+            replacement = "@",
             composeWords = true,
         )
-        assertEquals(KeyboardCommand.CommitText("@"), symbol.command)
+        assertEquals(KeyboardCommand.ReplaceLastCommitted("@"), replaced.command)
+        assertEquals("", replaced.state.composing)
+    }
+
+    @Test
+    fun `long-press on a composing letter rewrites the composing word`() {
+        val typed = KeyboardReducer.press(
+            KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF),
+            character("e"),
+            nowMillis = 1_000,
+            composeWords = true,
+        )
+        assertEquals(KeyboardCommand.SetComposingText("e"), typed.command)
+
+        val replaced = KeyboardReducer.replaceLastCharacter(
+            typed.state,
+            replacement = "é",
+            composeWords = true,
+        )
+        assertEquals(KeyboardCommand.SetComposingText("é"), replaced.command)
+        assertEquals("é", replaced.state.composing)
     }
 
     @Test

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/LongPressSymbolTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/LongPressSymbolTest.kt
@@ -1,0 +1,132 @@
+package com.vocahq.vocaphone.ime
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Long-press of a number-row key, replayed the way the IME talks to the
+ * editor.
+ *
+ * #196 made the reducer emit a delete before `@`, but that delete was
+ * [KeyboardCommand.DeleteBackward], which the IME sends as `KEYCODE_DEL`.
+ * Key events are applied by the target app after `commitText`, so a hold
+ * on `2` still typed `2@`. The replacement has to be
+ * [KeyboardCommand.ReplaceLastCommitted], which deletes and inserts in
+ * one batch.
+ */
+class LongPressSymbolTest {
+
+    @Test
+    fun `holding 2 for at-sign leaves only the at-sign`() {
+        val editor = FakeEditor()
+        var state = KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF)
+
+        state = editor.type(state, "2")
+        assertEquals("2", editor.text)
+
+        editor.replace(state, "@")
+        assertEquals("@", editor.text)
+    }
+
+    @Test
+    fun `holding 2 after a letter keeps the letter`() {
+        val editor = FakeEditor()
+        var state = KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF)
+
+        state = editor.type(state, "h")
+        state = editor.type(state, "2")
+        assertEquals("h2", editor.text)
+
+        editor.replace(state, "@")
+        assertEquals("h@", editor.text)
+    }
+
+    @Test
+    fun `holding e for an accent rewrites the composing letter`() {
+        val editor = FakeEditor()
+        var state = KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF)
+
+        state = editor.type(state, "h")
+        state = editor.type(state, "e")
+        assertEquals("he", editor.text)
+
+        editor.replace(state, "é")
+        assertEquals("hé", editor.text)
+    }
+
+    @Test
+    fun `a key-event undo after commitText leaves both characters`() {
+        val editor = FakeEditor()
+        editor.apply(KeyboardCommand.CommitText("2"))
+        editor.apply(KeyboardCommand.DeleteBackward)
+        editor.apply(KeyboardCommand.CommitText("@"))
+        assertEquals("2@", editor.text)
+    }
+
+    /**
+     * Mirrors `VocaPhoneInputMethodService.handleCommand` for the commands
+     * this path uses. [KeyboardCommand.DeleteBackward] is a key event, so
+     * it does not mutate the buffer before a following commit.
+     */
+    private class FakeEditor {
+        private val buffer = StringBuilder()
+        private var composingStart = -1
+
+        val text: String get() = buffer.toString()
+
+        fun apply(command: KeyboardCommand) {
+            when (command) {
+                is KeyboardCommand.SetComposingText -> {
+                    if (composingStart < 0) composingStart = buffer.length
+                    buffer.setLength(composingStart)
+                    buffer.append(command.text)
+                    if (command.text.isEmpty()) composingStart = -1
+                }
+                is KeyboardCommand.CommitText -> {
+                    composingStart = -1
+                    buffer.append(command.text)
+                }
+                is KeyboardCommand.ReplaceLastCommitted -> {
+                    composingStart = -1
+                    if (buffer.isNotEmpty()) buffer.deleteCharAt(buffer.length - 1)
+                    buffer.append(command.text)
+                }
+                KeyboardCommand.DeleteBackward -> {
+                    // sendKeyEvent(KEYCODE_DEL): the editor applies this later.
+                }
+                is KeyboardCommand.DeleteSurrounding -> {
+                    composingStart = -1
+                    val n = command.before.coerceAtMost(buffer.length)
+                    if (n > 0) buffer.delete(buffer.length - n, buffer.length)
+                }
+                KeyboardCommand.FinishComposing -> composingStart = -1
+                else -> throw IllegalArgumentException("unexpected $command")
+            }
+        }
+
+        fun type(state: KeyboardState, digitOrLetter: String): KeyboardState {
+            val reduction = KeyboardReducer.press(
+                state = state,
+                key = KeyboardKey(
+                    id = "character-$digitOrLetter",
+                    label = digitOrLetter,
+                    output = digitOrLetter,
+                ),
+                nowMillis = 1_000,
+                composeWords = true,
+            )
+            reduction.command?.let(::apply)
+            return reduction.state
+        }
+
+        fun replace(state: KeyboardState, replacement: String): KeyboardState {
+            val reduction = KeyboardReducer.replaceLastCharacter(
+                state = state,
+                replacement = replacement,
+                composeWords = true,
+            )
+            reduction.command?.let(::apply)
+            return reduction.state
+        }
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/LongPressSymbolTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/LongPressSymbolTest.kt
@@ -42,6 +42,31 @@ class LongPressSymbolTest {
     }
 
     @Test
+    fun `holding a for at-sign leaves only the at-sign`() {
+        val editor = FakeEditor()
+        var state = KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF)
+
+        state = editor.type(state, "a")
+        assertEquals("a", editor.text)
+
+        editor.replace(state, "@")
+        assertEquals("@", editor.text)
+    }
+
+    @Test
+    fun `holding a for at-sign after a letter keeps that letter`() {
+        val editor = FakeEditor()
+        var state = KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF)
+
+        state = editor.type(state, "h")
+        state = editor.type(state, "a")
+        assertEquals("ha", editor.text)
+
+        editor.replace(state, "@")
+        assertEquals("h@", editor.text)
+    }
+
+    @Test
     fun `holding e for an accent rewrites the composing letter`() {
         val editor = FakeEditor()
         var state = KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF)


### PR DESCRIPTION
## Summary

Follow-up to #196. Hold 2 still typed `2@`, and with long-press-for-symbols on, hold A typed `a@`. The seed character goes out on pointer down. The undo was `KEYCODE_DEL` for digits, or `finishComposingText` then `commitText` for letters, so the editor kept both.

Long-press now deletes the seed and inserts the variant in one InputConnection batch.

While testing that on a phone, q-p had no hints when the number row was already showing 1-0. They now show the first row of the `#+=` page.

Hold A also clipped `@ à á` off the left of the screen, and sliding to pick `æ` became a swipe. The accent strip grows to the right of the key, stays on the keyboard, and after the hold a slide picks a variant.

## Verification

- [ ] `just ios ci` — N/A. Linux host, no iOS files changed.
- [x] Android unit tests: `just android test '*KeyboardReducerTest' '*LongPressSymbolTest' '*KeyAccentsTest' '*AccentPickerTest'`. Full `just android ci` not run here; Quality (Android) on this PR covers assemble, lint, and the rest.
- [ ] Gateway changes: N/A, pin unchanged
- [x] Physical-device test: Nothing Phone (1) `A063` (`a775a5e9`). Number row on, long-press-for-symbols on. Hold 2 → `@` only. Hold A → `@` only. Hold A, slide → `æ` only, with `@ à á â ä æ ã å ā` all on screen.

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation: N/A, no data-flow, permission, retention, or network change