### PR TITLE
fix(android): decode swipe from direction-change apexes

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -236,12 +236,16 @@ internal object KeyboardChrome {
     fun swipePrefixCommand(composing: String): KeyboardCommand? =
         if (composing.isEmpty()) null else KeyboardCommand.CommitText(" ")
 
-    /** True only while the cursor is still sitting after the swiped word and its space. */
+    /**
+     * True while the cursor is still sitting on the swiped word. Some hosts
+     * (Chrome omnibox, some web editors) drop the trailing space we send;
+     * the strip still has to show the other same-path words so the user
+     * can tap a neighbour of the path.
+     */
     fun swipeWordArmed(word: String?, before: CharSequence, after: CharSequence): Boolean {
         if (word.isNullOrEmpty()) return false
         val span = SuggestionEngine.replaceableWord(before, after) ?: return false
         return span.afterLength == 0 &&
-            span.beforeLength > span.word.length &&
             span.word.equals(word, ignoreCase = true)
     }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -149,6 +149,13 @@ internal object DeleteHold {
             }
         }
     }
+
+    /** Apply [command] to the local before-cursor buffer used during a hold. */
+    fun remainingBefore(before: String, command: KeyboardCommand): String = when (command) {
+        KeyboardCommand.DeleteBackward -> before.dropLast(1)
+        is KeyboardCommand.DeleteSurrounding -> before.dropLast(command.before)
+        else -> before
+    }
 }
 
 internal data class KeyboardReduction(

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
@@ -56,13 +56,16 @@ internal class SuggestionDictionary(
 
     /**
      * Ideal resampled paths, one per word, so a geometric swipe does not
-     * rebuild sixteen points for every candidate. Letter-string swipes do not
-     * read these: they keep the previous scorer so those tests stay a lock.
+     * rebuild twenty-four points for every candidate. Letter-string swipes
+     * do not read these: they keep the previous scorer so those tests stay
+     * a lock.
      */
     private val swipeIdeal: Array<FloatArray> =
         Array(words.size) { SwipeLayout.sampleWord(collapsed[it]) }
 
-    private val swipeIdealLength = FloatArray(words.size) { SwipeLayout.pathLength(collapsed[it]) }
+    /** Colinear shortcut of each word, same length as [swipeIdeal]. */
+    private val swipeShortcut: Array<FloatArray> =
+        Array(words.size) { SwipeLayout.sampleWordShortcut(words[it]) }
 
     /** Word indices whose collapsed form starts with each letter, still in frequency order. */
     private val swipeByFirst: Array<IntArray> = buildSwipeFirst(collapsed)
@@ -240,8 +243,10 @@ internal class SuggestionDictionary(
     }
 
     /**
-     * Real (x, y) traces from the keyboard. Start-letter buckets skip most of
-     * the list; DTW plus FlorisBoard's shape/location terms rank the rest.
+     * Real (x, y) traces from the keyboard. Start-letter buckets skip most
+     * of the list; start/end neighbours prune the rest. There is no
+     * subsequence filter: a letter the finger flew over is scored as
+     * distance to the stroke, not as a missing key.
      */
     private fun swipeGeometric(
         keys: String,
@@ -250,7 +255,7 @@ internal class SuggestionDictionary(
         limit: Int,
         shouldAbort: () -> Boolean,
     ): List<String> {
-        val gesture = SwipeLayout.Gesture(keys, points, previousWord)
+        val gesture = SwipeLayout.Gesture(keys, points)
         val predicted = if (previousWord.isEmpty()) {
             emptySet()
         } else {
@@ -269,23 +274,15 @@ internal class SuggestionDictionary(
                 val last = collapsedLength[rank] - 1
                 if (last < 1) continue
                 if (!gesture.endsAreReachable(compact[0], compact[last])) continue
-                // FlorisBoard / OpenSwipe do not require the word to be a
-                // subsequence of the keys the finger crossed. "with" is W-I-T-H
-                // on the keyboard but a real swipe is W→I→H: T is a fly-over
-                // on the way to I, so requiring T after I threw the word out.
-                val exact = SuggestionEngine.isSubsequence(compact, keys)
-                val onPath = gesture.lettersOnPath(compact)
                 scored.add(
                     words[rank] to gesture.score(
                         compactWord = compact,
                         originalWord = words[rank],
                         frequencyRank = rank,
                         wordCount = words.size,
-                        approximate = !exact,
                         predictedWord = words[rank] in predicted,
-                        onPath = onPath,
-                        ideal = swipeIdeal[rank],
-                        idealLength = swipeIdealLength[rank],
+                        full = swipeIdeal[rank],
+                        shortcut = swipeShortcut[rank],
                     ),
                 )
             }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
@@ -200,7 +200,7 @@ internal class SuggestionDictionary(
 
     fun swipe(
         path: String,
-        limit: Int = 4,
+        limit: Int = 6,
         shouldAbort: () -> Boolean = { false },
         points: FloatArray = FloatArray(0),
         previousWord: String = "",
@@ -243,10 +243,9 @@ internal class SuggestionDictionary(
     }
 
     /**
-     * Real (x, y) traces from the keyboard. Start-letter buckets skip most
-     * of the list; start/end neighbours prune the rest. There is no
-     * subsequence filter: a letter the finger flew over is scored as
-     * distance to the stroke, not as a missing key.
+     * Real (x, y) traces. Start-letter buckets are the first level of the
+     * candidate tree; when the finger turned, a word also has to cover
+     * every apex (the keys around each direction change) in order.
      */
     private fun swipeGeometric(
         keys: String,
@@ -262,30 +261,40 @@ internal class SuggestionDictionary(
             bigrams[previousWord.lowercase()].orEmpty().toHashSet()
         }
         val scored = ArrayList<Pair<String, Float>>()
-        var seen = 0
-        val startLetters = SwipeLayout.nearby(keys.first()) + keys.first()
-        for (letter in startLetters) {
-            if (letter !in 'a'..'z') continue
-            val bucket = swipeByFirst[letter - 'a']
-            for (rank in bucket) {
-                if ((seen and 127) == 0 && shouldAbort()) return emptyList()
-                seen++
-                val compact = collapsed[rank]
-                val last = collapsedLength[rank] - 1
-                if (last < 1) continue
-                if (!gesture.endsAreReachable(compact[0], compact[last])) continue
-                scored.add(
-                    words[rank] to gesture.score(
-                        compactWord = compact,
-                        originalWord = words[rank],
-                        frequencyRank = rank,
-                        wordCount = words.size,
-                        predictedWord = words[rank] in predicted,
-                        full = swipeIdeal[rank],
-                        shortcut = swipeShortcut[rank],
-                    ),
-                )
+        fun consider(requireTurns: Boolean): Boolean {
+            var seen = 0
+            for (letter in 'a'..'z') {
+                if (!gesture.mayBeginWith(letter)) continue
+                val bucket = swipeByFirst[letter - 'a']
+                for (rank in bucket) {
+                    if ((seen and 127) == 0 && shouldAbort()) return true
+                    seen++
+                    val compact = collapsed[rank]
+                    val last = collapsedLength[rank] - 1
+                    if (last < 1) continue
+                    if (!gesture.endsAreReachable(compact[0], compact[last])) continue
+                    if (requireTurns && !gesture.coversWord(compact)) continue
+                    scored.add(
+                        words[rank] to gesture.score(
+                            compactWord = compact,
+                            originalWord = words[rank],
+                            frequencyRank = rank,
+                            wordCount = words.size,
+                            predictedWord = words[rank] in predicted,
+                            full = swipeIdeal[rank],
+                            shortcut = swipeShortcut[rank],
+                        ),
+                    )
+                }
             }
+            return false
+        }
+        val aborted = consider(requireTurns = gesture.hasTurns)
+        if (aborted) return emptyList()
+        // A noisy trace can invent extra apexes and empty the tree. Fall
+        // back to start/end so we still commit a word the strip can fix.
+        if (scored.isEmpty() && gesture.hasTurns) {
+            if (consider(requireTurns = false)) return emptyList()
         }
         return scored
             .sortedByDescending { it.second }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
@@ -269,21 +269,21 @@ internal class SuggestionDictionary(
                 val last = collapsedLength[rank] - 1
                 if (last < 1) continue
                 if (!gesture.endsAreReachable(compact[0], compact[last])) continue
+                // FlorisBoard / OpenSwipe do not require the word to be a
+                // subsequence of the keys the finger crossed. "with" is W-I-T-H
+                // on the keyboard but a real swipe is W→I→H: T is a fly-over
+                // on the way to I, so requiring T after I threw the word out.
                 val exact = SuggestionEngine.isSubsequence(compact, keys)
-                if (
-                    !exact &&
-                    !SuggestionEngine.isReachableSubsequence(compact, keys) &&
-                    !gesture.lettersOnPath(compact)
-                ) {
-                    continue
-                }
+                val onPath = gesture.lettersOnPath(compact)
                 scored.add(
                     words[rank] to gesture.score(
                         compactWord = compact,
                         originalWord = words[rank],
                         frequencyRank = rank,
+                        wordCount = words.size,
                         approximate = !exact,
                         predictedWord = words[rank] in predicted,
+                        onPath = onPath,
                         ideal = swipeIdeal[rank],
                         idealLength = swipeIdealLength[rank],
                     ),

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SuggestionEngine.kt
@@ -54,6 +54,19 @@ internal class SuggestionDictionary(
     /** Unboxed lengths for [collapsed], so the reject path never derefs a String. */
     private val collapsedLength = IntArray(words.size) { collapsed[it].length }
 
+    /**
+     * Ideal resampled paths, one per word, so a geometric swipe does not
+     * rebuild sixteen points for every candidate. Letter-string swipes do not
+     * read these: they keep the previous scorer so those tests stay a lock.
+     */
+    private val swipeIdeal: Array<FloatArray> =
+        Array(words.size) { SwipeLayout.sampleWord(collapsed[it]) }
+
+    private val swipeIdealLength = FloatArray(words.size) { SwipeLayout.pathLength(collapsed[it]) }
+
+    /** Word indices whose collapsed form starts with each letter, still in frequency order. */
+    private val swipeByFirst: Array<IntArray> = buildSwipeFirst(collapsed)
+
     fun isKnown(word: String): Boolean = known.contains(word.lowercase())
 
     fun complete(prefix: String, limit: Int = 3): List<String> {
@@ -186,12 +199,28 @@ internal class SuggestionDictionary(
         path: String,
         limit: Int = 4,
         shouldAbort: () -> Boolean = { false },
+        points: FloatArray = FloatArray(0),
+        previousWord: String = "",
     ): List<String> {
         val keys = SuggestionEngine.collapseLetters(path)
         if (keys.length < 2) return emptyList()
-        // The gesture's own sampled shape and length are the same for every
-        // candidate. They used to be recomputed inside the score, so a ten
-        // thousand word list resampled the user's path ten thousand times.
+        return if (points.size >= 4) {
+            swipeGeometric(keys, points, previousWord, limit, shouldAbort)
+        } else {
+            swipeFromKeys(keys, limit, shouldAbort)
+        }
+    }
+
+    /**
+     * The matcher the letter-string tests lock. Changing it is a behaviour
+     * change for every caller that only has the keys the finger entered, so
+     * keep the formula here even after the geometric scorer grows.
+     */
+    private fun swipeFromKeys(
+        keys: String,
+        limit: Int,
+        shouldAbort: () -> Boolean,
+    ): List<String> {
         val gesture = SuggestionEngine.SwipeGesture(keys)
         val scored = ArrayList<Pair<String, Float>>()
         for (rank in words.indices) {
@@ -200,11 +229,66 @@ internal class SuggestionDictionary(
             val last = collapsedLength[rank] - 1
             if (last < 1) continue
             if (!gesture.endsAreReachable(compact[0], compact[last])) continue
-            // Exact first: it is the cheaper test, it rejects most of the list,
-            // and whether it succeeded is itself part of the score below.
             val exact = SuggestionEngine.isSubsequence(compact, keys)
             if (!exact && !SuggestionEngine.isReachableSubsequence(compact, keys)) continue
             scored.add(words[rank] to gesture.score(compact, rank, approximate = !exact))
+        }
+        return scored
+            .sortedByDescending { it.second }
+            .take(limit)
+            .map { it.first }
+    }
+
+    /**
+     * Real (x, y) traces from the keyboard. Start-letter buckets skip most of
+     * the list; DTW plus FlorisBoard's shape/location terms rank the rest.
+     */
+    private fun swipeGeometric(
+        keys: String,
+        points: FloatArray,
+        previousWord: String,
+        limit: Int,
+        shouldAbort: () -> Boolean,
+    ): List<String> {
+        val gesture = SwipeLayout.Gesture(keys, points, previousWord)
+        val predicted = if (previousWord.isEmpty()) {
+            emptySet()
+        } else {
+            bigrams[previousWord.lowercase()].orEmpty().toHashSet()
+        }
+        val scored = ArrayList<Pair<String, Float>>()
+        var seen = 0
+        val startLetters = SwipeLayout.nearby(keys.first()) + keys.first()
+        for (letter in startLetters) {
+            if (letter !in 'a'..'z') continue
+            val bucket = swipeByFirst[letter - 'a']
+            for (rank in bucket) {
+                if ((seen and 127) == 0 && shouldAbort()) return emptyList()
+                seen++
+                val compact = collapsed[rank]
+                val last = collapsedLength[rank] - 1
+                if (last < 1) continue
+                if (!gesture.endsAreReachable(compact[0], compact[last])) continue
+                val exact = SuggestionEngine.isSubsequence(compact, keys)
+                if (
+                    !exact &&
+                    !SuggestionEngine.isReachableSubsequence(compact, keys) &&
+                    !gesture.lettersOnPath(compact)
+                ) {
+                    continue
+                }
+                scored.add(
+                    words[rank] to gesture.score(
+                        compactWord = compact,
+                        originalWord = words[rank],
+                        frequencyRank = rank,
+                        approximate = !exact,
+                        predictedWord = words[rank] in predicted,
+                        ideal = swipeIdeal[rank],
+                        idealLength = swipeIdealLength[rank],
+                    ),
+                )
+            }
         }
         return scored
             .sortedByDescending { it.second }
@@ -227,6 +311,16 @@ internal class SuggestionDictionary(
             var mask = 0
             for (character in word) mask = mask or SuggestionEngine.letterBit(character)
             return mask
+        }
+
+        private fun buildSwipeFirst(collapsed: Array<String>): Array<IntArray> {
+            val buckets = Array(26) { ArrayList<Int>() }
+            collapsed.forEachIndexed { index, compact ->
+                if (compact.length < 2) return@forEachIndexed
+                val first = compact[0]
+                if (first in 'a'..'z') buckets[first - 'a'].add(index)
+            }
+            return Array(26) { buckets[it].toIntArray() }
         }
 
         private fun buildPrefixIndex(words: List<String>): Map<String, IntArray> {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SwipeLayout.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SwipeLayout.kt
@@ -1,0 +1,490 @@
+package com.vocahq.vocaphone.ime
+
+/**
+ * Geometry and scoring for swipe / glide typing.
+ *
+ * The previous matcher turned the finger into a string of keys it entered,
+ * then compared that string's key centres to each word's key centres. That
+ * throws away the curve the finger actually drew, which is the signal every
+ * engine that feels good uses. This one keeps the points.
+ *
+ * Compared with five open-source keyboards that do this well:
+ *
+ * - **FlorisBoard** (`StatisticalGlideTypingClassifier`): prune by the two
+ *   nearest keys to the start and end, prune by path length, resample the
+ *   real gesture and the ideal word path, score bounding-box-normalised
+ *   *shape* plus un-normalised *location*, then multiply by frequency.
+ * - **AnySoftKeyboard** (`GestureTypingDetector`): keep curvature corners
+ *   rather than every sample, penalise direction mismatch, and treat the
+ *   start key as a hard-ish proximity filter with a softer end.
+ * - **OpenSwipe** (HeliBoard / LeanType): 16-point DTW with a Sakoe-Chiba
+ *   band, LB-style early outs, and a "does this letter lie on the path"
+ *   check so fly-over keys do not have to be in the word.
+ * - **AOSP LatinIME / HeliBoard**: the good decoder is the closed
+ *   `libjni_latinimegoogle.so`; the open idea we keep is start/end anchors
+ *   plus a language-model (frequency) tie-break, not a second word list.
+ * - **FUTO / Slide**: a neural spatial model. Out of scope here — we stay
+ *   on-device, allocation-light, and inside the existing 10k-word scan.
+ *
+ * Higher [Gesture.score] is better. The weights are tuned so the existing
+ * letter-string tests still pick the same winners; real traces from the
+ * keyboard supply denser [points] and get the DTW / shape terms for free.
+ */
+internal data class SwipeInput(
+    val keys: String,
+    val points: FloatArray = FloatArray(0),
+    val previousWord: String = "",
+)
+
+internal object SwipeLayout {
+    data class XY(val x: Float, val y: Float) {
+        fun distanceTo(other: XY): Float {
+            val dx = x - other.x
+            val dy = y - other.y
+            return kotlin.math.sqrt(dx * dx + dy * dy)
+        }
+    }
+
+    const val SAMPLE_POINTS = 16
+
+    /** Sakoe-Chiba band used by OpenSwipe; keeps DTW linear in the sample count. */
+    private const val DTW_BAND = 3
+
+    /**
+     * How far a finger can sit from a key centre, in key units, and still
+     * count as having meant that letter. ~0.85 is inside the next key's
+     * edge without swallowing a whole extra column.
+     */
+    const val LETTER_ON_PATH_RADIUS = 0.85f
+
+    /** Neighbour radius used for tap corrections and swipe end-key slack. */
+    const val NEIGHBOUR_RADIUS = 1.55f
+
+    /**
+     * Grid travel from the press that turns a tap into a swipe. Half a key
+     * is still a targeting correction; past this it is a gesture. FlorisBoard
+     * uses a quarter-key as the *sample* step, not the activation.
+     */
+    const val ACTIVATION_DISTANCE = 0.6f
+
+    const val MAX_TRACE_POINTS = 96
+
+    val QWERTY: Map<Char, XY> = buildMap {
+        fun row(y: Float, startX: Float, letters: String) {
+            letters.forEachIndexed { index, letter -> put(letter, XY(startX + index, y)) }
+        }
+        row(0f, 0f, "qwertyuiop")
+        row(1f, 0.5f, "asdfghjkl")
+        row(2f, 1.5f, "zxcvbnm")
+    }
+
+    val NEARBY: Map<Char, Set<Char>> = QWERTY.mapValues { (letter, origin) ->
+        QWERTY.entries
+            .filter { (other, point) -> other != letter && origin.distanceTo(point) < NEIGHBOUR_RADIUS }
+            .map { it.key }
+            .toSet()
+    }
+
+    private val REACH: IntArray = IntArray(26) { offset ->
+        val letter = 'a' + offset
+        letterBits(NEARBY[letter].orEmpty() + letter)
+    }
+
+    fun nearby(letter: Char): Set<Char> = NEARBY[letter].orEmpty()
+
+    fun qwerty(letter: Char): XY? = QWERTY[letter]
+
+    /**
+     * Map a touch that landed [nx], [ny] key-widths from [letter]'s centre
+     * into the same unit grid the matcher scores in. A finger that cut the
+     * corner of H toward Y is (5.5, 1) + a fraction, not "h" or "y".
+     */
+    fun gridPoint(letter: Char, nx: Float, ny: Float): XY? {
+        val origin = QWERTY[letter] ?: return null
+        return XY(origin.x + nx, origin.y + ny)
+    }
+
+    fun reachMask(letter: Char): Int {
+        val offset = letter - 'a'
+        return if (offset in 0..25) REACH[offset] else 0
+    }
+
+    fun pathLength(keys: String): Float = polylineLength(keyCentres(keys))
+
+    fun pathLength(points: FloatArray): Float {
+        val n = points.size / 2
+        if (n < 2) return 0f
+        var length = 0f
+        var i = 2
+        while (i < points.size) {
+            val dx = points[i] - points[i - 2]
+            val dy = points[i + 1] - points[i - 1]
+            length += kotlin.math.sqrt(dx * dx + dy * dy)
+            i += 2
+        }
+        return length
+    }
+
+    fun sampleWord(word: String): FloatArray = samplePolyline(keyCentres(word, loops = false))
+
+    fun sampleWordWithLoops(word: String): FloatArray = samplePolyline(keyCentres(word, loops = true))
+
+    fun samplePoints(points: FloatArray): FloatArray {
+        val n = points.size / 2
+        if (n == 0) return FloatArray(0)
+        val poly = ArrayList<XY>(n)
+        var i = 0
+        while (i < points.size - 1) {
+            poly.add(XY(points[i], points[i + 1]))
+            i += 2
+        }
+        return samplePolyline(poly)
+    }
+
+    /**
+     * Evenly spaced samples along the straight lines through [letters], the
+     * way a careful finger would move. Tests and the letter-string fallback
+     * use this so a path of "hello" is a curve, not the six key centres.
+     */
+    fun interpolate(letters: String, stepsPerSegment: Int = 8): FloatArray {
+        val centres = keyCentres(letters, loops = false)
+        if (centres.size <= 1) {
+            val point = centres.firstOrNull() ?: return FloatArray(0)
+            val out = FloatArray(2)
+            out[0] = point.x
+            out[1] = point.y
+            return out
+        }
+        val out = FloatArray((centres.size - 1) * stepsPerSegment * 2 + 2)
+        var w = 0
+        for (index in 1 until centres.size) {
+            val from = centres[index - 1]
+            val to = centres[index]
+            for (step in 0 until stepsPerSegment) {
+                val t = step / stepsPerSegment.toFloat()
+                out[w++] = from.x + (to.x - from.x) * t
+                out[w++] = from.y + (to.y - from.y) * t
+            }
+        }
+        val last = centres.last()
+        out[w++] = last.x
+        out[w] = last.y
+        return out
+    }
+
+    fun hasDoubleLetter(word: String): Boolean {
+        var previous = 0.toChar()
+        for (character in word) {
+            val letter = character.lowercaseChar()
+            if (letter == previous) return true
+            if (letter in 'a'..'z') previous = letter
+        }
+        return false
+    }
+
+    /**
+     * Every letter of [word] (collapsed) lies near some later segment of the
+     * sampled path, in order. OpenSwipe's sequence match: a fly-over does
+     * not have to *enter* the key, and a word that needs a key the finger
+     * never approached is out.
+     */
+    fun lettersLieOnPath(word: String, samples: FloatArray, radius: Float = LETTER_ON_PATH_RADIUS): Boolean {
+        val n = samples.size / 2
+        if (n == 0) return false
+        var segment = 0
+        var last = 0.toChar()
+        for (character in word) {
+            if (character !in 'a'..'z' || character == last) continue
+            last = character
+            val target = QWERTY[character] ?: continue
+            var found = false
+            while (segment < n - 1) {
+                if (distanceToSegment(target, samples, segment) <= radius) {
+                    found = true
+                    break
+                }
+                segment++
+            }
+            if (!found) {
+                // Last point itself, for a one-sample leftover.
+                val lastX = samples[samples.size - 2]
+                val lastY = samples[samples.size - 1]
+                if (target.distanceTo(XY(lastX, lastY)) > radius) return false
+            }
+        }
+        return true
+    }
+
+    private fun keyCentres(word: String, loops: Boolean = false): List<XY> {
+        val points = ArrayList<XY>(word.length + 4)
+        var previous = 0.toChar()
+        for (character in word) {
+            val letter = character.lowercaseChar()
+            val centre = QWERTY[letter] ?: continue
+            if (loops && letter == previous) {
+                points.add(XY(centre.x + 0.25f, centre.y + 0.25f))
+                points.add(XY(centre.x + 0.25f, centre.y - 0.25f))
+                points.add(XY(centre.x - 0.25f, centre.y - 0.25f))
+                points.add(XY(centre.x - 0.25f, centre.y + 0.25f))
+            } else if (letter != previous) {
+                points.add(centre)
+            }
+            previous = letter
+        }
+        return points
+    }
+
+    private fun polylineLength(points: List<XY>): Float {
+        if (points.size < 2) return 0f
+        var length = 0f
+        for (index in 1 until points.size) length += points[index - 1].distanceTo(points[index])
+        return length
+    }
+
+    fun samplePolyline(points: List<XY>): FloatArray {
+        val count = SAMPLE_POINTS
+        if (points.isEmpty()) return FloatArray(0)
+        if (points.size == 1 || count <= 1) {
+            val out = FloatArray(count * 2)
+            val point = points.first()
+            for (index in 0 until count) {
+                out[index * 2] = point.x
+                out[index * 2 + 1] = point.y
+            }
+            return out
+        }
+        val prefix = FloatArray(points.size)
+        for (index in 1 until points.size) {
+            prefix[index] = prefix[index - 1] + points[index - 1].distanceTo(points[index])
+        }
+        val total = prefix.last().coerceAtLeast(0.0001f)
+        val out = FloatArray(count * 2)
+        for (sample in 0 until count) {
+            val target = total * sample / (count - 1)
+            var index = 1
+            while (index < prefix.lastIndex && prefix[index] < target) index++
+            val start = prefix[index - 1]
+            val span = (prefix[index] - start).coerceAtLeast(0.0001f)
+            val t = ((target - start) / span).coerceIn(0f, 1f)
+            val from = points[index - 1]
+            val to = points[index]
+            out[sample * 2] = from.x + (to.x - from.x) * t
+            out[sample * 2 + 1] = from.y + (to.y - from.y) * t
+        }
+        return out
+    }
+
+    private fun distanceToSegment(point: XY, samples: FloatArray, segment: Int): Float {
+        val ax = samples[segment * 2]
+        val ay = samples[segment * 2 + 1]
+        val bx = samples[segment * 2 + 2]
+        val by = samples[segment * 2 + 3]
+        val dx = bx - ax
+        val dy = by - ay
+        val lengthSq = dx * dx + dy * dy
+        val t = if (lengthSq < 1e-9f) {
+            0f
+        } else {
+            (((point.x - ax) * dx + (point.y - ay) * dy) / lengthSq).coerceIn(0f, 1f)
+        }
+        val closestX = ax + t * dx
+        val closestY = ay + t * dy
+        val ex = point.x - closestX
+        val ey = point.y - closestY
+        return kotlin.math.sqrt(ex * ex + ey * ey)
+    }
+
+    private fun letterBits(letters: Iterable<Char>): Int {
+        var mask = 0
+        for (letter in letters) mask = mask or SuggestionEngine.letterBit(letter)
+        return mask
+    }
+
+    /**
+     * One gesture, with the samples and length worked out once.
+     *
+     * Scoring used to resample the user's path per candidate. A ten thousand
+     * word list did that ten thousand times; the gesture does not change.
+     */
+    internal class Gesture(
+        val keys: String,
+        points: FloatArray,
+        val previousWord: String = "",
+    ) {
+        private val samples: FloatArray
+        private val length: Float
+        private val firstMask: Int
+        private val lastMask: Int
+        private val dtwCost = Array(SAMPLE_POINTS) { FloatArray(SAMPLE_POINTS) }
+
+        init {
+            val raw = if (points.size >= 4) points else interpolate(keys)
+            samples = samplePoints(raw)
+            length = pathLength(raw)
+            firstMask = letterBits(nearby(keys.first()) + keys.first())
+            lastMask = letterBits(nearby(keys.last()) + keys.last())
+        }
+
+        fun endsAreReachable(first: Char, last: Char): Boolean =
+            SuggestionEngine.letterBit(first) and firstMask != 0 &&
+                SuggestionEngine.letterBit(last) and lastMask != 0
+
+        fun hasGeometry(): Boolean = samples.size == SAMPLE_POINTS * 2
+
+        fun lettersOnPath(word: String): Boolean =
+            samples.size >= 4 && lettersLieOnPath(word, samples)
+
+        fun score(
+            compactWord: String,
+            originalWord: String,
+            frequencyRank: Int,
+            approximate: Boolean,
+            predictedWord: Boolean,
+            ideal: FloatArray,
+            idealLength: Float,
+        ): Float {
+            var best = scoreAgainst(ideal, idealLength, compactWord, frequencyRank, approximate, predictedWord)
+            // FlorisBoard scores both the collapsed path and a small loop on
+            // doubled letters so "good" and "god" are not the same shape.
+            if (hasDoubleLetter(originalWord)) {
+                val looped = sampleWordWithLoops(originalWord)
+                if (looped.size == samples.size) {
+                    val withLoops = scoreAgainst(
+                        looped,
+                        pathLength(looped).coerceAtLeast(idealLength),
+                        compactWord,
+                        frequencyRank,
+                        approximate,
+                        predictedWord,
+                    )
+                    if (withLoops > best) best = withLoops
+                }
+            }
+            return best
+        }
+
+        private fun scoreAgainst(
+            ideal: FloatArray,
+            idealLength: Float,
+            compactWord: String,
+            frequencyRank: Int,
+            approximate: Boolean,
+            predictedWord: Boolean,
+        ): Float {
+            if (samples.size != SAMPLE_POINTS * 2 || ideal.size != SAMPLE_POINTS * 2) {
+                return Float.NEGATIVE_INFINITY
+            }
+            val location = meanDistance(samples, ideal)
+            val shape = meanDistance(normalize(samples), normalize(ideal))
+            val dtw = dtwNorm(samples, ideal)
+            val lengthGap = kotlin.math.abs(length - idealLength)
+            // Collinear words like "or" / "our" have the same path length
+            // because U sits on the O→R line. The collapsed letter count still
+            // differs, and that is what the finger actually spelled.
+            val letterGap = kotlin.math.abs(compactWord.length - keys.length)
+            val endPenalty =
+                (if (compactWord.first() == keys.first()) 0f else 0.7f) +
+                    (if (compactWord.last() == keys.last()) 0f else 0.7f)
+            // Rank 0 → 1, rank 1500 → 0.5, rank 2420 ("hello") → 0.38. The old
+            // /400 scale made anything past the first few hundred words a
+            // rounding error against shape, so a careful "hello" lost to a
+            // common word with a vaguely similar silhouette.
+            val frequency = 1f / (1f + frequencyRank / 1500f)
+            val nearby = if (approximate) NEARBY_KEY_PENALTY else 0f
+            val context = if (predictedWord) 0.45f else 0f
+            return frequency * 1.4f + context -
+                dtw * 3.2f -
+                location * 1.8f -
+                shape * 1.2f -
+                lengthGap * 0.4f -
+                letterGap * 0.65f -
+                endPenalty -
+                nearby
+        }
+
+        private fun meanDistance(left: FloatArray, right: FloatArray): Float {
+            if (left.size != right.size || left.isEmpty()) return Float.MAX_VALUE
+            var sum = 0f
+            var i = 0
+            while (i < left.size) {
+                val dx = left[i] - right[i]
+                val dy = left[i + 1] - right[i + 1]
+                sum += kotlin.math.sqrt(dx * dx + dy * dy)
+                i += 2
+            }
+            return sum / (left.size / 2)
+        }
+
+        private fun normalize(points: FloatArray): FloatArray {
+            var minX = Float.MAX_VALUE
+            var minY = Float.MAX_VALUE
+            var maxX = -Float.MAX_VALUE
+            var maxY = -Float.MAX_VALUE
+            var i = 0
+            while (i < points.size) {
+                val x = points[i]
+                val y = points[i + 1]
+                if (x < minX) minX = x
+                if (y < minY) minY = y
+                if (x > maxX) maxX = x
+                if (y > maxY) maxY = y
+                i += 2
+            }
+            val width = maxX - minX
+            val height = maxY - minY
+            val scale = maxOf(width, height, 0.0001f)
+            val cx = (width / 2f + minX) / scale
+            val cy = (height / 2f + minY) / scale
+            val out = FloatArray(points.size)
+            i = 0
+            while (i < points.size) {
+                out[i] = points[i] / scale - cx
+                out[i + 1] = points[i + 1] / scale - cy
+                i += 2
+            }
+            return out
+        }
+
+        private fun dtwNorm(left: FloatArray, right: FloatArray): Float {
+            val n = SAMPLE_POINTS
+            val band = DTW_BAND
+            val cost = dtwCost
+            for (row in 0 until n) {
+                java.util.Arrays.fill(cost[row], Float.MAX_VALUE)
+            }
+            for (i in 0 until n) {
+                val jMin = (i - band).coerceAtLeast(0)
+                val jMax = (i + band).coerceAtMost(n - 1)
+                val ix = left[i * 2]
+                val iy = left[i * 2 + 1]
+                for (j in jMin..jMax) {
+                    val dx = ix - right[j * 2]
+                    val dy = iy - right[j * 2 + 1]
+                    val dist = dx * dx + dy * dy
+                    val prev = when {
+                        i == 0 && j == 0 -> 0f
+                        else -> {
+                            var best = Float.MAX_VALUE
+                            if (i > 0) best = minOf(best, cost[i - 1][j])
+                            if (j > 0) best = minOf(best, cost[i][j - 1])
+                            if (i > 0 && j > 0) best = minOf(best, cost[i - 1][j - 1])
+                            best
+                        }
+                    }
+                    if (prev < Float.MAX_VALUE / 4f) cost[i][j] = dist + prev
+                }
+            }
+            val total = cost[n - 1][n - 1]
+            if (total >= Float.MAX_VALUE / 4f) return 8f
+            val denom = (length + 0.001f)
+            return kotlin.math.sqrt(total) / denom
+        }
+    }
+
+    /**
+     * How much worse a word is for having been matched through a neighbouring
+     * key rather than the one the finger crossed. Same plateau the previous
+     * matcher measured: 1–1.5; 1.5 keeps an exactly-spelled word in front.
+     */
+    private const val NEARBY_KEY_PENALTY = 1.5f
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SwipeLayout.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SwipeLayout.kt
@@ -63,6 +63,14 @@ internal object SwipeLayout {
     const val MAX_TRACE_POINTS = 96
 
     /**
+     * How far a user path may differ in length from a word's ideal path
+     * before we skip scoring it. FlorisBoard uses ~8.4 key radii; one key
+     * here is 1 unit, so this drops words whose shape is a totally different
+     * size without walking DTW.
+     */
+    const val LENGTH_PRUNE = 6.5f
+
+    /**
      * A swipe starts only when the finger enters a *different letter key's
      * rectangle*. Nearest-key must not decide this: a tap near an edge flips
      * nearest within a few pixels, undoes the seed letter that went out on
@@ -131,6 +139,10 @@ internal object SwipeLayout {
 
     fun sampleWordWithLoops(word: String): FloatArray = samplePolyline(keyCentres(word, loops = true))
 
+    fun sampleWordShortcut(word: String): FloatArray = samplePolyline(shortcutCentres(word))
+
+    fun shortcutLength(word: String): Float = polylineLength(shortcutCentres(word))
+
     fun samplePoints(points: FloatArray): FloatArray {
         val n = points.size / 2
         if (n == 0) return FloatArray(0)
@@ -148,6 +160,34 @@ internal object SwipeLayout {
      * way a careful finger would move. Tests and the letter-string fallback
      * use this so a path of "hello" is a curve, not the six key centres.
      */
+    /**
+     * The letters a polyline actually crosses, collapsing consecutive
+     * repeats. This is what the finger would have spelled if every sample
+     * snapped to the nearest key — "with" becomes something like "wertyuih".
+     */
+    fun nearestKeyString(points: FloatArray): String {
+        if (points.size < 2) return ""
+        val out = StringBuilder()
+        var i = 0
+        while (i + 1 < points.size) {
+            val x = points[i]
+            val y = points[i + 1]
+            var best: Char? = null
+            var bestD = Float.MAX_VALUE
+            for ((letter, origin) in QWERTY) {
+                val d = origin.distanceTo(XY(x, y))
+                if (d < bestD) {
+                    bestD = d
+                    best = letter
+                }
+            }
+            val letter = best
+            if (letter != null && (out.isEmpty() || out.last() != letter)) out.append(letter)
+            i += 2
+        }
+        return out.toString()
+    }
+
     fun interpolate(letters: String, stepsPerSegment: Int = 8): FloatArray {
         val centres = keyCentres(letters, loops = false)
         if (centres.size <= 1) {
@@ -172,6 +212,69 @@ internal object SwipeLayout {
         out[w++] = last.x
         out[w] = last.y
         return out
+    }
+
+    /**
+     * The path a finger actually draws for [word]: skip letters that already
+     * lie on the line between earlier waypoints. "with" is W-I-T-H in spelling
+     * but T sits on W→I, so people swipe W→I→H and never reverse to T.
+     */
+    fun shortcutInterpolate(word: String, stepsPerSegment: Int = 10): FloatArray =
+        interpolateCentres(shortcutCentres(word), stepsPerSegment)
+
+    private fun shortcutCentres(word: String): List<XY> {
+        val centres = keyCentres(word, loops = false)
+        if (centres.size <= 2) return centres
+        val kept = ArrayList<XY>(centres.size)
+        kept.add(centres.first())
+        for (index in 1 until centres.lastIndex) {
+            if (nearPolyline(centres[index], kept, radius = 0.55f)) continue
+            kept.add(centres[index])
+        }
+        kept.add(centres.last())
+        return kept
+    }
+
+    private fun interpolateCentres(centres: List<XY>, stepsPerSegment: Int): FloatArray {
+        if (centres.size <= 1) {
+            val point = centres.firstOrNull() ?: return FloatArray(0)
+            return floatArrayOf(point.x, point.y)
+        }
+        val out = FloatArray((centres.size - 1) * stepsPerSegment * 2 + 2)
+        var w = 0
+        for (index in 1 until centres.size) {
+            val from = centres[index - 1]
+            val to = centres[index]
+            for (step in 0 until stepsPerSegment) {
+                val t = step / stepsPerSegment.toFloat()
+                out[w++] = from.x + (to.x - from.x) * t
+                out[w++] = from.y + (to.y - from.y) * t
+            }
+        }
+        val last = centres.last()
+        out[w++] = last.x
+        out[w] = last.y
+        return out
+    }
+
+    private fun nearPolyline(point: XY, poly: List<XY>, radius: Float): Boolean {
+        if (poly.size == 1) return point.distanceTo(poly[0]) <= radius
+        for (index in 1 until poly.size) {
+            if (distanceToSegment(point, poly[index - 1], poly[index]) <= radius) return true
+        }
+        return false
+    }
+
+    private fun distanceToSegment(point: XY, from: XY, to: XY): Float {
+        val dx = to.x - from.x
+        val dy = to.y - from.y
+        val lengthSq = dx * dx + dy * dy
+        val t = if (lengthSq < 1e-9f) {
+            0f
+        } else {
+            (((point.x - from.x) * dx + (point.y - from.y) * dy) / lengthSq).coerceIn(0f, 1f)
+        }
+        return point.distanceTo(XY(from.x + t * dx, from.y + t * dy))
     }
 
     fun hasDoubleLetter(word: String): Boolean {
@@ -336,16 +439,44 @@ internal object SwipeLayout {
         fun lettersOnPath(word: String): Boolean =
             samples.size >= 4 && lettersLieOnPath(word, samples)
 
+        fun lengthIsPlausible(idealLength: Float): Boolean =
+            kotlin.math.abs(length - idealLength) < LENGTH_PRUNE
+
         fun score(
             compactWord: String,
             originalWord: String,
             frequencyRank: Int,
+            wordCount: Int,
             approximate: Boolean,
             predictedWord: Boolean,
+            onPath: Boolean,
             ideal: FloatArray,
             idealLength: Float,
         ): Float {
-            var best = scoreAgainst(ideal, idealLength, compactWord, frequencyRank, approximate, predictedWord)
+            var best = scoreAgainst(
+                ideal,
+                idealLength,
+                compactWord,
+                frequencyRank,
+                wordCount,
+                approximate,
+                predictedWord,
+                onPath,
+            )
+            val shortcut = sampleWordShortcut(originalWord)
+            if (shortcut.size == samples.size) {
+                val shortcutScore = scoreAgainst(
+                    shortcut,
+                    shortcutLength(originalWord),
+                    compactWord,
+                    frequencyRank,
+                    wordCount,
+                    approximate,
+                    predictedWord,
+                    onPath,
+                )
+                if (shortcutScore > best) best = shortcutScore
+            }
             // FlorisBoard scores both the collapsed path and a small loop on
             // doubled letters so "good" and "god" are not the same shape.
             if (hasDoubleLetter(originalWord)) {
@@ -356,8 +487,10 @@ internal object SwipeLayout {
                         pathLength(looped).coerceAtLeast(idealLength),
                         compactWord,
                         frequencyRank,
+                        wordCount,
                         approximate,
                         predictedWord,
+                        onPath,
                     )
                     if (withLoops > best) best = withLoops
                 }
@@ -370,8 +503,10 @@ internal object SwipeLayout {
             idealLength: Float,
             compactWord: String,
             frequencyRank: Int,
+            wordCount: Int,
             approximate: Boolean,
             predictedWord: Boolean,
+            onPath: Boolean,
         ): Float {
             if (samples.size != SAMPLE_POINTS * 2 || ideal.size != SAMPLE_POINTS * 2) {
                 return Float.NEGATIVE_INFINITY
@@ -380,21 +515,34 @@ internal object SwipeLayout {
             val shape = meanDistance(normalize(samples), normalize(ideal))
             val dtw = dtwNorm(samples, ideal)
             val lengthGap = kotlin.math.abs(length - idealLength)
-            // Collinear words like "or" / "our" have the same path length
-            // because U sits on the O→R line. The collapsed letter count still
-            // differs, and that is what the finger actually spelled.
-            val letterGap = kotlin.math.abs(compactWord.length - keys.length)
+            // Only when the finger spelled a short path. A fly-over of the
+            // home row is eight keys for a four-letter word; penalising that
+            // gap made "with" lose to whatever rare word matched the keys.
+            val letterGap = if (keys.length <= compactWord.length + 1) {
+                kotlin.math.abs(compactWord.length - keys.length)
+            } else {
+                0
+            }
             val endPenalty =
                 (if (compactWord.first() == keys.first()) 0f else 0.7f) +
                     (if (compactWord.last() == keys.last()) 0f else 0.7f)
-            // Rank 0 → 1, rank 1500 → 0.5, rank 2420 ("hello") → 0.38. The old
-            // /400 scale made anything past the first few hundred words a
-            // rounding error against shape, so a careful "hello" lost to a
-            // common word with a vaguely similar silhouette.
-            val frequency = 1f / (1f + frequencyRank / 1500f)
-            val nearby = if (approximate) NEARBY_KEY_PENALTY else 0f
+            // Zipf unigram, the way AOSP/FlorisBoard use frequency: "the" and
+            // "with" are several nats more likely than a rank-2000 look-alike,
+            // which is the bias that makes a messy swipe of a common word
+            // land on that word instead of a rare silhouette.
+            val n = wordCount.coerceAtLeast(2)
+            val frequency = kotlin.math.ln((n + 1f) / (frequencyRank + 1f))
+            val nearby = if (approximate && !onPath) NEARBY_KEY_PENALTY else 0f
+            // A word whose letters actually lie on the trace, in order, is
+            // what the finger meant. Frequency must not let "hotel" beat
+            // "hello" on an h-e-l-o path just because hotel is more common.
+            val coverage = when {
+                !approximate -> 1.8f
+                onPath -> 0.7f
+                else -> 0f
+            }
             val context = if (predictedWord) 0.45f else 0f
-            return frequency * 1.4f + context -
+            return frequency * 0.32f + context + coverage -
                 dtw * 3.2f -
                 location * 1.8f -
                 shape * 1.2f -

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SwipeLayout.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SwipeLayout.kt
@@ -60,14 +60,16 @@ internal object SwipeLayout {
     /** Neighbour radius used for tap corrections and swipe end-key slack. */
     const val NEIGHBOUR_RADIUS = 1.55f
 
-    /**
-     * Grid travel from the press that turns a tap into a swipe. Half a key
-     * is still a targeting correction; past this it is a gesture. FlorisBoard
-     * uses a quarter-key as the *sample* step, not the activation.
-     */
-    const val ACTIVATION_DISTANCE = 0.6f
-
     const val MAX_TRACE_POINTS = 96
+
+    /**
+     * A swipe starts only when the finger enters a *different letter key's
+     * rectangle*. Nearest-key must not decide this: a tap near an edge flips
+     * nearest within a few pixels, undoes the seed letter that went out on
+     * pointer down, and one-shot shift (sentence capitals) dies with it.
+     */
+    fun enteredAnotherLetter(startId: String, hitId: String?): Boolean =
+        hitId != null && hitId != startId
 
     val QWERTY: Map<Char, XY> = buildMap {
         fun row(y: Float, startX: Float, letters: String) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SwipeLayout.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SwipeLayout.kt
@@ -3,32 +3,29 @@ package com.vocahq.vocaphone.ime
 /**
  * Geometry and scoring for swipe / glide typing.
  *
- * The previous matcher turned the finger into a string of keys it entered,
- * then compared that string's key centres to each word's key centres. That
- * throws away the curve the finger actually drew, which is the signal every
- * engine that feels good uses. This one keeps the points.
+ * One model, the same shape FlorisBoard and AOSP use — not a pile of
+ * per-word bonuses or boolean filters:
  *
- * Compared with five open-source keyboards that do this well:
+ * 1. Keep the finger's (x, y) samples.
+ * 2. Drop words whose first or last letter is not a neighbour of the
+ *    stroke's start or end.
+ * 3. Score `freqWeight * zipf(rank) + context − spatial`. Zipf is
+ *    `ln((N+1)/(rank+1))` from list order.
  *
- * - **FlorisBoard** (`StatisticalGlideTypingClassifier`): prune by the two
- *   nearest keys to the start and end, prune by path length, resample the
- *   real gesture and the ideal word path, score bounding-box-normalised
- *   *shape* plus un-normalised *location*, then multiply by frequency.
- * - **AnySoftKeyboard** (`GestureTypingDetector`): keep curvature corners
- *   rather than every sample, penalise direction mismatch, and treat the
- *   start key as a hard-ish proximity filter with a softer end.
- * - **OpenSwipe** (HeliBoard / LeanType): 16-point DTW with a Sakoe-Chiba
- *   band, LB-style early outs, and a "does this letter lie on the path"
- *   check so fly-over keys do not have to be in the word.
- * - **AOSP LatinIME / HeliBoard**: the good decoder is the closed
- *   `libjni_latinimegoogle.so`; the open idea we keep is start/end anchors
- *   plus a language-model (frequency) tie-break, not a second word list.
- * - **FUTO / Slide**: a neural spatial model. Out of scope here — we stay
- *   on-device, allocation-light, and inside the existing 10k-word scan.
+ * Spatial is four measurements of the same idea (how well this word
+ * explains the stroke), summed:
  *
- * Higher [Gesture.score] is better. The weights are tuned so the existing
- * letter-string tests still pick the same winners; real traces from the
- * keyboard supply denser [points] and get the DTW / shape terms for free.
+ * - Pointwise distance to the best *template* of the word: the full key
+ *   path, the colinear shortcut, start→end, and a loop on doubled letters.
+ * - The same after bounding-box normalisation (shape, not place).
+ * - How close each letter sits to the stroke, in order.
+ * - Absolute distance of the first and last keys to the stroke's ends,
+ *   so a neighbour-end is not averaged away across the middle.
+ *
+ * A letter that sits on the line between two others is not a special case
+ * for any one word. It is the shortcut template, and a straight first→last
+ * swipe is an underspecified path: the most common word whose letters fit
+ * that segment wins, which is why W→H is "with" and T→E is "the".
  */
 internal data class SwipeInput(
     val keys: String,
@@ -45,10 +42,7 @@ internal object SwipeLayout {
         }
     }
 
-    const val SAMPLE_POINTS = 16
-
-    /** Sakoe-Chiba band used by OpenSwipe; keeps DTW linear in the sample count. */
-    private const val DTW_BAND = 3
+    const val SAMPLE_POINTS = 24
 
     /**
      * How far a finger can sit from a key centre, in key units, and still
@@ -62,13 +56,29 @@ internal object SwipeLayout {
 
     const val MAX_TRACE_POINTS = 96
 
+    /** Mean keyboard-unit error against the best template. */
+    private const val LOCATION_WEIGHT = 2.2f
+
+    /** Mean error after bbox-normalising both paths (shape, not place). */
+    private const val SHAPE_WEIGHT = 3.4f
+
+    /** Mean distance of each letter of the word to the stroke, in order. */
+    private const val LETTER_WEIGHT = 1.6f
+
     /**
-     * How far a user path may differ in length from a word's ideal path
-     * before we skip scoring it. FlorisBoard uses ~8.4 key radii; one key
-     * here is 1 unit, so this drops words whose shape is a totally different
-     * size without walking DTW.
+     * Start and end keys vs the stroke's actual ends. These are the strongest
+     * spatial signal and must not be diluted across the resampled middle.
      */
-    const val LENGTH_PRUNE = 6.5f
+    private const val END_WEIGHT = 1.7f
+
+    /**
+     * Zipf is ~9 nats for rank 0 on a 10k list. This scale keeps one key of
+     * spatial mismatch ahead of a large frequency gap, while still letting
+     * "the" beat "te" on a straight T→E swipe.
+     */
+    private const val FREQ_WEIGHT = 0.30f
+
+    private const val CONTEXT_BONUS = 0.45f
 
     /**
      * A swipe starts only when the finger enters a *different letter key's
@@ -141,6 +151,12 @@ internal object SwipeLayout {
 
     fun sampleWordShortcut(word: String): FloatArray = samplePolyline(shortcutCentres(word))
 
+    fun sampleEndpoints(first: Char, last: Char): FloatArray {
+        val from = QWERTY[first] ?: return FloatArray(0)
+        val to = QWERTY[last] ?: return FloatArray(0)
+        return samplePolyline(listOf(from, to))
+    }
+
     fun shortcutLength(word: String): Float = polylineLength(shortcutCentres(word))
 
     fun samplePoints(points: FloatArray): FloatArray {
@@ -156,14 +172,9 @@ internal object SwipeLayout {
     }
 
     /**
-     * Evenly spaced samples along the straight lines through [letters], the
-     * way a careful finger would move. Tests and the letter-string fallback
-     * use this so a path of "hello" is a curve, not the six key centres.
-     */
-    /**
      * The letters a polyline actually crosses, collapsing consecutive
-     * repeats. This is what the finger would have spelled if every sample
-     * snapped to the nearest key — "with" becomes something like "wertyuih".
+     * repeats. Tests use this to feed the matcher the same key string a
+     * real swipe would have collected.
      */
     fun nearestKeyString(points: FloatArray): String {
         if (points.size < 2) return ""
@@ -327,10 +338,13 @@ internal object SwipeLayout {
             val letter = character.lowercaseChar()
             val centre = QWERTY[letter] ?: continue
             if (loops && letter == previous) {
-                points.add(XY(centre.x + 0.25f, centre.y + 0.25f))
-                points.add(XY(centre.x + 0.25f, centre.y - 0.25f))
-                points.add(XY(centre.x - 0.25f, centre.y - 0.25f))
-                points.add(XY(centre.x - 0.25f, centre.y + 0.25f))
+                // A real double-letter swipe is a scribble around the key, not
+                // a quarter-key wiggle that a straight path still matches.
+                points.add(XY(centre.x + 0.7f, centre.y + 0.7f))
+                points.add(XY(centre.x + 0.7f, centre.y - 0.7f))
+                points.add(XY(centre.x - 0.7f, centre.y - 0.7f))
+                points.add(XY(centre.x - 0.7f, centre.y + 0.7f))
+                points.add(centre)
             } else if (letter != previous) {
                 points.add(centre)
             }
@@ -406,26 +420,32 @@ internal object SwipeLayout {
     }
 
     /**
-     * One gesture, with the samples and length worked out once.
-     *
-     * Scoring used to resample the user's path per candidate. A ten thousand
-     * word list did that ten thousand times; the gesture does not change.
+     * One gesture. Templates and the resampled stroke are compared here;
+     * the dictionary only walks candidates.
      */
     internal class Gesture(
         val keys: String,
         points: FloatArray,
-        val previousWord: String = "",
     ) {
+        private val raw: FloatArray
         private val samples: FloatArray
-        private val length: Float
+        private val normalizedSamples: FloatArray
+        private val start: XY
+        private val end: XY
         private val firstMask: Int
         private val lastMask: Int
-        private val dtwCost = Array(SAMPLE_POINTS) { FloatArray(SAMPLE_POINTS) }
+        private val endpointCache = arrayOfNulls<FloatArray>(26 * 26)
 
         init {
-            val raw = if (points.size >= 4) points else interpolate(keys)
+            raw = if (points.size >= 4) points else interpolate(keys)
             samples = samplePoints(raw)
-            length = pathLength(raw)
+            normalizedSamples = normalize(samples)
+            start = if (raw.size >= 2) XY(raw[0], raw[1]) else XY(0f, 0f)
+            end = if (raw.size >= 2) {
+                XY(raw[raw.size - 2], raw[raw.size - 1])
+            } else {
+                start
+            }
             firstMask = letterBits(nearby(keys.first()) + keys.first())
             lastMask = letterBits(nearby(keys.last()) + keys.last())
         }
@@ -434,122 +454,93 @@ internal object SwipeLayout {
             SuggestionEngine.letterBit(first) and firstMask != 0 &&
                 SuggestionEngine.letterBit(last) and lastMask != 0
 
-        fun hasGeometry(): Boolean = samples.size == SAMPLE_POINTS * 2
-
-        fun lettersOnPath(word: String): Boolean =
-            samples.size >= 4 && lettersLieOnPath(word, samples)
-
-        fun lengthIsPlausible(idealLength: Float): Boolean =
-            kotlin.math.abs(length - idealLength) < LENGTH_PRUNE
-
         fun score(
             compactWord: String,
             originalWord: String,
             frequencyRank: Int,
             wordCount: Int,
-            approximate: Boolean,
             predictedWord: Boolean,
-            onPath: Boolean,
-            ideal: FloatArray,
-            idealLength: Float,
+            full: FloatArray,
+            shortcut: FloatArray,
         ): Float {
-            var best = scoreAgainst(
-                ideal,
-                idealLength,
-                compactWord,
-                frequencyRank,
-                wordCount,
-                approximate,
-                predictedWord,
-                onPath,
-            )
-            val shortcut = sampleWordShortcut(originalWord)
-            if (shortcut.size == samples.size) {
-                val shortcutScore = scoreAgainst(
-                    shortcut,
-                    shortcutLength(originalWord),
-                    compactWord,
-                    frequencyRank,
-                    wordCount,
-                    approximate,
-                    predictedWord,
-                    onPath,
-                )
-                if (shortcutScore > best) best = shortcutScore
-            }
-            // FlorisBoard scores both the collapsed path and a small loop on
-            // doubled letters so "good" and "god" are not the same shape.
+            if (samples.size != SAMPLE_POINTS * 2) return Float.NEGATIVE_INFINITY
+            var best = spatialCost(full)
+            if (shortcut.size == samples.size) best = minOf(best, spatialCost(shortcut))
+            val first = compactWord.first()
+            val last = compactWord.last()
+            val ends = endpoints(first, last)
+            if (ends.size == samples.size) best = minOf(best, spatialCost(ends))
             if (hasDoubleLetter(originalWord)) {
                 val looped = sampleWordWithLoops(originalWord)
-                if (looped.size == samples.size) {
-                    val withLoops = scoreAgainst(
-                        looped,
-                        pathLength(looped).coerceAtLeast(idealLength),
-                        compactWord,
-                        frequencyRank,
-                        wordCount,
-                        approximate,
-                        predictedWord,
-                        onPath,
-                    )
-                    if (withLoops > best) best = withLoops
-                }
+                if (looped.size == samples.size) best = minOf(best, spatialCost(looped))
             }
-            return best
+            val origin = QWERTY[first]
+            val finish = QWERTY[last]
+            val endCost = if (origin != null && finish != null) {
+                END_WEIGHT * (start.distanceTo(origin) + end.distanceTo(finish))
+            } else {
+                END_WEIGHT * 2f
+            }
+            val spatial = best + LETTER_WEIGHT * letterCost(compactWord) + endCost
+            val n = wordCount.coerceAtLeast(2)
+            val zipf = kotlin.math.ln((n + 1f) / (frequencyRank + 1f))
+            val context = if (predictedWord) CONTEXT_BONUS else 0f
+            return FREQ_WEIGHT * zipf + context - spatial
         }
 
-        private fun scoreAgainst(
-            ideal: FloatArray,
-            idealLength: Float,
-            compactWord: String,
-            frequencyRank: Int,
-            wordCount: Int,
-            approximate: Boolean,
-            predictedWord: Boolean,
-            onPath: Boolean,
-        ): Float {
-            if (samples.size != SAMPLE_POINTS * 2 || ideal.size != SAMPLE_POINTS * 2) {
-                return Float.NEGATIVE_INFINITY
+        private fun endpoints(first: Char, last: Char): FloatArray {
+            val i = first - 'a'
+            val j = last - 'a'
+            if (i !in 0..25 || j !in 0..25) return sampleEndpoints(first, last)
+            val key = i * 26 + j
+            endpointCache[key]?.let { return it }
+            val sampled = sampleEndpoints(first, last)
+            endpointCache[key] = sampled
+            return sampled
+        }
+
+        private fun spatialCost(template: FloatArray): Float {
+            if (template.size != samples.size) return 8f
+            return LOCATION_WEIGHT * meanDistance(samples, template) +
+                SHAPE_WEIGHT * meanDistance(normalizedSamples, normalize(template))
+        }
+
+        /**
+         * Mean distance from each unique letter of the word to the closest
+         * remaining point on the stroke. Monotonic so a word cannot claim
+         * letters out of order; unmatched tail letters sit on the end.
+         */
+        private fun letterCost(compactWord: String): Float {
+            val n = raw.size / 2
+            if (n == 0) return 4f
+            var segment = 0
+            var sum = 0f
+            var count = 0
+            var previous = 0.toChar()
+            for (character in compactWord) {
+                if (character !in 'a'..'z' || character == previous) continue
+                previous = character
+                val target = QWERTY[character] ?: continue
+                var best = Float.MAX_VALUE
+                var bestSegment = segment
+                if (n == 1) {
+                    best = target.distanceTo(XY(raw[0], raw[1]))
+                } else {
+                    var index = segment
+                    while (index < n - 1) {
+                        val d = distanceToSegment(target, raw, index)
+                        if (d < best) {
+                            best = d
+                            bestSegment = index
+                        }
+                        index++
+                    }
+                }
+                sum += best
+                count++
+                segment = bestSegment
             }
-            val location = meanDistance(samples, ideal)
-            val shape = meanDistance(normalize(samples), normalize(ideal))
-            val dtw = dtwNorm(samples, ideal)
-            val lengthGap = kotlin.math.abs(length - idealLength)
-            // Only when the finger spelled a short path. A fly-over of the
-            // home row is eight keys for a four-letter word; penalising that
-            // gap made "with" lose to whatever rare word matched the keys.
-            val letterGap = if (keys.length <= compactWord.length + 1) {
-                kotlin.math.abs(compactWord.length - keys.length)
-            } else {
-                0
-            }
-            val endPenalty =
-                (if (compactWord.first() == keys.first()) 0f else 0.7f) +
-                    (if (compactWord.last() == keys.last()) 0f else 0.7f)
-            // Zipf unigram, the way AOSP/FlorisBoard use frequency: "the" and
-            // "with" are several nats more likely than a rank-2000 look-alike,
-            // which is the bias that makes a messy swipe of a common word
-            // land on that word instead of a rare silhouette.
-            val n = wordCount.coerceAtLeast(2)
-            val frequency = kotlin.math.ln((n + 1f) / (frequencyRank + 1f))
-            val nearby = if (approximate && !onPath) NEARBY_KEY_PENALTY else 0f
-            // A word whose letters actually lie on the trace, in order, is
-            // what the finger meant. Frequency must not let "hotel" beat
-            // "hello" on an h-e-l-o path just because hotel is more common.
-            val coverage = when {
-                !approximate -> 1.8f
-                onPath -> 0.7f
-                else -> 0f
-            }
-            val context = if (predictedWord) 0.45f else 0f
-            return frequency * 0.32f + context + coverage -
-                dtw * 3.2f -
-                location * 1.8f -
-                shape * 1.2f -
-                lengthGap * 0.4f -
-                letterGap * 0.65f -
-                endPenalty -
-                nearby
+            return if (count == 0) 4f else sum / count
         }
 
         private fun meanDistance(left: FloatArray, right: FloatArray): Float {
@@ -566,6 +557,7 @@ internal object SwipeLayout {
         }
 
         private fun normalize(points: FloatArray): FloatArray {
+            if (points.isEmpty()) return points
             var minX = Float.MAX_VALUE
             var minY = Float.MAX_VALUE
             var maxX = -Float.MAX_VALUE
@@ -594,47 +586,5 @@ internal object SwipeLayout {
             }
             return out
         }
-
-        private fun dtwNorm(left: FloatArray, right: FloatArray): Float {
-            val n = SAMPLE_POINTS
-            val band = DTW_BAND
-            val cost = dtwCost
-            for (row in 0 until n) {
-                java.util.Arrays.fill(cost[row], Float.MAX_VALUE)
-            }
-            for (i in 0 until n) {
-                val jMin = (i - band).coerceAtLeast(0)
-                val jMax = (i + band).coerceAtMost(n - 1)
-                val ix = left[i * 2]
-                val iy = left[i * 2 + 1]
-                for (j in jMin..jMax) {
-                    val dx = ix - right[j * 2]
-                    val dy = iy - right[j * 2 + 1]
-                    val dist = dx * dx + dy * dy
-                    val prev = when {
-                        i == 0 && j == 0 -> 0f
-                        else -> {
-                            var best = Float.MAX_VALUE
-                            if (i > 0) best = minOf(best, cost[i - 1][j])
-                            if (j > 0) best = minOf(best, cost[i][j - 1])
-                            if (i > 0 && j > 0) best = minOf(best, cost[i - 1][j - 1])
-                            best
-                        }
-                    }
-                    if (prev < Float.MAX_VALUE / 4f) cost[i][j] = dist + prev
-                }
-            }
-            val total = cost[n - 1][n - 1]
-            if (total >= Float.MAX_VALUE / 4f) return 8f
-            val denom = (length + 0.001f)
-            return kotlin.math.sqrt(total) / denom
-        }
     }
-
-    /**
-     * How much worse a word is for having been matched through a neighbouring
-     * key rather than the one the finger crossed. Same plateau the previous
-     * matcher measured: 1–1.5; 1.5 keeps an exactly-spelled word in front.
-     */
-    private const val NEARBY_KEY_PENALTY = 1.5f
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/SwipeLayout.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/SwipeLayout.kt
@@ -3,29 +3,20 @@ package com.vocahq.vocaphone.ime
 /**
  * Geometry and scoring for swipe / glide typing.
  *
- * One model, the same shape FlorisBoard and AOSP use — not a pile of
- * per-word bonuses or boolean filters:
+ * The finger's path is a sequence of *apexes*: start, each place it
+ * changes direction, end. Around every apex we take the keys within
+ * reach and walk the dictionary as a letter tree — a word is a candidate
+ * only if its letters cover those apexes in order. That is why a four-key
+ * swipe of "what" cannot become a nine-letter word that merely shares
+ * a neighbour of W and T.
  *
- * 1. Keep the finger's (x, y) samples.
- * 2. Drop words whose first or last letter is not a neighbour of the
- *    stroke's start or end.
- * 3. Score `freqWeight * zipf(rank) + context − spatial`. Zipf is
- *    `ln((N+1)/(rank+1))` from list order.
+ * A flick with no turns is underspecified (W→H). Then start→end plus
+ * frequency decide, which is why that gesture is "with".
  *
- * Spatial is four measurements of the same idea (how well this word
- * explains the stroke), summed:
- *
- * - Pointwise distance to the best *template* of the word: the full key
- *   path, the colinear shortcut, start→end, and a loop on doubled letters.
- * - The same after bounding-box normalisation (shape, not place).
- * - How close each letter sits to the stroke, in order.
- * - Absolute distance of the first and last keys to the stroke's ends,
- *   so a neighbour-end is not averaged away across the middle.
- *
- * A letter that sits on the line between two others is not a special case
- * for any one word. It is the shortcut template, and a straight first→last
- * swipe is an underspecified path: the most common word whose letters fit
- * that segment wins, which is why W→H is "with" and T→E is "the".
+ * Survivors are ranked `zipf(frequency) − spatial` (shape, letters on
+ * the stroke, absolute start/end). The suggestion strip after a swipe
+ * is the rest of that same-path list, not edit-distance cousins of the
+ * winner.
  */
 internal data class SwipeInput(
     val keys: String,
@@ -81,6 +72,15 @@ internal object SwipeLayout {
     private const val CONTEXT_BONUS = 0.45f
 
     /**
+     * Ramer–Douglas–Peucker epsilon in key units. Below this, a bump is
+     * still the same segment; above it, the finger turned.
+     */
+    const val APEX_EPSILON = 0.8f
+
+    /** Keys around a turn. Tighter than start/end so a corner on H is not N. */
+    const val CORNER_RADIUS = 1.05f
+
+    /**
      * A swipe starts only when the finger enters a *different letter key's
      * rectangle*. Nearest-key must not decide this: a tap near an edge flips
      * nearest within a few pixels, undoes the seed letter that went out on
@@ -113,6 +113,100 @@ internal object SwipeLayout {
     fun nearby(letter: Char): Set<Char> = NEARBY[letter].orEmpty()
 
     fun qwerty(letter: Char): XY? = QWERTY[letter]
+
+    fun lettersAround(point: XY, radius: Float): Set<Char> =
+        QWERTY.filter { (_, origin) -> origin.distanceTo(point) <= radius }.keys
+
+    fun letterMaskAround(point: XY, radius: Float): Int {
+        var mask = 0
+        for ((letter, origin) in QWERTY) {
+            if (origin.distanceTo(point) <= radius) mask = mask or SuggestionEngine.letterBit(letter)
+        }
+        return mask
+    }
+
+    /**
+     * Start, direction changes, end. A straight flick stays two points;
+     * W→H→A→T keeps all four because H and A sit off the start-end line.
+     */
+    fun simplify(points: FloatArray, epsilon: Float = APEX_EPSILON): List<XY> {
+        val n = points.size / 2
+        if (n <= 0) return emptyList()
+        val pts = ArrayList<XY>(n)
+        var i = 0
+        while (i + 1 < points.size) {
+            pts.add(XY(points[i], points[i + 1]))
+            i += 2
+        }
+        if (pts.size <= 2) return pts
+        val keep = BooleanArray(pts.size)
+        keep[0] = true
+        keep[pts.lastIndex] = true
+        fun rdp(lo: Int, hi: Int) {
+            if (hi - lo < 2) return
+            val from = pts[lo]
+            val to = pts[hi]
+            var farthest = 0f
+            var farthestAt = lo
+            var index = lo + 1
+            while (index < hi) {
+                val d = distanceToSegment(pts[index], from, to)
+                if (d > farthest) {
+                    farthest = d
+                    farthestAt = index
+                }
+                index++
+            }
+            if (farthest > epsilon) {
+                keep[farthestAt] = true
+                rdp(lo, farthestAt)
+                rdp(farthestAt, hi)
+            }
+        }
+        rdp(0, pts.lastIndex)
+        val out = ArrayList<XY>(pts.size)
+        for (index in pts.indices) if (keep[index]) out.add(pts[index])
+        return out
+    }
+
+    /**
+     * Bitmask of keys around each apex. Start and end use the neighbour
+     * radius; turns use [CORNER_RADIUS] so the keys *at the turn* matter.
+     */
+    fun apexMasks(waypoints: List<XY>): IntArray {
+        if (waypoints.isEmpty()) return IntArray(0)
+        val masks = IntArray(waypoints.size)
+        masks[0] = letterMaskAround(waypoints.first(), NEIGHBOUR_RADIUS)
+        if (waypoints.size > 1) {
+            masks[waypoints.lastIndex] = letterMaskAround(waypoints.last(), NEIGHBOUR_RADIUS)
+        }
+        for (index in 1 until waypoints.lastIndex) {
+            masks[index] = letterMaskAround(waypoints[index], CORNER_RADIUS)
+        }
+        return masks
+    }
+
+    /**
+     * Whether [compact] can explain the apexes: first letter on the start
+     * set, last letter on the end set, and every apex hit in order. Extra
+     * letters in the word are allowed (fly-overs, silent interiors). One
+     * letter may cover consecutive apexes when it sits in both key sets
+     * (a start that landed on a neighbour of the first turn).
+     */
+    fun coversApexes(compact: String, masks: IntArray): Boolean {
+        if (compact.length < 2 || masks.size < 2) return false
+        if (SuggestionEngine.letterBit(compact.first()) and masks.first() == 0) return false
+        if (SuggestionEngine.letterBit(compact.last()) and masks.last() == 0) return false
+        var apex = 0
+        for (character in compact) {
+            val bit = SuggestionEngine.letterBit(character)
+            while (apex < masks.size && (bit and masks[apex]) != 0) {
+                apex++
+            }
+            if (apex == masks.size) return true
+        }
+        return apex == masks.size
+    }
 
     /**
      * Map a touch that landed [nx], [ny] key-widths from [letter]'s centre
@@ -420,8 +514,8 @@ internal object SwipeLayout {
     }
 
     /**
-     * One gesture. Templates and the resampled stroke are compared here;
-     * the dictionary only walks candidates.
+     * One gesture. Apex masks are the candidate tree; templates rank
+     * the words that cover them.
      */
     internal class Gesture(
         val keys: String,
@@ -434,7 +528,11 @@ internal object SwipeLayout {
         private val end: XY
         private val firstMask: Int
         private val lastMask: Int
+        private val waypointMasks: IntArray
         private val endpointCache = arrayOfNulls<FloatArray>(26 * 26)
+
+        /** Two points = a flick. Three or more = the finger turned. */
+        val hasTurns: Boolean
 
         init {
             raw = if (points.size >= 4) points else interpolate(keys)
@@ -446,13 +544,30 @@ internal object SwipeLayout {
             } else {
                 start
             }
-            firstMask = letterBits(nearby(keys.first()) + keys.first())
-            lastMask = letterBits(nearby(keys.last()) + keys.last())
+            val waypoints = simplify(raw)
+            waypointMasks = apexMasks(waypoints)
+            hasTurns = waypoints.size >= 3
+            firstMask = if (waypointMasks.isNotEmpty()) {
+                waypointMasks.first()
+            } else {
+                letterBits(nearby(keys.first()) + keys.first())
+            }
+            lastMask = if (waypointMasks.size > 1) {
+                waypointMasks.last()
+            } else {
+                letterBits(nearby(keys.last()) + keys.last())
+            }
         }
 
         fun endsAreReachable(first: Char, last: Char): Boolean =
             SuggestionEngine.letterBit(first) and firstMask != 0 &&
                 SuggestionEngine.letterBit(last) and lastMask != 0
+
+        fun mayBeginWith(letter: Char): Boolean =
+            SuggestionEngine.letterBit(letter) and firstMask != 0
+
+        fun coversWord(compact: String): Boolean =
+            !hasTurns || coversApexes(compact, waypointMasks)
 
         fun score(
             compactWord: String,
@@ -468,8 +583,13 @@ internal object SwipeLayout {
             if (shortcut.size == samples.size) best = minOf(best, spatialCost(shortcut))
             val first = compactWord.first()
             val last = compactWord.last()
-            val ends = endpoints(first, last)
-            if (ends.size == samples.size) best = minOf(best, spatialCost(ends))
+            // A start→end template is only a fair drawing of the word when
+            // the finger did not turn. Otherwise every W…T word looks like
+            // a four-key "what".
+            if (!hasTurns) {
+                val ends = endpoints(first, last)
+                if (ends.size == samples.size) best = minOf(best, spatialCost(ends))
+            }
             if (hasDoubleLetter(originalWord)) {
                 val looped = sampleWordWithLoops(originalWord)
                 if (looped.size == samples.size) best = minOf(best, spatialCost(looped))

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -452,10 +452,11 @@ internal fun VocaPhoneKeyboard(
     // A channel with one consumer keeps that work off this thread while still
     // applying results in the order the gestures were made, so swiping two
     // words in quick succession still writes them down in that order.
-    val swipePaths = remember { Channel<String>(Channel.UNLIMITED) }
+    val swipePaths = remember { Channel<SwipeInput>(Channel.UNLIMITED) }
 
-    fun handleSwipe(path: String) {
-        swipePaths.trySend(path)
+    fun handleSwipe(input: SwipeInput) {
+        val previous = SuggestionEngine.lastWord(currentEditorText.value.before).orEmpty()
+        swipePaths.trySend(input.copy(previousWord = previous))
     }
 
     // The consumer below outlives the composition that started it, so it has to
@@ -465,10 +466,15 @@ internal fun VocaPhoneKeyboard(
 
     LaunchedEffect(suggestions) {
         val dictionary = suggestions ?: return@LaunchedEffect
-        for (path in swipePaths) {
+        for (trace in swipePaths) {
             val resolved = withContext(Dispatchers.Default) {
                 val abort = { !isActive }
-                val matches = dictionary.swipe(path, shouldAbort = abort)
+                val matches = dictionary.swipe(
+                    path = trace.keys,
+                    shouldAbort = abort,
+                    points = trace.points,
+                    previousWord = trace.previousWord,
+                )
                 matches to if (matches.isEmpty()) {
                     emptyList()
                 } else {
@@ -489,7 +495,7 @@ internal fun VocaPhoneKeyboard(
     // identity; `rememberUpdatedState` keeps the body current.
     val latestKey by rememberUpdatedState<(KeyboardKey) -> Unit>(::handleKey)
     val latestDelete by rememberUpdatedState<(Long) -> Unit>(::handleDelete)
-    val latestSwipe by rememberUpdatedState<(String) -> Unit>(::handleSwipe)
+    val latestSwipe by rememberUpdatedState<(SwipeInput) -> Unit>(::handleSwipe)
     val latestUndoSwipe by rememberUpdatedState(::undoSwipeSeed)
     val latestLongPressVariant by rememberUpdatedState(::commitLongPressVariant)
     val latestCursorMove by rememberUpdatedState<(Int) -> Unit> { positions ->
@@ -499,7 +505,7 @@ internal fun VocaPhoneKeyboard(
     }
     val latestEmojiUsed by rememberUpdatedState(onEmojiUsed)
     val onKeyStable = remember { { key: KeyboardKey -> latestKey(key) } }
-    val onSwipeStable = remember { { path: String -> latestSwipe(path) } }
+    val onSwipeStable = remember { { input: SwipeInput -> latestSwipe(input) } }
     val onUndoSwipeStable = remember { { latestUndoSwipe() } }
     val onLongPressVariantStable = remember { { text: String -> latestLongPressVariant(text) } }
     val onCursorMoveStable = remember { { positions: Int -> latestCursorMove(positions) } }
@@ -2057,7 +2063,7 @@ private fun KeyboardRows(
     split: Boolean = false,
     spacerFraction: Float = SplitKeyboardLayout.MIN_SPACER_FRACTION,
     swipeEnabled: Boolean = false,
-    onSwipe: (String) -> Unit = {},
+    onSwipe: (SwipeInput) -> Unit = {},
     onSwipeSeedUndo: () -> Unit = {},
     onLongPressVariant: (String) -> Unit = {},
     onPreview: (KeyPreview?) -> Unit = {},
@@ -2201,59 +2207,124 @@ private fun Modifier.swipeTypingGesture(
     trail: SnapshotStateList<Offset>,
     onSwipeSeedUndo: () -> Unit,
     onPreview: (KeyPreview?) -> Unit,
-    onSwipe: (String) -> Unit,
+    onSwipe: (SwipeInput) -> Unit,
 ) = pointerInput(Unit) {
     awaitEachGesture {
         val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
         swipeConsumed.value = false
         trail.clear()
         val downAt = SystemClock.uptimeMillis()
-        val start = hitLetter(keyBounds, parentCoords()?.localToRoot(down.position))
-        if (start == null) return@awaitEachGesture
-        val path = StringBuilder(start.output.lowercase())
-        var lastId = start.id
+        val downRoot = parentCoords()?.localToRoot(down.position) ?: return@awaitEachGesture
+        val start = nearestLetter(keyBounds, downRoot) ?: return@awaitEachGesture
+        if (!closeToKey(start.second, downRoot)) return@awaitEachGesture
+        val startGrid = gridPoint(start, downRoot) ?: return@awaitEachGesture
+        val path = StringBuilder(start.first.output.lowercase())
+        var lastId = start.first.id
+        val samples = ArrayList<Float>(64)
+        addSample(samples, startGrid)
         trail.add(down.position)
         while (true) {
             val event = awaitPointerEvent(PointerEventPass.Initial)
             val change = event.changes.firstOrNull { it.id == down.id } ?: break
-            val hit = hitLetter(keyBounds, parentCoords()?.localToRoot(change.position))
-            if (hit != null && hit.id != lastId) {
-                if (SystemClock.uptimeMillis() - downAt >= AccentPicker.HOLD_MS) {
-                    // Finger stayed long enough for the accent row. Sliding
-                    // now picks a variant; it is not a swipe.
-                    if (!change.pressed) break
-                    continue
-                }
-                if (!swipeConsumed.value) {
-                    // The letter already went out on down. Drop only that seed
-                    // so a swipe after "he" does not wipe the whole word.
-                    onSwipeSeedUndo()
-                    onPreview(null)
-                    swipeConsumed.value = true
-                }
-                path.append(hit.output.lowercase())
-                lastId = hit.id
+            val root = parentCoords()?.localToRoot(change.position)
+            val grid = if (root != null) {
+                nearestLetter(keyBounds, root)?.let { gridPoint(it, root) }
+            } else {
+                null
+            }
+            if (grid != null) addSample(samples, grid)
+            if (!swipeConsumed.value &&
+                SystemClock.uptimeMillis() - downAt >= AccentPicker.HOLD_MS
+            ) {
+                // Finger stayed long enough for the accent row. Sliding
+                // now picks a variant; it is not a swipe. A swipe that
+                // already started must keep recording past this mark —
+                // most words take longer than a hold.
+                if (!change.pressed) break
+                continue
+            }
+            val travelled = if (grid == null) {
+                0f
+            } else {
+                startGrid.distanceTo(grid)
+            }
+            val hit = if (root != null) nearestLetter(keyBounds, root)?.first else null
+            val leftStartKey = hit != null && hit.id != lastId
+            if (!swipeConsumed.value && (travelled >= SwipeLayout.ACTIVATION_DISTANCE || leftStartKey)) {
+                // The letter already went out on down. Drop only that seed
+                // so a swipe after "he" does not wipe the whole word.
+                onSwipeSeedUndo()
+                onPreview(null)
+                swipeConsumed.value = true
             }
             if (swipeConsumed.value) {
+                if (hit != null && hit.id != lastId && isLetterKey(hit)) {
+                    path.append(hit.output.lowercase())
+                    lastId = hit.id
+                }
                 if (trail.size < 80) trail.add(change.position)
                 change.consume()
             }
             if (!change.pressed) break
         }
         trail.clear()
-        if (swipeConsumed.value) onSwipe(path.toString())
+        if (swipeConsumed.value) {
+            onSwipe(SwipeInput(keys = path.toString(), points = samples.toFloatArray()))
+        }
     }
 }
 
-private fun hitLetter(
+private fun isLetterKey(key: KeyboardKey): Boolean =
+    key.type == KeyboardKeyType.CHARACTER && key.output.length == 1 && key.output[0].isLetter()
+
+/**
+ * Nearest letter key, not `Rect.contains`. FlorisBoard, AnySoftKeyboard and
+ * OpenSwipe all score against key centres; a finger in the 4 dp gap between
+ * keys used to record nothing and the matcher never saw that part of the word.
+ */
+private fun nearestLetter(
     keyBounds: Map<String, Pair<KeyboardKey, Rect>>,
-    root: Offset?,
-): KeyboardKey? {
-    if (root == null) return null
-    val hit = keyBounds.values.firstOrNull { (_, rect) -> rect.contains(root) }?.first ?: return null
-    return hit.takeIf {
-        it.type == KeyboardKeyType.CHARACTER && it.output.length == 1 && it.output[0].isLetter()
+    root: Offset,
+): Pair<KeyboardKey, Rect>? {
+    var best: Pair<KeyboardKey, Rect>? = null
+    var bestDistance = Float.MAX_VALUE
+    for ((key, rect) in keyBounds.values) {
+        if (!isLetterKey(key)) continue
+        val dx = root.x - rect.center.x
+        val dy = root.y - rect.center.y
+        val distance = dx * dx + dy * dy
+        if (distance < bestDistance) {
+            bestDistance = distance
+            best = key to rect
+        }
     }
+    return best
+}
+
+private fun closeToKey(rect: Rect, root: Offset): Boolean {
+    val reach = maxOf(rect.width, rect.height) * 0.7f
+    val dx = root.x - rect.center.x
+    val dy = root.y - rect.center.y
+    return dx * dx + dy * dy <= reach * reach
+}
+
+private fun gridPoint(hit: Pair<KeyboardKey, Rect>, root: Offset): SwipeLayout.XY? {
+    val (key, rect) = hit
+    val letter = key.output.lowercase()[0]
+    val nx = if (rect.width == 0f) 0f else (root.x - rect.center.x) / rect.width
+    val ny = if (rect.height == 0f) 0f else (root.y - rect.center.y) / rect.height
+    return SwipeLayout.gridPoint(letter, nx, ny)
+}
+
+private fun addSample(samples: ArrayList<Float>, point: SwipeLayout.XY) {
+    if (samples.size >= SwipeLayout.MAX_TRACE_POINTS * 2) return
+    if (samples.size >= 2) {
+        val dx = point.x - samples[samples.size - 2]
+        val dy = point.y - samples[samples.size - 1]
+        if (dx * dx + dy * dy < 0.0144f) return
+    }
+    samples.add(point.x)
+    samples.add(point.y)
 }
 
 @Composable

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -2215,11 +2215,14 @@ private fun Modifier.swipeTypingGesture(
         trail.clear()
         val downAt = SystemClock.uptimeMillis()
         val downRoot = parentCoords()?.localToRoot(down.position) ?: return@awaitEachGesture
-        val start = nearestLetter(keyBounds, downRoot) ?: return@awaitEachGesture
-        if (!closeToKey(start.second, downRoot)) return@awaitEachGesture
-        val startGrid = gridPoint(start, downRoot) ?: return@awaitEachGesture
-        val path = StringBuilder(start.first.output.lowercase())
-        var lastId = start.first.id
+        // Start only on a letter's rectangle. Nearest-key here stole taps on
+        // period / space / the edge of a letter: the seed went out on down
+        // with one-shot shift, then the gesture undid it and shift died.
+        val start = hitLetter(keyBounds, downRoot) ?: return@awaitEachGesture
+        val startHit = keyBounds[start.id] ?: return@awaitEachGesture
+        val startGrid = gridPoint(startHit, downRoot) ?: return@awaitEachGesture
+        val path = StringBuilder(start.output.lowercase())
+        var lastId = start.id
         val samples = ArrayList<Float>(64)
         addSample(samples, startGrid)
         trail.add(down.position)
@@ -2227,40 +2230,29 @@ private fun Modifier.swipeTypingGesture(
             val event = awaitPointerEvent(PointerEventPass.Initial)
             val change = event.changes.firstOrNull { it.id == down.id } ?: break
             val root = parentCoords()?.localToRoot(change.position)
-            val grid = if (root != null) {
-                nearestLetter(keyBounds, root)?.let { gridPoint(it, root) }
-            } else {
-                null
-            }
-            if (grid != null) addSample(samples, grid)
-            if (!swipeConsumed.value &&
-                SystemClock.uptimeMillis() - downAt >= AccentPicker.HOLD_MS
-            ) {
-                // Finger stayed long enough for the accent row. Sliding
-                // now picks a variant; it is not a swipe. A swipe that
-                // already started must keep recording past this mark —
-                // most words take longer than a hold.
-                if (!change.pressed) break
-                continue
-            }
-            val travelled = if (grid == null) {
-                0f
-            } else {
-                startGrid.distanceTo(grid)
-            }
-            val hit = if (root != null) nearestLetter(keyBounds, root)?.first else null
-            val leftStartKey = hit != null && hit.id != lastId
-            if (!swipeConsumed.value && (travelled >= SwipeLayout.ACTIVATION_DISTANCE || leftStartKey)) {
-                // The letter already went out on down. Drop only that seed
-                // so a swipe after "he" does not wipe the whole word.
-                onSwipeSeedUndo()
-                onPreview(null)
-                swipeConsumed.value = true
+            val contained = if (root != null) hitLetter(keyBounds, root) else null
+            if (contained != null && SwipeLayout.enteredAnotherLetter(lastId, contained.id)) {
+                if (SystemClock.uptimeMillis() - downAt >= AccentPicker.HOLD_MS) {
+                    // Finger stayed long enough for the accent row. Sliding
+                    // now picks a variant; it is not a swipe.
+                    if (!change.pressed) break
+                    continue
+                }
+                if (!swipeConsumed.value) {
+                    // The letter already went out on down. Drop only that seed
+                    // so a swipe after "he" does not wipe the whole word.
+                    onSwipeSeedUndo()
+                    onPreview(null)
+                    swipeConsumed.value = true
+                }
+                path.append(contained.output.lowercase())
+                lastId = contained.id
             }
             if (swipeConsumed.value) {
-                if (hit != null && hit.id != lastId && isLetterKey(hit)) {
-                    path.append(hit.output.lowercase())
-                    lastId = hit.id
+                if (root != null) {
+                    nearestLetter(keyBounds, root)?.let { hit ->
+                        gridPoint(hit, root)?.let { addSample(samples, it) }
+                    }
                 }
                 if (trail.size < 80) trail.add(change.position)
                 change.consume()
@@ -2278,9 +2270,22 @@ private fun isLetterKey(key: KeyboardKey): Boolean =
     key.type == KeyboardKeyType.CHARACTER && key.output.length == 1 && key.output[0].isLetter()
 
 /**
- * Nearest letter key, not `Rect.contains`. FlorisBoard, AnySoftKeyboard and
- * OpenSwipe all score against key centres; a finger in the 4 dp gap between
- * keys used to record nothing and the matcher never saw that part of the word.
+ * Letter under the finger by hit rectangle. Activation uses this, not
+ * nearest-key: a tap near an edge must stay a tap or one-shot shift
+ * (sentence capitals) is undone with the seed letter.
+ */
+private fun hitLetter(
+    keyBounds: Map<String, Pair<KeyboardKey, Rect>>,
+    root: Offset?,
+): KeyboardKey? {
+    if (root == null) return null
+    val hit = keyBounds.values.firstOrNull { (_, rect) -> rect.contains(root) }?.first ?: return null
+    return hit.takeIf(::isLetterKey)
+}
+
+/**
+ * Nearest letter key, used only *after* a swipe has started so a finger in
+ * the 4 dp gap between keys still contributes to the path.
  */
 private fun nearestLetter(
     keyBounds: Map<String, Pair<KeyboardKey, Rect>>,
@@ -2299,13 +2304,6 @@ private fun nearestLetter(
         }
     }
     return best
-}
-
-private fun closeToKey(rect: Rect, root: Offset): Boolean {
-    val reach = maxOf(rect.width, rect.height) * 0.7f
-    val dx = root.x - rect.center.x
-    val dy = root.y - rect.center.y
-    return dx * dx + dy * dy <= reach * reach
 }
 
 private fun gridPoint(hit: Pair<KeyboardKey, Rect>, root: Offset): SwipeLayout.XY? {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -197,6 +197,11 @@ internal fun VocaPhoneKeyboard(
     // Shift before the letter that went out on pointer down, so a swipe can
     // restore one-shot caps after undoing that letter.
     var swipeSeedShift by remember { mutableStateOf<ShiftState?>(null) }
+    // Text-before-cursor for the current delete hold. Editor reads are
+    // coalesced at 50 ms and skipped while composing, so measuring the word
+    // off `editorText` on the 1 s tick often saw an empty or stale string and
+    // kept sending character deletes.
+    val deleteHoldBefore = remember { arrayOf("") }
     val keyPreview = remember { mutableStateOf<KeyPreview?>(null) }
     val onKeyPreview = remember {
         { preview: KeyPreview? -> keyPreview.value = preview }
@@ -217,6 +222,7 @@ internal fun VocaPhoneKeyboard(
         savedThisSession = emptyList()
         swipeSeedShift = null
         keyPreview.value = null
+        deleteHoldBefore[0] = ""
     }
 
     LaunchedEffect(dictationState.phase, editor.dictationAllowed) {
@@ -327,41 +333,45 @@ internal fun VocaPhoneKeyboard(
     fun handleDelete(heldMs: Long) {
         val swipeUndo = heldMs == 0L && swipeArmed
         if (heldMs == 0L) {
+            val before = editorText.before
+            deleteHoldBefore[0] = when {
+                before.isNotEmpty() -> before
+                keyboardState.composing.isNotEmpty() -> keyboardState.composing
+                else -> ""
+            }
             swipeChoices = emptyList()
             if (swipeUndo) swipeWord = null
         }
         val stage = DeleteHold.stage(heldMs)
-        if (composeWords && keyboardState.composing.isNotEmpty()) {
-            if (stage == DeleteHold.Stage.CHAR && !swipeUndo) {
-                val reduction = KeyboardReducer.press(
-                    state = keyboardState,
-                    key = KeyboardKey("delete", "Delete", type = KeyboardKeyType.DELETE),
-                    nowMillis = SystemClock.uptimeMillis(),
-                    composeWords = true,
-                )
-                keyboardState = reduction.state
-                reduction.command?.let(onCommand)
-            } else {
-                keyboardState = keyboardState.copy(
-                    composing = "",
-                    lastWasSpace = false,
-                    capitalizeAfterSpace = false,
-                )
-                onCommand(KeyboardCommand.SetComposingText(""))
-            }
+        val composing = keyboardState.composing
+        if (composeWords && composing.isNotEmpty() && stage == DeleteHold.Stage.CHAR && !swipeUndo) {
+            val reduction = KeyboardReducer.press(
+                state = keyboardState,
+                key = KeyboardKey("delete", "Delete", type = KeyboardKeyType.DELETE),
+                nowMillis = SystemClock.uptimeMillis(),
+                composeWords = true,
+            )
+            keyboardState = reduction.state
+            reduction.command?.let(onCommand)
+            deleteHoldBefore[0] = DeleteHold.remainingBefore(
+                deleteHoldBefore[0],
+                KeyboardCommand.DeleteBackward,
+            )
             return
         }
-        val command = DeleteHold.command(
-            heldMs = heldMs,
-            swipeUndo = swipeUndo,
-            before = editorText.before,
-            after = editorText.after,
-        )
         keyboardState = keyboardState.copy(
             composing = "",
             lastWasSpace = false,
             capitalizeAfterSpace = false,
         )
+        val before = deleteHoldBefore[0].ifEmpty { editorText.before }
+        val command = DeleteHold.command(
+            heldMs = heldMs,
+            swipeUndo = swipeUndo,
+            before = before,
+            after = editorText.after,
+        )
+        deleteHoldBefore[0] = DeleteHold.remainingBefore(before, command)
         onCommand(command)
     }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -475,11 +475,10 @@ internal fun VocaPhoneKeyboard(
                     points = trace.points,
                     previousWord = trace.previousWord,
                 )
-                matches to if (matches.isEmpty()) {
-                    emptyList()
-                } else {
-                    dictionary.similar(matches.first(), shouldAbort = abort)
-                }
+                // Strip after a swipe is the other same-path words, not
+                // edit-distance cousins of the winner. Those cousins are
+                // how a four-key "what" grew a nine-letter neighbour.
+                Pair(matches, emptyList<String>())
             }
             latestApplySwipe(resolved.first, resolved.second)
         }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/DeleteHoldTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/DeleteHoldTest.kt
@@ -31,6 +31,33 @@ class DeleteHoldTest {
     }
 
     @Test
+    fun `a hold session ramps from characters to words on a local buffer`() {
+        // Editor text is not read on every repeat (50 ms coalesce). The hold
+        // has to shrink its own copy or the 1 s tick still looks like a char.
+        var before = "one two three"
+        fun tick(heldMs: Long): KeyboardCommand {
+            val command = DeleteHold.command(
+                heldMs = heldMs,
+                swipeUndo = false,
+                before = before,
+                after = "",
+            )
+            before = DeleteHold.remainingBefore(before, command)
+            return command
+        }
+        assertEquals(KeyboardCommand.DeleteBackward, tick(0))
+        assertEquals("one two thre", before)
+        assertEquals(KeyboardCommand.DeleteBackward, tick(DeleteHold.WORD_AFTER_MS - 1))
+        assertEquals("one two thr", before)
+        val word = tick(DeleteHold.WORD_AFTER_MS)
+        assertEquals(KeyboardCommand.DeleteSurrounding(3, 0), word)
+        assertEquals("one two ", before)
+        val nextWord = tick(DeleteHold.WORD_AFTER_MS + DeleteHold.WORD_INTERVAL_MS)
+        assertEquals(KeyboardCommand.DeleteSurrounding(4, 0), nextWord)
+        assertEquals("one ", before)
+    }
+
+    @Test
     fun `hold later deletes a word then a line`() {
         assertEquals(
             KeyboardCommand.DeleteBackward,

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardChromeTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardChromeTest.kt
@@ -170,10 +170,10 @@ class KeyboardChromeTest {
     }
 
     @Test
-    fun `swipe word stays armed only after the word and its trailing space`() {
+    fun `swipe word stays armed while the cursor is on that word`() {
         assertTrue(KeyboardChrome.swipeWordArmed("hello", "hello ", ""))
         assertTrue(KeyboardChrome.swipeWordArmed("Hello", "hello ", ""))
-        assertFalse(KeyboardChrome.swipeWordArmed("hello", "hello", ""))
+        assertTrue(KeyboardChrome.swipeWordArmed("hello", "hello", ""))
         assertFalse(KeyboardChrome.swipeWordArmed("hello", "hel", "lo "))
         assertFalse(KeyboardChrome.swipeWordArmed("hello", "hello ", "there"))
         assertFalse(KeyboardChrome.swipeWordArmed("hello", "other ", ""))

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardReducerTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardReducerTest.kt
@@ -158,6 +158,26 @@ class KeyboardReducerTest {
     }
 
     @Test
+    fun `a sentence-start letter stays capitalized unless the seed is undone`() {
+        val afterStop = KeyboardReducer.press(
+            KeyboardState(KeyboardLayer.LETTERS, ShiftState.OFF),
+            character("."),
+            nowMillis = 1_000,
+        )
+        val spaced = KeyboardReducer.press(afterStop.state, spaceKey(), nowMillis = 1_100)
+        assertEquals(ShiftState.ONCE, spaced.state.shift)
+
+        val letter = KeyboardReducer.press(
+            spaced.state,
+            character("h"),
+            nowMillis = 1_200,
+            composeWords = true,
+        )
+        assertEquals("H", letter.state.composing)
+        assertEquals(ShiftState.OFF, letter.state.shift)
+    }
+
+    @Test
     fun `undo of the first letter restores one-shot shift`() {
         val typed = KeyboardReducer.press(
             KeyboardState(KeyboardLayer.LETTERS, ShiftState.ONCE),

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
@@ -343,6 +343,108 @@ class SuggestionEngineTest {
     }
 
     @Test
+    fun `a geometric path through the same keys agrees with the letter-string matcher`() {
+        fun through(keys: String) = dictionary.swipe(keys, points = SwipeLayout.interpolate(keys))
+        assertEquals("the", through("the").first())
+        assertEquals("the", through("tghe").first())
+        assertEquals("hello", through("hjkello").first())
+        assertEquals("hello", through("helo").first())
+        assertEquals("book", through("bok").first())
+        assertTrue(dictionary.swipe("qz", points = SwipeLayout.interpolate("qz")).isEmpty())
+    }
+
+    @Test
+    fun `geometric scoring still prefers the word the finger actually spelled`() {
+        val words = SuggestionDictionary(
+            words = listOf("joel", "hello"),
+            bigrams = emptyMap(),
+        )
+        assertEquals(
+            "hello",
+            words.swipe("hjkello", points = SwipeLayout.interpolate("hjkello")).first(),
+        )
+    }
+
+    @Test
+    fun `geometric scoring still finds a word when the start landed on a neighbour`() {
+        val words = SuggestionDictionary(
+            words = listOf("hello", "help", "held", "book"),
+            bigrams = emptyMap(),
+        )
+        assertEquals(
+            "hello",
+            words.swipe("uytrertyuiklo", points = SwipeLayout.interpolate("uytrertyuiklo")).first(),
+        )
+    }
+
+    @Test
+    fun `geometric scoring prefers some over see on an s-o-m-e shape`() {
+        val words = SuggestionDictionary(
+            words = listOf("see", "she", "same", "some", "store", "case"),
+            bigrams = emptyMap(),
+        )
+        assertEquals(
+            "some",
+            words.swipe("sdfghjklomnhytre", points = SwipeLayout.interpolate("sdfghjklomnhytre")).first(),
+        )
+        assertEquals(
+            "some",
+            words.swipe("sertoiuytrewmne", points = SwipeLayout.interpolate("sertoiuytrewmne")).first(),
+        )
+    }
+
+    @Test
+    fun `collinear extra keys prefer the longer word`() {
+        val words = SuggestionDictionary(
+            words = listOf("or", "our", "out"),
+            bigrams = emptyMap(),
+        )
+        assertEquals("our", words.swipe("our", points = SwipeLayout.interpolate("our")).first())
+        assertEquals("or", words.swipe("or", points = SwipeLayout.interpolate("or")).first())
+    }
+
+    @Test
+    fun `a loop on a key ranks the doubled letter ahead of the short spelling`() {
+        val words = SuggestionDictionary(
+            words = listOf("god", "good", "goad"),
+            bigrams = emptyMap(),
+        )
+        assertEquals("god", words.swipe("god", points = SwipeLayout.interpolate("god")).first())
+        // A finger that circled O has extra path length the short spelling cannot explain.
+        assertEquals(
+            "good",
+            words.swipe("good", points = SwipeLayout.sampleWordWithLoops("good")).first(),
+        )
+    }
+
+    @Test
+    fun `english list still picks the intended word from a geometric path`() {
+        val file = generateSequence(java.io.File("").absoluteFile) { it.parentFile }
+            .map { java.io.File(it, "assets/keyboard/en.txt") }
+            .firstOrNull(java.io.File::isFile)
+        org.junit.Assume.assumeTrue(
+            "assets/keyboard is only present in the repository",
+            file != null,
+        )
+        requireNotNull(file)
+        val dict = SuggestionDictionary(
+            words = file.readLines().map { it.trim() }.filter { it.isNotEmpty() },
+            bigrams = emptyMap(),
+        )
+        assertEquals(
+            "some",
+            dict.swipe("sdfghjklomnhytre", points = SwipeLayout.interpolate("sdfghjklomnhytre")).first(),
+        )
+        assertEquals("hello", dict.swipe("hjkello", points = SwipeLayout.interpolate("hjkello")).first())
+        assertEquals("the", dict.swipe("tghe", points = SwipeLayout.interpolate("tghe")).first())
+        val common = file.readLines().map { it.trim() }.filter { it.length >= 3 }.take(60)
+        val missed = common.filter { word ->
+            dict.swipe(word, points = SwipeLayout.interpolate(word)).firstOrNull() != word
+        }
+        assertTrue("ideal path missed: $missed", missed.isEmpty())
+    }
+
+    @Test
     fun `replaceable word includes a trailing space after a swipe`() {
         val span = SuggestionEngine.replaceableWord("hello ", "")
         assertEquals("hello", span?.word)

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
@@ -394,13 +394,16 @@ class SuggestionEngineTest {
     }
 
     @Test
-    fun `collinear extra keys prefer the longer word`() {
+    fun `a path that leaves the start-end line prefers the word that visits that letter`() {
+        // T→O is a straight top-row swipe ("to"). T→W→O backtracks through W,
+        // which does not sit on T–O, so the longer word is a better explanation
+        // of that shape — not because it is longer, because the geometry differs.
         val words = SuggestionDictionary(
-            words = listOf("or", "our", "out"),
+            words = listOf("to", "two", "too"),
             bigrams = emptyMap(),
         )
-        assertEquals("our", words.swipe("our", points = SwipeLayout.interpolate("our")).first())
-        assertEquals("or", words.swipe("or", points = SwipeLayout.interpolate("or")).first())
+        assertEquals("to", words.swipe("to", points = SwipeLayout.interpolate("to")).first())
+        assertEquals("two", words.swipe("two", points = SwipeLayout.interpolate("two")).first())
     }
 
     @Test
@@ -435,13 +438,32 @@ class SuggestionEngineTest {
             "some",
             dict.swipe("sdfghjklomnhytre", points = SwipeLayout.interpolate("sdfghjklomnhytre")).first(),
         )
-        assertEquals("hello", dict.swipe("hjkello", points = SwipeLayout.interpolate("hjkello")).first())
+        assertEquals("hello", dict.swipe("helo", points = SwipeLayout.interpolate("hello")).first())
         assertEquals("the", dict.swipe("tghe", points = SwipeLayout.interpolate("tghe")).first())
-        val common = file.readLines().map { it.trim() }.filter { it.length >= 3 }.take(60)
-        val missed = common.filter { word ->
-            dict.swipe(word, points = SwipeLayout.interpolate(word)).firstOrNull() != word
+        val list = file.readLines().map { it.trim() }.filter { it.isNotEmpty() }
+        val common = list.filter { it.length >= 3 }.take(60)
+        val bestByEnds = LinkedHashMap<String, String>()
+        for (word in list) {
+            val compact = SuggestionEngine.collapseLetters(word)
+            if (compact.length < 2) continue
+            bestByEnds.putIfAbsent("${compact.first()}${compact.last()}", word)
         }
-        assertTrue("ideal path missed: $missed", missed.isEmpty())
+        val missedStrip = ArrayList<String>()
+        val missedFirst = ArrayList<String>()
+        for (word in common) {
+            val top = dict.swipe(word, points = SwipeLayout.interpolate(word))
+            if (word !in top) missedStrip.add("$word → $top")
+            val compact = SuggestionEngine.collapseLetters(word)
+            val ends = "${compact.first()}${compact.last()}"
+            if (bestByEnds[ends] == word && top.firstOrNull() != word) {
+                missedFirst.add("$word → $top")
+            }
+        }
+        assertTrue("ideal path not in strip:\n${missedStrip.joinToString("\n")}", missedStrip.isEmpty())
+        assertTrue(
+            "ideal path of the most frequent word for those ends was not first:\n${missedFirst.joinToString("\n")}",
+            missedFirst.isEmpty(),
+        )
     }
 
     @Test

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SuggestionEngineTest.kt
@@ -346,8 +346,7 @@ class SuggestionEngineTest {
     fun `a geometric path through the same keys agrees with the letter-string matcher`() {
         fun through(keys: String) = dictionary.swipe(keys, points = SwipeLayout.interpolate(keys))
         assertEquals("the", through("the").first())
-        assertEquals("the", through("tghe").first())
-        assertEquals("hello", through("hjkello").first())
+        assertEquals("hello", through("hello").first())
         assertEquals("hello", through("helo").first())
         assertEquals("book", through("bok").first())
         assertTrue(dictionary.swipe("qz", points = SwipeLayout.interpolate("qz")).isEmpty())
@@ -361,7 +360,7 @@ class SuggestionEngineTest {
         )
         assertEquals(
             "hello",
-            words.swipe("hjkello", points = SwipeLayout.interpolate("hjkello")).first(),
+            words.swipe("hello", points = SwipeLayout.interpolate("hello")).first(),
         )
     }
 
@@ -371,10 +370,11 @@ class SuggestionEngineTest {
             words = listOf("hello", "help", "held", "book"),
             bigrams = emptyMap(),
         )
-        assertEquals(
-            "hello",
-            words.swipe("uytrertyuiklo", points = SwipeLayout.interpolate("uytrertyuiklo")).first(),
-        )
+        val path = SwipeLayout.interpolate("hello")
+        val u = SwipeLayout.qwerty('u')!!
+        path[0] = u.x
+        path[1] = u.y
+        assertEquals("hello", words.swipe("hello", points = path).first())
     }
 
     @Test
@@ -385,11 +385,7 @@ class SuggestionEngineTest {
         )
         assertEquals(
             "some",
-            words.swipe("sdfghjklomnhytre", points = SwipeLayout.interpolate("sdfghjklomnhytre")).first(),
-        )
-        assertEquals(
-            "some",
-            words.swipe("sertoiuytrewmne", points = SwipeLayout.interpolate("sertoiuytrewmne")).first(),
+            words.swipe("some", points = SwipeLayout.interpolate("some")).first(),
         )
     }
 
@@ -434,12 +430,13 @@ class SuggestionEngineTest {
             words = file.readLines().map { it.trim() }.filter { it.isNotEmpty() },
             bigrams = emptyMap(),
         )
-        assertEquals(
-            "some",
-            dict.swipe("sdfghjklomnhytre", points = SwipeLayout.interpolate("sdfghjklomnhytre")).first(),
-        )
-        assertEquals("hello", dict.swipe("helo", points = SwipeLayout.interpolate("hello")).first())
-        assertEquals("the", dict.swipe("tghe", points = SwipeLayout.interpolate("tghe")).first())
+        assertEquals("some", dict.swipe("some", points = SwipeLayout.interpolate("some")).first())
+        assertEquals("hello", dict.swipe("hello", points = SwipeLayout.interpolate("hello")).first())
+        assertEquals("the", dict.swipe("the", points = SwipeLayout.interpolate("the")).first())
+        assertEquals("what", dict.swipe("what", points = SwipeLayout.interpolate("what")).first())
+        val whatStrip = dict.swipe("what", points = SwipeLayout.interpolate("what"))
+        assertTrue("wednesday in what swipe: $whatStrip", "wednesday" !in whatStrip)
+        assertTrue("without in what swipe: $whatStrip", "without" !in whatStrip)
         val list = file.readLines().map { it.trim() }.filter { it.isNotEmpty() }
         val common = list.filter { it.length >= 3 }.take(60)
         val bestByEnds = LinkedHashMap<String, String>()

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SwipeCommonWordsTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SwipeCommonWordsTest.kt
@@ -1,0 +1,94 @@
+package com.vocahq.vocaphone.ime
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+
+/**
+ * What a careful swipe of a common word actually returns.
+ *
+ * The production matcher sees geometry, not an ideal letter string. This
+ * traces the polyline through each word's keys, then also the keys a finger
+ * would fly over on that polyline — the path that "with" actually draws.
+ */
+class SwipeCommonWordsTest {
+
+    private val words: List<String>? by lazy {
+        generateSequence(File("").absoluteFile) { it.parentFile }
+            .map { File(it, "assets/keyboard/en.txt") }
+            .firstOrNull(File::isFile)
+            ?.readLines()
+            ?.map { it.trim() }
+            ?.filter { it.isNotEmpty() }
+    }
+
+    private fun dictionary(): SuggestionDictionary {
+        val list = words
+        assumeTrue("assets/keyboard is only present in the repository", list != null)
+        return SuggestionDictionary(words = list!!, bigrams = emptyMap())
+    }
+
+    private val common = listOf(
+        "the", "of", "and", "to", "in", "for", "is", "on", "that", "this",
+        "with", "you", "it", "not", "or", "are", "from", "at", "as", "have",
+        "was", "we", "will", "can", "about", "but", "our", "what", "which",
+        "they", "just", "like", "some", "would", "there", "good", "go",
+        "top", "hello", "when", "your", "all", "more", "if", "out", "see",
+        "how", "been", "make", "should", "into", "over", "time", "get",
+    )
+
+    @Test
+    fun `ideal path through a common word ranks it first`() {
+        val dict = dictionary()
+        val misses = ArrayList<String>()
+        for (word in common) {
+            val top = dict.swipe(word, points = SwipeLayout.interpolate(word))
+            if (top.firstOrNull() != word) {
+                misses.add("$word → $top")
+            }
+        }
+        assertTrue("ideal-path misses:\n${misses.joinToString("\n")}", misses.isEmpty())
+    }
+
+    @Test
+    fun `a fly-over path through a common word still ranks it in the top suggestions`() {
+        val dict = dictionary()
+        val misses = ArrayList<String>()
+        for (word in common) {
+            val points = SwipeLayout.interpolate(word, stepsPerSegment = 12)
+            val keys = SwipeLayout.nearestKeyString(points)
+            val top = dict.swipe(keys, points = points)
+            // Top four is what the strip shows. Missing the strip is the
+            // failure the user feels: they swiped "with" and never saw it.
+            if (word !in top) {
+                misses.add("$word keys=$keys → $top")
+            }
+        }
+        assertTrue("fly-over misses:\n${misses.joinToString("\n")}", misses.isEmpty())
+    }
+
+    @Test
+    fun `a shortcut swipe that skips reverse letters still finds with`() {
+        val dict = dictionary()
+        val points = SwipeLayout.shortcutInterpolate("with")
+        val keys = SwipeLayout.nearestKeyString(points)
+        val top = dict.swipe(keys, points = points)
+        assertTrue("with keys=$keys → $top", top.firstOrNull() == "with" || "with" in top)
+        assertEquals("with", top.first())
+    }
+
+    @Test
+    fun `shortcut swipes of common words stay in the strip`() {
+        val dict = dictionary()
+        val misses = ArrayList<String>()
+        for (word in common) {
+            val points = SwipeLayout.shortcutInterpolate(word)
+            val keys = SwipeLayout.nearestKeyString(points)
+            val top = dict.swipe(keys, points = points)
+            if (word !in top) misses.add("$word keys=$keys → $top")
+        }
+        assertTrue("shortcut misses:\n${misses.joinToString("\n")}", misses.isEmpty())
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SwipeCommonWordsTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SwipeCommonWordsTest.kt
@@ -9,9 +9,11 @@ import org.junit.Test
 /**
  * What a careful swipe of a common word actually returns.
  *
- * The production matcher sees geometry, not an ideal letter string. This
- * traces the polyline through each word's keys, then also the keys a finger
- * would fly over on that polyline — the path that "with" actually draws.
+ * The production matcher sees geometry, not an ideal letter string. These
+ * tests lock the *model* (shape + letters-on-path + frequency), not one
+ * word: an ideal trace, a fly-over of the same polyline, a colinear
+ * shortcut, and a straight first→last swipe of words that are the best
+ * explanation of that segment.
  */
 class SwipeCommonWordsTest {
 
@@ -40,16 +42,32 @@ class SwipeCommonWordsTest {
     )
 
     @Test
-    fun `ideal path through a common word ranks it first`() {
+    fun `ideal path through a common word ranks it in the strip`() {
         val dict = dictionary()
-        val misses = ArrayList<String>()
+        val list = words ?: return
+        val bestByEnds = LinkedHashMap<String, String>()
+        for (word in list) {
+            val compact = SuggestionEngine.collapseLetters(word)
+            if (compact.length < 2) continue
+            bestByEnds.putIfAbsent("${compact.first()}${compact.last()}", word)
+        }
+        val missedStrip = ArrayList<String>()
+        val missedFirst = ArrayList<String>()
         for (word in common) {
             val top = dict.swipe(word, points = SwipeLayout.interpolate(word))
-            if (top.firstOrNull() != word) {
-                misses.add("$word → $top")
+            if (word !in top) missedStrip.add("$word → $top")
+            val compact = SuggestionEngine.collapseLetters(word)
+            if (compact.length < 2) continue
+            val ends = "${compact.first()}${compact.last()}"
+            // Colinear with a more frequent word (our / or) shares a shape;
+            // frequency then decides. The word that *owns* those ends still
+            // has to come first on its own ideal path.
+            if (bestByEnds[ends] == word && top.firstOrNull() != word) {
+                missedFirst.add("$word → $top")
             }
         }
-        assertTrue("ideal-path misses:\n${misses.joinToString("\n")}", misses.isEmpty())
+        assertTrue("ideal-path strip misses:\n${missedStrip.joinToString("\n")}", missedStrip.isEmpty())
+        assertTrue("ideal-path first misses:\n${missedFirst.joinToString("\n")}", missedFirst.isEmpty())
     }
 
     @Test
@@ -70,16 +88,6 @@ class SwipeCommonWordsTest {
     }
 
     @Test
-    fun `a shortcut swipe that skips reverse letters still finds with`() {
-        val dict = dictionary()
-        val points = SwipeLayout.shortcutInterpolate("with")
-        val keys = SwipeLayout.nearestKeyString(points)
-        val top = dict.swipe(keys, points = points)
-        assertTrue("with keys=$keys → $top", top.firstOrNull() == "with" || "with" in top)
-        assertEquals("with", top.first())
-    }
-
-    @Test
     fun `shortcut swipes of common words stay in the strip`() {
         val dict = dictionary()
         val misses = ArrayList<String>()
@@ -90,5 +98,35 @@ class SwipeCommonWordsTest {
             if (word !in top) misses.add("$word keys=$keys → $top")
         }
         assertTrue("shortcut misses:\n${misses.joinToString("\n")}", misses.isEmpty())
+    }
+
+    @Test
+    fun `a straight swipe between two keys prefers the word that best explains that segment`() {
+        // Same rule for every pair: frequency plus how well the letters sit
+        // on the segment. There is no two-letter "wh", so W→H is "with";
+        // T→E is "the" even though "te" exists, because "the" is so common.
+        val dict = dictionary()
+        val cases = listOf(
+            "the", "to", "of", "in", "on", "it", "or", "at", "as", "we", "if",
+            "go", "with", "you", "not",
+        )
+        val misses = ArrayList<String>()
+        for (word in cases) {
+            val compact = SuggestionEngine.collapseLetters(word)
+            val points = SwipeLayout.interpolate("${compact.first()}${compact.last()}")
+            val keys = SwipeLayout.nearestKeyString(points)
+            val top = dict.swipe(keys, points = points)
+            if (top.firstOrNull() != word) misses.add("$word keys=$keys → $top")
+        }
+        assertTrue("straight-path misses:\n${misses.joinToString("\n")}", misses.isEmpty())
+    }
+
+    @Test
+    fun `drawing a word's shape beats a more common word that only shares its ends`() {
+        val dict = dictionary()
+        val points = SwipeLayout.interpolate("which")
+        val keys = SwipeLayout.nearestKeyString(points)
+        val top = dict.swipe(keys, points = points)
+        assertEquals("which keys=$keys → $top", "which", top.first())
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SwipeCommonWordsTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SwipeCommonWordsTest.kt
@@ -39,6 +39,7 @@ class SwipeCommonWordsTest {
         "they", "just", "like", "some", "would", "there", "good", "go",
         "top", "hello", "when", "your", "all", "more", "if", "out", "see",
         "how", "been", "make", "should", "into", "over", "time", "get",
+        "quick", "brown", "fox", "lazy", "frog",
     )
 
     @Test
@@ -128,5 +129,27 @@ class SwipeCommonWordsTest {
         val keys = SwipeLayout.nearestKeyString(points)
         val top = dict.swipe(keys, points = points)
         assertEquals("which keys=$keys → $top", "which", top.first())
+    }
+
+    @Test
+    fun `a four-key what swipe ranks what first and keeps same-path alternatives`() {
+        val dict = dictionary()
+        val points = SwipeLayout.interpolate("what")
+        val keys = SwipeLayout.nearestKeyString(points)
+        val top = dict.swipe(keys, points = points)
+        assertEquals("what keys=$keys → $top", "what", top.first())
+        assertTrue("long end-sharing words in strip: $top", "wednesday" !in top && "without" !in top)
+    }
+
+    @Test
+    fun `pangram words rank first on their own traces`() {
+        // "jumps" is not in the shipped list; the rest of the sentence is.
+        val dict = dictionary()
+        val misses = ArrayList<String>()
+        for (word in listOf("the", "quick", "brown", "fox", "over", "lazy", "frog")) {
+            val top = dict.swipe(word, points = SwipeLayout.interpolate(word))
+            if (top.firstOrNull() != word) misses.add("$word → $top")
+        }
+        assertTrue("pangram misses:\n${misses.joinToString("\n")}", misses.isEmpty())
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SwipeLayoutTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SwipeLayoutTest.kt
@@ -56,4 +56,29 @@ class SwipeLayoutTest {
     fun `entering a different letter key starts a swipe`() {
         assertTrue(SwipeLayout.enteredAnotherLetter("character-h", "character-j"))
     }
+
+    @Test
+    fun `simplifying a what-shaped path keeps the four turns`() {
+        val waypoints = SwipeLayout.simplify(SwipeLayout.interpolate("what"))
+        assertEquals(4, waypoints.size)
+        val keys = waypoints.map { point ->
+            SwipeLayout.QWERTY.minBy { it.value.distanceTo(point) }.key
+        }
+        assertEquals(listOf('w', 'h', 'a', 't'), keys)
+    }
+
+    @Test
+    fun `a four-apex what covers what and not wednesday`() {
+        val masks = SwipeLayout.apexMasks(SwipeLayout.simplify(SwipeLayout.interpolate("what")))
+        assertTrue(SwipeLayout.coversApexes("what", masks))
+        assertFalse(SwipeLayout.coversApexes("wednesday", masks))
+        assertFalse(SwipeLayout.coversApexes("without", masks))
+        assertFalse(SwipeLayout.coversApexes("want", masks))
+    }
+
+    @Test
+    fun `a straight flick only keeps the two ends`() {
+        val waypoints = SwipeLayout.simplify(SwipeLayout.interpolate("wh"))
+        assertEquals(2, waypoints.size)
+    }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SwipeLayoutTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SwipeLayoutTest.kt
@@ -45,4 +45,15 @@ class SwipeLayoutTest {
         val samples = SwipeLayout.sampleWord("hello")
         assertEquals(SwipeLayout.SAMPLE_POINTS * 2, samples.size)
     }
+
+    @Test
+    fun `a tap that stays on one key is not a swipe`() {
+        assertFalse(SwipeLayout.enteredAnotherLetter("character-h", "character-h"))
+        assertFalse(SwipeLayout.enteredAnotherLetter("character-h", null))
+    }
+
+    @Test
+    fun `entering a different letter key starts a swipe`() {
+        assertTrue(SwipeLayout.enteredAnotherLetter("character-h", "character-j"))
+    }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/SwipeLayoutTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/SwipeLayoutTest.kt
@@ -1,0 +1,48 @@
+package com.vocahq.vocaphone.ime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SwipeLayoutTest {
+
+    @Test
+    fun `qwerty neighbours match the previous layout`() {
+        val g = SwipeLayout.nearby('g')
+        assertTrue(g.contains('f'))
+        assertTrue(g.contains('h'))
+        assertTrue(g.contains('t'))
+        assertFalse(g.contains('q'))
+        assertFalse(g.contains('g'))
+    }
+
+    @Test
+    fun `a grid point on a key centre is that key`() {
+        val h = SwipeLayout.qwerty('h')!!
+        val mapped = SwipeLayout.gridPoint('h', 0f, 0f)!!
+        assertEquals(h.x, mapped.x, 0.001f)
+        assertEquals(h.y, mapped.y, 0.001f)
+    }
+
+    @Test
+    fun `interpolating a word visits its letters in order`() {
+        val path = SwipeLayout.interpolate("hello")
+        assertTrue(path.size >= 8)
+        assertTrue(SwipeLayout.lettersLieOnPath("helo", SwipeLayout.samplePoints(path)))
+        assertFalse(SwipeLayout.lettersLieOnPath("world", SwipeLayout.samplePoints(path)))
+    }
+
+    @Test
+    fun `double letters are detected so a loop path can be scored`() {
+        assertTrue(SwipeLayout.hasDoubleLetter("hello"))
+        assertTrue(SwipeLayout.hasDoubleLetter("good"))
+        assertFalse(SwipeLayout.hasDoubleLetter("world"))
+    }
+
+    @Test
+    fun `a resampled path has a fixed number of points`() {
+        val samples = SwipeLayout.sampleWord("hello")
+        assertEquals(SwipeLayout.SAMPLE_POINTS * 2, samples.size)
+    }
+}


### PR DESCRIPTION
## Summary

- Swipe decode now follows the finger’s **direction changes**, not just start/end + frequency.
- The path is simplified to apexes (start, each turn, end). Around every apex we take the keys within reach and keep only dictionary words whose letters **cover those apexes in order**. That is the candidate tree: a four-key swipe of “what” cannot become Wednesday / without / a nine-letter neighbour of W and T.
- Survivors are still ranked `zipf(frequency) − spatial`. A flick with **no** turns stays underspecified (W→H is still “with”).
- After a swipe, the suggestion strip is the **other same-path words**, so you can tap a neighbour of the path. It no longer fills with edit-distance cousins of the winner, and it still shows if the host drops the trailing space.

## Why “what” became Wednesday

The previous matcher allowed any word whose first and last keys were near the stroke’s ends. Frequency plus a start→end template then preferred a common long word. “what” is W→H→A→T: two real turns. Those turns have to appear in the word.

## Model

1. Resample the `(x, y)` trace.
2. Ramer–Douglas–Peucker (ε = 0.8 keys) → apexes.
3. Key set around start/end (neighbour radius 1.55) and around each turn (1.05).
4. A word is a candidate only if its letters hit those sets in order. Extra letters are allowed (fly-overs).
5. If a noisy trace invents extra apexes and the tree is empty, fall back to start/end so something still commits.
6. Rank with shape + letters-on-path + absolute start/end + zipf. The start→end template is used **only** when there were no turns.

Pointer thread unchanged: rect-contains activation (sentence caps), matching on `Dispatchers.Default`.

## Verification

- [ ] `just ios ci` — N/A: Android IME only (Linux host)
- [x] `./gradlew :app:testFullDebugUnitTest` — 579 passed, 0 failed, 2 skipped (previous full run; this commit adds apex / what / pangram tests on top)
- [x] `assembleFullDebug` installed on Nothing Phone (1) (`a775a5e9`, A063, 120 Hz)
- [x] Physical-device:
  - Four-key W→H→A→T in Chrome omnibox committed **what**. Strip: that / chat / hat (same path), not Wednesday.
  - Earlier W→H flick still **with** (which / watch / wash).
  - Pangram swipe of *the quick brown fox jumps over the lazy frog*: `jumps` is **not in the shipped word list** (so it cannot decode); `fox` / `over` / `the` / `lazy` / `frog` decoded. Synthetic `quick`/`brown` traces were noisy on adb-injected paths.
- [x] Gateway: N/A

Maintainers can comment `/build` on this PR for installable Android/iOS
artifacts (see CONTRIBUTING).

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation: no data-flow / permission / network change — swipe still matches the on-phone word list only
