### PR TITLE
feat: repair dictated speech before the writing styles run

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ the active cursor. A gateway is never required for on-device mode.
   you want larger models or shared compute. That path is self-hosted, not on-device
 - 54 transcription languages plus Automatic, and four writing styles: Formal,
   Casual, Very Casual, and Excited
+- Clean up speech, on by default: hesitation sounds ("um", "uh"), false starts
+  and repeated words are dropped, and missing sentence punctuation is filled in,
+  entirely on the phone with no model and no network call. Turn it off in
+  Settings, or pick the Raw writing style, and the model's own words go in
+  untouched
 - Optional on-device translation where the model was actually trained for it:
   Canary between English, German, Spanish and French, and the multilingual
   Whisper models into English. Language says what you are speaking; Translate to

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/DictatedTranscript.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/DictatedTranscript.kt
@@ -1,0 +1,41 @@
+package com.vocahq.vocaphone.core
+
+/**
+ * Everything that happens to a transcript between the model returning it and
+ * the record the keyboard inserts from.
+ *
+ * One funnel rather than three call sites, because the *order* is load-bearing
+ * and was previously only implicit:
+ *
+ * 1. Sanitize. The later stages capitalize sentences and add terminators, and
+ *    doing that to `[BLANK_AUDIO]` only makes it look more like something the
+ *    user meant to say.
+ * 2. Repair — the one stage allowed to change the words, and only when the user
+ *    has left Clean up speech on. It runs before styling because it is what
+ *    puts the sentence boundaries *there*: styling capitalizes and terminates
+ *    around boundaries, and cannot find one that is missing. Never for `RAW`,
+ *    which promises the model's own output.
+ * 3. Style — but only for transcripts produced on this device. A gateway has
+ *    already applied the writing style the session asked for, and applying it
+ *    twice is how "Hello." becomes "Hello.." on one route and not the other.
+ *
+ * Mirrors the iOS client's `DictatedTranscript`, minus the digits step, which
+ * only that platform has.
+ */
+object DictatedTranscript {
+    fun finished(
+        raw: String?,
+        style: WritingStyle,
+        language: String = "auto",
+        styledUpstream: Boolean = false,
+        repairSpeech: Boolean,
+    ): String {
+        val cleaned = TranscriptSanitizer.clean(raw)
+        val repaired = if (repairSpeech && style != WritingStyle.RAW) {
+            TranscriptRepair.apply(cleaned, language)
+        } else {
+            cleaned
+        }
+        return if (styledUpstream) repaired else TranscriptStyler.apply(repaired, style, language)
+    }
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/ProtectedSpans.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/ProtectedSpans.kt
@@ -1,0 +1,85 @@
+package com.vocahq.vocaphone.core
+
+/**
+ * The runs of a transcript that no text stage may edit: URLs, email addresses,
+ * bare domains, decimals and times, ordinals, and dotted initialisms.
+ *
+ * Every stage that rewrites punctuation has the same problem — `example.com`
+ * ends in a full stop that is not a sentence, `3.5` contains one that is not a
+ * mark at all — so they all mask first, work on the masked text, and restore
+ * last. The placeholder is a private-use character pair rather than a word, so
+ * a stage that lowercases or capitalizes cannot damage it and a stage that
+ * splits on letters cannot split it.
+ */
+class ProtectedSpans private constructor(
+    val text: String,
+    private val tokens: List<String>,
+) {
+    /**
+     * Puts the original spans back. Takes the text rather than reading [text],
+     * because the caller has rewritten everything around them.
+     */
+    fun restore(masked: String): String = PLACEHOLDER.replace(masked) { match ->
+        tokens.getOrNull(match.groupValues[1].toInt()) ?: match.value
+    }
+
+    companion object {
+        const val OPEN = '\uE000'
+        const val CLOSE = '\uE001'
+
+        /**
+         * Top-level domains a bare hostname is allowed to end in, plus any
+         * two-letter country code.
+         *
+         * Matching *any* dotted pair instead — which this did — masks
+         * `report.Then` in "I finished the report.Then I left" and the missing
+         * space after the full stop can then never be repaired. Deliberately
+         * case-sensitive: a real domain is written in lowercase, and `.To` at
+         * the start of a sentence is not one.
+         */
+        private const val TOP_LEVEL_DOMAINS =
+            "com|org|net|edu|gov|int|mil|io|dev|app|ai|co|me|tv|cc|xyz|info|biz" +
+                "|online|site|tech|store|blog|cloud|link|live|news|shop|space|wiki|zone" +
+                "|[a-z]{2}"
+
+        private val SPANS = Regex(
+            """((?i:https?)://[^\s]+[^\s.,;:!?"“”'\)\]]""" +
+                """|[\w.+-]+@(?:[\w-]+\.)+[A-Za-z]{2,}""" +
+                """|(?:[\w-]+\.)+(?:$TOP_LEVEL_DOMAINS)\b""" +
+                // A path may contain dots; it may not end on the full stop that
+                // ends the sentence the address is sitting in.
+                """(?:/[^\s]*[^\s.,;:!?"“”'\)\]])?""" +
+                """|\d+(?:[.,:/]\d+)+""" +
+                """|\d+(?i:st|nd|rd|th)\b""" +
+                """|(?:[A-Za-z]\.){2,})""",
+        )
+
+        private val PLACEHOLDER = Regex("$OPEN(\\d+)$CLOSE")
+
+        fun mask(text: String): ProtectedSpans {
+            val matches = SPANS.findAll(text).toList()
+            var result = text
+            for (index in matches.indices.reversed()) {
+                result = result.replaceRange(matches[index].range, "$OPEN$index$CLOSE")
+            }
+            return ProtectedSpans(result, matches.map { it.value })
+        }
+
+        /**
+         * Applies [transform] to everything that is not a placeholder. Case
+         * changes have to skip them: the digits inside would survive, but the
+         * characters are the only thing [restore] can match on.
+         */
+        fun mapOutsidePlaceholders(text: String, transform: (String) -> String): String {
+            val result = StringBuilder(text.length)
+            var end = 0
+            PLACEHOLDER.findAll(text).forEach { match ->
+                result.append(transform(text.substring(end, match.range.first)))
+                result.append(match.value)
+                end = match.range.last + 1
+            }
+            result.append(transform(text.substring(end)))
+            return result.toString()
+        }
+    }
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/ProtectedSpans.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/ProtectedSpans.kt
@@ -28,27 +28,46 @@ class ProtectedSpans private constructor(
         const val CLOSE = '\uE001'
 
         /**
-         * Top-level domains a bare hostname is allowed to end in, plus any
-         * two-letter country code.
-         *
-         * Matching *any* dotted pair instead — which this did — masks
-         * `report.Then` in "I finished the report.Then I left" and the missing
-         * space after the full stop can then never be repaired. Deliberately
-         * case-sensitive: a real domain is written in lowercase, and `.To` at
-         * the start of a sentence is not one.
+         * Top-level domains common enough to recognize even when the name in
+         * front of them was capitalized — "Example.com" opening a sentence.
          */
         private const val TOP_LEVEL_DOMAINS =
             "com|org|net|edu|gov|int|mil|io|dev|app|ai|co|me|tv|cc|xyz|info|biz" +
                 "|online|site|tech|store|blog|cloud|link|live|news|shop|space|wiki|zone" +
                 "|[a-z]{2}"
 
+        /**
+         * Any other bare hostname, recognized by case rather than by a list.
+         *
+         * There are roughly 1,500 top-level domains, so an allowlist misses
+         * real ones — `example.museum` — and punctuation repair then splits the
+         * address in half. Matching *any* dotted pair instead has the opposite
+         * fault: it masks `report.Then` in "I finished the report.Then I left",
+         * and the missing space can never be repaired.
+         *
+         * Case is what actually separates them. A hostname is written in
+         * lowercase from end to end; a full stop that ended a sentence is
+         * followed by a capital. This clause requires the former, and the
+         * leading `\b` keeps it from matching the tail of a capitalized word.
+         *
+         * What is left over is `report.then` — an all-lowercase run-on, from an
+         * engine that emits a full stop but no capital. That one is genuinely
+         * ambiguous, and it is masked, because leaving a space out is a blemish
+         * where breaking an address in half is data loss.
+         */
+        private const val LOWERCASE_HOSTNAME = """\b(?:[a-z0-9][a-z0-9-]*\.)+[a-z]{2,24}\b"""
+
+        /**
+         * A path may contain dots; it may not end on the full stop that ends
+         * the sentence the address is sitting in.
+         */
+        private const val PATH = """(?:/[^\s]*[^\s.,;:!?"“”'\)\]])?"""
+
         private val SPANS = Regex(
             """((?i:https?)://[^\s]+[^\s.,;:!?"“”'\)\]]""" +
                 """|[\w.+-]+@(?:[\w-]+\.)+[A-Za-z]{2,}""" +
-                """|(?:[\w-]+\.)+(?:$TOP_LEVEL_DOMAINS)\b""" +
-                // A path may contain dots; it may not end on the full stop that
-                // ends the sentence the address is sitting in.
-                """(?:/[^\s]*[^\s.,;:!?"“”'\)\]])?""" +
+                """|(?:[\w-]+\.)+(?:$TOP_LEVEL_DOMAINS)\b$PATH""" +
+                """|$LOWERCASE_HOSTNAME$PATH""" +
                 """|\d+(?:[.,:/]\d+)+""" +
                 """|\d+(?i:st|nd|rd|th)\b""" +
                 """|(?:[A-Za-z]\.){2,})""",

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/ProtectedSpans.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/ProtectedSpans.kt
@@ -45,14 +45,19 @@ class ProtectedSpans private constructor(
          * so this asks about the last label and nothing else. The leading `\b`
          * keeps it from matching the tail of a longer word.
          *
-         * Two things are left over, both preferred to the alternative. An
-         * all-caps `EXAMPLE.COM` is not recognized, and `report.then` — an
-         * all-lowercase run-on, from an engine that emits a full stop but no
-         * capital — is masked as though it were a hostname. Neither is a shape
-         * a speech model realistically produces, and where the two errors do
-         * meet, a missing space is a blemish and a broken address is data loss.
+         * All caps counts too, so `NASA.GOV` survives. What that cannot be is a
+         * sentence boundary: an engine that shouts the word after a full stop
+         * shouted the one before it as well, and `report.THEN` is not a shape
+         * any of them produce. Title Case is the one that stays out —
+         * `report.Then` is the sentence boundary this whole clause exists to
+         * preserve.
+         *
+         * One thing is left over: `report.then`, an all-lowercase run-on from an
+         * engine that emits a full stop but no capital, is masked as though it
+         * were a hostname. That shape is genuinely ambiguous, and a missing
+         * space is a blemish where a broken address is data loss.
          */
-        private const val HOSTNAME = """\b(?:[\w-]+\.)+[a-z]{2,24}\b"""
+        private const val HOSTNAME = """\b(?:[\w-]+\.)+(?:[a-z]{2,24}|[A-Z]{2,24})\b"""
 
         /**
          * A path may contain dots; it may not end on the full stop that ends

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/ProtectedSpans.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/ProtectedSpans.kt
@@ -28,34 +28,31 @@ class ProtectedSpans private constructor(
         const val CLOSE = '\uE001'
 
         /**
-         * Top-level domains common enough to recognize even when the name in
-         * front of them was capitalized — "Example.com" opening a sentence.
+         * A bare hostname, recognized by the case of its last label rather than
+         * by a list of top-level domains.
+         *
+         * An allowlist cannot work: there are roughly 1,500 top-level domains,
+         * and every one left off it — `example.museum` — gets its dot read as
+         * sentence punctuation and the address split in half. Matching *any*
+         * dotted pair instead has the opposite fault: it masks `report.Then` in
+         * "I finished the report.Then I left", and the missing space can never
+         * be repaired.
+         *
+         * The whole signal is in the label **after** the final dot. A top-level
+         * domain is written in lowercase; a full stop that ended a sentence is
+         * followed by a capital. Nothing before that dot carries information —
+         * requiring the name to be lowercase too only loses `Example.museum` —
+         * so this asks about the last label and nothing else. The leading `\b`
+         * keeps it from matching the tail of a longer word.
+         *
+         * Two things are left over, both preferred to the alternative. An
+         * all-caps `EXAMPLE.COM` is not recognized, and `report.then` — an
+         * all-lowercase run-on, from an engine that emits a full stop but no
+         * capital — is masked as though it were a hostname. Neither is a shape
+         * a speech model realistically produces, and where the two errors do
+         * meet, a missing space is a blemish and a broken address is data loss.
          */
-        private const val TOP_LEVEL_DOMAINS =
-            "com|org|net|edu|gov|int|mil|io|dev|app|ai|co|me|tv|cc|xyz|info|biz" +
-                "|online|site|tech|store|blog|cloud|link|live|news|shop|space|wiki|zone" +
-                "|[a-z]{2}"
-
-        /**
-         * Any other bare hostname, recognized by case rather than by a list.
-         *
-         * There are roughly 1,500 top-level domains, so an allowlist misses
-         * real ones — `example.museum` — and punctuation repair then splits the
-         * address in half. Matching *any* dotted pair instead has the opposite
-         * fault: it masks `report.Then` in "I finished the report.Then I left",
-         * and the missing space can never be repaired.
-         *
-         * Case is what actually separates them. A hostname is written in
-         * lowercase from end to end; a full stop that ended a sentence is
-         * followed by a capital. This clause requires the former, and the
-         * leading `\b` keeps it from matching the tail of a capitalized word.
-         *
-         * What is left over is `report.then` — an all-lowercase run-on, from an
-         * engine that emits a full stop but no capital. That one is genuinely
-         * ambiguous, and it is masked, because leaving a space out is a blemish
-         * where breaking an address in half is data loss.
-         */
-        private const val LOWERCASE_HOSTNAME = """\b(?:[a-z0-9][a-z0-9-]*\.)+[a-z]{2,24}\b"""
+        private const val HOSTNAME = """\b(?:[\w-]+\.)+[a-z]{2,24}\b"""
 
         /**
          * A path may contain dots; it may not end on the full stop that ends
@@ -66,8 +63,7 @@ class ProtectedSpans private constructor(
         private val SPANS = Regex(
             """((?i:https?)://[^\s]+[^\s.,;:!?"“”'\)\]]""" +
                 """|[\w.+-]+@(?:[\w-]+\.)+[A-Za-z]{2,}""" +
-                """|(?:[\w-]+\.)+(?:$TOP_LEVEL_DOMAINS)\b$PATH""" +
-                """|$LOWERCASE_HOSTNAME$PATH""" +
+                """|$HOSTNAME$PATH""" +
                 """|\d+(?:[.,:/]\d+)+""" +
                 """|\d+(?i:st|nd|rd|th)\b""" +
                 """|(?:[A-Za-z]\.){2,})""",

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/SentencePunctuation.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/SentencePunctuation.kt
@@ -38,6 +38,20 @@ data class SentencePunctuation(
         /** Marks that never take a space before them and always take one after. */
         const val UNIVERSAL_TERMINATORS = ".!?。！？।۔။។།؟"
 
+        /** Marks that separate parts of a sentence rather than ending one. */
+        const val UNIVERSAL_SEPARATORS = ",;:،、၊"
+
+        /**
+         * Every character the repair stage treats as punctuation, in any
+         * script. One list rather than a per-rule literal, because a rule that
+         * inserts a mark and a rule that spaces around one disagreeing about
+         * what a mark *is* is invisible until a transcript in that script comes
+         * out wrong. Contains no character-class metacharacter, so it can be
+         * interpolated into a `[...]` on both platforms and produce the same
+         * class.
+         */
+        const val UNIVERSAL_MARKS = "$UNIVERSAL_TERMINATORS$UNIVERSAL_SEPARATORS…"
+
         val LATIN = SentencePunctuation(".", ",", "!", "?", ".!?", " ")
         val CJK = SentencePunctuation("。", "、", "！", "？", "。！？.!?", "")
         val ARABIC = SentencePunctuation(".", "،", "!", "؟", ".!?؟", " ")

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/SentencePunctuation.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/SentencePunctuation.kt
@@ -1,0 +1,101 @@
+package com.vocahq.vocaphone.core
+
+/**
+ * The marks a script closes a sentence with, and the rule for deciding which
+ * script a transcript is written in.
+ *
+ * Shared by [TranscriptRepair], which *inserts* marks, and [TranscriptStyler],
+ * which formats around marks that are already there. Two copies of this table
+ * would drift, and the visible failure is a Hindi transcript that one stage
+ * ends with a danda and the other with a full stop.
+ */
+data class SentencePunctuation(
+    val terminator: String,
+    val separator: String,
+    val exclamation: String,
+    val question: String,
+    /**
+     * Every mark that can close a sentence: this script's, plus the ones a
+     * model borrows from other scripts often enough to matter.
+     */
+    val terminators: String,
+    /**
+     * What sits between two sentences. Empty for the scripts that do not put a
+     * space after their punctuation.
+     */
+    val join: String,
+) {
+    /**
+     * Whether sentences here are built the way English builds them — a full
+     * stop, a following space, a capital. [TranscriptRepair]'s inference rules
+     * are written against English and are a no-op in any other Latin language,
+     * but a script that spaces or terminates differently would be damaged by
+     * them.
+     */
+    val usesLatinLayout: Boolean get() = join == " " && terminator == "."
+
+    companion object {
+        /** Marks that never take a space before them and always take one after. */
+        const val UNIVERSAL_TERMINATORS = ".!?。！？।۔။។།؟"
+
+        val LATIN = SentencePunctuation(".", ",", "!", "?", ".!?", " ")
+        val CJK = SentencePunctuation("。", "、", "！", "？", "。！？.!?", "")
+        val ARABIC = SentencePunctuation(".", "،", "!", "؟", ".!?؟", " ")
+        val URDU = SentencePunctuation("۔", "،", "!", "؟", "۔.!?؟", " ")
+        val DANDA = SentencePunctuation("।", ",", "!", "?", "।.!?", " ")
+
+        /**
+         * Scripts written with a full stop rather than the danda their
+         * neighbours use. Still accepts a danda on input, because a
+         * multilingual model emits one for Tamil often enough.
+         */
+        val INDIC_LATIN = SentencePunctuation(".", ",", "!", "?", "।.!?", " ")
+
+        /** Thai and Lao close a sentence with a space, not a mark. */
+        val UNTERMINATED = SentencePunctuation("", " ", "!", "?", "!?", " ")
+        val BURMESE = SentencePunctuation("။", "၊", "!", "?", "။.!?", " ")
+        val KHMER = SentencePunctuation("។", ",", "!", "?", "។.!?", " ")
+        val TIBETAN = SentencePunctuation("།", "།", "!", "?", "།.!?", " ")
+
+        /**
+         * The profile for [language], falling back to what the text itself is
+         * written in when the engine reported nothing (Automatic).
+         */
+        fun resolve(language: String, text: String): SentencePunctuation {
+            val base = when (language.lowercase().substringBefore('-')) {
+                "ja", "zh", "yue" -> CJK
+                "ar", "fa", "ps" -> ARABIC
+                "ur", "sd", "ks" -> URDU
+                "hi", "mr", "ne", "bn", "as", "pa" -> DANDA
+                "ta", "te", "kn", "ml", "gu", "si" -> INDIC_LATIN
+                "th", "lo" -> UNTERMINATED
+                "my" -> BURMESE
+                "km" -> KHMER
+                "bo" -> TIBETAN
+                else -> when {
+                    text.any { it in "。、！？" } -> CJK
+                    text.any { it in "،؟" } -> ARABIC
+                    text.contains('۔') -> URDU
+                    text.contains('।') || containsDandaScript(text) -> DANDA
+                    else -> LATIN
+                }
+            }
+            val merged = StringBuilder()
+            for (character in UNIVERSAL_TERMINATORS + base.terminators) {
+                if (character !in merged) merged.append(character)
+            }
+            return base.copy(terminators = merged.toString())
+        }
+
+        /**
+         * Devanagari, Bengali/Assamese, and Gurmukhi conventionally use the
+         * danda. This is the fallback when Automatic was selected and the
+         * engine did not expose the language it detected.
+         */
+        fun containsDandaScript(text: String): Boolean = text.any { character ->
+            character.code in 0x0900..0x097F ||
+                character.code in 0x0980..0x09FF ||
+                character.code in 0x0A00..0x0A7F
+        }
+    }
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptRepair.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptRepair.kt
@@ -146,24 +146,52 @@ object TranscriptRepair {
     private val LITERAL_EXCEPTIONS = setOf("err")
 
     /**
+     * How many markers a transcript needs before Automatic will treat it as
+     * English.
+     *
+     * One is not enough. A German sentence only has to brush against a single
+     * English-looking word to lose its "er", and "er kommt her" did exactly
+     * that. Two independent markers is a far higher bar for an accident to
+     * clear, and English prose of any length clears it easily.
+     */
+    private const val ENGLISH_MARKERS_NEEDED = 2
+
+    /**
      * High-frequency English words that are **not** also words in the other
      * Latin-script languages this app transcribes. That exclusion is the whole
-     * point of the list, so it is shorter than a frequency table would be:
+     * point of the list, so it is much shorter than a frequency table would be:
      * `is` is Dutch, `was` and `will` are German, `for` is Danish, `of` is
-     * Dutch for "or", and `i` is Danish for "in". Any of those would call a
-     * German sentence English and cost it an "um".
+     * Dutch for "or", `i` is Danish for "in", `her` is German for "hither",
+     * `over` is Dutch, `want` is Dutch for "because", and `come` is Italian for
+     * "how". Any of those would call a foreign sentence English and cost it a
+     * word.
      */
     private val ENGLISH_MARKERS = setOf(
         "the", "and", "you", "your", "yours", "with", "that", "thats", "this",
         "these", "those", "what", "whats", "which", "when", "where", "who",
         "how", "have", "has", "had", "are", "were", "been", "being",
         "not", "dont", "doesnt", "didnt", "isnt", "arent", "cant", "wont",
-        "it", "its", "they", "them", "their", "theyre", "she", "her", "his",
-        "there", "theres", "would", "could", "should", "about", "because",
-        "know", "think", "going", "please", "thanks", "very", "again", "only",
-        "over", "some", "than", "then", "through", "want", "need", "make",
-        "made", "take", "come", "from", "more", "most", "much", "many",
+        "wouldnt", "couldnt", "shouldnt", "havent", "hasnt",
+        "it", "its", "they", "them", "their", "theyre", "theres", "wheres",
+        "she", "his", "there", "would", "could", "should", "about", "because",
+        "know", "knew", "think", "thought", "going", "please", "thanks",
+        "very", "again", "only", "some", "than", "then", "through",
+        "need", "make", "made", "take", "took", "from", "more", "most",
+        "much", "many", "something", "anything", "everything", "nothing",
+        "yeah", "gonna", "wanna", "gotta", "ive", "youre", "youve",
+        "today", "tomorrow", "yesterday", "here", "there", "everyone",
+        "people", "thing", "things", "time", "good", "great", "sure",
+        "right", "wrong", "back", "down", "off", "got", "getting",
+        "said", "told", "asked", "does", "did", "doing", "actually",
+        "probably", "really", "always", "never", "maybe",
     )
+
+    /**
+     * Letters that belong to another Latin alphabet. A transcript carrying one
+     * is not English whatever else it contains, and this is the cheapest hard
+     * veto available before counting anything.
+     */
+    private const val FOREIGN_LETTERS = "äöüßåæøœçñõãêôîûàèìòùáéíóúýðþğışłżźćęą"
 
     /**
      * Only the non-lexical hesitation sounds, same bar as [UNIVERSAL_FILLERS].
@@ -208,15 +236,26 @@ object TranscriptRepair {
     }
 
     /**
-     * Whether the English filler set applies. An explicit English transcript
-     * always qualifies; on Automatic the sentence has to say so itself, which
-     * keeps a German "um acht Uhr" intact at the cost of leaving a filler in a
-     * two-word English fragment that carries no marker.
+     * Whether the English filler set applies.
+     *
+     * An explicit `en` always qualifies, and so does a language the engine
+     * detected as English. On Automatic nothing has said what the language is,
+     * so the sentence has to say it itself — twice over, and without a letter
+     * from another alphabet in it.
+     *
+     * The cost is a filler left in a short English fragment that carries fewer
+     * than two markers. That is the right direction to be wrong in: leaving an
+     * "um" is a blemish, and deleting the subject of a German sentence is not.
      */
     private fun looksEnglish(code: String, words: List<Word>): Boolean {
         if (code == "en") return true
         if (code.isNotEmpty() && code != "auto") return false
-        return words.any { it.key in ENGLISH_MARKERS }
+        val seen = mutableSetOf<String>()
+        for (word in words) {
+            if (word.text.lowercase().any { it in FOREIGN_LETTERS }) return false
+            if (word.key in ENGLISH_MARKERS) seen += word.key
+        }
+        return seen.size >= ENGLISH_MARKERS_NEEDED
     }
 
     private fun isFiller(word: Word, code: String, english: Boolean): Boolean {
@@ -268,28 +307,30 @@ object TranscriptRepair {
     // region False starts
 
     /**
-     * Words whose immediate repeat is a stutter rather than a sentence.
-     * Closed-class only: an article or a pronoun said twice in a row is the
-     * speaker restarting, where a repeated content word ("very very") is
-     * emphasis the speaker meant.
+     * Words whose immediate repeat is a stutter and essentially never grammar:
+     * determiners, prepositions, conjunctions and subject pronouns. A repeated
+     * content word ("very very") is emphasis the speaker meant, and is not here.
+     *
+     * Deliberately narrower than "closed class". A copula, an auxiliary or a
+     * possessive or a modal doubles legitimately far too often to guess at —
+     * "what it is is a problem", "the things I have have value", "I gave her
+     * her coat", "I can can peaches", "there, there" — so none of those are
+     * here either. The cost of leaving a real stutter in is a duplicated word;
+     * the cost of being wrong is a deleted one.
      */
     private val FUNCTION_WORDS = setOf(
-        "the", "a", "an", "and", "but", "so", "or", "to", "of", "in", "on", "at",
-        "for", "with", "from", "by", "as", "if", "then", "than",
+        "the", "a", "an", "and", "but", "or", "to", "of", "in", "on", "at",
+        "for", "with", "from", "by", "as", "if", "than",
         "i", "you", "we", "they", "he", "she", "it", "this", "these", "those",
-        "there", "my", "your", "our", "their", "his", "her", "its",
-        "is", "are", "was", "were", "am", "be", "been",
-        "do", "does", "did", "have", "has",
-        "can", "could", "will", "would", "should", "must",
         "what", "when", "where", "why", "who", "how",
     )
 
     /**
-     * Doubles that are ordinary English. "The thing that that man said" and
-     * "she had had enough" are both correct, and both look exactly like a
-     * stutter to a rule that only compares two words.
+     * Doubles that are ordinary English even though the word is on the list
+     * above. "The thing that that man said" is correct, and looks exactly like
+     * a stutter to a rule that only compares two words.
      */
-    private val LEGITIMATE_DOUBLES = setOf("that", "had")
+    private val LEGITIMATE_DOUBLES = setOf("that")
 
     /**
      * Longest false start collapsed. Beyond this it is a repeated sentence,
@@ -303,6 +344,11 @@ object TranscriptRepair {
      * Only an immediate repeat, and only the second copy is kept, because it is
      * the copy the speaker carried on from: "we should, we should probably
      * ship" has the comma on the abandoned half and the sentence on the other.
+     *
+     * A multi-word repeat also has to be followed by something. That is what
+     * separates a false start from a phrase said twice on purpose: the speaker
+     * who restarts goes on to finish the sentence, where "I love you I love
+     * you" and "no no no no" end where they end.
      */
     private fun collapseStutters(text: String, punctuation: SentencePunctuation): String {
         val words = split(text)
@@ -338,6 +384,9 @@ object TranscriptRepair {
         punctuation: SentencePunctuation,
     ): Boolean {
         if (index + length * 2 > words.size) return false
+        // A repeat with nothing after it was said twice on purpose. A false
+        // start is the beginning of a sentence the speaker then finishes.
+        if (length > 1 && index + length * 2 >= words.size) return false
         for (offset in 0 until length) {
             val first = words[index + offset]
             val second = words[index + length + offset]
@@ -483,6 +532,14 @@ object TranscriptRepair {
         "all", "more", "less", "about", "mostly", "otherwise", "apparently",
     )
 
+    /**
+     * Quantifiers that turn an opener into a phrase. "However many people
+     * come" means "no matter how many", and the comma would say the opposite.
+     */
+    private val QUANTIFIER_FOLLOWERS = setOf(
+        "many", "much", "long", "far", "little", "few", "often", "else",
+    )
+
     private val AUXILIARIES = setOf(
         "do", "does", "did", "dont", "doesnt", "didnt",
         "is", "are", "was", "were", "isnt", "arent", "wasnt", "werent",
@@ -503,6 +560,14 @@ object TranscriptRepair {
         "what", "whats", "when", "whens", "where", "wheres",
         "why", "whys", "who", "whos", "whom", "whose", "how", "hows",
     )
+
+    /**
+     * A `how` question may put a quantifier and its noun in front of the
+     * auxiliary: "How many people are coming?". That is a question shape, not
+     * the noun-clause shape that makes "what the problem is remains unclear" a
+     * statement.
+     */
+    private val HOW_QUANTIFIERS = setOf("many", "much")
 
     private val SUBJECT_PRONOUNS = setOf(
         "i", "you", "we", "they", "he", "she", "it", "there",
@@ -564,6 +629,7 @@ object TranscriptRepair {
             val length = match(OPENERS_TAKING_COMMA, words, index) ?: continue
             if (words[index + length - 1].trailing.isNotEmpty()) continue
             if (index + length + 2 > words.size) continue
+            if (words[index + length].key in QUANTIFIER_FOLLOWERS) continue
             words[index + length - 1].trailing = punctuation.separator
         }
     }
@@ -628,12 +694,27 @@ object TranscriptRepair {
         val keys = sentence.map { words[it].key }
         if (keys.size < 2) return false
         if (keys[0] in QUESTION_WORDS) {
-            // "What time is it" asks; "What I meant was simple" states. Both
-            // reach an auxiliary, but only the second puts a subject in front
-            // of it — the wh-word is that clause's own subject or object.
-            for (offset in 1 until minOf(keys.size, 4)) {
+            // "What time is it" asks; "What I meant was simple" and "what the
+            // problem is remains unclear" state. A question inverts the
+            // auxiliary to the front, so it turns up within a word or two of
+            // the wh-word; an embedded noun clause puts a whole subject there
+            // first and pushes the auxiliary back.
+            //
+            // Two words of room is the normal allowance. "How many people are
+            // coming" has a quantifier and its noun in front of the auxiliary,
+            // so it gets one extra explicitly-recognized shape. Reading "what
+            // john said was wrong" as a question is not worth that wider rule.
+            for (offset in 1 until minOf(keys.size, 3)) {
                 if (keys[offset] in SUBJECT_PRONOUNS) return false
+                if (keys[offset] in DETERMINERS) return false
                 if (keys[offset] in AUXILIARIES) return true
+            }
+            if (keys.size >= 4 &&
+                keys[0] == "how" &&
+                keys[1] in HOW_QUANTIFIERS &&
+                keys[3] in AUXILIARIES
+            ) {
+                return true
             }
             return false
         }

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptRepair.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptRepair.kt
@@ -107,24 +107,63 @@ object TranscriptRepair {
     // region Fillers
 
     /**
-     * The hesitation sounds, after [canonical] has flattened however many
-     * letters the model chose to spell them with.
+     * Hesitation sounds that are not a word in any language this app
+     * transcribes, so they can go whatever was spoken.
      *
-     * Every one of these is non-lexical: there is no sentence in which the word
-     * carries meaning, which is the whole reason removing it is safe. That is
-     * also why `like`, `you know`, `I mean` and `actually` are **not** here.
-     * Each is a real word often enough that dropping it needs judgement about
-     * what the speaker meant, and this stage does not have any.
+     * Every one is non-lexical: there is no sentence in which it carries
+     * meaning, which is the whole reason removing it is safe. That is also why
+     * `like`, `you know`, `I mean` and `actually` are **not** here. Each is a
+     * real word often enough that dropping it needs judgement about what the
+     * speaker meant, and this stage does not have any.
      */
-    private val UNIVERSAL_FILLERS = setOf("um", "uhm", "umh", "uh", "er", "erm", "hm")
+    private val ALWAYS_SAFE_FILLERS = setOf("uh", "uhm", "umh", "erm", "hm")
+
+    /**
+     * English hesitation sounds that are ordinary words somewhere else.
+     *
+     * `um` is German for "at" — "um acht Uhr" — and `er` is German for "he" and
+     * Dutch for "there". Dropping them from a German transcript deletes
+     * content, so they go only when the transcript is English, or when
+     * Automatic was selected and [looksEnglish] recognizes the sentence around
+     * them.
+     */
+    private val ENGLISH_FILLERS = setOf("um", "er")
 
     /**
      * Sounds that mean *yes* or *no*, and must survive. `mhm` and `uh-huh` are
      * answers to a question, and a transcript that drops them says the opposite
      * of what was said. They are listed rather than merely absent so that
-     * widening [UNIVERSAL_FILLERS] cannot quietly swallow one.
+     * widening the filler sets cannot quietly swallow one.
      */
     private val AFFIRMATIONS = setOf("mhm", "mhmm", "mmhm", "uhuh", "uhhuh", "nuhuh", "huh", "hu")
+
+    /**
+     * Words that reach a filler spelling only because [canonical] flattens
+     * repeated letters, and so have to be caught before it runs. "Err on the
+     * side of caution" is the verb; a model writing a hesitation as `err`
+     * rather than `uh` is rare enough that keeping the word wins.
+     */
+    private val LITERAL_EXCEPTIONS = setOf("err")
+
+    /**
+     * High-frequency English words that are **not** also words in the other
+     * Latin-script languages this app transcribes. That exclusion is the whole
+     * point of the list, so it is shorter than a frequency table would be:
+     * `is` is Dutch, `was` and `will` are German, `for` is Danish, `of` is
+     * Dutch for "or", and `i` is Danish for "in". Any of those would call a
+     * German sentence English and cost it an "um".
+     */
+    private val ENGLISH_MARKERS = setOf(
+        "the", "and", "you", "your", "yours", "with", "that", "thats", "this",
+        "these", "those", "what", "whats", "which", "when", "where", "who",
+        "how", "have", "has", "had", "are", "were", "been", "being",
+        "not", "dont", "doesnt", "didnt", "isnt", "arent", "cant", "wont",
+        "it", "its", "they", "them", "their", "theyre", "she", "her", "his",
+        "there", "theres", "would", "could", "should", "about", "because",
+        "know", "think", "going", "please", "thanks", "very", "again", "only",
+        "over", "some", "than", "then", "through", "want", "need", "make",
+        "made", "take", "come", "from", "more", "most", "much", "many",
+    )
 
     /**
      * Only the non-lexical hesitation sounds, same bar as [UNIVERSAL_FILLERS].
@@ -155,37 +194,54 @@ object TranscriptRepair {
     /**
      * Collapses a run of one repeated letter, so however long the model drew
      * the sound out it lands on the same key: `ummmm` and `uhhh` become `um`
-     * and `uh`. Also drops the hyphen in `uh-huh`, which is why that spelling
-     * reaches [AFFIRMATIONS] intact.
+     * and `uh`. `uh-huh` arrives with its hyphen already gone — [Word.key]
+     * keeps only letters and digits — and so reaches [AFFIRMATIONS] intact.
      */
     private fun canonical(key: String): String {
         val result = StringBuilder(key.length)
         var previous: Char? = null
         for (character in key) {
-            if (character == '-') continue
             if (character != previous) result.append(character)
             previous = character
         }
         return result.toString()
     }
 
-    private fun isFiller(word: Word, code: String): Boolean {
+    /**
+     * Whether the English filler set applies. An explicit English transcript
+     * always qualifies; on Automatic the sentence has to say so itself, which
+     * keeps a German "um acht Uhr" intact at the cost of leaving a filler in a
+     * two-word English fragment that carries no marker.
+     */
+    private fun looksEnglish(code: String, words: List<Word>): Boolean {
+        if (code == "en") return true
+        if (code.isNotEmpty() && code != "auto") return false
+        return words.any { it.key in ENGLISH_MARKERS }
+    }
+
+    private fun isFiller(word: Word, code: String, english: Boolean): Boolean {
         if (word.isProtected) return false
         // A quoted filler is being talked about rather than said: someone
         // dictating `he said "um" a lot` means the word to be there.
         if (word.leading.any { it in QUOTES } || word.trailing.any { it in QUOTES }) return false
-        val key = canonical(word.key)
-        if (key.isEmpty() || key in AFFIRMATIONS) return false
-        return key in UNIVERSAL_FILLERS || LOCAL_FILLERS[code]?.contains(key) == true
+        val raw = word.key
+        if (raw.isEmpty() || raw in LITERAL_EXCEPTIONS) return false
+        val key = canonical(raw)
+        if (key in AFFIRMATIONS) return false
+        if (key in ALWAYS_SAFE_FILLERS) return true
+        if (english && key in ENGLISH_FILLERS) return true
+        return LOCAL_FILLERS[code]?.contains(key) == true
     }
 
     private fun removeFillers(text: String, code: String): String {
         var result = text
         UNSPACED_FILLERS[code]?.forEach { filler -> result = result.replace(filler, "") }
 
+        val words = split(result)
+        val english = looksEnglish(code, words)
         val kept = mutableListOf<Word>()
-        for (word in split(result)) {
-            if (!isFiller(word, code)) {
+        for (word in words) {
+            if (!isFiller(word, code, english)) {
                 kept += word
                 continue
             }
@@ -311,15 +367,20 @@ object TranscriptRepair {
      */
     private fun repairMarks(text: String, punctuation: SentencePunctuation): String {
         var result = text.replace(Regex("\\s+"), " ").trim()
+        // Built from the shared sets rather than a literal per rule, so the
+        // Swift original cannot quietly cover a different set of scripts.
+        val marks = "[${SentencePunctuation.UNIVERSAL_MARKS}]"
+        val terminators = "[${SentencePunctuation.UNIVERSAL_TERMINATORS}]"
+        val separators = "[${SentencePunctuation.UNIVERSAL_SEPARATORS}]"
 
         // Never a space before a mark.
-        result = result.replace(Regex("\\s+([.!?。！？।۔،,;:、၊…])"), "$1")
+        result = result.replace(Regex("\\s+($marks)"), "$1")
         // A run of one separator is one separator.
-        result = result.replace(Regex("([,;:、])\\1+"), "$1")
+        result = result.replace(Regex("($separators)\\1+"), "$1")
         // A separator touching a terminator: the terminator wins, whichever
         // order the model put them in.
-        result = result.replace(Regex("[,;:、]\\s*([.!?。！？।۔])"), "$1")
-        result = result.replace(Regex("([.!?。！？।۔])\\s*[,;:、]"), "$1")
+        result = result.replace(Regex("$separators\\s*($terminators)"), "$1")
+        result = result.replace(Regex("($terminators)\\s*$separators"), "$1")
         // Shouting and stammering. Four or more stops is an ellipsis that got
         // away; three stays an ellipsis.
         result = result.replace(Regex("!{2,}"), "!")
@@ -331,17 +392,20 @@ object TranscriptRepair {
         if (punctuation.join == " ") {
             // Always a space after a mark, unless another mark follows it —
             // that is an ellipsis or a quoted close, not two sentences.
-            result = result.replace(Regex("([,;:])(?=[^\\s,;:.!?…\\)\\]\"”’])"), "$1 ")
             result = result.replace(
-                Regex("([.!?])(?=[\\p{L}\\p{N}${ProtectedSpans.OPEN}])"),
+                Regex("($separators)(?=[^\\s${SentencePunctuation.UNIVERSAL_MARKS}\\)\\]\"”’])"),
+                "$1 ",
+            )
+            result = result.replace(
+                Regex("($terminators)(?=[\\p{L}\\p{N}${ProtectedSpans.OPEN}])"),
                 "$1 ",
             )
         }
 
         // A mark with nothing in front of it, and a separator with nothing
         // after it, are both left over from something that was removed.
-        result = result.replace(Regex("^[\\s,;:.!?、。…]+"), "")
-        result = result.replace(Regex("[,;:、]+\\s*$"), "")
+        result = result.replace(Regex("^[\\s${SentencePunctuation.UNIVERSAL_MARKS}]+"), "")
+        result = result.replace(Regex("($separators)+\\s*$"), "")
         return result.trim()
     }
 
@@ -388,19 +452,35 @@ object TranscriptRepair {
         "maybe", "now", "then", "today", "tomorrow", "yesterday",
     )
 
-    /** "so that", "but as" — a phrase, not a new clause. */
-    private val NOT_CLAUSE_STARTERS = setOf("that", "much", "many", "far", "long", "as")
+    /**
+     * After a conjunction these continue the phrase rather than opening a
+     * clause: "so that", "so much", "but as".
+     */
+    private val PHRASE_FOLLOWERS = setOf("that", "much", "many", "far", "long", "as")
+
+    private val DETERMINERS = setOf("the", "a", "an")
 
     /**
-     * After one of these, `okay` and `alright` are adjectives describing
-     * something, not somebody starting a sentence.
+     * Openers that are neither a subject nor an auxiliary but still start a
+     * sentence often enough to count as one beginning.
      */
-    private val COPULAS = setOf(
+    private val CLAUSE_OPENERS = setOf("so", "well", "just", "first", "next")
+
+    /**
+     * After one of these, `okay` and `alright` are describing something — "the
+     * results came back okay" — rather than somebody starting a new sentence.
+     * Copulas and the particles that finish a phrasal verb, which is the other
+     * position an adjective lands in.
+     */
+    private val ADJECTIVE_PREDECESSORS = setOf(
         "is", "are", "was", "were", "am", "be", "been", "being",
         "seem", "seems", "seemed", "look", "looks", "looked",
         "feel", "feels", "felt", "sound", "sounds", "sounded",
+        "went", "goes", "going", "gone", "doing", "does", "works", "worked",
+        "turned", "came", "back", "out", "up", "fine", "along",
         "not", "quite", "pretty", "totally", "perfectly", "really",
-        "its", "thats", "everything", "all", "more", "less", "about",
+        "its", "thats", "everything", "anything", "something", "nothing",
+        "all", "more", "less", "about", "mostly", "otherwise", "apparently",
     )
 
     private val AUXILIARIES = setOf(
@@ -409,6 +489,14 @@ object TranscriptRepair {
         "can", "cant", "could", "couldnt", "will", "wont", "would", "wouldnt",
         "should", "shouldnt", "shall", "may", "might", "must",
         "have", "has", "had", "havent", "hasnt", "hadnt", "am",
+    )
+
+    /**
+     * Modals that turn an inverted `had`/`were` opening into a condition rather
+     * than a question: "Had I known that, I would have called."
+     */
+    private val CONDITIONAL_MODALS = setOf(
+        "would", "could", "should", "might", "wouldve", "couldve", "shouldve",
     )
 
     private val QUESTION_WORDS = setOf(
@@ -446,11 +534,16 @@ object TranscriptRepair {
         var index = 1
         while (index < words.size) {
             val length = match(SENTENCE_STARTERS, words, index)
+            // A marker only ends the previous sentence when a clause of its own
+            // follows. "The results came back okay and we shipped" is one
+            // sentence; "…came back okay lets ship" is two, and the difference
+            // is entirely the next word.
             if (length == null ||
                 index + length + 2 > words.size ||
                 wordsSinceMark(words, index) < 4 ||
                 words[index - 1].trailing.isNotEmpty() ||
-                words[index - 1].key in COPULAS
+                words[index - 1].key in ADJECTIVE_PREDECESSORS ||
+                !startsClause(words[index + length].key)
             ) {
                 index++
                 continue
@@ -490,7 +583,11 @@ object TranscriptRepair {
             if (words[index - 1].trailing.isNotEmpty()) continue
             if (wordsSinceMark(words, index) < 4) continue
             val next = words[index + 1].key
-            if (next !in CLAUSE_STARTERS || next in NOT_CLAUSE_STARTERS) continue
+            if (next !in CLAUSE_STARTERS || next in PHRASE_FOLLOWERS) continue
+            // A determiner is the ambiguous case: "…but the tests are failing"
+            // is a clause, "…but the truth" is an object. Only the first has
+            // room for a verb after it.
+            if (next in DETERMINERS && index + 4 > words.size) continue
             words[index - 1].trailing = punctuation.separator
         }
     }
@@ -502,15 +599,29 @@ object TranscriptRepair {
      */
     private fun markQuestions(words: MutableList<Word>, punctuation: SentencePunctuation) {
         for (sentence in sentences(words, punctuation)) {
-            val last = words[sentence.last]
-            val closing = last.trailing.lastOrNull()
-            val open = closing == null || closing !in punctuation.terminators
-            if (!open && closing.toString() != punctuation.terminator) continue
+            val existing = words[sentence.last].trailing.lastOrNull {
+                it in punctuation.terminators
+            }
+            // A sentence the model closed with `!` was a choice. One it closed
+            // with the plain terminator, or did not close at all, was not.
+            if (existing != null && existing.toString() != punctuation.terminator) continue
             if (sentence.count() > MAX_QUESTION_WORDS) continue
             if (!isQuestion(words, sentence)) continue
-            if (!open) words[sentence.last].trailing = last.trailing.dropLast(1)
-            words[sentence.last].trailing += punctuation.question
+            close(words[sentence.last], punctuation.question, punctuation)
         }
+    }
+
+    /**
+     * Closes a word with [mark], replacing the terminator it already carries
+     * rather than doubling it, and going *inside* any quote or bracket. A
+     * question that reached the model in quotes ends `it?"`, never `it."?`.
+     */
+    private fun close(word: Word, mark: String, punctuation: SentencePunctuation) {
+        val existing = word.trailing.indexOfLast { it in punctuation.terminators }
+        if (existing >= 0) word.trailing = word.trailing.removeRange(existing, existing + 1)
+        val wrapper = word.trailing.indexOfFirst { it in QUOTES || it in ")]}»" }
+        val at = if (wrapper >= 0) wrapper else word.trailing.length
+        word.trailing = word.trailing.substring(0, at) + mark + word.trailing.substring(at)
     }
 
     private fun isQuestion(words: List<Word>, sentence: IntRange): Boolean {
@@ -526,7 +637,13 @@ object TranscriptRepair {
             }
             return false
         }
-        return keys[0] in AUXILIARIES && keys[1] in SUBJECT_PRONOUNS
+        if (keys[0] !in AUXILIARIES || keys[1] !in SUBJECT_PRONOUNS) return false
+        // "Had I known" and "Were it up to me" invert the same way a question
+        // does; the modal further along is what tells them apart.
+        if (keys[0] == "had" || keys[0] == "were") {
+            return keys.drop(2).none { it in CONDITIONAL_MODALS }
+        }
+        return true
     }
 
     // endregion
@@ -546,6 +663,15 @@ object TranscriptRepair {
         }
         return null
     }
+
+    /**
+     * Whether a clause could start at this word. The question a split has to
+     * answer is "is a new sentence beginning here", and a subject, an
+     * auxiliary, or a question word is what one begins with.
+     */
+    private fun startsClause(key: String): Boolean =
+        key in CLAUSE_STARTERS || key in AUXILIARIES || key in QUESTION_WORDS ||
+            key in CLAUSE_OPENERS
 
     private fun opensSentence(
         words: List<Word>,

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptRepair.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptRepair.kt
@@ -1,0 +1,614 @@
+package com.vocahq.vocaphone.core
+
+/**
+ * Turns what a speech model heard into what the speaker meant to write:
+ * hesitation sounds dropped, false starts collapsed, and the punctuation the
+ * model left out put in.
+ *
+ * This is deliberately **not** part of [TranscriptStyler]. That stage documents
+ * a contract it has to keep — no style adds, removes, or substitutes a word —
+ * and this stage exists precisely to break it, under a switch of its own.
+ * Keeping them apart is what lets the styles still be described honestly.
+ *
+ * Everything here is rule-based. There is no model, no network call, and no
+ * language understanding: the rules are the conservative subset where a mistake
+ * is nearly impossible to make, and anything needing judgement about what the
+ * speaker meant is left alone on purpose. The order of the stages is
+ * load-bearing and is documented at each one.
+ *
+ * Mirrors the iOS client's `TranscriptRepair`; the two are expected to produce
+ * the same text for the same transcript.
+ */
+object TranscriptRepair {
+
+    /**
+     * @param text a transcript that has already been through [TranscriptSanitizer].
+     * @param language the language the finished text is written in, or `"auto"`.
+     */
+    fun apply(text: String?, language: String = "auto"): String {
+        val source = text.orEmpty().trim()
+        if (source.isEmpty()) return ""
+
+        val punctuation = SentencePunctuation.resolve(language, source)
+        val code = language.lowercase().substringBefore('-')
+        val spans = ProtectedSpans.mask(source)
+
+        // 1. Fillers first: they are the noise every later rule would otherwise
+        //    have to reason around. "we should um we should ship" is not a
+        //    stutter until the "um" between the copies is gone.
+        var working = removeFillers(spans.text, code)
+        // 2. Stutters, on the text the fillers left behind.
+        working = collapseStutters(working, punctuation)
+        // 3. Normalize the marks that are there before inferring the ones that
+        //    are not, so inference counts real sentence boundaries.
+        working = repairMarks(working, punctuation)
+        // 4. Inference is written against how English builds a sentence. In a
+        //    script that spaces or terminates differently it would do damage,
+        //    and in another Latin language its trigger words never match.
+        if (punctuation.usesLatinLayout) working = infer(working, punctuation)
+
+        val repaired = spans.restore(working).trim()
+        // A transcript that repaired down to nothing is a rule misfiring, not a
+        // silent recording — the sanitizer has already had its say about those.
+        // Hand back what came in rather than an empty text field.
+        return if (repaired.any { it.isLetterOrDigit() }) repaired else source
+    }
+
+    // region Words
+
+    /**
+     * A whitespace-delimited chunk split into the punctuation around it and the
+     * word inside, so a rule can drop a word without losing the comma attached
+     * to it, or match a word without its full stop getting in the way.
+     */
+    private data class Word(
+        var leading: String,
+        var text: String,
+        var trailing: String,
+    ) {
+        val isEmpty: Boolean get() = leading.isEmpty() && text.isEmpty() && trailing.isEmpty()
+
+        val rendered: String get() = leading + text + trailing
+
+        /**
+         * Lowercased letters and digits only. Apostrophes go, so `don't` and
+         * `dont` match, and the placeholder characters stay so a masked URL can
+         * never compare equal to a bare number.
+         */
+        val key: String
+            get() = text.lowercase().filter {
+                it.isLetterOrDigit() || it == ProtectedSpans.OPEN || it == ProtectedSpans.CLOSE
+            }
+
+        val isProtected: Boolean get() = text.contains(ProtectedSpans.OPEN)
+
+        val startsUppercase: Boolean
+            get() = text.firstOrNull { it.isLetter() }?.isUpperCase() == true
+    }
+
+    private fun isWordCharacter(character: Char): Boolean =
+        character.isLetterOrDigit() || character == '\'' || character == '’' ||
+            character == '-' || character == ProtectedSpans.OPEN || character == ProtectedSpans.CLOSE
+
+    private fun split(text: String): MutableList<Word> =
+        text.split(Regex("\\s+")).filter { it.isNotEmpty() }.map { chunk ->
+            var start = 0
+            while (start < chunk.length && !isWordCharacter(chunk[start])) start++
+            var end = chunk.length
+            while (end > start && !isWordCharacter(chunk[end - 1])) end--
+            Word(chunk.substring(0, start), chunk.substring(start, end), chunk.substring(end))
+        }.toMutableList()
+
+    private fun joined(words: List<Word>): String =
+        words.filterNot { it.isEmpty }.joinToString(" ") { it.rendered }
+
+    // endregion
+
+    // region Fillers
+
+    /**
+     * The hesitation sounds, after [canonical] has flattened however many
+     * letters the model chose to spell them with.
+     *
+     * Every one of these is non-lexical: there is no sentence in which the word
+     * carries meaning, which is the whole reason removing it is safe. That is
+     * also why `like`, `you know`, `I mean` and `actually` are **not** here.
+     * Each is a real word often enough that dropping it needs judgement about
+     * what the speaker meant, and this stage does not have any.
+     */
+    private val UNIVERSAL_FILLERS = setOf("um", "uhm", "umh", "uh", "er", "erm", "hm")
+
+    /**
+     * Sounds that mean *yes* or *no*, and must survive. `mhm` and `uh-huh` are
+     * answers to a question, and a transcript that drops them says the opposite
+     * of what was said. They are listed rather than merely absent so that
+     * widening [UNIVERSAL_FILLERS] cannot quietly swallow one.
+     */
+    private val AFFIRMATIONS = setOf("mhm", "mhmm", "mmhm", "uhuh", "uhhuh", "nuhuh", "huh", "hu")
+
+    /**
+     * Only the non-lexical hesitation sounds, same bar as [UNIVERSAL_FILLERS].
+     * A language is absent here because nobody has checked it, not because it
+     * has no fillers.
+     */
+    private val LOCAL_FILLERS = mapOf(
+        "de" to setOf("äh", "ähm", "öh", "öhm"),
+        "nl" to setOf("eh", "ehm", "uh"),
+        "fr" to setOf("euh", "heu"),
+        "es" to setOf("eh", "em"),
+        "it" to setOf("ehm", "eh"),
+    )
+
+    /**
+     * Fillers in the scripts that are written without spaces, where there are
+     * no words to walk. Removed as plain substrings, which is only safe because
+     * each of these carries a length mark that a content word does not.
+     */
+    private val UNSPACED_FILLERS = mapOf(
+        "ja" to listOf("えーと", "えっと", "ええと", "あのー", "あのう"),
+        "zh" to listOf("呃"),
+        "yue" to listOf("呃"),
+    )
+
+    private const val QUOTES = "\"'“”‘’«»„"
+
+    /**
+     * Collapses a run of one repeated letter, so however long the model drew
+     * the sound out it lands on the same key: `ummmm` and `uhhh` become `um`
+     * and `uh`. Also drops the hyphen in `uh-huh`, which is why that spelling
+     * reaches [AFFIRMATIONS] intact.
+     */
+    private fun canonical(key: String): String {
+        val result = StringBuilder(key.length)
+        var previous: Char? = null
+        for (character in key) {
+            if (character == '-') continue
+            if (character != previous) result.append(character)
+            previous = character
+        }
+        return result.toString()
+    }
+
+    private fun isFiller(word: Word, code: String): Boolean {
+        if (word.isProtected) return false
+        // A quoted filler is being talked about rather than said: someone
+        // dictating `he said "um" a lot` means the word to be there.
+        if (word.leading.any { it in QUOTES } || word.trailing.any { it in QUOTES }) return false
+        val key = canonical(word.key)
+        if (key.isEmpty() || key in AFFIRMATIONS) return false
+        return key in UNIVERSAL_FILLERS || LOCAL_FILLERS[code]?.contains(key) == true
+    }
+
+    private fun removeFillers(text: String, code: String): String {
+        var result = text
+        UNSPACED_FILLERS[code]?.forEach { filler -> result = result.replace(filler, "") }
+
+        val kept = mutableListOf<Word>()
+        for (word in split(result)) {
+            if (!isFiller(word, code)) {
+                kept += word
+                continue
+            }
+            // The filler goes, but a sentence it happened to end does not:
+            // "I was thinking. Um. We should ship" keeps both full stops.
+            val terminators = word.trailing.filter { it in "!?.。！？।۔" }
+            val previous = kept.lastOrNull()
+            if (terminators.isNotEmpty() && previous != null) {
+                if (previous.trailing.none { it in terminators }) {
+                    previous.trailing += terminators
+                }
+            } else if (word.trailing.contains(',') && previous?.trailing?.endsWith(",") == true) {
+                // A filler set off by commas on both sides takes both with it:
+                // "I think, um, we should" is "I think we should", not
+                // "I think, we should".
+                previous.trailing = previous.trailing.dropLast(1)
+            }
+        }
+        return joined(kept)
+    }
+
+    // endregion
+
+    // region False starts
+
+    /**
+     * Words whose immediate repeat is a stutter rather than a sentence.
+     * Closed-class only: an article or a pronoun said twice in a row is the
+     * speaker restarting, where a repeated content word ("very very") is
+     * emphasis the speaker meant.
+     */
+    private val FUNCTION_WORDS = setOf(
+        "the", "a", "an", "and", "but", "so", "or", "to", "of", "in", "on", "at",
+        "for", "with", "from", "by", "as", "if", "then", "than",
+        "i", "you", "we", "they", "he", "she", "it", "this", "these", "those",
+        "there", "my", "your", "our", "their", "his", "her", "its",
+        "is", "are", "was", "were", "am", "be", "been",
+        "do", "does", "did", "have", "has",
+        "can", "could", "will", "would", "should", "must",
+        "what", "when", "where", "why", "who", "how",
+    )
+
+    /**
+     * Doubles that are ordinary English. "The thing that that man said" and
+     * "she had had enough" are both correct, and both look exactly like a
+     * stutter to a rule that only compares two words.
+     */
+    private val LEGITIMATE_DOUBLES = setOf("that", "had")
+
+    /**
+     * Longest false start collapsed. Beyond this it is a repeated sentence,
+     * which [TranscriptSanitizer] already has thresholds for.
+     */
+    private const val MAX_STUTTER_WORDS = 4
+
+    /**
+     * Collapses a phrase said twice in a row — "we should we should probably".
+     *
+     * Only an immediate repeat, and only the second copy is kept, because it is
+     * the copy the speaker carried on from: "we should, we should probably
+     * ship" has the comma on the abandoned half and the sentence on the other.
+     */
+    private fun collapseStutters(text: String, punctuation: SentencePunctuation): String {
+        val words = split(text)
+        if (words.size < 2) return text
+
+        val result = mutableListOf<Word>()
+        var index = 0
+        while (index < words.size) {
+            // Longest first, so "we should we should" is one phrase twice over
+            // rather than two separate doubled words.
+            val length = (minOf(MAX_STUTTER_WORDS, (words.size - index) / 2) downTo 1)
+                .firstOrNull { matchesRepeat(words, index, it, punctuation) }
+            if (length == null) {
+                result += words[index]
+                index++
+                continue
+            }
+            val leading = words[index].leading
+            val second = words.subList(index + length, index + length * 2).map { it.copy() }
+            if (leading.isNotEmpty() && second.first().leading.isEmpty()) {
+                second.first().leading = leading
+            }
+            result += second
+            index += length * 2
+        }
+        return joined(result)
+    }
+
+    private fun matchesRepeat(
+        words: List<Word>,
+        index: Int,
+        length: Int,
+        punctuation: SentencePunctuation,
+    ): Boolean {
+        if (index + length * 2 > words.size) return false
+        for (offset in 0 until length) {
+            val first = words[index + offset]
+            val second = words[index + length + offset]
+            if (first.isProtected || first.key.isEmpty() || first.key != second.key) return false
+            // A sentence ended between the copies, so the second one starts a
+            // new thought: "I went home. Home is quiet."
+            if (ends(first, punctuation)) return false
+        }
+        if (length == 1) {
+            val key = words[index].key
+            if (key !in FUNCTION_WORDS || key in LEGITIMATE_DOUBLES) return false
+        }
+        return true
+    }
+
+    private fun ends(word: Word, punctuation: SentencePunctuation): Boolean =
+        word.trailing.any { it in punctuation.terminators }
+
+    // endregion
+
+    // region Marks that are already there
+
+    /**
+     * Normalizes the punctuation the model emitted: spacing around it, runs of
+     * it, and pairs of marks that cannot both be right. Nothing here decides
+     * where a sentence ends; it only tidies the decisions already made.
+     */
+    private fun repairMarks(text: String, punctuation: SentencePunctuation): String {
+        var result = text.replace(Regex("\\s+"), " ").trim()
+
+        // Never a space before a mark.
+        result = result.replace(Regex("\\s+([.!?。！？।۔،,;:、၊…])"), "$1")
+        // A run of one separator is one separator.
+        result = result.replace(Regex("([,;:、])\\1+"), "$1")
+        // A separator touching a terminator: the terminator wins, whichever
+        // order the model put them in.
+        result = result.replace(Regex("[,;:、]\\s*([.!?。！？।۔])"), "$1")
+        result = result.replace(Regex("([.!?。！？।۔])\\s*[,;:、]"), "$1")
+        // Shouting and stammering. Four or more stops is an ellipsis that got
+        // away; three stays an ellipsis.
+        result = result.replace(Regex("!{2,}"), "!")
+        result = result.replace(Regex("\\?{2,}"), "?")
+        result = result.replace(Regex("\\.{4,}"), "...")
+        result = result.replace(Regex("([!?])\\.+"), "$1")
+        result = result.replace(Regex("\\.([!?])"), "$1")
+
+        if (punctuation.join == " ") {
+            // Always a space after a mark, unless another mark follows it —
+            // that is an ellipsis or a quoted close, not two sentences.
+            result = result.replace(Regex("([,;:])(?=[^\\s,;:.!?…\\)\\]\"”’])"), "$1 ")
+            result = result.replace(
+                Regex("([.!?])(?=[\\p{L}\\p{N}${ProtectedSpans.OPEN}])"),
+                "$1 ",
+            )
+        }
+
+        // A mark with nothing in front of it, and a separator with nothing
+        // after it, are both left over from something that was removed.
+        result = result.replace(Regex("^[\\s,;:.!?、。…]+"), "")
+        result = result.replace(Regex("[,;:、]+\\s*$"), "")
+        return result.trim()
+    }
+
+    // endregion
+
+    // region Marks that are missing
+
+    /**
+     * Phrases that start a new thought when they turn up mid-flow. Each is a
+     * discourse marker with no other job, which is what makes a sentence break
+     * in front of it safe.
+     */
+    private val SENTENCE_STARTERS = listOf(
+        listOf("okay"), listOf("ok"), listOf("alright"), listOf("all", "right"),
+        listOf("anyway"), listOf("anyhow"), listOf("by", "the", "way"),
+        listOf("in", "any", "case"),
+    )
+
+    /**
+     * Markers that take a comma when they open a sentence. `so` and `well` are
+     * missing on purpose: both open a sentence far more often without one.
+     */
+    private val OPENERS_TAKING_COMMA = listOf(
+        listOf("okay"), listOf("ok"), listOf("alright"), listOf("all", "right"),
+        listOf("anyway"), listOf("anyhow"), listOf("however"), listOf("actually"),
+        listOf("by", "the", "way"), listOf("in", "fact"), listOf("of", "course"),
+        listOf("for", "example"),
+    )
+
+    /** Conjunctions that take a comma when they join two full clauses. */
+    private val CLAUSE_CONJUNCTIONS = setOf("but", "so", "yet", "however")
+
+    /**
+     * Words that can open a clause of their own. The test for "is a full clause
+     * coming" is "does a subject start right here", which these are the common
+     * ones for.
+     */
+    private val CLAUSE_STARTERS = setOf(
+        "i", "im", "ive", "ill", "id", "you", "youre", "youve", "youll", "youd",
+        "we", "weve", "well", "wed", "were", "they", "theyre", "theyve", "theyll",
+        "he", "hes", "hed", "she", "shes", "shed", "it", "its", "thats", "this",
+        "there", "theres", "my", "your", "our", "their", "his", "her",
+        "the", "a", "an", "nobody", "everyone", "someone", "people", "lets",
+        "maybe", "now", "then", "today", "tomorrow", "yesterday",
+    )
+
+    /** "so that", "but as" — a phrase, not a new clause. */
+    private val NOT_CLAUSE_STARTERS = setOf("that", "much", "many", "far", "long", "as")
+
+    /**
+     * After one of these, `okay` and `alright` are adjectives describing
+     * something, not somebody starting a sentence.
+     */
+    private val COPULAS = setOf(
+        "is", "are", "was", "were", "am", "be", "been", "being",
+        "seem", "seems", "seemed", "look", "looks", "looked",
+        "feel", "feels", "felt", "sound", "sounds", "sounded",
+        "not", "quite", "pretty", "totally", "perfectly", "really",
+        "its", "thats", "everything", "all", "more", "less", "about",
+    )
+
+    private val AUXILIARIES = setOf(
+        "do", "does", "did", "dont", "doesnt", "didnt",
+        "is", "are", "was", "were", "isnt", "arent", "wasnt", "werent",
+        "can", "cant", "could", "couldnt", "will", "wont", "would", "wouldnt",
+        "should", "shouldnt", "shall", "may", "might", "must",
+        "have", "has", "had", "havent", "hasnt", "hadnt", "am",
+    )
+
+    private val QUESTION_WORDS = setOf(
+        "what", "whats", "when", "whens", "where", "wheres",
+        "why", "whys", "who", "whos", "whom", "whose", "how", "hows",
+    )
+
+    private val SUBJECT_PRONOUNS = setOf(
+        "i", "you", "we", "they", "he", "she", "it", "there",
+        "that", "this", "anyone", "anybody", "someone", "somebody", "everyone",
+    )
+
+    /**
+     * Longest sentence still short enough for the question test to be worth
+     * trusting. Past this a wh-word is far more often opening a noun clause.
+     */
+    private const val MAX_QUESTION_WORDS = 12
+
+    private fun infer(text: String, punctuation: SentencePunctuation): String {
+        val words = split(text)
+        if (words.isEmpty()) return text
+        splitAtStarters(words, punctuation)
+        commaAfterOpeners(words, punctuation)
+        commaBeforeConjunctions(words, punctuation)
+        markQuestions(words, punctuation)
+        return joined(words)
+    }
+
+    /**
+     * Ends the sentence in front of a discourse marker that has clearly started
+     * a new one. Requires a substantial unpunctuated clause behind it and a
+     * clause of its own in front, so a marker inside a sentence is left alone.
+     */
+    private fun splitAtStarters(words: MutableList<Word>, punctuation: SentencePunctuation) {
+        var index = 1
+        while (index < words.size) {
+            val length = match(SENTENCE_STARTERS, words, index)
+            if (length == null ||
+                index + length + 2 > words.size ||
+                wordsSinceMark(words, index) < 4 ||
+                words[index - 1].trailing.isNotEmpty() ||
+                words[index - 1].key in COPULAS
+            ) {
+                index++
+                continue
+            }
+            words[index - 1].trailing = punctuation.terminator
+            matchCaseOfSentence(words, index)
+            index += length
+        }
+    }
+
+    /**
+     * "Okay we should ship" — the marker opens the sentence and the rest of it
+     * follows, which in writing takes a comma.
+     */
+    private fun commaAfterOpeners(words: MutableList<Word>, punctuation: SentencePunctuation) {
+        for (index in words.indices) {
+            if (!opensSentence(words, index, punctuation)) continue
+            val length = match(OPENERS_TAKING_COMMA, words, index) ?: continue
+            if (words[index + length - 1].trailing.isNotEmpty()) continue
+            if (index + length + 2 > words.size) continue
+            words[index + length - 1].trailing = punctuation.separator
+        }
+    }
+
+    /**
+     * "…ship it on Friday but I don't know…" — a conjunction joining two full
+     * clauses takes a comma in front of it.
+     */
+    private fun commaBeforeConjunctions(
+        words: MutableList<Word>,
+        punctuation: SentencePunctuation,
+    ) {
+        for (index in words.indices) {
+            if (index < 4 || index + 2 >= words.size) continue
+            if (words[index].key !in CLAUSE_CONJUNCTIONS) continue
+            if (words[index].leading.isNotEmpty() || words[index].trailing.isNotEmpty()) continue
+            if (words[index - 1].trailing.isNotEmpty()) continue
+            if (wordsSinceMark(words, index) < 4) continue
+            val next = words[index + 1].key
+            if (next !in CLAUSE_STARTERS || next in NOT_CLAUSE_STARTERS) continue
+            words[index - 1].trailing = punctuation.separator
+        }
+    }
+
+    /**
+     * Puts a question mark on a sentence that asks something. Applies to a
+     * sentence with no terminator at all and to one the model closed with a
+     * plain full stop; `!` is left alone, because someone chose it.
+     */
+    private fun markQuestions(words: MutableList<Word>, punctuation: SentencePunctuation) {
+        for (sentence in sentences(words, punctuation)) {
+            val last = words[sentence.last]
+            val closing = last.trailing.lastOrNull()
+            val open = closing == null || closing !in punctuation.terminators
+            if (!open && closing.toString() != punctuation.terminator) continue
+            if (sentence.count() > MAX_QUESTION_WORDS) continue
+            if (!isQuestion(words, sentence)) continue
+            if (!open) words[sentence.last].trailing = last.trailing.dropLast(1)
+            words[sentence.last].trailing += punctuation.question
+        }
+    }
+
+    private fun isQuestion(words: List<Word>, sentence: IntRange): Boolean {
+        val keys = sentence.map { words[it].key }
+        if (keys.size < 2) return false
+        if (keys[0] in QUESTION_WORDS) {
+            // "What time is it" asks; "What I meant was simple" states. Both
+            // reach an auxiliary, but only the second puts a subject in front
+            // of it — the wh-word is that clause's own subject or object.
+            for (offset in 1 until minOf(keys.size, 4)) {
+                if (keys[offset] in SUBJECT_PRONOUNS) return false
+                if (keys[offset] in AUXILIARIES) return true
+            }
+            return false
+        }
+        return keys[0] in AUXILIARIES && keys[1] in SUBJECT_PRONOUNS
+    }
+
+    // endregion
+
+    // region Inference helpers
+
+    /** Whether the phrase at [index] is one of [phrases], and how long it is. */
+    private fun match(phrases: List<List<String>>, words: List<Word>, index: Int): Int? {
+        for (phrase in phrases) {
+            if (index + phrase.size > words.size) continue
+            if (phrase.withIndex().any { (offset, key) -> words[index + offset].key != key }) {
+                continue
+            }
+            // A mark inside the phrase means it is not being said as one.
+            if ((0 until phrase.size - 1).any { words[index + it].trailing.isNotEmpty() }) continue
+            return phrase.size
+        }
+        return null
+    }
+
+    private fun opensSentence(
+        words: List<Word>,
+        index: Int,
+        punctuation: SentencePunctuation,
+    ): Boolean = index == 0 || ends(words[index - 1], punctuation)
+
+    /**
+     * How many words back to the last punctuation of any kind. This is the
+     * stand-in for "is there a whole clause behind me": a rule that would add a
+     * mark four words after the last one is guessing, not repairing.
+     */
+    private fun wordsSinceMark(words: List<Word>, index: Int): Int {
+        var count = 0
+        var cursor = index - 1
+        while (cursor >= 0) {
+            count++
+            if (words[cursor].trailing.isNotEmpty()) break
+            cursor--
+        }
+        return count
+    }
+
+    private fun sentences(words: List<Word>, punctuation: SentencePunctuation): List<IntRange> {
+        val result = mutableListOf<IntRange>()
+        var start = 0
+        for (index in words.indices) {
+            if (!ends(words[index], punctuation)) continue
+            result += start..index
+            start = index + 1
+        }
+        if (start < words.size) result += start..words.lastIndex
+        return result
+    }
+
+    /**
+     * Capitalizes a sentence this stage just created, but only when the
+     * sentence it was split out of was capitalized too.
+     *
+     * The alternative — always capitalizing — puts a stray capital in the
+     * middle of `clean` style output, which exists to flatten exactly that.
+     * Following the text's own convention is right on both routes: a gateway
+     * transcript arrives already cased and gets a capital, a raw local one
+     * arrives lowercase and is left for [TranscriptStyler] to decide about.
+     */
+    private fun matchCaseOfSentence(words: MutableList<Word>, index: Int) {
+        var cursor = index - 1
+        var sentenceStart = index
+        while (cursor >= 0) {
+            if (words[cursor].trailing.isNotEmpty() && cursor != index - 1) break
+            sentenceStart = cursor
+            cursor--
+        }
+        if (!words[sentenceStart].startsUppercase) return
+        val text = words[index].text
+        val position = text.indexOfFirst { it.isLetter() }
+        if (position < 0 || !text[position].isLowerCase()) return
+        words[index].text = text.replaceRange(
+            position,
+            position + 1,
+            text[position].uppercaseChar().toString(),
+        )
+    }
+
+    // endregion
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptStyler.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptStyler.kt
@@ -3,46 +3,21 @@ package com.vocahq.vocaphone.core
 /**
  * Applies the same presentation-only contract as the gateway to a local
  * transcript. It deliberately never adds, removes, or substitutes words.
+ *
+ * Dropping a filler or inserting a missing sentence break would both break that
+ * contract, which is why they are [TranscriptRepair]'s job and run before this
+ * stage under a switch of their own.
  */
 object TranscriptStyler {
-    private data class Punctuation(
-        val terminator: String,
-        val separator: String,
-        val exclamation: String,
-        val question: String,
-        val terminators: String,
-        val join: String,
-    )
-
-    private data class Masked(val text: String, val tokens: List<String>)
-
-    private val universalTerminators = ".!?。！？।۔။។།؟"
-    private val latin = Punctuation(".", ",", "!", "?", ".!?", " ")
-    private val cjk = Punctuation("。", "、", "！", "？", "。！？.!?", "")
-    private val arabic = Punctuation(".", "،", "!", "؟", ".!?؟", " ")
-    private val urdu = Punctuation("۔", "،", "!", "؟", "۔.!?؟", " ")
-    private val danda = Punctuation("।", ",", "!", "?", "।.!?", " ")
-    private val indicLatin = Punctuation(".", ",", "!", "?", "।.!?", " ")
-    private val unterminated = Punctuation("", " ", "!", "?", "!?", " ")
-    private val burmese = Punctuation("။", "၊", "!", "?", "။.!?", " ")
-    private val khmer = Punctuation("។", ",", "!", "?", "။.!?", " ")
-    private val tibetan = Punctuation("།", "།", "!", "?", "།.!?", " ")
-
-    private val protectedSpans = Regex(
-        """(?i)(https?://[^\s]+[^\s.,;:!?\"“”'\)\]]|[\w.+-]+@(?:[\w-]+\.)+[A-Za-z]{2,}|"""
-            + """(?:[\w-]+\.)+[A-Za-z]{2,}(?:/[^\s.,;:!?\"“”'\)\]]*)?|\d+(?:[.,:/]\d+)+|"""
-            + """\d+(?:st|nd|rd|th)\b|(?:[A-Za-z]\.){2,})""",
-    )
-    private val placeholder = Regex("\\uE000(\\d+)\\uE001")
 
     fun apply(text: String?, style: WritingStyle, language: String = "auto"): String {
         val source = text.orEmpty()
         if (style == WritingStyle.RAW) return source.trim()
         if (source.isBlank()) return ""
 
-        val punctuation = punctuation(language, source)
-        val masked = mask(source)
-        val normalized = normalizeSentenceTerminators(normalizeSpacing(masked.text), punctuation)
+        val punctuation = SentencePunctuation.resolve(language, source)
+        val spans = ProtectedSpans.mask(source)
+        val normalized = normalizeSentenceTerminators(normalizeSpacing(spans.text), punctuation)
         // Whisper and Parakeet Title-Case content words ("the Keyboard Is Ready").
         // Flatten those before Clean/Formal/Casual so mid-sentence capitals are
         // not left as-is. Mixed-case names and ALL-CAPS acronyms stay.
@@ -67,62 +42,13 @@ object TranscriptStyler {
             )
             WritingStyle.RAW -> normalized
         }
-        val lowered = if (style == WritingStyle.VERY_CASUAL) lowerOutsidePlaceholders(result) else result
-        return restore(lowered, masked.tokens)
-    }
-
-    private fun punctuation(language: String, text: String): Punctuation {
-        val code = language.lowercase().substringBefore('-')
-        return when (code) {
-            "ja", "zh" -> cjk
-            "ar", "fa", "ps" -> arabic
-            "ur", "sd", "ks" -> urdu
-            "hi", "mr", "ne", "bn", "as", "pa" -> danda
-            "ta", "te", "kn", "ml", "gu", "si" -> indicLatin
-            "th", "lo" -> unterminated
-            "my" -> burmese
-            "km" -> khmer
-            "bo" -> tibetan
-            else -> when {
-                text.any { it in "。、！？" } -> cjk
-                text.any { it in "،؟" } -> arabic
-                text.contains('۔') -> urdu
-                text.contains('।') || containsDandaScript(text) -> danda
-                else -> latin
-            }
-        }.copy(terminators = universalTerminators + terminatorsFor(language, text))
-    }
-
-    /** Automatic-language fallback for scripts that conventionally use danda. */
-    private fun containsDandaScript(text: String): Boolean = text.any { character ->
-        character.code in 0x0900..0x097F ||
-            character.code in 0x0980..0x09FF ||
-            character.code in 0x0A00..0x0A7F
-    }
-
-    private fun terminatorsFor(language: String, text: String): String = when {
-        language.lowercase().startsWith("ja") || language.lowercase().startsWith("zh") -> cjk.terminators
-        language.lowercase().startsWith("ur") -> urdu.terminators
-        language.lowercase().startsWith("hi") -> danda.terminators
-        else -> ""
-    }
-
-    private fun mask(text: String): Masked {
-        val matches = protectedSpans.findAll(text).toList()
-        var result = text
-        for (index in matches.indices.reversed()) {
-            result = result.replaceRange(
-                matches[index].range,
-                "\uE000$index\uE001",
-            )
+        val lowered = if (style == WritingStyle.VERY_CASUAL) {
+            ProtectedSpans.mapOutsidePlaceholders(result) { it.lowercase() }
+        } else {
+            result
         }
-        return Masked(result, matches.map { it.value })
+        return spans.restore(lowered)
     }
-
-    private fun restore(text: String, tokens: List<String>): String =
-        placeholder.replace(text) { match ->
-            tokens.getOrNull(match.groupValues[1].toInt()) ?: match.value
-        }
 
     private fun normalizeSpacing(text: String): String = text
         .replace(Regex("\\s+"), " ")
@@ -134,7 +60,10 @@ object TranscriptStyler {
      * the script is known, normalize sentence boundaries while masked URLs,
      * decimals, abbreviations, and ellipses remain untouched.
      */
-    private fun normalizeSentenceTerminators(text: String, punctuation: Punctuation): String {
+    private fun normalizeSentenceTerminators(
+        text: String,
+        punctuation: SentencePunctuation,
+    ): String {
         if (punctuation.terminator != "।") return text
         return buildString(text.length) {
             text.forEachIndexed { index, character ->
@@ -151,7 +80,7 @@ object TranscriptStyler {
         }
     }
 
-    private fun ensureTerminator(text: String, punctuation: Punctuation): String {
+    private fun ensureTerminator(text: String, punctuation: SentencePunctuation): String {
         if (text.isEmpty() || punctuation.terminator.isEmpty()) return text
         return if (text.last() in punctuation.terminators) text
         else text + punctuation.terminator
@@ -167,8 +96,10 @@ object TranscriptStyler {
         val result = StringBuilder(text.length)
         var index = 0
         while (index < text.length) {
-            if (text[index] == '\uE000') {
-                val end = text.indexOf('\uE001', index)
+            // Copy a protected span whole: flatten would lowercase the digits
+            // inside it, and restore could not match the placeholder afterwards.
+            if (text[index] == ProtectedSpans.OPEN) {
+                val end = text.indexOf(ProtectedSpans.CLOSE, index)
                 if (end >= 0) {
                     result.append(text, index, end + 1)
                     index = end + 1
@@ -178,7 +109,9 @@ object TranscriptStyler {
             if (text[index].isLetter()) {
                 val start = index
                 index++
-                while (index < text.length && (text[index].isLetter() || text[index] == '\'' || text[index] == '’')) {
+                while (index < text.length &&
+                    (text[index].isLetter() || text[index] == '\'' || text[index] == '’')
+                ) {
                     index++
                 }
                 result.append(softenToken(text.substring(start, index)))
@@ -221,7 +154,10 @@ object TranscriptStyler {
         return contracted && rest in setOf("m", "ll", "d", "ve", "re", "s")
     }
 
-    private fun capitalizeSentenceStarts(text: String, punctuation: Punctuation): String {
+    private fun capitalizeSentenceStarts(
+        text: String,
+        punctuation: SentencePunctuation,
+    ): String {
         val result = StringBuilder(text.length)
         var capitalize = true
         text.forEach { character ->
@@ -236,7 +172,7 @@ object TranscriptStyler {
         return result.toString()
     }
 
-    private fun casual(text: String, punctuation: Punctuation): String {
+    private fun casual(text: String, punctuation: SentencePunctuation): String {
         val capitalized = capitalizeSentenceStarts(text, punctuation)
         if (punctuation.terminator.isEmpty() || capitalized.endsWith("..")) return capitalized
         return if (capitalized.endsWith(punctuation.terminator)) {
@@ -246,7 +182,7 @@ object TranscriptStyler {
         }
     }
 
-    private fun segments(text: String, punctuation: Punctuation): List<String> {
+    private fun segments(text: String, punctuation: SentencePunctuation): List<String> {
         if (text.isEmpty()) return emptyList()
         val result = mutableListOf<String>()
         var start = 0
@@ -275,7 +211,7 @@ object TranscriptStyler {
 
     private fun splitTerminator(
         sentence: String,
-        punctuation: Punctuation,
+        punctuation: SentencePunctuation,
     ): Pair<String, String> {
         val body = sentence.trim()
         if (body.isEmpty()) return "" to ""
@@ -286,7 +222,10 @@ object TranscriptStyler {
         return body to ""
     }
 
-    private fun veryCasual(sentences: List<String>, punctuation: Punctuation): String {
+    private fun veryCasual(
+        sentences: List<String>,
+        punctuation: SentencePunctuation,
+    ): String {
         val parts = sentences.mapIndexedNotNull { index, sentence ->
             val (body, terminator) = splitTerminator(sentence, punctuation)
             if (body.isEmpty()) return@mapIndexedNotNull null
@@ -300,7 +239,7 @@ object TranscriptStyler {
         return parts.joinToString(punctuation.join)
     }
 
-    private fun excited(sentences: List<String>, punctuation: Punctuation): String {
+    private fun excited(sentences: List<String>, punctuation: SentencePunctuation): String {
         val parts = sentences.mapNotNull { sentence ->
             val (body, terminator) = splitTerminator(sentence, punctuation)
             if (body.isEmpty()) null
@@ -311,17 +250,5 @@ object TranscriptStyler {
             }
         }
         return parts.joinToString(punctuation.join)
-    }
-
-    private fun lowerOutsidePlaceholders(text: String): String {
-        val result = StringBuilder(text.length)
-        var end = 0
-        placeholder.findAll(text).forEach { match ->
-            result.append(text.substring(end, match.range.first).lowercase())
-            result.append(match.value)
-            end = match.range.last + 1
-        }
-        result.append(text.substring(end).lowercase())
-        return result.toString()
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -15,14 +15,13 @@ import com.vocahq.vocaphone.audio.MicrophoneInterruption
 import com.vocahq.vocaphone.audio.PcmConversion
 import com.vocahq.vocaphone.audio.SilentCapture
 import com.vocahq.vocaphone.audio.WavWriter
+import com.vocahq.vocaphone.core.DictatedTranscript
 import com.vocahq.vocaphone.core.DictationFailure
 import com.vocahq.vocaphone.core.DictationPhase
 import com.vocahq.vocaphone.core.DictationState
 import com.vocahq.vocaphone.core.DictationTone
 import com.vocahq.vocaphone.core.MissingPermission
 import com.vocahq.vocaphone.core.ModelLanguageSupport
-import com.vocahq.vocaphone.core.TranscriptSanitizer
-import com.vocahq.vocaphone.core.TranscriptStyler
 import com.vocahq.vocaphone.data.HistoryRepository
 import com.vocahq.vocaphone.data.DiagnosticLog
 import com.vocahq.vocaphone.gateway.GatewayClient
@@ -691,8 +690,14 @@ class DictationController(
             }
             // The gateway has already applied the requested writing style to
             // streamed output. Local inference is styled in deliverLocal below;
-            // applying it here would style gateway text twice.
-            val cleaned = TranscriptSanitizer.clean(transcript)
+            // applying it here would style gateway text twice. It has not
+            // repaired anything, though — that stage only exists on the phone.
+            val cleaned = DictatedTranscript.finished(
+                transcript,
+                style = configuration.style,
+                styledUpstream = true,
+                repairSpeech = configuration.repairSpeech,
+            )
             if (transcript != null && cleaned.isEmpty()) {
                 wavFile.delete()
                 fail(sessionId, GatewayException.emptyTranscript(), null, configuration, generation)
@@ -777,7 +782,12 @@ class DictationController(
             diagnostics.recordTiming("transcription_started", source.name)
             val session = client.finish(sessionId)
             // Marker-only output means the model heard nothing worth writing.
-            val transcript = TranscriptSanitizer.clean(session.transcript)
+            val transcript = DictatedTranscript.finished(
+                session.transcript,
+                style = configuration.style,
+                styledUpstream = true,
+                repairSpeech = configuration.repairSpeech,
+            )
             if (transcript.isEmpty()) {
                 throw GatewayException(
                     session.errorCode ?: "empty_transcript",
@@ -873,14 +883,15 @@ class DictationController(
     private fun styleLocalTranscript(
         local: LocalTranscription,
         configuration: VocaPhoneSettings,
-    ): String = TranscriptStyler.apply(
-        TranscriptSanitizer.clean(local.text),
-        configuration.style,
-        ModelLanguageSupport.outputLanguage(
+    ): String = DictatedTranscript.finished(
+        local.text,
+        style = configuration.style,
+        language = ModelLanguageSupport.outputLanguage(
             requested = configuration.effectiveLanguage.wireValue,
             reported = local.language,
             translateTo = configuration.translationTarget,
         ),
+        repairSpeech = configuration.repairSpeech,
     )
 
     private suspend fun deliver(

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -695,6 +695,10 @@ class DictationController(
             val cleaned = DictatedTranscript.finished(
                 transcript,
                 style = configuration.style,
+                // Only repair reads this on a gateway route — the style is
+                // already applied — but a German transcript keeps its "um"
+                // only if this stage is told the language.
+                language = configuration.effectiveLanguage.wireValue,
                 styledUpstream = true,
                 repairSpeech = configuration.repairSpeech,
             )
@@ -785,6 +789,7 @@ class DictationController(
             val transcript = DictatedTranscript.finished(
                 session.transcript,
                 style = configuration.style,
+                language = configuration.effectiveLanguage.wireValue,
                 styledUpstream = true,
                 repairSpeech = configuration.repairSpeech,
             )

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -189,6 +189,17 @@ data class VocaPhoneSettings(
      */
     val translateTo: TranscriptionLanguage = ModelTranslationSupport.OFF,
     val style: WritingStyle = WritingStyle.DEFAULT,
+    /**
+     * Whether hesitation sounds, false starts, and missing sentence punctuation
+     * are repaired before the writing style is applied.
+     *
+     * On by default, and the only dictation setting that changes the words in a
+     * transcript rather than its formatting. It earns that because the words it
+     * removes are not words: "um" is a sound someone makes while deciding what
+     * to say, and nobody dictating meant to type it. Never applied to
+     * [WritingStyle.RAW], which promises the model's own output.
+     */
+    val repairSpeech: Boolean = true,
     val dictationTone: DictationTone = DictationTone.DEFAULT,
     val microphone: MicrophonePreference = MicrophonePreference.DEFAULT,
     val audioRetention: AudioRetention = AudioRetention.DEFAULT,
@@ -396,6 +407,8 @@ class SettingsRepository(private val context: Context) {
     suspend fun setSyncWhisperDictionary(enabled: Boolean) =
         put(Keys.SYNC_WHISPER_DICTIONARY, enabled)
 
+    suspend fun setRepairSpeech(enabled: Boolean) = put(Keys.REPAIR_SPEECH, enabled)
+
     suspend fun setNumberRowEnabled(enabled: Boolean) = put(Keys.NUMBER_ROW, enabled)
 
     suspend fun setKeyboardHeight(height: KeyboardHeight) = put(Keys.KEYBOARD_HEIGHT, height.storedValue)
@@ -564,6 +577,7 @@ class SettingsRepository(private val context: Context) {
         transcriptionQuality = TranscriptionQuality.fromStored(this[Keys.TRANSCRIPTION_QUALITY]),
         customVocabulary = this[Keys.CUSTOM_VOCABULARY].orEmpty(),
         syncWhisperDictionary = this[Keys.SYNC_WHISPER_DICTIONARY] ?: true,
+        repairSpeech = this[Keys.REPAIR_SPEECH] ?: true,
         numberRowEnabled = this[Keys.NUMBER_ROW] ?: true,
         keyboardHeight = KeyboardHeight.fromStored(this[Keys.KEYBOARD_HEIGHT]),
         splitKeyboard = SplitKeyboard.fromStored(this[Keys.SPLIT_KEYBOARD]),
@@ -607,6 +621,7 @@ class SettingsRepository(private val context: Context) {
         val TRANSCRIPTION_QUALITY = stringPreferencesKey("transcription_quality")
         val CUSTOM_VOCABULARY = stringPreferencesKey("custom_vocabulary")
         val SYNC_WHISPER_DICTIONARY = booleanPreferencesKey("sync_whisper_dictionary")
+        val REPAIR_SPEECH = booleanPreferencesKey("repair_speech")
         val NUMBER_ROW = booleanPreferencesKey("keyboard_number_row")
         val KEYBOARD_HEIGHT = stringPreferencesKey("keyboard_height")
         val SPLIT_KEYBOARD = stringPreferencesKey("keyboard_split")

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
@@ -403,6 +403,7 @@ fun VocaPhoneApp(
                 onLanguage = { viewModel.setLanguage(it) },
                 onTranslateTo = { viewModel.setTranslateTo(it) },
                 onStyle = { viewModel.setStyle(it) },
+                onRepairSpeech = { viewModel.setRepairSpeech(it) },
                 onDictationTone = { viewModel.setDictationTone(it) },
                 onPreviewDictationTone = { viewModel.toggleDictationTonePreview(it) },
                 tonePreviewListening = tonePreviewListening,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -84,6 +84,7 @@ fun SettingsScreen(
     onLanguage: (TranscriptionLanguage) -> Unit,
     onTranslateTo: (TranscriptionLanguage) -> Unit,
     onStyle: (WritingStyle) -> Unit,
+    onRepairSpeech: (Boolean) -> Unit,
     onDictationTone: (DictationTone) -> Unit,
     onPreviewDictationTone: (DictationTone) -> Unit,
     tonePreviewListening: Boolean,
@@ -369,6 +370,26 @@ fun SettingsScreen(
                         settings.style.example,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Section(
+                    title = "Clean up",
+                    // The one switch on this page that changes words rather
+                    // than formatting, which is why it says so here instead of
+                    // leaving it to be discovered.
+                    supporting = "The only setting that changes your words. " +
+                        "Never applied to the Raw writing style.",
+                ) {
+                    SettingToggle(
+                        title = "Clean up speech",
+                        detail = "Drops hesitation sounds and false starts, and fills in " +
+                            "missing sentence punctuation: \"so um we should we should ship " +
+                            "it friday\" becomes \"So we should ship it Friday.\" Only sounds " +
+                            "with no meaning go — \"um\", \"uh\", \"er\". Real words stay, " +
+                            "including \"like\" and \"you know\", and so do \"mhm\" and " +
+                            "\"uh-huh\", which are answers.",
+                        checked = settings.repairSpeech,
+                        onCheckedChange = onRepairSpeech,
                     )
                 }
                 Section(

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
@@ -317,6 +317,9 @@ class VocaPhoneViewModel(application: Application) : AndroidViewModel(applicatio
     fun setStyle(style: WritingStyle) =
         viewModelScope.launch { container.settings.setStyle(style) }
 
+    fun setRepairSpeech(enabled: Boolean) =
+        viewModelScope.launch { container.settings.setRepairSpeech(enabled) }
+
     fun setDictationTone(tone: DictationTone) {
         _tonePreviewListening.value = false
         viewModelScope.launch { container.settings.setDictationTone(tone) }

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/DictatedTranscriptTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/DictatedTranscriptTest.kt
@@ -1,0 +1,134 @@
+package com.vocahq.vocaphone.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The order of the three steps is the whole point of the funnel, and each wrong
+ * order produces text that looks like a different bug.
+ */
+class DictatedTranscriptTest {
+
+    /**
+     * Sanitizing first, because a model's own annotations are not something to
+     * capitalize and punctuate into looking like speech.
+     */
+    @Test
+    fun `markers are removed before anything else`() {
+        assertEquals(
+            "Five copies please.",
+            DictatedTranscript.finished(
+                "[BLANK_AUDIO] five copies please",
+                style = WritingStyle.FORMAL,
+                repairSpeech = false,
+            ),
+        )
+    }
+
+    /**
+     * Repair before styling, because repair is what puts the sentence
+     * boundaries there. Styling capitalizes and terminates *around* a boundary
+     * and cannot find one that is missing.
+     */
+    @Test
+    fun `repair happens before styling`() {
+        assertEquals(
+            "What time is it?",
+            DictatedTranscript.finished(
+                "um what time is it",
+                style = WritingStyle.FORMAL,
+                repairSpeech = true,
+            ),
+        )
+        // Without repair the styler sees no question and closes the sentence
+        // with the full stop it is contractually allowed to add.
+        assertEquals(
+            "Um what time is it.",
+            DictatedTranscript.finished(
+                "um what time is it",
+                style = WritingStyle.FORMAL,
+                repairSpeech = false,
+            ),
+        )
+    }
+
+    /**
+     * Raw promises the model's own output, so the one stage that changes words
+     * never runs for it however the preference is set.
+     */
+    @Test
+    fun `raw is never repaired`() {
+        assertEquals(
+            "um so we we should ship it",
+            DictatedTranscript.finished(
+                "um so we we should ship it",
+                style = WritingStyle.RAW,
+                repairSpeech = true,
+            ),
+        )
+    }
+
+    /**
+     * A gateway has already applied the session's writing style, so that route
+     * says so and the styler never runs twice.
+     */
+    @Test
+    fun `an already styled transcript is not styled again`() {
+        assertEquals(
+            "Hello there.",
+            DictatedTranscript.finished(
+                "Hello there.",
+                style = WritingStyle.CASUAL,
+                styledUpstream = true,
+                repairSpeech = false,
+            ),
+        )
+        // The same text through the local route would lose its full stop to the
+        // casual style — which is exactly what must not happen twice.
+        assertEquals(
+            "Hello there",
+            DictatedTranscript.finished(
+                "Hello there.",
+                style = WritingStyle.CASUAL,
+                repairSpeech = false,
+            ),
+        )
+    }
+
+    /**
+     * The gateway does not repair, so this route still does — and because the
+     * text arrives cased, a sentence repair creates is cased to match.
+     */
+    @Test
+    fun `an already styled transcript is still repaired`() {
+        assertEquals(
+            "We shipped it on Friday. Anyway, the tests are green",
+            DictatedTranscript.finished(
+                "We shipped it on Friday um anyway the tests are green",
+                style = WritingStyle.CASUAL,
+                styledUpstream = true,
+                repairSpeech = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `nothing in means nothing out`() {
+        assertTrue(
+            DictatedTranscript.finished(
+                null,
+                style = WritingStyle.CASUAL,
+                styledUpstream = true,
+                repairSpeech = true,
+            ).isEmpty(),
+        )
+        assertTrue(
+            DictatedTranscript.finished(
+                "   ",
+                style = WritingStyle.FORMAL,
+                repairSpeech = true,
+            ).isEmpty(),
+        )
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptRepairTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptRepairTest.kt
@@ -1,0 +1,367 @@
+package com.vocahq.vocaphone.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Two halves, tested apart: what repair is allowed to remove, and what it is
+ * allowed to add. The cases that matter most are the ones asserting it does
+ * *neither* — a rule that fires on a word someone meant is worse than the
+ * filler it was written to catch.
+ *
+ * Every expectation here is also asserted by the iOS client's
+ * `TranscriptRepairTests`. They are meant to stay identical.
+ */
+class TranscriptRepairTest {
+
+    // region Fillers
+
+    @Test
+    fun `hesitation sounds are removed`() {
+        assertEquals("we should ship it", TranscriptRepair.apply("um we should ship it"))
+        assertEquals("we should ship it", TranscriptRepair.apply("we should uh ship it"))
+        assertEquals("we should ship it", TranscriptRepair.apply("we should er ship it"))
+        assertEquals("we should ship it", TranscriptRepair.apply("erm we should ship it"))
+    }
+
+    /** However long the model drew the sound out, it is the same sound. */
+    @Test
+    fun `elongated fillers are removed`() {
+        assertEquals("we should ship it", TranscriptRepair.apply("ummmm we should ship it"))
+        assertEquals("we should ship it", TranscriptRepair.apply("we uhhh should ship it"))
+        assertEquals("we should ship it", TranscriptRepair.apply("hmmm we should ship it"))
+    }
+
+    /**
+     * A filler set off by commas takes both of them with it, or the sentence is
+     * left with a comma that separates nothing.
+     */
+    @Test
+    fun `commas around a filler go with it`() {
+        assertEquals("I think we should ship", TranscriptRepair.apply("I think, um, we should ship"))
+        assertEquals("we should ship it", TranscriptRepair.apply("um, we should ship it"))
+    }
+
+    /** The filler goes; the sentence it happened to end does not. */
+    @Test
+    fun `a filler keeps the sentence it closed`() {
+        assertEquals(
+            "I was thinking. We should ship it",
+            TranscriptRepair.apply("I was thinking. Um. We should ship it"),
+        )
+    }
+
+    /**
+     * These are answers. A transcript that drops them says the opposite of what
+     * was said.
+     */
+    @Test
+    fun `affirmations survive`() {
+        assertEquals("mhm that works for me", TranscriptRepair.apply("mhm that works for me"))
+        assertEquals("uh-huh that works", TranscriptRepair.apply("uh-huh that works"))
+        assertEquals("huh", TranscriptRepair.apply("huh"))
+    }
+
+    /**
+     * Every one of these is a real word often enough that removing it needs
+     * judgement about what the speaker meant, which this stage does not have.
+     */
+    @Test
+    fun `real words are never treated as fillers`() {
+        val source = "I mean it is like you know actually pretty good so"
+        assertEquals(source, TranscriptRepair.apply(source))
+        assertEquals("ah well oh dear", TranscriptRepair.apply("ah well oh dear"))
+    }
+
+    /** Quoted, the filler is being talked about rather than said. */
+    @Test
+    fun `a quoted filler is kept`() {
+        assertEquals("he said \"um\" a lot", TranscriptRepair.apply("he said \"um\" a lot"))
+    }
+
+    /** Only in the language that has them: a German "eh" is not a French one. */
+    @Test
+    fun `local fillers need their language`() {
+        assertEquals(
+            "wir sollten morgen liefern",
+            TranscriptRepair.apply("wir sollten ähm morgen liefern", "de"),
+        )
+        // "eh" is Spanish hesitation and an English interjection, so it goes
+        // only when the transcript is Spanish.
+        assertEquals(
+            "deberíamos enviarlo",
+            TranscriptRepair.apply("eh deberíamos enviarlo", "es"),
+        )
+        assertEquals("eh what was that", TranscriptRepair.apply("eh what was that", "en"))
+    }
+
+    /** Repairing a transcript down to nothing is a rule misfiring, not silence. */
+    @Test
+    fun `a transcript is never repaired away`() {
+        assertEquals("um", TranscriptRepair.apply("um"))
+        assertEquals("um uh", TranscriptRepair.apply("um uh"))
+    }
+
+    // endregion
+
+    // region False starts
+
+    @Test
+    fun `a repeated phrase collapses`() {
+        assertEquals(
+            "we should probably ship it",
+            TranscriptRepair.apply("we should we should probably ship it"),
+        )
+        assertEquals("I think so", TranscriptRepair.apply("I think I think so"))
+    }
+
+    /**
+     * The second copy is the one the speaker carried on from, so it is the one
+     * that keeps its punctuation.
+     */
+    @Test
+    fun `the completed copy is the one kept`() {
+        assertEquals(
+            "we should probably ship",
+            TranscriptRepair.apply("we should, we should probably ship"),
+        )
+    }
+
+    @Test
+    fun `a doubled function word collapses`() {
+        assertEquals("the tests are green", TranscriptRepair.apply("the the tests are green"))
+        assertEquals("send it to me", TranscriptRepair.apply("send it to to me"))
+    }
+
+    /** A repeated content word is emphasis the speaker meant. */
+    @Test
+    fun `a doubled content word survives`() {
+        assertEquals("that is very very good", TranscriptRepair.apply("that is very very good"))
+        assertEquals("no no not that one", TranscriptRepair.apply("no no not that one"))
+    }
+
+    /** Both of these are ordinary English and both look exactly like a stutter. */
+    @Test
+    fun `legitimate doubles survive`() {
+        assertEquals("she had had enough", TranscriptRepair.apply("she had had enough"))
+        assertEquals(
+            "the thing that that man said",
+            TranscriptRepair.apply("the thing that that man said"),
+        )
+    }
+
+    /** A sentence ended between the copies, so the second starts a new thought. */
+    @Test
+    fun `a repeat across a sentence boundary survives`() {
+        assertEquals(
+            "I went home. Home is quiet",
+            TranscriptRepair.apply("I went home. Home is quiet"),
+        )
+    }
+
+    // endregion
+
+    // region Marks that are already there
+
+    @Test
+    fun `spacing around marks is normalized`() {
+        assertEquals("hello there, how are you", TranscriptRepair.apply("hello there ,how are you"))
+        assertEquals("one. two. three", TranscriptRepair.apply("one.two.three"))
+    }
+
+    /**
+     * A bare hostname has to end in something that is actually a domain, or
+     * "the report.Then I left" is masked as one and the missing space after the
+     * full stop can never be repaired.
+     */
+    @Test
+    fun `a dotted pair of words is not a hostname`() {
+        assertEquals(
+            "I finished the report. Then I left",
+            TranscriptRepair.apply("I finished the report.Then I left"),
+        )
+        assertEquals(
+            "visit example.com/a.b. thanks",
+            TranscriptRepair.apply("visit example.com/a.b. thanks"),
+        )
+    }
+
+    @Test
+    fun `runs of marks collapse`() {
+        assertEquals("that is great!", TranscriptRepair.apply("that is great!!!"))
+        assertEquals("really? I did not know", TranscriptRepair.apply("really?? I did not know"))
+        assertEquals("wait for it...", TranscriptRepair.apply("wait for it...."))
+        // Three is an ellipsis and stays one.
+        assertEquals("wait for it...", TranscriptRepair.apply("wait for it..."))
+    }
+
+    @Test
+    fun `a separator touching a terminator loses`() {
+        assertEquals("that is all. thanks", TranscriptRepair.apply("that is all ,. thanks"))
+    }
+
+    @Test
+    fun `orphaned marks are dropped`() {
+        assertEquals("we should ship it", TranscriptRepair.apply(", we should ship it,"))
+    }
+
+    // endregion
+
+    // region Marks that are missing
+
+    /** The whole complaint, end to end. */
+    @Test
+    fun `a run-on gets its sentences back`() {
+        assertEquals(
+            "so i was thinking that we should probably ship it on friday, " +
+                "but i dont know if the tests are green. okay, lets check",
+            TranscriptRepair.apply(
+                "so i was thinking that um we should we should probably ship it on " +
+                    "friday but i dont know if the the tests are green okay lets check",
+            ),
+        )
+    }
+
+    @Test
+    fun `a conjunction joining two clauses takes a comma`() {
+        assertEquals(
+            "we can ship it on friday, but i need the tests",
+            TranscriptRepair.apply("we can ship it on friday but i need the tests"),
+        )
+    }
+
+    /**
+     * Not every "but" joins two clauses, and not every clause is long enough to
+     * be sure it is one.
+     */
+    @Test
+    fun `a conjunction inside a clause is left alone`() {
+        assertEquals("nothing but trouble here", TranscriptRepair.apply("nothing but trouble here"))
+        assertEquals("slow but steady wins", TranscriptRepair.apply("slow but steady wins"))
+        // "so that" is a phrase, not a new clause.
+        assertEquals(
+            "i moved the file so that the tests would pass",
+            TranscriptRepair.apply("i moved the file so that the tests would pass"),
+        )
+    }
+
+    @Test
+    fun `an opening discourse marker takes a comma`() {
+        assertEquals("okay, lets ship it", TranscriptRepair.apply("okay lets ship it"))
+        assertEquals(
+            "actually, i changed my mind",
+            TranscriptRepair.apply("actually i changed my mind"),
+        )
+    }
+
+    /**
+     * "so" and "well" open a sentence far more often without a comma than with
+     * one, which is why neither is in the list.
+     */
+    @Test
+    fun `so and well do not take a comma`() {
+        assertEquals(
+            "so i was thinking about it",
+            TranscriptRepair.apply("so i was thinking about it"),
+        )
+        assertEquals(
+            "well that settles it then",
+            TranscriptRepair.apply("well that settles it then"),
+        )
+    }
+
+    /**
+     * "okay" after a copula is an adjective describing something, not somebody
+     * starting a sentence.
+     */
+    @Test
+    fun `okay as an adjective does not split`() {
+        assertEquals(
+            "make sure the build is okay before you ship it",
+            TranscriptRepair.apply("make sure the build is okay before you ship it"),
+        )
+    }
+
+    @Test
+    fun `questions get a question mark`() {
+        assertEquals("what time is it?", TranscriptRepair.apply("what time is it"))
+        assertEquals("do you want coffee?", TranscriptRepair.apply("do you want coffee"))
+        assertEquals(
+            "how many people are coming?",
+            TranscriptRepair.apply("how many people are coming"),
+        )
+        // A model that closed a question with a full stop is corrected.
+        assertEquals("can you send it?", TranscriptRepair.apply("can you send it."))
+    }
+
+    /**
+     * A wh-word opening a noun clause is not a question, and the giveaway is a
+     * subject sitting between it and the verb.
+     */
+    @Test
+    fun `a statement starting with a wh-word is not a question`() {
+        assertEquals("what i meant was simple", TranscriptRepair.apply("what i meant was simple"))
+        assertEquals("how he did it is unclear", TranscriptRepair.apply("how he did it is unclear"))
+        assertEquals(
+            "when i get there i will call you",
+            TranscriptRepair.apply("when i get there i will call you"),
+        )
+    }
+
+    /** Someone chose the exclamation mark. Repair does not overrule it. */
+    @Test
+    fun `an exclamation is left alone`() {
+        assertEquals("what a day!", TranscriptRepair.apply("what a day!"))
+    }
+
+    // endregion
+
+    // region Spans nothing may touch
+
+    @Test
+    fun `protected spans survive every stage`() {
+        assertEquals(
+            "send it to me@example.com at 3.30 today",
+            TranscriptRepair.apply("um send it to me@example.com at 3.30 today"),
+        )
+        assertEquals(
+            "open https://example.com/a.b and tell me",
+            TranscriptRepair.apply("open https://example.com/a.b and uh tell me"),
+        )
+        assertEquals("it is the 1st of may", TranscriptRepair.apply("it is the 1st of may"))
+    }
+
+    // endregion
+
+    // region Other scripts
+
+    /**
+     * The inference rules are written against how English builds a sentence. In
+     * a script that terminates differently they would do damage, so they do not
+     * run at all.
+     */
+    @Test
+    fun `inference is skipped outside latin layout`() {
+        val hindi = "मैं कल बाजार जाऊंगा"
+        assertEquals(hindi, TranscriptRepair.apply(hindi, "hi"))
+        assertEquals("明日出荷します", TranscriptRepair.apply("えーと明日出荷します", "ja"))
+    }
+
+    /**
+     * Another Latin language keeps its layout, and the English trigger words
+     * simply never match — which is the point of choosing English-only words.
+     */
+    @Test
+    fun `another latin language is untouched`() {
+        val french = "nous devrions livrer vendredi mais je ne sais pas"
+        assertEquals(french, TranscriptRepair.apply(french, "fr"))
+    }
+
+    @Test
+    fun `nothing in means nothing out`() {
+        assertEquals("", TranscriptRepair.apply(null))
+        assertEquals("", TranscriptRepair.apply("   "))
+    }
+
+    // endregion
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptRepairTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptRepairTest.kt
@@ -262,6 +262,16 @@ class TranscriptRepairTest {
             "Example.com is the site we use",
             TranscriptRepair.apply("Example.com is the site we use"),
         )
+        // The name in front of the dot carries no signal, so a capitalized one
+        // with an unlisted domain has to survive too.
+        assertEquals(
+            "visit Example.museum for details",
+            TranscriptRepair.apply("visit Example.museum for details"),
+        )
+        assertEquals(
+            "see Acme.photography today",
+            TranscriptRepair.apply("see Acme.photography today"),
+        )
         assertEquals(
             "visit example.com/a.b. thanks",
             TranscriptRepair.apply("visit example.com/a.b. thanks"),

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptRepairTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptRepairTest.kt
@@ -128,6 +128,7 @@ class TranscriptRepairTest {
             "er kommt in einer Stunde nach Hause",
             TranscriptRepair.apply("er kommt in einer Stunde nach Hause"),
         )
+        assertEquals("er kommt her", TranscriptRepair.apply("er kommt her"))
         assertEquals(
             "we should ship it that day",
             TranscriptRepair.apply("um we should ship it that day"),
@@ -192,6 +193,7 @@ class TranscriptRepairTest {
     fun `a doubled content word survives`() {
         assertEquals("that is very very good", TranscriptRepair.apply("that is very very good"))
         assertEquals("no no not that one", TranscriptRepair.apply("no no not that one"))
+        assertEquals("I love you I love you", TranscriptRepair.apply("I love you I love you"))
     }
 
     /** Both of these are ordinary English and both look exactly like a stutter. */
@@ -202,6 +204,9 @@ class TranscriptRepairTest {
             "the thing that that man said",
             TranscriptRepair.apply("the thing that that man said"),
         )
+        assertEquals("I gave her her coat", TranscriptRepair.apply("I gave her her coat"))
+        assertEquals("my my what a surprise", TranscriptRepair.apply("my my what a surprise"))
+        assertEquals("I can can peaches", TranscriptRepair.apply("I can can peaches"))
     }
 
     /** A sentence ended between the copies, so the second starts a new thought. */
@@ -271,6 +276,10 @@ class TranscriptRepairTest {
         assertEquals(
             "see Acme.photography today",
             TranscriptRepair.apply("see Acme.photography today"),
+        )
+        assertEquals(
+            "visit NASA.GOV for details",
+            TranscriptRepair.apply("visit NASA.GOV for details"),
         )
         assertEquals(
             "visit example.com/a.b. thanks",
@@ -344,6 +353,10 @@ class TranscriptRepairTest {
             "actually, i changed my mind",
             TranscriptRepair.apply("actually i changed my mind"),
         )
+        assertEquals(
+            "however many people come we can fit them",
+            TranscriptRepair.apply("however many people come we can fit them"),
+        )
     }
 
     /**
@@ -393,6 +406,10 @@ class TranscriptRepairTest {
     @Test
     fun `a statement starting with a wh-word is not a question`() {
         assertEquals("what i meant was simple", TranscriptRepair.apply("what i meant was simple"))
+        assertEquals(
+            "what the problem is remains unclear",
+            TranscriptRepair.apply("what the problem is remains unclear"),
+        )
         assertEquals("how he did it is unclear", TranscriptRepair.apply("how he did it is unclear"))
         assertEquals(
             "when i get there i will call you",

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptRepairTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptRepairTest.kt
@@ -95,11 +95,65 @@ class TranscriptRepairTest {
         assertEquals("eh what was that", TranscriptRepair.apply("eh what was that", "en"))
     }
 
+    /**
+     * `um` is German for "at" and `er` is German for "he" and Dutch for
+     * "there". Removing them from those transcripts deletes content, which is
+     * why they are the one part of the filler set that has to know what
+     * language it is looking at.
+     */
+    @Test
+    fun `fillers that are words elsewhere survive`() {
+        assertEquals(
+            "wir treffen uns um acht Uhr",
+            TranscriptRepair.apply("wir treffen uns um acht Uhr", "de"),
+        )
+        assertEquals(
+            "er kommt in einer Stunde",
+            TranscriptRepair.apply("er kommt in einer Stunde", "de"),
+        )
+        // The unambiguous German filler still goes, and "um" beside it stays.
+        assertEquals(
+            "wir sollten um acht liefern",
+            TranscriptRepair.apply("wir sollten ähm um acht liefern", "de"),
+        )
+    }
+
+    /**
+     * On Automatic nothing has said what the language is, so the sentence has
+     * to. A German one carries no English marker and keeps its "er".
+     */
+    @Test
+    fun `automatic needs the sentence to read as english`() {
+        assertEquals(
+            "er kommt in einer Stunde nach Hause",
+            TranscriptRepair.apply("er kommt in einer Stunde nach Hause"),
+        )
+        assertEquals(
+            "we should ship it that day",
+            TranscriptRepair.apply("um we should ship it that day"),
+        )
+        // Said explicitly, no marker is needed.
+        assertEquals("ship it", TranscriptRepair.apply("um ship it", "en"))
+    }
+
+    /**
+     * "err" only looks like a filler after repeated letters are flattened, so
+     * it is caught before that runs.
+     */
+    @Test
+    fun `the verb err survives`() {
+        assertEquals("to err is human", TranscriptRepair.apply("to err is human"))
+        assertEquals(
+            "i am not sure about that",
+            TranscriptRepair.apply("errr i am not sure about that"),
+        )
+    }
+
     /** Repairing a transcript down to nothing is a rule misfiring, not silence. */
     @Test
     fun `a transcript is never repaired away`() {
-        assertEquals("um", TranscriptRepair.apply("um"))
-        assertEquals("um uh", TranscriptRepair.apply("um uh"))
+        assertEquals("um", TranscriptRepair.apply("um", "en"))
+        assertEquals("um uh", TranscriptRepair.apply("um uh", "en"))
     }
 
     // endregion
@@ -315,6 +369,64 @@ class TranscriptRepairTest {
     }
 
     // endregion
+
+    /**
+     * "…but the truth" is an object, not a clause. Only a determiner with room
+     * for a verb after it is one.
+     */
+    @Test
+    fun `a determiner object does not take a comma`() {
+        assertEquals(
+            "nothing at all here matters but the truth",
+            TranscriptRepair.apply("nothing at all here matters but the truth"),
+        )
+        assertEquals(
+            "we can ship it on friday, but the tests are failing",
+            TranscriptRepair.apply("we can ship it on friday but the tests are failing"),
+        )
+    }
+
+    /** A marker only ends the previous sentence when a clause follows it. */
+    @Test
+    fun `a starter without a clause after it does not split`() {
+        assertEquals(
+            "the results came back okay and we shipped",
+            TranscriptRepair.apply("the results came back okay and we shipped"),
+        )
+        assertEquals(
+            "i tested the whole thing. anyway, we can ship",
+            TranscriptRepair.apply("i tested the whole thing anyway we can ship"),
+        )
+    }
+
+    /**
+     * "Had I known" inverts exactly the way a question does. The modal further
+     * along is the only thing that tells them apart.
+     */
+    @Test
+    fun `an inverted conditional is not a question`() {
+        assertEquals(
+            "had i known that i would have called",
+            TranscriptRepair.apply("had i known that i would have called"),
+        )
+        assertEquals("had you seen the report?", TranscriptRepair.apply("had you seen the report"))
+    }
+
+    /** The mark belongs to the sentence, so it goes inside what wraps it. */
+    @Test
+    fun `a question mark goes inside the quotes`() {
+        assertEquals("\"can you send it?\"", TranscriptRepair.apply("\"can you send it\""))
+        assertEquals("\"can you send it?\"", TranscriptRepair.apply("\"can you send it.\""))
+    }
+
+    /**
+     * The two clients build their punctuation classes from one shared set, so a
+     * script whose separator only one of them listed cannot drift.
+     */
+    @Test
+    fun `non-latin separators are spaced too`() {
+        assertEquals("مرحبا، كيف حالك", TranscriptRepair.apply("مرحبا ،كيف حالك", "ar"))
+    }
 
     // region Spans nothing may touch
 

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptRepairTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/TranscriptRepairTest.kt
@@ -220,19 +220,47 @@ class TranscriptRepairTest {
     @Test
     fun `spacing around marks is normalized`() {
         assertEquals("hello there, how are you", TranscriptRepair.apply("hello there ,how are you"))
-        assertEquals("one. two. three", TranscriptRepair.apply("one.two.three"))
+        // Not hostname-shaped — a digit cannot be a top-level domain.
+        assertEquals(
+            "stop. 42 people came to the party",
+            TranscriptRepair.apply("stop.42 people came to the party"),
+        )
     }
 
     /**
-     * A bare hostname has to end in something that is actually a domain, or
-     * "the report.Then I left" is masked as one and the missing space after the
-     * full stop can never be repaired.
+     * A capital after the full stop is a sentence starting, not a domain, and
+     * the space it is missing has to be put back.
      */
     @Test
-    fun `a dotted pair of words is not a hostname`() {
+    fun `a capital after a full stop is not a hostname`() {
         assertEquals(
             "I finished the report. Then I left",
             TranscriptRepair.apply("I finished the report.Then I left"),
+        )
+        assertEquals(
+            "Report. Then I left the office",
+            TranscriptRepair.apply("Report.Then I left the office"),
+        )
+    }
+
+    /**
+     * There are roughly 1,500 top-level domains, so a hostname is recognized by
+     * being written in lowercase throughout rather than by a list of them.
+     * Splitting a dictated address in half is data loss; a missing space is not.
+     */
+    @Test
+    fun `an unlisted top-level domain is still a hostname`() {
+        assertEquals(
+            "visit example.museum for details",
+            TranscriptRepair.apply("visit example.museum for details"),
+        )
+        assertEquals(
+            "read more at my-site.photography today",
+            TranscriptRepair.apply("read more at my-site.photography today"),
+        )
+        assertEquals(
+            "Example.com is the site we use",
+            TranscriptRepair.apply("Example.com is the site we use"),
         )
         assertEquals(
             "visit example.com/a.b. thanks",

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -72,7 +72,7 @@ Settings is grouped by what you are trying to do, in five destinations:
 | Destination | What lives there |
 | --- | --- |
 | **Keyboard** | Height, a live preview, suggestions, autocorrect, prediction, learned words, smart punctuation, emoji suggestions, haptics, swipe typing |
-| **Dictation** | Automatic insertion, Quick Dictation, language, writing style, numbers as digits, microphone, recording sounds, custom words |
+| **Dictation** | Automatic insertion, Quick Dictation, language, writing style, clean up speech, numbers as digits, microphone, recording sounds, custom words |
 | **Transcription** | Which source is in use, on-device models, gateway pairing and health |
 | **Privacy and permissions** | Microphone status, Full Access explanation and manual path, what is kept |
 | **Diagnostics** | Version, redacted export, and clearing the log |

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		12A7F7D550BED2750227A111 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA135DE504590121F6D8843 /* DiagnosticLog.swift */; };
 		12F5617A0ECD4D904FC8FEA6 /* HomePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C96151B8C8ECE035FF0D8F /* HomePresentation.swift */; };
 		1301ECD8CCADCC436412B07A /* UsageReportingCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AA42EFADB6B77B0C9A5E44 /* UsageReportingCopy.swift */; };
+		1561F13494150F9085A131B4 /* SentencePunctuation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AF826E0D2C7820CBB4B78C /* SentencePunctuation.swift */; };
 		1598ED7D2DFA1F557A2783C3 /* TranscriptRetention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6FFEA14B55E6F6C61FBAC /* TranscriptRetention.swift */; };
 		15CB6862BDAB7694EE44D7F8 /* DictationBarStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7842B22D05FB171B261101A /* DictationBarStyle.swift */; };
 		15E349A8DDDFD47EFA7EE2FA /* ReliabilityFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5877B4AB653982A0433A37 /* ReliabilityFeatureTests.swift */; };
@@ -41,12 +42,14 @@
 		1B72FBEA5D41DB51B82A1305 /* SetupStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA031D86C1DE3C2F8B047308 /* SetupStatusTests.swift */; };
 		1BB4BED912ADFA11ED122052 /* DictationPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCCE5FE1A8242B96B8CA9FD /* DictationPresentation.swift */; };
 		1BB4E87432DBABB0D9552FDE /* LocalModelIntegrity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629821E8C5C22C9824A13665 /* LocalModelIntegrity.swift */; };
+		1D8B94886C8506BB36C1887C /* ProtectedSpans.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57FC525B204634FF41CDCDA /* ProtectedSpans.swift */; };
 		1D96E4B5456A18FA04F5F15D /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */; };
 		1EE70552DF2972DCE328ED01 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA135DE504590121F6D8843 /* DiagnosticLog.swift */; };
 		1F45494DE6D2E1E471D446B5 /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11816AC1A2219D15E870CE3E /* EmojiCatalog.swift */; };
 		214B0AB3D2362EC3EE656E53 /* SherpaLongAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */; };
 		21FF5DE4F40DB8D70AC170E2 /* CustomVocabulary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AA9291707DE7366D08EB0C /* CustomVocabulary.swift */; };
 		22293F4CFA1E2512027DFFBC /* TranscriptSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B121356A503DF83BFA0E0D0C /* TranscriptSanitizer.swift */; };
+		224B29F8D659FFBE60E53060 /* TranscriptRepairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71DC06463C8AA4C516363157 /* TranscriptRepairTests.swift */; };
 		22810975F2690A367F97719E /* DictatedTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575BDB070A428051B623F095 /* DictatedTranscript.swift */; };
 		22916AAC244D261969A38330 /* DownloadReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF56F0E966D9AECA1DCFF65E /* DownloadReadiness.swift */; };
 		243C684C09456958880B6AC1 /* TypingStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AA0EB543777294237739CF /* TypingStripView.swift */; };
@@ -116,6 +119,7 @@
 		52B45B602C490B27A6405A45 /* TranscriptionQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E2BF42CAC209DA12464566 /* TranscriptionQuality.swift */; };
 		52D566C02915D934240601EA /* PairingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFB4BB0345784837C629340 /* PairingPayload.swift */; };
 		53A1176717AEAE72A1F5B9F1 /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
+		54A3525CD8F0DFA70980501B /* SentencePunctuation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AF826E0D2C7820CBB4B78C /* SentencePunctuation.swift */; };
 		5634120C15A37F9E2C0FF2C0 /* LearnedWords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */; };
 		5673DF7E07F7F800FB847C2A /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */; };
 		56783518C221839DE432BCC7 /* DesignSystemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755A4279065D41A705E1F19D /* DesignSystemTests.swift */; };
@@ -125,6 +129,7 @@
 		590AE5D90BD9113ABA4EEF3F /* BrandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9711C18238B39EA2E842C0F /* BrandPalette.swift */; };
 		594C4A6790AD798CA3A7D427 /* SpeechAudioConditioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */; };
 		5A151959ABCE2ADE4646A79D /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
+		5ADC4420E2E23403BFC8716D /* TranscriptRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */; };
 		5C558BDC79705E089820562F /* KeyLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87128326897BFA30E7B2038 /* KeyLayout.swift */; };
 		5D5A394AA7E8170CFE4E128B /* RecordingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF871FC84B4C6B2627A43C2 /* RecordingCoordinator.swift */; };
 		5E7C819783E63C4FC95E706B /* TelemetryFailureMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D81AEA9FD59906139F273D /* TelemetryFailureMapping.swift */; };
@@ -163,6 +168,7 @@
 		7E3D8E857A83184E74B15433 /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */; };
 		81131D34DE3F3CBDBA61BE4E /* SwipeTrailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */; };
 		81BFE90A24876CEE127974AE /* TypingFieldPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2CD13AAF5FDF79DD5D0075 /* TypingFieldPolicy.swift */; };
+		81DDEADAD62C978ED52AAE90 /* SentencePunctuation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AF826E0D2C7820CBB4B78C /* SentencePunctuation.swift */; };
 		825C92F4A7114541F04C8313 /* TranscriptionSourceStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5995603DDA33014FFA52B079 /* TranscriptionSourceStatus.swift */; };
 		82A1659A07D52F972E9010DD /* SherpaIncrementalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41205764F091734B2DE6D02 /* SherpaIncrementalSession.swift */; };
 		8345B143988A279FD48D6819 /* ModelTranslationSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7235E2DEF5A0082A417E3E /* ModelTranslationSupport.swift */; };
@@ -197,6 +203,7 @@
 		97EE4663316E8CF2EAE9761A /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */; };
 		98AE213452E133E22550785B /* KeyboardHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858088F81E12EC57E13F9492 /* KeyboardHaptics.swift */; };
 		9AE625A9A97E5A57DC6520E9 /* TelemetryStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D9836F52892447650F0375 /* TelemetryStats.swift */; };
+		9B5622A66F2595319CE5825E /* SentencePunctuation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AF826E0D2C7820CBB4B78C /* SentencePunctuation.swift */; };
 		9C3766171C286926385A9F1E /* SpokenNumbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E590CFC53039DA367280B8CD /* SpokenNumbers.swift */; };
 		9C6AF2EE68EB7AA4D4CF0F61 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA135DE504590121F6D8843 /* DiagnosticLog.swift */; };
 		9EE31A21EE5F9D71A15404DA /* SpellChecking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4BE75828FCA9C70DFEDC96 /* SpellChecking.swift */; };
@@ -222,6 +229,7 @@
 		AD2CCDE7DC189E63810890BB /* SwipeRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C4BD2142E9377F123A8848 /* SwipeRecognizer.swift */; };
 		AE4E1B1B8CB72567DEF58A40 /* TranscriptionQualityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCAE41267FF8113463CFFF96 /* TranscriptionQualityTests.swift */; };
 		AEF583A0E9B4984F72636A0A /* KeyboardHandoffPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46E8BCA13C319737A50B7CE9 /* KeyboardHandoffPresentation.swift */; };
+		AF3CF11CC0E9E65B026EBEF8 /* TranscriptRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */; };
 		B063AE9288450BE04769F7DD /* TypingCandidates.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAA4440B24071020CD693DB /* TypingCandidates.swift */; };
 		B0DF0FF5821BD7E8C839065C /* GatewayClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4211FAA8E574AEF57D788FA /* GatewayClient.swift */; };
 		B1D4DE96B74C3327DA6A0FAD /* SwipeTrailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */; };
@@ -253,6 +261,7 @@
 		C63521DE52DC5A8DCD6847AE /* EmojiPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348E2313B75BA61D777FA18B /* EmojiPanelView.swift */; };
 		C6E529713960996E85EFD275 /* SherpaIncrementalSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0A732D03A2951F028DDF6E /* SherpaIncrementalSessionTests.swift */; };
 		C729D3D95B9B597E56C485E7 /* SpokenNumbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E590CFC53039DA367280B8CD /* SpokenNumbers.swift */; };
+		C7ADFFD337103F3F6CF7BBA6 /* ProtectedSpans.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57FC525B204634FF41CDCDA /* ProtectedSpans.swift */; };
 		C80FCACABE7FF798EFD1EB61 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894063AE1B3DDA92C529268D /* AppConfiguration.swift */; };
 		C845C02425BC2788BABB26C2 /* SpeechAudioConditioningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59DB522E7DFDE3B3E009AFD /* SpeechAudioConditioningTests.swift */; };
 		C958410A61E962F39B4F5E4D /* LearnedWords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */; };
@@ -265,6 +274,7 @@
 		D1CD3C13398FA4514EF57CA7 /* TranscriptHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28ECEDA044D2B1021710F205 /* TranscriptHistoryView.swift */; };
 		D32F9FCE7750E51A69E56F10 /* DesignSystemPreviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71760E0F5AF9B1965E960E1 /* DesignSystemPreviews.swift */; };
 		D347613BCA81EB9BF9AAC2DD /* TranscriptionSourceStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5995603DDA33014FFA52B079 /* TranscriptionSourceStatus.swift */; };
+		D37101A845F65CA081F8B6E4 /* ProtectedSpans.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57FC525B204634FF41CDCDA /* ProtectedSpans.swift */; };
 		D4CA018F48AA244D322B9156 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F3A6E7B826D1389D462944 /* ContentView.swift */; };
 		D4FEC9D26550CB1696FDF424 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */; };
 		D6533E4D830A06E9845CE624 /* KeyboardViewPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8E5D91EDE2C0E67DFC0250 /* KeyboardViewPreview.swift */; };
@@ -292,10 +302,12 @@
 		E4162282629880D2A33913CA /* KeyGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF7CAC171521FC372DF2BF0 /* KeyGridView.swift */; };
 		E4187B9A8DA6FBBA6DE095AC /* DictationPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCCE5FE1A8242B96B8CA9FD /* DictationPresentation.swift */; };
 		E5595FE143CBC103B6DAE2C8 /* TypingWordList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6743BB4173E2F719E3D8CB /* TypingWordList.swift */; };
+		E5CA31ED8B208F173ACDA3EF /* TranscriptRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */; };
 		E5EAD40641B38DDA0CCA0300 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894063AE1B3DDA92C529268D /* AppConfiguration.swift */; };
 		E6FDBF8529AEB00D2CFB245E /* UsageReportingCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AA42EFADB6B77B0C9A5E44 /* UsageReportingCopy.swift */; };
 		E9C82042A1155CC1E50BF2B6 /* StartDictationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A7126FEDA473D8C112A397 /* StartDictationIntent.swift */; };
 		E9E86F6940BDB4381A8C9FF5 /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C304CF763960E5F1D8F76B2B /* LiveActivityManager.swift */; };
+		ED04BFBB1AB30BB6226D77B3 /* TranscriptRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */; };
 		EE7A49C4F95388AF42E1B30C /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
 		EF4B66CAC02A63D743384B49 /* DownloadReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF56F0E966D9AECA1DCFF65E /* DownloadReadiness.swift */; };
 		EFEB53E947DAF4C77FE5E059 /* DictatedTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575BDB070A428051B623F095 /* DictatedTranscript.swift */; };
@@ -304,6 +316,7 @@
 		F1CDF580A8C552E1A03524A1 /* DictationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3489C985467C23EB6A90AD /* DictationBarView.swift */; };
 		F1E23C92AD4C90D424DB84D9 /* LocalModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473A608BF3F8827B3D3842B0 /* LocalModelCatalog.swift */; };
 		F1EC3EE86C05A57F3A42EFF1 /* DownloadReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF56F0E966D9AECA1DCFF65E /* DownloadReadiness.swift */; };
+		F231FFC3DFB742B826516E5E /* ProtectedSpans.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57FC525B204634FF41CDCDA /* ProtectedSpans.swift */; };
 		F37F68399E06B767B5D6ACC7 /* KeyGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF7CAC171521FC372DF2BF0 /* KeyGridView.swift */; };
 		F3A845A38CC7840D2877FD26 /* KeyAlternatives.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0EBA8DE4056FCA3CB7F093C /* KeyAlternatives.swift */; };
 		F426CFBED733974D61FDB432 /* ModelLanguageSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41EF03C8A4F930315EFE77 /* ModelLanguageSupportTests.swift */; };
@@ -424,9 +437,11 @@
 		6CF871FC84B4C6B2627A43C2 /* RecordingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingCoordinator.swift; sourceTree = "<group>"; };
 		70B3F1DBA8332A13B095E4BA /* PairingScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScannerView.swift; sourceTree = "<group>"; };
 		70CAE08F934281250A314597 /* PreviewMatrix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewMatrix.swift; sourceTree = "<group>"; };
+		71DC06463C8AA4C516363157 /* TranscriptRepairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptRepairTests.swift; sourceTree = "<group>"; };
 		755A4279065D41A705E1F19D /* DesignSystemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemTests.swift; sourceTree = "<group>"; };
 		75FD84E65614D9F94D8EF0AC /* DictationBarComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarComponents.swift; sourceTree = "<group>"; };
 		786DEF44BDB4C70935762971 /* VocaPhoneLiveActivity.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VocaPhoneLiveActivity.entitlements; sourceTree = "<group>"; };
+		78AF826E0D2C7820CBB4B78C /* SentencePunctuation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentencePunctuation.swift; sourceTree = "<group>"; };
 		7948F8C6C72A8D7A16C18562 /* SharedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStore.swift; sourceTree = "<group>"; };
 		796D6FA2FF5B98026FAA85AD /* onnxruntime.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = onnxruntime.xcframework; path = ThirdParty/SherpaOnnx/onnxruntime.xcframework; sourceTree = "<group>"; };
 		7A53786C8D2346452C69A748 /* InsertionTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsertionTargetTests.swift; sourceTree = "<group>"; };
@@ -458,6 +473,7 @@
 		97639A09609D9E6E76153CDB /* KeyboardHapticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHapticsTests.swift; sourceTree = "<group>"; };
 		98325CD266139FCDEE156D8F /* KeyboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardViewController.swift; sourceTree = "<group>"; };
 		9859ACCB32CD57E4F3E4D46A /* WordComposerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordComposerTests.swift; sourceTree = "<group>"; };
+		991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptRepair.swift; sourceTree = "<group>"; };
 		9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayEndpoint.swift; sourceTree = "<group>"; };
 		9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPreferences.swift; sourceTree = "<group>"; };
 		9DCCE5FE1A8242B96B8CA9FD /* DictationPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationPresentation.swift; sourceTree = "<group>"; };
@@ -508,6 +524,7 @@
 		D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelLanguageSupport.swift; sourceTree = "<group>"; };
 		D1AA0EB543777294237739CF /* TypingStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingStripView.swift; sourceTree = "<group>"; };
 		D41205764F091734B2DE6D02 /* SherpaIncrementalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaIncrementalSession.swift; sourceTree = "<group>"; };
+		D57FC525B204634FF41CDCDA /* ProtectedSpans.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectedSpans.swift; sourceTree = "<group>"; };
 		D80C83295868E17F215D9382 /* TypingStripPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingStripPresentationTests.swift; sourceTree = "<group>"; };
 		D97C6225AC98D4FE053BDB13 /* KeyboardPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPreview.swift; sourceTree = "<group>"; };
 		DBAE2B11D3A27A798D0F39ED /* local_model_pins.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = local_model_pins.json; sourceTree = "<group>"; };
@@ -643,8 +660,10 @@
 				D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */,
 				8F7235E2DEF5A0082A417E3E /* ModelTranslationSupport.swift */,
 				DBFB4BB0345784837C629340 /* PairingPayload.swift */,
+				D57FC525B204634FF41CDCDA /* ProtectedSpans.swift */,
 				0AB84927D76F9C32C4BE1547 /* QuickDictationAvailability.swift */,
 				AF6C44F954E7A62974C66109 /* SemanticPalette.swift */,
+				78AF826E0D2C7820CBB4B78C /* SentencePunctuation.swift */,
 				36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */,
 				7948F8C6C72A8D7A16C18562 /* SharedStore.swift */,
 				D41205764F091734B2DE6D02 /* SherpaIncrementalSession.swift */,
@@ -653,6 +672,7 @@
 				E590CFC53039DA367280B8CD /* SpokenNumbers.swift */,
 				FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */,
 				A8E2BF42CAC209DA12464566 /* TranscriptionQuality.swift */,
+				991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */,
 				56B6FFEA14B55E6F6C61FBAC /* TranscriptRetention.swift */,
 				B121356A503DF83BFA0E0D0C /* TranscriptSanitizer.swift */,
 				F0DBF47C7F5E5B13752056CB /* TranscriptStyler.swift */,
@@ -794,6 +814,7 @@
 				ABDF2EC3AB09FF78FD1EF935 /* TranscriptHistoryModelTests.swift */,
 				FCAE41267FF8113463CFFF96 /* TranscriptionQualityTests.swift */,
 				B154124C04655D1A36F1B4E4 /* TranscriptionSourceTests.swift */,
+				71DC06463C8AA4C516363157 /* TranscriptRepairTests.swift */,
 				C8E491E7E805F47388A668E1 /* TranscriptSanitizerTests.swift */,
 				A45A3914F898AD0570486806 /* TranscriptStylerTests.swift */,
 				0B31528AA0DAB644EFBBE967 /* TypingCandidatesTests.swift */,
@@ -1071,8 +1092,10 @@
 				3EF8AE348290CBB5FE45BD11 /* ModelLanguageSupport.swift in Sources */,
 				3E812EB0A69DFF8CC9A7CA6E /* ModelTranslationSupport.swift in Sources */,
 				FAD55FD707FD21407E0980FA /* PairingPayload.swift in Sources */,
+				1D8B94886C8506BB36C1887C /* ProtectedSpans.swift in Sources */,
 				6192C923119F158CCE94B48E /* QuickDictationAvailability.swift in Sources */,
 				EE7A49C4F95388AF42E1B30C /* SemanticPalette.swift in Sources */,
+				81DDEADAD62C978ED52AAE90 /* SentencePunctuation.swift in Sources */,
 				36295638EAABF35D05369EB0 /* SessionRecord.swift in Sources */,
 				A794CD8D0B445E5118500EC3 /* SharedStore.swift in Sources */,
 				503DA76554CDB360C2E32566 /* SherpaIncrementalSession.swift in Sources */,
@@ -1085,6 +1108,7 @@
 				282E28F25550DF3BFB996429 /* SwipeRecognizer.swift in Sources */,
 				B1D4DE96B74C3327DA6A0FAD /* SwipeTrailView.swift in Sources */,
 				E366EFAD9B70FE3FC43FEBAD /* TextInsertion.swift in Sources */,
+				5ADC4420E2E23403BFC8716D /* TranscriptRepair.swift in Sources */,
 				9137DE19695E0CADB0EFBFB0 /* TranscriptRetention.swift in Sources */,
 				057296EB66A8C88C3B2A762C /* TranscriptSanitizer.swift in Sources */,
 				CA31A30F8E764B891884324F /* TranscriptStyler.swift in Sources */,
@@ -1150,10 +1174,12 @@
 				84EB79403F7CED013A82334F /* PairingScannerView.swift in Sources */,
 				D9D9DB4E8F749BCC02AD0B5B /* PreviewFixtures.swift in Sources */,
 				2F1F7D8997BCA83AF5334382 /* PreviewMatrix.swift in Sources */,
+				C7ADFFD337103F3F6CF7BBA6 /* ProtectedSpans.swift in Sources */,
 				B4EE97A67B156A6D5BA0D258 /* QuickDictationAvailability.swift in Sources */,
 				5D5A394AA7E8170CFE4E128B /* RecordingCoordinator.swift in Sources */,
 				A59723F937FABF80B8158883 /* RecordingSoundFeedback.swift in Sources */,
 				53A1176717AEAE72A1F5B9F1 /* SemanticPalette.swift in Sources */,
+				9B5622A66F2595319CE5825E /* SentencePunctuation.swift in Sources */,
 				B463A007E4ABBFF427073748 /* SessionRecord.swift in Sources */,
 				387B6B6A0B0AE57B6324B55F /* SettingsView.swift in Sources */,
 				366E7DFAD5B2666FC1FF9FB3 /* SetupStatus.swift in Sources */,
@@ -1181,6 +1207,7 @@
 				89E3D47D85EBD6AD5A093813 /* TextInsertion.swift in Sources */,
 				24D6E87B9EE199DCFDFC66D6 /* TranscriptHistoryModel.swift in Sources */,
 				D1CD3C13398FA4514EF57CA7 /* TranscriptHistoryView.swift in Sources */,
+				ED04BFBB1AB30BB6226D77B3 /* TranscriptRepair.swift in Sources */,
 				45AB9DD91FB8969A4BB19A60 /* TranscriptRetention.swift in Sources */,
 				22293F4CFA1E2512027DFFBC /* TranscriptSanitizer.swift in Sources */,
 				18E5AC9EE6C8C0190F45D14B /* TranscriptStyler.swift in Sources */,
@@ -1218,8 +1245,10 @@
 				33A2193E058E05B4B4FB3860 /* ModelLanguageSupport.swift in Sources */,
 				E1C9002BB583DA067026C250 /* ModelTranslationSupport.swift in Sources */,
 				364C315F292BA4BD66E23C2A /* PairingPayload.swift in Sources */,
+				F231FFC3DFB742B826516E5E /* ProtectedSpans.swift in Sources */,
 				58CDCA65875E94B8F7BE0101 /* QuickDictationAvailability.swift in Sources */,
 				F4E8B1A9D00B14184B01B223 /* SemanticPalette.swift in Sources */,
+				54A3525CD8F0DFA70980501B /* SentencePunctuation.swift in Sources */,
 				3F3E17AFAAE8EB6B79A872BE /* SessionRecord.swift in Sources */,
 				B2406DA05AE90DDB7EED6246 /* SharedStore.swift in Sources */,
 				F0EC49ECABE510B52F876C8F /* SherpaIncrementalSession.swift in Sources */,
@@ -1228,6 +1257,7 @@
 				C729D3D95B9B597E56C485E7 /* SpokenNumbers.swift in Sources */,
 				6C48D9ED8AF4FE61AB76AE49 /* StopQuickDictationIntent.swift in Sources */,
 				D4FEC9D26550CB1696FDF424 /* TextInsertion.swift in Sources */,
+				E5CA31ED8B208F173ACDA3EF /* TranscriptRepair.swift in Sources */,
 				29D15EC565FE20FEE4FFE469 /* TranscriptRetention.swift in Sources */,
 				3D08A881E95118E5B57E9FCD /* TranscriptSanitizer.swift in Sources */,
 				95A08342703AE27BD09E08AC /* TranscriptStyler.swift in Sources */,
@@ -1297,10 +1327,12 @@
 				9F93D09F955DA7B5CC65F058 /* OnboardingPresentationTests.swift in Sources */,
 				2E93E016656B5EA74568DD4F /* PairingPayload.swift in Sources */,
 				DCF552B58B7A7A12C517C17B /* PairingPayloadTests.swift in Sources */,
+				D37101A845F65CA081F8B6E4 /* ProtectedSpans.swift in Sources */,
 				BCB8CA3BAACE6280D9ED4B22 /* QuickDictationAvailability.swift in Sources */,
 				15E349A8DDDFD47EFA7EE2FA /* ReliabilityFeatureTests.swift in Sources */,
 				6CEF2A686643F72F4BCDD51D /* SemanticPalette.swift in Sources */,
 				C37AC6FC3CBF2147D8A50DDA /* SemanticPaletteTests.swift in Sources */,
+				1561F13494150F9085A131B4 /* SentencePunctuation.swift in Sources */,
 				2C362C9B71AA6A93A6D7E4DB /* SessionRecord.swift in Sources */,
 				28C271BC0195C62E93292A9C /* SessionRecordTests.swift in Sources */,
 				3219DC5DD26E1998A7A0CD5C /* SetupStatus.swift in Sources */,
@@ -1336,6 +1368,8 @@
 				D7CC096732C721CE14B5F682 /* TextInsertion.swift in Sources */,
 				8A69E16ABEF642C3D68FADD5 /* TranscriptHistoryModel.swift in Sources */,
 				834AEADC7B9757282E300418 /* TranscriptHistoryModelTests.swift in Sources */,
+				AF3CF11CC0E9E65B026EBEF8 /* TranscriptRepair.swift in Sources */,
+				224B29F8D659FFBE60E53060 /* TranscriptRepairTests.swift in Sources */,
 				1598ED7D2DFA1F557A2783C3 /* TranscriptRetention.swift in Sources */,
 				77E93C2F64DEB6AAB50C09F0 /* TranscriptSanitizer.swift in Sources */,
 				2CB5468923B46D6ACAE60BE2 /* TranscriptSanitizerTests.swift in Sources */,

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -363,6 +363,10 @@ struct DictationSettingsView: View {
         store: KeyboardPreferences.defaults
     ) private var numbersAsDigits = false
     @AppStorage(
+        KeyboardPreferences.repairSpeechKey,
+        store: KeyboardPreferences.defaults
+    ) private var repairSpeech = true
+    @AppStorage(
         KeyboardPreferences.transcriptionLanguageKey,
         store: KeyboardPreferences.defaults
     ) private var transcriptionLanguageRawValue = TranscriptionLanguage.automatic.rawValue
@@ -393,6 +397,7 @@ struct DictationSettingsView: View {
             quickDictationSection
             languageSection
             writingStyleSection
+            cleanUpSection
             numbersSection
             microphoneSection
             recordingFeedbackSection
@@ -484,9 +489,35 @@ struct DictationSettingsView: View {
                 Text("“\(selectedWritingStyle.example)”")
                 Text(
                     "Styles only change formatting. Your words, times, links and "
-                        + "contractions are never altered; numbers change only if "
-                        + "you turn on Write numbers as digits below."
+                        + "contractions are never altered by a style; words change "
+                        + "only through Clean up speech, and numbers only through "
+                        + "Write numbers as digits, both below."
                 )
+            }
+        }
+    }
+
+    /// The one switch in Dictation that changes words rather than formatting,
+    /// which is why it says so in the footer instead of leaving it to be
+    /// discovered.
+    private var cleanUpSection: some View {
+        Section {
+            Toggle("Clean up speech", isOn: $repairSpeech)
+        } header: {
+            Text("Clean up")
+        } footer: {
+            VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                Text(
+                    "Hesitation sounds and false starts are dropped, and missing "
+                        + "sentence punctuation is filled in: “so um we should we "
+                        + "should ship it friday” becomes “So we should ship it Friday.”"
+                )
+                Text(
+                    "Only sounds with no meaning go — “um”, “uh”, “er”. Real words "
+                        + "stay, including “like”, “you know” and “I mean”, and so do "
+                        + "“mhm” and “uh-huh”, which are answers."
+                )
+                Text("Never applied to the Raw writing style.")
             }
         }
     }

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -950,6 +950,10 @@ final class RecordingCoordinator {
                 record.transcript = DictatedTranscript.finished(
                     transcript,
                     style: WritingStyle(rawValue: record.style) ?? .casual,
+                    // Only repair reads this on a gateway route — the style is
+                    // already applied — but a German transcript keeps its "um"
+                    // only if this stage is told the language.
+                    language: record.language,
                     styledUpstream: true,
                     repairSpeech: KeyboardPreferences.repairSpeech,
                     numbersAsDigits: KeyboardPreferences.numbersAsDigits
@@ -995,6 +999,7 @@ final class RecordingCoordinator {
             record.transcript = DictatedTranscript.finished(
                 transcript,
                 style: WritingStyle(rawValue: record.style) ?? .casual,
+                language: record.language,
                 styledUpstream: true,
                 repairSpeech: KeyboardPreferences.repairSpeech,
                 numbersAsDigits: KeyboardPreferences.numbersAsDigits

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -949,6 +949,9 @@ final class RecordingCoordinator {
             ) {
                 record.transcript = DictatedTranscript.finished(
                     transcript,
+                    style: WritingStyle(rawValue: record.style) ?? .casual,
+                    styledUpstream: true,
+                    repairSpeech: KeyboardPreferences.repairSpeech,
                     numbersAsDigits: KeyboardPreferences.numbersAsDigits
                 )
                 record.error = nil
@@ -991,6 +994,9 @@ final class RecordingCoordinator {
             }
             record.transcript = DictatedTranscript.finished(
                 transcript,
+                style: WritingStyle(rawValue: record.style) ?? .casual,
+                styledUpstream: true,
+                repairSpeech: KeyboardPreferences.repairSpeech,
                 numbersAsDigits: KeyboardPreferences.numbersAsDigits
             )
             record.error = nil
@@ -1119,6 +1125,7 @@ final class RecordingCoordinator {
                     reported: transcribed.language,
                     translateTo: KeyboardPreferences.translationTarget
                 ),
+                repairSpeech: KeyboardPreferences.repairSpeech,
                 numbersAsDigits: KeyboardPreferences.numbersAsDigits
             )
             record.error = nil

--- a/ios/VocaPhoneShared/DictatedTranscript.swift
+++ b/ios/VocaPhoneShared/DictatedTranscript.swift
@@ -3,29 +3,39 @@ import Foundation
 /// Everything that happens to a transcript between the model returning it and
 /// the record that the keyboard inserts from.
 ///
-/// One funnel rather than three call sites, because the *order* is load-bearing
+/// One funnel rather than four call sites, because the *order* is load-bearing
 /// and was previously only implicit:
 ///
-/// 1. Sanitize. The styler capitalizes sentences and adds terminators, and
+/// 1. Sanitize. The later stages capitalize sentences and add terminators, and
 ///    doing that to `[BLANK_AUDIO]` only makes it look more like something the
 ///    user meant to say.
-/// 2. Style — but only for transcripts produced on this device. A gateway has
+/// 2. Repair — the one stage allowed to change the words, and only when the
+///    user has left Clean up speech on. It runs before styling because it is
+///    what puts the sentence boundaries *there*: styling capitalizes and
+///    terminates around boundaries, and cannot find one that is missing.
+///    Never for `raw`, which promises the model's own output.
+/// 3. Style — but only for transcripts produced on this device. A gateway has
 ///    already applied the writing style the session asked for, and applying it
 ///    twice is how "Hello." becomes "Hello.." on one route and not the other.
-/// 3. Digits. After styling, never before: the styler capitalizes the first
+/// 4. Digits. After styling, never before: the styler capitalizes the first
 ///    letter of a sentence, so a sentence already reduced to "20 people came"
 ///    would have it look past the digits and capitalize "People".
 enum DictatedTranscript {
     static func finished(
         _ raw: String?,
-        style: WritingStyle? = nil,
+        style: WritingStyle,
         language: String = "auto",
+        styledUpstream: Bool = false,
+        repairSpeech: Bool,
         numbersAsDigits: Bool
     ) -> String {
         let cleaned = TranscriptSanitizer.clean(raw)
-        let styled = style.map {
-            TranscriptStyler.apply(cleaned, style: $0, language: language)
-        } ?? cleaned
+        let repaired = repairSpeech && style != .raw
+            ? TranscriptRepair.apply(cleaned, language: language)
+            : cleaned
+        let styled = styledUpstream
+            ? repaired
+            : TranscriptStyler.apply(repaired, style: style, language: language)
         guard numbersAsDigits else { return styled }
         return SpokenNumbers.digits(in: styled)
     }

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -270,6 +270,7 @@ enum KeyboardPreferences {
     static let quickDictationKey = "quickDictationEnabled"
     static let writingStyleKey = "writingStyle"
     static let numbersAsDigitsKey = "numbersAsDigitsEnabled"
+    static let repairSpeechKey = "speechRepairEnabled"
     static let transcriptionLanguageKey = "transcriptionLanguage"
     static let translateToKey = "translateTo"
     static let microphonePreferenceKey = "microphonePreference"
@@ -423,6 +424,18 @@ enum KeyboardPreferences {
     static var numbersAsDigits: Bool {
         get { boolean(numbersAsDigitsKey, default: false) }
         set { defaults?.set(newValue, forKey: numbersAsDigitsKey) }
+    }
+
+    /// Whether hesitation sounds, false starts, and missing sentence
+    /// punctuation are repaired before the writing style is applied.
+    ///
+    /// On by default, and the only setting in this file that changes the words
+    /// in a transcript rather than its formatting. It earns that because the
+    /// words it removes are not words: "um" is a sound someone makes while
+    /// deciding what to say, and nobody dictating meant to type it.
+    static var repairSpeech: Bool {
+        get { boolean(repairSpeechKey, default: true) }
+        set { defaults?.set(newValue, forKey: repairSpeechKey) }
     }
 
     static var writingStyle: WritingStyle {

--- a/ios/VocaPhoneShared/ProtectedSpans.swift
+++ b/ios/VocaPhoneShared/ProtectedSpans.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// The runs of a transcript that no text stage may edit: URLs, email addresses,
+/// bare domains, decimals and times, ordinals, and dotted initialisms.
+///
+/// Every stage that rewrites punctuation has the same problem — `example.com`
+/// ends in a full stop that is not a sentence, `3.5` contains one that is not a
+/// mark at all — so they all mask first, work on the masked text, and restore
+/// last. The placeholder is a private-use scalar pair rather than a word, so a
+/// stage that lowercases or capitalizes cannot damage it and a stage that splits
+/// on letters cannot split it.
+struct ProtectedSpans {
+    static let open: Character = "\u{E000}"
+    static let close: Character = "\u{E001}"
+
+    let text: String
+    let tokens: [String]
+
+    /// Top-level domains a bare hostname is allowed to end in, plus any
+    /// two-letter country code.
+    ///
+    /// Matching *any* dotted pair instead — which this did — masks
+    /// `report.Then` in "I finished the report.Then I left" and the missing
+    /// space after the full stop can then never be repaired. Deliberately
+    /// case-sensitive: a real domain is written in lowercase, and `.To` at the
+    /// start of a sentence is not one.
+    private static let topLevelDomains =
+        "com|org|net|edu|gov|int|mil|io|dev|app|ai|co|me|tv|cc|xyz|info|biz"
+        + "|online|site|tech|store|blog|cloud|link|live|news|shop|space|wiki|zone"
+        + "|[a-z]{2}"
+
+    private static let pattern =
+        "((?i:https?)://[^\\s]+[^\\s.,;:!?\\\"“”'\\)\\]]"
+        + "|[\\w.+-]+@(?:[\\w-]+\\.)+[A-Za-z]{2,}"
+        + "|(?:[\\w-]+\\.)+(?:" + topLevelDomains + ")\\b"
+        // A path may contain dots; it may not end on the full stop that ends
+        // the sentence the address is sitting in.
+        + "(?:/[^\\s]*[^\\s.,;:!?\\\"“”'\\)\\]])?"
+        + "|\\d+(?:[.,:/]\\d+)+"
+        + "|\\d+(?i:st|nd|rd|th)\\b"
+        + "|(?:[A-Za-z]\\.){2,})"
+
+    private static let expression = try? NSRegularExpression(pattern: pattern)
+    private static let placeholder = try? NSRegularExpression(
+        pattern: "\u{E000}(\\d+)\u{E001}"
+    )
+
+    static func mask(_ text: String) -> ProtectedSpans {
+        guard let expression else { return ProtectedSpans(text: text, tokens: []) }
+        let string = text as NSString
+        let matches = expression.matches(
+            in: text, range: NSRange(location: 0, length: string.length)
+        )
+        let result = NSMutableString(string: text)
+        for index in matches.indices.reversed() {
+            result.replaceCharacters(
+                in: matches[index].range,
+                with: "\(open)\(index)\(close)"
+            )
+        }
+        return ProtectedSpans(
+            text: String(result),
+            tokens: matches.map { string.substring(with: $0.range) }
+        )
+    }
+
+    /// Puts the original spans back. Takes the text rather than reading
+    /// ``text``, because the caller has rewritten everything around them.
+    func restore(_ masked: String) -> String {
+        guard let placeholder = Self.placeholder else { return masked }
+        let string = masked as NSString
+        let matches = placeholder.matches(
+            in: masked, range: NSRange(location: 0, length: string.length)
+        )
+        let result = NSMutableString(string: masked)
+        for match in matches.reversed() {
+            let index = Int(string.substring(with: match.range(at: 1))) ?? -1
+            guard tokens.indices.contains(index) else { continue }
+            result.replaceCharacters(in: match.range, with: tokens[index])
+        }
+        return String(result)
+    }
+
+    /// Applies `transform` to everything that is not a placeholder. Case
+    /// changes have to skip them: the digits inside would survive, but the
+    /// scalars are the only thing ``restore(_:)`` can match on.
+    static func mapOutsidePlaceholders(
+        _ text: String,
+        _ transform: (String) -> String
+    ) -> String {
+        guard let placeholder else { return transform(text) }
+        let string = text as NSString
+        let matches = placeholder.matches(
+            in: text, range: NSRange(location: 0, length: string.length)
+        )
+        var result = ""
+        var cursor = 0
+        for match in matches {
+            let before = NSRange(location: cursor, length: match.range.location - cursor)
+            result += transform(string.substring(with: before))
+            result += string.substring(with: match.range)
+            cursor = match.range.location + match.range.length
+        }
+        result += transform(string.substring(from: cursor))
+        return result
+    }
+
+    /// Whether `character` opens a placeholder, for the stages that walk
+    /// characters and have to step over one whole.
+    static func isPlaceholderStart(_ character: Character) -> Bool { character == open }
+}

--- a/ios/VocaPhoneShared/ProtectedSpans.swift
+++ b/ios/VocaPhoneShared/ProtectedSpans.swift
@@ -16,26 +16,41 @@ struct ProtectedSpans {
     let text: String
     let tokens: [String]
 
-    /// Top-level domains a bare hostname is allowed to end in, plus any
-    /// two-letter country code.
-    ///
-    /// Matching *any* dotted pair instead — which this did — masks
-    /// `report.Then` in "I finished the report.Then I left" and the missing
-    /// space after the full stop can then never be repaired. Deliberately
-    /// case-sensitive: a real domain is written in lowercase, and `.To` at the
-    /// start of a sentence is not one.
+    /// Top-level domains common enough to recognize even when the name in
+    /// front of them was capitalized — "Example.com" opening a sentence.
     private static let topLevelDomains =
         "com|org|net|edu|gov|int|mil|io|dev|app|ai|co|me|tv|cc|xyz|info|biz"
         + "|online|site|tech|store|blog|cloud|link|live|news|shop|space|wiki|zone"
         + "|[a-z]{2}"
 
+    /// Any other bare hostname, recognized by case rather than by a list.
+    ///
+    /// There are roughly 1,500 top-level domains, so an allowlist misses real
+    /// ones — `example.museum` — and punctuation repair then splits the address
+    /// in half. Matching *any* dotted pair instead has the opposite fault: it
+    /// masks `report.Then` in "I finished the report.Then I left", and the
+    /// missing space can never be repaired.
+    ///
+    /// Case is what actually separates them. A hostname is written in
+    /// lowercase from end to end; a full stop that ended a sentence is followed
+    /// by a capital. This clause requires the former, and the leading `\b`
+    /// keeps it from matching the tail of a capitalized word.
+    ///
+    /// What is left over is `report.then` — an all-lowercase run-on, from an
+    /// engine that emits a full stop but no capital. That one is genuinely
+    /// ambiguous, and it is masked, because leaving a space out is a blemish
+    /// where breaking an address in half is data loss.
+    private static let lowercaseHostname = "\\b(?:[a-z0-9][a-z0-9-]*\\.)+[a-z]{2,24}\\b"
+
+    private static let path = "(?:/[^\\s]*[^\\s.,;:!?\\\"“”'\\)\\]])?"
+
     private static let pattern =
         "((?i:https?)://[^\\s]+[^\\s.,;:!?\\\"“”'\\)\\]]"
         + "|[\\w.+-]+@(?:[\\w-]+\\.)+[A-Za-z]{2,}"
-        + "|(?:[\\w-]+\\.)+(?:" + topLevelDomains + ")\\b"
         // A path may contain dots; it may not end on the full stop that ends
         // the sentence the address is sitting in.
-        + "(?:/[^\\s]*[^\\s.,;:!?\\\"“”'\\)\\]])?"
+        + "|(?:[\\w-]+\\.)+(?:" + topLevelDomains + ")\\b" + path
+        + "|" + lowercaseHostname + path
         + "|\\d+(?:[.,:/]\\d+)+"
         + "|\\d+(?i:st|nd|rd|th)\\b"
         + "|(?:[A-Za-z]\\.){2,})"

--- a/ios/VocaPhoneShared/ProtectedSpans.swift
+++ b/ios/VocaPhoneShared/ProtectedSpans.swift
@@ -16,41 +16,38 @@ struct ProtectedSpans {
     let text: String
     let tokens: [String]
 
-    /// Top-level domains common enough to recognize even when the name in
-    /// front of them was capitalized — "Example.com" opening a sentence.
-    private static let topLevelDomains =
-        "com|org|net|edu|gov|int|mil|io|dev|app|ai|co|me|tv|cc|xyz|info|biz"
-        + "|online|site|tech|store|blog|cloud|link|live|news|shop|space|wiki|zone"
-        + "|[a-z]{2}"
+    /// A bare hostname, recognized by the case of its last label rather than by
+    /// a list of top-level domains.
+    ///
+    /// An allowlist cannot work: there are roughly 1,500 top-level domains, and
+    /// every one left off it — `example.museum` — gets its dot read as sentence
+    /// punctuation and the address split in half. Matching *any* dotted pair
+    /// instead has the opposite fault: it masks `report.Then` in "I finished
+    /// the report.Then I left", and the missing space can never be repaired.
+    ///
+    /// The whole signal is in the label **after** the final dot. A top-level
+    /// domain is written in lowercase; a full stop that ended a sentence is
+    /// followed by a capital. Nothing before that dot carries information —
+    /// requiring the name to be lowercase too only loses `Example.museum` —
+    /// so this asks about the last label and nothing else. The leading `\b`
+    /// keeps it from matching the tail of a longer word.
+    ///
+    /// Two things are left over, both preferred to the alternative. An
+    /// all-caps `EXAMPLE.COM` is not recognized, and `report.then` — an
+    /// all-lowercase run-on, from an engine that emits a full stop but no
+    /// capital — is masked as though it were a hostname. Neither is a shape a
+    /// speech model realistically produces, and where the two errors do meet,
+    /// a missing space is a blemish and a broken address is data loss.
+    private static let hostname = "\\b(?:[\\w-]+\\.)+[a-z]{2,24}\\b"
 
-    /// Any other bare hostname, recognized by case rather than by a list.
-    ///
-    /// There are roughly 1,500 top-level domains, so an allowlist misses real
-    /// ones — `example.museum` — and punctuation repair then splits the address
-    /// in half. Matching *any* dotted pair instead has the opposite fault: it
-    /// masks `report.Then` in "I finished the report.Then I left", and the
-    /// missing space can never be repaired.
-    ///
-    /// Case is what actually separates them. A hostname is written in
-    /// lowercase from end to end; a full stop that ended a sentence is followed
-    /// by a capital. This clause requires the former, and the leading `\b`
-    /// keeps it from matching the tail of a capitalized word.
-    ///
-    /// What is left over is `report.then` — an all-lowercase run-on, from an
-    /// engine that emits a full stop but no capital. That one is genuinely
-    /// ambiguous, and it is masked, because leaving a space out is a blemish
-    /// where breaking an address in half is data loss.
-    private static let lowercaseHostname = "\\b(?:[a-z0-9][a-z0-9-]*\\.)+[a-z]{2,24}\\b"
-
+    /// A path may contain dots; it may not end on the full stop that ends the
+    /// sentence the address is sitting in.
     private static let path = "(?:/[^\\s]*[^\\s.,;:!?\\\"“”'\\)\\]])?"
 
     private static let pattern =
         "((?i:https?)://[^\\s]+[^\\s.,;:!?\\\"“”'\\)\\]]"
         + "|[\\w.+-]+@(?:[\\w-]+\\.)+[A-Za-z]{2,}"
-        // A path may contain dots; it may not end on the full stop that ends
-        // the sentence the address is sitting in.
-        + "|(?:[\\w-]+\\.)+(?:" + topLevelDomains + ")\\b" + path
-        + "|" + lowercaseHostname + path
+        + "|" + hostname + path
         + "|\\d+(?:[.,:/]\\d+)+"
         + "|\\d+(?i:st|nd|rd|th)\\b"
         + "|(?:[A-Za-z]\\.){2,})"

--- a/ios/VocaPhoneShared/ProtectedSpans.swift
+++ b/ios/VocaPhoneShared/ProtectedSpans.swift
@@ -32,13 +32,17 @@ struct ProtectedSpans {
     /// so this asks about the last label and nothing else. The leading `\b`
     /// keeps it from matching the tail of a longer word.
     ///
-    /// Two things are left over, both preferred to the alternative. An
-    /// all-caps `EXAMPLE.COM` is not recognized, and `report.then` — an
-    /// all-lowercase run-on, from an engine that emits a full stop but no
-    /// capital — is masked as though it were a hostname. Neither is a shape a
-    /// speech model realistically produces, and where the two errors do meet,
-    /// a missing space is a blemish and a broken address is data loss.
-    private static let hostname = "\\b(?:[\\w-]+\\.)+[a-z]{2,24}\\b"
+    /// All caps counts too, so `NASA.GOV` survives. What that cannot be is a
+    /// sentence boundary: an engine that shouts the word after a full stop
+    /// shouted the one before it as well, and `report.THEN` is not a shape any
+    /// of them produce. Title Case is the one that stays out — `report.Then`
+    /// is the sentence boundary this whole clause exists to preserve.
+    ///
+    /// One thing is left over: `report.then`, an all-lowercase run-on from an
+    /// engine that emits a full stop but no capital, is masked as though it
+    /// were a hostname. That shape is genuinely ambiguous, and a missing space
+    /// is a blemish where a broken address is data loss.
+    private static let hostname = "\\b(?:[\\w-]+\\.)+(?:[a-z]{2,24}|[A-Z]{2,24})\\b"
 
     /// A path may contain dots; it may not end on the full stop that ends the
     /// sentence the address is sitting in.

--- a/ios/VocaPhoneShared/SentencePunctuation.swift
+++ b/ios/VocaPhoneShared/SentencePunctuation.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// The marks a script closes a sentence with, and the rule for deciding which
+/// script a transcript is written in.
+///
+/// Shared by ``TranscriptRepair``, which *inserts* marks, and
+/// ``TranscriptStyler``, which formats around marks that are already there. Two
+/// copies of this table would drift, and the visible failure is a Hindi
+/// transcript that one stage ends with a danda and the other with a full stop.
+struct SentencePunctuation: Sendable, Equatable {
+    let terminator: String
+    let separator: String
+    let exclamation: String
+    let question: String
+    /// Every mark that can close a sentence: this script's, plus the ones a
+    /// model borrows from other scripts often enough to matter.
+    let terminators: String
+    /// What sits between two sentences. Empty for the scripts that do not put a
+    /// space after their punctuation.
+    let join: String
+
+    /// Whether sentences here are built the way English builds them — a full
+    /// stop, a following space, a capital. ``TranscriptRepair``'s inference
+    /// rules are written against English and are a no-op in any other Latin
+    /// language, but a script that spaces differently would be damaged by them.
+    var usesLatinLayout: Bool { join == " " && terminator == "." }
+
+    /// Marks that never take a space before them and always take one after.
+    static let universalTerminators = ".!?。！？।۔။។།؟"
+
+    static let latin = SentencePunctuation(
+        terminator: ".", separator: ",", exclamation: "!", question: "?",
+        terminators: ".!?", join: " "
+    )
+    static let cjk = SentencePunctuation(
+        terminator: "。", separator: "、", exclamation: "！", question: "？",
+        terminators: "。！？.!?", join: ""
+    )
+    static let arabic = SentencePunctuation(
+        terminator: ".", separator: "،", exclamation: "!", question: "؟",
+        terminators: ".!?؟", join: " "
+    )
+    static let urdu = SentencePunctuation(
+        terminator: "۔", separator: "،", exclamation: "!", question: "؟",
+        terminators: "۔.!?؟", join: " "
+    )
+    static let danda = SentencePunctuation(
+        terminator: "।", separator: ",", exclamation: "!", question: "?",
+        terminators: "।.!?", join: " "
+    )
+    /// Scripts written with a full stop rather than the danda their neighbours
+    /// use. Still accepts a danda on input, because a multilingual model emits
+    /// one for Tamil often enough.
+    static let indicLatin = SentencePunctuation(
+        terminator: ".", separator: ",", exclamation: "!", question: "?",
+        terminators: "।.!?", join: " "
+    )
+    /// Thai and Lao close a sentence with a space, not a mark.
+    static let unterminated = SentencePunctuation(
+        terminator: "", separator: " ", exclamation: "!", question: "?",
+        terminators: "!?", join: " "
+    )
+    static let burmese = SentencePunctuation(
+        terminator: "။", separator: "၊", exclamation: "!", question: "?",
+        terminators: "။.!?", join: " "
+    )
+    static let khmer = SentencePunctuation(
+        terminator: "។", separator: ",", exclamation: "!", question: "?",
+        terminators: "។.!?", join: " "
+    )
+    static let tibetan = SentencePunctuation(
+        terminator: "།", separator: "།", exclamation: "!", question: "?",
+        terminators: "།.!?", join: " "
+    )
+
+    /// The profile for `language`, falling back to what the text itself is
+    /// written in when the engine reported nothing (Automatic).
+    static func resolve(language: String, text: String) -> SentencePunctuation {
+        let code = language.lowercased().split(separator: "-").first.map(String.init) ?? ""
+        let base: SentencePunctuation
+        switch code {
+        case "ja", "zh", "yue": base = cjk
+        case "ar", "fa", "ps": base = arabic
+        case "ur", "sd", "ks": base = urdu
+        case "hi", "mr", "ne", "bn", "as", "pa": base = danda
+        case "ta", "te", "kn", "ml", "gu", "si": base = indicLatin
+        case "th", "lo": base = unterminated
+        case "my": base = burmese
+        case "km": base = khmer
+        case "bo": base = tibetan
+        default:
+            if text.contains(where: { "。、！？".contains($0) }) { base = cjk }
+            else if text.contains(where: { "،؟".contains($0) }) { base = arabic }
+            else if text.contains("۔") { base = urdu }
+            else if text.contains("।") || containsDandaScript(text) { base = danda }
+            else { base = latin }
+        }
+        var seen = Set<Character>()
+        let merged = String(
+            (universalTerminators + base.terminators).filter { seen.insert($0).inserted }
+        )
+        return SentencePunctuation(
+            terminator: base.terminator,
+            separator: base.separator,
+            exclamation: base.exclamation,
+            question: base.question,
+            terminators: merged,
+            join: base.join
+        )
+    }
+
+    /// Devanagari, Bengali/Assamese, and Gurmukhi conventionally use the danda.
+    /// This is the fallback when Automatic was selected and the engine did not
+    /// expose the language it detected.
+    static func containsDandaScript(_ text: String) -> Bool {
+        text.unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0x0900...0x097F, 0x0980...0x09FF, 0x0A00...0x0A7F: true
+            default: false
+            }
+        }
+    }
+}

--- a/ios/VocaPhoneShared/SentencePunctuation.swift
+++ b/ios/VocaPhoneShared/SentencePunctuation.swift
@@ -28,6 +28,17 @@ struct SentencePunctuation: Sendable, Equatable {
     /// Marks that never take a space before them and always take one after.
     static let universalTerminators = ".!?。！？।۔။។།؟"
 
+    /// Marks that separate parts of a sentence rather than ending one.
+    static let universalSeparators = ",;:،、၊"
+
+    /// Every character the repair stage treats as punctuation, in any script.
+    /// One list rather than a per-rule literal, because a rule that inserts a
+    /// mark and a rule that spaces around one disagreeing about what a mark
+    /// *is* is invisible until a transcript in that script comes out wrong.
+    /// Contains no character-class metacharacter, so it can be interpolated
+    /// into a `[...]` on both platforms and produce the same class.
+    static let universalMarks = universalTerminators + universalSeparators + "…"
+
     static let latin = SentencePunctuation(
         terminator: ".", separator: ",", exclamation: "!", question: "?",
         terminators: ".!?", join: " "

--- a/ios/VocaPhoneShared/TranscriptRepair.swift
+++ b/ios/VocaPhoneShared/TranscriptRepair.swift
@@ -114,24 +114,55 @@ enum TranscriptRepair {
 
     // MARK: - Fillers
 
-    /// The hesitation sounds, after ``canonical(_:)`` has flattened however many
-    /// letters the model chose to spell them with.
+    /// Hesitation sounds that are not a word in any language this app
+    /// transcribes, so they can go whatever was spoken.
     ///
-    /// Every one of these is non-lexical: there is no sentence in which the word
-    /// carries meaning, which is the whole reason removing it is safe. That is
-    /// also why `like`, `you know`, `I mean` and `actually` are **not** here.
-    /// Each is a real word often enough that dropping it needs judgement about
-    /// what the speaker meant, and this stage does not have any.
-    private static let universalFillers: Set<String> = [
-        "um", "uhm", "umh", "uh", "er", "erm", "hm",
-    ]
+    /// Every one is non-lexical: there is no sentence in which it carries
+    /// meaning, which is the whole reason removing it is safe. That is also why
+    /// `like`, `you know`, `I mean` and `actually` are **not** here. Each is a
+    /// real word often enough that dropping it needs judgement about what the
+    /// speaker meant, and this stage does not have any.
+    private static let alwaysSafeFillers: Set<String> = ["uh", "uhm", "umh", "erm", "hm"]
+
+    /// English hesitation sounds that are ordinary words somewhere else.
+    ///
+    /// `um` is German for "at" — "um acht Uhr" — and `er` is German for "he"
+    /// and Dutch for "there". Dropping them from a German transcript deletes
+    /// content, so they go only when the transcript is English, or when
+    /// Automatic was selected and ``looksEnglish(_:)`` recognizes the sentence
+    /// around them.
+    private static let englishFillers: Set<String> = ["um", "er"]
 
     /// Sounds that mean *yes* or *no*, and must survive. `mhm` and `uh-huh` are
     /// answers to a question, and a transcript that drops them says the opposite
     /// of what was said. They are listed rather than merely absent so that
-    /// widening ``universalFillers`` cannot quietly swallow one.
+    /// widening the filler sets cannot quietly swallow one.
     private static let affirmations: Set<String> = [
         "mhm", "mhmm", "mmhm", "uhuh", "uhhuh", "nuhuh", "huh", "hu",
+    ]
+
+    /// Words that reach a filler spelling only because ``canonical(_:)``
+    /// flattens repeated letters, and so have to be caught before it runs.
+    /// "Err on the side of caution" is the verb; a model writing a hesitation
+    /// as `err` rather than `uh` is rare enough that keeping the word wins.
+    private static let literalExceptions: Set<String> = ["err"]
+
+    /// High-frequency English words that are **not** also words in the other
+    /// Latin-script languages this app transcribes. That exclusion is the whole
+    /// point of the list, so it is shorter than a frequency table would be:
+    /// `is` is Dutch, `was` and `will` are German, `for` is Danish, `of` is
+    /// Dutch for "or", and `i` is Danish for "in". Any of those would call a
+    /// German sentence English and cost it an "um".
+    private static let englishMarkers: Set<String> = [
+        "the", "and", "you", "your", "yours", "with", "that", "thats", "this",
+        "these", "those", "what", "whats", "which", "when", "where", "who",
+        "how", "have", "has", "had", "are", "were", "been", "being",
+        "not", "dont", "doesnt", "didnt", "isnt", "arent", "cant", "wont",
+        "it", "its", "they", "them", "their", "theyre", "she", "her", "his",
+        "there", "theres", "would", "could", "should", "about", "because",
+        "know", "think", "going", "please", "thanks", "very", "again", "only",
+        "over", "some", "than", "then", "through", "want", "need", "make",
+        "made", "take", "come", "from", "more", "most", "much", "many",
     ]
 
     /// Only the non-lexical hesitation sounds, same bar as ``universalFillers``.
@@ -157,28 +188,42 @@ enum TranscriptRepair {
 
     /// Collapses a run of one repeated letter, so however long the model drew
     /// the sound out it lands on the same key: `ummmm` and `uhhh` become `um`
-    /// and `uh`. Also drops the hyphen in `uh-huh`, which is why that spelling
-    /// reaches ``affirmations`` intact.
+    /// and `uh`. `uh-huh` arrives with its hyphen already gone — ``Word/key``
+    /// keeps only letters and digits — and so reaches ``affirmations`` intact.
     private static func canonical(_ key: String) -> String {
         var result = ""
         var previous: Character?
-        for character in key where character != "-" {
+        for character in key {
             if character != previous { result.append(character) }
             previous = character
         }
         return result
     }
 
-    private static func isFiller(_ word: Word, code: String) -> Bool {
+    /// Whether the English filler set applies. An explicit English transcript
+    /// always qualifies; on Automatic the sentence has to say so itself, which
+    /// keeps a German "um acht Uhr" intact at the cost of leaving a filler in a
+    /// two-word English fragment that carries no marker.
+    private static func looksEnglish(_ code: String, words: [Word]) -> Bool {
+        if code == "en" { return true }
+        guard code.isEmpty || code == "auto" else { return false }
+        return words.contains { englishMarkers.contains($0.key) }
+    }
+
+    private static func isFiller(_ word: Word, code: String, english: Bool) -> Bool {
         guard !word.isProtected else { return false }
         // A quoted filler is being talked about rather than said: someone
         // dictating `he said "um" a lot` means the word to be there.
         guard !word.leading.contains(where: isQuote),
               !word.trailing.contains(where: isQuote)
         else { return false }
-        let key = canonical(word.key)
-        guard !key.isEmpty, !affirmations.contains(key) else { return false }
-        return universalFillers.contains(key) || localFillers[code]?.contains(key) == true
+        let raw = word.key
+        guard !raw.isEmpty, !literalExceptions.contains(raw) else { return false }
+        let key = canonical(raw)
+        guard !affirmations.contains(key) else { return false }
+        if alwaysSafeFillers.contains(key) { return true }
+        if english, englishFillers.contains(key) { return true }
+        return localFillers[code]?.contains(key) == true
     }
 
     private static func isQuote(_ character: Character) -> Bool {
@@ -191,9 +236,11 @@ enum TranscriptRepair {
             result = result.replacingOccurrences(of: filler, with: "")
         }
 
+        let words = split(result)
+        let english = looksEnglish(code, words: words)
         var kept: [Word] = []
-        for word in split(result) {
-            guard isFiller(word, code: code) else {
+        for word in words {
+            guard isFiller(word, code: code, english: english) else {
                 kept.append(word)
                 continue
             }
@@ -321,18 +368,20 @@ enum TranscriptRepair {
     ) -> String {
         var result = replacing("\\s+", with: " ", in: text)
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let marks = "[" + NSRegularExpression.escapedPattern(
-            for: SentencePunctuation.universalTerminators + ",;:、၊…"
-        ) + "]"
+        // Built from the shared sets rather than a literal per rule, so the
+        // Kotlin port cannot quietly cover a different set of scripts.
+        let marks = "[" + SentencePunctuation.universalMarks + "]"
+        let terminators = "[" + SentencePunctuation.universalTerminators + "]"
+        let separators = "[" + SentencePunctuation.universalSeparators + "]"
 
         // Never a space before a mark.
         result = replacing("\\s+(" + marks + ")", with: "$1", in: result)
         // A run of one separator is one separator.
-        result = replacing("([,;:、])\\1+", with: "$1", in: result)
+        result = replacing("(" + separators + ")\\1+", with: "$1", in: result)
         // A separator touching a terminator: the terminator wins, whichever
         // order the model put them in.
-        result = replacing("[,;:、]\\s*([.!?。！？।۔])", with: "$1", in: result)
-        result = replacing("([.!?。！？।۔])\\s*[,;:、]", with: "$1", in: result)
+        result = replacing(separators + "\\s*(" + terminators + ")", with: "$1", in: result)
+        result = replacing("(" + terminators + ")\\s*" + separators, with: "$1", in: result)
         // Shouting and stammering. Four or more stops is an ellipsis that got
         // away; three stays an ellipsis.
         result = replacing("!{2,}", with: "!", in: result)
@@ -345,17 +394,22 @@ enum TranscriptRepair {
             // Always a space after a mark, unless another mark follows it —
             // that is an ellipsis or a quoted close, not two sentences.
             result = replacing(
-                "([,;:])(?=[^\\s,;:.!?…\\)\\]\"”’])", with: "$1 ", in: result
+                "(" + separators + ")(?=[^\\s"
+                    + SentencePunctuation.universalMarks + "\\)\\]\"”’])",
+                with: "$1 ",
+                in: result
             )
             result = replacing(
-                "([.!?])(?=[\\p{L}\\p{N}\u{E000}])", with: "$1 ", in: result
+                "(" + terminators + ")(?=[\\p{L}\\p{N}\u{E000}])",
+                with: "$1 ",
+                in: result
             )
         }
 
         // A mark with nothing in front of it, and a separator with nothing
         // after it, are both left over from something that was removed.
-        result = replacing("^[\\s,;:.!?、。…]+", with: "", in: result)
-        result = replacing("[,;:、]+\\s*$", with: "", in: result)
+        result = replacing("^[\\s" + SentencePunctuation.universalMarks + "]+", with: "", in: result)
+        result = replacing("(" + separators + ")+\\s*$", with: "", in: result)
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
@@ -391,6 +445,18 @@ enum TranscriptRepair {
     /// Conjunctions that take a comma when they join two full clauses.
     private static let clauseConjunctions: Set<String> = ["but", "so", "yet", "however"]
 
+    /// After a conjunction these continue the phrase rather than opening a
+    /// clause: "so that", "so much", "but as".
+    private static let phraseFollowers: Set<String> = [
+        "that", "much", "many", "far", "long", "as",
+    ]
+
+    private static let determiners: Set<String> = ["the", "a", "an"]
+
+    /// Openers that are neither a subject nor an auxiliary but still start a
+    /// sentence often enough to count as one beginning.
+    private static let clauseOpeners: Set<String> = ["so", "well", "just", "first", "next"]
+
     /// Words that can open a clause of their own. The test for "is a full
     /// clause coming" is "does a subject start right here", which these are the
     /// common ones for.
@@ -403,14 +469,19 @@ enum TranscriptRepair {
         "maybe", "now", "then", "today", "tomorrow", "yesterday",
     ]
 
-    /// After one of these, `okay` and `alright` are adjectives describing
-    /// something, not somebody starting a sentence.
-    private static let copulas: Set<String> = [
+    /// After one of these, `okay` and `alright` are describing something —
+    /// "the results came back okay" — rather than somebody starting a new
+    /// sentence. Copulas and the particles that finish a phrasal verb, which is
+    /// the other position an adjective lands in.
+    private static let adjectivePredecessors: Set<String> = [
         "is", "are", "was", "were", "am", "be", "been", "being",
         "seem", "seems", "seemed", "look", "looks", "looked",
         "feel", "feels", "felt", "sound", "sounds", "sounded",
+        "went", "goes", "going", "gone", "doing", "does", "works", "worked",
+        "turned", "came", "back", "out", "up", "fine", "along",
         "not", "quite", "pretty", "totally", "perfectly", "really",
-        "its", "thats", "everything", "all", "more", "less", "about",
+        "its", "thats", "everything", "anything", "something", "nothing",
+        "all", "more", "less", "about", "mostly", "otherwise", "apparently",
     ]
 
     private static let auxiliaries: Set<String> = [
@@ -458,7 +529,12 @@ enum TranscriptRepair {
                   index + length + 2 <= words.count,
                   wordsSinceMark(words, before: index) >= 4,
                   words[index - 1].trailing.isEmpty,
-                  !copulas.contains(words[index - 1].key)
+                  !adjectivePredecessors.contains(words[index - 1].key),
+                  // A marker only ends the previous sentence when a clause of
+                  // its own follows. "The results came back okay and we
+                  // shipped" is one sentence; "…came back okay lets ship" is
+                  // two, and the difference is entirely the next word.
+                  startsClause(words[index + length].key)
             else {
                 index += 1
                 continue
@@ -492,14 +568,19 @@ enum TranscriptRepair {
         punctuation: SentencePunctuation
     ) {
         for index in words.indices where index >= 4 && index + 2 < words.count {
+            let next = words[index + 1].key
             guard clauseConjunctions.contains(words[index].key),
                   words[index].leading.isEmpty,
                   words[index].trailing.isEmpty,
                   words[index - 1].trailing.isEmpty,
                   wordsSinceMark(words, before: index) >= 4,
-                  clauseStarters.contains(words[index + 1].key),
+                  clauseStarters.contains(next),
                   // "so that", "so much", "but as" — a phrase, not a new clause.
-                  !["that", "much", "many", "far", "long", "as"].contains(words[index + 1].key)
+                  !phraseFollowers.contains(next),
+                  // A determiner is the ambiguous case: "…but the tests are
+                  // failing" is a clause, "…but the truth" is an object. Only
+                  // the first has room for a verb after it.
+                  !determiners.contains(next) || index + 4 <= words.count
             else { continue }
             words[index - 1].trailing = punctuation.separator
         }
@@ -513,17 +594,38 @@ enum TranscriptRepair {
         punctuation: SentencePunctuation
     ) {
         for sentence in sentences(words, punctuation: punctuation) {
-            let last = words[sentence.upperBound]
-            let closing = last.trailing.last
-            let open = closing == nil || !punctuation.terminators.contains(closing!)
-            guard open || String(closing!) == punctuation.terminator,
+            let existing = words[sentence.upperBound].trailing
+                .last { punctuation.terminators.contains($0) }
+            // A sentence the model closed with `!` was a choice. One it closed
+            // with the plain terminator, or did not close at all, was not.
+            guard existing == nil || String(existing!) == punctuation.terminator,
                   sentence.count <= maximumQuestionWords,
                   isQuestion(words, sentence)
             else { continue }
-            if !open { words[sentence.upperBound].trailing.removeLast() }
-            words[sentence.upperBound].trailing += punctuation.question
+            close(&words[sentence.upperBound], with: punctuation.question, punctuation: punctuation)
         }
     }
+
+    /// Closes a word with `mark`, replacing the terminator it already carries
+    /// rather than doubling it, and going *inside* any quote or bracket. A
+    /// question that reached the model in quotes ends `it?"`, never `it."?`.
+    private static func close(
+        _ word: inout Word,
+        with mark: String,
+        punctuation: SentencePunctuation
+    ) {
+        if let existing = word.trailing.lastIndex(where: { punctuation.terminators.contains($0) }) {
+            word.trailing.remove(at: existing)
+        }
+        let wrapper = word.trailing.firstIndex { isQuote($0) || ")]}»".contains($0) }
+        word.trailing.insert(contentsOf: mark, at: wrapper ?? word.trailing.endIndex)
+    }
+
+    /// Modals that turn an inverted `had`/`were` opening into a condition
+    /// rather than a question: "Had I known that, I would have called."
+    private static let conditionalModals: Set<String> = [
+        "would", "could", "should", "might", "wouldve", "couldve", "shouldve",
+    ]
 
     private static func isQuestion(_ words: [Word], _ sentence: ClosedRange<Int>) -> Bool {
         let keys = sentence.map { words[$0].key }
@@ -538,7 +640,13 @@ enum TranscriptRepair {
             }
             return false
         }
-        return auxiliaries.contains(keys[0]) && subjectPronouns.contains(keys[1])
+        guard auxiliaries.contains(keys[0]), subjectPronouns.contains(keys[1]) else { return false }
+        // "Had I known" and "Were it up to me" invert the same way a question
+        // does; the modal further along is what tells them apart.
+        if keys[0] == "had" || keys[0] == "were" {
+            return !keys.dropFirst(2).contains { conditionalModals.contains($0) }
+        }
+        return true
     }
 
     // MARK: - Inference helpers
@@ -562,6 +670,16 @@ enum TranscriptRepair {
             if matched { return phrase.count }
         }
         return nil
+    }
+
+    /// Whether a clause could start at this word. The question a split has to
+    /// answer is "is a new sentence beginning here", and a subject, an
+    /// auxiliary, or a question word is what one begins with.
+    private static func startsClause(_ key: String) -> Bool {
+        clauseStarters.contains(key)
+            || auxiliaries.contains(key)
+            || questionWords.contains(key)
+            || clauseOpeners.contains(key)
     }
 
     private static func opensSentence(

--- a/ios/VocaPhoneShared/TranscriptRepair.swift
+++ b/ios/VocaPhoneShared/TranscriptRepair.swift
@@ -147,22 +147,41 @@ enum TranscriptRepair {
     /// as `err` rather than `uh` is rare enough that keeping the word wins.
     private static let literalExceptions: Set<String> = ["err"]
 
+    /// How many markers a transcript needs before Automatic will treat it as
+    /// English.
+    ///
+    /// One is not enough. A German sentence only has to brush against a single
+    /// English-looking word to lose its "er", and "er kommt her" did exactly
+    /// that. Two independent markers is a far higher bar for an accident to
+    /// clear, and English prose of any length clears it easily.
+    private static let englishMarkersNeeded = 2
+
     /// High-frequency English words that are **not** also words in the other
     /// Latin-script languages this app transcribes. That exclusion is the whole
-    /// point of the list, so it is shorter than a frequency table would be:
-    /// `is` is Dutch, `was` and `will` are German, `for` is Danish, `of` is
-    /// Dutch for "or", and `i` is Danish for "in". Any of those would call a
-    /// German sentence English and cost it an "um".
+    /// point of the list, so it is much shorter than a frequency table would
+    /// be: `is` is Dutch, `was` and `will` are German, `for` is Danish, `of` is
+    /// Dutch for "or", `i` is Danish for "in", `her` is German for "hither",
+    /// `over` is Dutch, `want` is Dutch for "because", and `come` is Italian
+    /// for "how". Any of those would call a foreign sentence English and cost
+    /// it a word.
     private static let englishMarkers: Set<String> = [
         "the", "and", "you", "your", "yours", "with", "that", "thats", "this",
         "these", "those", "what", "whats", "which", "when", "where", "who",
         "how", "have", "has", "had", "are", "were", "been", "being",
         "not", "dont", "doesnt", "didnt", "isnt", "arent", "cant", "wont",
-        "it", "its", "they", "them", "their", "theyre", "she", "her", "his",
-        "there", "theres", "would", "could", "should", "about", "because",
-        "know", "think", "going", "please", "thanks", "very", "again", "only",
-        "over", "some", "than", "then", "through", "want", "need", "make",
-        "made", "take", "come", "from", "more", "most", "much", "many",
+        "wouldnt", "couldnt", "shouldnt", "havent", "hasnt",
+        "it", "its", "they", "them", "their", "theyre", "theres", "wheres",
+        "she", "his", "there", "would", "could", "should", "about", "because",
+        "know", "knew", "think", "thought", "going", "please", "thanks",
+        "very", "again", "only", "some", "than", "then", "through",
+        "need", "make", "made", "take", "took", "from", "more", "most",
+        "much", "many", "something", "anything", "everything", "nothing",
+        "yeah", "gonna", "wanna", "gotta", "ive", "youre", "youve",
+        "today", "tomorrow", "yesterday", "here", "there", "everyone",
+        "people", "thing", "things", "time", "good", "great", "sure",
+        "right", "wrong", "back", "down", "off", "got", "getting",
+        "said", "told", "asked", "does", "did", "doing", "actually",
+        "probably", "really", "always", "never", "maybe",
     ]
 
     /// Only the non-lexical hesitation sounds, same bar as ``universalFillers``.
@@ -200,14 +219,32 @@ enum TranscriptRepair {
         return result
     }
 
-    /// Whether the English filler set applies. An explicit English transcript
-    /// always qualifies; on Automatic the sentence has to say so itself, which
-    /// keeps a German "um acht Uhr" intact at the cost of leaving a filler in a
-    /// two-word English fragment that carries no marker.
+    /// Letters that belong to another Latin alphabet. A transcript carrying one
+    /// is not English whatever else it contains, and this is the cheapest hard
+    /// veto available before counting anything.
+    private static let foreignLetters = "äöüßåæøœçñõãêôîûàèìòùáéíóúýðþğışłżźćęą"
+
+    /// Whether the English filler set applies.
+    ///
+    /// An explicit `en` always qualifies, and so does a language the engine
+    /// detected as English. On Automatic nothing has said what the language is,
+    /// so the sentence has to say it itself — twice over, and without a letter
+    /// from another alphabet in it.
+    ///
+    /// The cost is a filler left in a short English fragment that carries fewer
+    /// than two markers. That is the right direction to be wrong in: leaving an
+    /// "um" is a blemish, and deleting the subject of a German sentence is not.
     private static func looksEnglish(_ code: String, words: [Word]) -> Bool {
         if code == "en" { return true }
         guard code.isEmpty || code == "auto" else { return false }
-        return words.contains { englishMarkers.contains($0.key) }
+        var seen = Set<String>()
+        for word in words {
+            if word.text.lowercased().contains(where: { foreignLetters.contains($0) }) {
+                return false
+            }
+            if englishMarkers.contains(word.key) { seen.insert(word.key) }
+        }
+        return seen.count >= englishMarkersNeeded
     }
 
     private static func isFiller(_ word: Word, code: String, english: Bool) -> Bool {
@@ -266,25 +303,28 @@ enum TranscriptRepair {
 
     // MARK: - Stutters
 
-    /// Words whose immediate repeat is a stutter rather than a sentence.
-    /// Closed-class only: an article or a pronoun said twice in a row is the
-    /// speaker restarting, where a repeated content word ("very very") is
-    /// emphasis the speaker meant.
+    /// Words whose immediate repeat is a stutter and essentially never
+    /// grammar: determiners, prepositions, conjunctions and subject pronouns. A
+    /// repeated content word ("very very") is emphasis the speaker meant, and
+    /// is not here.
+    ///
+    /// Deliberately narrower than "closed class". A copula, an auxiliary or a
+    /// possessive or a modal doubles legitimately far too often to guess at —
+    /// "what it is is a problem", "the things I have have value", "I gave her
+    /// her coat", "I can can peaches", "there, there" — so none of those are
+    /// here either. The cost of leaving a real stutter in is a duplicated word;
+    /// the cost of being wrong is a deleted one.
     private static let functionWords: Set<String> = [
-        "the", "a", "an", "and", "but", "so", "or", "to", "of", "in", "on", "at",
-        "for", "with", "from", "by", "as", "if", "then", "than",
+        "the", "a", "an", "and", "but", "or", "to", "of", "in", "on", "at",
+        "for", "with", "from", "by", "as", "if", "than",
         "i", "you", "we", "they", "he", "she", "it", "this", "these", "those",
-        "there", "my", "your", "our", "their", "his", "her", "its",
-        "is", "are", "was", "were", "am", "be", "been",
-        "do", "does", "did", "have", "has",
-        "can", "could", "will", "would", "should", "must",
         "what", "when", "where", "why", "who", "how",
     ]
 
-    /// Doubles that are ordinary English. "The thing that that man said" and
-    /// "she had had enough" are both correct, and both look exactly like a
-    /// stutter to a rule that only compares two words.
-    private static let legitimateDoubles: Set<String> = ["that", "had"]
+    /// Doubles that are ordinary English even though the word is on the list
+    /// above. "The thing that that man said" is correct, and looks exactly like
+    /// a stutter to a rule that only compares two words.
+    private static let legitimateDoubles: Set<String> = ["that"]
 
     /// Longest false start collapsed. Beyond this it is a repeated sentence,
     /// which ``TranscriptSanitizer`` already has thresholds for.
@@ -295,6 +335,11 @@ enum TranscriptRepair {
     /// Only an immediate repeat, and only the second copy is kept, because it is
     /// the copy the speaker carried on from: "we should, we should probably
     /// ship" has the comma on the abandoned half and the sentence on the other.
+    ///
+    /// A multi-word repeat also has to be followed by something. That is what
+    /// separates a false start from a phrase said twice on purpose: the speaker
+    /// who restarts goes on to finish the sentence, where "I love you I love
+    /// you" and "no no no no" end where they end.
     private static func collapseStutters(
         _ text: String,
         punctuation: SentencePunctuation
@@ -338,6 +383,9 @@ enum TranscriptRepair {
         punctuation: SentencePunctuation
     ) -> Bool {
         guard index + length * 2 <= words.count else { return false }
+        // A repeat with nothing after it was said twice on purpose. A false
+        // start is the beginning of a sentence the speaker then finishes.
+        if length > 1, index + length * 2 >= words.count { return false }
         for offset in 0..<length {
             let first = words[index + offset]
             let second = words[index + length + offset]
@@ -497,6 +545,12 @@ enum TranscriptRepair {
         "why", "whys", "who", "whos", "whom", "whose", "how", "hows",
     ]
 
+    /// A `how` question may put a quantifier and its noun in front of the
+    /// auxiliary: "How many people are coming?". That is a question shape, not
+    /// the noun-clause shape that makes "what the problem is remains unclear"
+    /// a statement.
+    private static let howQuantifiers: Set<String> = ["many", "much"]
+
     private static let subjectPronouns: Set<String> = [
         "i", "you", "we", "they", "he", "she", "it", "there",
         "that", "this", "anyone", "anybody", "someone", "somebody", "everyone",
@@ -545,6 +599,12 @@ enum TranscriptRepair {
         }
     }
 
+    /// Quantifiers that turn an opener into a phrase. "However many people come"
+    /// means "no matter how many", and the comma would say the opposite.
+    private static let quantifierFollowers: Set<String> = [
+        "many", "much", "long", "far", "little", "few", "often", "else",
+    ]
+
     /// "Okay we should ship" — the marker opens the sentence and the rest of it
     /// follows, which in writing takes a comma.
     private static func commaAfterOpeners(
@@ -555,7 +615,8 @@ enum TranscriptRepair {
             guard opensSentence(words, at: index, punctuation: punctuation),
                   let length = match(openersTakingComma, in: words, at: index),
                   words[index + length - 1].trailing.isEmpty,
-                  index + length + 2 <= words.count
+                  index + length + 2 <= words.count,
+                  !quantifierFollowers.contains(words[index + length].key)
             else { continue }
             words[index + length - 1].trailing = punctuation.separator
         }
@@ -631,12 +692,26 @@ enum TranscriptRepair {
         let keys = sentence.map { words[$0].key }
         guard keys.count >= 2 else { return false }
         if questionWords.contains(keys[0]) {
-            // "What time is it" asks; "What I meant was simple" states. Both
-            // reach an auxiliary, but only the second puts a subject in front
-            // of it — the wh-word is that clause's own subject or object.
-            for offset in 1..<min(keys.count, 4) {
+            // "What time is it" asks; "What I meant was simple" and "what the
+            // problem is remains unclear" state. A question inverts the
+            // auxiliary to the front, so it turns up within a word or two of
+            // the wh-word; an embedded noun clause puts a whole subject there
+            // first and pushes the auxiliary back.
+            //
+            // Two words of room is the normal allowance. "How many people are
+            // coming" has a quantifier and its noun in front of the auxiliary,
+            // so it gets one extra explicitly-recognized shape. Reading "what
+            // john said was wrong" as a question is not worth that wider rule.
+            for offset in 1..<min(keys.count, 3) {
                 if subjectPronouns.contains(keys[offset]) { return false }
+                if determiners.contains(keys[offset]) { return false }
                 if auxiliaries.contains(keys[offset]) { return true }
+            }
+            if keys.count >= 4,
+               keys[0] == "how",
+               howQuantifiers.contains(keys[1]),
+               auxiliaries.contains(keys[3]) {
+                return true
             }
             return false
         }

--- a/ios/VocaPhoneShared/TranscriptRepair.swift
+++ b/ios/VocaPhoneShared/TranscriptRepair.swift
@@ -1,0 +1,628 @@
+import Foundation
+
+/// Turns what a speech model heard into what the speaker meant to write:
+/// hesitation sounds dropped, false starts collapsed, and the punctuation the
+/// model left out put in.
+///
+/// This is deliberately **not** part of ``TranscriptStyler``. That stage
+/// documents a contract it has to keep — no style adds, removes, or substitutes
+/// a word — and this stage exists precisely to break it, under a switch of its
+/// own. Keeping them apart is what lets the styles still be described honestly.
+///
+/// Everything here is rule-based. There is no model, no network call, and no
+/// language understanding: the rules are the conservative subset where a
+/// mistake is nearly impossible to make, and anything needing judgement about
+/// what the speaker meant is left alone on purpose. The order of the stages is
+/// load-bearing and is documented at each one.
+///
+/// Mirrors the Android client's `TranscriptRepair`; the two are expected to
+/// produce the same text for the same transcript.
+enum TranscriptRepair {
+
+    // MARK: - Entry point
+
+    /// - Parameters:
+    ///   - text: a transcript that has already been through ``TranscriptSanitizer``.
+    ///   - language: the language the finished text is written in, or `"auto"`.
+    static func apply(_ text: String?, language: String = "auto") -> String {
+        let source = (text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !source.isEmpty else { return "" }
+
+        let punctuation = SentencePunctuation.resolve(language: language, text: source)
+        let code = language.lowercased().split(separator: "-").first.map(String.init) ?? ""
+        let spans = ProtectedSpans.mask(source)
+
+        var working = spans.text
+        // 1. Fillers first: they are the noise every later rule would otherwise
+        //    have to reason around. "we should um we should ship" is not a
+        //    stutter until the "um" between the copies is gone.
+        working = removeFillers(working, code: code)
+        // 2. Stutters, on the text the fillers left behind.
+        working = collapseStutters(working, punctuation: punctuation)
+        // 3. Normalize the marks that are there before inferring the ones that
+        //    are not, so inference counts real sentence boundaries.
+        working = repairMarks(working, punctuation: punctuation)
+        // 4. Inference is written against how English builds a sentence. In a
+        //    script that spaces or terminates differently it would do damage,
+        //    and in another Latin language its trigger words simply never match.
+        if punctuation.usesLatinLayout {
+            working = infer(working, punctuation: punctuation)
+        }
+
+        let repaired = spans.restore(working)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // A transcript that repaired down to nothing is a rule misfiring, not a
+        // silent recording — the sanitizer has already had its say about those.
+        // Hand back what came in rather than an empty text field.
+        return repaired.contains(where: { $0.isLetter || $0.isNumber }) ? repaired : source
+    }
+
+    // MARK: - Words
+
+    /// A whitespace-delimited chunk split into the punctuation around it and the
+    /// word inside, so a rule can drop a word without losing the comma that was
+    /// attached to it, or match a word without its full stop getting in the way.
+    private struct Word {
+        var leading: String
+        var text: String
+        var trailing: String
+
+        var isEmpty: Bool { leading.isEmpty && text.isEmpty && trailing.isEmpty }
+        var rendered: String { leading + text + trailing }
+
+        /// Lowercased letters and digits only. Apostrophes go, so `don't` and
+        /// `dont` match, and the placeholder scalars stay so a masked URL can
+        /// never compare equal to a bare number.
+        var key: String {
+            text.lowercased().filter {
+                $0.isLetter || $0.isNumber
+                    || $0 == ProtectedSpans.open || $0 == ProtectedSpans.close
+            }
+        }
+
+        var isProtected: Bool { text.contains(ProtectedSpans.open) }
+
+        var startsUppercase: Bool {
+            text.first(where: \.isLetter)?.isUppercase ?? false
+        }
+    }
+
+    private static func isWordCharacter(_ character: Character) -> Bool {
+        character.isLetter || character.isNumber
+            || character == "'" || character == "’" || character == "-"
+            || character == ProtectedSpans.open || character == ProtectedSpans.close
+    }
+
+    private static func split(_ text: String) -> [Word] {
+        text.split(whereSeparator: \.isWhitespace).map { chunk in
+            let characters = Array(chunk)
+            var start = 0
+            while start < characters.count, !isWordCharacter(characters[start]) { start += 1 }
+            var end = characters.count
+            while end > start, !isWordCharacter(characters[end - 1]) { end -= 1 }
+            return Word(
+                leading: String(characters[0..<start]),
+                text: String(characters[start..<end]),
+                trailing: String(characters[end...])
+            )
+        }
+    }
+
+    private static func joined(_ words: [Word]) -> String {
+        words.filter { !$0.isEmpty }.map(\.rendered).joined(separator: " ")
+    }
+
+    // MARK: - Fillers
+
+    /// The hesitation sounds, after ``canonical(_:)`` has flattened however many
+    /// letters the model chose to spell them with.
+    ///
+    /// Every one of these is non-lexical: there is no sentence in which the word
+    /// carries meaning, which is the whole reason removing it is safe. That is
+    /// also why `like`, `you know`, `I mean` and `actually` are **not** here.
+    /// Each is a real word often enough that dropping it needs judgement about
+    /// what the speaker meant, and this stage does not have any.
+    private static let universalFillers: Set<String> = [
+        "um", "uhm", "umh", "uh", "er", "erm", "hm",
+    ]
+
+    /// Sounds that mean *yes* or *no*, and must survive. `mhm` and `uh-huh` are
+    /// answers to a question, and a transcript that drops them says the opposite
+    /// of what was said. They are listed rather than merely absent so that
+    /// widening ``universalFillers`` cannot quietly swallow one.
+    private static let affirmations: Set<String> = [
+        "mhm", "mhmm", "mmhm", "uhuh", "uhhuh", "nuhuh", "huh", "hu",
+    ]
+
+    /// Only the non-lexical hesitation sounds, same bar as ``universalFillers``.
+    /// A language is absent here because nobody has checked it, not because it
+    /// has no fillers.
+    private static let localFillers: [String: Set<String>] = [
+        "de": ["äh", "ähm", "öh", "öhm"],
+        "nl": ["eh", "ehm", "uh"],
+        "fr": ["euh", "heu"],
+        "es": ["eh", "em"],
+        "it": ["ehm", "eh"],
+    ]
+
+    /// Fillers in the scripts that are written without spaces, where there are
+    /// no words to walk. Removed as plain substrings, which is only safe because
+    /// each of these is written with a length mark that a content word does not
+    /// carry.
+    private static let unspacedFillers: [String: [String]] = [
+        "ja": ["えーと", "えっと", "ええと", "あのー", "あのう"],
+        "zh": ["呃"],
+        "yue": ["呃"],
+    ]
+
+    /// Collapses a run of one repeated letter, so however long the model drew
+    /// the sound out it lands on the same key: `ummmm` and `uhhh` become `um`
+    /// and `uh`. Also drops the hyphen in `uh-huh`, which is why that spelling
+    /// reaches ``affirmations`` intact.
+    private static func canonical(_ key: String) -> String {
+        var result = ""
+        var previous: Character?
+        for character in key where character != "-" {
+            if character != previous { result.append(character) }
+            previous = character
+        }
+        return result
+    }
+
+    private static func isFiller(_ word: Word, code: String) -> Bool {
+        guard !word.isProtected else { return false }
+        // A quoted filler is being talked about rather than said: someone
+        // dictating `he said "um" a lot` means the word to be there.
+        guard !word.leading.contains(where: isQuote),
+              !word.trailing.contains(where: isQuote)
+        else { return false }
+        let key = canonical(word.key)
+        guard !key.isEmpty, !affirmations.contains(key) else { return false }
+        return universalFillers.contains(key) || localFillers[code]?.contains(key) == true
+    }
+
+    private static func isQuote(_ character: Character) -> Bool {
+        "\"'“”‘’«»„".contains(character)
+    }
+
+    private static func removeFillers(_ text: String, code: String) -> String {
+        var result = text
+        for filler in unspacedFillers[code] ?? [] {
+            result = result.replacingOccurrences(of: filler, with: "")
+        }
+
+        var kept: [Word] = []
+        for word in split(result) {
+            guard isFiller(word, code: code) else {
+                kept.append(word)
+                continue
+            }
+            // The filler goes, but a sentence it happened to end does not:
+            // "I was thinking. Um. We should ship" keeps both full stops.
+            let terminators = word.trailing.filter { "!?.。！？।۔".contains($0) }
+            if !terminators.isEmpty, var previous = kept.last {
+                if !previous.trailing.contains(where: { terminators.contains($0) }) {
+                    previous.trailing += terminators
+                    kept[kept.count - 1] = previous
+                }
+            } else if word.trailing.contains(","), var previous = kept.last,
+                      previous.trailing.hasSuffix(",") {
+                // A filler set off by commas on both sides takes both with it:
+                // "I think, um, we should" is "I think we should", not
+                // "I think, we should".
+                previous.trailing.removeLast()
+                kept[kept.count - 1] = previous
+            }
+        }
+        return joined(kept)
+    }
+
+    // MARK: - Stutters
+
+    /// Words whose immediate repeat is a stutter rather than a sentence.
+    /// Closed-class only: an article or a pronoun said twice in a row is the
+    /// speaker restarting, where a repeated content word ("very very") is
+    /// emphasis the speaker meant.
+    private static let functionWords: Set<String> = [
+        "the", "a", "an", "and", "but", "so", "or", "to", "of", "in", "on", "at",
+        "for", "with", "from", "by", "as", "if", "then", "than",
+        "i", "you", "we", "they", "he", "she", "it", "this", "these", "those",
+        "there", "my", "your", "our", "their", "his", "her", "its",
+        "is", "are", "was", "were", "am", "be", "been",
+        "do", "does", "did", "have", "has",
+        "can", "could", "will", "would", "should", "must",
+        "what", "when", "where", "why", "who", "how",
+    ]
+
+    /// Doubles that are ordinary English. "The thing that that man said" and
+    /// "she had had enough" are both correct, and both look exactly like a
+    /// stutter to a rule that only compares two words.
+    private static let legitimateDoubles: Set<String> = ["that", "had"]
+
+    /// Longest false start collapsed. Beyond this it is a repeated sentence,
+    /// which ``TranscriptSanitizer`` already has thresholds for.
+    private static let maximumStutterWords = 4
+
+    /// Collapses a phrase said twice in a row — "we should we should probably".
+    ///
+    /// Only an immediate repeat, and only the second copy is kept, because it is
+    /// the copy the speaker carried on from: "we should, we should probably
+    /// ship" has the comma on the abandoned half and the sentence on the other.
+    private static func collapseStutters(
+        _ text: String,
+        punctuation: SentencePunctuation
+    ) -> String {
+        let words = split(text)
+        guard words.count >= 2 else { return text }
+
+        var result: [Word] = []
+        var index = 0
+        while index < words.count {
+            var collapsed = false
+            // Longest first, so "we should we should" is one phrase twice over
+            // rather than two separate doubled words.
+            for length in stride(from: min(maximumStutterWords, (words.count - index) / 2), through: 1, by: -1)
+            where matchesRepeat(words, at: index, length: length, punctuation: punctuation) {
+                if let leading = words[index].leading.isEmpty ? nil : words[index].leading,
+                   words[index + length].leading.isEmpty {
+                    var carried = words[index + length]
+                    carried.leading = leading
+                    result.append(carried)
+                    result.append(contentsOf: words[(index + length + 1)..<(index + length * 2)])
+                } else {
+                    result.append(contentsOf: words[(index + length)..<(index + length * 2)])
+                }
+                index += length * 2
+                collapsed = true
+                break
+            }
+            if !collapsed {
+                result.append(words[index])
+                index += 1
+            }
+        }
+        return joined(result)
+    }
+
+    private static func matchesRepeat(
+        _ words: [Word],
+        at index: Int,
+        length: Int,
+        punctuation: SentencePunctuation
+    ) -> Bool {
+        guard index + length * 2 <= words.count else { return false }
+        for offset in 0..<length {
+            let first = words[index + offset]
+            let second = words[index + length + offset]
+            guard !first.isProtected, !first.key.isEmpty, first.key == second.key else { return false }
+            // A sentence ended between the copies, so the second one starts a
+            // new thought: "I went home. Home is quiet."
+            if ends(first, punctuation: punctuation) { return false }
+        }
+        if length == 1 {
+            let key = words[index].key
+            guard functionWords.contains(key), !legitimateDoubles.contains(key) else { return false }
+        }
+        return true
+    }
+
+    private static func ends(_ word: Word, punctuation: SentencePunctuation) -> Bool {
+        word.trailing.contains { punctuation.terminators.contains($0) }
+    }
+
+    // MARK: - Marks that are already there
+
+    /// Normalizes the punctuation the model emitted: spacing around it, runs of
+    /// it, and pairs of marks that cannot both be right. Nothing here decides
+    /// where a sentence ends; it only tidies the decisions already made.
+    private static func repairMarks(
+        _ text: String,
+        punctuation: SentencePunctuation
+    ) -> String {
+        var result = replacing("\\s+", with: " ", in: text)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let marks = "[" + NSRegularExpression.escapedPattern(
+            for: SentencePunctuation.universalTerminators + ",;:、၊…"
+        ) + "]"
+
+        // Never a space before a mark.
+        result = replacing("\\s+(" + marks + ")", with: "$1", in: result)
+        // A run of one separator is one separator.
+        result = replacing("([,;:、])\\1+", with: "$1", in: result)
+        // A separator touching a terminator: the terminator wins, whichever
+        // order the model put them in.
+        result = replacing("[,;:、]\\s*([.!?。！？।۔])", with: "$1", in: result)
+        result = replacing("([.!?。！？।۔])\\s*[,;:、]", with: "$1", in: result)
+        // Shouting and stammering. Four or more stops is an ellipsis that got
+        // away; three stays an ellipsis.
+        result = replacing("!{2,}", with: "!", in: result)
+        result = replacing("\\?{2,}", with: "?", in: result)
+        result = replacing("\\.{4,}", with: "...", in: result)
+        result = replacing("([!?])\\.+", with: "$1", in: result)
+        result = replacing("\\.([!?])", with: "$1", in: result)
+
+        if punctuation.join == " " {
+            // Always a space after a mark, unless another mark follows it —
+            // that is an ellipsis or a quoted close, not two sentences.
+            result = replacing(
+                "([,;:])(?=[^\\s,;:.!?…\\)\\]\"”’])", with: "$1 ", in: result
+            )
+            result = replacing(
+                "([.!?])(?=[\\p{L}\\p{N}\u{E000}])", with: "$1 ", in: result
+            )
+        }
+
+        // A mark with nothing in front of it, and a separator with nothing
+        // after it, are both left over from something that was removed.
+        result = replacing("^[\\s,;:.!?、。…]+", with: "", in: result)
+        result = replacing("[,;:、]+\\s*$", with: "", in: result)
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func replacing(
+        _ pattern: String, with template: String, in text: String
+    ) -> String {
+        guard let expression = try? NSRegularExpression(pattern: pattern) else { return text }
+        return expression.stringByReplacingMatches(
+            in: text,
+            range: NSRange(location: 0, length: (text as NSString).length),
+            withTemplate: template
+        )
+    }
+
+    // MARK: - Marks that are missing
+
+    /// Phrases that start a new thought when they turn up mid-flow. Each is a
+    /// discourse marker with no other job, which is what makes a sentence break
+    /// in front of it safe.
+    private static let sentenceStarters: [[String]] = [
+        ["okay"], ["ok"], ["alright"], ["all", "right"],
+        ["anyway"], ["anyhow"], ["by", "the", "way"], ["in", "any", "case"],
+    ]
+
+    /// Markers that take a comma when they open a sentence. `so` and `well` are
+    /// missing on purpose: both open a sentence far more often without one.
+    private static let openersTakingComma: [[String]] = [
+        ["okay"], ["ok"], ["alright"], ["all", "right"],
+        ["anyway"], ["anyhow"], ["however"], ["actually"],
+        ["by", "the", "way"], ["in", "fact"], ["of", "course"], ["for", "example"],
+    ]
+
+    /// Conjunctions that take a comma when they join two full clauses.
+    private static let clauseConjunctions: Set<String> = ["but", "so", "yet", "however"]
+
+    /// Words that can open a clause of their own. The test for "is a full
+    /// clause coming" is "does a subject start right here", which these are the
+    /// common ones for.
+    private static let clauseStarters: Set<String> = [
+        "i", "im", "ive", "ill", "id", "you", "youre", "youve", "youll", "youd",
+        "we", "weve", "well", "wed", "were", "they", "theyre", "theyve", "theyll",
+        "he", "hes", "hed", "she", "shes", "shed", "it", "its", "thats", "this",
+        "there", "theres", "my", "your", "our", "their", "his", "her",
+        "the", "a", "an", "nobody", "everyone", "someone", "people", "lets",
+        "maybe", "now", "then", "today", "tomorrow", "yesterday",
+    ]
+
+    /// After one of these, `okay` and `alright` are adjectives describing
+    /// something, not somebody starting a sentence.
+    private static let copulas: Set<String> = [
+        "is", "are", "was", "were", "am", "be", "been", "being",
+        "seem", "seems", "seemed", "look", "looks", "looked",
+        "feel", "feels", "felt", "sound", "sounds", "sounded",
+        "not", "quite", "pretty", "totally", "perfectly", "really",
+        "its", "thats", "everything", "all", "more", "less", "about",
+    ]
+
+    private static let auxiliaries: Set<String> = [
+        "do", "does", "did", "dont", "doesnt", "didnt",
+        "is", "are", "was", "were", "isnt", "arent", "wasnt", "werent",
+        "can", "cant", "could", "couldnt", "will", "wont", "would", "wouldnt",
+        "should", "shouldnt", "shall", "may", "might", "must",
+        "have", "has", "had", "havent", "hasnt", "hadnt", "am",
+    ]
+
+    private static let questionWords: Set<String> = [
+        "what", "whats", "when", "whens", "where", "wheres",
+        "why", "whys", "who", "whos", "whom", "whose", "how", "hows",
+    ]
+
+    private static let subjectPronouns: Set<String> = [
+        "i", "you", "we", "they", "he", "she", "it", "there",
+        "that", "this", "anyone", "anybody", "someone", "somebody", "everyone",
+    ]
+
+    /// Longest sentence still short enough for the question test to be worth
+    /// trusting. Past this a wh-word is far more often opening a noun clause.
+    private static let maximumQuestionWords = 12
+
+    private static func infer(_ text: String, punctuation: SentencePunctuation) -> String {
+        var words = split(text)
+        guard !words.isEmpty else { return text }
+        splitAtStarters(&words, punctuation: punctuation)
+        commaAfterOpeners(&words, punctuation: punctuation)
+        commaBeforeConjunctions(&words, punctuation: punctuation)
+        markQuestions(&words, punctuation: punctuation)
+        return joined(words)
+    }
+
+    /// Ends the sentence in front of a discourse marker that has clearly started
+    /// a new one. Requires a substantial unpunctuated clause behind it and a
+    /// clause of its own in front, so a marker inside a sentence is left alone.
+    private static func splitAtStarters(
+        _ words: inout [Word],
+        punctuation: SentencePunctuation
+    ) {
+        var index = 1
+        while index < words.count {
+            guard let length = match(sentenceStarters, in: words, at: index),
+                  index + length + 2 <= words.count,
+                  wordsSinceMark(words, before: index) >= 4,
+                  words[index - 1].trailing.isEmpty,
+                  !copulas.contains(words[index - 1].key)
+            else {
+                index += 1
+                continue
+            }
+            words[index - 1].trailing = punctuation.terminator
+            matchCaseOfSentence(&words, newSentenceAt: index)
+            index += length
+        }
+    }
+
+    /// "Okay we should ship" — the marker opens the sentence and the rest of it
+    /// follows, which in writing takes a comma.
+    private static func commaAfterOpeners(
+        _ words: inout [Word],
+        punctuation: SentencePunctuation
+    ) {
+        for index in words.indices {
+            guard opensSentence(words, at: index, punctuation: punctuation),
+                  let length = match(openersTakingComma, in: words, at: index),
+                  words[index + length - 1].trailing.isEmpty,
+                  index + length + 2 <= words.count
+            else { continue }
+            words[index + length - 1].trailing = punctuation.separator
+        }
+    }
+
+    /// "…ship it on Friday but I don't know…" — a conjunction joining two full
+    /// clauses takes a comma in front of it.
+    private static func commaBeforeConjunctions(
+        _ words: inout [Word],
+        punctuation: SentencePunctuation
+    ) {
+        for index in words.indices where index >= 4 && index + 2 < words.count {
+            guard clauseConjunctions.contains(words[index].key),
+                  words[index].leading.isEmpty,
+                  words[index].trailing.isEmpty,
+                  words[index - 1].trailing.isEmpty,
+                  wordsSinceMark(words, before: index) >= 4,
+                  clauseStarters.contains(words[index + 1].key),
+                  // "so that", "so much", "but as" — a phrase, not a new clause.
+                  !["that", "much", "many", "far", "long", "as"].contains(words[index + 1].key)
+            else { continue }
+            words[index - 1].trailing = punctuation.separator
+        }
+    }
+
+    /// Puts a question mark on a sentence that asks something. Applies to a
+    /// sentence with no terminator at all and to one the model closed with a
+    /// plain full stop; `!` is left alone, because someone chose it.
+    private static func markQuestions(
+        _ words: inout [Word],
+        punctuation: SentencePunctuation
+    ) {
+        for sentence in sentences(words, punctuation: punctuation) {
+            let last = words[sentence.upperBound]
+            let closing = last.trailing.last
+            let open = closing == nil || !punctuation.terminators.contains(closing!)
+            guard open || String(closing!) == punctuation.terminator,
+                  sentence.count <= maximumQuestionWords,
+                  isQuestion(words, sentence)
+            else { continue }
+            if !open { words[sentence.upperBound].trailing.removeLast() }
+            words[sentence.upperBound].trailing += punctuation.question
+        }
+    }
+
+    private static func isQuestion(_ words: [Word], _ sentence: ClosedRange<Int>) -> Bool {
+        let keys = sentence.map { words[$0].key }
+        guard keys.count >= 2 else { return false }
+        if questionWords.contains(keys[0]) {
+            // "What time is it" asks; "What I meant was simple" states. Both
+            // reach an auxiliary, but only the second puts a subject in front
+            // of it — the wh-word is that clause's own subject or object.
+            for offset in 1..<min(keys.count, 4) {
+                if subjectPronouns.contains(keys[offset]) { return false }
+                if auxiliaries.contains(keys[offset]) { return true }
+            }
+            return false
+        }
+        return auxiliaries.contains(keys[0]) && subjectPronouns.contains(keys[1])
+    }
+
+    // MARK: - Inference helpers
+
+    /// Whether the phrase at `index` is one of `phrases`, and how long it is.
+    private static func match(_ phrases: [[String]], in words: [Word], at index: Int) -> Int? {
+        for phrase in phrases where index + phrase.count <= words.count {
+            var matched = true
+            for (offset, key) in phrase.enumerated() where words[index + offset].key != key {
+                matched = false
+                break
+            }
+            // A mark inside the phrase means it is not being said as one.
+            if matched {
+                for offset in 0..<(phrase.count - 1)
+                where !words[index + offset].trailing.isEmpty {
+                    matched = false
+                    break
+                }
+            }
+            if matched { return phrase.count }
+        }
+        return nil
+    }
+
+    private static func opensSentence(
+        _ words: [Word],
+        at index: Int,
+        punctuation: SentencePunctuation
+    ) -> Bool {
+        index == 0 || ends(words[index - 1], punctuation: punctuation)
+    }
+
+    /// How many words back to the last punctuation of any kind. This is the
+    /// stand-in for "is there a whole clause behind me": a rule that would add a
+    /// mark four words after the last one is guessing, not repairing.
+    private static func wordsSinceMark(_ words: [Word], before index: Int) -> Int {
+        var count = 0
+        var cursor = index - 1
+        while cursor >= 0 {
+            count += 1
+            if !words[cursor].trailing.isEmpty { break }
+            cursor -= 1
+        }
+        return count
+    }
+
+    private static func sentences(
+        _ words: [Word],
+        punctuation: SentencePunctuation
+    ) -> [ClosedRange<Int>] {
+        var result: [ClosedRange<Int>] = []
+        var start = 0
+        for index in words.indices where ends(words[index], punctuation: punctuation) {
+            result.append(start...index)
+            start = index + 1
+        }
+        if start < words.count { result.append(start...(words.count - 1)) }
+        return result
+    }
+
+    /// Capitalizes a sentence this stage just created, but only when the
+    /// sentence it was split out of was capitalized too.
+    ///
+    /// The alternative — always capitalizing — puts a stray capital in the
+    /// middle of `clean` style output, which exists to flatten exactly that.
+    /// Following the text's own convention is right on both routes: a gateway
+    /// transcript arrives already cased and gets a capital, a raw local one
+    /// arrives lowercase and is left for ``TranscriptStyler`` to decide about.
+    private static func matchCaseOfSentence(_ words: inout [Word], newSentenceAt index: Int) {
+        var cursor = index - 1
+        var sentenceStart = index
+        while cursor >= 0 {
+            if !words[cursor].trailing.isEmpty && cursor != index - 1 { break }
+            sentenceStart = cursor
+            cursor -= 1
+        }
+        guard words[sentenceStart].startsUppercase,
+              let first = words[index].text.first(where: \.isLetter),
+              first.isLowercase
+        else { return }
+        var text = words[index].text
+        guard let position = text.firstIndex(of: first) else { return }
+        text.replaceSubrange(position...position, with: String(first).uppercased())
+        words[index].text = text
+    }
+}

--- a/ios/VocaPhoneShared/TranscriptStyler.swift
+++ b/ios/VocaPhoneShared/TranscriptStyler.swift
@@ -3,66 +3,11 @@ import Foundation
 /// Local equivalent of the gateway's presentation-only transcript styles.
 /// Words are never added, removed, or substituted; only case, spacing, and
 /// sentence punctuation may change.
+///
+/// Dropping a filler or inserting a missing sentence break would both break
+/// that contract, which is why they are ``TranscriptRepair``'s job and run
+/// before this stage under a switch of their own.
 enum TranscriptStyler {
-    private struct Punctuation {
-        let terminator: String
-        let separator: String
-        let exclamation: String
-        let question: String
-        let terminators: String
-        let join: String
-    }
-
-    private struct Masked {
-        let text: String
-        let tokens: [String]
-    }
-
-    private static let universalTerminators = ".!?。！？।۔။။།؟"
-    private static let latin = Punctuation(
-        terminator: ".", separator: ",", exclamation: "!", question: "?",
-        terminators: ".!?", join: " "
-    )
-    private static let cjk = Punctuation(
-        terminator: "。", separator: "、", exclamation: "！", question: "？",
-        terminators: "。！？.!?", join: ""
-    )
-    private static let arabic = Punctuation(
-        terminator: ".", separator: "،", exclamation: "!", question: "؟",
-        terminators: ".!?؟", join: " "
-    )
-    private static let urdu = Punctuation(
-        terminator: "۔", separator: "،", exclamation: "!", question: "؟",
-        terminators: "۔.!?؟", join: " "
-    )
-    private static let danda = Punctuation(
-        terminator: "।", separator: ",", exclamation: "!", question: "?",
-        terminators: "।.!?", join: " "
-    )
-    private static let indicLatin = Punctuation(
-        terminator: ".", separator: ",", exclamation: "!", question: "?",
-        terminators: "।.!?", join: " "
-    )
-    private static let unterminated = Punctuation(
-        terminator: "", separator: " ", exclamation: "!", question: "?",
-        terminators: "!?", join: " "
-    )
-    private static let burmese = Punctuation(
-        terminator: "။", separator: "၊", exclamation: "!", question: "?",
-        terminators: "။.!?", join: " "
-    )
-    private static let khmer = Punctuation(
-        terminator: "។", separator: ",", exclamation: "!", question: "?",
-        terminators: "។.!?", join: " "
-    )
-    private static let tibetan = Punctuation(
-        terminator: "།", separator: "།", exclamation: "!", question: "?",
-        terminators: "།.!?", join: " "
-    )
-
-    private static let protectedPattern = "(?i)(https?://[^\\s]+[^\\s.,;:!?\\\"“”'\\)\\]]|[\\w.+-]+@(?:[\\w-]+\\.)+[A-Za-z]{2,}|(?:[\\w-]+\\.)+[A-Za-z]{2,}(?:/[^\\s.,;:!?\\\"“”'\\)\\]]*)?|\\d+(?:[.,:/]\\d+)+|\\d+(?:st|nd|rd|th)\\b|(?:[A-Za-z]\\.){2,})"
-    private static let placeholderPattern = "__VOCA_TOKEN_(\\d+)__"
-
     static func apply(
         _ text: String?,
         style: WritingStyle,
@@ -72,10 +17,10 @@ enum TranscriptStyler {
         if style == .raw { return source.trimmingCharacters(in: .whitespacesAndNewlines) }
         guard !source.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return "" }
 
-        let punctuation = punctuation(for: language, text: source)
-        let masked = mask(source)
+        let punctuation = SentencePunctuation.resolve(language: language, text: source)
+        let spans = ProtectedSpans.mask(source)
         let normalized = normalizeSentenceTerminators(
-            normalizeSpacing(masked.text),
+            normalizeSpacing(spans.text),
             punctuation: punctuation
         )
         // Whisper and Parakeet Title-Case content words. Flatten those before
@@ -106,105 +51,10 @@ enum TranscriptStyler {
         case .excited:
             result = excited(segments(flattened, punctuation: punctuation), punctuation: punctuation)
         }
-        let lowered = style == .veryCasual ? lowerOutsidePlaceholders(result) : result
-        return restore(lowered, tokens: masked.tokens)
-    }
-
-    private static func punctuation(for language: String, text: String) -> Punctuation {
-        let code = language.lowercased().split(separator: "-").first.map(String.init) ?? ""
-        let base: Punctuation
-        switch code {
-        case "ja", "zh": base = cjk
-        case "ar", "fa", "ps": base = arabic
-        case "ur", "sd", "ks": base = urdu
-        case "hi", "mr", "ne", "bn", "as", "pa": base = danda
-        case "ta", "te", "kn", "ml", "gu", "si": base = indicLatin
-        case "th", "lo": base = unterminated
-        case "my": base = burmese
-        case "km": base = khmer
-        case "bo": base = tibetan
-        default:
-            if text.contains(where: { "。、！？".contains($0) }) { base = cjk }
-            else if text.contains(where: { "،؟".contains($0) }) { base = arabic }
-            else if text.contains("۔") { base = urdu }
-            else if text.contains("।") || containsDandaScript(text) { base = danda }
-            else { base = latin }
-        }
-        var seen = Set<Character>()
-        let merged = String((universalTerminators + base.terminators).filter { seen.insert($0).inserted })
-        return Punctuation(
-            terminator: base.terminator,
-            separator: base.separator,
-            exclamation: base.exclamation,
-            question: base.question,
-            terminators: merged,
-            join: base.join
-        )
-    }
-
-    /// Devanagari, Bengali/Assamese, and Gurmukhi conventionally use danda.
-    /// This is the fallback when Automatic was selected and an engine did not
-    /// expose the language it detected.
-    private static func containsDandaScript(_ text: String) -> Bool {
-        text.unicodeScalars.contains { scalar in
-            switch scalar.value {
-            case 0x0900...0x097F, 0x0980...0x09FF, 0x0A00...0x0A7F:
-                true
-            default:
-                false
-            }
-        }
-    }
-
-    private static func mask(_ text: String) -> Masked {
-        let regex = try! NSRegularExpression(pattern: protectedPattern)
-        let string = text as NSString
-        let matches = regex.matches(in: text, range: NSRange(location: 0, length: string.length))
-        let tokens = matches.map { string.substring(with: $0.range) }
-        let result = NSMutableString(string: text)
-        for index in matches.indices.reversed() {
-            result.replaceCharacters(
-                in: matches[index].range,
-                with: "__VOCA_TOKEN_\(index)__"
-            )
-        }
-        return Masked(text: String(result), tokens: tokens)
-    }
-
-    /// Index of the last character of `__VOCA_TOKEN_<n>__` starting at `index`.
-    private static func endOfPlaceholder(in characters: [Character], from index: Int) -> Int? {
-        let prefix: [Character] = Array("__VOCA_TOKEN_")
-        guard index + prefix.count + 3 <= characters.count else { return nil }
-        for offset in prefix.indices where characters[index + offset] != prefix[offset] {
-            return nil
-        }
-        var cursor = index + prefix.count
-        var sawDigit = false
-        while cursor < characters.count {
-            let character = characters[cursor]
-            guard character >= "0", character <= "9" else { break }
-            sawDigit = true
-            cursor += 1
-        }
-        guard sawDigit,
-              cursor + 1 < characters.count,
-              characters[cursor] == "_",
-              characters[cursor + 1] == "_"
-        else { return nil }
-        return cursor + 1
-    }
-
-    private static func restore(_ text: String, tokens: [String]) -> String {
-        let regex = try! NSRegularExpression(pattern: placeholderPattern)
-        let original = text as NSString
-        let matches = regex.matches(in: text, range: NSRange(location: 0, length: original.length))
-        let result = NSMutableString(string: text)
-        for match in matches.reversed() {
-            let index = Int(original.substring(with: match.range(at: 1))) ?? -1
-            guard tokens.indices.contains(index) else { continue }
-            result.replaceCharacters(in: match.range, with: tokens[index])
-        }
-        return String(result)
+        let lowered = style == .veryCasual
+            ? ProtectedSpans.mapOutsidePlaceholders(result) { $0.lowercased() }
+            : result
+        return spans.restore(lowered)
     }
 
     private static func normalizeSpacing(_ text: String) -> String {
@@ -223,7 +73,7 @@ enum TranscriptStyler {
     /// while leaving masked URLs, decimals, abbreviations, and ellipses intact.
     private static func normalizeSentenceTerminators(
         _ text: String,
-        punctuation: Punctuation
+        punctuation: SentencePunctuation
     ) -> String {
         guard punctuation.terminator == "।" else { return text }
         let characters = Array(text)
@@ -245,7 +95,10 @@ enum TranscriptStyler {
         return result
     }
 
-    private static func ensureTerminator(_ text: String, punctuation: Punctuation) -> String {
+    private static func ensureTerminator(
+        _ text: String,
+        punctuation: SentencePunctuation
+    ) -> String {
         guard !text.isEmpty, !punctuation.terminator.isEmpty else { return text }
         guard let last = text.last, !punctuation.terminators.contains(last) else { return text }
         return text + punctuation.terminator
@@ -258,11 +111,15 @@ enum TranscriptStyler {
         let characters = Array(text)
         var index = 0
         while index < characters.count {
-            // `__VOCA_TOKEN_N__` contains the letters TOKEN. Copy the marker
-            // whole; flatten would lowercase it and restore could not match.
-            if let end = endOfPlaceholder(in: characters, from: index) {
-                result.append(contentsOf: characters[index...end])
-                index = end + 1
+            // Copy a protected span whole: flatten would lowercase the digits
+            // inside it, and restore could not match the placeholder afterwards.
+            if characters[index] == ProtectedSpans.open {
+                let start = index
+                while index < characters.count, characters[index] != ProtectedSpans.close {
+                    index += 1
+                }
+                if index < characters.count { index += 1 }
+                result.append(contentsOf: characters[start..<index])
                 continue
             }
             let character = characters[index]
@@ -315,7 +172,10 @@ enum TranscriptStyler {
         return contracted && ["m", "ll", "d", "ve", "re", "s"].contains(rest)
     }
 
-    private static func capitalizeSentenceStarts(_ text: String, punctuation: Punctuation) -> String {
+    private static func capitalizeSentenceStarts(
+        _ text: String,
+        punctuation: SentencePunctuation
+    ) -> String {
         var result = ""
         var shouldCapitalize = true
         for character in text {
@@ -330,7 +190,7 @@ enum TranscriptStyler {
         return result
     }
 
-    private static func casual(_ text: String, punctuation: Punctuation) -> String {
+    private static func casual(_ text: String, punctuation: SentencePunctuation) -> String {
         let capitalized = capitalizeSentenceStarts(text, punctuation: punctuation)
         guard !punctuation.terminator.isEmpty, !capitalized.hasSuffix("..") else { return capitalized }
         return capitalized.hasSuffix(punctuation.terminator)
@@ -338,7 +198,10 @@ enum TranscriptStyler {
             : capitalized
     }
 
-    private static func segments(_ text: String, punctuation: Punctuation) -> [String] {
+    private static func segments(
+        _ text: String,
+        punctuation: SentencePunctuation
+    ) -> [String] {
         guard !text.isEmpty else { return [] }
         let characters = Array(text)
         var result: [String] = []
@@ -368,7 +231,7 @@ enum TranscriptStyler {
 
     private static func splitTerminator(
         _ sentence: String,
-        punctuation: Punctuation
+        punctuation: SentencePunctuation
     ) -> (body: String, terminator: String) {
         let body = sentence.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let last = body.last,
@@ -378,7 +241,10 @@ enum TranscriptStyler {
         return (String(body.dropLast()), String(last))
     }
 
-    private static func veryCasual(_ sentences: [String], punctuation: Punctuation) -> String {
+    private static func veryCasual(
+        _ sentences: [String],
+        punctuation: SentencePunctuation
+    ) -> String {
         var parts: [String] = []
         for (index, sentence) in sentences.enumerated() {
             let split = splitTerminator(sentence, punctuation: punctuation)
@@ -394,7 +260,10 @@ enum TranscriptStyler {
         return parts.joined(separator: punctuation.join)
     }
 
-    private static func excited(_ sentences: [String], punctuation: Punctuation) -> String {
+    private static func excited(
+        _ sentences: [String],
+        punctuation: SentencePunctuation
+    ) -> String {
         sentences.compactMap { sentence in
             let split = splitTerminator(sentence, punctuation: punctuation)
             guard !split.body.isEmpty else { return nil }
@@ -404,21 +273,5 @@ enum TranscriptStyler {
             return capitalizeSentenceStarts(split.body, punctuation: punctuation) + punctuation.exclamation
         }
         .joined(separator: punctuation.join)
-    }
-
-    private static func lowerOutsidePlaceholders(_ text: String) -> String {
-        let regex = try! NSRegularExpression(pattern: placeholderPattern)
-        let original = text as NSString
-        let matches = regex.matches(in: text, range: NSRange(location: 0, length: original.length))
-        var result = ""
-        var cursor = 0
-        for match in matches {
-            let before = NSRange(location: cursor, length: match.range.location - cursor)
-            result += original.substring(with: before).lowercased()
-            result += original.substring(with: match.range)
-            cursor = match.range.location + match.range.length
-        }
-        result += original.substring(from: cursor).lowercased()
-        return result
     }
 }

--- a/ios/VocaPhoneTests/DictatedTranscriptTests.swift
+++ b/ios/VocaPhoneTests/DictatedTranscriptTests.swift
@@ -1,7 +1,7 @@
 import Testing
 
-/// The order of the three steps is the whole point of the funnel, and each
-/// wrong order produces text that looks like a different bug.
+/// The order of the four steps is the whole point of the funnel, and each wrong
+/// order produces text that looks like a different bug.
 struct DictatedTranscriptTests {
     /// Digits after styling. The styler capitalizes the first *letter* of a
     /// sentence, so a sentence that already began with "20" would have it skip
@@ -11,6 +11,7 @@ struct DictatedTranscriptTests {
             DictatedTranscript.finished(
                 "twenty people came",
                 style: .formal,
+                repairSpeech: false,
                 numbersAsDigits: true
             ) == "20 people came."
         )
@@ -23,38 +24,127 @@ struct DictatedTranscriptTests {
             DictatedTranscript.finished(
                 "[BLANK_AUDIO] five copies please",
                 style: .formal,
+                repairSpeech: false,
                 numbersAsDigits: true
             ) == "5 copies please."
         )
     }
 
+    /// Repair before styling, because repair is what puts the sentence
+    /// boundaries there. Styling capitalizes and terminates *around* a
+    /// boundary and cannot find one that is missing.
+    @Test func repairHappensBeforeStyling() {
+        #expect(
+            DictatedTranscript.finished(
+                "um what time is it",
+                style: .formal,
+                repairSpeech: true,
+                numbersAsDigits: false
+            ) == "What time is it?"
+        )
+        // Without repair the styler sees no question and closes the sentence
+        // with the full stop it is contractually allowed to add.
+        #expect(
+            DictatedTranscript.finished(
+                "um what time is it",
+                style: .formal,
+                repairSpeech: false,
+                numbersAsDigits: false
+            ) == "Um what time is it."
+        )
+    }
+
+    /// Raw promises the model's own output, so the one stage that changes words
+    /// never runs for it however the preference is set.
+    @Test func rawIsNeverRepaired() {
+        #expect(
+            DictatedTranscript.finished(
+                "um so we we should ship it",
+                style: .raw,
+                repairSpeech: true,
+                numbersAsDigits: false
+            ) == "um so we we should ship it"
+        )
+    }
+
     /// A gateway has already applied the session's writing style, so that route
-    /// passes `nil` and the styler never runs twice.
+    /// says so and the styler never runs twice.
     @Test func anAlreadyStyledTranscriptIsNotStyledAgain() {
         let styled = "Hello there."
-        #expect(DictatedTranscript.finished(styled, numbersAsDigits: false) == styled)
+        #expect(
+            DictatedTranscript.finished(
+                styled,
+                style: .casual,
+                styledUpstream: true,
+                repairSpeech: false,
+                numbersAsDigits: false
+            ) == styled
+        )
         // The same text through the local route would lose its full stop to the
         // casual style — which is exactly what must not happen twice.
         #expect(
-            DictatedTranscript.finished(styled, style: .casual, numbersAsDigits: false)
-                == "Hello there"
+            DictatedTranscript.finished(
+                styled,
+                style: .casual,
+                repairSpeech: false,
+                numbersAsDigits: false
+            ) == "Hello there"
+        )
+    }
+
+    /// The gateway does not repair, so this route still does — and because the
+    /// text arrives cased, a sentence repair creates is cased to match.
+    @Test func anAlreadyStyledTranscriptIsStillRepaired() {
+        #expect(
+            DictatedTranscript.finished(
+                "We shipped it on Friday um anyway the tests are green",
+                style: .casual,
+                styledUpstream: true,
+                repairSpeech: true,
+                numbersAsDigits: false
+            ) == "We shipped it on Friday. Anyway, the tests are green"
         )
     }
 
     /// Off is off: the words the model returned are the words that get inserted.
     @Test func numbersStayWordsWhenThePreferenceIsOff() {
         #expect(
-            DictatedTranscript.finished("six pm at office", numbersAsDigits: false)
-                == "six pm at office"
+            DictatedTranscript.finished(
+                "six pm at office",
+                style: .casual,
+                styledUpstream: true,
+                repairSpeech: false,
+                numbersAsDigits: false
+            ) == "six pm at office"
         )
         #expect(
-            DictatedTranscript.finished("six pm at office", numbersAsDigits: true)
-                == "6 pm at office"
+            DictatedTranscript.finished(
+                "six pm at office",
+                style: .casual,
+                styledUpstream: true,
+                repairSpeech: false,
+                numbersAsDigits: true
+            ) == "6 pm at office"
         )
     }
 
     @Test func nothingInMeansNothingOut() {
-        #expect(DictatedTranscript.finished(nil, numbersAsDigits: true).isEmpty)
-        #expect(DictatedTranscript.finished("   ", style: .formal, numbersAsDigits: true).isEmpty)
+        #expect(
+            DictatedTranscript.finished(
+                nil,
+                style: .casual,
+                styledUpstream: true,
+                repairSpeech: true,
+                numbersAsDigits: true
+            ).isEmpty
+        )
+        #expect(
+            DictatedTranscript.finished(
+                "   ",
+                style: .formal,
+                repairSpeech: true,
+                numbersAsDigits: true
+            ).isEmpty
+        )
     }
 }

--- a/ios/VocaPhoneTests/TranscriptRepairTests.swift
+++ b/ios/VocaPhoneTests/TranscriptRepairTests.swift
@@ -75,10 +75,52 @@ struct TranscriptRepairTests {
         #expect(TranscriptRepair.apply("eh what was that", language: "en") == "eh what was that")
     }
 
+    /// `um` is German for "at" and `er` is German for "he" and Dutch for
+    /// "there". Removing them from those transcripts deletes content, which is
+    /// why they are the one part of the filler set that has to know what
+    /// language it is looking at.
+    @Test func fillersThatAreWordsElsewhereSurvive() {
+        #expect(
+            TranscriptRepair.apply("wir treffen uns um acht Uhr", language: "de")
+                == "wir treffen uns um acht Uhr"
+        )
+        #expect(
+            TranscriptRepair.apply("er kommt in einer Stunde", language: "de")
+                == "er kommt in einer Stunde"
+        )
+        // The unambiguous German filler still goes, and "um" beside it stays.
+        #expect(
+            TranscriptRepair.apply("wir sollten ähm um acht liefern", language: "de")
+                == "wir sollten um acht liefern"
+        )
+    }
+
+    /// On Automatic nothing has said what the language is, so the sentence has
+    /// to. A German one carries no English marker and keeps its "er".
+    @Test func automaticNeedsTheSentenceToReadAsEnglish() {
+        #expect(
+            TranscriptRepair.apply("er kommt in einer Stunde nach Hause")
+                == "er kommt in einer Stunde nach Hause"
+        )
+        #expect(TranscriptRepair.apply("um we should ship it that day") == "we should ship it that day")
+        // Said explicitly, no marker is needed.
+        #expect(TranscriptRepair.apply("um ship it", language: "en") == "ship it")
+    }
+
+    /// "err" only looks like a filler after repeated letters are flattened, so
+    /// it is caught before that runs.
+    @Test func theVerbErrSurvives() {
+        #expect(TranscriptRepair.apply("to err is human") == "to err is human")
+        #expect(
+            TranscriptRepair.apply("errr i am not sure about that")
+                == "i am not sure about that"
+        )
+    }
+
     /// Repairing a transcript down to nothing is a rule misfiring, not silence.
     @Test func aTranscriptIsNeverRepairedAway() {
-        #expect(TranscriptRepair.apply("um") == "um")
-        #expect(TranscriptRepair.apply("um uh") == "um uh")
+        #expect(TranscriptRepair.apply("um", language: "en") == "um")
+        #expect(TranscriptRepair.apply("um uh", language: "en") == "um uh")
     }
 
     // MARK: - False starts
@@ -237,6 +279,53 @@ struct TranscriptRepairTests {
     /// Someone chose the exclamation mark. Repair does not overrule it.
     @Test func anExclamationIsLeftAlone() {
         #expect(TranscriptRepair.apply("what a day!") == "what a day!")
+    }
+
+    /// "…but the truth" is an object, not a clause. Only a determiner with room
+    /// for a verb after it is one.
+    @Test func aDeterminerObjectDoesNotTakeAComma() {
+        #expect(
+            TranscriptRepair.apply("nothing at all here matters but the truth")
+                == "nothing at all here matters but the truth"
+        )
+        #expect(
+            TranscriptRepair.apply("we can ship it on friday but the tests are failing")
+                == "we can ship it on friday, but the tests are failing"
+        )
+    }
+
+    /// A marker only ends the previous sentence when a clause follows it.
+    @Test func aStarterWithoutAClauseAfterItDoesNotSplit() {
+        #expect(
+            TranscriptRepair.apply("the results came back okay and we shipped")
+                == "the results came back okay and we shipped"
+        )
+        #expect(
+            TranscriptRepair.apply("i tested the whole thing anyway we can ship")
+                == "i tested the whole thing. anyway, we can ship"
+        )
+    }
+
+    /// "Had I known" inverts exactly the way a question does. The modal further
+    /// along is the only thing that tells them apart.
+    @Test func anInvertedConditionalIsNotAQuestion() {
+        #expect(
+            TranscriptRepair.apply("had i known that i would have called")
+                == "had i known that i would have called"
+        )
+        #expect(TranscriptRepair.apply("had you seen the report") == "had you seen the report?")
+    }
+
+    /// The mark belongs to the sentence, so it goes inside what wraps it.
+    @Test func aQuestionMarkGoesInsideTheQuotes() {
+        #expect(TranscriptRepair.apply("\"can you send it\"") == "\"can you send it?\"")
+        #expect(TranscriptRepair.apply("\"can you send it.\"") == "\"can you send it?\"")
+    }
+
+    /// The two clients build their punctuation classes from one shared set, so
+    /// a script whose separator only one of them listed cannot drift.
+    @Test func nonLatinSeparatorsAreSpacedToo() {
+        #expect(TranscriptRepair.apply("مرحبا ،كيف حالك", language: "ar") == "مرحبا، كيف حالك")
     }
 
     // MARK: - Spans nothing may touch

--- a/ios/VocaPhoneTests/TranscriptRepairTests.swift
+++ b/ios/VocaPhoneTests/TranscriptRepairTests.swift
@@ -1,0 +1,279 @@
+import Testing
+
+/// Two halves, tested apart: what repair is allowed to remove, and what it is
+/// allowed to add. The cases that matter most are the ones asserting it does
+/// *neither* — a rule that fires on a word someone meant is worse than the
+/// filler it was written to catch.
+struct TranscriptRepairTests {
+
+    // MARK: - Fillers
+
+    @Test func hesitationSoundsAreRemoved() {
+        #expect(TranscriptRepair.apply("um we should ship it") == "we should ship it")
+        #expect(TranscriptRepair.apply("we should uh ship it") == "we should ship it")
+        #expect(TranscriptRepair.apply("we should er ship it") == "we should ship it")
+        #expect(TranscriptRepair.apply("erm we should ship it") == "we should ship it")
+    }
+
+    /// However long the model drew the sound out, it is the same sound.
+    @Test func elongatedFillersAreRemoved() {
+        #expect(TranscriptRepair.apply("ummmm we should ship it") == "we should ship it")
+        #expect(TranscriptRepair.apply("we uhhh should ship it") == "we should ship it")
+        #expect(TranscriptRepair.apply("hmmm we should ship it") == "we should ship it")
+    }
+
+    /// A filler set off by commas takes both of them with it, or the sentence
+    /// is left with a comma that separates nothing.
+    @Test func commasAroundAFillerGoWithIt() {
+        #expect(TranscriptRepair.apply("I think, um, we should ship") == "I think we should ship")
+        #expect(TranscriptRepair.apply("um, we should ship it") == "we should ship it")
+    }
+
+    /// The filler goes; the sentence it happened to end does not.
+    @Test func aFillerKeepsTheSentenceItClosed() {
+        #expect(
+            TranscriptRepair.apply("I was thinking. Um. We should ship it")
+                == "I was thinking. We should ship it"
+        )
+    }
+
+    /// These are answers. A transcript that drops them says the opposite of
+    /// what was said.
+    @Test func affirmationsSurvive() {
+        #expect(TranscriptRepair.apply("mhm that works for me") == "mhm that works for me")
+        #expect(TranscriptRepair.apply("uh-huh that works") == "uh-huh that works")
+        #expect(TranscriptRepair.apply("huh") == "huh")
+    }
+
+    /// Every one of these is a real word often enough that removing it needs
+    /// judgement about what the speaker meant, which this stage does not have.
+    @Test func realWordsAreNeverTreatedAsFillers() {
+        let source = "I mean it is like you know actually pretty good so"
+        #expect(TranscriptRepair.apply(source) == source)
+        #expect(TranscriptRepair.apply("ah well oh dear") == "ah well oh dear")
+    }
+
+    /// Quoted, the filler is being talked about rather than said.
+    @Test func aQuotedFillerIsKept() {
+        #expect(
+            TranscriptRepair.apply("he said \"um\" a lot") == "he said \"um\" a lot"
+        )
+    }
+
+    /// Only in the language that has them: a German "eh" is not a French one.
+    @Test func localFillersNeedTheirLanguage() {
+        #expect(
+            TranscriptRepair.apply("wir sollten ähm morgen liefern", language: "de")
+                == "wir sollten morgen liefern"
+        )
+        // "eh" is Spanish hesitation and an English interjection, so it goes
+        // only when the transcript is Spanish.
+        #expect(
+            TranscriptRepair.apply("eh deberíamos enviarlo", language: "es")
+                == "deberíamos enviarlo"
+        )
+        #expect(TranscriptRepair.apply("eh what was that", language: "en") == "eh what was that")
+    }
+
+    /// Repairing a transcript down to nothing is a rule misfiring, not silence.
+    @Test func aTranscriptIsNeverRepairedAway() {
+        #expect(TranscriptRepair.apply("um") == "um")
+        #expect(TranscriptRepair.apply("um uh") == "um uh")
+    }
+
+    // MARK: - False starts
+
+    @Test func aRepeatedPhraseCollapses() {
+        #expect(
+            TranscriptRepair.apply("we should we should probably ship it")
+                == "we should probably ship it"
+        )
+        #expect(TranscriptRepair.apply("I think I think so") == "I think so")
+    }
+
+    /// The second copy is the one the speaker carried on from, so it is the one
+    /// that keeps its punctuation.
+    @Test func theCompletedCopyIsTheOneKept() {
+        #expect(
+            TranscriptRepair.apply("we should, we should probably ship")
+                == "we should probably ship"
+        )
+    }
+
+    @Test func aDoubledFunctionWordCollapses() {
+        #expect(TranscriptRepair.apply("the the tests are green") == "the tests are green")
+        #expect(TranscriptRepair.apply("send it to to me") == "send it to me")
+    }
+
+    /// A repeated content word is emphasis the speaker meant.
+    @Test func aDoubledContentWordSurvives() {
+        #expect(TranscriptRepair.apply("that is very very good") == "that is very very good")
+        #expect(TranscriptRepair.apply("no no not that one") == "no no not that one")
+    }
+
+    /// Both of these are ordinary English and both look exactly like a stutter.
+    @Test func legitimateDoublesSurvive() {
+        #expect(TranscriptRepair.apply("she had had enough") == "she had had enough")
+        #expect(
+            TranscriptRepair.apply("the thing that that man said") == "the thing that that man said"
+        )
+    }
+
+    /// A sentence ended between the copies, so the second starts a new thought.
+    @Test func aRepeatAcrossASentenceBoundarySurvives() {
+        #expect(TranscriptRepair.apply("I went home. Home is quiet") == "I went home. Home is quiet")
+    }
+
+    // MARK: - Marks that are already there
+
+    @Test func spacingAroundMarksIsNormalized() {
+        #expect(TranscriptRepair.apply("hello there ,how are you") == "hello there, how are you")
+        #expect(TranscriptRepair.apply("one.two.three") == "one. two. three")
+    }
+
+    /// A bare hostname has to end in something that is actually a domain, or
+    /// "the report.Then I left" is masked as one and the missing space after
+    /// the full stop can never be repaired.
+    @Test func aDottedPairOfWordsIsNotAHostname() {
+        #expect(
+            TranscriptRepair.apply("I finished the report.Then I left")
+                == "I finished the report. Then I left"
+        )
+        #expect(
+            TranscriptRepair.apply("visit example.com/a.b. thanks")
+                == "visit example.com/a.b. thanks"
+        )
+    }
+
+    @Test func runsOfMarksCollapse() {
+        #expect(TranscriptRepair.apply("that is great!!!") == "that is great!")
+        #expect(TranscriptRepair.apply("really?? I did not know") == "really? I did not know")
+        #expect(TranscriptRepair.apply("wait for it....") == "wait for it...")
+        // Three is an ellipsis and stays one.
+        #expect(TranscriptRepair.apply("wait for it...") == "wait for it...")
+    }
+
+    @Test func aSeparatorTouchingATerminatorLoses() {
+        #expect(TranscriptRepair.apply("that is all ,. thanks") == "that is all. thanks")
+    }
+
+    @Test func orphanedMarksAreDropped() {
+        #expect(TranscriptRepair.apply(", we should ship it,") == "we should ship it")
+    }
+
+    // MARK: - Marks that are missing
+
+    /// The whole complaint, end to end.
+    @Test func aRunOnGetsItsSentencesBack() {
+        #expect(
+            TranscriptRepair.apply(
+                "so i was thinking that um we should we should probably ship it on "
+                    + "friday but i dont know if the the tests are green okay lets check"
+            )
+                == "so i was thinking that we should probably ship it on friday, "
+                + "but i dont know if the tests are green. okay, lets check"
+        )
+    }
+
+    @Test func aConjunctionJoiningTwoClausesTakesAComma() {
+        #expect(
+            TranscriptRepair.apply("we can ship it on friday but i need the tests")
+                == "we can ship it on friday, but i need the tests"
+        )
+    }
+
+    /// Not every "but" joins two clauses, and not every clause is long enough
+    /// to be sure it is one.
+    @Test func aConjunctionInsideAClauseIsLeftAlone() {
+        #expect(TranscriptRepair.apply("nothing but trouble here") == "nothing but trouble here")
+        #expect(TranscriptRepair.apply("slow but steady wins") == "slow but steady wins")
+        // "so that" is a phrase, not a new clause.
+        #expect(
+            TranscriptRepair.apply("i moved the file so that the tests would pass")
+                == "i moved the file so that the tests would pass"
+        )
+    }
+
+    @Test func anOpeningDiscourseMarkerTakesAComma() {
+        #expect(TranscriptRepair.apply("okay lets ship it") == "okay, lets ship it")
+        #expect(TranscriptRepair.apply("actually i changed my mind") == "actually, i changed my mind")
+    }
+
+    /// "so" and "well" open a sentence far more often without a comma than
+    /// with one, which is why neither is in the list.
+    @Test func soAndWellDoNotTakeAComma() {
+        #expect(TranscriptRepair.apply("so i was thinking about it") == "so i was thinking about it")
+        #expect(TranscriptRepair.apply("well that settles it then") == "well that settles it then")
+    }
+
+    /// "okay" after a copula is an adjective describing something, not somebody
+    /// starting a sentence.
+    @Test func okayAsAnAdjectiveDoesNotSplit() {
+        #expect(
+            TranscriptRepair.apply("make sure the build is okay before you ship it")
+                == "make sure the build is okay before you ship it"
+        )
+    }
+
+    @Test func questionsGetAQuestionMark() {
+        #expect(TranscriptRepair.apply("what time is it") == "what time is it?")
+        #expect(TranscriptRepair.apply("do you want coffee") == "do you want coffee?")
+        #expect(TranscriptRepair.apply("how many people are coming") == "how many people are coming?")
+        // A model that closed a question with a full stop is corrected.
+        #expect(TranscriptRepair.apply("can you send it.") == "can you send it?")
+    }
+
+    /// A wh-word opening a noun clause is not a question, and the giveaway is a
+    /// subject sitting between it and the verb.
+    @Test func aStatementStartingWithAWhWordIsNotAQuestion() {
+        #expect(TranscriptRepair.apply("what i meant was simple") == "what i meant was simple")
+        #expect(TranscriptRepair.apply("how he did it is unclear") == "how he did it is unclear")
+        #expect(
+            TranscriptRepair.apply("when i get there i will call you")
+                == "when i get there i will call you"
+        )
+    }
+
+    /// Someone chose the exclamation mark. Repair does not overrule it.
+    @Test func anExclamationIsLeftAlone() {
+        #expect(TranscriptRepair.apply("what a day!") == "what a day!")
+    }
+
+    // MARK: - Spans nothing may touch
+
+    @Test func protectedSpansSurviveEveryStage() {
+        #expect(
+            TranscriptRepair.apply("um send it to me@example.com at 3.30 today")
+                == "send it to me@example.com at 3.30 today"
+        )
+        #expect(
+            TranscriptRepair.apply("open https://example.com/a.b and uh tell me")
+                == "open https://example.com/a.b and tell me"
+        )
+        #expect(TranscriptRepair.apply("it is the 1st of may") == "it is the 1st of may")
+    }
+
+    // MARK: - Other scripts
+
+    /// The inference rules are written against how English builds a sentence.
+    /// In a script that terminates differently they would do damage, so they
+    /// do not run at all.
+    @Test func inferenceIsSkippedOutsideLatinLayout() {
+        let hindi = "मैं कल बाजार जाऊंगा"
+        #expect(TranscriptRepair.apply(hindi, language: "hi") == hindi)
+        let japanese = "えーと明日出荷します"
+        #expect(TranscriptRepair.apply(japanese, language: "ja") == "明日出荷します")
+    }
+
+    /// Another Latin language keeps its layout, and the English trigger words
+    /// simply never match — which is the point of choosing English-only words.
+    @Test func anotherLatinLanguageIsUntouched() {
+        let french = "nous devrions livrer vendredi mais je ne sais pas"
+        #expect(TranscriptRepair.apply(french, language: "fr") == french)
+    }
+
+    @Test func nothingInMeansNothingOut() {
+        #expect(TranscriptRepair.apply(nil).isEmpty)
+        #expect(TranscriptRepair.apply("   ").isEmpty)
+    }
+}

--- a/ios/VocaPhoneTests/TranscriptRepairTests.swift
+++ b/ios/VocaPhoneTests/TranscriptRepairTests.swift
@@ -170,16 +170,42 @@ struct TranscriptRepairTests {
 
     @Test func spacingAroundMarksIsNormalized() {
         #expect(TranscriptRepair.apply("hello there ,how are you") == "hello there, how are you")
-        #expect(TranscriptRepair.apply("one.two.three") == "one. two. three")
+        // Not hostname-shaped — a digit cannot be a top-level domain.
+        #expect(
+            TranscriptRepair.apply("stop.42 people came to the party")
+                == "stop. 42 people came to the party"
+        )
     }
 
-    /// A bare hostname has to end in something that is actually a domain, or
-    /// "the report.Then I left" is masked as one and the missing space after
-    /// the full stop can never be repaired.
-    @Test func aDottedPairOfWordsIsNotAHostname() {
+    /// A capital after the full stop is a sentence starting, not a domain, and
+    /// the space it is missing has to be put back.
+    @Test func aCapitalAfterAFullStopIsNotAHostname() {
         #expect(
             TranscriptRepair.apply("I finished the report.Then I left")
                 == "I finished the report. Then I left"
+        )
+        #expect(
+            TranscriptRepair.apply("Report.Then I left the office")
+                == "Report. Then I left the office"
+        )
+    }
+
+    /// There are roughly 1,500 top-level domains, so a hostname is recognized
+    /// by being written in lowercase throughout rather than by a list of them.
+    /// Splitting a dictated address in half is data loss; a missing space is
+    /// not.
+    @Test func anUnlistedTopLevelDomainIsStillAHostname() {
+        #expect(
+            TranscriptRepair.apply("visit example.museum for details")
+                == "visit example.museum for details"
+        )
+        #expect(
+            TranscriptRepair.apply("read more at my-site.photography today")
+                == "read more at my-site.photography today"
+        )
+        #expect(
+            TranscriptRepair.apply("Example.com is the site we use")
+                == "Example.com is the site we use"
         )
         #expect(
             TranscriptRepair.apply("visit example.com/a.b. thanks")

--- a/ios/VocaPhoneTests/TranscriptRepairTests.swift
+++ b/ios/VocaPhoneTests/TranscriptRepairTests.swift
@@ -102,6 +102,7 @@ struct TranscriptRepairTests {
             TranscriptRepair.apply("er kommt in einer Stunde nach Hause")
                 == "er kommt in einer Stunde nach Hause"
         )
+        #expect(TranscriptRepair.apply("er kommt her") == "er kommt her")
         #expect(TranscriptRepair.apply("um we should ship it that day") == "we should ship it that day")
         // Said explicitly, no marker is needed.
         #expect(TranscriptRepair.apply("um ship it", language: "en") == "ship it")
@@ -151,6 +152,7 @@ struct TranscriptRepairTests {
     @Test func aDoubledContentWordSurvives() {
         #expect(TranscriptRepair.apply("that is very very good") == "that is very very good")
         #expect(TranscriptRepair.apply("no no not that one") == "no no not that one")
+        #expect(TranscriptRepair.apply("I love you I love you") == "I love you I love you")
     }
 
     /// Both of these are ordinary English and both look exactly like a stutter.
@@ -159,6 +161,9 @@ struct TranscriptRepairTests {
         #expect(
             TranscriptRepair.apply("the thing that that man said") == "the thing that that man said"
         )
+        #expect(TranscriptRepair.apply("I gave her her coat") == "I gave her her coat")
+        #expect(TranscriptRepair.apply("my my what a surprise") == "my my what a surprise")
+        #expect(TranscriptRepair.apply("I can can peaches") == "I can can peaches")
     }
 
     /// A sentence ended between the copies, so the second starts a new thought.
@@ -218,6 +223,10 @@ struct TranscriptRepairTests {
                 == "see Acme.photography today"
         )
         #expect(
+            TranscriptRepair.apply("visit NASA.GOV for details")
+                == "visit NASA.GOV for details"
+        )
+        #expect(
             TranscriptRepair.apply("visit example.com/a.b. thanks")
                 == "visit example.com/a.b. thanks"
         )
@@ -275,6 +284,10 @@ struct TranscriptRepairTests {
     @Test func anOpeningDiscourseMarkerTakesAComma() {
         #expect(TranscriptRepair.apply("okay lets ship it") == "okay, lets ship it")
         #expect(TranscriptRepair.apply("actually i changed my mind") == "actually, i changed my mind")
+        #expect(
+            TranscriptRepair.apply("however many people come we can fit them")
+                == "however many people come we can fit them"
+        )
     }
 
     /// "so" and "well" open a sentence far more often without a comma than
@@ -305,6 +318,10 @@ struct TranscriptRepairTests {
     /// subject sitting between it and the verb.
     @Test func aStatementStartingWithAWhWordIsNotAQuestion() {
         #expect(TranscriptRepair.apply("what i meant was simple") == "what i meant was simple")
+        #expect(
+            TranscriptRepair.apply("what the problem is remains unclear")
+                == "what the problem is remains unclear"
+        )
         #expect(TranscriptRepair.apply("how he did it is unclear") == "how he did it is unclear")
         #expect(
             TranscriptRepair.apply("when i get there i will call you")

--- a/ios/VocaPhoneTests/TranscriptRepairTests.swift
+++ b/ios/VocaPhoneTests/TranscriptRepairTests.swift
@@ -207,6 +207,16 @@ struct TranscriptRepairTests {
             TranscriptRepair.apply("Example.com is the site we use")
                 == "Example.com is the site we use"
         )
+        // The name in front of the dot carries no signal, so a capitalized one
+        // with an unlisted domain has to survive too.
+        #expect(
+            TranscriptRepair.apply("visit Example.museum for details")
+                == "visit Example.museum for details"
+        )
+        #expect(
+            TranscriptRepair.apply("see Acme.photography today")
+                == "see Acme.photography today"
+        )
         #expect(
             TranscriptRepair.apply("visit example.com/a.b. thanks")
                 == "visit example.com/a.b. thanks"


### PR DESCRIPTION
## Summary

**What changed?** A new `TranscriptRepair` stage on both clients, between the
sanitizer and the styler, under a new setting — **Dictation ▸ Clean up speech**,
on by default, never applied to the Raw style.

```
Sanitize → Repair → Style → Digits
```

**Why is it needed?** Dictated text arrived with every "um" and "uh" the model
heard, and with whatever punctuation it happened to emit — which for the CTC and
zipformer engines is often none at all. Neither could be fixed where you would
look for it: `TranscriptStyler` documents a contract it has to keep ("no style
adds, removes, or substitutes a word"), and inserting a sentence break is exactly
what that forbids. Adding a stage rather than bending that one keeps the styles
honest, and their description unchanged.

Everything is rule-based — no model, no network call, nothing leaves the phone.

### What repair does

- **Fillers** — `um`, `uh`, `er`, `erm`, `hm` and their elongations, plus the
  German, Dutch, French, Spanish, Italian and Japanese equivalents. Non-lexical
  sounds only: `like`, `you know` and `I mean` stay, and so do `mhm` and
  `uh-huh`, which are answers. A quoted `"um"` stays too.
- **False starts** — "we should we should" → "we should", keeping the copy the
  speaker carried on from. `had had` and `that that` are left alone.
- **Marks already there** — spacing, runs of them, and pairs that cannot both be
  right.
- **Marks that are missing** — a comma before a conjunction joining two full
  clauses, a comma after an opening discourse marker, a sentence break in front
  of one that has clearly started a new thought, and a question mark on a
  sentence that asks something. English-only triggers, and skipped entirely
  outside a Latin sentence layout.

```
so i was thinking that um we should we should probably ship it on friday
but i dont know if the the tests are green okay lets check
→
So I was thinking that we should probably ship it on Friday, but I don't
know if the tests are green. Okay, let's check.
```

### Two things that came out of it

`SentencePunctuation` (the per-script marks) and `ProtectedSpans` (URLs,
decimals, ordinals, initialisms) were private copies inside the styler and are
now shared types. A rule that inserts a mark and a rule that formats around one
must not disagree about what script a transcript is in — and they already had:
the two clients' punctuation classes had drifted apart on the Arabic comma, the
Arabic question mark, and the Khmer and Tibetan terminators. Android's Khmer
profile also listed the Burmese terminator.

`ProtectedSpans` tightens the bare-hostname pattern, which matched *any* dotted
pair of words. It was masking `report.Then` in "I finished the report.Then I
left", after which the missing space could never be repaired. Pre-existing bug in
the styler.

Android gains a `DictatedTranscript` funnel mirroring the iOS one, so both
clients apply the stages in the same documented order.

### Second commit: language safety

A review pass, mostly hunting for rules that fire on something the speaker meant.
The one that mattered: `um` is German for "at" and `er` is German for "he" and
Dutch for "there", so "um acht Uhr" came out as "acht Uhr". Those two are now the
only language-dependent part of the filler set — dropped when the transcript says
it is English, or when Automatic was selected and the sentence around them
carries a word that is English and not also German, Dutch, Danish, Norwegian,
Swedish or Portuguese. The gateway routes now pass the session's language too;
they were sending `"auto"` unconditionally.

Also fixed there: "to err is human" lost its verb; "nothing at all here matters
but the truth" gained a comma; "the results came back okay and we shipped" gained
a full stop; "had i known that i would have called" gained a question mark; and a
question in quotes ended `it."?` instead of `it?"`.

### Known trade-off

On Automatic, `um` and `er` are only dropped when the sentence around them
carries a recognisably-English word. A two-word English fragment ("um yeah")
keeps its filler. Erring that way is deliberate — the alternative deletes content
from German and Dutch transcripts.

## Verification

- [x] `just ios ci` — 558 tests, 0 failures
- [x] `just android ci` — 652 tests, 0 failures; lint and 16 KB alignment clean
- [x] Gateway changes: none. Client-side only; the `gateway/` pin is untouched
- [ ] Physical-device test — **not done.** No keyboard, microphone, background
      audio, or insertion code changed: this is pure text transformation with
      unit coverage on both platforms. The new Settings toggle itself has not
      been exercised on hardware.

55 new test cases, the same expectations asserted on both platforms, weighted
toward what repair must *not* touch.

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated — README gains the feature, `docs/troubleshooting.md`
      lists the new Dictation setting. No data-flow, permission, retention, or
      network behaviour changed: repair runs entirely on the phone.