### PR TITLE
build: prepare Android 0.1.3

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.vocahq.vocaphone"
         minSdk = 33
         targetSdk = 36
-        versionCode = 23
-        versionName = "0.1.2"
+        versionCode = 24
+        versionName = "0.1.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/docs/play-store.md
+++ b/docs/play-store.md
@@ -28,8 +28,8 @@ Upload the full AAB only. Never upload the fdroid APK or an fdroid bundle to
 Play. The fdroid flavour drops prebuilt sherpa-onnx / ONNX Runtime so F-Droid
 can rebuild from source; Play testers should get the full catalog.
 
-Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 23,
-`versionName` `0.1.2`. Keep that until the next Play-bound tag needs a bump;
+Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 24,
+`versionName` `0.1.3`. Keep that until the next Play-bound tag needs a bump;
 the release workflow refuses to publish when the tag is not `android/v$versionName`.
 
 `dependenciesInfo.includeInApk` / `includeInBundle` stay `false` so AGP does

--- a/fastlane/metadata/android/en-US/changelogs/24.txt
+++ b/fastlane/metadata/android/en-US/changelogs/24.txt
@@ -1,0 +1,1 @@
+Hold 2 for @, or A for @ with long-press-for-symbols, now types only the symbol. Accents stay on the keyboard so you can slide to è or æ. QWERTY shows the #+= row when the number row is already on. Swiping the next word no longer wipes the one you just typed. Setup, Dictate, History, and Settings wrap on smaller phones and large text.

--- a/fdroid/com.vocahq.vocaphone.yml
+++ b/fdroid/com.vocahq.vocaphone.yml
@@ -36,9 +36,9 @@ Repo: https://github.com/VocaHQ/vocaphone.git
 Binaries: https://github.com/VocaHQ/vocaphone/releases/download/android/v%v/vocaphone-fdroid.apk
 
 Builds:
-  - versionName: 0.1.2
-    versionCode: 23
-    commit: android/v0.1.2
+  - versionName: 0.1.3
+    versionCode: 24
+    commit: android/v0.1.3
     subdir: android/app
     submodules: true
     gradle:
@@ -58,5 +58,5 @@ AllowedAPKSigningKeys: e6131446f8afeff13516f78036db9ea26aaa16e01b39f37182bf262cc
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags ^android/v[0-9.]+$
-CurrentVersion: 0.1.2
-CurrentVersionCode: 23
+CurrentVersion: 0.1.3
+CurrentVersionCode: 24

--- a/web/README.md
+++ b/web/README.md
@@ -13,7 +13,7 @@ Then open `http://127.0.0.1:4173/`. The iPhone setup guide is available at
 `http://127.0.0.1:4173/privacy/`.
 
 The site uses only local brand assets and system fonts. The Android install and
-download CTAs point at a pinned release tag (`android/v0.1.2`), where the release
+download CTAs point at a pinned release tag (`android/v0.1.3`), where the release
 includes the APK and its verification files. New Android tags are `android/v*`;
 **move the pin when you cut the next Android release people should install**
 (see [releasing.md](../docs/releasing.md)). `npm run check` asserts the tag the

--- a/web/index.html
+++ b/web/index.html
@@ -161,7 +161,7 @@
           <div class="hero-actions">
             <a
               class="button button-primary"
-              href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.2"
+              href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.3"
             >
               <svg class="mark-solid" aria-hidden="true"><use href="#mark-android" /></svg>
               get the android beta
@@ -597,7 +597,7 @@
             </div>
             <p>Native whisper.cpp and sherpa-onnx models run inside the Android phone and insert text directly.</p>
             <div class="platform-card-actions">
-              <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.2">
+              <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.3">
                 <svg class="mark-solid" aria-hidden="true"><use href="#mark-android" /></svg>
                 get the beta <span aria-hidden="true">↗</span>
               </a>
@@ -729,16 +729,16 @@
             <ul class="install-facts">
               <li><b>Requires</b><span>Android 13 or newer</span></li>
               <li><b>Install</b><span>Download and sideload the signed APK</span></li>
-              <li><b>Latest</b><span>v0.1.2</span></li>
+              <li><b>Latest</b><span>v0.1.3</span></li>
               <li><b>Privacy</b><span>On-device model or optional gateway</span></li>
             </ul>
             <p class="install-note">
               Uninstall <code>io.github.mrsunglasses.localflow</code> before
               sideloading if that older Local Flow build is still installed.
             </p>
-            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.2">
+            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.3">
               <svg class="mark-solid" aria-hidden="true"><use href="#mark-android" /></svg>
