### PR TITLE
feat: add experimental Roman Hinglish transcription mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ android/*.hprof
 
 # Local Netlify folder
 .netlify
+
+# Roman Hinglish benchmark audio. Downloaded by tools/hinglish/benchmark/fetch.py
+# or recorded by record.py; never committed, per the recordings rule above.
+tools/hinglish/benchmark/audio/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ not load `gateway/.env` into the shell (that is the Compose bearer token).
 | `assets/keyboard/` | Shared word list, bigrams, emoji catalog (both keyboards) |
 | `web/` | Static marketing site (vocaphone.vocahq.com) |
 | `docs/` | Architecture, privacy, device setup, releasing — not marketing |
+| `tools/hinglish/` | Roman Hinglish: the weight-conversion reproduction script and the evaluation harness. Desktop-only; nothing here ships in either app |
 | `fdroid/` | F-Droid metadata |
 | `telemetry/` | Optional self-hosted Aptabase (usage counters, not STT) |
 
@@ -84,7 +85,16 @@ the submodule can still run `just`, `just ios …`, `just android …`, and
 `just doctor`.
 
 Do not edit `android/third_party/whisper.cpp/` except as an intentional submodule
-pin. Ignore its upstream `AGENTS.md`.
+pin. Ignore its upstream `AGENTS.md`. (`tools/hinglish/convert-apex-ggml.sh`
+clones its own copy at the pinned revision and patches that clone; it never
+touches the submodule.)
+
+Model weights are never committed. A catalog entry pins a Hugging Face
+repository, an immutable revision, and a SHA-256 per file, and the client
+verifies the digest as it downloads. A pin that points at a third-party
+conversion needs its provenance established rather than assumed — see
+[docs/hinglish-roman.md](docs/hinglish-roman.md) for how that was done for the
+one entry that has one.
 
 ## Commands that exist
 
@@ -208,7 +218,9 @@ insertion, or network code.
 **Do not commit** (even in fixtures, screenshots, or docs):
 
 - Recordings or transcripts (`*.m4a`, `*.caf`, `*.wav` except the checked-in
-  Android cue/test fixtures already allowlisted)
+  Android cue/test fixtures already allowlisted). This includes the Roman
+  Hinglish benchmark audio under `tools/hinglish/benchmark/audio/`, which is
+  gitignored and fetched or recorded locally
 - Bearer tokens, `gateway/.env`, Keychain dumps
 - Signing material: `*.p12`, `*.mobileprovision`, keystores, provisioning profiles
 - Tailnet hostnames, personal gateway URLs, LAN IPs of real deployments

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ docs/                   Architecture, device setup, privacy, decisions, historic
 | [Google Play prep](docs/play-store.md) | Full-flavor AAB, upload signing, listing and Console checklist |
 | [Tailscale](docs/tailscale.md) | Private HTTPS ingress for the gateway |
 | [Architecture](docs/architecture.md) | Components, state transitions, engine boundary, and observability |
+| [Roman Hinglish](docs/hinglish-roman.md) | The experimental Hinglish mode: model, spelling convention, privacy, and how to benchmark it |
 | [Privacy](docs/privacy.md) | Audio lifecycle, authentication, metrics, and threat model |
 | [Troubleshooting](docs/troubleshooting.md) | Keyboard, microphone, model, network, and Docker failures |
 | [Decisions](docs/decisions.md) | Current assumptions and choices still requiring confirmation |

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/DevanagariRomanizer.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/DevanagariRomanizer.kt
@@ -1,0 +1,292 @@
+package com.vocahq.vocaphone.core
+
+/**
+ * Devanagari to Latin, in the spelling people actually type.
+ *
+ * This is not IAST and deliberately not reversible. IAST would give "ājˈ mujhe"
+ * where a Hinglish speaker writes "Aaj mujhe", and a transcript that reads like
+ * a linguistics paper is not the feature. The scheme is documented in
+ * `docs/hinglish-roman.md`; the rules that make it look natural are the three
+ * below, and each is here because the naive answer is visibly wrong.
+ *
+ * **Schwa deletion.** Every Devanagari consonant carries an implicit `a` that
+ * Hindi does not always pronounce. Rendering it always gives "gharaa" for घर and
+ * "karanaa" for करना. The rule applied here drops the implicit vowel at the end
+ * of a word, and drops it mid-word when the next syllable carries a written
+ * vowel of its own — करना becomes "karna" while समझ stays "samajh", because in
+ * समझ the following syllable has no written vowel either. The mid-word case
+ * never fires on the first syllable: without that guard पता collapses to "pta".
+ *
+ * **Long vowels shorten at the end.** आ is "aa" in आज ("aaj") and "a" in करना
+ * ("karna"); ई is "ee" in ठीक ("theek") and "i" in कभी ("kabhi"). Writing "aa"
+ * and "ee" everywhere produces "karnaa" and "kabhee", which nobody types.
+ * Finality is judged after schwa deletion and ignores a trailing nasal, so नहीं
+ * is "nahin" rather than "naheen".
+ *
+ * **Anusvara is `n`, except before a lip consonant.** संभव is "sambhav" and
+ * अंदर is "andar"; one letter, two sounds, and the following consonant is what
+ * decides.
+ *
+ * Nothing outside the Devanagari block is touched. Latin runs pass through byte
+ * for byte, which is what keeps the English half of a code-switched sentence
+ * spelled the way it was spoken.
+ */
+object DevanagariRomanizer {
+
+    private const val DEVANAGARI_START = 'ऀ'
+    private const val DEVANAGARI_END = 'ॿ'
+    private const val VIRAMA = '्'
+    private const val NUKTA = '़'
+    private const val ANUSVARA = 'ं'
+    private const val CHANDRABINDU = 'ँ'
+    private const val VISARGA = 'ः'
+    private const val ZWJ = '‍'
+    private const val ZWNJ = '‌'
+
+    /** Whether [text] contains anything this romanizer would rewrite. */
+    fun containsDevanagari(text: String): Boolean = text.any(::isDevanagari)
+
+    private fun isDevanagari(character: Char): Boolean =
+        character in DEVANAGARI_START..DEVANAGARI_END
+
+    /**
+     * Part of a Devanagari word rather than a separator between two of them.
+     *
+     * A danda and a Devanagari digit are in the same Unicode block as the
+     * letters but are not part of the akshara model, and swallowing them into
+     * the word breaks the rule that decides where a word ends: with the danda
+     * counted, ठीक। has a syllable after क and the implicit vowel survives as
+     * "theeka.".
+     */
+    private fun isWordCharacter(character: Char): Boolean =
+        (isDevanagari(character) && character !in STANDALONE) ||
+            character == ZWJ ||
+            character == ZWNJ
+
+    /**
+     * Romanizes every Devanagari run in [text], leaving everything else exactly
+     * as it arrived.
+     */
+    fun romanize(text: String): String {
+        if (!containsDevanagari(text)) return text
+        val out = StringBuilder(text.length + text.length / 2)
+        var index = 0
+        while (index < text.length) {
+            val character = text[index]
+            if (!isDevanagari(character)) {
+                out.append(character)
+                index++
+                continue
+            }
+            val standalone = STANDALONE[character]
+            if (standalone != null) {
+                out.append(standalone)
+                index++
+                continue
+            }
+            var end = index
+            while (end < text.length && isWordCharacter(text[end])) end++
+            out.append(romanizeWord(text.substring(index, end)))
+            index = end
+        }
+        return out.toString()
+    }
+
+    /** One written vowel, or the implicit one a bare consonant carries. */
+    private enum class Vowel(val long: String, val short: String = long) {
+        A("a"),
+        AA("aa", "a"),
+        I("i"),
+        II("ee", "i"),
+        U("u"),
+        UU("oo", "u"),
+        RI("ri"),
+        E("e"),
+        AI("ai"),
+        O("o"),
+        AU("au"),
+        ;
+
+        /** The final-position spelling; only the long vowels differ. */
+        fun render(final: Boolean): String = if (final) short else long
+    }
+
+    /**
+     * One syllable: an onset, the vowel that follows it, and any nasal or
+     * visarga hanging off the end.
+     *
+     * [implicit] is the whole reason this is a data class rather than a string:
+     * an `a` that was written (अ, ा) and an `a` that is merely implied look the
+     * same once rendered, and only the implied one may be deleted.
+     */
+    private data class Syllable(
+        val onset: String,
+        val vowel: Vowel?,
+        val implicit: Boolean,
+        val nasal: String = "",
+    )
+
+    private fun romanizeWord(word: String): String {
+        val syllables = parse(word)
+        applySchwaDeletion(syllables)
+        return render(syllables)
+    }
+
+    private fun parse(word: String): MutableList<Syllable> {
+        val syllables = mutableListOf<Syllable>()
+        var index = 0
+        while (index < word.length) {
+            val character = word[index]
+            when {
+                character == ZWJ || character == ZWNJ -> index++
+
+                character in INDEPENDENT_VOWELS -> {
+                    syllables += Syllable("", INDEPENDENT_VOWELS.getValue(character), implicit = false)
+                    index++
+                }
+
+                character in CONSONANTS -> {
+                    var onset = CONSONANTS.getValue(character)
+                    index++
+                    if (index < word.length && word[index] == NUKTA) {
+                        onset = NUKTA_FORMS[character] ?: onset
+                        index++
+                    }
+                    var vowel: Vowel? = Vowel.A
+                    var implicit = true
+                    if (index < word.length) {
+                        when {
+                            word[index] == VIRAMA -> {
+                                vowel = null
+                                implicit = false
+                                index++
+                            }
+                            word[index] in MATRAS -> {
+                                vowel = MATRAS.getValue(word[index])
+                                implicit = false
+                                index++
+                            }
+                        }
+                    }
+                    syllables += Syllable(onset, vowel, implicit)
+                }
+
+                // Accents and rare editorial signs. They have no Latin spelling
+                // worth guessing at, so they are dropped rather than passed
+                // through as a character nobody can read. Digits and the danda
+                // never reach here: they end the word instead.
+                else -> index++
+            }
+            // A nasal or visarga binds to the syllable it follows, whatever
+            // produced that syllable. With nothing to bind to — a word that
+            // opens with a stray sign — it is dropped.
+            while (index < word.length && word[index] in NASAL_SIGNS) {
+                val sign = if (word[index] == VISARGA) "h" else "n"
+                if (syllables.isNotEmpty()) {
+                    syllables[syllables.lastIndex] = syllables.last().copy(nasal = sign)
+                }
+                index++
+            }
+        }
+        return syllables
+    }
+
+    /**
+     * Drops the implicit `a` where Hindi does not pronounce it.
+     *
+     * Word-finally, always. Mid-word, only when the next syllable carries a
+     * written vowel — and never on the first syllable, which is what keeps पता
+     * from becoming "pta".
+     */
+    private fun applySchwaDeletion(syllables: MutableList<Syllable>) {
+        for (index in syllables.indices) {
+            val syllable = syllables[index]
+            if (!syllable.implicit || syllable.onset.isEmpty()) continue
+            val isLast = index == syllables.lastIndex
+            val nextHasWrittenVowel = !isLast &&
+                syllables[index + 1].let { it.vowel != null && !it.implicit }
+            if (isLast || (index > 0 && nextHasWrittenVowel)) {
+                syllables[index] = syllable.copy(vowel = null, implicit = false)
+            }
+        }
+    }
+
+    private fun render(syllables: List<Syllable>): String {
+        // Which syllable is last for the purpose of shortening a long vowel.
+        //
+        // "Last vowel" is not the test and getting that wrong turns आज into
+        // "aj": schwa deletion leaves ज carrying no vowel at all, so the ā
+        // before it looks final while a whole consonant still follows. What
+        // counts is whether any letter comes after — onset or vowel. A trailing
+        // nasal is transparent, which is why नहीं is "nahin" and not "naheen".
+        val lastLetterIndex = syllables.indexOfLast { it.onset.isNotEmpty() || it.vowel != null }
+        return buildString {
+            syllables.forEachIndexed { index, syllable ->
+                append(syllable.onset)
+                syllable.vowel?.let { append(it.render(final = index == lastLetterIndex)) }
+                if (syllable.nasal == "n") {
+                    // One letter, two sounds: संभव is "sambhav", अंदर is "andar".
+                    val next = syllables.getOrNull(index + 1)?.onset.orEmpty()
+                    append(if (next.firstOrNull() in LABIALS) "m" else "n")
+                } else {
+                    append(syllable.nasal)
+                }
+            }
+        }
+    }
+
+    private val LABIALS = setOf('p', 'b', 'm')
+
+    private val NASAL_SIGNS = setOf(ANUSVARA, CHANDRABINDU, VISARGA)
+
+    private val INDEPENDENT_VOWELS = mapOf(
+        'अ' to Vowel.A, 'आ' to Vowel.AA,
+        'इ' to Vowel.I, 'ई' to Vowel.II,
+        'उ' to Vowel.U, 'ऊ' to Vowel.UU,
+        'ऋ' to Vowel.RI, 'ॠ' to Vowel.RI,
+        'ऍ' to Vowel.E, 'ए' to Vowel.E,
+        'ऎ' to Vowel.E, 'ऐ' to Vowel.AI,
+        'ऑ' to Vowel.O, 'ओ' to Vowel.O,
+        'ऒ' to Vowel.O, 'औ' to Vowel.AU,
+    )
+
+    private val MATRAS = mapOf(
+        'ा' to Vowel.AA,
+        'ि' to Vowel.I, 'ी' to Vowel.II,
+        'ु' to Vowel.U, 'ू' to Vowel.UU,
+        'ृ' to Vowel.RI, 'ॄ' to Vowel.RI,
+        'ॅ' to Vowel.E, 'ॆ' to Vowel.E,
+        'े' to Vowel.E, 'ै' to Vowel.AI,
+        'ॉ' to Vowel.O, 'ॊ' to Vowel.O,
+        'ो' to Vowel.O, 'ौ' to Vowel.AU,
+    )
+
+    private val CONSONANTS = mapOf(
+        'क' to "k", 'ख' to "kh", 'ग' to "g", 'घ' to "gh", 'ङ' to "n",
+        'च' to "ch", 'छ' to "chh", 'ज' to "j", 'झ' to "jh", 'ञ' to "n",
+        'ट' to "t", 'ठ' to "th", 'ड' to "d", 'ढ' to "dh", 'ण' to "n",
+        'त' to "t", 'थ' to "th", 'द' to "d", 'ध' to "dh", 'न' to "n",
+        'प' to "p", 'फ' to "ph", 'ब' to "b", 'भ' to "bh", 'म' to "m",
+        'य' to "y", 'र' to "r", 'ऱ' to "r", 'ल' to "l", 'ळ' to "l",
+        'व' to "v",
+        'श' to "sh", 'ष' to "sh", 'स' to "s", 'ह' to "h",
+        // The precomposed nukta letters, which arrive as one code point rather
+        // than as a base plus U+093C.
+        'क़' to "q", 'ख़' to "kh", 'ग़' to "gh", 'ज़' to "z",
+        'ड़' to "r", 'ढ़' to "rh", 'फ़' to "f", 'य़' to "y",
+    )
+
+    /** What a following U+093C turns the base consonant into. */
+    private val NUKTA_FORMS = mapOf(
+        'क' to "q", 'ख' to "kh", 'ग' to "gh", 'ज' to "z",
+        'ड' to "r", 'ढ' to "rh", 'फ' to "f", 'य' to "y",
+    )
+
+    /** Devanagari that is not part of a syllable: digits, danda, om. */
+    private val STANDALONE = mapOf(
+        '।' to ".", '॥' to ".",
+        '०' to "0", '१' to "1", '२' to "2", '३' to "3", '४' to "4",
+        '५' to "5", '६' to "6", '७' to "7", '८' to "8", '९' to "9",
+        'ॐ' to "om", 'ऽ' to "",
+    )
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/HinglishNormalizer.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/HinglishNormalizer.kt
@@ -1,0 +1,260 @@
+package com.vocahq.vocaphone.core
+
+import java.util.Locale
+
+/**
+ * The last pass on a Roman Hinglish transcript, and the only thing standing
+ * between a good decode and Devanagari in a text field.
+ *
+ * The Hinglish model writes Latin nearly all of the time. Nearly is the problem:
+ * on an unfamiliar proper noun, or a stretch of clean Hindi with no English in
+ * it, it can fall back to the script it was fine-tuned away from. Deleting that
+ * would silently lose words the user said, so it is transliterated instead —
+ * [DevanagariRomanizer] turns "में" into text rather than into nothing.
+ *
+ * Everything else here is deliberately small. This is not a corrector: it does
+ * not repair grammar, does not second-guess word choice, and never rewrites a
+ * word that is spelled like English. Over-correction on a dictation transcript
+ * is worse than an inconsistent spelling, because the user cannot tell it
+ * happened.
+ *
+ * Runs entirely on the device. No model, no network, no lookup service — the
+ * whole layer is the tables below. The spelling convention they encode is
+ * written down in `docs/hinglish-roman.md`.
+ */
+object HinglishNormalizer {
+
+    /**
+     * Which passes to run.
+     *
+     * Configurable because the two spelling passes are conventions rather than
+     * facts. Someone who writes "kyon" is not wrong, and a build that wanted to
+     * leave their spelling alone should be able to say so without also giving up
+     * transliteration, which is not a preference at all.
+     */
+    data class Options(
+        /** Rewrite Devanagari as Latin rather than leaving or dropping it. */
+        val transliterateDevanagari: Boolean = true,
+        /** Settle transliterator output on one spelling per word. */
+        val applyRomanizedConventions: Boolean = true,
+        /** Settle the handful of Hindi spellings that are never English words. */
+        val applyGlobalConventions: Boolean = true,
+        /** Collapse whitespace and turn a danda into a full stop. */
+        val normalizePunctuation: Boolean = true,
+    ) {
+        companion object {
+            val DEFAULT = Options()
+        }
+    }
+
+    fun containsDevanagari(text: String): Boolean = DevanagariRomanizer.containsDevanagari(text)
+
+    fun normalize(text: String, options: Options = Options.DEFAULT): String {
+        if (text.isBlank()) return ""
+        val masked = mask(text)
+        var result = masked.text
+        if (options.transliterateDevanagari) {
+            result = transliterateWithConventions(result, options.applyRomanizedConventions)
+        }
+        if (options.applyGlobalConventions) {
+            result = applyGlobalConventions(result)
+        }
+        if (options.normalizePunctuation) {
+            result = normalizePunctuation(result)
+        }
+        return restore(result, masked.tokens).trim()
+    }
+
+    // ---------------------------------------------------------------- masking
+
+    /**
+     * Spans that must survive every pass below untouched.
+     *
+     * A URL, an email address, a file path, a shell command, an @handle: none of
+     * them are language, and all of them break if a spelling rule reaches
+     * inside. Replaced with a placeholder no rule can match, then put back
+     * verbatim at the end — the same device [TranscriptStyler] uses, for the
+     * same reason.
+     *
+     * Devanagari inside such a span stays Devanagari on purpose. A URL is not
+     * prose, and a transliterated host name is a broken link rather than a
+     * readable one.
+     */
+    private data class Masked(val text: String, val tokens: List<String>)
+
+    /**
+     * Case sensitivity is load-bearing here, which is why there is no
+     * `IGNORE_CASE` on the whole pattern: the last alternative is what makes
+     * `API` and `HTTP` survive, and case-folding it would match every ordinary
+     * two-to-eight-letter word in the transcript and mask the entire sentence.
+     */
+    private val PROTECTED = Regex(
+        listOf(
+            // A URL or a bare host.
+            """(?i:\b(?:[a-z][a-z0-9+.-]*://|www\.)\S+)""",
+            // An email address.
+            """(?i:\b[\w.+-]+@[\w-]+\.[\w.-]+\b)""",
+            // A path or a command: anything with an internal slash.
+            """\S*[/\\]\S*""",
+            // A filename or a dotted identifier.
+            """(?i:\b\w+\.[a-z0-9]{1,8}\b)""",
+            // A handle or a hashtag.
+            """[@#][\w.-]+""",
+            // An abbreviation the model wrote in capitals: API, GPU, HTTP.
+            """\b[A-Z][A-Z0-9]{1,7}\b""",
+        ).joinToString("|"),
+    )
+
+    private const val PLACEHOLDER_OPEN = '\u0001'
+    private const val PLACEHOLDER_CLOSE = '\u0002'
+
+    private val PLACEHOLDER = Regex("$PLACEHOLDER_OPEN(\\d+)$PLACEHOLDER_CLOSE")
+
+    private fun mask(text: String): Masked {
+        val tokens = mutableListOf<String>()
+        val masked = PROTECTED.replace(text) { match ->
+            tokens += match.value
+            "$PLACEHOLDER_OPEN${tokens.size - 1}$PLACEHOLDER_CLOSE"
+        }
+        return Masked(masked, tokens)
+    }
+
+    private fun restore(text: String, tokens: List<String>): String =
+        PLACEHOLDER.replace(text) { match ->
+            Regex.escapeReplacement(tokens[match.groupValues[1].toInt()])
+        }
+
+    // -------------------------------------------------------- transliteration
+
+    /**
+     * Transliterates each Devanagari run and settles its spelling immediately.
+     *
+     * Doing it here rather than over the finished string is what makes
+     * [ROMANIZED_CONVENTIONS] safe. "men" out of the transliterator is में;
+     * "men" that arrived already in Latin is the English word, and rewriting
+     * that to "mein" is exactly the over-correction this layer must not do.
+     * Provenance is only knowable at this moment, so the rule is applied at this
+     * moment.
+     */
+    private fun transliterateWithConventions(text: String, applyConventions: Boolean): String {
+        if (!DevanagariRomanizer.containsDevanagari(text)) return text
+        val romanized = DevanagariRomanizer.romanize(text)
+        if (!applyConventions) return romanized
+        // A word that was already in the source cannot have come out of the
+        // transliterator, so it is left alone whatever the table says.
+        val original = WORD.findAll(text).map { it.value }.toSet()
+        return WORD.replace(romanized) { match ->
+            val word = match.value
+            if (word in original) {
+                word
+            } else {
+                ROMANIZED_CONVENTIONS[word.lowercase(Locale.ROOT)]
+                    ?.let { matchCase(word, it) }
+                    ?: word
+            }
+        }
+    }
+
+    private val WORD = Regex("""\p{L}+""")
+
+    /**
+     * One spelling per word for transliterator output, where the mechanical
+     * answer is not the one people type.
+     *
+     * Short by design. The romanizer's own rules already produce "mujhe",
+     * "nahin", "hai" and "theek"; these are the leftovers where a Devanagari
+     * spelling maps to a Roman one convention has moved away from. में is the
+     * clearest: it is म + े + ं, mechanically "men", and every Hinglish speaker
+     * writes "mein".
+     */
+    private val ROMANIZED_CONVENTIONS = mapOf(
+        "men" to "mein",
+        "kyon" to "kyun",
+        "kyonki" to "kyunki",
+        "hon" to "hoon",
+        "hun" to "hoon",
+        "jaen" to "jayen",
+    )
+
+    // ----------------------------------------------------- global conventions
+
+    /**
+     * Spellings settled across the whole transcript, including text the model
+     * already wrote in Latin.
+     *
+     * Every key here has to be a form that is *not* an English word, because by
+     * this point provenance is gone and a collision would rewrite English. That
+     * rules out the tempting ones — "to", "the", "is", "men" — and leaves a
+     * short list where the rewrite is unambiguous.
+     */
+    private val GLOBAL_CONVENTIONS = mapOf(
+        "muje" to "mujhe",
+        "mujey" to "mujhe",
+        "mujhy" to "mujhe",
+        "kyu" to "kyun",
+        "kyoon" to "kyun",
+        "kyuki" to "kyunki",
+        "kyunke" to "kyunki",
+        "nahi" to "nahin",
+        "nhi" to "nahin",
+        "thik" to "theek",
+        "thk" to "theek",
+        "acha" to "accha",
+        "achha" to "accha",
+        "bahot" to "bahut",
+        "bhot" to "bahut",
+        "kese" to "kaise",
+        "krna" to "karna",
+        "krke" to "karke",
+        "smjh" to "samajh",
+    )
+
+    private fun applyGlobalConventions(text: String): String {
+        val settled = WORD.replace(text) { match ->
+            GLOBAL_CONVENTIONS[match.value.lowercase(Locale.ROOT)]
+                ?.let { matchCase(match.value, it) }
+                ?: match.value
+        }
+        return HEY.replace(settled, "hai")
+    }
+
+    /**
+     * "theek hey" is "theek hai"; "Hey, ..." is English and stays.
+     *
+     * The one rule that needs a guard rather than a table, because "hey" is a
+     * real English word. It is only rewritten mid-sentence and lowercase:
+     * English "hey" is an opener, and an opener is capitalized or followed by a
+     * comma. Wrong in the safe direction leaves a spelling slightly off; wrong
+     * in the other direction rewrites what someone said.
+     */
+    private val HEY = Regex("""(?<=\S )hey\b(?![,!])""")
+
+    /** Keeps a rewritten word in the case it arrived in. */
+    private fun matchCase(original: String, replacement: String): String = when {
+        original.length > 1 && original.all { it.isUpperCase() } ->
+            replacement.uppercase(Locale.ROOT)
+        original.first().isUpperCase() ->
+            replacement.replaceFirstChar { it.uppercase(Locale.ROOT) }
+        else -> replacement
+    }
+
+    // ------------------------------------------------------------ punctuation
+
+    /**
+     * Whitespace and the two marks the script change leaves behind.
+     *
+     * The danda is a Devanagari full stop with no business in a Latin sentence;
+     * [DevanagariRomanizer] already converts the ones attached to a word, and
+     * this catches a free-standing one. Capitalization and sentence terminators
+     * are deliberately absent — [TranscriptStyler] runs after this and owns them
+     * for every language.
+     */
+    private fun normalizePunctuation(text: String): String = text
+        .replace('।', '.')
+        .replace('॥', '.')
+        .replace(Regex("""[ \t]{2,}"""), " ")
+        .replace(Regex(""" +([,.!?;:])"""), "$1")
+        .replace(Regex("""([,.!?;:])(?=[^\s\d,.!?;:])"""), "$1 ")
+        .split('\n')
+        .joinToString("\n") { it.trim() }
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/ModelLanguageSupport.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/ModelLanguageSupport.kt
@@ -26,6 +26,19 @@ object ModelLanguageSupport {
         if (requested == TranscriptionLanguage.AUTOMATIC.wireValue) reported else requested
 
     /**
+     * The language token an engine is actually given.
+     *
+     * Roman Hinglish is not a language a decoder knows. The model that produces
+     * it is a Hindi fine-tune, and the token it wants is `hi`; passing
+     * `hinglish_roman` through to whisper.cpp gets the string rejected and the
+     * decode falls back to detection. The distinction is kept everywhere else —
+     * the transcript language stays `hinglish_roman`, which is what tells the
+     * normalizer and the writing styles they are looking at Latin text.
+     */
+    fun decoderLanguage(requested: String): String =
+        if (requested == TranscriptionLanguage.HINGLISH_ROMAN.wireValue) "hi" else requested
+
+    /**
      * The language the finished transcript is actually written in.
      *
      * [translateTo] wins outright when set, and that is the whole point of the
@@ -52,6 +65,14 @@ object ModelLanguageSupport {
         modelLanguages: Set<String>,
     ): Boolean {
         if (language == TranscriptionLanguage.AUTOMATIC) return true
+        // An output script inverts the default. "Nothing was claimed" is a good
+        // reason not to lock a user out of Hindi, because almost everything
+        // transcribes Hindi; it is a bad reason to offer Roman Hinglish, which
+        // exactly one model in the catalog can produce and which every other
+        // model would answer with Devanagari or an English translation. Silence
+        // is a no here, and a gateway that has never heard of the value would
+        // reject it as unsupported anyway.
+        if (language.isOutputScript) return language.wireValue in modelLanguages
         if (modelLanguages.isEmpty()) return true
         return language.wireValue in modelLanguages
     }

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptStyler.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptStyler.kt
@@ -74,6 +74,11 @@ object TranscriptStyler {
     private fun punctuation(language: String, text: String): Punctuation {
         val code = language.lowercase().substringBefore('-')
         return when (code) {
+            // Roman Hinglish is Latin by definition. Inference would reach the
+            // same answer today only because the normalizer runs first; saying
+            // it here is what keeps a leaked danda from re-scripting the whole
+            // sentence.
+            TranscriptionLanguage.HINGLISH_ROMAN.wireValue -> latin
             "ja", "zh" -> cjk
             "ar", "fa", "ps" -> arabic
             "ur", "sd", "ks" -> urdu

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptionLanguage.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptionLanguage.kt
@@ -14,6 +14,14 @@ package com.vocahq.vocaphone.core
  * Odia and Kashmiri are deliberately absent: only Dolphin covers them, and no
  * Whisper build can be pinned to either, so a row for them could never be
  * honoured by anything the user could switch to.
+ *
+ * [HINGLISH_ROMAN] is the one entry that is not a language. It is an output
+ * contract — Hindi and English as spoken, written in one Latin script — and it
+ * exists as a row here because that is the choice the user is actually making
+ * and because everything downstream, from the picker to the writing styles,
+ * already keys off this enum. Exactly one model in the catalog can honour it,
+ * and [com.vocahq.vocaphone.core.ModelLanguageSupport] refuses to offer the row
+ * to anything that has not said so in as many words.
  */
 enum class TranscriptionLanguage(val wireValue: String) {
     AUTOMATIC("auto"),
@@ -37,6 +45,7 @@ enum class TranscriptionLanguage(val wireValue: String) {
     GUJARATI("gu"),
     HEBREW("he"),
     HINDI("hi"),
+    HINGLISH_ROMAN("hinglish_roman"),
     HUNGARIAN("hu"),
     INDONESIAN("id"),
     ITALIAN("it"),
@@ -95,6 +104,7 @@ enum class TranscriptionLanguage(val wireValue: String) {
             GUJARATI -> "Gujarati"
             HEBREW -> "Hebrew"
             HINDI -> "Hindi"
+            HINGLISH_ROMAN -> "Hinglish — Roman"
             HUNGARIAN -> "Hungarian"
             INDONESIAN -> "Indonesian"
             ITALIAN -> "Italian"
@@ -132,13 +142,34 @@ enum class TranscriptionLanguage(val wireValue: String) {
         }
 
     val shortLabel: String
-        get() = if (this == AUTOMATIC) "Auto" else wireValue.uppercase()
+        get() = when (this) {
+            AUTOMATIC -> "Auto"
+            // The only wire value that is not a two- or three-letter code, and
+            // "HINGLISH_ROMAN" on a keyboard chip is unreadable.
+            HINGLISH_ROMAN -> "Hinglish"
+            else -> wireValue.uppercase()
+        }
 
     val detail: String
         get() = when (this) {
             AUTOMATIC -> "Uses the language of the model selected on your gateway."
+            HINGLISH_ROMAN ->
+                "Experimental. Writes mixed Hindi and English in the Latin alphabet, " +
+                    "as spoken. Needs the Hinglish model on this phone."
             else -> "Requires a matching multilingual or $displayName model on your gateway."
         }
+
+    /**
+     * Whether this row describes an output script rather than a spoken language.
+     *
+     * The distinction matters in two places: the picker's explanatory copy, and
+     * every check that assumes a row can be honoured by any model claiming to
+     * cover it. See [com.vocahq.vocaphone.core.ModelLanguageSupport.isSelectable].
+     */
+    val isOutputScript: Boolean get() = this == HINGLISH_ROMAN
+
+    /** Marked in the UI so nobody mistakes it for a finished feature. */
+    val isExperimental: Boolean get() = this == HINGLISH_ROMAN
 
     companion object {
         val DEFAULT = AUTOMATIC

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -19,10 +19,12 @@ import com.vocahq.vocaphone.core.DictationFailure
 import com.vocahq.vocaphone.core.DictationPhase
 import com.vocahq.vocaphone.core.DictationState
 import com.vocahq.vocaphone.core.DictationTone
+import com.vocahq.vocaphone.core.HinglishNormalizer
 import com.vocahq.vocaphone.core.MissingPermission
 import com.vocahq.vocaphone.core.ModelLanguageSupport
 import com.vocahq.vocaphone.core.TranscriptSanitizer
 import com.vocahq.vocaphone.core.TranscriptStyler
+import com.vocahq.vocaphone.core.TranscriptionLanguage
 import com.vocahq.vocaphone.data.HistoryRepository
 import com.vocahq.vocaphone.data.DiagnosticLog
 import com.vocahq.vocaphone.gateway.GatewayClient
@@ -873,15 +875,25 @@ class DictationController(
     private fun styleLocalTranscript(
         local: LocalTranscription,
         configuration: VocaPhoneSettings,
-    ): String = TranscriptStyler.apply(
-        TranscriptSanitizer.clean(local.text),
-        configuration.style,
-        ModelLanguageSupport.outputLanguage(
+    ): String {
+        val outputLanguage = ModelLanguageSupport.outputLanguage(
             requested = configuration.effectiveLanguage.wireValue,
             reported = local.language,
             translateTo = configuration.translationTarget,
-        ),
-    )
+        )
+        val cleaned = TranscriptSanitizer.clean(local.text)
+        // Roman Hinglish is the one mode whose output script is a promise rather
+        // than a side effect, so it gets the pass that keeps that promise. Every
+        // other language reaches the styles exactly as it did before: the
+        // normalizer would be a no-op on Latin text, but running it on Hindi
+        // would romanize a transcript nobody asked to have romanized.
+        val normalized = if (outputLanguage == TranscriptionLanguage.HINGLISH_ROMAN.wireValue) {
+            HinglishNormalizer.normalize(cleaned)
+        } else {
+            cleaned
+        }
+        return TranscriptStyler.apply(normalized, configuration.style, outputLanguage)
+    }
 
     private suspend fun deliver(
         transcript: String,

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelCatalog.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelCatalog.kt
@@ -99,7 +99,29 @@ data class LocalModelDescriptor(
     val detectsLanguage: Boolean = false,
     /** Whether short recordings may use a cropped whisper encoder window. */
     val cropsAudioContext: Boolean = false,
+    /**
+     * Kept out of every recommendation, and labelled where it is offered.
+     *
+     * Not the same as "big" or "slow", both of which the picker already warns
+     * about. This says the model's *output* has not been validated to the
+     * standard the rest of the catalog is held to, so it must never be reached
+     * by a user who did not go looking for it.
+     */
+    val experimental: Boolean = false,
 ) {
+    /**
+     * Whether this model's output script is the whole point of it.
+     *
+     * The Roman Hinglish model is the only one so far: it does not transcribe
+     * "Hindi", it transcribes Hindi and English into one Latin script, and that
+     * is a different promise from any language code. Declaring the output-script
+     * code in [languageCodes] is how a model says so, and it is what stops the
+     * translate row offering to turn the result into English — which is exactly
+     * the failure this mode exists to avoid.
+     */
+    val producesFixedScript: Boolean
+        get() = com.vocahq.vocaphone.core.TranscriptionLanguage.HINGLISH_ROMAN.wireValue in
+            languageCodes
     /**
      * Which languages this model can translate speech *into*.
      *
@@ -116,6 +138,11 @@ data class LocalModelDescriptor(
         get() = when {
             sherpaFamily == SherpaFamily.CANARY -> languageCodes
             englishOnly || "distil" in id -> emptySet()
+            // A fixed-script model has one output contract and translating is
+            // not it. Whisper's translate task would still run — it is the same
+            // decoder — and it would hand back the English translation this mode
+            // exists to avoid, from a row the user reasonably read as harmless.
+            producesFixedScript -> emptySet()
             engine == LocalModelEngine.WHISPER -> setOf("en")
             else -> emptySet()
         }
@@ -270,7 +297,56 @@ object LocalModelCatalog {
             "9a423fe4d40c82774b6af34115b8b935f34152246eb19e80e376071d3f999487", 12, "100 languages"),
     )
 
-    val all: List<LocalModelDescriptor> = whisper + SherpaModelCatalog.all
+    /**
+     * Roman Hinglish: mixed Hindi and English, written in one Latin script.
+     *
+     * `Oriserve/Whisper-Hindi2Hinglish-Apex` is a fine-tune of
+     * `openai/whisper-large-v3-turbo` (Apache-2.0) whose training target is
+     * romanized Hindi, so the script comes out of the decoder rather than out of
+     * a transliteration pass. Its `config.json` is turbo's topology exactly — 32
+     * encoder layers, 4 decoder layers, `d_model` 1280, 128 mel bins, 51866
+     * tokens — which is why whisper.cpp runs it unmodified and why the quantized
+     * file is byte-for-byte the size of the stock turbo build.
+     *
+     * Upstream publishes safetensors and nothing else. The GGML conversion is
+     * pinned at a third-party repository, at an immutable commit, by SHA-256 —
+     * and the digest was not taken on trust: `tools/hinglish/convert-apex-ggml.sh`
+     * reproduces it from Oriserve's own weights, and that script is how it should
+     * be re-checked before this pin is ever moved.
+     *
+     * [languageCodes] holds one entry and it is not a language. That is the
+     * honest claim: asking this model for Hindi gets Roman Hinglish, and asking
+     * it for German gets Roman Hinglish too.
+     */
+    private val hinglish: List<LocalModelDescriptor> = listOf(
+        LocalModelDescriptor(
+            id = "hinglish-apex-large-v3-turbo-q5_0",
+            displayName = "Hinglish — Roman (Experimental)",
+            engine = LocalModelEngine.WHISPER,
+            repository = "Marquestra/Whisper-Hindi2Hinglish-Apex-GGML",
+            revision = "d1de3ff618856e5675c47d3158ca820506fb4d9e",
+            files = listOf(
+                PinnedFile(
+                    "ggml-apex-hinglish-q5_0.bin",
+                    574_041_195L,
+                    "9d877151b15cec1feb9110cfbc0a3162cf377bcc0ab1935174226f461cf60f13",
+                ),
+            ),
+            sizeBytes = 574_041_195L,
+            minimumRamGB = 4,
+            languages = "Hindi + English, Roman script",
+            languageCodes = setOf(TranscriptionLanguage.HINGLISH_ROMAN.wireValue),
+            // Fine-tuned onto one output contract, so nothing is detected and
+            // nothing can be pinned to something else.
+            detectsLanguage = false,
+            // Large-class encoder: the same reason the stock turbo builds keep
+            // whisper's full thirty-second window.
+            cropsAudioContext = false,
+            experimental = true,
+        ),
+    )
+
+    val all: List<LocalModelDescriptor> = whisper + SherpaModelCatalog.all + hinglish
 
     /**
      * sherpa-onnx ships as a prebuilt JNI library, so it is absent from builds
@@ -376,8 +452,18 @@ object LocalModelCatalog {
 
     /** The lightest download that still transcribes this phone's language. */
     private fun smallestCovering(profile: DeviceProfile): LocalModelDescriptor? =
-        all.filter { profile.fits(it) && it.coversLanguage(profile.language) }
+        recommendable.filter { profile.fits(it) && it.coversLanguage(profile.language) }
             .minByOrNull { it.sizeBytes }
+
+    /**
+     * Everything a recommendation may land on.
+     *
+     * An experimental model has to be gone looking for. Reaching one by way of
+     * "smallest download" or "nothing else fit" would put unvalidated output in
+     * front of a user who never asked for it, which is the one thing the flag is
+     * there to prevent.
+     */
+    private val recommendable: List<LocalModelDescriptor> get() = all.filterNot { it.experimental }
 
     private fun firstFitting(
         profile: DeviceProfile,
@@ -388,9 +474,9 @@ object LocalModelCatalog {
 
     /** Nothing fit the budget, so fall back to whatever the phone can hold. */
     private fun lastResort(profile: DeviceProfile): LocalModelDescriptor =
-        all.filter { isUsableOnDevice(it, profile.totalRamGB, profile.sherpaAvailable) }
+        recommendable.filter { isUsableOnDevice(it, profile.totalRamGB, profile.sherpaAvailable) }
             .minByOrNull { it.minimumRamGB }
-            ?: all.first()
+            ?: recommendable.first()
 
     /** The fastest sensible Whisper fallback for this CPU class. */
     fun recommendedWhisper(profile: DeviceProfile): LocalModelDescriptor =

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/WhisperContext.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/WhisperContext.kt
@@ -29,7 +29,12 @@ internal class WhisperContext private constructor(private var pointer: Long) {
                 pointer,
                 threads,
                 samples,
-                if (language == "auto") "auto" else language,
+                // Roman Hinglish is an output contract, not a token the
+                // decoder knows: the model behind it is a Hindi fine-tune and
+                // "hi" is what it wants. The transcript keeps the original code,
+                // which is what tells the normalizer and the writing styles what
+                // script they are looking at.
+                ModelLanguageSupport.decoderLanguage(language),
                 translateTo.isNotEmpty(),
                 quality.whisperBeamSize,
                 quality.whisperTemperatureIncrement,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/LanguagePickerSheet.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/LanguagePickerSheet.kt
@@ -138,7 +138,16 @@ fun LanguagePickerSheet(
             modifier = Modifier.fillMaxWidth().heightIn(max = 420.dp).padding(top = 8.dp),
         ) {
             items(available, key = { it.wireValue }) { language ->
-                LanguageRow(label(language), selected == language, enabled = true) {
+                LanguageRow(
+                    label(language),
+                    // Every other row is a language and needs no explaining.
+                    // Roman Hinglish is a script promise about two languages at
+                    // once, and it is experimental, so it says both here rather
+                    // than leaving the name to carry it.
+                    detail = language.detail.takeIf { language.isExperimental },
+                    isSelected = selected == language,
+                    enabled = true,
+                ) {
                     onSelect(language)
                     onDismiss()
                 }
@@ -153,7 +162,12 @@ fun LanguagePickerSheet(
                     )
                 }
                 items(unavailable, key = { it.wireValue }) { language ->
-                    LanguageRow(label(language), selected == language, enabled = false) {}
+                    LanguageRow(
+                        label(language),
+                        detail = language.detail.takeIf { language.isExperimental },
+                        isSelected = selected == language,
+                        enabled = false,
+                    ) {}
                 }
             }
             if (available.isEmpty() && unavailable.isEmpty()) {
@@ -174,6 +188,7 @@ fun LanguagePickerSheet(
 @Composable
 private fun LanguageRow(
     label: String,
+    detail: String?,
     isSelected: Boolean,
     enabled: Boolean,
     onClick: () -> Unit,
@@ -191,12 +206,17 @@ private fun LanguageRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Text(
-            label,
-            style = MaterialTheme.typography.bodyLarge,
-            color = colour,
-            modifier = Modifier.weight(1f),
-        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(label, style = MaterialTheme.typography.bodyLarge, color = colour)
+            if (detail != null) {
+                Text(
+                    detail,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                        .copy(alpha = if (enabled) 1f else 0.5f),
+                )
+            }
+        }
         if (isSelected) {
             Icon(
                 painter = painterResource(R.drawable.ic_step_done),

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/DevanagariRomanizerTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/DevanagariRomanizerTest.kt
@@ -1,0 +1,154 @@
+package com.vocahq.vocaphone.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The romanizer is a spelling convention, so these are convention tests: one
+ * spelling per word, chosen because it is the one people type. They are not
+ * pinning a "correct" transliteration — several would be defensible — they are
+ * pinning the one this repo committed to in `docs/hinglish-roman.md`, so that a
+ * change to the rules cannot quietly change how every transcript reads.
+ *
+ * The grouping is by rule rather than by word, because each group is a rule that
+ * has a visibly wrong naive answer.
+ */
+class DevanagariRomanizerTest {
+
+    private fun assertRomanizes(vararg cases: Pair<String, String>) {
+        cases.forEach { (devanagari, expected) ->
+            assertEquals(devanagari, expected, DevanagariRomanizer.romanize(devanagari))
+        }
+    }
+
+    @Test
+    fun `implicit vowels are dropped at the end of a word`() {
+        // Without this every word gains a syllable: "gharaa", "kalaa", "ekaa".
+        assertRomanizes(
+            "घर" to "ghar",
+            "कल" to "kal",
+            "एक" to "ek",
+            "आज" to "aaj",
+        )
+    }
+
+    @Test
+    fun `implicit vowels are dropped mid-word before a written vowel`() {
+        assertRomanizes(
+            "करना" to "karna",
+            "करनी" to "karni",
+            "देखना" to "dekhna",
+            "समझना" to "samajhna",
+        )
+    }
+
+    @Test
+    fun `implicit vowels survive where the next syllable has no written vowel`() {
+        // समझ is the counterexample to the rule above: ज carries no written
+        // vowel either, so the schwa on म is pronounced and "samjh" is wrong.
+        assertRomanizes(
+            "समझ" to "samajh",
+            "भारत" to "bhaarat",
+        )
+    }
+
+    @Test
+    fun `the first syllable never loses its implicit vowel`() {
+        // Without the guard पता collapses to "pta", which is unreadable.
+        assertRomanizes(
+            "पता" to "pata",
+            "बताना" to "bataana",
+        )
+    }
+
+    @Test
+    fun `long vowels shorten only at the end of a word`() {
+        assertRomanizes(
+            "ठीक" to "theek",
+            "कभी" to "kabhi",
+            "काम" to "kaam",
+            "बात" to "baat",
+            "साथ" to "saath",
+            "मेरी" to "meri",
+            "दूसरा" to "doosra",
+        )
+    }
+
+    @Test
+    fun `a trailing nasal does not make the vowel before it non-final`() {
+        // "naheen" and "hoon" for these would both be wrong for the same reason.
+        assertRomanizes(
+            "नहीं" to "nahin",
+            "हूँ" to "hun",
+            "मैं" to "main",
+            "हैं" to "hain",
+        )
+    }
+
+    @Test
+    fun `anusvara is m before a lip consonant and n everywhere else`() {
+        assertRomanizes(
+            "संभव" to "sambhav",
+            "अंदर" to "andar",
+        )
+    }
+
+    @Test
+    fun `conjuncts keep both consonants and no vowel between them`() {
+        assertRomanizes(
+            "क्या" to "kya",
+            "नमस्ते" to "namaste",
+            "अच्छा" to "achchha",
+            "कुछ" to "kuchh",
+        )
+    }
+
+    @Test
+    fun `nukta letters take their own sounds`() {
+        assertRomanizes(
+            "ज़रूर" to "zaroor",
+            "फ़ोन" to "fon",
+            "बड़ा" to "bara",
+        )
+    }
+
+    @Test
+    fun `devanagari digits and danda become their latin equivalents`() {
+        assertRomanizes(
+            "१२३" to "123",
+            "ठीक।" to "theek.",
+        )
+    }
+
+    @Test
+    fun `latin text passes through untouched`() {
+        val english = "Deploy the API to staging at 4:30 PM, then ping me."
+        assertEquals(english, DevanagariRomanizer.romanize(english))
+        assertFalse(DevanagariRomanizer.containsDevanagari(english))
+    }
+
+    @Test
+    fun `a code-switched sentence keeps its english half verbatim`() {
+        assertEquals(
+            "aaj mujhe office men ek important meeting attend karni hai",
+            DevanagariRomanizer.romanize(
+                "आज मुझे office में एक important meeting attend करनी है",
+            ),
+        )
+    }
+
+    @Test
+    fun `nothing devanagari survives romanization`() {
+        val mixed = "कल मेरी client के साथ deployment meeting है। ठीक है ना?"
+        assertTrue(DevanagariRomanizer.containsDevanagari(mixed))
+        assertFalse(DevanagariRomanizer.containsDevanagari(DevanagariRomanizer.romanize(mixed)))
+    }
+
+    @Test
+    fun `romanizing twice changes nothing the second time`() {
+        val once = DevanagariRomanizer.romanize("आज मुझे office में meeting है")
+        assertEquals(once, DevanagariRomanizer.romanize(once))
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/HinglishNormalizerTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/HinglishNormalizerTest.kt
@@ -1,0 +1,206 @@
+package com.vocahq.vocaphone.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * What the normalizer must guarantee, and what it must not do.
+ *
+ * The guarantees are narrow on purpose. Two of them are absolute — no Devanagari
+ * reaches a text field, and no English word is rewritten — and everything else
+ * is a spelling convention that a reasonable person could have settled
+ * differently. So the strict assertions live on the script and on the words that
+ * were genuinely spoken in English; the spelling assertions check one documented
+ * choice at a time rather than pinning whole sentences, which would make the
+ * suite brittle for no gain.
+ */
+class HinglishNormalizerTest {
+
+    private fun normalize(text: String) = HinglishNormalizer.normalize(text)
+
+    // --------------------------------------------------------------- script
+
+    @Test
+    fun `devanagari never survives`() {
+        listOf(
+            "आज मुझे office में एक important meeting attend करनी है",
+            "कल मेरी client के साथ deployment meeting है",
+            "सब कुछ ठीक है।",
+            "मैं थोड़ी देर में call करता हूँ",
+        ).forEach { spoken ->
+            val normalized = normalize(spoken)
+            assertFalse(
+                "Devanagari leaked from \"$spoken\" as \"$normalized\"",
+                HinglishNormalizer.containsDevanagari(normalized),
+            )
+        }
+    }
+
+    @Test
+    fun `devanagari is transliterated rather than deleted`() {
+        // The failure this rules out is the quiet one: dropping the script
+        // instead of converting it loses words the user actually said, and the
+        // transcript still looks like a clean sentence.
+        val normalized = normalize("मुझे कल जाना है")
+        assertEquals(4, normalized.split(" ").size)
+        assertTrue(normalized, normalized.contains("mujhe"))
+    }
+
+    @Test
+    fun `an already roman transcript is left alone`() {
+        val roman = "Kal meri client ke saath deployment meeting hai."
+        assertEquals(roman, normalize(roman))
+    }
+
+    // -------------------------------------------------------------- english
+
+    @Test
+    fun `english words spoken in english are preserved verbatim`() {
+        val normalized = normalize(
+            "मुझे server पर नया deployment करना है और database migrate करना है",
+        )
+        listOf("server", "deployment", "database", "migrate").forEach { word ->
+            assertTrue("lost \"$word\" in \"$normalized\"", normalized.contains(word))
+        }
+    }
+
+    @Test
+    fun `an english homograph of a hindi spelling is not rewritten`() {
+        // "men" is में out of the transliterator and the English plural
+        // everywhere else. Only the first may become "mein"; rewriting the
+        // second is the over-correction this layer exists to avoid.
+        assertEquals("Three men joined the call.", normalize("Three men joined the call."))
+        assertTrue(normalize("मैं office में हूँ").contains("mein"))
+    }
+
+    @Test
+    fun `proper nouns and brand names are untouched`() {
+        val normalized = normalize("कल Google Meet पर Priya से baat karni hai")
+        listOf("Google", "Meet", "Priya").forEach { word ->
+            assertTrue("lost \"$word\" in \"$normalized\"", normalized.contains(word))
+        }
+    }
+
+    // ------------------------------------------------------------ protected
+
+    @Test
+    fun `urls emails paths and handles survive every pass`() {
+        listOf(
+            "docs पर जाओ https://vocahq.com/setup?ref=a_b",
+            "मुझे mail करो at yaviral@example.com",
+            "फ़ाइल है /var/log/whisper.log में",
+            "@priya को tag करो #release में",
+        ).forEach { spoken ->
+            val protectedSpan = Regex("""\S*(?:://|@|/|#)\S*""").find(spoken)!!.value
+            assertTrue(
+                "lost \"$protectedSpan\" from \"${normalize(spoken)}\"",
+                normalize(spoken).contains(protectedSpan),
+            )
+        }
+    }
+
+    @Test
+    fun `a command keeps its flags`() {
+        val normalized = normalize("फिर run करो git push --force-with-lease")
+        assertTrue(normalized, normalized.contains("--force-with-lease"))
+    }
+
+    @Test
+    fun `shouted abbreviations keep their capitals`() {
+        val normalized = normalize("API का response GPU पर slow है")
+        assertTrue(normalized, normalized.contains("API"))
+        assertTrue(normalized, normalized.contains("GPU"))
+    }
+
+    @Test
+    fun `numbers dates and prices are left as they arrived`() {
+        val normalized = normalize("meeting है 3:30 बजे और budget है 45,000 रुपये")
+        assertTrue(normalized, normalized.contains("3:30"))
+        assertTrue(normalized, normalized.contains("45,000"))
+    }
+
+    // ------------------------------------------------------------- spelling
+
+    @Test
+    fun `one spelling per word, per the documented convention`() {
+        // One word per assertion, so a convention change reads as a convention
+        // change rather than as a broken sentence.
+        assertTrue(normalize("मुझे").contains("mujhe"))
+        assertTrue(normalize("muje aana hai").contains("mujhe"))
+        assertTrue(normalize("kyu nahi aaye").contains("kyun"))
+        assertTrue(normalize("nahi aa raha").contains("nahin"))
+        assertTrue(normalize("thik hai").contains("theek"))
+    }
+
+    @Test
+    fun `hey becomes hai mid-sentence and stays hey as an opener`() {
+        assertEquals("Sab theek hai", normalize("Sab theek hey"))
+        assertEquals("Hey, kaise ho?", normalize("Hey, kaise ho?"))
+    }
+
+    @Test
+    fun `case is carried through a rewrite`() {
+        assertTrue(normalize("Muje kal jaana hai").startsWith("Mujhe"))
+    }
+
+    // -------------------------------------------------------- punctuation
+
+    @Test
+    fun `a danda becomes a full stop`() {
+        val normalized = normalize("सब ठीक है ।")
+        assertTrue(normalized, normalized.endsWith("."))
+        assertFalse(normalized, normalized.contains('।'))
+    }
+
+    @Test
+    fun `spacing around punctuation is tidied without inventing any`() {
+        assertEquals("Haan, theek hai.", normalize("Haan ,   theek hai."))
+    }
+
+    @Test
+    fun `terminators are not added here`() {
+        // TranscriptStyler runs after this and owns capitalization and sentence
+        // endings for every language. Doing it twice would fight it.
+        assertEquals("theek hai", normalize("theek hai"))
+    }
+
+    // ----------------------------------------------------------- behaviour
+
+    @Test
+    fun `normalizing twice changes nothing the second time`() {
+        val once = normalize("आज मुझे office में meeting attend करनी है")
+        assertEquals(once, normalize(once))
+    }
+
+    @Test
+    fun `blank input gives blank output`() {
+        assertEquals("", normalize(""))
+        assertEquals("", normalize("   \n  "))
+    }
+
+    @Test
+    fun `each pass can be turned off independently`() {
+        val spoken = "muje में jaana hai"
+        assertEquals(
+            spoken,
+            HinglishNormalizer.normalize(
+                spoken,
+                HinglishNormalizer.Options(
+                    transliterateDevanagari = false,
+                    applyRomanizedConventions = false,
+                    applyGlobalConventions = false,
+                    normalizePunctuation = false,
+                ),
+            ),
+        )
+        // Transliteration on, conventions off: the mechanical spelling stands.
+        assertTrue(
+            HinglishNormalizer.normalize(
+                "में",
+                HinglishNormalizer.Options(applyRomanizedConventions = false),
+            ).contains("men"),
+        )
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/ModelLanguageSupportTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/ModelLanguageSupportTest.kt
@@ -37,12 +37,27 @@ class ModelLanguageSupportTest {
     fun `an unknown gateway never locks the picker`() {
         // Older gateway, no model selected, or an imported one. Being uninformed
         // must not look like being unsupported.
-        for (language in TranscriptionLanguage.entries) {
+        //
+        // Output-script rows are the one exception, and they are excluded here
+        // rather than weakening the rule. "Almost every model transcribes Hindi"
+        // is what makes silence a yes; nothing about that reasoning carries over
+        // to Roman Hinglish, which one model in the catalog produces and every
+        // other model would answer with Devanagari. See
+        // `HinglishModelTest.the roman row needs a model that says so`.
+        for (language in TranscriptionLanguage.entries.filterNot { it.isOutputScript }) {
             assertTrue(
                 "$language must stay selectable when the gateway made no claim",
                 ModelLanguageSupport.isSelectable(language, emptySet()),
             )
         }
+    }
+
+    @Test
+    fun `an output script is offered only where it is claimed outright`() {
+        val roman = TranscriptionLanguage.HINGLISH_ROMAN
+        assertFalse(ModelLanguageSupport.isSelectable(roman, emptySet()))
+        assertFalse(ModelLanguageSupport.isSelectable(roman, dolphin))
+        assertTrue(ModelLanguageSupport.isSelectable(roman, setOf(roman.wireValue)))
     }
 
     @Test

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/WireValuesTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/WireValuesTest.kt
@@ -23,7 +23,8 @@ class WireValuesTest {
             listOf(
                 "auto", "ar", "as", "bn", "bg", "yue", "ca", "hr", "cs", "da",
                 "nl", "en", "et", "tl", "fi", "fr", "de", "el", "gu", "he",
-                "hi", "hu", "id", "it", "ja", "kn", "ko", "lv", "lt", "ms",
+                "hi", "hinglish_roman", "hu", "id", "it", "ja", "kn", "ko", "lv", "lt",
+                "ms",
                 "ml", "mt", "zh", "mr", "ne", "no", "fa", "pl", "pt", "pa",
                 "ro", "ru", "sr", "sk", "sl", "es", "sw", "sv", "ta", "te",
                 "th", "tr", "uk", "ur", "vi",

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/HinglishModelTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/HinglishModelTest.kt
@@ -1,0 +1,168 @@
+package com.vocahq.vocaphone.local
+
+import com.vocahq.vocaphone.core.ModelLanguageSupport
+import com.vocahq.vocaphone.core.TranscriptionLanguage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The catalog and picker side of Roman Hinglish: who may reach it, what it
+ * claims, and what it must never be mistaken for.
+ *
+ * Every assertion here is about containment. The mode is experimental, it is one
+ * model, and it produces text no other model in the catalog produces — so the
+ * risk is not that it fails, it is that it leaks: into a recommendation, into
+ * another language's decode, or into the translate row.
+ */
+class HinglishModelTest {
+
+    private val hinglish = requireNotNull(
+        LocalModelCatalog.find("hinglish-apex-large-v3-turbo-q5_0"),
+    )
+
+    private val roman = TranscriptionLanguage.HINGLISH_ROMAN.wireValue
+
+    @Test
+    fun `the model is pinned by repository, revision and digest`() {
+        assertEquals("Marquestra/Whisper-Hindi2Hinglish-Apex-GGML", hinglish.repository)
+        assertEquals(40, hinglish.revision.length)
+        assertEquals(1, hinglish.files.size)
+        hinglish.files.forEach { file ->
+            assertEquals("SHA-256 is 64 hex characters", 64, file.sha256.length)
+            assertTrue(file.sha256.all { it in "0123456789abcdef" })
+            assertTrue(file.sizeBytes > 0)
+        }
+        assertEquals(hinglish.files.sumOf { it.sizeBytes }, hinglish.sizeBytes)
+    }
+
+    @Test
+    fun `the download url is built from the pin and nothing else`() {
+        assertEquals(
+            "https://huggingface.co/Marquestra/Whisper-Hindi2Hinglish-Apex-GGML/resolve/" +
+                "${hinglish.revision}/ggml-apex-hinglish-q5_0.bin",
+            LocalModelCatalog.downloadUrl(hinglish, hinglish.primaryFile),
+        )
+    }
+
+    @Test
+    fun `it claims the output script and no language`() {
+        // Claiming "hi" would be the tempting lie. It does not transcribe Hindi
+        // — it transcribes Hindi into Latin — and a user who picked Hindi
+        // expecting Devanagari would get neither an error nor what they asked
+        // for.
+        assertEquals(setOf(roman), hinglish.languageCodes)
+        assertFalse(hinglish.coversLanguage("hi"))
+        assertFalse(hinglish.coversLanguage("en"))
+        assertTrue(hinglish.producesFixedScript)
+    }
+
+    @Test
+    fun `it is never offered as a recommendation`() {
+        val languages = listOf("hi", "en", "de", "bn", "ta")
+        val budgets = listOf(2L, 3L, 4L, 6L, 8L, 12L)
+        for (language in languages) {
+            for (ram in budgets) {
+                val profile = DeviceProfile(
+                    totalRamGB = ram,
+                    cpuCores = 8,
+                    performanceClass = 33,
+                    abi = "arm64-v8a",
+                    maxCpuKHz = 2_400_000,
+                    sherpaAvailable = true,
+                    language = language,
+                )
+                assertFalse(
+                    "recommended for $language at ${ram}GB",
+                    LocalModelCatalog.recommendations(profile).any { it.model.id == hinglish.id },
+                )
+                assertTrue(LocalModelCatalog.recommended(profile).id != hinglish.id)
+            }
+        }
+    }
+
+    @Test
+    fun `it cannot translate`() {
+        // Whisper's translate task is still in there — it is the same decoder —
+        // and offering the row would hand back the English translation this mode
+        // exists to avoid.
+        assertTrue(hinglish.translationTargets.isEmpty())
+        assertEquals("", hinglish.resolveTranslationTarget("en", "hi"))
+    }
+
+    @Test
+    fun `the roman row needs a model that says so in as many words`() {
+        val language = TranscriptionLanguage.HINGLISH_ROMAN
+        assertTrue(ModelLanguageSupport.isSelectable(language, setOf(roman)))
+        assertFalse(ModelLanguageSupport.isSelectable(language, setOf("hi", "en")))
+        // Silence is a no here, unlike every ordinary language: an unknown
+        // gateway has certainly not been taught this value, and offering it
+        // would produce Devanagari or an English translation.
+        assertFalse(ModelLanguageSupport.isSelectable(language, emptySet()))
+    }
+
+    @Test
+    fun `ordinary languages still default to selectable when nothing is claimed`() {
+        // The rule above must not have narrowed anything else.
+        listOf(TranscriptionLanguage.HINDI, TranscriptionLanguage.ENGLISH).forEach { language ->
+            assertTrue(ModelLanguageSupport.isSelectable(language, emptySet()))
+        }
+    }
+
+    @Test
+    fun `a stale roman choice falls back to automatic`() {
+        assertEquals(
+            TranscriptionLanguage.AUTOMATIC,
+            ModelLanguageSupport.resolve(TranscriptionLanguage.HINGLISH_ROMAN, setOf("hi", "en")),
+        )
+    }
+
+    @Test
+    fun `the decoder is asked for hindi and the transcript stays roman`() {
+        // The token is a whisper implementation detail; the transcript language
+        // is the contract the normalizer and the writing styles read.
+        assertEquals("hi", ModelLanguageSupport.decoderLanguage(roman))
+        assertEquals(roman, ModelLanguageSupport.transcriptLanguage(roman, reported = "hi"))
+        assertEquals(roman, ModelLanguageSupport.outputLanguage(roman, "hi", translateTo = ""))
+    }
+
+    @Test
+    fun `no other language is routed through this mapping`() {
+        listOf("hi", "en", "auto", "de", "").forEach { code ->
+            assertEquals(code, ModelLanguageSupport.decoderLanguage(code))
+        }
+    }
+
+    @Test
+    fun `no other model claims the roman code`() {
+        val claiming = LocalModelCatalog.all.filter { roman in it.languageCodes }
+        assertEquals(listOf(hinglish.id), claiming.map { it.id })
+    }
+
+    @Test
+    fun `the label says experimental where a user will read it`() {
+        assertTrue(hinglish.experimental)
+        assertTrue(hinglish.displayName.contains("Experimental"))
+        assertTrue(TranscriptionLanguage.HINGLISH_ROMAN.isExperimental)
+        assertTrue(TranscriptionLanguage.HINGLISH_ROMAN.detail.contains("Experimental"))
+        assertEquals("Hinglish", TranscriptionLanguage.HINGLISH_ROMAN.shortLabel)
+    }
+
+    @Test
+    fun `nothing else in the catalog became experimental`() {
+        assertEquals(
+            listOf(hinglish.id),
+            LocalModelCatalog.all.filter { it.experimental }.map { it.id },
+        )
+    }
+
+    @Test
+    fun `it runs on whisper cpp, so it needs no sherpa jni`() {
+        assertEquals(LocalModelEngine.WHISPER, hinglish.engine)
+        assertNotNull(LocalModelCatalog.find(hinglish.id))
+        assertTrue(LocalModelCatalog.isUsableOnDevice(hinglish, 6L, sherpaAvailable = false))
+        assertFalse(LocalModelCatalog.isUsableOnDevice(hinglish, 3L, sherpaAvailable = false))
+    }
+}

--- a/docs/hinglish-roman.md
+++ b/docs/hinglish-roman.md
@@ -1,0 +1,182 @@
+# Roman Hinglish
+
+**Experimental.** Android only. Off unless you go looking for it.
+
+Speak the way a lot of people in India actually speak — Hindi and English in the
+same sentence — and get it back in one Latin alphabet:
+
+> "आज मुझे office में एक important meeting attend करनी है"
+> → **"Aaj mujhe office mein ek important meeting attend karni hai."**
+
+Two things it is deliberately not:
+
+- Not Devanagari. "आज मुझे office में…" is a failure of this mode, not a variant
+  of it. Pick **Hindi** with a multilingual model for that.
+- Not a translation. "I have to attend an important meeting today" is a failure
+  too. This mode transcribes the words that were said, not their meaning.
+
+## Turning it on
+
+1. **Settings → On-device model → More models**
+2. Download **Hinglish — Roman (Experimental)** — 574 MB, needs 4 GB of RAM.
+3. **Settings → Transcription language → Hinglish — Roman**
+
+The language row is greyed out until that model is downloaded and selected, and
+it is the only model that offers it. Every other model — on the phone or on your
+gateway — leaves the row disabled with "Needs a different model", because asking
+any of them for Roman Hinglish gets Devanagari or an English translation rather
+than an error.
+
+Selecting a different model afterwards falls the setting back to **Automatic**
+rather than sending a language nothing can honour.
+
+## The model
+
+| | |
+| --- | --- |
+| Upstream | [`Oriserve/Whisper-Hindi2Hinglish-Apex`](https://huggingface.co/Oriserve/Whisper-Hindi2Hinglish-Apex) |
+| Licence | Apache-2.0 |
+| Base | `openai/whisper-large-v3-turbo`, fine-tuned on romanized Hindi |
+| Architecture | 32 encoder layers, 4 decoder layers, `d_model` 1280, 128 mel bins, 51866 tokens — turbo's topology exactly, which is why whisper.cpp runs it unmodified |
+| Download | 574 MB (`q5_0`), one file |
+| Requirement | 4 GB RAM, Android only |
+| Upstream WER | Common Voice 35.96 · FLEURS 29.79 · IndicVoices 47.64, per the model card |
+
+Attribution, as Apache-2.0 asks: the weights are Oriserve's work, redistributed
+here only as a pinned download link. VocaPhone modifies nothing about them.
+
+### Why the weights are pinned where they are
+
+Oriserve publishes safetensors and nothing else — no GGML, which is the only
+format whisper.cpp reads. The catalog therefore pins a **third-party GGML
+conversion**, at an immutable commit, by SHA-256:
+
+```
+repository  Marquestra/Whisper-Hindi2Hinglish-Apex-GGML
+revision    d1de3ff618856e5675c47d3158ca820506fb4d9e
+file        ggml-apex-hinglish-q5_0.bin
+sha256      9d877151b15cec1feb9110cfbc0a3162cf377bcc0ab1935174226f461cf60f13
+```
+
+That digest was not taken on trust. `tools/hinglish/convert-apex-ggml.sh`
+converts Oriserve's own weights from scratch — pinned model revision, pinned
+whisper.cpp revision — and the `fp16` file it produces is **byte-for-byte
+identical** to the one in that repository (`84457be0…`), which is what
+establishes that the conversion is of these weights and nothing else. Re-run it
+before moving the pin, ever.
+
+The download is verified again on the phone: `LocalModelManager` hashes the
+bytes as they arrive, discards the file if the digest does not match, and
+`LocalModelIntegrity` re-checks size and its verification marker before every
+load.
+
+### Replacing or updating the model
+
+1. Convert and take digests: `./tools/hinglish/convert-apex-ggml.sh`
+2. Confirm the digest against whatever repository you intend to pin.
+3. Update `id`, `repository`, `revision`, `files` and `sizeBytes` in
+   `LocalModelCatalog.hinglish` (Kotlin).
+4. `just android test '*HinglishModelTest'` — the pin's shape is asserted there.
+5. Benchmark before and after: `tools/hinglish/benchmark/README.md`. A pin move
+   that has not been benchmarked is a regression waiting to happen.
+
+## Privacy
+
+Identical to every other on-device model. The audio never leaves the phone: the
+model is downloaded once from Hugging Face and every decode after that is local,
+offline-capable, and involves no server of ours or anyone else's. The
+normalization layer below is a lookup table and a transliterator — no cloud LLM,
+no network, nothing to opt out of.
+
+## The spelling convention
+
+Roman Hinglish has no orthography, so this repository picked one and wrote it
+down. Two layers produce it:
+
+1. The **model** writes Latin directly; its spelling is its own.
+2. **`HinglishNormalizer`** cleans up after it — transliterating any Devanagari
+   that leaks through, and settling a short list of words on one spelling.
+
+Both layers are on-device, deterministic, and unit-tested
+(`HinglishNormalizerTest`, `DevanagariRomanizerTest`).
+
+### Transliteration rules
+
+Applied by `DevanagariRomanizer` when Devanagari reaches the output. It is not
+IAST: the goal is what people type, not what a linguist would write.
+
+| Rule | Example |
+| --- | --- |
+| The implicit `a` is dropped at the end of a word | घर → `ghar`, not `ghara` |
+| …and mid-word before a written vowel | करना → `karna`, not `karana` |
+| …but never on the first syllable | पता → `pata`, not `pta` |
+| …and not where the next syllable has no written vowel either | समझ → `samajh` |
+| Long vowels shorten word-finally | आज → `aaj`, करना → `karna`; ठीक → `theek`, कभी → `kabhi` |
+| A trailing nasal does not count as the end | नहीं → `nahin`, not `naheen` |
+| Anusvara is `m` before a lip consonant, `n` elsewhere | संभव → `sambhav`, अंदर → `andar` |
+| Nukta letters take their own sounds | ज़ → `z`, फ़ → `f`, ड़ → `r` |
+| Danda becomes a full stop; Devanagari digits become Latin | ठीक। → `theek.`, १२३ → `123` |
+
+Devanagari is always **transliterated, never deleted**. Dropping it would lose
+words the user said while leaving a transcript that still looks clean.
+
+### Settled spellings
+
+Applied only to words the transliterator produced, because provenance matters:
+`men` out of the transliterator is में; `men` that arrived in Latin is the
+English plural and is left alone.
+
+| | |
+| --- | --- |
+| `mein` | में — mechanically "men", but nobody writes that |
+| `kyun`, `kyunki` | not `kyon` |
+| `hoon` | not `hun` |
+
+Applied to the whole transcript, including what the model wrote in Latin. Every
+entry is a form that is **not** an English word, which is what makes it safe:
+
+`muje`/`mujey`/`mujhy` → `mujhe` · `kyu`/`kyoon` → `kyun` · `nahi`/`nhi` →
+`nahin` · `thik`/`thk` → `theek` · `acha`/`achha` → `accha` ·
+`bahot`/`bhot` → `bahut` · `kese` → `kaise` · `krna` → `karna` ·
+`krke` → `karke` · `smjh` → `samajh`
+
+And one guarded rule: **`hey` → `hai`**, but only lowercase and mid-sentence.
+"theek hey" is Hindi; "Hey, kaise ho?" is English and stays. Wrong in the safe
+direction leaves a spelling slightly off; wrong in the other direction rewrites
+what someone said.
+
+### What is never touched
+
+URLs, email addresses, file paths, commands, filenames, `@handles`, `#hashtags`
+and shouted abbreviations (`API`, `GPU`) are masked before any rule runs and
+restored verbatim afterwards. Capitalization and sentence terminators are not
+this layer's job — `TranscriptStyler` runs after it and owns them for every
+language, exactly as it does for Hindi or German.
+
+Every pass is individually switchable through `HinglishNormalizer.Options`, for
+a build that wants transliteration without the spelling opinions.
+
+## Known limitations
+
+- **Android only.** iOS runs WhisperKit, which needs a Core ML build; no verified
+  one exists for Apex. The language row, the gating and the whole normalization
+  layer are mirrored in Swift and tested there, so adding the model later is one
+  catalog entry rather than a port — but until then the row is unreachable on
+  iOS and a test asserts that it is.
+- **No translation.** The row is unavailable for this model on purpose. Whisper's
+  translate task would still run and would hand back the English translation this
+  mode exists to avoid.
+- **One output, always.** There is no way to ask this model for Devanagari or for
+  any other language. It answers everything in Roman Hinglish, which is why it
+  claims one language code and not `hi`.
+- **574 MB and 4 GB of RAM.** A large-class encoder. On a mid-range phone expect
+  it to be slower than the small multilingual models, and it will not stream —
+  whisper never does here.
+- **Accuracy is unmeasured on real speech.** The upstream WER figures are
+  Oriserve's, on their benchmarks. This repository's own harness exists
+  (`tools/hinglish/benchmark/`) but has not been run against a recorded set;
+  until it has, "experimental" is the accurate label and the reason the mode is
+  kept out of every recommendation.
+- **Not a corrector.** It will not fix grammar, and it will not rescue a word it
+  heard wrong. Deliberately: over-correction on a dictation transcript is worse
+  than an odd spelling, because the user cannot tell it happened.

--- a/docs/hinglish-roman.md
+++ b/docs/hinglish-roman.md
@@ -156,6 +156,47 @@ language, exactly as it does for Hindi or German.
 Every pass is individually switchable through `HinglishNormalizer.Options`, for
 a build that wants transliteration without the spelling opinions.
 
+## Measured, so far
+
+One run of `tools/hinglish/benchmark/` over the 11 public clips, on an Apple
+Silicon Mac, `q5_0` in both cases. Both models are the same size and the same
+architecture, so this is close to a controlled comparison of the fine-tune
+alone.
+
+| | stock `large-v3-turbo` | + the normalization layer | **Hinglish Apex** |
+| --- | --- | --- | --- |
+| Devanagari leakage | **100%** | 0% | **0%** |
+| Translation rate | — | — | 0% |
+| Real-time factor | 0.34 | 0.34 | 0.30 |
+| Time to first transcript | 1.53 s | 1.51 s | 1.35 s |
+| Peak RSS | 846 MB | 847 MB | 835 MB |
+| Download | 574 MB | 574 MB | 574 MB |
+
+The first column is why the mode exists: asked for Hindi, the stock model
+returns Devanagari every single time, which is a different feature.
+
+The second column is the more interesting one, because it is the cheap
+alternative — keep the model you already have and just transliterate. It fixes
+the script and nothing else, and the English is where it falls down:
+
+| | stock turbo + transliteration | Hinglish Apex |
+| --- | --- | --- |
+| | `…gul par parpormens pul` | `…gul par performance full` |
+| | `apanra logan` | `Aap pandrah log hain.` |
+| | `yenjar saaink rikhenge` | `Main just thank you, thank you.` |
+
+A transliterator cannot recover an English word the decoder already wrote in
+Devanagari — "performance" comes back as "parpormens" — and on conversational
+audio the stock model's Hindi is poor enough that romanizing it faithfully just
+produces readable nonsense. The fine-tune is doing the work.
+
+Indicative accuracy, over the six clips whose reference the model card
+publishes: **WER 0.23, CER 0.14, English preservation 1.00, translation rate 0.**
+Treat that as a smoke test rather than a result — the references are Apex's own
+published output, which is why `score.py` excludes them unless you pass
+`--trust-model-card`. A real word error rate needs the read-aloud set recorded;
+see the benchmark README.
+
 ## Known limitations
 
 - **Android only.** iOS runs WhisperKit, which needs a Core ML build; no verified
@@ -172,11 +213,12 @@ a build that wants transliteration without the spelling opinions.
 - **574 MB and 4 GB of RAM.** A large-class encoder. On a mid-range phone expect
   it to be slower than the small multilingual models, and it will not stream —
   whisper never does here.
-- **Accuracy is unmeasured on real speech.** The upstream WER figures are
-  Oriserve's, on their benchmarks. This repository's own harness exists
-  (`tools/hinglish/benchmark/`) but has not been run against a recorded set;
-  until it has, "experimental" is the accurate label and the reason the mode is
-  kept out of every recommendation.
+- **Word error rate is not properly measured yet.** The numbers above come from
+  11 short public clips, six of which are scored against the model's own
+  published output. The 40-prompt read-aloud set exists in the manifest and has
+  not been recorded, so nothing here covers accent breadth, noise, or fast
+  speech. Until it has, "experimental" is the accurate label and the reason the
+  mode is kept out of every recommendation.
 - **Not a corrector.** It will not fix grammar, and it will not rescue a word it
   heard wrong. Deliberately: over-correction on a dictation transcript is worse
   than an odd spelling, because the user cannot tell it happened.

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		06DDF0287EE04B56BDA4C2B5 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = BD7C720E296C2265F0174573 /* PrivacyInfo.xcprivacy */; };
 		07138BD901EA33F72339A4F7 /* TelemetryRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27748467103CFAD3F6A2F603 /* TelemetryRecord.swift */; };
 		07D7CA474CBB8812C0E83D1C /* VocaPhoneActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8988211922DAD4FC77AF89EB /* VocaPhoneActivityAttributes.swift */; };
+		08E9CF500085E4D49605A4C3 /* DevanagariRomanizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34239D3207AA91C26BB2388D /* DevanagariRomanizer.swift */; };
 		0B939DE9494D3B8F14F18142 /* ModelLanguageSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */; };
 		0D07EBF90CE481AE0C1976CF /* SetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346B6558EE5557A35C916067 /* SetupView.swift */; };
 		0E4F6A827869289078B1F4D5 /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491DFC2F5F017E14BF64E308 /* DesignSystem.swift */; };
@@ -44,6 +45,7 @@
 		1D96E4B5456A18FA04F5F15D /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */; };
 		1EE70552DF2972DCE328ED01 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA135DE504590121F6D8843 /* DiagnosticLog.swift */; };
 		1F45494DE6D2E1E471D446B5 /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11816AC1A2219D15E870CE3E /* EmojiCatalog.swift */; };
+		200833A928F4BC6D41FB258C /* DevanagariRomanizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34239D3207AA91C26BB2388D /* DevanagariRomanizer.swift */; };
 		214B0AB3D2362EC3EE656E53 /* SherpaLongAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */; };
 		21FF5DE4F40DB8D70AC170E2 /* CustomVocabulary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AA9291707DE7366D08EB0C /* CustomVocabulary.swift */; };
 		22293F4CFA1E2512027DFFBC /* TranscriptSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B121356A503DF83BFA0E0D0C /* TranscriptSanitizer.swift */; };
@@ -120,6 +122,7 @@
 		56783518C221839DE432BCC7 /* DesignSystemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755A4279065D41A705E1F19D /* DesignSystemTests.swift */; };
 		5769EF4A106AFBD7B375DC5D /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */; };
 		582C18BD155158A79ADCBB5A /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */; };
+		58B71791CC9477572F83D0D0 /* DevanagariRomanizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34239D3207AA91C26BB2388D /* DevanagariRomanizer.swift */; };
 		58CDCA65875E94B8F7BE0101 /* QuickDictationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB84927D76F9C32C4BE1547 /* QuickDictationAvailability.swift */; };
 		590AE5D90BD9113ABA4EEF3F /* BrandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9711C18238B39EA2E842C0F /* BrandPalette.swift */; };
 		594C4A6790AD798CA3A7D427 /* SpeechAudioConditioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */; };
@@ -134,6 +137,7 @@
 		61D705F2D38349B0A9667F2E /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */; };
 		62F20884ED82C44DD050F3E5 /* KeyGridLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2C1575D306E7683092FBA /* KeyGridLayoutTests.swift */; };
 		63835D9307A147564F896FB5 /* SmartPunctuation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07178E9C6A3CF354CD83A2C1 /* SmartPunctuation.swift */; };
+		639443046F5EF626F1BD0699 /* DevanagariRomanizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34239D3207AA91C26BB2388D /* DevanagariRomanizer.swift */; };
 		63BC0E226633FBBE88C60EBE /* SmartPunctuationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8CE24C7BC4F4CA618F4B79 /* SmartPunctuationTests.swift */; };
 		6565BFD7DC56DDCECDBC0D7C /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */; };
 		67883BFA07C1D055BF00E118 /* ModelTranslationSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA1F0347FCF246193F6CF96 /* ModelTranslationSupportTests.swift */; };
