### PR TITLE
feat(ios): clarify Quick Dictation handoff

### DIFF
--- a/ios/VocaPhoneKeyboard/DictationPresentation.swift
+++ b/ios/VocaPhoneKeyboard/DictationPresentation.swift
@@ -142,6 +142,10 @@ struct DictationContext: Equatable {
     /// Typing candidates for the idle bar. Empty in every state that owns a
     /// session, because the strip is not shown there.
     var candidates: [TypingCandidate] = []
+    /// The keyboard found a fresh Quick Dictation heartbeat when it created this
+    /// session. This is presentation state only; the containing app confirms its
+    /// active audio input before recording starts.
+    var prefersQuickDictation = false
     /// Where this session's transcription runs, when the containing app has
     /// resolved it. `nil` for a legacy or interrupted record, and the copy stays
     /// neutral rather than guessing — naming the wrong place is worse than
@@ -156,7 +160,7 @@ extension DictationBarModel {
         case .idle, .completed, .canceled, .expired:
             return resting(context)
         case .launchingApp, .awaitingReturn:
-            return handoff
+            return handoff(context)
         case .recording:
             return listening
         case .finalizing, .uploading, .transcribing:
@@ -223,22 +227,43 @@ extension DictationBarModel {
         )
     }
 
-    private static let handoff = DictationBarModel(
-        title: "Opening vocaphone",
-        body: .message("Speak when the app appears."),
-        accent: .brand,
-        pulse: .working,
-        primary: DictationButton(
-            title: "Open app",
-            symbol: "arrow.up.forward.app.fill",
-            action: .openApp,
-            hint: "Opens vocaphone to continue."
-        ),
-        secondaries: [.cancel],
-        showsElapsedTime: false,
-        isExpanded: true,
-        announcement: nil
-    )
+    private static func handoff(_ context: DictationContext) -> DictationBarModel {
+        if context.state == .launchingApp, context.prefersQuickDictation {
+            return DictationBarModel(
+                title: "Starting dictation",
+                body: .message("Quick Dictation keeps you in this app."),
+                accent: .brand,
+                pulse: .working,
+                primary: DictationButton(
+                    title: "Open app",
+                    symbol: "arrow.up.forward.app.fill",
+                    action: .openApp,
+                    hint: "Opens vocaphone if starting here does not complete."
+                ),
+                secondaries: [.cancel],
+                showsElapsedTime: false,
+                isExpanded: true,
+                announcement: nil
+            )
+        }
+
+        return DictationBarModel(
+            title: "Opening vocaphone",
+            body: .message("Speak when the app appears."),
+            accent: .brand,
+            pulse: .working,
+            primary: DictationButton(
+                title: "Open app",
+                symbol: "arrow.up.forward.app.fill",
+                action: .openApp,
+                hint: "Opens vocaphone to continue."
+            ),
+            secondaries: [.cancel],
+            showsElapsedTime: false,
+            isExpanded: true,
+            announcement: nil
+        )
+    }
 
     private static let listening = DictationBarModel(
         title: "Listening",

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -635,14 +635,15 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // back to; the app needs to know so it does not cover that field with
         // hand-off instructions.
         record.startedInContainingApp = KeyboardPreferences.containingAppIsForeground
+        let availability = try? store.loadQuickDictationAvailability()
+        record.prefersQuickDictation = availability?.isReady() == true
         do {
             try record.transition(to: .launchingApp)
             try store.save(record)
             activeSessionID = record.sessionID
             sessionTargetDocumentID = record.sourceDocumentID
             render(record)
-            let availability = try? store.loadQuickDictationAvailability()
-            if availability?.isReady() == true {
+            if record.prefersQuickDictation == true {
                 dictationBar.flash("Starting with Quick Dictation…")
                 scheduleContainingAppFallback(for: record)
             } else {
@@ -728,17 +729,28 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         }
     }
 
-    private func openContainingApp(for record: SessionRecord) {
+    private func openContainingApp(for incoming: SessionRecord) {
         appLaunchFallbackTask?.cancel()
         appLaunchFallbackTask = nil
+        var record = incoming
+        // A healthy standby path starts in the host app. Once this fallback runs,
+        // persist the real route before opening vocaphone so the keyboard never
+        // continues to promise a no-switch start after it has begun foregrounding
+        // the containing app.
+        if record.prefersQuickDictation == true {
+            record.prefersQuickDictation = false
+            try? store.save(record)
+            render(record)
+        }
+        let sessionID = record.sessionID
         guard let url = URL(
-            string: "\(AppConfiguration.urlScheme)://dictate?session=\(record.sessionID.uuidString)"
+            string: "\(AppConfiguration.urlScheme)://dictate?session=\(sessionID.uuidString)"
         ) else { return }
         openURLFromKeyboard(url) { [weak self] opened in
             DispatchQueue.main.async {
                 guard let self else { return }
                 if opened { return }
-                if var waiting = try? self.store.load(record.sessionID),
+                if var waiting = try? self.store.load(sessionID),
                    waiting.state == .launchingApp
                 {
                     self.transition(&waiting, to: .awaitingReturn)
@@ -939,6 +951,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
                 // the document, and only once the session it came from is over.
                 canUndo: lastInsertedText != nil,
                 candidates: typing.strip.candidates,
+                prefersQuickDictation: record?.prefersQuickDictation == true,
                 processingLocation: record?.processingLocation
             )
         )

--- a/ios/VocaPhoneShared/SessionRecord.swift
+++ b/ios/VocaPhoneShared/SessionRecord.swift
@@ -105,6 +105,13 @@ struct SessionRecord: Codable, Equatable, Identifiable, Sendable {
     /// no other app to return to, so the hand-off guidance must be suppressed.
     /// Optional so records written before this field still decode.
     var startedInContainingApp: Bool?
+    /// Captured by the keyboard when it finds a fresh Quick Dictation heartbeat.
+    /// It records the requested no-switch route for this session, not a promise
+    /// that capture has already started: the containing app still independently
+    /// validates its active audio input before it can claim the request. It flips
+    /// to `false` if the keyboard has to foreground vocaphone as a fallback.
+    /// Optional so records written before this field still decode.
+    var prefersQuickDictation: Bool?
     /// When the containing app took ownership of a hand-off, written before the
     /// microphone is warm. The keyboard's launch fallback waits on this: warming
     /// the graph can take longer than the fallback window — a first on-device
@@ -140,6 +147,7 @@ struct SessionRecord: Codable, Equatable, Identifiable, Sendable {
         self.style = style
         meterLevel = 0
         startedInContainingApp = nil
+        prefersQuickDictation = nil
         claimedAt = nil
         processingLocation = nil
     }

--- a/ios/VocaPhoneTests/DictationPresentationTests.swift
+++ b/ios/VocaPhoneTests/DictationPresentationTests.swift
@@ -11,6 +11,7 @@ struct DictationPresentationTests {
         canRetry: Bool = false,
         canUndo: Bool = false,
         hasFullAccess: Bool = true,
+        prefersQuickDictation: Bool = false,
         location: SessionProcessingLocation? = nil
     ) -> DictationBarModel {
         DictationBarModel.make(
@@ -22,6 +23,7 @@ struct DictationPresentationTests {
                 autoInsertsTranscripts: autoInsert,
                 canRetry: canRetry,
                 canUndo: canUndo,
+                prefersQuickDictation: prefersQuickDictation,
                 processingLocation: location
             )
         )
@@ -135,6 +137,22 @@ struct DictationPresentationTests {
         ]
         for state in live {
             #expect(Self.model(state).secondaries.contains { $0.action == .cancel })
+        }
+    }
+
+    @Test func quickDictationExplainsThatItStaysInTheCurrentApp() {
+        let model = Self.model(.launchingApp, prefersQuickDictation: true)
+
+        #expect(model.title == "Starting dictation")
+        #expect(model.body == .message("Quick Dictation keeps you in this app."))
+        #expect(model.primary.action == .openApp)
+        #expect(model.primary.hint?.contains("if starting here does not complete") == true)
+    }
+
+    @Test func normalAndFallbackHandoffsStillExplainThatVocaphoneOpens() {
+        for state in [SessionState.launchingApp, .awaitingReturn] {
+            let model = Self.model(state)
+            #expect(model.title == "Opening vocaphone")
         }
     }
 

--- a/ios/VocaPhoneTests/SessionRecordTests.swift
+++ b/ios/VocaPhoneTests/SessionRecordTests.swift
@@ -111,6 +111,21 @@ struct SessionRecordTests {
         #expect(try store.load(record.sessionID)?.startedInContainingApp == true)
     }
 
+    @Test func quickDictationPreferenceRoundTripsAndDefaultsToUnknown() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(rootOverride: directory)
+
+        var record = SessionRecord()
+        #expect(record.prefersQuickDictation == nil)
+        record.prefersQuickDictation = true
+        try record.transition(to: .launchingApp)
+        try store.save(record)
+
+        #expect(try store.load(record.sessionID)?.prefersQuickDictation == true)
+    }
+
     /// Records written before the field existed must still decode, otherwise a
     /// pending dictation would be dropped on upgrade.
     @Test func recordsWithoutTheContainingAppFlagStillDecode() throws {
@@ -124,6 +139,7 @@ struct SessionRecordTests {
         let record = try decoder.decode(SessionRecord.self, from: Data(json.utf8))
 
         #expect(record.startedInContainingApp == nil)
+        #expect(record.prefersQuickDictation == nil)
         #expect(record.state == .recording)
         // No processing location either. The interface answers that with
         // neutral wording rather than guessing a route.


### PR DESCRIPTION
## Summary

- Make a keyboard-initiated Quick Dictation session explicitly say it remains in the current app.
- Persist the selected route so a delayed fallback updates the keyboard to accurately say VocaPhone is opening.
- Cover no-switch, fallback, and backward-compatible session-record behavior.

## Verification

- [x] `just ios ci` — 495 tests passed; preview isolation passed
- [x] `just android ci` — N/A (iOS-only change)
- [x] Gateway changes — N/A
- [ ] Physical-device test — blocked locally: the production team `92962VK378` has no available signing profiles/account on this machine

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for data-flow, permission, retention, or network changes — N/A; this changes only existing shared-session presentation and fallback state