-              open v0.1.2 <span aria-hidden="true">↗</span>
+              open v0.1.3 <span aria-hidden="true">↗</span>
             </a>
             <p class="install-note">
               Download <code>vocaphone.apk</code> from that tag and verify it with
@@ -785,7 +785,7 @@
           <h2 id="download-title">say less.<br />type more.</h2>
           <p>Download a model to your phone and turn speech into text without sending your voice anywhere.</p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.2"><svg class="mark-solid" aria-hidden="true"><use href="#mark-android" /></svg>get Android beta v0.1.2 <span aria-hidden="true">↗</span></a>
+            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.3"><svg class="mark-solid" aria-hidden="true"><use href="#mark-android" /></svg>get Android beta v0.1.3 <span aria-hidden="true">↗</span></a>
             <a class="button button-primary" href="https://testflight.apple.com/join/wd85wQ3W"><svg class="mark-solid" aria-hidden="true"><use href="#mark-apple" /></svg>join the iPhone TestFlight <span aria-hidden="true">↗</span></a>
           </div>
           <span class="download-fineprint">no gateway required · free &amp; open source · AGPL-3.0</span>
@@ -803,7 +803,7 @@
           <p>product</p>
           <a href="#why">why VocaPhone</a>
           <a href="#how">how it works</a>
-          <a href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.2">releases</a>
+          <a href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.3">releases</a>
         </div>
         <div>
           <p>resources</p>

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -199,9 +199,9 @@ test("availability and install paths are honest", () => {
   assert.match(html, /There is\s+no App Store release yet/);
   assert.match(
     html,
-    /href="https:\/\/github\.com\/VocaHQ\/vocaphone\/releases\/tag\/android\/v0\.1\.2"/,
+    /href="https:\/\/github\.com\/VocaHQ\/vocaphone\/releases\/tag\/android\/v0\.1\.3"/,
   );
-  assert.match(html, /v0\.1\.2/);
+  assert.match(html, /v0\.1\.3/);
   assert.match(html, /io\.github\.mrsunglasses\.localflow/);
   assert.match(html, /href="\/iphone\/"/);
   assert.match(html, /SHA256SUMS\.txt/);
@@ -227,14 +227,14 @@ test("availability and install paths are honest", () => {
   assert.match(hero, /<use href="#mark-android"/);
   assert.match(hero, /<use href="#mark-apple"/);
   assert.ok(
-    hero.includes("https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.2"),
+    hero.includes("https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.3"),
     "hero is missing the Android release link",
   );
 
   const androidCard = androidInstallBlock(html);
   const uninstallAt = androidCard.indexOf("io.github.mrsunglasses.localflow");
   const tagHrefAt = androidCard.indexOf(
-    "https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.2",
+    "https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.3",
   );
   const checksumAt = androidCard.indexOf("SHA256SUMS.txt");
   assert.ok(uninstallAt !== -1, "uninstall note missing from Android install block");


### PR DESCRIPTION
## Summary

Bump `versionCode` 24 / `versionName` `0.1.3` so the next prefixed tag can publish. Move the website pin, Play listing notes (`changelogs/24.txt`, 336 characters), and F-Droid metadata with it.

Covers what landed on `main` after `android/v0.1.2`:

- Long-press inserts only the chosen symbol, including letters and the accent strip (#203, follow-up to #196)
- Swiping the next word no longer deletes the one you just typed (#202)
- App layouts wrap on smaller phones, short landscape, and large text (#201)

## Why 0.1.3, not 0.2.0

Last Android ship is `android/v0.1.2` (`versionCode` 23). Engines, protocol, minSdk, and the privacy model are unchanged. This is a patch on 0.1.

The tag has to be `android/v0.1.3`. Do not tag from this PR; tag after merge.

## Release notes

Play's 500-character listing is in `fastlane/metadata/android/en-US/changelogs/24.txt`.

Hold 2 for @, or A for @ with long-press-for-symbols, now types only the symbol. Accents stay on the keyboard so you can slide to è or æ. QWERTY shows the #+= row when the number row is already on. Swiping the next word no longer wipes the one you just typed. Setup, Dictate, History, and Settings wrap on smaller phones and large text.

## Verification

- [ ] `just ios ci` — N/A (Android version pin + web pin only)
- [ ] `just android ci` — N/A locally; GitHub Quality (Android) will run because `android/app/build.gradle.kts` changed. The edit is version numbers only.
- [x] `cd web && npm run check` — 20/20
- [ ] Gateway changes: N/A
- [x] Physical-device test of the unreleased work: Nothing Phone (1) `A063`. Long-press 2 → `@` only; hold A → `@` only; hold A and slide → `æ` with the full accent row on screen.

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated only for the store version pin (`docs/play-store.md`)