@@ -190,7 +194,9 @@
 		9418E647BE968A5FC2064D06 /* SpokenNumbersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8201161064874EF522DF3F70 /* SpokenNumbersTests.swift */; };
 		94B667AC0FFB905D57BE2CA3 /* VocaPhoneLiveActivity.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = CF080065DC31C6DA8E693163 /* VocaPhoneLiveActivity.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		95A08342703AE27BD09E08AC /* TranscriptStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DBF47C7F5E5B13752056CB /* TranscriptStyler.swift */; };
+		964ACC4502C023346DAC4112 /* HinglishNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D6FD7DB0DE766B09CC0EFB /* HinglishNormalizer.swift */; };
 		966E2D9A6D13630E7A2122A6 /* KeyLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87128326897BFA30E7B2038 /* KeyLayout.swift */; };
+		96BDAA3771880DC40CB1AE1D /* HinglishNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D6FD7DB0DE766B09CC0EFB /* HinglishNormalizer.swift */; };
 		97EE4663316E8CF2EAE9761A /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */; };
 		98AE213452E133E22550785B /* KeyboardHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858088F81E12EC57E13F9492 /* KeyboardHaptics.swift */; };
 		9AE625A9A97E5A57DC6520E9 /* TelemetryStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D9836F52892447650F0375 /* TelemetryStats.swift */; };
