### PR TITLE
Setup: keep Grant inline, spotlight the next step, open Settings after denial

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/Components.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/Components.kt
@@ -80,9 +80,6 @@ internal object AdaptiveLayout {
     fun stackActions(widthDp: Float, fontScale: Float): Boolean =
         effectiveWidth(widthDp, fontScale) < 360f
 
-    fun stackChecklistAction(widthDp: Float, fontScale: Float): Boolean =
-        effectiveWidth(widthDp, fontScale) < 400f
-
     fun stackInfo(widthDp: Float, fontScale: Float): Boolean =
         effectiveWidth(widthDp, fontScale) < 320f
 
@@ -480,35 +477,25 @@ fun ChecklistRow(
     modifier: Modifier = Modifier,
     actionColor: Color = MaterialTheme.colorScheme.primary,
 ) {
-    BoxWithConstraints(modifier.fillMaxWidth().padding(vertical = 6.dp)) {
-        val stacked = !satisfied && AdaptiveLayout.stackChecklistAction(
-            maxWidth.value,
-            LocalDensity.current.fontScale,
+    // Always a single row: label takes the leftover width and wraps, the short
+    // action (Grant, Open, Set up) stays vertically centered. Stacking under
+    // 400dp looked broken on every handset and still looked wrong on a foldable
+    // cover screen; weight + wrap scales from a tiny phone to an open foldable.
+    Row(
+        modifier = modifier.fillMaxWidth().padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ChecklistContent(
+            title = title,
+            detail = detail,
+            satisfied = satisfied,
+            modifier = Modifier.weight(1f),
         )
-        if (stacked) {
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                ChecklistContent(title = title, detail = detail, satisfied = false)
-                TextButton(
-                    onClick = onAction,
-                    modifier = Modifier.align(Alignment.End),
-                    colors = ButtonDefaults.textButtonColors(contentColor = actionColor),
-                ) { Text(actionLabel) }
-            }
-        } else {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                ChecklistContent(
-                    title = title,
-                    detail = detail,
-                    satisfied = satisfied,
-                    modifier = Modifier.weight(1f),
-                )
-                if (!satisfied) {
-                    TextButton(
-                        onClick = onAction,
-                        colors = ButtonDefaults.textButtonColors(contentColor = actionColor),
-                    ) { Text(actionLabel) }
-                }
-            }
+        if (!satisfied) {
+            TextButton(
+                onClick = onAction,
+                colors = ButtonDefaults.textButtonColors(contentColor = actionColor),
+            ) { Text(actionLabel) }
         }
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/Components.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/Components.kt
@@ -47,7 +47,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -476,6 +479,11 @@ fun ChecklistRow(
     onAction: () -> Unit,
     modifier: Modifier = Modifier,
     actionColor: Color = MaterialTheme.colorScheme.primary,
+    /**
+     * Compact rows keep title + check only. Used for satisfied steps and for
+     * unfinished steps that are not the current spotlight target.
+     */
+    compact: Boolean = false,
 ) {
     // Always a single row: label takes the leftover width and wraps, the short
     // action (Grant, Open, Set up) stays vertically centered. Stacking under
@@ -489,9 +497,10 @@ fun ChecklistRow(
             title = title,
             detail = detail,
             satisfied = satisfied,
+            compact = compact,
             modifier = Modifier.weight(1f),
         )
-        if (!satisfied) {
+        if (!satisfied && !compact) {
             TextButton(
                 onClick = onAction,
                 colors = ButtonDefaults.textButtonColors(contentColor = actionColor),
@@ -505,6 +514,7 @@ private fun ChecklistContent(
     title: String,
     detail: String,
     satisfied: Boolean,
+    compact: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
@@ -523,11 +533,18 @@ private fun ChecklistContent(
         Spacer(Modifier.width(12.dp))
         Column(Modifier.weight(1f)) {
             Text(title, style = MaterialTheme.typography.bodyLarge)
-            Text(
-                detail,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            if (!compact && detail.isNotEmpty()) {
+                Text(
+                    detail,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = if (satisfied) {
+                        Modifier.semantics { liveRegion = LiveRegionMode.Polite }
+                    } else {
+                        Modifier
+                    },
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/DictateScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/DictateScreen.kt
@@ -73,6 +73,7 @@ fun DictateScreen(
     onRetry: (String) -> Unit,
     onDismiss: () -> Unit,
     onOpenGateway: () -> Unit,
+    onRefreshSetup: () -> Unit,
     onOpenLanguage: () -> Unit,
     onOpenStyle: () -> Unit,
     onOpenModel: () -> Unit,
@@ -218,6 +219,7 @@ fun DictateScreen(
                 SetupRepair(
                     status = setup,
                     onOpenGateway = onOpenGateway,
+                    onRefreshSetup = onRefreshSetup,
                 )
 
                 val fieldColors = TextFieldDefaults.colors(

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
@@ -338,6 +338,7 @@ fun VocaPhoneApp(
                 telemetryPendingCount = viewModel::telemetryPendingCount,
                 telemetryDeliveryStatus = viewModel::telemetryDeliveryStatus,
                 onFinish = { viewModel.setOnboardingComplete(true) },
+                onRefreshSetup = viewModel::refreshSetup,
                 modifier = content,
             )
 
@@ -351,6 +352,7 @@ fun VocaPhoneApp(
                 onRetry = viewModel::retry,
                 onDismiss = viewModel::dismissDictation,
                 onOpenGateway = { showingGateway = true },
+                onRefreshSetup = viewModel::refreshSetup,
                 onOpenLanguage = {
                     destination = Destination.SETTINGS
                     settingsPage = SettingsPage.HOME

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupPermissions.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupPermissions.kt
@@ -1,0 +1,81 @@
+package com.vocahq.vocaphone.ui
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.Settings
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+
+/**
+ * Permission handoff for setup: track whether we have already asked, and open
+ * the app Settings page once Android will no longer show its own dialog.
+ */
+internal object SetupPermissions {
+    private const val PREFS = "setup_permissions_asked"
+
+    fun openAppSettings(context: Context) {
+        context.startActivity(
+            Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = Uri.fromParts("package", context.packageName, null)
+            },
+        )
+    }
+
+    fun markAsked(context: Context, permission: String) {
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(permission, true)
+            .apply()
+    }
+
+    fun wasAsked(context: Context, permission: String): Boolean =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .getBoolean(permission, false)
+
+    /**
+     * True when the runtime dialog will not appear again: we have already asked,
+     * the permission is still missing, and rationale is false.
+     */
+    fun needsAppSettings(
+        granted: Boolean,
+        asked: Boolean,
+        showRationale: Boolean,
+    ): Boolean = !granted && asked && !showRationale
+
+    fun needsAppSettings(activity: Activity, permission: String): Boolean =
+        needsAppSettings(
+            granted = ContextCompat.checkSelfPermission(activity, permission) ==
+                PackageManager.PERMISSION_GRANTED,
+            asked = wasAsked(activity, permission),
+            showRationale = ActivityCompat.shouldShowRequestPermissionRationale(
+                activity,
+                permission,
+            ),
+        )
+
+    fun grantOrOpenLabel(activity: Activity, permission: String): String =
+        if (needsAppSettings(activity, permission)) "Open" else "Grant"
+
+    fun requestOrOpenSettings(
+        activity: Activity,
+        permission: String,
+        request: (String) -> Unit,
+    ) {
+        if (needsAppSettings(activity, permission)) {
+            openAppSettings(activity)
+        } else {
+            markAsked(activity, permission)
+            request(permission)
+        }
+    }
+}
+
+internal tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupRepair.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupRepair.kt
@@ -22,15 +22,18 @@ import androidx.compose.ui.unit.dp
 fun SetupRepair(
     status: SetupStatus,
     onOpenGateway: () -> Unit,
+    onRefreshSetup: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val missing = status.remainingSteps
     if (missing.isEmpty()) return
 
     val context = LocalContext.current
+    val activity = context.findActivity()
     val requestPermission = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { }
+        ActivityResultContracts.RequestPermission(),
+    ) { onRefreshSetup() }
+    val nextStep = missing.first()
 
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -46,32 +49,44 @@ fun SetupRepair(
                 style = MaterialTheme.typography.bodyMedium,
             )
             missing.forEach { step ->
+                val spotlight = step == nextStep
                 when (step) {
-                    SetupStep.MICROPHONE -> ChecklistRow(
-                        title = "Microphone",
-                        detail = "Records only while you are dictating.",
+                    SetupStep.MICROPHONE -> SetupPermissionRow(
+                        step = step,
+                        permission = Manifest.permission.RECORD_AUDIO,
                         satisfied = false,
-                        actionLabel = "Grant",
-                        onAction = { requestPermission.launch(Manifest.permission.RECORD_AUDIO) },
+                        nextStep = nextStep,
+                        recentlyReady = emptySet(),
+                        activity = activity,
+                        requestPermission = requestPermission::launch,
                         actionColor = LocalContentColor.current,
                     )
 
-                    SetupStep.NOTIFICATIONS -> ChecklistRow(
-                        title = "Notifications",
-                        detail = "Shows the ongoing recording notification Android requires.",
+                    SetupStep.NOTIFICATIONS -> SetupPermissionRow(
+                        step = step,
+                        permission = Manifest.permission.POST_NOTIFICATIONS,
                         satisfied = false,
-                        actionLabel = "Grant",
-                        onAction = { requestPermission.launch(Manifest.permission.POST_NOTIFICATIONS) },
+                        nextStep = nextStep,
+                        recentlyReady = emptySet(),
+                        activity = activity,
+                        requestPermission = requestPermission::launch,
                         actionColor = LocalContentColor.current,
                     )
 
                     SetupStep.KEYBOARD -> ChecklistRow(
-                        title = "VocaPhone keyboard",
-                        detail = "Enable and select VocaPhone in Android's keyboard settings.",
+                        title = step.label,
+                        detail = SetupCopy.keyboardStatus(status.ime),
                         satisfied = false,
-                        actionLabel = "Open",
-                        onAction = { ImeSetup.openSettings(context) },
+                        actionLabel = SetupCopy.keyboardAction(status.ime) ?: "Open",
+                        onAction = {
+                            if (status.ime.enabled) {
+                                ImeSetup.showPicker(context)
+                            } else {
+                                ImeSetup.openSettings(context)
+                            }
+                        },
                         actionColor = LocalContentColor.current,
+                        compact = !spotlight,
                     )
 
                     SetupStep.GATEWAY -> ChecklistRow(
@@ -81,6 +96,7 @@ fun SetupRepair(
                         actionLabel = "Set up",
                         onAction = onOpenGateway,
                         actionColor = LocalContentColor.current,
+                        compact = !spotlight,
                     )
                 }
             }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupRepair.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupRepair.kt
@@ -25,14 +25,16 @@ fun SetupRepair(
     onRefreshSetup: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val missing = status.remainingSteps
-    if (missing.isEmpty()) return
-
+    // Launcher must register unconditionally; early-return after the last
+    // remaining step would otherwise skip remember* and crash composition.
     val context = LocalContext.current
     val activity = context.findActivity()
     val requestPermission = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
     ) { onRefreshSetup() }
+
+    val missing = status.remainingSteps
+    if (missing.isEmpty()) return
     val nextStep = missing.first()
 
     Column(

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.currentStateAsState
 import androidx.compose.ui.unit.dp
 import com.vocahq.vocaphone.BuildConfig
 import com.vocahq.vocaphone.R
@@ -256,10 +258,15 @@ internal fun SetupPermissionRow(
         satisfied -> SetupCopy.stepReady(step)
         else -> SetupCopy.permissionDetail(step)
     }
-    val label = if (activity != null) {
-        SetupPermissions.grantOrOpenLabel(activity, permission)
-    } else {
-        "Grant"
+    // Permission dialogs and Settings pause the activity. Equal SetupStatus
+    // after a denial does not recompose on its own, so watch lifecycle and
+    // re-read Grant vs Open when we resume.
+    val lifecycleState by LocalLifecycleOwner.current.lifecycle.currentStateAsState()
+    val label = when {
+        activity == null -> "Grant"
+        else -> when (lifecycleState) {
+            else -> SetupPermissions.grantOrOpenLabel(activity, permission)
+        }
     }
     ChecklistRow(
         title = step.label,
@@ -291,8 +298,13 @@ internal fun rememberRecentlyReadySteps(status: SetupStatus): Set<SetupStep> {
         previous = status
         if (newly.isEmpty()) return@LaunchedEffect
         recentlyReady = recentlyReady + newly
-        delay(2_000)
-        recentlyReady = recentlyReady - newly.toSet()
+        try {
+            delay(2_000)
+        } finally {
+            // Cancellation (another step flipping mid-delay) must still clear,
+            // or the ready line and live region stick forever.
+            recentlyReady = recentlyReady - newly.toSet()
+        }
     }
     return recentlyReady
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,6 +30,14 @@ import com.vocahq.vocaphone.local.LocalModelDescriptor
 import com.vocahq.vocaphone.local.LocalModelState
 import com.vocahq.vocaphone.settings.VocaPhoneSettings
 import com.vocahq.vocaphone.telemetry.TelemetryInspectPayload
+import kotlinx.coroutines.delay
+
+/** Satisfied or non-spotlight rows collapse to title + check. Ready notice expands briefly. */
+internal fun collapseChecklistRow(
+    satisfied: Boolean,
+    isNextUnfinished: Boolean,
+    showingReady: Boolean = false,
+): Boolean = !showingReady && (satisfied || !isNextUnfinished)
 
 internal object SetupCopy {
     /** Vector mark. Adaptive mipmaps crash painterResource. */
@@ -56,6 +65,27 @@ internal object SetupCopy {
         status.enabled -> "Choose VocaPhone keyboard"
         else -> "Enable keyboard"
     }
+
+    /** One wrap-friendly line under the IME card about what to tap next. */
+    fun keyboardTapHint(status: ImeSetupStatus): String? = when {
+        status.selected -> null
+        status.enabled -> "Pick VocaPhone from the list that appears."
+        else -> "In keyboard settings, turn on VocaPhone."
+    }
+
+    fun stepReady(step: SetupStep): String = when (step) {
+        SetupStep.MICROPHONE -> "Microphone ready"
+        SetupStep.NOTIFICATIONS -> "Notifications ready"
+        SetupStep.KEYBOARD -> "Keyboard ready"
+        SetupStep.GATEWAY -> "Speech source ready"
+    }
+
+    fun permissionDetail(step: SetupStep): String = when (step) {
+        SetupStep.MICROPHONE -> "Only while you dictate."
+        SetupStep.NOTIFICATIONS -> "Shown while you record."
+        SetupStep.KEYBOARD -> keyboardStatus(ImeSetupStatus())
+        SetupStep.GATEWAY -> "The speech source that transcribes your speech."
+    }
 }
 
 /**
@@ -78,13 +108,17 @@ fun SetupScreen(
     telemetryPendingCount: () -> Int,
     telemetryDeliveryStatus: () -> String,
     onFinish: () -> Unit,
+    onRefreshSetup: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
+    val activity = context.findActivity()
     val requestPermission = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { }
+        ActivityResultContracts.RequestPermission(),
+    ) { onRefreshSetup() }
     val askUsageReporting = BuildConfig.TELEMETRY && !settings.telemetryAsked
     var askingUsageReporting by remember { mutableStateOf(false) }
+    val recentlyReady = rememberRecentlyReadySteps(status)
 
     Column(
         modifier = modifier.fillMaxSize(),
@@ -109,21 +143,32 @@ fun SetupScreen(
             }
 
             ImeSetupCard(status.ime)
+            SetupCopy.keyboardTapHint(status.ime)?.let { hint ->
+                Text(
+                    hint,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
 
             Section("Permissions") {
-                ChecklistRow(
-                    title = "Microphone",
-                    detail = "Only while you dictate.",
+                SetupPermissionRow(
+                    step = SetupStep.MICROPHONE,
+                    permission = Manifest.permission.RECORD_AUDIO,
                     satisfied = status.microphone,
-                    actionLabel = "Grant",
-                    onAction = { requestPermission.launch(Manifest.permission.RECORD_AUDIO) },
+                    nextStep = status.remainingSteps.firstOrNull(),
+                    recentlyReady = recentlyReady,
+                    activity = activity,
+                    requestPermission = requestPermission::launch,
                 )
-                ChecklistRow(
-                    title = "Notifications",
-                    detail = "Shown while you record.",
+                SetupPermissionRow(
+                    step = SetupStep.NOTIFICATIONS,
+                    permission = Manifest.permission.POST_NOTIFICATIONS,
                     satisfied = status.notifications,
-                    actionLabel = "Grant",
-                    onAction = { requestPermission.launch(Manifest.permission.POST_NOTIFICATIONS) },
+                    nextStep = status.remainingSteps.firstOrNull(),
+                    recentlyReady = recentlyReady,
+                    activity = activity,
+                    requestPermission = requestPermission::launch,
                 )
             }
 
@@ -188,6 +233,68 @@ fun SetupScreen(
             deliveryStatus = telemetryDeliveryStatus,
         )
     }
+}
+
+@Composable
+internal fun SetupPermissionRow(
+    step: SetupStep,
+    permission: String,
+    satisfied: Boolean,
+    nextStep: SetupStep?,
+    recentlyReady: Set<SetupStep>,
+    activity: android.app.Activity?,
+    requestPermission: (String) -> Unit,
+    actionColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.primary,
+) {
+    val showingReady = satisfied && step in recentlyReady
+    val compact = collapseChecklistRow(
+        satisfied = satisfied,
+        isNextUnfinished = nextStep == step,
+        showingReady = showingReady,
+    )
+    val detail = when {
+        satisfied -> SetupCopy.stepReady(step)
+        else -> SetupCopy.permissionDetail(step)
+    }
+    val label = if (activity != null) {
+        SetupPermissions.grantOrOpenLabel(activity, permission)
+    } else {
+        "Grant"
+    }
+    ChecklistRow(
+        title = step.label,
+        detail = detail,
+        satisfied = satisfied,
+        actionLabel = label,
+        onAction = {
+            if (activity != null) {
+                SetupPermissions.requestOrOpenSettings(activity, permission, requestPermission)
+            } else {
+                requestPermission(permission)
+            }
+        },
+        actionColor = actionColor,
+        compact = compact,
+    )
+}
+
+/**
+ * Tracks steps that just flipped to satisfied so the row can show a brief
+ * ready line and TalkBack can announce it, then collapses again.
+ */
+@Composable
+internal fun rememberRecentlyReadySteps(status: SetupStatus): Set<SetupStep> {
+    var recentlyReady by remember { mutableStateOf(emptySet<SetupStep>()) }
+    var previous by remember { mutableStateOf(status) }
+    LaunchedEffect(status) {
+        val newly = SetupStep.entries.filter { status.isSatisfied(it) && !previous.isSatisfied(it) }
+        previous = status
+        if (newly.isEmpty()) return@LaunchedEffect
+        recentlyReady = recentlyReady + newly
+        delay(2_000)
+        recentlyReady = recentlyReady - newly.toSet()
+    }
+    return recentlyReady
 }
 
 /** Setup handoff for enabling and selecting the system keyboard. */

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/AdaptiveLayoutTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/AdaptiveLayoutTest.kt
@@ -33,12 +33,6 @@ class AdaptiveLayoutTest {
     }
 
     @Test
-    fun `long checklist actions stack in inset cards on a pixel`() {
-        assertTrue(AdaptiveLayout.stackChecklistAction(widthDp = 347f, fontScale = 1f))
-        assertFalse(AdaptiveLayout.stackChecklistAction(widthDp = 480f, fontScale = 1f))
-    }
-
-    @Test
     fun `diagnostic rows stack only when values lose useful width`() {
         assertTrue(AdaptiveLayout.stackInfo(widthDp = 300f, fontScale = 1f))
         assertFalse(AdaptiveLayout.stackInfo(widthDp = 379f, fontScale = 1f))

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupChecklistTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupChecklistTest.kt
@@ -1,0 +1,75 @@
+package com.vocahq.vocaphone.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SetupChecklistTest {
+
+    @Test
+    fun collapseSatisfiedAndLaterUnfinishedRows() {
+        val next = SetupStatus().remainingSteps.first()
+        assertEquals(SetupStep.MICROPHONE, next)
+
+        assertTrue(
+            collapseChecklistRow(satisfied = true, isNextUnfinished = false),
+        )
+        assertFalse(
+            collapseChecklistRow(satisfied = false, isNextUnfinished = true),
+        )
+        assertTrue(
+            collapseChecklistRow(satisfied = false, isNextUnfinished = false),
+        )
+        assertFalse(
+            collapseChecklistRow(
+                satisfied = true,
+                isNextUnfinished = false,
+                showingReady = true,
+            ),
+        )
+    }
+
+    @Test
+    fun deniedAfterAskOpensAppSettings() {
+        assertFalse(
+            SetupPermissions.needsAppSettings(
+                granted = false,
+                asked = false,
+                showRationale = false,
+            ),
+        )
+        assertFalse(
+            SetupPermissions.needsAppSettings(
+                granted = false,
+                asked = true,
+                showRationale = true,
+            ),
+        )
+        assertTrue(
+            SetupPermissions.needsAppSettings(
+                granted = false,
+                asked = true,
+                showRationale = false,
+            ),
+        )
+        assertFalse(
+            SetupPermissions.needsAppSettings(
+                granted = true,
+                asked = true,
+                showRationale = false,
+            ),
+        )
+    }
+
+    @Test
+    fun keyboardRepairFollowsTwoStepIme() {
+        val off = ImeSetupStatus()
+        val enabled = ImeSetupStatus(enabled = true)
+        val selected = ImeSetupStatus(enabled = true, selected = true)
+
+        assertEquals("Enable keyboard", SetupCopy.keyboardAction(off))
+        assertEquals("Choose VocaPhone keyboard", SetupCopy.keyboardAction(enabled))
+        assertEquals(null, SetupCopy.keyboardAction(selected))
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupCopyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupCopyTest.kt
@@ -35,6 +35,12 @@ class SetupCopyTest {
             SetupCopy.SLOW_ON_PHONES,
             SetupCopy.SLOW_ON_PHONES_DETAIL,
             MORE_MODELS_LABEL,
+            SetupCopy.keyboardTapHint(ImeSetupStatus()).orEmpty(),
+            SetupCopy.keyboardTapHint(ImeSetupStatus(enabled = true)).orEmpty(),
+            SetupCopy.stepReady(SetupStep.MICROPHONE),
+            SetupCopy.stepReady(SetupStep.NOTIFICATIONS),
+            SetupCopy.stepReady(SetupStep.KEYBOARD),
+            SetupCopy.stepReady(SetupStep.GATEWAY),
         )
         copy.forEach { line ->
             assertTrue(line.isNotBlank())
@@ -59,5 +65,8 @@ class SetupCopyTest {
         assertEquals("Choose VocaPhone keyboard", SetupCopy.keyboardAction(enabled))
         assertEquals("VocaPhone is the selected keyboard.", SetupCopy.keyboardStatus(selected))
         assertNull(SetupCopy.keyboardAction(selected))
+        assertEquals("In keyboard settings, turn on VocaPhone.", SetupCopy.keyboardTapHint(off))
+        assertEquals("Pick VocaPhone from the list that appears.", SetupCopy.keyboardTapHint(enabled))
+        assertNull(SetupCopy.keyboardTapHint(selected))
     }
 }


### PR DESCRIPTION
Setup Permissions put Grant under the Microphone and Notifications labels on every normal phone. The checklist stacked under 400dp, which is the usual handset content width.

This PR keeps that short action on the same row, then borrows the portable bits of iOS onboarding without turning Android into a paged wizard:

- Finished checklist rows collapse to a one-line check so the next unfinished step stays visible on small phones and cover screens (setup and Dictate repair).
- After a permanent permission denial, Grant becomes Open and goes to the app Settings page instead of a dead system prompt.
- Permission results refresh setup status right away (same path as resume).
- Dictate repair reuses the main IME Enable vs Switch picker path.
- One wrapping tap hint under the keyboard card.
- A brief ready line with a polite live-region announcement when mic, notifications, or keyboard flips.

## Test plan

- [x] Clear app data, open setup on a normal phone: Grant sits beside Microphone / Notifications
- [x] Deny mic permanently: button becomes Open and lands in app Settings; granting there flips the row without leaving and coming back through a cold start only
- [x] Grant mic: brief Microphone ready, then the next unfinished step expands
- [x] Same spotlight behavior in Dictate repair on a narrow / cover layout
- [x] Keyboard card: enable vs choose hint; repair uses picker when IME is enabled but not selected
- [x] Foldable / wide layout still respects the 720dp content cap
- [x] Unit: AdaptiveLayoutTest, SetupChecklistTest, SetupCopyTest, SetupStatusTest