### PR TITLE
Fix the vocaphone.vocahq.com audit from #212

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -269,7 +269,7 @@
               </div>
               <div class="note-page">
                 <span class="note-date">TODAY, 6:42 PM</span>
-                <h4>Tomorrow</h4>
+                <p class="note-title">Tomorrow</p>
                 <p>
                   Pick up the keys, call the electrician, and move dinner to
                   <mark>seven thirty.</mark><span class="text-caret"></span>
@@ -480,7 +480,7 @@
 
           <div class="gateway-copy">
             <span class="section-tag">gateway is optional</span>
-            <h2 id="gateway-title">two local paths.<br />you choose the hardware.</h2>
+            <h2 id="gateway-title">two paths.<br />you choose the hardware.</h2>
             <p>
               Keep everything on your phone for the simplest offline setup. Or run
               VocaGateway on your Mac, Linux machine, or home server when you want
@@ -505,9 +505,14 @@
               </article>
             </div>
 
-            <a class="button gateway-button" href="https://github.com/VocaHQ/vocagateway">
-              explore VocaGateway on GitHub <span aria-hidden="true">↗</span>
-            </a>
+            <div class="gateway-actions">
+              <a class="button gateway-button" href="https://vocagateway.vocahq.com">
+                explore VocaGateway <span aria-hidden="true">↗</span>
+              </a>
+              <a class="button button-secondary" href="https://github.com/VocaHQ/vocagateway">
+                view on GitHub <span aria-hidden="true">↗</span>
+              </a>
+            </div>
           </div>
 
           <div class="gateway-visual" aria-hidden="true">

--- a/web/iphone/index.html
+++ b/web/iphone/index.html
@@ -13,7 +13,7 @@
     <meta property="og:title" content="Install VocaPhone on iPhone" />
     <meta
       property="og:description"
-      content="Build from source, install the keyboard, and run speech-to-text on your iPhone."
+      content="Join the public TestFlight, or build from source, then install the keyboard and run speech-to-text on your iPhone."
     />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />
@@ -35,7 +35,7 @@
     <meta name="twitter:title" content="Install VocaPhone on iPhone" />
     <meta
       name="twitter:description"
-      content="Build VocaPhone from source, install the private keyboard, and run speech-to-text on your iPhone."
+      content="Join the public TestFlight, or build from source, then install the private keyboard and run speech-to-text on your iPhone."
     />
     <meta name="twitter:image" content="https://vocaphone.vocahq.com/assets/og-image.png" />
     <meta
@@ -63,7 +63,7 @@
     <main class="guide-main" id="guide-content">
       <section class="guide-hero dot-field">
         <div>
-          <span class="section-tag">iPhone · build from source</span>
+          <span class="section-tag">iPhone · public TestFlight</span>
           <h1>private voice typing,<br />on your iPhone.</h1>
           <p>
             VocaPhone needs iOS 17 or newer. The quickest way on is the public