@@ -239,6 +245,7 @@
 		BC36D829FEE2BEC0A6BC30C2 /* KeyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5118F8CFAAE127CD5FF92076 /* KeyView.swift */; };
 		BCB8CA3BAACE6280D9ED4B22 /* QuickDictationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB84927D76F9C32C4BE1547 /* QuickDictationAvailability.swift */; };
 		BD67C86E9CCCEEBB2ABC845A /* TypingCandidates.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAA4440B24071020CD693DB /* TypingCandidates.swift */; };
+		BE1F4E236AC60B85B3F0A2F3 /* HinglishNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D6FD7DB0DE766B09CC0EFB /* HinglishNormalizer.swift */; };
 		BF1BF9FEBFC0373AE2C4187D /* DarwinNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3498C523755A678225152570 /* DarwinNotifications.swift */; };
 		BF22B8C9A4943F8B06F74216 /* DictationBarComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FD84E65614D9F94D8EF0AC /* DictationBarComponents.swift */; };
 		C2C99C66A00384823A3A0A22 /* SherpaLongAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */; };
@@ -287,11 +294,13 @@
 		E366EFAD9B70FE3FC43FEBAD /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */; };
 		E4162282629880D2A33913CA /* KeyGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF7CAC171521FC372DF2BF0 /* KeyGridView.swift */; };
 		E4187B9A8DA6FBBA6DE095AC /* DictationPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCCE5FE1A8242B96B8CA9FD /* DictationPresentation.swift */; };
