### PR TITLE
fix(android): unstick the Listening dictation notification

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationService.kt
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat
 import com.vocahq.vocaphone.VocaPhoneApplication
 import com.vocahq.vocaphone.R
 import com.vocahq.vocaphone.core.DictationPhase
+import com.vocahq.vocaphone.core.DictationState
 import com.vocahq.vocaphone.ui.MainActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -87,31 +88,49 @@ class DictationService : Service() {
     }
 
     private fun observeUntilIdle() {
-        observer?.cancel()
+        val previous = observer
         val controller = VocaPhoneApplication.container(this).dictation
         observer = scope.launch {
-            // Capture starts a moment after `start` returns, so the service must
-            // wait for the microphone to actually be held before it treats an idle
-            // state as the end of the dictation. The timeout is the last resort;
-            // a start that resolves without ever recording says so, and waiting
-            // it out held a microphone foreground service — an ongoing "VocaPhone
-            // is recording" notification and the system's microphone indicator —
-            // for ten seconds over a dictation that never began. Tapping the mic
-            // before the gateway is configured did exactly that.
-            val settled = withTimeoutOrNull(START_TIMEOUT_MILLIS) {
-                controller.state.first { DictationStartWatch.hasSettled(it.phase) }
+            try {
+                // Capture starts a moment after `start` returns, so the service
+                // must wait for the controller to move off the idle snapshot it
+                // subscribed with. StateFlow conflates, so a short tap can skip
+                // LISTENING/FINALIZING and land on a new IDLE — that new instance
+                // is still progress, and treating only hasSettled phases as the
+                // end of the wait left "Listening" up until the timeout.
+                val initial = controller.state.value
+                val progressed = withTimeoutOrNull(START_TIMEOUT_MILLIS) {
+                    controller.state.first { DictationStartWatch.hasProgressed(it, initial) }
+                }
+                if (progressed != null && !progressed.phase.isTerminal) {
+                    var lastStatus: String? = null
+                    controller.state
+                        .onEach { state ->
+                            if (state.statusText != lastStatus) {
+                                lastStatus = state.statusText
+                                publish(state.statusText)
+                            }
+                        }
+                        .first { it.phase.isTerminal }
+                }
+            } finally {
+                if (observer === coroutineContext[Job]) {
+                    stopForegroundAndSelf()
+                }
             }
-            if (settled?.phase?.holdsMicrophone == true) {
-                controller.state
-                    .onEach { notificationManager().notify(NOTIFICATION_ID, notification(it.statusText)) }
-                    .first { it.phase.isTerminal }
-            }
-            stopForegroundAndSelf()
         }
+        previous?.cancel()
+    }
+
+    private fun publish(status: String) {
+        startForeground(
+            NOTIFICATION_ID,
+            notification(status),
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
+        )
     }
 
     private fun stopForegroundAndSelf() {
-        observer?.cancel()
         observer = null
         stopForeground(STOP_FOREGROUND_REMOVE)
         stopSelf()
@@ -227,6 +246,10 @@ class DictationService : Service() {
  * [DictationService] starts before capture begins, so it needs to recognise the
  * outcomes that never reach the microphone at all — otherwise the only thing
  * that ends the wait is a timeout the user spends looking at a notification.
+ *
+ * Phase checks alone are not enough: the controller publishes on Default and
+ * the service collects on Main, so StateFlow can skip LISTENING/FINALIZING.
+ * [hasProgressed] is the StateFlow-safe test.
  */
 internal object DictationStartWatch {
     fun hasSettled(phase: DictationPhase): Boolean = when (phase) {
@@ -237,6 +260,16 @@ internal object DictationStartWatch {
         DictationPhase.PERMISSION_REPAIR, DictationPhase.FAILED -> true
         else -> false
     }
+
+    /**
+     * The service subscribed with [initial], the idle value already in the
+     * flow. Any later instance — including a new Idle from a short-tap reset,
+     * or Transcribing when Listening was conflated away — means the start
+     * attempt has moved. Identity, not [DictationState.equals]: two Idle
+     * snapshots compare equal, and that was the hang.
+     */
+    fun hasProgressed(current: DictationState, initial: DictationState): Boolean =
+        current !== initial
 }
 
 /**

--- a/android/app/src/test/java/com/vocahq/vocaphone/dictation/DictationStartWatchTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/dictation/DictationStartWatchTest.kt
@@ -1,7 +1,15 @@
 package com.vocahq.vocaphone.dictation
 
 import com.vocahq.vocaphone.core.DictationPhase
+import com.vocahq.vocaphone.core.DictationState
+import java.util.UUID
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -59,5 +67,68 @@ class DictationStartWatchTest {
         assertTrue(DictationPhase.FAILED.isTerminal)
         assertFalse(DictationPhase.TRANSCRIBING.isTerminal)
         assertFalse(DictationPhase.INSERTING.isTerminal)
+    }
+
+    @Test
+    fun `the idle snapshot the service subscribed with is not progress`() {
+        val initial = DictationState()
+        assertFalse(DictationStartWatch.hasProgressed(initial, initial))
+        assertTrue(DictationStartWatch.hasProgressed(DictationState(), initial))
+    }
+
+    /**
+     * Controller updates run off Main; the service collects on it. StateFlow
+     * then skips LISTENING/FINALIZING on a short tap and only delivers the
+     * reset Idle. hasSettled(Idle) is false, which is how the notification
+     * stayed on Listening after the dictation had already finished.
+     */
+    @Test
+    fun `a conflated short tap is progress even though it is idle again`() = runTest {
+        val initial = DictationState()
+        val flow = MutableStateFlow(initial)
+        flow.value = DictationState(
+            sessionId = UUID.randomUUID(),
+            phase = DictationPhase.LISTENING,
+        )
+        flow.value = DictationState()
+        val seen = flow.first { DictationStartWatch.hasProgressed(it, initial) }
+        assertEquals(DictationPhase.IDLE, seen.phase)
+        assertTrue(seen.phase.isTerminal)
+        assertTrue(DictationStartWatch.hasProgressed(seen, initial))
+    }
+
+    @Test
+    fun `hasSettled misses a conflated short tap`() = runTest {
+        val flow = MutableStateFlow(DictationState())
+        flow.value = DictationState(
+            sessionId = UUID.randomUUID(),
+            phase = DictationPhase.LISTENING,
+        )
+        flow.value = DictationState()
+        val settled = withTimeoutOrNull(50) {
+            flow.first { DictationStartWatch.hasSettled(it.phase) }
+        }
+        assertNull(settled)
+    }
+
+    /**
+     * The same skip can land on Transcribing. That is not terminal: the
+     * foreground service has to stay up through on-device inference.
+     */
+    @Test
+    fun `a conflated jump to transcribing is progress and stays busy`() = runTest {
+        val initial = DictationState()
+        val flow = MutableStateFlow(initial)
+        flow.value = DictationState(
+            sessionId = UUID.randomUUID(),
+            phase = DictationPhase.LISTENING,
+        )
+        flow.value = DictationState(
+            sessionId = UUID.randomUUID(),
+            phase = DictationPhase.TRANSCRIBING,
+        )
+        val seen = flow.first { DictationStartWatch.hasProgressed(it, initial) }
+        assertEquals(DictationPhase.TRANSCRIBING, seen.phase)
+        assertFalse(seen.phase.isTerminal)
     }
 }


### PR DESCRIPTION
## Summary

- The FGS notification could stay on "Listening" after dictation had already finished (#171), especially on a quick start/stop. The observer waited only for LISTENING/FINALIZING, and StateFlow can skip those when the controller publishes off Main.
- Keep the recording notification. Treat any new state instance as progress, keep the FGS until a terminal phase (including Transcribing), update it via `startForeground`, and always remove it in `finally`.

## Verification

- [x] `just ios ci` — not run (Android FGS observer only)
- [x] `just android ci` — not full; `./gradlew :app:testFullDebugUnitTest --tests 'com.vocahq.vocaphone.dictation.DictationStartWatchTest'`
- [x] Gateway changes: none
- [ ] Physical-device test, if keyboard, microphone, background audio, or insertion changed

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for data-flow, permission, retention, or network changes — n/a