--- a/web/styles.css
+++ b/web/styles.css
@@ -21,6 +21,7 @@
   --font-display: "Avenir Next", "SF Pro Display", "Helvetica Neue", Helvetica, Arial, sans-serif;
   --font-body: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  --menu-bar-height: 58px;
 }
 
 * {
@@ -30,7 +31,7 @@
 html {
   overflow-x: clip;
   scroll-behavior: smooth;
-  scroll-padding-top: 76px;
+  scroll-padding-top: calc(var(--menu-bar-height) + 18px);
 }
 
 body {
@@ -1035,6 +1036,25 @@ svg {
   word-spacing: 0.035em;
 }
 
+/* The menu bar is fixed and opaque. scroll-padding-top already saves
+   in-page jumps; these titles also need their own top padding so a
+   heading that scrolls up on its own does not sit under the bar.
+   The extra 18px matches the html scroll offset and covers the
+   first-line ink that tight display line-heights paint above the box. */
+.section-heading h2,
+.platform-intro h2,
+.faq-heading h2,
+.manifesto-copy h2,
+.download-copy h2,
+.real-proof-copy h2,
+.gateway-copy h2,
+.guide-hero h1,
+.guide-intro h2,
+.guide-callout h2 {
+  padding-top: calc(var(--menu-bar-height) + 18px);
+  scroll-margin-top: calc(var(--menu-bar-height) + 18px);
+}
+
 .section-heading > p,
 .platform-intro > p {
   max-width: 570px;
@@ -1132,20 +1152,21 @@ svg {
   letter-spacing: 0.04em;
 }
 
-.note-page h4 {
-  margin: 8px 0 24px;
-  font-family: var(--font-display);
-  font-size: 34px;
-  font-weight: 650;
-  letter-spacing: -0.05em;
-}
-
 .note-page p {
   max-width: 430px;
   margin: 0;
   font-family: "New York", Georgia, serif;
   font-size: 25px;
   line-height: 1.52;
+}
+
+.note-page .note-title {
+  margin: 8px 0 24px;
+  font-family: var(--font-display);
+  font-size: 34px;
+  font-weight: 650;
+  letter-spacing: -0.05em;
+  line-height: 1.05;
 }
 
 .note-page mark {
@@ -2061,6 +2082,13 @@ svg {
   color: #59625d;
   font-size: 11px;
   line-height: 1.55;
+}
+
+.gateway-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
 }
 
 .gateway-button {
@@ -3737,6 +3765,10 @@ svg {
 }
 
 @media (max-width: 640px) {
+  :root {
+    --menu-bar-height: 54px;
+  }
+
   .menu-bar {
     min-height: 54px;
     padding-inline: 14px;
@@ -4020,7 +4052,7 @@ svg {
     padding: 15px;
   }
 
-  .gateway-button {
+  .gateway-actions .button {
     width: 100%;
     justify-content: center;
     text-align: center;
@@ -4150,7 +4182,7 @@ svg {
     padding: 42px 28px;
   }
 
-  .note-page p {
+  .note-page p:not(.note-title) {
     font-size: 20px;
   }
 

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -62,9 +62,11 @@ test("on-device transcription is the primary product promise", () => {
 });
 
 test("VocaGateway is presented as an explicit optional path", () => {
-  assert.match(html, /two local paths/i);
+  assert.match(html, /two paths/i);
+  assert.doesNotMatch(html, /two local paths/i);
   assert.match(html, /Mac, Linux machine, or home server/i);
   assert.match(html, /trusted LAN, an encrypted private\s+network, or HTTPS/i);
+  assert.match(html, /href="https:\/\/vocagateway\.vocahq\.com"/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocagateway"/);
   assert.doesNotMatch(html, /no gateway\. no catch/i);
   assert.doesNotMatch(html, />no gateway needed</i);
@@ -118,8 +120,9 @@ test("production metadata is complete", () => {
     /property="og:image:width" content="1200"/,
     /property="og:image:height" content="630"/,
     /property="og:image:alt"\s+content="VocaPhone on Android and iPhone, on-device first with an optional self-hosted gateway"/,
+    /property="og:description"\s+content="Join the public TestFlight, or build from source, then install the keyboard and run speech-to-text on your iPhone\."/,
     /name="twitter:title" content="Install VocaPhone on iPhone"/,
-    /name="twitter:description"\s+content="Build VocaPhone from source, install the private keyboard, and run speech-to-text on your iPhone\."/,
+    /name="twitter:description"\s+content="Join the public TestFlight, or build from source, then install the private keyboard and run speech-to-text on your iPhone\."/,
     /name="twitter:image" content="https:\/\/vocaphone\.vocahq\.com\/assets\/og-image\.png"/,
     /name="twitter:image:alt"\s+content="VocaPhone on Android and iPhone, on-device first with an optional self-hosted gateway"/,
   ]) {
@@ -251,6 +254,8 @@ test("availability and install paths are honest", () => {
     iphoneHtml,
     /href="https:\/\/github\.com\/VocaHQ\/vocaphone#build-and-test"/,
   );
+  assert.match(iphoneHtml, /iPhone · public TestFlight/);
+  assert.doesNotMatch(iphoneHtml, /iPhone · build from source/);
   assert.match(iphoneHtml, /href="https:\/\/testflight\.apple\.com\/join\/wd85wQ3W"/);
   assert.match(iphoneHtml, /There is no App Store release yet/);
   // The guide is the path that always works, so it must keep saying why it is
@@ -286,6 +291,15 @@ test("every platform mark points at a symbol that exists", () => {
   assert.doesNotMatch(css, /\.mark-sprite\s*\{[^}]*display:\s*none/);
 });
 
+test("decorative Notes mockup stays out of the heading outline", () => {
+  const notesMock = html.match(
+    /<div class="note-page">[\s\S]*?<\/div>\s*<\/div>\s*<div class="speech-chip">/,
+  );
+  assert.ok(notesMock, "Notes mockup missing");
+  assert.match(notesMock[0], /<p class="note-title">Tomorrow<\/p>/);
+  assert.doesNotMatch(notesMock[0], /<h[1-6]\b/);
+});
+
 test("decorative product frames do not expose focusable controls", () => {
   const hiddenFrames = [...html.matchAll(/<div class="phone-frame[^>]*aria-hidden="true">([\s\S]*?)<\/div>\s*<p>/g)];
   assert.ok(hiddenFrames.length >= 2);
@@ -298,6 +312,18 @@ test("numbered story headings remain in normal flow", () => {
   assert.match(
     css,
     /\.story-number\s*\{[\s\S]*?position:\s*static;[\s\S]*?margin-bottom:\s*24px;/,
+  );
+});
+
+test("display headings clear the fixed menu bar", () => {
+  assert.match(css, /--menu-bar-height:\s*58px;/);
+  assert.match(
+    css,
+    /html\s*\{[\s\S]*?scroll-padding-top:\s*calc\(var\(--menu-bar-height\) \+ 18px\);/,
+  );
+  assert.match(
+    css,
+    /\.download-copy h2,[\s\S]*?\.guide-hero h1,[\s\S]*?\{[\s\S]*?padding-top:\s*calc\(var\(--menu-bar-height\) \+ 18px\);[\s\S]*?scroll-margin-top:\s*calc\(var\(--menu-bar-height\) \+ 18px\);/,
   );
 });
 


### PR DESCRIPTION
Closes #212.

/iphone/ kicker and social copy lead with the public TestFlight. Xcode stays the fallback. No App Store listing.

Gateway heading is two paths, not two local paths. The primary button goes to vocagateway.vocahq.com. GitHub stays as a second link.

The Notes mock Tomorrow line is a paragraph, not a heading.

Big display headings get top clearance so they sit below the fixed menu bar.

Draft. I did not merge.