+		E4B068729AD728EE2DD54CAD /* HinglishNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D6FD7DB0DE766B09CC0EFB /* HinglishNormalizer.swift */; };
 		E5595FE143CBC103B6DAE2C8 /* TypingWordList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6743BB4173E2F719E3D8CB /* TypingWordList.swift */; };
 		E5EAD40641B38DDA0CCA0300 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894063AE1B3DDA92C529268D /* AppConfiguration.swift */; };
 		E6FDBF8529AEB00D2CFB245E /* UsageReportingCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AA42EFADB6B77B0C9A5E44 /* UsageReportingCopy.swift */; };
 		E9C82042A1155CC1E50BF2B6 /* StartDictationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A7126FEDA473D8C112A397 /* StartDictationIntent.swift */; };
 		E9E86F6940BDB4381A8C9FF5 /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C304CF763960E5F1D8F76B2B /* LiveActivityManager.swift */; };
+		EE4FA7F3FB2D5BB363275F83 /* HinglishRomanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA69377BFB741802DBD0F1A3 /* HinglishRomanTests.swift */; };
 		EE7A49C4F95388AF42E1B30C /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
 		EFEB53E947DAF4C77FE5E059 /* DictatedTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575BDB070A428051B623F095 /* DictatedTranscript.swift */; };
 		F0EC49ECABE510B52F876C8F /* SherpaIncrementalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41205764F091734B2DE6D02 /* SherpaIncrementalSession.swift */; };
@@ -378,6 +387,7 @@
 		2E6C1FB17BFD787FDDCBBF82 /* SherpaOnnxBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SherpaOnnxBridge.h; sourceTree = "<group>"; };
 		32BFD71F9D14772A0C7330CD /* DictationBarLabelColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarLabelColorTests.swift; sourceTree = "<group>"; };
 		332854D2644CFCE5843E3F31 /* StopQuickDictationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopQuickDictationIntent.swift; sourceTree = "<group>"; };
+		34239D3207AA91C26BB2388D /* DevanagariRomanizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevanagariRomanizer.swift; sourceTree = "<group>"; };
 		342F2B3B437269514C969C77 /* SetupStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupStatus.swift; sourceTree = "<group>"; };
 		346B6558EE5557A35C916067 /* SetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupView.swift; sourceTree = "<group>"; };
 		348E2313B75BA61D777FA18B /* EmojiPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPanelView.swift; sourceTree = "<group>"; };
@@ -480,6 +490,7 @@
 		B9BB34E20645F3D8C78A0363 /* Telemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Telemetry.swift; sourceTree = "<group>"; };
 		BA0A732D03A2951F028DDF6E /* SherpaIncrementalSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaIncrementalSessionTests.swift; sourceTree = "<group>"; };
 		BA1F0FABCAE6669D0EB07FC3 /* SwipeAlternates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeAlternates.swift; sourceTree = "<group>"; };
+		BA69377BFB741802DBD0F1A3 /* HinglishRomanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HinglishRomanTests.swift; sourceTree = "<group>"; };
 		BC9677581A0FA938AD9C520C /* PreviewFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewFixtures.swift; sourceTree = "<group>"; };
 		BD7C720E296C2265F0174573 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		BE0BE99770A5F7F08891E2BD /* KeyboardURLLauncher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeyboardURLLauncher.h; sourceTree = "<group>"; };
@@ -488,6 +499,7 @@
 		C3D3E1455AD292ED6DA1DFAC /* VocaPhoneLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocaPhoneLiveActivity.swift; sourceTree = "<group>"; };
 		C4211FAA8E574AEF57D788FA /* GatewayClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayClient.swift; sourceTree = "<group>"; };
 		C45D98EAFE18C689DC7551E9 /* LanguageMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageMenuTests.swift; sourceTree = "<group>"; };
+		C4D6FD7DB0DE766B09CC0EFB /* HinglishNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HinglishNormalizer.swift; sourceTree = "<group>"; };
 		C7842B22D05FB171B261101A /* DictationBarStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarStyle.swift; sourceTree = "<group>"; };
 		C8E491E7E805F47388A668E1 /* TranscriptSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSanitizerTests.swift; sourceTree = "<group>"; };
 		CA4CAEF7B3212512BACDE655 /* TelemetryConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryConfig.swift; sourceTree = "<group>"; };
@@ -622,9 +634,11 @@
 				A9711C18238B39EA2E842C0F /* BrandPalette.swift */,
 				85AA9291707DE7366D08EB0C /* CustomVocabulary.swift */,
 				3498C523755A678225152570 /* DarwinNotifications.swift */,
+				34239D3207AA91C26BB2388D /* DevanagariRomanizer.swift */,
 				5FA135DE504590121F6D8843 /* DiagnosticLog.swift */,
 				575BDB070A428051B623F095 /* DictatedTranscript.swift */,
 				9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */,
+				C4D6FD7DB0DE766B09CC0EFB /* HinglishNormalizer.swift */,
 				9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */,
 				A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */,
 				4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */,
@@ -752,6 +766,7 @@
 				56047A6705008B5F17F003CE /* DictationPresentationTests.swift */,
 				882F3122E12BD0F2BF44ADC9 /* EmojiCatalogTests.swift */,
 				41C0A3D1DBF6BCF25C37CF24 /* EmojiSuggestionsTests.swift */,
+				BA69377BFB741802DBD0F1A3 /* HinglishRomanTests.swift */,
 				F72772F0CCE3BA274182C5F4 /* HomePresentationTests.swift */,
 				7A53786C8D2346452C69A748 /* InsertionTargetTests.swift */,
 				EF0326EF6FB3E96C942C6065 /* KeyAlternativesTests.swift */,
@@ -1032,6 +1047,7 @@
 				0580A3BE7DFF0FB43B4A41BD /* BrandPalette.swift in Sources */,
 				21FF5DE4F40DB8D70AC170E2 /* CustomVocabulary.swift in Sources */,
 				B61F7C13B4B93422C9BA3680 /* DarwinNotifications.swift in Sources */,
+				58B71791CC9477572F83D0D0 /* DevanagariRomanizer.swift in Sources */,
 				AA2103E195D36B18D25CBF86 /* DiagnosticLog.swift in Sources */,
 				22810975F2690A367F97719E /* DictatedTranscript.swift in Sources */,
 				BF22B8C9A4943F8B06F74216 /* DictationBarComponents.swift in Sources */,
@@ -1042,6 +1058,7 @@
 				C63521DE52DC5A8DCD6847AE /* EmojiPanelView.swift in Sources */,
 				40959874C3AE5396E1177CC4 /* EmojiSuggestions.swift in Sources */,
 				7E3D8E857A83184E74B15433 /* GatewayEndpoint.swift in Sources */,
+				E4B068729AD728EE2DD54CAD /* HinglishNormalizer.swift in Sources */,
 				771730250FDC04B40A57E462 /* KeyAlternatives.swift in Sources */,
 				E4162282629880D2A33913CA /* KeyGridView.swift in Sources */,
 				4C8B6E06406E63E122F9CBD1 /* KeyLayout.swift in Sources */,
@@ -1098,6 +1115,7 @@
 				BF1BF9FEBFC0373AE2C4187D /* DarwinNotifications.swift in Sources */,
 				0E4F6A827869289078B1F4D5 /* DesignSystem.swift in Sources */,
 				D32F9FCE7750E51A69E56F10 /* DesignSystemPreviews.swift in Sources */,
+				200833A928F4BC6D41FB258C /* DevanagariRomanizer.swift in Sources */,
 				1EE70552DF2972DCE328ED01 /* DiagnosticLog.swift in Sources */,
 				DCAAD00B7ED79568106DAD0C /* DictatedTranscript.swift in Sources */,
 				17A121351047369782528CA2 /* DictationBarComponents.swift in Sources */,
@@ -1108,6 +1126,7 @@
 				B0DF0FF5821BD7E8C839065C /* GatewayClient.swift in Sources */,
 				062CD049AAD6768AE5AB3766 /* GatewayEndpoint.swift in Sources */,
 				4016476924F9555E1E861673 /* GatewaySetupView.swift in Sources */,
+				964ACC4502C023346DAC4112 /* HinglishNormalizer.swift in Sources */,
 				F11A2E1FF01BA4115116AFB5 /* HomePresentation.swift in Sources */,
 				4E4687E35DB482CFC5EB37F9 /* KeyAlternatives.swift in Sources */,
 				F37F68399E06B767B5D6ACC7 /* KeyGridView.swift in Sources */,
@@ -1190,10 +1209,12 @@
 				5FB6858C38350EC77F45EB62 /* BrandPalette.swift in Sources */,
 				25A9766454D6E24C9AD7BF2B /* CustomVocabulary.swift in Sources */,
 				867671B90E038F77BE36A4E6 /* DarwinNotifications.swift in Sources */,
+				639443046F5EF626F1BD0699 /* DevanagariRomanizer.swift in Sources */,
 				12A7F7D550BED2750227A111 /* DiagnosticLog.swift in Sources */,
 				EFEB53E947DAF4C77FE5E059 /* DictatedTranscript.swift in Sources */,
 				3655C2E063B7C9B8F286057B /* FinishRecordingIntent.swift in Sources */,
 				1D96E4B5456A18FA04F5F15D /* GatewayEndpoint.swift in Sources */,
+				96BDAA3771880DC40CB1AE1D /* HinglishNormalizer.swift in Sources */,
 				5769EF4A106AFBD7B375DC5D /* KeyboardPreferences.swift in Sources */,
 				582C18BD155158A79ADCBB5A /* KeyboardStatus.swift in Sources */,
 				5634120C15A37F9E2C0FF2C0 /* LearnedWords.swift in Sources */,
@@ -1234,6 +1255,7 @@
 				16A937522A6A8C972B1107A2 /* DarwinNotifications.swift in Sources */,
 				396FBA5370CCA2D012DD1ADC /* DesignSystem.swift in Sources */,
 				56783518C221839DE432BCC7 /* DesignSystemTests.swift in Sources */,
+				08E9CF500085E4D49605A4C3 /* DevanagariRomanizer.swift in Sources */,
 				9C6AF2EE68EB7AA4D4CF0F61 /* DiagnosticLog.swift in Sources */,
 				9282771B81021A932B1C6EA1 /* DictatedTranscript.swift in Sources */,
 				67B842A93BF69D4542744655 /* DictatedTranscriptTests.swift in Sources */,
@@ -1249,6 +1271,8 @@
 				75EC59510885420249491B03 /* EmojiSuggestions.swift in Sources */,
 				CD600A39A4DFB39AD6F0E5E1 /* EmojiSuggestionsTests.swift in Sources */,
 				A2112E100F4277466EA8DD4F /* GatewayEndpoint.swift in Sources */,
+				BE1F4E236AC60B85B3F0A2F3 /* HinglishNormalizer.swift in Sources */,
+				EE4FA7F3FB2D5BB363275F83 /* HinglishRomanTests.swift in Sources */,
 				12F5617A0ECD4D904FC8FEA6 /* HomePresentation.swift in Sources */,
 				162E1C513A0E6585E3445812 /* HomePresentationTests.swift in Sources */,
 				2912856F09ED7566DB955AF9 /* InsertionTargetTests.swift in Sources */,

--- a/ios/VocaPhoneShared/DevanagariRomanizer.swift
+++ b/ios/VocaPhoneShared/DevanagariRomanizer.swift
@@ -1,0 +1,282 @@
+import Foundation
+
+/// Devanagari to Latin, in the spelling people actually type.
+///
+/// A line-for-line mirror of
+/// `android/app/src/main/java/com/vocahq/vocaphone/core/DevanagariRomanizer.kt`.
+/// The two must agree character for character: the same dictation on the two
+/// phones has to produce the same transcript, and this is the layer where a
+/// divergence would be invisible until someone compared two screenshots.
+///
+/// This is not IAST and deliberately not reversible. IAST would give "ājˈ mujhe"
+/// where a Hinglish speaker writes "Aaj mujhe", and a transcript that reads like
+/// a linguistics paper is not the feature. The scheme is documented in
+/// `docs/hinglish-roman.md`; the three rules that make it look natural are the
+/// ones below, and each is here because the naive answer is visibly wrong.
+///
+/// **Schwa deletion.** Every Devanagari consonant carries an implicit `a` that
+/// Hindi does not always pronounce. Rendering it always gives "gharaa" for घर and
+/// "karanaa" for करना. The implicit vowel is dropped at the end of a word, and
+/// mid-word when the next syllable carries a written vowel of its own — करना
+/// becomes "karna" while समझ stays "samajh", because in समझ the following
+/// syllable has no written vowel either. The mid-word case never fires on the
+/// first syllable: without that guard पता collapses to "pta".
+///
+/// **Long vowels shorten at the end.** आ is "aa" in आज ("aaj") and "a" in करना
+/// ("karna"); ई is "ee" in ठीक ("theek") and "i" in कभी ("kabhi"). Finality is
+/// judged after schwa deletion and ignores a trailing nasal, so नहीं is "nahin"
+/// rather than "naheen".
+///
+/// **Anusvara is `n`, except before a lip consonant.** संभव is "sambhav" and
+/// अंदर is "andar"; one letter, two sounds, and the following consonant decides.
+///
+/// Nothing outside the Devanagari block is touched. Latin runs pass through
+/// unchanged, which is what keeps the English half of a code-switched sentence
+/// spelled the way it was spoken.
+enum DevanagariRomanizer {
+
+    // Scalars, not Characters, and that distinction is the whole correctness of
+    // this file. Swift's `Character` is a grapheme cluster, so "मु" — a
+    // consonant with a vowel sign attached — arrives as one indivisible
+    // Character and a Character-by-Character parser can never see the matra it
+    // has to read. Kotlin iterates UTF-16 units and sees the two separately,
+    // which is the behaviour being mirrored. Every table key below is a single
+    // scalar for the same reason.
+    private static let virama: Unicode.Scalar = "\u{094D}"
+    private static let nukta: Unicode.Scalar = "\u{093C}"
+    private static let anusvara: Unicode.Scalar = "\u{0902}"
+    private static let chandrabindu: Unicode.Scalar = "\u{0901}"
+    private static let visarga: Unicode.Scalar = "\u{0903}"
+    private static let zwj: Unicode.Scalar = "\u{200D}"
+    private static let zwnj: Unicode.Scalar = "\u{200C}"
+
+    private static let nasalSigns: Set<Unicode.Scalar> = [anusvara, chandrabindu, visarga]
+    private static let joiners: Set<Unicode.Scalar> = [zwj, zwnj]
+    private static let labials: Set<Character> = ["p", "b", "m"]
+
+    /// Whether `text` contains anything this romanizer would rewrite.
+    static func containsDevanagari(_ text: String) -> Bool {
+        text.unicodeScalars.contains(where: isDevanagari)
+    }
+
+    private static func isDevanagari(_ scalar: Unicode.Scalar) -> Bool {
+        (0x0900...0x097F).contains(Int(scalar.value))
+    }
+
+    /// A danda and a Devanagari digit share the block with the letters but are
+    /// not part of the akshara model, and swallowing them into the word breaks
+    /// the rule that decides where a word ends: with the danda counted, ठीक। has
+    /// a syllable after क and the implicit vowel survives as "theeka.".
+    private static func isWordScalar(_ scalar: Unicode.Scalar) -> Bool {
+        (isDevanagari(scalar) && standalone[scalar] == nil) || joiners.contains(scalar)
+    }
+
+    /// Romanizes every Devanagari run in `text`, leaving everything else exactly
+    /// as it arrived.
+    static func romanize(_ text: String) -> String {
+        guard containsDevanagari(text) else { return text }
+        var out = ""
+        out.reserveCapacity(text.count + text.count / 2)
+        var word: [Unicode.Scalar] = []
+
+        func flush() {
+            guard !word.isEmpty else { return }
+            out += romanizeWord(word)
+            word.removeAll(keepingCapacity: true)
+        }
+
+        for scalar in text.unicodeScalars {
+            if isWordScalar(scalar) {
+                word.append(scalar)
+            } else if let mapped = standalone[scalar] {
+                flush()
+                out += mapped
+            } else {
+                flush()
+                out.unicodeScalars.append(scalar)
+            }
+        }
+        flush()
+        return out
+    }
+
+    /// One written vowel, or the implicit one a bare consonant carries.
+    private enum Vowel {
+        case a, aa, i, ii, u, uu, ri, e, ai, o, au
+
+        /// The final-position spelling; only the long vowels differ.
+        func render(final: Bool) -> String {
+            switch self {
+            case .a: "a"
+            case .aa: final ? "a" : "aa"
+            case .i: "i"
+            case .ii: final ? "i" : "ee"
+            case .u: "u"
+            case .uu: final ? "u" : "oo"
+            case .ri: "ri"
+            case .e: "e"
+            case .ai: "ai"
+            case .o: "o"
+            case .au: "au"
+            }
+        }
+    }
+
+    /// One syllable: an onset, the vowel that follows it, and any nasal or
+    /// visarga hanging off the end.
+    ///
+    /// `implicit` is the whole reason this is a struct rather than a string: an
+    /// `a` that was written (अ, ा) and an `a` that is merely implied look the
+    /// same once rendered, and only the implied one may be deleted.
+    private struct Syllable {
+        var onset: String
+        var vowel: Vowel?
+        var implicit: Bool
+        var nasal: String = ""
+    }
+
+    private static func romanizeWord(_ word: [Unicode.Scalar]) -> String {
+        var syllables = parse(word)
+        applySchwaDeletion(&syllables)
+        return render(syllables)
+    }
+
+    private static func parse(_ word: [Unicode.Scalar]) -> [Syllable] {
+        var syllables: [Syllable] = []
+        var index = 0
+        while index < word.count {
+            let scalar = word[index]
+            if joiners.contains(scalar) {
+                index += 1
+            } else if let vowel = independentVowels[scalar] {
+                syllables.append(Syllable(onset: "", vowel: vowel, implicit: false))
+                index += 1
+            } else if let base = consonants[scalar] {
+                var onset = base
+                index += 1
+                if index < word.count, word[index] == nukta {
+                    onset = nuktaForms[scalar] ?? onset
+                    index += 1
+                }
+                var vowel: Vowel? = .a
+                var implicit = true
+                if index < word.count {
+                    if word[index] == virama {
+                        vowel = nil
+                        implicit = false
+                        index += 1
+                    } else if let matra = matras[word[index]] {
+                        vowel = matra
+                        implicit = false
+                        index += 1
+                    }
+                }
+                syllables.append(Syllable(onset: onset, vowel: vowel, implicit: implicit))
+            } else {
+                // Accents and rare editorial signs. They have no Latin spelling
+                // worth guessing at, so they are dropped rather than passed
+                // through as a character nobody can read. Digits and the danda
+                // never reach here: they end the word instead.
+                index += 1
+            }
+            // A nasal or visarga binds to the syllable it follows, whatever
+            // produced that syllable. With nothing to bind to — a word opening
+            // with a stray sign — it is dropped.
+            while index < word.count, nasalSigns.contains(word[index]) {
+                if !syllables.isEmpty {
+                    syllables[syllables.count - 1].nasal = word[index] == visarga ? "h" : "n"
+                }
+                index += 1
+            }
+        }
+        return syllables
+    }
+
+    /// Drops the implicit `a` where Hindi does not pronounce it: word-finally
+    /// always, and mid-word only when the next syllable carries a written vowel
+    /// — never on the first syllable, which is what keeps पता from becoming
+    /// "pta".
+    private static func applySchwaDeletion(_ syllables: inout [Syllable]) {
+        for index in syllables.indices {
+            guard syllables[index].implicit, !syllables[index].onset.isEmpty else { continue }
+            let isLast = index == syllables.count - 1
+            let nextHasWrittenVowel = !isLast
+                && syllables[index + 1].vowel != nil
+                && !syllables[index + 1].implicit
+            if isLast || (index > 0 && nextHasWrittenVowel) {
+                syllables[index].vowel = nil
+                syllables[index].implicit = false
+            }
+        }
+    }
+
+    private static func render(_ syllables: [Syllable]) -> String {
+        // "Last vowel" is not the test, and getting that wrong turns आज into
+        // "aj": schwa deletion leaves ज carrying no vowel at all, so the ā before
+        // it looks final while a whole consonant still follows. What counts is
+        // whether any letter comes after — onset or vowel. A trailing nasal is
+        // transparent, which is why नहीं is "nahin" and not "naheen".
+        let lastLetterIndex = syllables.lastIndex { !$0.onset.isEmpty || $0.vowel != nil }
+        var out = ""
+        for (index, syllable) in syllables.enumerated() {
+            out += syllable.onset
+            if let vowel = syllable.vowel {
+                out += vowel.render(final: index == lastLetterIndex)
+            }
+            if syllable.nasal == "n" {
+                // One letter, two sounds: संभव is "sambhav", अंदर is "andar".
+                let next = index + 1 < syllables.count ? syllables[index + 1].onset : ""
+                out += labials.contains(next.first ?? " ") ? "m" : "n"
+            } else {
+                out += syllable.nasal
+            }
+        }
+        return out
+    }
+
+    private static let independentVowels: [Unicode.Scalar: Vowel] = [
+        "अ": .a, "आ": .aa,
+        "इ": .i, "ई": .ii,
+        "उ": .u, "ऊ": .uu,
+        "ऋ": .ri, "ॠ": .ri,
+        "ऍ": .e, "ए": .e, "ऎ": .e, "ऐ": .ai,
+        "ऑ": .o, "ओ": .o, "ऒ": .o, "औ": .au,
+    ]
+
+    private static let matras: [Unicode.Scalar: Vowel] = [
+        "\u{093E}": .aa,
+        "\u{093F}": .i, "\u{0940}": .ii,
+        "\u{0941}": .u, "\u{0942}": .uu,
+        "\u{0943}": .ri, "\u{0944}": .ri,
+        "\u{0945}": .e, "\u{0946}": .e, "\u{0947}": .e, "\u{0948}": .ai,
+        "\u{0949}": .o, "\u{094A}": .o, "\u{094B}": .o, "\u{094C}": .au,
+    ]
+
+    private static let consonants: [Unicode.Scalar: String] = [
+        "क": "k", "ख": "kh", "ग": "g", "घ": "gh", "ङ": "n",
+        "च": "ch", "छ": "chh", "ज": "j", "झ": "jh", "ञ": "n",
+        "ट": "t", "ठ": "th", "ड": "d", "ढ": "dh", "ण": "n",
+        "त": "t", "थ": "th", "द": "d", "ध": "dh", "न": "n",
+        "प": "p", "फ": "ph", "ब": "b", "भ": "bh", "म": "m",
+        "य": "y", "र": "r", "ऱ": "r", "ल": "l", "ळ": "l", "व": "v",
+        "श": "sh", "ष": "sh", "स": "s", "ह": "h",
+        // The precomposed nukta letters, which arrive as one code point rather
+        // than as a base plus U+093C.
+        "\u{0958}": "q", "\u{0959}": "kh", "\u{095A}": "gh", "\u{095B}": "z",
+        "\u{095C}": "r", "\u{095D}": "rh", "\u{095E}": "f", "\u{095F}": "y",
+    ]
+
+    /// What a following U+093C turns the base consonant into.
+    private static let nuktaForms: [Unicode.Scalar: String] = [
+        "क": "q", "ख": "kh", "ग": "gh", "ज": "z",
+        "ड": "r", "ढ": "rh", "फ": "f", "य": "y",
+    ]
+
+    /// Devanagari that is not part of a syllable: digits, danda, om.
+    private static let standalone: [Unicode.Scalar: String] = [
+        "।": ".", "॥": ".",
+        "०": "0", "१": "1", "२": "2", "३": "3", "४": "4",
+        "५": "5", "६": "6", "७": "7", "८": "8", "९": "9",
+        "ॐ": "om", "ऽ": "",
+    ]
+}

--- a/ios/VocaPhoneShared/HinglishNormalizer.swift
+++ b/ios/VocaPhoneShared/HinglishNormalizer.swift
@@ -1,0 +1,314 @@
+import Foundation
+
+/// The last pass on a Roman Hinglish transcript, and the only thing standing
+/// between a good decode and Devanagari in a text field.
+///
+/// A mirror of
+/// `android/app/src/main/java/com/vocahq/vocaphone/core/HinglishNormalizer.kt`,
+/// tables included. The two clients must produce the same transcript from the
+/// same words, and the tables are where a divergence would hide.
+///
+/// The Hinglish model writes Latin nearly all of the time. Nearly is the
+/// problem: on an unfamiliar proper noun, or a stretch of clean Hindi with no
+/// English in it, it can fall back to the script it was fine-tuned away from.
+/// Deleting that would silently lose words the user said, so it is
+/// transliterated instead — `DevanagariRomanizer` turns "में" into text rather
+/// than into nothing.
+///
+/// Everything else here is deliberately small. This is not a corrector: it does
+/// not repair grammar, does not second-guess word choice, and never rewrites a
+/// word spelled like English. Over-correction on a dictation transcript is worse
+/// than an inconsistent spelling, because the user cannot tell it happened.
+///
+/// Runs entirely on the device. No model, no network, no lookup service — the
+/// whole layer is the tables below, and the convention they encode is written
+/// down in `docs/hinglish-roman.md`.
+enum HinglishNormalizer {
+
+    /// Which passes to run.
+    ///
+    /// Configurable because the two spelling passes are conventions rather than
+    /// facts. Someone who writes "kyon" is not wrong, and a build that wanted to
+    /// leave their spelling alone should be able to say so without also giving
+    /// up transliteration, which is not a preference at all.
+    struct Options: Sendable {
+        /// Rewrite Devanagari as Latin rather than leaving or dropping it.
+        var transliterateDevanagari: Bool
+        /// Settle transliterator output on one spelling per word.
+        var applyRomanizedConventions: Bool
+        /// Settle the handful of Hindi spellings that are never English words.
+        var applyGlobalConventions: Bool
+        /// Collapse whitespace and turn a danda into a full stop.
+        var normalizePunctuation: Bool
+
+        init(
+            transliterateDevanagari: Bool = true,
+            applyRomanizedConventions: Bool = true,
+            applyGlobalConventions: Bool = true,
+            normalizePunctuation: Bool = true
+        ) {
+            self.transliterateDevanagari = transliterateDevanagari
+            self.applyRomanizedConventions = applyRomanizedConventions
+            self.applyGlobalConventions = applyGlobalConventions
+            self.normalizePunctuation = normalizePunctuation
+        }
+
+        static let `default` = Options()
+    }
+
+    static func containsDevanagari(_ text: String) -> Bool {
+        DevanagariRomanizer.containsDevanagari(text)
+    }
+
+    static func normalize(_ text: String, options: Options = .default) -> String {
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return "" }
+        let masked = mask(text)
+        var result = masked.text
+        if options.transliterateDevanagari {
+            result = transliterateWithConventions(
+                result,
+                applyConventions: options.applyRomanizedConventions
+            )
+        }
+        if options.applyGlobalConventions {
+            result = applyGlobalConventions(result)
+        }
+        if options.normalizePunctuation {
+            result = normalizePunctuation(result)
+        }
+        return restore(result, tokens: masked.tokens)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: - Masking
+
+    private struct Masked {
+        let text: String
+        let tokens: [String]
+    }
+
+    /// Spans that must survive every pass below untouched.
+    ///
+    /// A URL, an email address, a file path, a shell command, an @handle: none of
+    /// them are language, and all of them break if a spelling rule reaches
+    /// inside. Devanagari inside such a span stays Devanagari on purpose — a
+    /// transliterated host name is a broken link rather than a readable one.
+    ///
+    /// Case sensitivity is load-bearing, which is why there is no
+    /// `caseInsensitive` option on the whole pattern: the last alternative is
+    /// what makes `API` and `HTTP` survive, and case-folding it would match every
+    /// ordinary two-to-eight-letter word and mask the entire sentence.
+    private static let protectedSpans = try! NSRegularExpression(
+        pattern: [
+            // A URL or a bare host.
+            #"(?i:\b(?:[a-z][a-z0-9+.-]*://|www\.)\S+)"#,
+            // An email address.
+            #"(?i:\b[\w.+-]+@[\w-]+\.[\w.-]+\b)"#,
+            // A path or a command: anything with an internal slash.
+            #"\S*[/\\]\S*"#,
+            // A filename or a dotted identifier.
+            #"(?i:\b\w+\.[a-z0-9]{1,8}\b)"#,
+            // A handle or a hashtag.
+            #"[@#][\w.-]+"#,
+            // An abbreviation the model wrote in capitals: API, GPU, HTTP.
+            #"\b[A-Z][A-Z0-9]{1,7}\b"#,
+        ].joined(separator: "|")
+    )
+
+    private static let placeholderOpen = "\u{0001}"
+    private static let placeholderClose = "\u{0002}"
+    private static let placeholder = try! NSRegularExpression(
+        pattern: "\u{0001}(\\d+)\u{0002}"
+    )
+
+    private static func mask(_ text: String) -> Masked {
+        var tokens: [String] = []
+        var result = ""
+        var cursor = text.startIndex
+        let matches = protectedSpans.matches(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        )
+        for match in matches {
+            guard let range = Range(match.range, in: text), range.lowerBound >= cursor else {
+                continue
+            }
+            result += text[cursor..<range.lowerBound]
+            result += "\(placeholderOpen)\(tokens.count)\(placeholderClose)"
+            tokens.append(String(text[range]))
+            cursor = range.upperBound
+        }
+        result += text[cursor...]
+        return Masked(text: result, tokens: tokens)
+    }
+
+    private static func restore(_ text: String, tokens: [String]) -> String {
+        replacing(text, placeholder) { match in
+            guard let index = Int(match.dropFirst().dropLast()), index < tokens.count else {
+                return match
+            }
+            return tokens[index]
+        }
+    }
+
+    // MARK: - Transliteration
+
+    /// Transliterates each Devanagari run and settles its spelling immediately.
+    ///
+    /// Doing it here rather than over the finished string is what makes
+    /// `romanizedConventions` safe. "men" out of the transliterator is में; "men"
+    /// that arrived already in Latin is the English word, and rewriting that to
+    /// "mein" is exactly the over-correction this layer must not do. Provenance
+    /// is only knowable at this moment, so the rule is applied at this moment.
+    private static func transliterateWithConventions(
+        _ text: String,
+        applyConventions: Bool
+    ) -> String {
+        guard DevanagariRomanizer.containsDevanagari(text) else { return text }
+        let romanized = DevanagariRomanizer.romanize(text)
+        guard applyConventions else { return romanized }
+        // A word already in the source cannot have come out of the
+        // transliterator, so it is left alone whatever the table says.
+        let original = Set(words(in: text))
+        return replacing(romanized, wordPattern) { word in
+            if original.contains(word) { return word }
+            guard let replacement = romanizedConventions[word.lowercased()] else { return word }
+            return matchCase(word, replacement)
+        }
+    }
+
+    private static let wordPattern = try! NSRegularExpression(pattern: #"\p{L}+"#)
+
+    private static func words(in text: String) -> [String] {
+        wordPattern
+            .matches(in: text, range: NSRange(text.startIndex..., in: text))
+            .compactMap { Range($0.range, in: text).map { String(text[$0]) } }
+    }
+
+    /// One spelling per word for transliterator output, where the mechanical
+    /// answer is not the one people type.
+    ///
+    /// Short by design. The romanizer's own rules already produce "mujhe",
+    /// "nahin", "hai" and "theek"; these are the leftovers. में is the clearest:
+    /// it is म + े + ं, mechanically "men", and every Hinglish speaker writes
+    /// "mein".
+    private static let romanizedConventions: [String: String] = [
+        "men": "mein",
+        "kyon": "kyun",
+        "kyonki": "kyunki",
+        "hon": "hoon",
+        "hun": "hoon",
+        "jaen": "jayen",
+    ]
+
+    // MARK: - Global conventions
+
+    /// Spellings settled across the whole transcript, including text the model
+    /// already wrote in Latin.
+    ///
+    /// Every key has to be a form that is *not* an English word, because by this
+    /// point provenance is gone and a collision would rewrite English. That rules
+    /// out the tempting ones — "to", "the", "is", "men" — and leaves a short list
+    /// where the rewrite is unambiguous.
+    private static let globalConventions: [String: String] = [
+        "muje": "mujhe",
+        "mujey": "mujhe",
+        "mujhy": "mujhe",
+        "kyu": "kyun",
+        "kyoon": "kyun",
+        "kyuki": "kyunki",
+        "kyunke": "kyunki",
+        "nahi": "nahin",
+        "nhi": "nahin",
+        "thik": "theek",
+        "thk": "theek",
+        "acha": "accha",
+        "achha": "accha",
+        "bahot": "bahut",
+        "bhot": "bahut",
+        "kese": "kaise",
+        "krna": "karna",
+        "krke": "karke",
+        "smjh": "samajh",
+    ]
+
+    private static func applyGlobalConventions(_ text: String) -> String {
+        let settled = replacing(text, wordPattern) { word in
+            guard let replacement = globalConventions[word.lowercased()] else { return word }
+            return matchCase(word, replacement)
+        }
+        return replacing(settled, heyPattern) { _ in "hai" }
+    }
+
+    /// "theek hey" is "theek hai"; "Hey, ..." is English and stays.
+    ///
+    /// The one rule that needs a guard rather than a table, because "hey" is a
+    /// real English word. It is only rewritten mid-sentence and lowercase:
+    /// English "hey" is an opener, and an opener is capitalized or followed by a
+    /// comma. Wrong in the safe direction leaves a spelling slightly off; wrong
+    /// in the other direction rewrites what someone said.
+    private static let heyPattern = try! NSRegularExpression(
+        pattern: #"(?<=\S )hey\b(?![,!])"#
+    )
+
+    /// Keeps a rewritten word in the case it arrived in.
+    private static func matchCase(_ original: String, _ replacement: String) -> String {
+        if original.count > 1, original.allSatisfy(\.isUppercase) {
+            return replacement.uppercased()
+        }
+        if original.first?.isUppercase == true {
+            return replacement.prefix(1).uppercased() + replacement.dropFirst()
+        }
+        return replacement
+    }
+
+    // MARK: - Punctuation
+
+    private static let repeatedSpaces = try! NSRegularExpression(pattern: #"[ \t]{2,}"#)
+    private static let spaceBeforeMark = try! NSRegularExpression(pattern: #" +([,.!?;:])"#)
+    private static let markNeedingSpace = try! NSRegularExpression(
+        pattern: #"([,.!?;:])(?=[^\s\d,.!?;:])"#
+    )
+
+    /// Whitespace and the two marks the script change leaves behind.
+    ///
+    /// The danda is a Devanagari full stop with no business in a Latin sentence;
+    /// `DevanagariRomanizer` already converts the ones attached to a word, and
+    /// this catches a free-standing one. Capitalization and sentence terminators
+    /// are deliberately absent — `TranscriptStyler` runs after this and owns them
+    /// for every language.
+    private static func normalizePunctuation(_ text: String) -> String {
+        var result = text.replacingOccurrences(of: "।", with: ".")
+        result = result.replacingOccurrences(of: "॥", with: ".")
+        result = replacing(result, repeatedSpaces) { _ in " " }
+        result = replacing(result, spaceBeforeMark) { String($0.drop { $0 == " " }) }
+        result = replacing(result, markNeedingSpace) { "\($0) " }
+        return result
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .joined(separator: "\n")
+    }
+
+    // MARK: - Regex helper
+
+    /// `NSRegularExpression` with a closure over the matched text, which is what
+    /// Kotlin's `Regex.replace { }` gives for free and Foundation does not.
+    private static func replacing(
+        _ text: String,
+        _ pattern: NSRegularExpression,
+        _ transform: (String) -> String
+    ) -> String {
+        var result = ""
+        var cursor = text.startIndex
+        for match in pattern.matches(in: text, range: NSRange(text.startIndex..., in: text)) {
+            guard let range = Range(match.range, in: text), range.lowerBound >= cursor else {
+                continue
+            }
+            result += text[cursor..<range.lowerBound]
+            result += transform(String(text[range]))
+            cursor = range.upperBound
+        }
+        result += text[cursor...]
+        return result
+    }
+}

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -84,6 +84,11 @@ enum TranscriptionLanguage: String, Codable, CaseIterable, Identifiable, Sendabl
     case gujarati = "gu"
     case hebrew = "he"
     case hindi = "hi"
+    /// Not a language: an output contract. Mixed Hindi and English, as spoken,
+    /// written in one Latin script. Mirrors `TranscriptionLanguage.kt`; only a
+    /// model that names this code can honour it, which `ModelLanguageSupport`
+    /// enforces rather than assuming.
+    case hinglishRoman = "hinglish_roman"
     case hungarian = "hu"
     case indonesian = "id"
     case italian = "it"
@@ -144,6 +149,7 @@ enum TranscriptionLanguage: String, Codable, CaseIterable, Identifiable, Sendabl
         case .gujarati: "Gujarati"
         case .hebrew: "Hebrew"
         case .hindi: "Hindi"
+        case .hinglishRoman: "Hinglish — Roman"
         case .hungarian: "Hungarian"
         case .indonesian: "Indonesian"
         case .italian: "Italian"
@@ -184,13 +190,31 @@ enum TranscriptionLanguage: String, Codable, CaseIterable, Identifiable, Sendabl
     /// The chip label. Derived from the code rather than switched over, so a new
     /// language is one line in the case list and not three.
     var shortLabel: String {
-        self == .automatic ? "Auto" : rawValue.uppercased()
+        switch self {
+        case .automatic: "Auto"
+        // The only raw value that is not a two- or three-letter code, and
+        // "HINGLISH_ROMAN" on a keyboard chip is unreadable.
+        case .hinglishRoman: "Hinglish"
+        default: rawValue.uppercased()
+        }
     }
+
+    /// Whether this row describes an output script rather than a spoken
+    /// language. See `ModelLanguageSupport.isSelectable`.
+    var isOutputScript: Bool { self == .hinglishRoman }
+
+    /// Marked in the UI so nobody mistakes it for a finished feature.
+    var isExperimental: Bool { self == .hinglishRoman }
 
     var detail: String {
         switch self {
         case .automatic:
             "Uses the language of the model selected on your gateway."
+        case .hinglishRoman:
+            """
+            Experimental. Writes mixed Hindi and English in the Latin alphabet, \
+            as spoken. Needs the Hinglish model on this phone.
+            """
         default:
             "Requires a matching multilingual or \(displayName) model on your gateway."
         }

--- a/ios/VocaPhoneShared/ModelLanguageSupport.swift
+++ b/ios/VocaPhoneShared/ModelLanguageSupport.swift
@@ -27,6 +27,17 @@ enum ModelLanguageSupport {
         requested == TranscriptionLanguage.automatic.rawValue ? reported : requested
     }
 
+    /// The language token an engine is actually given.
+    ///
+    /// Roman Hinglish is not a language a decoder knows. The model that produces
+    /// it is a Hindi fine-tune and the token it wants is `hi`. The distinction is
+    /// kept everywhere else — the transcript language stays `hinglish_roman`,
+    /// which is what tells the normalizer and the writing styles they are looking
+    /// at Latin text. Mirrors `ModelLanguageSupport.kt`.
+    static func decoderLanguage(_ requested: String) -> String {
+        requested == TranscriptionLanguage.hinglishRoman.rawValue ? "hi" : requested
+    }
+
     /// The language the finished transcript is actually written in.
     ///
     /// `translateTo` wins outright when set, and that is the whole point of the
@@ -53,6 +64,13 @@ enum ModelLanguageSupport {
         modelLanguages: Set<String>
     ) -> Bool {
         if language == .automatic { return true }
+        // An output script inverts the default. "Nothing was claimed" is a good
+        // reason not to lock a user out of Hindi, because almost everything
+        // transcribes Hindi; it is a bad reason to offer Roman Hinglish, which
+        // exactly one model can produce and which every other model would answer
+        // with Devanagari or an English translation. Silence is a no here, and a
+        // gateway that has never heard of the value would reject it anyway.
+        if language.isOutputScript { return modelLanguages.contains(language.rawValue) }
         if modelLanguages.isEmpty { return true }
         return modelLanguages.contains(language.rawValue)
     }

--- a/ios/VocaPhoneTests/HinglishRomanTests.swift
+++ b/ios/VocaPhoneTests/HinglishRomanTests.swift
@@ -1,0 +1,263 @@
+import Foundation
+import Testing
+
+/// The iOS half of Roman Hinglish, and the parity check that keeps it the same
+/// feature on both phones.
+///
+/// The romanizer and the normalizer are ports, so most of these cases are the
+/// Kotlin cases restated: `DevanagariRomanizerTest.kt` and
+/// `HinglishNormalizerTest.kt`. Restated rather than shared, because the point is
+/// that two independent implementations agree — a shared fixture would only
+/// prove the fixture parses.
+struct HinglishRomanTests {
+
+    // MARK: - Romanization
+
+    @Test func implicitVowelsAreDroppedAtTheEndOfAWord() {
+        // Without this every word gains a syllable: "gharaa", "kalaa", "ekaa".
+        #expect(DevanagariRomanizer.romanize("घर") == "ghar")
+        #expect(DevanagariRomanizer.romanize("कल") == "kal")
+        #expect(DevanagariRomanizer.romanize("एक") == "ek")
+        #expect(DevanagariRomanizer.romanize("आज") == "aaj")
+    }
+
+    @Test func implicitVowelsAreDroppedMidWordBeforeAWrittenVowel() {
+        #expect(DevanagariRomanizer.romanize("करना") == "karna")
+        #expect(DevanagariRomanizer.romanize("करनी") == "karni")
+        #expect(DevanagariRomanizer.romanize("देखना") == "dekhna")
+    }
+
+    @Test func implicitVowelsSurviveWhereTheNextSyllableHasNoWrittenVowel() {
+        // समझ is the counterexample: ज carries no written vowel either, so the
+        // schwa on म is pronounced and "samjh" is wrong.
+        #expect(DevanagariRomanizer.romanize("समझ") == "samajh")
+        #expect(DevanagariRomanizer.romanize("भारत") == "bhaarat")
+    }
+
+    @Test func theFirstSyllableNeverLosesItsImplicitVowel() {
+        // Without the guard पता collapses to "pta", which is unreadable.
+        #expect(DevanagariRomanizer.romanize("पता") == "pata")
+        #expect(DevanagariRomanizer.romanize("बताना") == "bataana")
+    }
+
+    @Test func longVowelsShortenOnlyAtTheEndOfAWord() {
+        #expect(DevanagariRomanizer.romanize("ठीक") == "theek")
+        #expect(DevanagariRomanizer.romanize("कभी") == "kabhi")
+        #expect(DevanagariRomanizer.romanize("काम") == "kaam")
+        #expect(DevanagariRomanizer.romanize("दूसरा") == "doosra")
+    }
+
+    @Test func aTrailingNasalDoesNotMakeTheVowelBeforeItNonFinal() {
+        #expect(DevanagariRomanizer.romanize("नहीं") == "nahin")
+        #expect(DevanagariRomanizer.romanize("हूँ") == "hun")
+        #expect(DevanagariRomanizer.romanize("मैं") == "main")
+        #expect(DevanagariRomanizer.romanize("हैं") == "hain")
+    }
+
+    @Test func anusvaraIsMBeforeALipConsonantAndNEverywhereElse() {
+        #expect(DevanagariRomanizer.romanize("संभव") == "sambhav")
+        #expect(DevanagariRomanizer.romanize("अंदर") == "andar")
+    }
+
+    @Test func conjunctsKeepBothConsonantsAndNoVowelBetweenThem() {
+        #expect(DevanagariRomanizer.romanize("क्या") == "kya")
+        #expect(DevanagariRomanizer.romanize("नमस्ते") == "namaste")
+        #expect(DevanagariRomanizer.romanize("कुछ") == "kuchh")
+    }
+
+    @Test func nuktaLettersTakeTheirOwnSounds() {
+        #expect(DevanagariRomanizer.romanize("ज़रूर") == "zaroor")
+        #expect(DevanagariRomanizer.romanize("फ़ोन") == "fon")
+        #expect(DevanagariRomanizer.romanize("बड़ा") == "bara")
+    }
+
+    @Test func devanagariDigitsAndDandaBecomeTheirLatinEquivalents() {
+        #expect(DevanagariRomanizer.romanize("१२३") == "123")
+        #expect(DevanagariRomanizer.romanize("ठीक।") == "theek.")
+    }
+
+    @Test func aCodeSwitchedSentenceKeepsItsEnglishHalfVerbatim() {
+        #expect(
+            DevanagariRomanizer.romanize("आज मुझे office में एक important meeting attend करनी है")
+                == "aaj mujhe office men ek important meeting attend karni hai"
+        )
+    }
+
+    // MARK: - Normalization
+
+    @Test func devanagariNeverSurvives() {
+        for spoken in [
+            "आज मुझे office में एक important meeting attend करनी है",
+            "कल मेरी client के साथ deployment meeting है",
+            "सब कुछ ठीक है।",
+            "मैं थोड़ी देर में call करता हूँ",
+        ] {
+            let normalized = HinglishNormalizer.normalize(spoken)
+            #expect(!HinglishNormalizer.containsDevanagari(normalized), "leaked: \(normalized)")
+        }
+    }
+
+    @Test func devanagariIsTransliteratedRatherThanDeleted() {
+        // The failure this rules out is the quiet one: dropping the script loses
+        // words the user said, and the transcript still looks like a clean
+        // sentence.
+        let normalized = HinglishNormalizer.normalize("मुझे कल जाना है")
+        #expect(normalized.split(separator: " ").count == 4)
+        #expect(normalized.contains("mujhe"))
+    }
+
+    @Test func anAlreadyRomanTranscriptIsLeftAlone() {
+        let roman = "Kal meri client ke saath deployment meeting hai."
+        #expect(HinglishNormalizer.normalize(roman) == roman)
+    }
+
+    @Test func englishWordsSpokenInEnglishArePreservedVerbatim() {
+        let normalized = HinglishNormalizer.normalize(
+            "मुझे server पर नया deployment करना है और database migrate करना है"
+        )
+        for word in ["server", "deployment", "database", "migrate"] {
+            #expect(normalized.contains(word), "lost \(word) in \(normalized)")
+        }
+    }
+
+    @Test func anEnglishHomographOfAHindiSpellingIsNotRewritten() {
+        // "men" is में out of the transliterator and the English plural
+        // everywhere else. Only the first may become "mein".
+        #expect(
+            HinglishNormalizer.normalize("Three men joined the call.")
+                == "Three men joined the call."
+        )
+        #expect(HinglishNormalizer.normalize("मैं office में हूँ").contains("mein"))
+    }
+
+    @Test func protectedSpansSurviveEveryPass() {
+        let cases = [
+            ("docs पर जाओ https://vocahq.com/setup?ref=a_b", "https://vocahq.com/setup?ref=a_b"),
+            ("मुझे mail करो at yaviral@example.com", "yaviral@example.com"),
+            ("फ़ाइल है /var/log/whisper.log में", "/var/log/whisper.log"),
+            ("फिर run करो git push --force-with-lease", "--force-with-lease"),
+            ("@priya को tag करो #release में", "@priya"),
+            ("API का response GPU पर slow है", "API"),
+            ("meeting है 3:30 बजे और budget है 45,000 रुपये", "45,000"),
+        ]
+        for (spoken, span) in cases {
+            let normalized = HinglishNormalizer.normalize(spoken)
+            #expect(normalized.contains(span), "lost \(span) from \(normalized)")
+        }
+    }
+
+    @Test func oneSpellingPerWordPerTheDocumentedConvention() {
+        #expect(HinglishNormalizer.normalize("मुझे").contains("mujhe"))
+        #expect(HinglishNormalizer.normalize("muje aana hai").contains("mujhe"))
+        #expect(HinglishNormalizer.normalize("kyu nahi aaye").contains("kyun"))
+        #expect(HinglishNormalizer.normalize("nahi aa raha").contains("nahin"))
+        #expect(HinglishNormalizer.normalize("thik hai").contains("theek"))
+    }
+
+    @Test func heyBecomesHaiMidSentenceAndStaysHeyAsAnOpener() {
+        #expect(HinglishNormalizer.normalize("Sab theek hey") == "Sab theek hai")
+        #expect(HinglishNormalizer.normalize("Hey, kaise ho?") == "Hey, kaise ho?")
+    }
+
+    @Test func caseIsCarriedThroughARewrite() {
+        #expect(HinglishNormalizer.normalize("Muje kal jaana hai").hasPrefix("Mujhe"))
+    }
+
+    @Test func punctuationIsTidiedWithoutInventingAny() {
+        #expect(HinglishNormalizer.normalize("Haan ,   theek hai.") == "Haan, theek hai.")
+        // TranscriptStyler runs after this and owns capitalization and sentence
+        // endings for every language. Doing it twice would fight it.
+        #expect(HinglishNormalizer.normalize("theek hai") == "theek hai")
+        #expect(HinglishNormalizer.normalize("सब ठीक है ।").hasSuffix("."))
+    }
+
+    @Test func normalizingTwiceChangesNothingTheSecondTime() {
+        let once = HinglishNormalizer.normalize("आज मुझे office में meeting attend करनी है")
+        #expect(HinglishNormalizer.normalize(once) == once)
+    }
+
+    @Test func blankInputGivesBlankOutput() {
+        #expect(HinglishNormalizer.normalize("") == "")
+        #expect(HinglishNormalizer.normalize("   \n  ") == "")
+    }
+
+    @Test func eachPassCanBeTurnedOffIndependently() {
+        let spoken = "muje में jaana hai"
+        #expect(
+            HinglishNormalizer.normalize(
+                spoken,
+                options: .init(
+                    transliterateDevanagari: false,
+                    applyRomanizedConventions: false,
+                    applyGlobalConventions: false,
+                    normalizePunctuation: false
+                )
+            ) == spoken
+        )
+        // Transliteration on, conventions off: the mechanical spelling stands.
+        #expect(
+            HinglishNormalizer
+                .normalize("में", options: .init(applyRomanizedConventions: false))
+                .contains("men")
+        )
+    }
+
+    // MARK: - Selection
+
+    @Test func theRomanRowNeedsAModelThatSaysSoInAsManyWords() {
+        let roman = TranscriptionLanguage.hinglishRoman
+        #expect(ModelLanguageSupport.isSelectable(roman, modelLanguages: [roman.rawValue]))
+        #expect(!ModelLanguageSupport.isSelectable(roman, modelLanguages: ["hi", "en"]))
+        // Silence is a no here, unlike every ordinary language: an unknown
+        // gateway has certainly not been taught this value.
+        #expect(!ModelLanguageSupport.isSelectable(roman, modelLanguages: []))
+    }
+
+    @Test func ordinaryLanguagesStillDefaultToSelectableWhenNothingIsClaimed() {
+        // The rule above must not have narrowed anything else.
+        #expect(ModelLanguageSupport.isSelectable(.hindi, modelLanguages: []))
+        #expect(ModelLanguageSupport.isSelectable(.english, modelLanguages: []))
+    }
+
+    @Test func aStaleRomanChoiceFallsBackToAutomatic() {
+        #expect(
+            ModelLanguageSupport.resolve(.hinglishRoman, modelLanguages: ["hi", "en"]) == .automatic
+        )
+    }
+
+    @Test func theDecoderIsAskedForHindiAndTheTranscriptStaysRoman() {
+        let roman = TranscriptionLanguage.hinglishRoman.rawValue
+        #expect(ModelLanguageSupport.decoderLanguage(roman) == "hi")
+        #expect(ModelLanguageSupport.transcriptLanguage(requested: roman, reported: "hi") == roman)
+        // No other language is routed through this mapping.
+        for code in ["hi", "en", "auto", "de", ""] {
+            #expect(ModelLanguageSupport.decoderLanguage(code) == code)
+        }
+    }
+
+    @Test func theLabelSaysExperimentalWhereAUserWillReadIt() {
+        #expect(TranscriptionLanguage.hinglishRoman.isExperimental)
+        #expect(TranscriptionLanguage.hinglishRoman.isOutputScript)
+        #expect(TranscriptionLanguage.hinglishRoman.detail.contains("Experimental"))
+        #expect(TranscriptionLanguage.hinglishRoman.shortLabel == "Hinglish")
+        #expect(TranscriptionLanguage.hinglishRoman.displayName == "Hinglish — Roman")
+    }
+
+    /// iOS ships no Hinglish model yet: WhisperKit needs a Core ML build and no
+    /// verified one exists. The row must therefore be unreachable here — greyed
+    /// in the picker, never selected by accident — while the layers underneath it
+    /// stay in step with Android so that adding the model later is one catalog
+    /// entry and not a port.
+    @Test func noModelOnThisPlatformCanHonourTheRomanRowYet() {
+        let roman = TranscriptionLanguage.hinglishRoman.rawValue
+        #expect(LocalModelCatalog.all.allSatisfy { !$0.languageCodes.contains(roman) })
+        for descriptor in LocalModelCatalog.all {
+            #expect(
+                !ModelLanguageSupport.isSelectable(
+                    .hinglishRoman,
+                    modelLanguages: descriptor.languageCodes
+                )
+            )
+        }
+    }
+}

--- a/ios/VocaPhoneTests/ModelLanguageSupportTests.swift
+++ b/ios/VocaPhoneTests/ModelLanguageSupportTests.swift
@@ -26,12 +26,23 @@ struct ModelLanguageSupportTests {
     /// Older gateway, no model selected, or an imported one. Being uninformed
     /// must not look like being unsupported.
     @Test func anUnknownGatewayNeverLocksThePicker() {
-        for language in TranscriptionLanguage.allCases {
+        // Output-script rows are excluded rather than the rule being weakened.
+        // "Almost every model transcribes Hindi" is what makes silence a yes;
+        // nothing about that carries over to Roman Hinglish, which one model
+        // produces and every other model would answer with Devanagari.
+        for language in TranscriptionLanguage.allCases where !language.isOutputScript {
             #expect(
                 ModelLanguageSupport.isSelectable(language, modelLanguages: []),
                 "\(language) must stay selectable when the gateway made no claim"
             )
         }
+    }
+
+    @Test func anOutputScriptIsOfferedOnlyWhereItIsClaimedOutright() {
+        let roman = TranscriptionLanguage.hinglishRoman
+        #expect(!ModelLanguageSupport.isSelectable(roman, modelLanguages: []))
+        #expect(!ModelLanguageSupport.isSelectable(roman, modelLanguages: ["hi", "en"]))
+        #expect(ModelLanguageSupport.isSelectable(roman, modelLanguages: [roman.rawValue]))
     }
 
     /// The user picked Hindi, then switched the gateway to an English-only model.

--- a/ios/VocaPhoneTests/SessionRecordTests.swift
+++ b/ios/VocaPhoneTests/SessionRecordTests.swift
@@ -456,7 +456,8 @@ struct SessionRecordTests {
         #expect(TranscriptionLanguage.allCases.map(\.rawValue) == [
             "auto", "ar", "as", "bn", "bg", "yue", "ca", "hr", "cs", "da",
             "nl", "en", "et", "tl", "fi", "fr", "de", "el", "gu", "he",
-            "hi", "hu", "id", "it", "ja", "kn", "ko", "lv", "lt", "ms",
+            "hi", "hinglish_roman", "hu", "id", "it", "ja", "kn", "ko", "lv", "lt",
+            "ms",
             "ml", "mt", "zh", "mr", "ne", "no", "fa", "pl", "pt", "pa",
             "ro", "ru", "sr", "sk", "sl", "es", "sw", "sv", "ta", "te",
             "th", "tr", "uk", "ur", "vi",

--- a/tools/hinglish/benchmark/README.md
+++ b/tools/hinglish/benchmark/README.md
@@ -1,0 +1,112 @@
+# Roman Hinglish evaluation set
+
+What this measures, how to run it, and — the part that matters most — where the
+reference transcripts come from.
+
+Nothing here runs on a phone or ships in either app. It is a desktop harness for
+deciding whether the Roman Hinglish model is good enough to stop being
+experimental.
+
+## The reference problem, stated plainly
+
+Word error rate needs a reference transcript. For this mode the reference has to
+be **Roman Hinglish**, and no public speech corpus publishes one. Common Voice
+Hindi and FLEURS publish Devanagari; CMU Hinglish DoG publishes real
+Roman-Hinglish text but no matching audio. Romanizing a Devanagari reference with
+this repo's own transliterator and then scoring against it would measure the
+transliterator, not the model.
+
+So the manifest has two tiers, and each is honest about what it can support.
+
+| Tier | What it is | Reference | Good for |
+| --- | --- | --- | --- |
+| `samples` | 11 public clips from the Apex model repository (Apache-2.0), five of them Common Voice Hindi (CC0) | Six carry the text the model card publishes (`model-card`); five carry none (`unlabelled`) | Devanagari leakage, translation rate, RTF, time to first transcript, peak RSS — none of which need a trustworthy reference |
+| `prompts` | 40 sentences read aloud by whoever is running the benchmark | The sentence that was read, so it is exact by construction (`read-aloud`) | Everything, including WER, CER and English preservation |
+
+`model-card` references are the model's own published output. `score.py`
+therefore **excludes them from WER and CER by default** — scoring a model against
+its own output is not a measurement. Pass `--trust-model-card` to include them
+anyway when comparing a *different* model against Apex.
+
+## Categories
+
+The 40 prompts cover every category worth separating, because the failure modes
+differ and an average hides them:
+
+`conversational` · `technical` · `proper-nouns` · `numbers` · `hindi-heavy` ·
+`english-heavy` · `disfluent` · `questions` · `protected`
+
+`protected` is dictation-specific: paths, email addresses and commands spoken
+aloud, which is where a normalization layer does the most damage if it is wrong.
+
+What the prompts deliberately do **not** cover, and what a full evaluation still
+needs:
+
+- **Accent breadth.** One reader is one accent. Record the prompts again with a
+  second and third speaker and score each set separately.
+- **Noise.** Record one pass in a quiet room and one in a noisy one. `score.py`
+  takes `--audio-dir`, so each pass is its own directory and its own row.
+- **Fast speech and long pauses.** The `disfluent` prompts approximate this;
+  reading them at speed is the actual test.
+
+## Running it
+
+```bash
+# One-time: build whisper.cpp and get the model.
+cmake -S android/third_party/whisper.cpp -B /tmp/whisper-build -DCMAKE_BUILD_TYPE=Release
+cmake --build /tmp/whisper-build -j
+
+# The public clips. Needs ffmpeg. Writes into ./audio, which is gitignored.
+python3 tools/hinglish/benchmark/fetch.py
+
+# The read-aloud prompts. Reads each sentence out, records, writes ./audio.
+python3 tools/hinglish/benchmark/record.py
+
+# Score.
+python3 tools/hinglish/benchmark/score.py \
+  --whisper-cli /tmp/whisper-build/bin/whisper-cli \
+  --model ~/models/ggml-apex-hinglish-q5_0.bin \
+  --normalize \
+  --json /tmp/apex.json
+```
+
+`--normalize` applies a Python port of the app's normalization layer, so the
+numbers describe what a user would actually see rather than the raw decode. Run
+it both ways: the difference between them is exactly what the normalizer is
+worth.
+
+To compare against the stock multilingual model on the same audio — which is the
+comparison that decides whether this mode earns its download:
+
+```bash
+python3 tools/hinglish/benchmark/score.py \
+  --whisper-cli /tmp/whisper-build/bin/whisper-cli \
+  --model ~/models/ggml-large-v3-turbo-q5_0.bin \
+  --json /tmp/turbo.json
+```
+
+## Metrics
+
+| Metric | What a bad number means |
+| --- | --- |
+| `wer` / `cer` | Words came back wrong. Computed on collapsed spellings, so "mujhe" and "muje" are not counted as an error — see `collapse` in `score.py` |
+| `english_preservation` | Words genuinely spoken in English did not come back as English. A Hindi-only model fails this by romanizing them; a translation fails it in the other direction |
+| `devanagari_leakage` | The mode broke its one promise. Must be 0 after `--normalize` |
+| `translation_rate` | The model answered the meaning instead of the words |
+| `rtf` | Decode seconds per audio second on this machine |
+| `ttft_ms` | What a dictation user waits for. Whisper does not stream, so on a short clip this is the whole decode |
+| `peak_rss_mb` | Peak resident memory of the decode process |
+
+Phone-side CPU, GPU and battery cost are **not** measured here and this harness
+cannot measure them: it runs on a desktop. Take those from a device session as
+described in `docs/device-setup.md`.
+
+## Adding a sample
+
+1. Add an entry to `samples` with `url`, `file`, `license`, `attribution`,
+   `category`, `reference` and `english_words`.
+2. `python3 fetch.py --record-digests` once, to pin the source SHA-256.
+3. Commit the manifest. **Never commit the audio** — see AGENTS.md.
+
+Only add audio whose licence allows redistribution of the *link* and whose
+speaker consented. No private recordings, no clips scraped from anywhere.

--- a/tools/hinglish/benchmark/fetch.py
+++ b/tools/hinglish/benchmark/fetch.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Download the Roman Hinglish evaluation clips this manifest names.
+
+    python3 tools/hinglish/benchmark/fetch.py
+
+No audio is committed to this repository — see AGENTS.md, "Do not commit
+recordings or transcripts". Every clip here is fetched from a public source
+under a licence that allows it, pinned by URL and SHA-256, and written into a
+gitignored directory. Nothing private and nothing copyright-unclear is in the
+manifest, and nothing should be added to it that is.
+
+MP3 sources are converted to the 16 kHz mono WAV whisper.cpp reads, which needs
+ffmpeg on PATH.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def to_wav(source: Path, destination: Path) -> None:
+    """16 kHz mono PCM, which is the only thing whisper.cpp reads."""
+    subprocess.run(
+        [
+            "ffmpeg", "-nostdin", "-loglevel", "error", "-y",
+            "-i", str(source),
+            "-ar", "16000", "-ac", "1", "-c:a", "pcm_s16le",
+            str(destination),
+        ],
+        check=True,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=HERE / "manifest.json")
+    parser.add_argument("--out", type=Path, default=HERE / "audio")
+    parser.add_argument(
+        "--record-digests",
+        action="store_true",
+        help="write the digest of each freshly downloaded source back into the "
+             "manifest. Use once when adding a sample; never on a normal fetch, "
+             "which is meant to verify rather than to trust.",
+    )
+    args = parser.parse_args()
+
+    if not shutil.which("ffmpeg"):
+        print("ffmpeg is required to normalize the clips to 16 kHz mono", file=sys.stderr)
+        return 2
+
+    manifest = json.loads(args.manifest.read_text())
+    args.out.mkdir(parents=True, exist_ok=True)
+    cache = args.out / ".sources"
+    cache.mkdir(exist_ok=True)
+
+    changed = False
+    for sample in manifest["samples"]:
+        target = args.out / sample["file"]
+        if target.exists():
+            continue
+        source = cache / Path(sample["url"]).name
+        if not source.exists():
+            print(f"fetching {sample['id']}")
+            urllib.request.urlretrieve(sample["url"], source)  # noqa: S310
+
+        digest = sha256(source)
+        expected = sample.get("source_sha256")
+        if args.record_digests and not expected:
+            sample["source_sha256"] = digest
+            changed = True
+        elif expected and digest != expected:
+            print(
+                f"{sample['id']}: digest mismatch\n  expected {expected}\n  got      {digest}",
+                file=sys.stderr,
+            )
+            return 1
+
+        to_wav(source, target)
+
+    if changed:
+        args.manifest.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
+        print(f"updated {args.manifest}")
+
+    print(f"{len(manifest['samples'])} clips ready in {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/hinglish/benchmark/manifest.json
+++ b/tools/hinglish/benchmark/manifest.json
@@ -1,0 +1,580 @@
+{
+  "$comment": [
+    "Roman Hinglish evaluation set. Audio is never committed; fetch.py",
+    "downloads it into a gitignored directory. See README.md for what each",
+    "field means, how references are sourced, and how to add a sample.",
+    "",
+    "Two tiers, because Roman-Hinglish audio with an independent Roman",
+    "reference does not exist as a public corpus. `samples` is real public",
+    "audio; `prompts` is a read-aloud script whose reference is exact by",
+    "construction because it is the text the speaker was reading."
+  ],
+  "spelling_convention": "docs/hinglish-roman.md",
+  "samples": [
+    {
+      "id": "oriserve-01",
+      "category": "conversational",
+      "url": "https://huggingface.co/Oriserve/Whisper-Hindi2Hinglish-Apex/resolve/f3214eed20b4e4d4144e739982d911f87b9cb223/audios/c0637211-7384-4abc-af69-5aacf7549824_1_2629072_2656224.wav",
+      "file": "oriserve-01.wav",
+      "license": "Apache-2.0",
+      "attribution": "Oriserve/Whisper-Hindi2Hinglish-Apex demo clips",
+      "reference": "Mehnat to poora karte hain.",
+      "reference_provenance": "model-card",
+      "english_words": []
+    },
+    {
+      "id": "oriserve-02",
+      "category": "conversational",
+      "url": "https://huggingface.co/Oriserve/Whisper-Hindi2Hinglish-Apex/resolve/f3214eed20b4e4d4144e739982d911f87b9cb223/audios/c0faba11-27ba-4837-a2eb-ccd67be07f40_1_3185088_3227568.wav",
+      "file": "oriserve-02.wav",
+      "license": "Apache-2.0",
+      "attribution": "Oriserve/Whisper-Hindi2Hinglish-Apex demo clips",
+      "reference": "Haan vahi dekh aapko bataen na.",
+      "reference_provenance": "model-card",
+      "english_words": []
+    },
+    {
+      "id": "oriserve-03",
+      "category": "conversational",
+      "url": "https://huggingface.co/Oriserve/Whisper-Hindi2Hinglish-Apex/resolve/f3214eed20b4e4d4144e739982d911f87b9cb223/audios/663eb653-d6b5-4fda-b5f2-9ef98adc0a61_0_1098400_1118688.wav",
+      "file": "oriserve-03.wav",
+      "license": "Apache-2.0",
+      "attribution": "Oriserve/Whisper-Hindi2Hinglish-Apex demo clips",
+      "reference": "Aap pandrah log hain.",
+      "reference_provenance": "model-card",
+      "english_words": []
+    },
+    {
+      "id": "oriserve-04",
+      "category": "conversational",
+      "url": "https://huggingface.co/Oriserve/Whisper-Hindi2Hinglish-Apex/resolve/f3214eed20b4e4d4144e739982d911f87b9cb223/audios/f5e0178c-354c-40c9-b3a7-687c86240a77_1_2613728_2630112.wav",
+      "file": "oriserve-04.wav",
+      "license": "Apache-2.0",
+      "attribution": "Oriserve/Whisper-Hindi2Hinglish-Apex demo clips",
+      "reference": "Thik hai saal ki.",
+      "reference_provenance": "model-card",
+      "english_words": []
+    },
+    {
+      "id": "oriserve-05",
+      "category": "conversational",
+      "url": "https://huggingface.co/Oriserve/Whisper-Hindi2Hinglish-Apex/resolve/f3214eed20b4e4d4144e739982d911f87b9cb223/audios/f5e0178c-354c-40c9-b3a7-687c86240a77_1_1152496_1175488.wav",
+      "file": "oriserve-05.wav",
+      "license": "Apache-2.0",
+      "attribution": "Oriserve/Whisper-Hindi2Hinglish-Apex demo clips",
+      "reference": "Nahin, just thank you, thank you.",
+      "reference_provenance": "model-card",
+      "english_words": [
+        "just",
+        "thank",
+        "you",
+        "thank",
+        "you"
+      ]
+    },
+    {
+      "id": "oriserve-06",
+      "category": "conversational",
+      "url": "https://huggingface.co/Oriserve/Whisper-Hindi2Hinglish-Apex/resolve/f3214eed20b4e4d4144e739982d911f87b9cb223/audios/c0637211-7384-4abc-af69-5aacf7549824_1_2417088_2444224.wav",
+      "file": "oriserve-06.wav",
+      "license": "Apache-2.0",
+      "attribution": "Oriserve/Whisper-Hindi2Hinglish-Apex demo clips",
+      "reference": "Haan haan, dekhe hain.",
+      "reference_provenance": "model-card",
+      "english_words": []
+    },
+    {
+      "id": "commonvoice-01",
+      "category": "hindi-heavy",
+      "url": "https://huggingface.co/Oriserve/Whisper-Hindi2Hinglish-Apex/resolve/f3214eed20b4e4d4144e739982d911f87b9cb223/audios/common_voice_hi_23796065.mp3",
+      "file": "commonvoice-01.wav",
+      "license": "CC0-1.0",
+      "attribution": "Mozilla Common Voice hi, redistributed in the Apex model repo",
+      "reference": null,
+      "reference_provenance": "unlabelled",
+      "english_words": []
+    },
+    {
+      "id": "commonvoice-02",
+      "category": "hindi-heavy",
+      "url": "https://huggingface.co/Oriserve/Whisper-Hindi2Hinglish-Apex/resolve/f3214eed20b4e4d4144e739982d911f87b9cb223/audios/common_voice_hi_40904697.mp3",
+      "file": "commonvoice-02.wav",
+      "license": "CC0-1.0",
+      "attribution": "Mozilla Common Voice hi, redistributed in the Apex model repo",
+      "reference": null,
+      "reference_provenance": "unlabelled",
+      "english_words": []
+    },
+    {
+      "id": "commonvoice-03",
+      "category": "hindi-heavy",
+      "url": "https://huggingface.co/Oriserve/Whisper-Hindi2Hinglish-Apex/resolve/f3214eed20b4e4d4144e739982d911f87b9cb223/audios/common_voice_hi_41429198.mp3",
+      "file": "commonvoice-03.wav",
+      "license": "CC0-1.0",
+      "attribution": "Mozilla Common Voice hi, redistributed in the Apex model repo",
+      "reference": null,
+      "reference_provenance": "unlabelled",
+      "english_words": []
+    },
+    {
+      "id": "commonvoice-04",
+      "category": "hindi-heavy",
+      "url": "https://huggingface.co/Oriserve/Whisper-Hindi2Hinglish-Apex/resolve/f3214eed20b4e4d4144e739982d911f87b9cb223/audios/common_voice_hi_41429259.mp3",
+      "file": "commonvoice-04.wav",
+      "license": "CC0-1.0",
+      "attribution": "Mozilla Common Voice hi, redistributed in the Apex model repo",
+      "reference": null,
+      "reference_provenance": "unlabelled",
+      "english_words": []
+    },
+    {
+      "id": "commonvoice-05",
+      "category": "hindi-heavy",
+      "url": "https://huggingface.co/Oriserve/Whisper-Hindi2Hinglish-Apex/resolve/f3214eed20b4e4d4144e739982d911f87b9cb223/audios/common_voice_hi_41666099.mp3",
+      "file": "commonvoice-05.wav",
+      "license": "CC0-1.0",
+      "attribution": "Mozilla Common Voice hi, redistributed in the Apex model repo",
+      "reference": null,
+      "reference_provenance": "unlabelled",
+      "english_words": []
+    }
+  ],
+  "prompts": [
+    {
+      "id": "prompt-01",
+      "category": "conversational",
+      "file": "prompt-01.wav",
+      "reference": "Aaj mausam kaafi accha hai, chalo bahar chalte hain.",
+      "reference_provenance": "read-aloud",
+      "english_words": []
+    },
+    {
+      "id": "prompt-02",
+      "category": "conversational",
+      "file": "prompt-02.wav",
+      "reference": "Mujhe samajh nahin aa raha ki kya karna chahiye.",
+      "reference_provenance": "read-aloud",
+      "english_words": []
+    },
+    {
+      "id": "prompt-03",
+      "category": "conversational",
+      "file": "prompt-03.wav",
+      "reference": "Kal shaam ko free ho to milte hain.",
+      "reference_provenance": "read-aloud",
+      "english_words": []
+    },
+    {
+      "id": "prompt-04",
+      "category": "conversational",
+      "file": "prompt-04.wav",
+      "reference": "Bahut din ho gaye tumse baat kiye hue.",
+      "reference_provenance": "read-aloud",
+      "english_words": []
+    },
+    {
+      "id": "prompt-05",
+      "category": "conversational",
+      "file": "prompt-05.wav",
+      "reference": "Theek hai, main tumhe baad mein call karta hoon.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "call"
+      ]
+    },
+    {
+      "id": "prompt-06",
+      "category": "technical",
+      "file": "prompt-06.wav",
+      "reference": "Server pe naya deployment push kar diya hai.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "Server",
+        "deployment",
+        "push"
+      ]
+    },
+    {
+      "id": "prompt-07",
+      "category": "technical",
+      "file": "prompt-07.wav",
+      "reference": "Database migration chal rahi hai, thoda wait karo.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "Database",
+        "migration",
+        "wait"
+      ]
+    },
+    {
+      "id": "prompt-08",
+      "category": "technical",
+      "file": "prompt-08.wav",
+      "reference": "API ka response time kaafi slow ho gaya hai.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "API",
+        "response",
+        "time",
+        "slow"
+      ]
+    },
+    {
+      "id": "prompt-09",
+      "category": "technical",
+      "file": "prompt-09.wav",
+      "reference": "Model ko GPU pe train karna padega, CPU pe bahut time lagega.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "Model",
+        "GPU",
+        "train",
+        "CPU",
+        "time"
+      ]
+    },
+    {
+      "id": "prompt-10",
+      "category": "technical",
+      "file": "prompt-10.wav",
+      "reference": "Pull request review kar do, main merge kar dunga.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "Pull",
+        "request",
+        "review",
+        "merge"
+      ]
+    },
+    {
+      "id": "prompt-11",
+      "category": "technical",
+      "file": "prompt-11.wav",
+      "reference": "Yeh bug production mein aa raha hai, staging mein nahin.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "bug",
+        "production",
+        "staging"
+      ]
+    },
+    {
+      "id": "prompt-12",
+      "category": "proper-nouns",
+      "file": "prompt-12.wav",
+      "reference": "Priya ne Google Meet ka link bheja hai.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "Google",
+        "Meet",
+        "link"
+      ]
+    },
+    {
+      "id": "prompt-13",
+      "category": "proper-nouns",
+      "file": "prompt-13.wav",
+      "reference": "Rahul aur Ananya dono Bangalore shift ho rahe hain.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "Bangalore",
+        "shift"
+      ]
+    },
+    {
+      "id": "prompt-14",
+      "category": "proper-nouns",
+      "file": "prompt-14.wav",
+      "reference": "Maine Swiggy se khana order kiya tha.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "Swiggy",
+        "order"
+      ]
+    },
+    {
+      "id": "prompt-15",
+      "category": "proper-nouns",
+      "file": "prompt-15.wav",
+      "reference": "WhatsApp pe message kar dena, main dekh lunga.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "WhatsApp",
+        "message"
+      ]
+    },
+    {
+      "id": "prompt-16",
+      "category": "numbers",
+      "file": "prompt-16.wav",
+      "reference": "Meeting kal subah saade das baje hai.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "Meeting"
+      ]
+    },
+    {
+      "id": "prompt-17",
+      "category": "numbers",
+      "file": "prompt-17.wav",
+      "reference": "Iska price pandrah hazar rupaye hai.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "price"
+      ]
+    },
+    {
+      "id": "prompt-18",
+      "category": "numbers",
+      "file": "prompt-18.wav",
+      "reference": "Mera flight number six A one four seven hai.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "flight",
+        "number"
+      ]
+    },
+    {
+      "id": "prompt-19",
+      "category": "numbers",
+      "file": "prompt-19.wav",
+      "reference": "Twenty six January ko chhutti hai.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "January"
+      ]
+    },
+    {
+      "id": "prompt-20",
+      "category": "numbers",
+      "file": "prompt-20.wav",
+      "reference": "Batch size thirty two rakho aur learning rate point zero zero one.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "Batch",
+        "size",
+        "learning",
+        "rate"
+      ]
+    },
+    {
+      "id": "prompt-21",
+      "category": "hindi-heavy",
+      "file": "prompt-21.wav",
+      "reference": "Kal raat ko bahut tez baarish hui thi.",
+      "reference_provenance": "read-aloud",
+      "english_words": []
+    },
+    {
+      "id": "prompt-22",
+      "category": "hindi-heavy",
+      "file": "prompt-22.wav",
+      "reference": "Maa ne kaha tha ki jaldi ghar aa jaana.",
+      "reference_provenance": "read-aloud",
+      "english_words": []
+    },
+    {
+      "id": "prompt-23",
+      "category": "hindi-heavy",
+      "file": "prompt-23.wav",
+      "reference": "Yeh kitaab maine pichle saal padhi thi.",
+      "reference_provenance": "read-aloud",
+      "english_words": []
+    },
+    {
+      "id": "prompt-24",
+      "category": "hindi-heavy",
+      "file": "prompt-24.wav",
+      "reference": "Usne kuch nahin kaha, bas chup chaap chala gaya.",
+      "reference_provenance": "read-aloud",
+      "english_words": []
+    },
+    {
+      "id": "prompt-25",
+      "category": "hindi-heavy",
+      "file": "prompt-25.wav",
+      "reference": "Humein kal subah jaldi nikalna hoga.",
+      "reference_provenance": "read-aloud",
+      "english_words": []
+    },
+    {
+      "id": "prompt-26",
+      "category": "english-heavy",
+      "file": "prompt-26.wav",
+      "reference": "The quarterly report is ready, bas ek review baaki hai.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "The",
+        "quarterly",
+        "report",
+        "is",
+        "ready",
+        "review"
+      ]
+    },
+    {
+      "id": "prompt-27",
+      "category": "english-heavy",
+      "file": "prompt-27.wav",
+      "reference": "I think we should postpone the launch, kya lagta hai tumhe?",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "I",
+        "think",
+        "we",
+        "should",
+        "postpone",
+        "the",
+        "launch"
+      ]
+    },
+    {
+      "id": "prompt-28",
+      "category": "english-heavy",
+      "file": "prompt-28.wav",
+      "reference": "Send me the invoice by Friday, please, warna delay ho jayega.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "Send",
+        "me",
+        "the",
+        "invoice",
+        "by",
+        "Friday",
+        "please",
+        "delay"
+      ]
+    },
+    {
+      "id": "prompt-29",
+      "category": "english-heavy",
+      "file": "prompt-29.wav",
+      "reference": "The build is failing on CI, thoda dekh lo.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "The",
+        "build",
+        "is",
+        "failing",
+        "on",
+        "CI"
+      ]
+    },
+    {
+      "id": "prompt-30",
+      "category": "disfluent",
+      "file": "prompt-30.wav",
+      "reference": "Matlab, umm, mujhe abhi decide nahin karna hai.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "decide"
+      ]
+    },
+    {
+      "id": "prompt-31",
+      "category": "disfluent",
+      "file": "prompt-31.wav",
+      "reference": "Haan haan bilkul, koi problem nahin hai.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "problem"
+      ]
+    },
+    {
+      "id": "prompt-32",
+      "category": "disfluent",
+      "file": "prompt-32.wav",
+      "reference": "Toh basically yeh hua ki flight cancel ho gayi.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "basically",
+        "flight",
+        "cancel"
+      ]
+    },
+    {
+      "id": "prompt-33",
+      "category": "disfluent",
+      "file": "prompt-33.wav",
+      "reference": "Arre yaar, phir se wahi galti kar di maine.",
+      "reference_provenance": "read-aloud",
+      "english_words": []
+    },
+    {
+      "id": "prompt-34",
+      "category": "questions",
+      "file": "prompt-34.wav",
+      "reference": "Tum kahan ho abhi, office pahunche ya nahin?",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "office"
+      ]
+    },
+    {
+      "id": "prompt-35",
+      "category": "questions",
+      "file": "prompt-35.wav",
+      "reference": "Kyun nahin aaye kal party mein?",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "party"
+      ]
+    },
+    {
+      "id": "prompt-36",
+      "category": "questions",
+      "file": "prompt-36.wav",
+      "reference": "Kitna time lagega yeh kaam khatam hone mein?",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "time"
+      ]
+    },
+    {
+      "id": "prompt-37",
+      "category": "questions",
+      "file": "prompt-37.wav",
+      "reference": "Kya main tumhe kal wapas call kar sakta hoon?",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "call"
+      ]
+    },
+    {
+      "id": "prompt-38",
+      "category": "protected",
+      "file": "prompt-38.wav",
+      "reference": "Log file yahan hai slash var slash log slash whisper dot log.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "Log",
+        "file",
+        "log",
+        "whisper"
+      ]
+    },
+    {
+      "id": "prompt-39",
+      "category": "protected",
+      "file": "prompt-39.wav",
+      "reference": "Mujhe mail bhej do priya at example dot com pe.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "mail"
+      ]
+    },
+    {
+      "id": "prompt-40",
+      "category": "protected",
+      "file": "prompt-40.wav",
+      "reference": "Repo clone karo aur phir npm install chala dena.",
+      "reference_provenance": "read-aloud",
+      "english_words": [
+        "Repo",
+        "clone",
+        "npm",
+        "install"
+      ]
+    }
+  ]
+}

--- a/tools/hinglish/benchmark/normalize.py
+++ b/tools/hinglish/benchmark/normalize.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""A Python port of the app's Roman Hinglish normalization layer.
+
+Mirrors `core/HinglishNormalizer.kt` and `core/DevanagariRomanizer.kt`, so that
+`score.py --normalize` measures what a user would actually see rather than the
+raw decode. The rules and the tables are documented once, in
+`docs/hinglish-roman.md`; the reasoning behind each is in the Kotlin.
+
+Third copy of the same logic, which is a real cost. It buys the one number that
+decides whether the normalizer earns its place — leakage and WER with it against
+leakage and WER without it — and the parity test below is what keeps the copy
+from drifting silently:
+
+    python3 tools/hinglish/benchmark/normalize.py --self-test
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import unicodedata
+
+# ------------------------------------------------------------ transliteration
+
+VIRAMA, NUKTA, ANUSVARA, CHANDRABINDU, VISARGA = "\u094d", "\u093c", "\u0902", "\u0901", "\u0903"
+ZWJ, ZWNJ = "\u200d", "\u200c"
+NASAL_SIGNS = {ANUSVARA, CHANDRABINDU, VISARGA}
+JOINERS = {ZWJ, ZWNJ}
+LABIALS = {"p", "b", "m"}
+
+# (non-final, final). Only the long vowels differ; a long vowel shortens at the
+# end of a word, so आज is "aaj" and करना is "karna".
+VOWELS = {
+    "A": ("a", "a"), "AA": ("aa", "a"), "I": ("i", "i"), "II": ("ee", "i"),
+    "U": ("u", "u"), "UU": ("oo", "u"), "RI": ("ri", "ri"), "E": ("e", "e"),
+    "AI": ("ai", "ai"), "O": ("o", "o"), "AU": ("au", "au"),
+}
+
+INDEPENDENT = {
+    "अ": "A", "आ": "AA", "इ": "I", "ई": "II", "उ": "U", "ऊ": "UU",
+    "ऋ": "RI", "ॠ": "RI", "ऍ": "E", "ए": "E", "ऎ": "E", "ऐ": "AI",
+    "ऑ": "O", "ओ": "O", "ऒ": "O", "औ": "AU",
+}
+
+MATRAS = {
+    "\u093e": "AA", "\u093f": "I", "\u0940": "II", "\u0941": "U", "\u0942": "UU",
+    "\u0943": "RI", "\u0944": "RI", "\u0945": "E", "\u0946": "E", "\u0947": "E",
+    "\u0948": "AI", "\u0949": "O", "\u094a": "O", "\u094b": "O", "\u094c": "AU",
+}
+
+CONSONANTS = {
+    "क": "k", "ख": "kh", "ग": "g", "घ": "gh", "ङ": "n",
+    "च": "ch", "छ": "chh", "ज": "j", "झ": "jh", "ञ": "n",
+    "ट": "t", "ठ": "th", "ड": "d", "ढ": "dh", "ण": "n",
+    "त": "t", "थ": "th", "द": "d", "ध": "dh", "न": "n",
+    "प": "p", "फ": "ph", "ब": "b", "भ": "bh", "म": "m",
+    "य": "y", "र": "r", "ऱ": "r", "ल": "l", "ळ": "l", "व": "v",
+    "श": "sh", "ष": "sh", "स": "s", "ह": "h",
+    "\u0958": "q", "\u0959": "kh", "\u095a": "gh", "\u095b": "z",
+    "\u095c": "r", "\u095d": "rh", "\u095e": "f", "\u095f": "y",
+}
+
+NUKTA_FORMS = {
+    "क": "q", "ख": "kh", "ग": "gh", "ज": "z",
+    "ड": "r", "ढ": "rh", "फ": "f", "य": "y",
+}
+
+# Devanagari that is not part of a syllable. These end a word rather than
+# joining it: with the danda counted in, ठीक। keeps a syllable after क and
+# romanizes as "theeka.".
+STANDALONE = {
+    "।": ".", "॥": ".", "ॐ": "om", "ऽ": "",
+    "०": "0", "१": "1", "२": "2", "३": "3", "४": "4",
+    "५": "5", "६": "6", "७": "7", "८": "8", "९": "9",
+}
+
+
+def _is_devanagari(character: str) -> bool:
+    return "\u0900" <= character <= "\u097f"
+
+
+def _parse(word: str) -> list[list]:
+    """Into syllables of [onset, vowel, implicit, nasal]."""
+    syllables: list[list] = []
+    index = 0
+    while index < len(word):
+        character = word[index]
+        if character in JOINERS:
+            index += 1
+        elif character in INDEPENDENT:
+            syllables.append(["", INDEPENDENT[character], False, ""])
+            index += 1
+        elif character in CONSONANTS:
+            onset = CONSONANTS[character]
+            index += 1
+            if index < len(word) and word[index] == NUKTA:
+                onset = NUKTA_FORMS.get(character, onset)
+                index += 1
+            vowel, implicit = "A", True
+            if index < len(word):
+                if word[index] == VIRAMA:
+                    vowel, implicit = None, False
+                    index += 1
+                elif word[index] in MATRAS:
+                    vowel, implicit = MATRAS[word[index]], False
+                    index += 1
+            syllables.append([onset, vowel, implicit, ""])
+        else:
+            index += 1
+        while index < len(word) and word[index] in NASAL_SIGNS:
+            if syllables:
+                syllables[-1][3] = "h" if word[index] == VISARGA else "n"
+            index += 1
+    return syllables
+
+
+def _delete_schwa(syllables: list[list]) -> None:
+    """Word-finally always; mid-word only before a written vowel, and never on
+    the first syllable, which is what keeps पता from becoming "pta"."""
+    for index, syllable in enumerate(syllables):
+        if not syllable[2] or not syllable[0]:
+            continue
+        is_last = index == len(syllables) - 1
+        next_written = (
+            not is_last
+            and syllables[index + 1][1] is not None
+            and not syllables[index + 1][2]
+        )
+        if is_last or (index > 0 and next_written):
+            syllable[1], syllable[2] = None, False
+
+
+def _render(syllables: list[list]) -> str:
+    # Whether any *letter* comes after, not whether any vowel does: schwa
+    # deletion leaves ज in आज carrying no vowel, and judging by vowels alone
+    # makes the ā look final and spells it "aj".
+    last_letter = max(
+        (i for i, s in enumerate(syllables) if s[0] or s[1] is not None), default=-1
+    )
+    out = []
+    for index, (onset, vowel, _implicit, nasal) in enumerate(syllables):
+        out.append(onset)
+        if vowel is not None:
+            out.append(VOWELS[vowel][1 if index == last_letter else 0])
+        if nasal == "n":
+            following = syllables[index + 1][0] if index + 1 < len(syllables) else ""
+            out.append("m" if following[:1] in LABIALS else "n")
+        else:
+            out.append(nasal)
+    return "".join(out)
+
+
+def romanize(text: str) -> str:
+    if not any(_is_devanagari(c) for c in text):
+        return text
+    out, word = [], []
+
+    def flush():
+        if word:
+            syllables = _parse("".join(word))
+            _delete_schwa(syllables)
+            out.append(_render(syllables))
+            word.clear()
+
+    for character in text:
+        if _is_devanagari(character) and character not in STANDALONE:
+            word.append(character)
+        elif character in JOINERS:
+            word.append(character)
+        elif character in STANDALONE:
+            flush()
+            out.append(STANDALONE[character])
+        else:
+            flush()
+            out.append(character)
+    flush()
+    return "".join(out)
+
+
+# ------------------------------------------------------------- normalization
+
+PROTECTED = re.compile(
+    "|".join([
+        r"(?i:\b(?:[a-z][a-z0-9+.-]*://|www\.)\S+)",
+        r"(?i:\b[\w.+-]+@[\w-]+\.[\w.-]+\b)",
+        r"\S*[/\\]\S*",
+        r"(?i:\b\w+\.[a-z0-9]{1,8}\b)",
+        r"[@#][\w.-]+",
+        r"\b[A-Z][A-Z0-9]{1,7}\b",
+    ])
+)
+WORD = re.compile(r"[^\W\d_]+", re.UNICODE)
+PLACEHOLDER = re.compile("\u0001(\\d+)\u0002")
+HEY = re.compile(r"(?<=\S )hey\b(?![,!])")
+
+ROMANIZED_CONVENTIONS = {
+    "men": "mein", "kyon": "kyun", "kyonki": "kyunki",
+    "hon": "hoon", "hun": "hoon", "jaen": "jayen",
+}
+
+GLOBAL_CONVENTIONS = {
+    "muje": "mujhe", "mujey": "mujhe", "mujhy": "mujhe",
+    "kyu": "kyun", "kyoon": "kyun", "kyuki": "kyunki", "kyunke": "kyunki",
+    "nahi": "nahin", "nhi": "nahin",
+    "thik": "theek", "thk": "theek",
+    "acha": "accha", "achha": "accha",
+    "bahot": "bahut", "bhot": "bahut",
+    "kese": "kaise", "krna": "karna", "krke": "karke", "smjh": "samajh",
+}
+
+
+def _match_case(original: str, replacement: str) -> str:
+    if len(original) > 1 and original.isupper():
+        return replacement.upper()
+    if original[:1].isupper():
+        return replacement[:1].upper() + replacement[1:]
+    return replacement
+
+
+def normalize(
+    text: str,
+    transliterate: bool = True,
+    romanized_conventions: bool = True,
+    global_conventions: bool = True,
+    punctuation: bool = True,
+) -> str:
+    if not text.strip():
+        return ""
+
+    tokens: list[str] = []
+
+    def stash(match):
+        tokens.append(match.group(0))
+        return f"\u0001{len(tokens) - 1}\u0002"
+
+    result = PROTECTED.sub(stash, text)
+
+    if transliterate and any(_is_devanagari(c) for c in result):
+        original = set(WORD.findall(result))
+        romanized = romanize(result)
+        if romanized_conventions:
+            def settle(match):
+                word = match.group(0)
+                if word in original:
+                    return word
+                replacement = ROMANIZED_CONVENTIONS.get(word.lower())
+                return _match_case(word, replacement) if replacement else word
+
+            result = WORD.sub(settle, romanized)
+        else:
+            result = romanized
+
+    if global_conventions:
+        def settle_global(match):
+            replacement = GLOBAL_CONVENTIONS.get(match.group(0).lower())
+            return _match_case(match.group(0), replacement) if replacement else match.group(0)
+
+        result = HEY.sub("hai", WORD.sub(settle_global, result))
+
+    if punctuation:
+        result = result.replace("।", ".").replace("॥", ".")
+        result = re.sub(r"[ \t]{2,}", " ", result)
+        result = re.sub(r" +([,.!?;:])", r"\1", result)
+        result = re.sub(r"([,.!?;:])(?=[^\s\d,.!?;:])", r"\1 ", result)
+        result = "\n".join(line.strip() for line in result.split("\n"))
+
+    result = PLACEHOLDER.sub(lambda m: tokens[int(m.group(1))], result)
+    return unicodedata.normalize("NFC", result).strip()
+
+
+def contains_devanagari(text: str) -> bool:
+    return any(_is_devanagari(c) for c in text)
+
+
+# ------------------------------------------------------------------ self-test
+
+# The same cases the Kotlin and Swift suites assert, so a drift in any one of
+# the three copies shows up here rather than in a benchmark number nobody can
+# explain. Keep in step with `DevanagariRomanizerTest.kt`.
+_CASES = [
+    ("घर", "ghar"), ("कल", "kal"), ("एक", "ek"), ("आज", "aaj"),
+    ("करना", "karna"), ("करनी", "karni"), ("देखना", "dekhna"),
+    ("समझ", "samajh"), ("भारत", "bhaarat"),
+    ("पता", "pata"), ("बताना", "bataana"),
+    ("ठीक", "theek"), ("कभी", "kabhi"), ("काम", "kaam"), ("दूसरा", "doosra"),
+    ("नहीं", "nahin"), ("हूँ", "hun"), ("मैं", "main"), ("हैं", "hain"),
+    ("संभव", "sambhav"), ("अंदर", "andar"),
+    ("क्या", "kya"), ("नमस्ते", "namaste"), ("कुछ", "kuchh"),
+    ("ज़रूर", "zaroor"), ("फ़ोन", "fon"), ("बड़ा", "bara"),
+    ("१२३", "123"), ("ठीक।", "theek."),
+]
+
+_NORMALIZED = [
+    ("आज मुझे office में एक important meeting attend करनी है",
+     "aaj mujhe office mein ek important meeting attend karni hai"),
+    ("Three men joined the call.", "Three men joined the call."),
+    ("Sab theek hey", "Sab theek hai"),
+    ("Hey, kaise ho?", "Hey, kaise ho?"),
+    ("Haan ,   theek hai.", "Haan, theek hai."),
+]
+
+
+def _self_test() -> int:
+    failures = 0
+    for source, expected in _CASES:
+        actual = romanize(source)
+        if actual != expected:
+            print(f"romanize({source!r}) == {actual!r}, expected {expected!r}")
+            failures += 1
+    for source, expected in _NORMALIZED:
+        actual = normalize(source)
+        if actual != expected:
+            print(f"normalize({source!r}) == {actual!r}, expected {expected!r}")
+            failures += 1
+    total = len(_CASES) + len(_NORMALIZED)
+    print(f"{total - failures}/{total} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv:
+        raise SystemExit(_self_test())
+    for line in sys.stdin:
+        print(normalize(line.rstrip("\n")))

--- a/tools/hinglish/benchmark/record.py
+++ b/tools/hinglish/benchmark/record.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Record the read-aloud half of the Roman Hinglish evaluation set.
+
+    python3 tools/hinglish/benchmark/record.py
+
+Prints one sentence at a time, records while you read it, and writes 16 kHz mono
+WAV into a gitignored directory. Forty short sentences take about ten minutes.
+
+This exists because the reference problem has no public answer: Roman-Hinglish
+audio with an independent Roman transcript is not a corpus anyone publishes. A
+sentence you read is its own reference, exactly, which is the only way to get a
+trustworthy word error rate for this mode. See README.md.
+
+Recording is your own voice into a local file. Nothing is uploaded, and the
+audio directory is gitignored — do not commit it.
+
+Needs ffmpeg with a microphone input (`avfoundation` on macOS, `alsa` on Linux).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def input_args(device: str | None) -> list[str]:
+    if sys.platform == "darwin":
+        return ["-f", "avfoundation", "-i", device or ":default"]
+    return ["-f", "alsa", "-i", device or "default"]
+
+
+def record(destination: Path, device: str | None) -> None:
+    """Records until Enter. ffmpeg stops cleanly on `q` on its stdin."""
+    process = subprocess.Popen(
+        [
+            "ffmpeg", "-loglevel", "error", "-y",
+            *input_args(device),
+            "-ar", "16000", "-ac", "1", "-c:a", "pcm_s16le",
+            str(destination),
+        ],
+        stdin=subprocess.PIPE,
+    )
+    try:
+        input()
+    finally:
+        if process.stdin:
+            process.stdin.write(b"q")
+            process.stdin.close()
+        process.wait()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=HERE / "manifest.json")
+    parser.add_argument("--out", type=Path, default=HERE / "audio")
+    parser.add_argument(
+        "--device",
+        help="ffmpeg input device. macOS: ffmpeg -f avfoundation -list_devices true -i ''",
+    )
+    parser.add_argument("--category", help="record only this category")
+    parser.add_argument(
+        "--redo", action="store_true", help="re-record prompts that already have a file"
+    )
+    args = parser.parse_args()
+
+    manifest = json.loads(args.manifest.read_text())
+    prompts = manifest["prompts"]
+    if args.category:
+        prompts = [p for p in prompts if p["category"] == args.category]
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    pending = [p for p in prompts if args.redo or not (args.out / p["file"]).exists()]
+    if not pending:
+        print("every prompt is already recorded")
+        return 0
+
+    print(f"{len(pending)} to record. Enter starts, Enter stops. Ctrl-C quits.\n")
+    for index, prompt in enumerate(pending, start=1):
+        print(f"[{index}/{len(pending)}] {prompt['category']}")
+        print(f"  {prompt['reference']}")
+        try:
+            input("  Enter to start... ")
+            print("  recording — Enter to stop")
+            record(args.out / prompt["file"], args.device)
+        except KeyboardInterrupt:
+            print("\nstopped; rerun to continue where you left off")
+            return 0
+        print()
+    print(f"done — {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/hinglish/benchmark/score.py
+++ b/tools/hinglish/benchmark/score.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Score a whisper.cpp model on the Roman Hinglish evaluation set.
+
+    python3 tools/hinglish/benchmark/score.py \
+        --model ~/models/ggml-apex-hinglish-q5_0.bin \
+        --whisper-cli ~/whisper.cpp/build/bin/whisper-cli
+
+Audio is not in the repository. Run `fetch.py` first; it downloads the clips
+this manifest names from their upstream sources and checks their digests.
+
+What is measured, and why each metric is here rather than just word error rate:
+
+  wer / cer            How much of what was said came back, against the Roman
+                       reference. Both are computed on *collapsed* spellings —
+                       see `collapse` — because "mujhe" and "muje" are the same
+                       word and counting them as an error measures the spelling
+                       convention rather than the model.
+  english_preservation Of the words genuinely spoken in English, how many came
+                       back as English words. This is the metric a translation
+                       model would fail and a Hindi model would fail, in
+                       different directions, while both could post a fair WER.
+  devanagari_leakage   Fraction of samples with any Devanagari in the output.
+                       The one metric that must be zero after normalization: it
+                       is the promise the mode makes.
+  translation_rate     Fraction of samples that came back as English prose
+                       rather than as romanized Hindi — the specific failure
+                       where the model answers the meaning instead of the words.
+  rtf                  Decode seconds per audio second, on this machine.
+  ttft_ms              Wall time to the first transcript. Whisper is not
+                       streaming, so for a short clip this is the whole decode;
+                       it is reported separately because it is what a dictation
+                       user actually waits for.
+  peak_rss_mb          Peak resident memory of the decode process.
+
+Results go to stdout as a table and, with --json, to a file that can be diffed
+between runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import resource
+import subprocess
+import sys
+import time
+import unicodedata
+import wave
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+MANIFEST = HERE / "manifest.json"
+DEVANAGARI = re.compile(r"[ऀ-ॿ]")
+
+# ---------------------------------------------------------------- normalizing
+
+
+def collapse(word: str) -> str:
+    """Fold the spellings of one romanized Hindi word onto a single key.
+
+    Roman Hinglish has no orthography. "mujhe" and "muje", "kyun" and "kyon",
+    "theek" and "thik" are the same word, and a scorer that calls four of those
+    six errors is measuring a convention nobody agreed to. So scoring happens on
+    a deliberately lossy key: long and short vowels merge, aspirates lose their
+    h, doubled letters collapse, and the nasal endings unify.
+
+    This is only ever applied on both sides at once, so it cannot flatter the
+    model — it can only stop the metric punishing a spelling difference.
+    """
+    word = unicodedata.normalize("NFKC", word).lower()
+    word = re.sub(r"[^a-z0-9]", "", word)
+    if not word:
+        return ""
+    # Long vowels onto short.
+    word = word.replace("aa", "a").replace("ee", "i").replace("oo", "u")
+    word = word.replace("ii", "i").replace("uu", "u")
+    # One spelling per sound where Roman Hinglish uses several.
+    word = word.replace("chh", "ch").replace("sh", "s").replace("z", "j")
+    word = word.replace("v", "w").replace("y", "i")
+    # Aspiration is the most common spelling difference and the least
+    # meaningful one in this script.
+    word = re.sub(r"([kgcjtdpb])h", r"\1", word)
+    # Doubled letters.
+    word = re.sub(r"(.)\1+", r"\1", word)
+    # Nasal endings: "hain", "hai", "hain'" all key the same.
+    word = re.sub(r"[nm]$", "n", word)
+    return word
+
+
+def tokens(text: str) -> list[str]:
+    return [t for t in (collapse(w) for w in re.findall(r"\S+", text)) if t]
+
+
+def raw_words(text: str) -> list[str]:
+    return re.findall(r"[^\s]+", text)
+
+
+# -------------------------------------------------------------------- metrics
+
+
+def edit_distance(a: list, b: list) -> int:
+    if not a:
+        return len(b)
+    previous = list(range(len(b) + 1))
+    for i, item_a in enumerate(a, start=1):
+        current = [i]
+        for j, item_b in enumerate(b, start=1):
+            current.append(
+                min(
+                    previous[j] + 1,
+                    current[j - 1] + 1,
+                    previous[j - 1] + (item_a != item_b),
+                )
+            )
+        previous = current
+    return previous[-1]
+
+
+def wer(reference: str, hypothesis: str) -> float:
+    ref = tokens(reference)
+    if not ref:
+        return 0.0
+    return edit_distance(ref, tokens(hypothesis)) / len(ref)
+
+
+def cer(reference: str, hypothesis: str) -> float:
+    ref = list("".join(tokens(reference)))
+    if not ref:
+        return 0.0
+    return edit_distance(ref, list("".join(tokens(hypothesis)))) / len(ref)
+
+
+def english_preservation(english_words: list[str], hypothesis: str) -> float | None:
+    """Of the words genuinely spoken in English, how many survived as English.
+
+    `None` when the sample has no English in it, so that Hindi-only clips do not
+    silently score 100% and inflate the average.
+    """
+    if not english_words:
+        return None
+    present = {collapse(w) for w in raw_words(hypothesis)}
+    kept = sum(1 for w in english_words if collapse(w) in present)
+    return kept / len(english_words)
+
+
+def looks_translated(reference: str, hypothesis: str, english_words: list[str]) -> bool:
+    """Whether the model answered the meaning instead of the words.
+
+    The signature of a translation is that the Hindi half is gone: the English
+    words survive (they were English already) while almost none of the romanized
+    Hindi words do. Judged on the Hindi half alone, with a deliberately low bar,
+    because this is a "did the model do the wrong task" flag rather than a
+    quality score.
+    """
+    english = {collapse(w) for w in english_words}
+    hindi = [t for t in tokens(reference) if t not in english]
+    if len(hindi) < 3:
+        return False
+    present = set(tokens(hypothesis))
+    matched = sum(1 for t in hindi if t in present)
+    return matched / len(hindi) < 0.25
+
+
+def audio_seconds(path: Path) -> float:
+    with wave.open(str(path), "rb") as handle:
+        return handle.getnframes() / float(handle.getframerate())
+
+
+# ------------------------------------------------------------------- decoding
+
+
+def decode(cli: Path, model: Path, audio: Path, language: str) -> tuple[str, float, int]:
+    """Runs one decode and reports the text, wall seconds and peak RSS in bytes."""
+    before = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+    started = time.perf_counter()
+    result = subprocess.run(
+        [
+            str(cli),
+            "--model", str(model),
+            "--file", str(audio),
+            "--language", language,
+            "--no-timestamps",
+            "--no-prints",
+            "--output-txt", "--output-file", "-",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    elapsed = time.perf_counter() - started
+    after = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+    if result.returncode != 0:
+        raise RuntimeError(f"{audio.name}: whisper-cli exited {result.returncode}\n{result.stderr}")
+    # macOS reports ru_maxrss in bytes, Linux in kilobytes.
+    scale = 1 if sys.platform == "darwin" else 1024
+    return result.stdout.strip(), elapsed, max(after - before, after) * scale
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, type=Path, help="ggml model file")
+    parser.add_argument("--whisper-cli", required=True, type=Path)
+    parser.add_argument("--audio-dir", type=Path, default=HERE / "audio")
+    parser.add_argument("--manifest", type=Path, default=MANIFEST)
+    parser.add_argument(
+        "--language",
+        default="hi",
+        help="decoder token. The app maps hinglish_roman to hi; pass the same here.",
+    )
+    parser.add_argument(
+        "--normalize",
+        action="store_true",
+        help="apply the app's normalization layer before scoring (needs normalize.py)",
+    )
+    parser.add_argument("--json", type=Path, help="write the full per-sample results here")
+    parser.add_argument("--category", help="score only this category")
+    parser.add_argument(
+        "--trust-model-card",
+        action="store_true",
+        help="include the clips whose reference is the Apex model card's own "
+             "published output in WER and CER. Off by default: scoring a model "
+             "against its own output measures nothing. Turn it on only when the "
+             "model under test is not Apex.",
+    )
+    args = parser.parse_args()
+
+    manifest = json.loads(args.manifest.read_text())
+    # The two tiers are scored as one list; `reference_provenance` is what keeps
+    # them distinguishable in the output and in the WER rule below.
+    samples = manifest["samples"] + manifest.get("prompts", [])
+    if args.category:
+        samples = [s for s in samples if s["category"] == args.category]
+    samples = [s for s in samples if (args.audio_dir / s["file"]).exists()]
+    if not samples:
+        print(
+            "no audio found — run fetch.py for the public clips and record.py "
+            "for the read-aloud prompts",
+            file=sys.stderr,
+        )
+        return 2
+
+    normalize = (lambda text: text)
+    if args.normalize:
+        sys.path.insert(0, str(HERE))
+        from normalize import normalize as normalize_text  # noqa: PLC0415
+
+        normalize = normalize_text
+
+    rows = []
+    for sample in samples:
+        audio = args.audio_dir / sample["file"]
+        text, elapsed, peak = decode(args.whisper_cli, args.model, audio, args.language)
+        text = normalize(text)
+        english = sample.get("english_words", [])
+        reference = sample.get("reference")
+        provenance = sample.get("reference_provenance", "unlabelled")
+        # Only a reference that was not produced by the model under test can
+        # support an error rate. An unlabelled clip has none at all, and a
+        # model-card reference is Apex's own output — useful for comparing some
+        # other model against it, worthless for scoring Apex.
+        scorable = reference is not None and (
+            provenance != "model-card" or args.trust_model_card
+        )
+        rows.append(
+            {
+                "id": sample["id"],
+                "category": sample["category"],
+                "provenance": provenance,
+                "reference": reference,
+                "hypothesis": text,
+                "wer": wer(reference, text) if scorable else None,
+                "cer": cer(reference, text) if scorable else None,
+                "english_preservation": (
+                    english_preservation(english, text) if scorable else None
+                ),
+                "devanagari_leak": bool(DEVANAGARI.search(text)),
+                "translated": (
+                    looks_translated(reference, text, english) if scorable else None
+                ),
+                "seconds": elapsed,
+                "audio_seconds": audio_seconds(audio),
+                "peak_rss_mb": peak / 1_000_000,
+            }
+        )
+
+    def mean(key, rows=rows):
+        values = [r[key] for r in rows if r[key] is not None]
+        return sum(values) / len(values) if values else float("nan")
+
+    def rate(key, rows=rows):
+        judged = [r for r in rows if r[key] is not None]
+        return sum(bool(r[key]) for r in judged) / len(judged) if judged else float("nan")
+
+    scored = [r for r in rows if r["wer"] is not None]
+    summary = {
+        "model": args.model.name,
+        "model_bytes": args.model.stat().st_size,
+        "samples": len(rows),
+        # Said out loud, because "WER 0.21 over 51 samples" would be a lie when
+        # only 40 of them carry a reference this model can be scored against.
+        "scored_against_a_reference": len(scored),
+        "wer": mean("wer"),
+        "cer": mean("cer"),
+        "english_preservation": mean("english_preservation"),
+        # Leakage is the one metric every clip can support: it needs no
+        # reference, only the output.
+        "devanagari_leakage": sum(r["devanagari_leak"] for r in rows) / len(rows),
+        "translation_rate": rate("translated"),
+        "rtf": sum(r["seconds"] for r in rows) / sum(r["audio_seconds"] for r in rows),
+        "ttft_ms": mean("seconds") * 1000,
+        "peak_rss_mb": max(r["peak_rss_mb"] for r in rows),
+    }
+
+    print(f"{'category':<28} {'n':>3} {'WER':>7} {'CER':>7} {'EN':>7} {'deva':>6} {'trans':>6}")
+    categories = sorted({r["category"] for r in rows})
+    for category in categories:
+        group = [r for r in rows if r["category"] == category]
+        print(
+            f"{category:<28} {len(group):>3} "
+            f"{mean('wer', group):>7.3f} {mean('cer', group):>7.3f} "
+            f"{mean('english_preservation', group):>7.3f} "
+            f"{sum(r['devanagari_leak'] for r in group) / len(group):>6.2f} "
+            f"{rate('translated', group):>6.2f}"
+        )
+    print()
+    for key, value in summary.items():
+        print(f"{key:<22} {value}")
+
+    if args.json:
+        args.json.write_text(json.dumps({"summary": summary, "samples": rows}, indent=2))
+        print(f"\nwrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/hinglish/convert-apex-ggml.sh
+++ b/tools/hinglish/convert-apex-ggml.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Reproduce the Roman Hinglish GGML weights that android/.../LocalModelCatalog.kt pins.
+#
+# The catalog does not host weights. It pins a third-party GGML conversion of
+# Oriserve/Whisper-Hindi2Hinglish-Apex by SHA-256, and this script is how that
+# pin was — and can be — checked: it converts the official Apache-2.0
+# safetensors itself and prints digests to compare against the catalog.
+#
+# Nothing here runs on a user's device and nothing here is a build step. It
+# needs ~10 GB of disk and downloads ~1.7 GB of weights.
+#
+#   ./tools/hinglish/convert-apex-ggml.sh [workdir]
+#
+# Pins, so two people running this get the same bytes:
+#   - the upstream model at an immutable commit
+#   - whisper.cpp at this repo's submodule revision (the converter and the
+#     quantizer both live there, and both have changed output format before)
+set -euo pipefail
+
+MODEL_REPO="Oriserve/Whisper-Hindi2Hinglish-Apex"
+MODEL_REVISION="f3214eed20b4e4d4144e739982d911f87b9cb223"
+WHISPER_CPP_REVISION="592feef04a1802b18cbeffd0fd0eb5d02570c2ec"
+# convert-h5-to-ggml.py reads mel_filters.npz out of the openai/whisper tree.
+OPENAI_WHISPER_REVISION="5f86d1d86363843179951550570367b37c5d6f78"
+
+WORK="${1:-${TMPDIR:-/tmp}/vocaphone-hinglish-convert}"
+mkdir -p "$WORK"
+cd "$WORK"
+echo "workdir: $WORK"
+
+command -v uv >/dev/null || { echo "uv is required: https://docs.astral.sh/uv/"; exit 1; }
+command -v cmake >/dev/null || { echo "cmake is required"; exit 1; }
+
+# The sentinel rather than the directory: a half-installed venv from an
+# interrupted run exists but cannot convert anything, and re-running the script
+# has to be the fix for that rather than a no-op.
+if [ ! -f .venv/.vocaphone-ready ]; then
+  [ -d .venv ] || uv venv
+  uv pip install --python .venv "torch" "transformers" "numpy" "huggingface_hub[cli]"
+  touch .venv/.vocaphone-ready
+fi
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+clone_at() { # url revision dir
+  [ -d "$3" ] || git clone --filter=blob:none "$1" "$3"
+  git -C "$3" fetch --depth 1 origin "$2" 2>/dev/null || git -C "$3" fetch origin
+  git -C "$3" checkout --detach "$2"
+}
+
+clone_at https://github.com/ggml-org/whisper.cpp.git "$WHISPER_CPP_REVISION" whisper.cpp
+clone_at https://github.com/openai/whisper.git "$OPENAI_WHISPER_REVISION" openai-whisper
+
+# Named file by file rather than by glob. The repo also carries a directory of
+# demo clips, and `hf download` treats a bare pattern as a filename, so a glob
+# here silently fetches either everything or nothing depending on the CLI
+# version. These four are what the converter reads.
+for file in config.json generation_config.json vocab.json added_tokens.json model.safetensors; do
+  hf download "$MODEL_REPO" "$file" --revision "$MODEL_REVISION" --local-dir apex-hf
+done
+
+# Apex ships bfloat16 weights and the upstream converter cannot read them: it
+# calls .numpy() on the tensor and torch refuses, with "Got unsupported
+# ScalarType BFloat16". Upcasting to float32 at load time is the fix, and it is
+# lossless — bfloat16 is a truncated float32 — so the float16 the converter
+# writes is the same either way. Patched here rather than in the submodule,
+# which this repository does not modify.
+python3 - <<'PATCH'
+from pathlib import Path
+path = Path("whisper.cpp/models/convert-h5-to-ggml.py")
+source = path.read_text()
+original = "model = WhisperForConditionalGeneration.from_pretrained(dir_model)"
+patched = original + ".float()"
+if patched not in source:
+    assert original in source, "upstream converter changed; re-check the bfloat16 patch"
+    path.write_text(source.replace(original, patched))
+PATCH
+
+mkdir -p out
+python3 whisper.cpp/models/convert-h5-to-ggml.py apex-hf openai-whisper out
+mv out/ggml-model.bin out/ggml-apex-hinglish-fp16.bin
+
+cmake -S whisper.cpp -B whisper.cpp/build -DCMAKE_BUILD_TYPE=Release \
+  -DWHISPER_BUILD_TESTS=OFF -DWHISPER_BUILD_EXAMPLES=ON >/dev/null
+# Upstream renamed the target from `quantize` to `whisper-quantize`; try both so
+# this keeps working across a submodule bump in either direction.
+cmake --build whisper.cpp/build --target whisper-quantize -j >/dev/null 2>&1 ||
+  cmake --build whisper.cpp/build --target quantize -j >/dev/null
+QUANTIZE="$(find whisper.cpp/build -type f -perm +111 \
+  \( -name whisper-quantize -o -name quantize \) | head -1)"
+[ -n "$QUANTIZE" ] || { echo "could not find the whisper.cpp quantize binary"; exit 1; }
+
+for q in q5_0 q8_0; do
+  "$QUANTIZE" out/ggml-apex-hinglish-fp16.bin "out/ggml-apex-hinglish-$q.bin" "$q"
+done
+
+echo
+echo "SHA-256 (compare against LocalModelCatalog.kt / docs/hinglish-roman.md):"
+for f in out/ggml-apex-hinglish-*.bin; do
+  printf '%s  %s  %s\n' "$(shasum -a 256 "$f" | cut -d' ' -f1)" \
+    "$(wc -c <"$f" | tr -d ' ')" "$(basename "$f")"
+done


### PR DESCRIPTION
## Summary

Speak Hindi and English mixed and get it back in one Latin alphabet:

> "आज मुझे office में एक important meeting attend करनी है"
> → **"Aaj mujhe office mein ek important meeting attend karni hai."**

Deliberately neither Devanagari nor an English translation — the words that were
said, in the script people actually type them in.

**Android only, opt-in, experimental.** A 574 MB optional download, kept out of
every recommendation, and labelled `Hinglish — Roman (Experimental)` everywhere a
user can reach it. Nothing about the existing languages or models changes.

### The model, and why the pin is trustworthy

[`Oriserve/Whisper-Hindi2Hinglish-Apex`](https://huggingface.co/Oriserve/Whisper-Hindi2Hinglish-Apex),
Apache-2.0, a fine-tune of `whisper-large-v3-turbo` whose `config.json` is turbo's
topology exactly — so whisper.cpp runs it unmodified.

Upstream publishes safetensors only, so the catalog pins a **third-party GGML
conversion**. That is not taken on trust: `tools/hinglish/convert-apex-ggml.sh`
reproduces the conversion from Oriserve's own weights at pinned revisions, and all
three files it produces are **byte-for-byte identical** to the pinned repository,
including the `q5_0` we ship (`9d877151…`). Re-run it before ever moving the pin.

### One rule is deliberately inverted

`hinglish_roman` is a row in `TranscriptionLanguage`, but it is an *output
contract* rather than a language. For every ordinary language, a model that
claims nothing means "offer it anyway" — sound, because almost everything
transcribes Hindi. None of that reasoning survives here: one model in the catalog
produces Roman Hinglish and every other would answer with Devanagari or a
translation. So silence is a **no**, and `ModelLanguageSupport` enforces it.

This required amending an existing invariant test on both platforms. Output-script
rows are excluded explicitly rather than the rule being weakened.

The decoder is still asked for `hi`; only the transcript language stays
`hinglish_roman`, which is what tells the normalizer and the writing styles what
they are holding.

### Normalization

`HinglishNormalizer` keeps the promise when the model slips back into Devanagari.
It **transliterates rather than deletes** — dropping the script would silently lose
words while leaving a transcript that still reads cleanly. It settles a short list
of spellings, protects URLs, paths, commands and shouted abbreviations, and refuses
to touch anything spelled like English: `men` out of the transliterator is में,
`men` that arrived in Latin is the English plural, and only provenance separates
them. Fully on-device — a lookup table and a transliterator, no network, no LLM.

Convention documented in [`docs/hinglish-roman.md`](docs/hinglish-roman.md).

### Measured

11 public clips, `q5_0` both sides, same size and architecture:

| | stock `large-v3-turbo` | + normalization layer | **Hinglish Apex** |
| --- | --- | --- | --- |
| Devanagari leakage | **100%** | 0% | **0%** |
| Real-time factor | 0.34 | 0.34 | 0.30 |
| Time to first transcript | 1.53 s | 1.51 s | 1.35 s |
| Peak RSS | 846 MB | 847 MB | 835 MB |

The middle column is the cheap alternative — keep the existing model and just
transliterate. It fixes the script and nothing else: an English word the decoder
already committed to Devanagari cannot be recovered, so "performance" comes back
as "parpormens".

### iOS

Ships no model: WhisperKit needs a Core ML build. The language row, the gating and
the whole normalization layer are mirrored in Swift and tested there, and a test
asserts the row is **unreachable** on iOS — so adding a model later is one catalog
entry rather than a port.

Note for reviewers: the Swift romanizer iterates Unicode **scalars**, not
`Character`. A Devanagari consonant with a vowel sign is a single grapheme cluster,
and a `Character`-based parser can never see the matra it has to read.

## Verification

- [x] `just ios ci` — 526 tests, 0 failures
- [x] `just android ci` — 632 tests, 0 failures
- [ ] Gateway changes — N/A, no gateway involvement
- [ ] Physical-device test — **partial.** Release build installed and running on a
      POCO F1 (arm64, API 34); end-to-end dictation with the model downloaded is
      not yet confirmed. No keyboard, microphone, background-audio or insertion
      code is touched by this PR — the change is a catalog entry, a language row,
      and a post-processing pass.

Benchmark harness: `tools/hinglish/benchmark/README.md`.

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated — `docs/hinglish-roman.md` covers the model source,
      licence and attribution, privacy behaviour, spelling convention, and how to
      replace the model later. `AGENTS.md` and `README.md` link it.

Benchmark audio is downloaded or recorded locally into a gitignored directory and
never committed. Transcription stays fully on-device; the only network access is
the one-time model download from Hugging Face, verified by SHA-256 as it streams.

## Known limitations

- Word error rate is **not** properly measured. The indicative 0.23 is over six
  clips whose references are the model's own published output — `score.py`
  excludes them unless `--trust-model-card` is passed. The 40-prompt read-aloud
  set exists in the manifest but has not been recorded, so nothing here covers
  accent breadth, noise, or fast speech. Hence "experimental".
- 574 MB and 4 GB of RAM; a large-class encoder will be slow on a mid-range phone.
- Translation is unavailable for this model on purpose — Whisper's translate task
  would hand back the English translation this mode exists to avoid.
- F-Droid is unaffected: this rides the whisper.cpp path, which that flavor keeps.

## Follow-ups, not in this PR

- **sherpa-onnx route for iOS.** Both platforms already link sherpa-onnx and the
  vendored library already exposes `OfflineWhisperModelConfig` (`c-api.h:845`,
  `OfflineRecognizer.kt:87`), so one ONNX artifact could serve both. Third parties
  have already exported large-v3-turbo *fine-tunes* to sherpa ONNX, so the path is
  proven. Needs a new `SherpaFamily` member and an export we host.
- **A lighter model.** `Oriserve/Whisper-Hindi2Hinglish-Swift` is a `whisper-base`
  fine-tune — 60 MB at q5_1, RTF 0.069, 233 MB peak RSS — but WER 0.40 against
  Apex's 0.23, and English preservation 0.80 against 1.00.
