### PR TITLE
fix: recover empty local model transcripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ __pycache__/
 .swiftpm/
 DerivedData/
 /ios/build/
+# `just ios <recipe>` from the repository root puts derived data here, not
+# under ios/ — gigabytes of it, and the last thing a stray `git add -A` needs.
+/build/
 *.xcresult
 *.xcarchive
 *.ipa

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ gateway/.venv/
 gateway/.pytest_cache/
 gateway/.ruff_cache/
 gateway/.mypy_cache/
-gateway/.omo/
+.omo/
 gateway/data/
 gateway/*.db
 gateway/*.sqlite

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptionQuality.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/TranscriptionQuality.kt
@@ -1,5 +1,7 @@
 package com.vocahq.vocaphone.core
 
+import com.vocahq.vocaphone.local.LocalModelEngine
+
 /**
  * How much decoding work an on-device model may spend on one dictation.
  *
@@ -25,7 +27,24 @@ enum class TranscriptionQuality(val storedValue: String) {
             ACCURATE -> "Accurate"
         }
 
-    val detail: String
+    /**
+     * What this setting buys, for the engine it is being shown next to.
+     *
+     * whisper.cpp reads it: [whisperBeamSize] widens the search for Accurate.
+     * No sherpa family does — every bundled one is pinned to greedy search (see
+     * [com.vocahq.vocaphone.local.SherpaFamily.supportsBeamSearch]), greedy
+     * ignores the beam width, and the empty-result recovery is a fixed ladder
+     * that never consults quality. Promising a wider search there describes a
+     * control that currently does nothing.
+     */
+    fun detail(engine: LocalModelEngine): String = when (engine) {
+        LocalModelEngine.WHISPER -> whisperDetail
+        LocalModelEngine.SHERPA_ONNX ->
+            "This model runs one safe decoding mode, so the accuracy setting " +
+                "does not change its result. It applies to Whisper models."
+    }
+
+    private val whisperDetail: String
         get() = when (this) {
             FAST -> "Quickest result. Skips the retries that rescue a hard passage."
             BALANCED -> "Beam search where it is cheap, and a retry when a window looks wrong."

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelCatalog.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelCatalog.kt
@@ -46,6 +46,7 @@ enum class SherpaFamily(
      */
     val acceptsLanguage: Boolean = false,
 ) {
+
     // Kaldi's dither=1 on int16 audio is approximately 1 / 32768 here. It is
     // the upstream workaround for Parakeet returning no tokens on valid audio
     // with an all-zero dither setting (sherpa-onnx #2258).
@@ -57,6 +58,25 @@ enum class SherpaFamily(
     NEMO_CTC,
     PARAFORMER,
     ;
+
+    /**
+     * Whether the accuracy setting changes the recognizer this family builds.
+     *
+     * It reaches exactly two config fields, and greedy search reads neither:
+     * `decodingMethod` is pinned, and `maxActivePaths` is the beam width a beam
+     * search would have used. So while [supportsBeamSearch] is false the three
+     * accuracy settings produce an identical recognizer -- and treating quality
+     * as part of this family's loaded identity rebuilds a several-hundred-
+     * megabyte ONNX graph to arrive at the one already in memory.
+     */
+    val nativeConfigVariesWithQuality: Boolean get() = supportsBeamSearch
+
+    /**
+     * The quality this family's recognizer is actually built at, so a reload
+     * decision cannot turn on a distinction the native config does not have.
+     */
+    fun effectiveQuality(quality: TranscriptionQuality): TranscriptionQuality =
+        if (nativeConfigVariesWithQuality) quality else TranscriptionQuality.DEFAULT
 
     /** The only safe way to turn a quality setting into a decoding method. */
     fun decodingMethod(quality: TranscriptionQuality): String =

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/LocalModelManager.kt
@@ -556,9 +556,15 @@ class LocalModelManager(
     private suspend fun prepareEngine(
         model: LocalModelDescriptor,
         resolvedLanguage: String,
-        quality: TranscriptionQuality,
+        requestedQuality: TranscriptionQuality,
         resolvedTranslateTo: String,
     ) {
+        // Normalised to what the recognizer is actually built at. Every bundled
+        // sherpa family is on greedy search, which reads neither field quality
+        // reaches, so without this the accuracy control rebuilds a large model
+        // to produce an identical one -- a long "Preparing…" and a peak-memory
+        // spike for no change in the transcript.
+        val quality = model.sherpaFamily?.effectiveQuality(requestedQuality) ?: requestedQuality
         val directory = directoryFor(model)
         // Stat-only: cheap enough to run per dictation, unlike a digest pass.
         withContext(Dispatchers.IO) { LocalModelIntegrity.verifySizes(model, directory) }

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaIncrementalSession.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaIncrementalSession.kt
@@ -83,6 +83,10 @@ internal class SherpaIncrementalSession(
         )
         var transcript = SherpaTranscript.EMPTY
         var overlapsPrevious = false
+        // How much of the front of the next chunk the previous split already
+        // decoded. Everything a window can lose sits after it, so it is what
+        // the emptiness of its answer is judged on.
+        var retainedHead = 0
         var droppedAudibleChunk = false
         var conditioningChanged = false
         // The gain the first decoded window was levelled with. `gainFor` is
@@ -110,9 +114,18 @@ internal class SherpaIncrementalSession(
             }
             val levelled = SpeechAudioConditioning.conditionStreaming(chunk, audio.peak)
             val decoded = decode(levelled)
+            // Judged on what this window did not inherit from the one before
+            // it. A window that is mostly retained overlap can be six seconds
+            // long and carry half a second of new speech, and asking whether
+            // the *chunk* was long enough is what let that half second vanish
+            // without the file ever being re-read.
+            val newRegion = chunk.copyOfRange(retainedHead.coerceAtMost(chunk.size), chunk.size)
             if (decoded.text.isEmpty() &&
-                chunk.size > SherpaLongAudio.MIN_SUSPECT_CHUNK_SECONDS * SherpaLongAudio.SAMPLE_RATE &&
-                SherpaLongAudio.carriesSpeech(level, loudestFrame)
+                SherpaLongAudio.carriesRecoverableSpeech(
+                    newRegion = newRegion,
+                    loudestFrame = SherpaLongAudio.loudestFrame(newRegion),
+                    loudestFrameSoFar = loudestFrame,
+                )
             ) {
                 droppedAudibleChunk = true
             }
@@ -132,6 +145,7 @@ internal class SherpaIncrementalSession(
                 consume(available.copyOfRange(0, split.endExclusive))
                 audio.discardPrefix(split.nextStart)
                 overlapsPrevious = split.nextStart < split.endExclusive
+                retainedHead = split.endExclusive - split.nextStart
             }
         }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaIncrementalSession.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaIncrementalSession.kt
@@ -123,6 +123,7 @@ internal class SherpaIncrementalSession(
             if (decoded.text.isEmpty() &&
                 SherpaLongAudio.carriesRecoverableSpeech(
                     newRegion = newRegion,
+                    inheritsAudio = retainedHead > 0,
                     loudestFrame = SherpaLongAudio.loudestFrame(newRegion),
                     loudestFrameSoFar = loudestFrame,
                 )

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaLongAudio.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaLongAudio.kt
@@ -218,6 +218,38 @@ internal object SherpaLongAudio {
     fun carriesSpeech(loudestFrame: Double, loudestFrameSoFar: Double): Boolean =
         loudestFrame >= maxOf(SILENT_CHUNK_RMS, loudestFrameSoFar * SILENCE_RMS_RATIO)
 
+    /**
+     * The part of [chunk] that is not inherited from the window before it.
+     *
+     * A chunk that overlaps its predecessor begins with audio that predecessor
+     * already decoded. Everything a later window can *lose* is what comes after
+     * that, so it is what the emptiness of its answer has to be judged on.
+     */
+    fun newRegion(samples: FloatArray, chunk: SherpaAudioChunk, previousEnd: Int): FloatArray {
+        val start = maxOf(chunk.start, previousEnd).coerceAtMost(chunk.endExclusive)
+        return samples.copyOfRange(start, chunk.endExclusive)
+    }
+
+    /**
+     * Whether an empty answer for [newRegion] is a loss worth spending decodes
+     * on, rather than the ordinary silence at the end of a recording.
+     *
+     * Two things have to hold. The region must be longer than the widest overlap
+     * the chunker ever retains, because below that it cannot be told apart from
+     * that overlap -- a recording ending just after a boundary leaves exactly
+     * such a tail, and it is a fragment of a word at best. And it must carry
+     * speech next to what the recording has already been heard to contain, so a
+     * trailing pause is not amplified into a retry.
+     */
+    fun carriesRecoverableSpeech(
+        newRegion: FloatArray,
+        loudestFrame: Double,
+        loudestFrameSoFar: Double,
+    ): Boolean {
+        if (newRegion.size <= OVERLAP_MILLIS * SAMPLE_RATE / 1_000) return false
+        return carriesSpeech(loudestFrame, loudestFrameSoFar)
+    }
+
     private fun rms(samples: FloatArray, start: Int, endExclusive: Int): Double {
         if (endExclusive <= start) return 0.0
         var sum = 0.0
@@ -235,12 +267,28 @@ internal object SherpaTranscriptMerger {
     // only be a phrase the speaker genuinely repeated, not duplicated audio.
     private const val MAX_OVERLAP_WORDS = 4
 
+    /**
+     * The same bound for scripts written without spaces, where half a second of
+     * speech is a few characters rather than a few words.
+     *
+     * Without this path a Chinese or Japanese transcript is one "word" on each
+     * side of the seam, nothing ever matches, and the overlap is written twice
+     * with a space wedged between it -- in a script that does not use spaces.
+     * iOS has had this branch; matching it is what keeps the two transcripts of
+     * one recording the same transcript.
+     */
+    private const val MAX_OVERLAP_CHARACTERS = 6
+
     fun append(existing: String, next: String, deduplicateOverlap: Boolean = true): String {
         val left = existing.trim()
         val right = next.trim()
         if (left.isEmpty()) return right
         if (right.isEmpty()) return left
         if (!deduplicateOverlap) return join(left, right)
+
+        if (!left.any(Char::isWhitespace) && !right.any(Char::isWhitespace)) {
+            return appendUnspaced(left, right)
+        }
 
         val leftWords = left.split(Regex("\\s+"))
         val rightWords = right.split(Regex("\\s+"))
@@ -256,6 +304,20 @@ internal object SherpaTranscriptMerger {
         val suffix = rightWords.joinToString(" ")
         if (prefix.isEmpty()) return suffix
         return join(prefix, suffix)
+    }
+
+    /**
+     * Joins two segments of a script that does not separate words with spaces.
+     *
+     * The longest suffix of [left] that opens [right] is the repeat, bounded the
+     * same way the word path is bounded and joined without a separator.
+     */
+    private fun appendUnspaced(left: String, right: String): String {
+        val maxOverlap = minOf(MAX_OVERLAP_CHARACTERS, left.length, right.length)
+        val overlap = (maxOverlap downTo 1).firstOrNull { count ->
+            left.regionMatches(left.length - count, right, 0, count)
+        } ?: 0
+        return left + right.substring(overlap)
     }
 
     private fun wordKey(word: String): String = word

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaLongAudio.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaLongAudio.kt
@@ -234,19 +234,26 @@ internal object SherpaLongAudio {
      * Whether an empty answer for [newRegion] is a loss worth spending decodes
      * on, rather than the ordinary silence at the end of a recording.
      *
-     * Two things have to hold. The region must be longer than the widest overlap
-     * the chunker ever retains, because below that it cannot be told apart from
-     * that overlap -- a recording ending just after a boundary leaves exactly
-     * such a tail, and it is a fragment of a word at best. And it must carry
-     * speech next to what the recording has already been heard to contain, so a
-     * trailing pause is not amplified into a retry.
+     * It must carry speech next to what the recording has already been heard to
+     * contain, so a trailing pause is not amplified into a retry.
+     *
+     * [inheritsAudio] is what the length bar is for, and why it does not always
+     * apply. A window that begins inside the one before it has to be told apart
+     * from that retained overlap, and below the widest overlap the chunker ever
+     * retains it cannot be -- a recording ending just after a boundary leaves
+     * exactly such a tail, a fragment of a word at best. A window that inherited
+     * nothing has no overlap to be confused with: it is the whole of what the
+     * user has said, and a two-word dictation is short precisely because that is
+     * all there was to say. Applying the bar there was what stopped "yes" from
+     * ever being retried.
      */
     fun carriesRecoverableSpeech(
         newRegion: FloatArray,
+        inheritsAudio: Boolean,
         loudestFrame: Double,
         loudestFrameSoFar: Double,
     ): Boolean {
-        if (newRegion.size <= OVERLAP_MILLIS * SAMPLE_RATE / 1_000) return false
+        if (inheritsAudio && newRegion.size <= OVERLAP_MILLIS * SAMPLE_RATE / 1_000) return false
         return carriesSpeech(loudestFrame, loudestFrameSoFar)
     }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
@@ -51,21 +51,32 @@ internal class SherpaRecognizer private constructor(
      */
     fun transcribe(samples: FloatArray): SherpaTranscript {
         var transcript = SherpaTranscript.EMPTY
+        var previousEnd = 0
+        var loudestSoFar = 0.0
         SherpaLongAudio.chunks(samples).forEach { chunk ->
-            // Whether a short empty answer is ordinary depends on what came
-            // before it, not on how long the window is. A short window that
-            // follows text is the retained overlap a recording ending just
-            // after a boundary leaves behind, and an empty answer for it is
-            // correct. A short window with nothing decoded ahead of it is the
-            // whole of what the user said so far -- the reported failure -- and
-            // it earns the bounded recovery ladder however short it is.
-            val nothingDecodedYet = transcript.text.isEmpty()
+            // Whether a short empty answer is ordinary is a question about the
+            // audio this window did not inherit from the one before it. A final
+            // window that is only the retained overlap has nothing new in it,
+            // and an empty answer there is correct. A final window carrying a
+            // whole further sentence is the reported failure, and it is that
+            // whether or not an earlier window already produced text -- judging
+            // it by the transcript so far is what let a closing sentence
+            // disappear behind a successful opening one.
+            val newRegion = SherpaLongAudio.newRegion(samples, chunk, previousEnd)
+            val newRegionLevel = SherpaLongAudio.loudestFrame(newRegion)
+            val carriesNewSpeech = SherpaLongAudio.carriesRecoverableSpeech(
+                newRegion = newRegion,
+                loudestFrame = newRegionLevel,
+                loudestFrameSoFar = loudestSoFar,
+            )
             val chunkResult = SherpaEmptyChunkRecovery.decode(
                 samples = samples.copyOfRange(chunk.start, chunk.endExclusive),
                 decodeOnce = ::decode,
                 deduplicateOverlap = !translating,
-                recoverAudibleShortInput = nothingDecodedYet,
+                recoverAudibleShortInput = carriesNewSpeech,
             )
+            loudestSoFar = maxOf(loudestSoFar, newRegionLevel)
+            previousEnd = chunk.endExclusive
             transcript = transcript.append(
                 chunkResult,
                 deduplicateOverlap = chunk.overlapsPrevious && !translating,

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
@@ -66,6 +66,7 @@ internal class SherpaRecognizer private constructor(
             val newRegionLevel = SherpaLongAudio.loudestFrame(newRegion)
             val carriesNewSpeech = SherpaLongAudio.carriesRecoverableSpeech(
                 newRegion = newRegion,
+                inheritsAudio = chunk.overlapsPrevious,
                 loudestFrame = newRegionLevel,
                 loudestFrameSoFar = loudestSoFar,
             )

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
@@ -51,16 +51,20 @@ internal class SherpaRecognizer private constructor(
      */
     fun transcribe(samples: FloatArray): SherpaTranscript {
         var transcript = SherpaTranscript.EMPTY
-        val chunks = SherpaLongAudio.chunks(samples)
-        chunks.forEach { chunk ->
+        SherpaLongAudio.chunks(samples).forEach { chunk ->
+            // Whether a short empty answer is ordinary depends on what came
+            // before it, not on how long the window is. A short window that
+            // follows text is the retained overlap a recording ending just
+            // after a boundary leaves behind, and an empty answer for it is
+            // correct. A short window with nothing decoded ahead of it is the
+            // whole of what the user said so far -- the reported failure -- and
+            // it earns the bounded recovery ladder however short it is.
+            val nothingDecodedYet = transcript.text.isEmpty()
             val chunkResult = SherpaEmptyChunkRecovery.decode(
                 samples = samples.copyOfRange(chunk.start, chunk.endExclusive),
                 decodeOnce = ::decode,
                 deduplicateOverlap = !translating,
-                // An empty final overlap is normal. A complete, audible short
-                // recording that produced no tokens is not; recover it before
-                // surfacing an empty-transcript failure.
-                recoverAudibleShortInput = chunks.size == 1,
+                recoverAudibleShortInput = nothingDecodedYet,
             )
             transcript = transcript.append(
                 chunkResult,
@@ -263,16 +267,19 @@ internal object SherpaEmptyChunkRecovery {
         deduplicateOverlap: Boolean = true,
         recoverAudibleShortInput: Boolean = false,
     ): SherpaTranscript {
-        val firstAttempt = decodeOnce(samples)
-        // Length is what this recovers from, so a window that is not long
-        // enough to be dropped for its length has nothing to recover. Room
-        // tone is the other ordinary reason for an empty answer, and the
-        // cheapest thing to rule out before spending two more decodes: the
-        // scan costs a pass over the samples, the retry costs inference.
-        if (firstAttempt.text.isNotEmpty() || SherpaLongAudio.isEffectivelySilent(samples)) {
-            return firstAttempt
-        }
+        // Room tone is the ordinary reason for an empty answer, and the cheapest
+        // thing to rule out -- before the first decode, not after it. The scan
+        // costs one pass over the samples; a decode of a pause costs inference
+        // to be told what the scan already knew. iOS guards in the same place.
+        if (SherpaLongAudio.isEffectivelySilent(samples)) return SherpaTranscript.EMPTY
 
+        val firstAttempt = decodeOnce(samples)
+        if (firstAttempt.text.isNotEmpty()) return firstAttempt
+
+        // Length is what the split recovers from, so a window that is not long
+        // enough to be dropped for its length has nothing there to recover --
+        // unless the caller has already established that this window is the
+        // whole of what the user has said so far.
         if (!recoverAudibleShortInput &&
             samples.size <= SherpaLongAudio.MIN_SUSPECT_CHUNK_SECONDS * SherpaLongAudio.SAMPLE_RATE
         ) return firstAttempt
@@ -283,6 +290,9 @@ internal object SherpaEmptyChunkRecovery {
             // established split ladder and its predictable latency.
             val repeated = decodeOnce(samples)
             if (repeated.text.isNotEmpty()) return repeated
+            // Very short speech can begin or end too close to the encoder
+            // context. Half a second either side moves it inside, and is
+            // bounded so a recording cannot grow its own decode cost.
             val padding = FloatArray(SherpaLongAudio.SAMPLE_RATE / 2)
             val padded = decodeOnce(padding + samples + padding)
             if (padded.text.isNotEmpty()) return padded
@@ -293,9 +303,13 @@ internal object SherpaEmptyChunkRecovery {
         // word crossing its exact centre. One split and no more: a half-length
         // window that is still empty is not being lost to its length, and
         // subdividing again multiplies the decodes for nothing.
+        // Clamped to a quarter of the waveform: without it a recording shorter
+        // than the overlap itself hands both halves the entire thing, which is
+        // two identical full decodes and no split at all. Only reachable now
+        // that a short complete recording gets this far.
         val midpoint = samples.size / 2
-        val halfOverlap = SherpaLongAudio.OVERLAP_MILLIS *
-            SherpaLongAudio.SAMPLE_RATE / 2_000
+        val halfOverlap = (SherpaLongAudio.OVERLAP_MILLIS * SherpaLongAudio.SAMPLE_RATE / 2_000)
+            .coerceAtMost(midpoint / 2)
         val leftEnd = (midpoint + halfOverlap).coerceAtMost(samples.size)
         val rightStart = (midpoint - halfOverlap).coerceAtLeast(0)
         return decodeOnce(samples.copyOfRange(0, leftEnd))

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
@@ -51,8 +51,17 @@ internal class SherpaRecognizer private constructor(
      */
     fun transcribe(samples: FloatArray): SherpaTranscript {
         var transcript = SherpaTranscript.EMPTY
-        SherpaLongAudio.chunks(samples).forEach { chunk ->
-            val chunkResult = transcribeChunk(samples.copyOfRange(chunk.start, chunk.endExclusive))
+        val chunks = SherpaLongAudio.chunks(samples)
+        chunks.forEach { chunk ->
+            val chunkResult = SherpaEmptyChunkRecovery.decode(
+                samples = samples.copyOfRange(chunk.start, chunk.endExclusive),
+                decodeOnce = ::decode,
+                deduplicateOverlap = !translating,
+                // An empty final overlap is normal. A complete, audible short
+                // recording that produced no tokens is not; recover it before
+                // surfacing an empty-transcript failure.
+                recoverAudibleShortInput = chunks.size == 1,
+            )
             transcript = transcript.append(
                 chunkResult,
                 deduplicateOverlap = chunk.overlapsPrevious && !translating,
@@ -252,6 +261,7 @@ internal object SherpaEmptyChunkRecovery {
         samples: FloatArray,
         decodeOnce: (FloatArray) -> SherpaTranscript,
         deduplicateOverlap: Boolean = true,
+        recoverAudibleShortInput: Boolean = false,
     ): SherpaTranscript {
         val firstAttempt = decodeOnce(samples)
         // Length is what this recovers from, so a window that is not long
@@ -259,12 +269,23 @@ internal object SherpaEmptyChunkRecovery {
         // tone is the other ordinary reason for an empty answer, and the
         // cheapest thing to rule out before spending two more decodes: the
         // scan costs a pass over the samples, the retry costs inference.
-        if (firstAttempt.text.isNotEmpty() ||
-            samples.size <=
-            SherpaLongAudio.MIN_SUSPECT_CHUNK_SECONDS * SherpaLongAudio.SAMPLE_RATE ||
-            SherpaLongAudio.isEffectivelySilent(samples)
-        ) {
+        if (firstAttempt.text.isNotEmpty() || SherpaLongAudio.isEffectivelySilent(samples)) {
             return firstAttempt
+        }
+
+        if (!recoverAudibleShortInput &&
+            samples.size <= SherpaLongAudio.MIN_SUSPECT_CHUNK_SECONDS * SherpaLongAudio.SAMPLE_RATE
+        ) return firstAttempt
+
+        if (recoverAudibleShortInput) {
+            // A fresh offline stream can recover a nondeterministic no-token
+            // answer for a complete short recording. Long windows keep the
+            // established split ladder and its predictable latency.
+            val repeated = decodeOnce(samples)
+            if (repeated.text.isNotEmpty()) return repeated
+            val padding = FloatArray(SherpaLongAudio.SAMPLE_RATE / 2)
+            val padded = decodeOnce(padding + samples + padding)
+            if (padded.text.isNotEmpty()) return padded
         }
 
         // Retain context on both sides of the recovery boundary. A plain

--- a/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/local/SherpaRecognizer.kt
@@ -260,6 +260,9 @@ internal object SherpaEmptyChunkRecovery {
      *   halves overlap so the word crossing the centre survives, and matching
      *   the repeat back out only works when the same audio returns the same
      *   words — which is exactly what a translator does not promise.
+     * @param recoverAudibleShortInput true when an empty answer here cannot be
+     *   the ordinary short trailing overlap. See [SherpaRecognizer.transcribe]
+     *   for how that is decided.
      */
     fun decode(
         samples: FloatArray,
@@ -280,14 +283,18 @@ internal object SherpaEmptyChunkRecovery {
         // enough to be dropped for its length has nothing there to recover --
         // unless the caller has already established that this window is the
         // whole of what the user has said so far.
-        if (!recoverAudibleShortInput &&
+        val short =
             samples.size <= SherpaLongAudio.MIN_SUSPECT_CHUNK_SECONDS * SherpaLongAudio.SAMPLE_RATE
-        ) return firstAttempt
+        if (!recoverAudibleShortInput && short) return firstAttempt
 
-        if (recoverAudibleShortInput) {
+        // The two extra rungs are for short speech and stay there. A ten-second
+        // window is already the length the split recovers from, and padding it
+        // by half a second either side buys nothing for the cost of a whole
+        // further decode -- so a long window keeps the established ladder and
+        // its predictable latency however little has been decoded before it.
+        if (short) {
             // A fresh offline stream can recover a nondeterministic no-token
-            // answer for a complete short recording. Long windows keep the
-            // established split ladder and its predictable latency.
+            // answer.
             val repeated = decodeOnce(samples)
             if (repeated.text.isNotEmpty()) return repeated
             // Very short speech can begin or end too close to the encoder

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -44,6 +44,7 @@ import com.vocahq.vocaphone.core.TranscriptionLanguage
 import com.vocahq.vocaphone.core.TranscriptionQuality
 import com.vocahq.vocaphone.core.WritingStyle
 import com.vocahq.vocaphone.local.LocalModelCatalog
+import com.vocahq.vocaphone.local.LocalModelEngine
 import com.vocahq.vocaphone.local.LocalModelDescriptor
 import com.vocahq.vocaphone.local.LocalModelState
 import com.vocahq.vocaphone.settings.AudioRetention
@@ -236,7 +237,11 @@ fun SettingsScreen(
             SettingsPage.MODELS -> {
                 Section(
                     title = "Accuracy",
-                    supporting = "${settings.transcriptionQuality.detail}\n" +
+                    supporting = "${
+                        settings.transcriptionQuality.detail(
+                            localModel?.engine ?: LocalModelEngine.WHISPER,
+                        )
+                    }\n" +
                         "Applies to models running on this phone. The gateway decides for itself.",
                 ) {
                     ChipChoiceRow(

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaDecodingMethodTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaDecodingMethodTest.kt
@@ -2,6 +2,7 @@ package com.vocahq.vocaphone.local
 
 import com.vocahq.vocaphone.core.TranscriptionQuality
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -59,5 +60,56 @@ class SherpaDecodingMethodTest {
                 )
             }
         }
+    }
+
+    /**
+     * The accuracy control reaches `decodingMethod` and `maxActivePaths`, and
+     * greedy search reads neither. Letting it stay part of the loaded identity
+     * rebuilds a several-hundred-megabyte graph to produce an identical one.
+     */
+    @Test
+    fun `a greedy family builds the same recognizer at every accuracy setting`() {
+        for (family in SherpaFamily.entries) {
+            assertFalse(family.nativeConfigVariesWithQuality)
+            for (quality in TranscriptionQuality.entries) {
+                assertEquals(TranscriptionQuality.DEFAULT, family.effectiveQuality(quality))
+            }
+        }
+    }
+
+    @Test
+    fun `changing accuracy alone does not reload a sherpa engine`() {
+        for (quality in TranscriptionQuality.entries) {
+            val effective = SherpaFamily.NEMO_TRANSDUCER.effectiveQuality(quality)
+            assertFalse(
+                shouldReloadLocalEngine(
+                    engine = LocalModelEngine.SHERPA_ONNX,
+                    loadedModelID = "parakeet",
+                    requestedModelID = "parakeet",
+                    loadedLanguage = "en",
+                    requestedLanguage = "en",
+                    loadedQuality = SherpaFamily.NEMO_TRANSDUCER
+                        .effectiveQuality(TranscriptionQuality.FAST),
+                    requestedQuality = effective,
+                    languageIsBakedIn = false,
+                ),
+            )
+        }
+    }
+
+    /** Everything else still invalidates it. */
+    @Test
+    fun `a different model still reloads`() {
+        assertTrue(
+            shouldReloadLocalEngine(
+                engine = LocalModelEngine.SHERPA_ONNX,
+                loadedModelID = "parakeet",
+                requestedModelID = "canary",
+                loadedLanguage = "en",
+                requestedLanguage = "en",
+                loadedQuality = TranscriptionQuality.DEFAULT,
+                requestedQuality = TranscriptionQuality.DEFAULT,
+            ),
+        )
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
@@ -263,6 +263,90 @@ class SherpaLongAudioTest {
         assertEquals(listOf(224_000, 116_000, 116_000), decodedSizes)
     }
 
+    /**
+     * The tail that stays ignorable, and the one that never was. A window can be
+     * well under the suspect length and still be the last seconds of the
+     * recording; asking whether the *chunk* was long enough let a closing
+     * sentence vanish behind a successful opening one.
+     */
+    @Test
+    fun `only new audio past the retained overlap is worth recovering`() {
+        val overlapSamples = SherpaLongAudio.OVERLAP_MILLIS * SherpaLongAudio.SAMPLE_RATE / 1_000
+        val overlapOnly = FloatArray(overlapSamples) { 0.4f }
+        val newSpeech = FloatArray(2 * SherpaLongAudio.SAMPLE_RATE) { 0.4f }
+        val roomTone = FloatArray(2 * SherpaLongAudio.SAMPLE_RATE) { 0.01f }
+
+        assertFalse(
+            SherpaLongAudio.carriesRecoverableSpeech(
+                overlapOnly, SherpaLongAudio.loudestFrame(overlapOnly), 0.4,
+            ),
+        )
+        assertTrue(
+            SherpaLongAudio.carriesRecoverableSpeech(
+                newSpeech, SherpaLongAudio.loudestFrame(newSpeech), 0.4,
+            ),
+        )
+        // Past the overlap but not speech next to what has already been heard.
+        assertFalse(
+            SherpaLongAudio.carriesRecoverableSpeech(
+                roomTone, SherpaLongAudio.loudestFrame(roomTone), 0.4,
+            ),
+        )
+    }
+
+    @Test
+    fun `a new region is what the window did not inherit from the one before it`() {
+        val samples = FloatArray(20 * SherpaLongAudio.SAMPLE_RATE) { 0.2f }
+        val chunk = SherpaAudioChunk(
+            start = 9 * SherpaLongAudio.SAMPLE_RATE,
+            endExclusive = 20 * SherpaLongAudio.SAMPLE_RATE,
+            overlapsPrevious = true,
+        )
+
+        val newRegion = SherpaLongAudio.newRegion(
+            samples, chunk, previousEnd = 10 * SherpaLongAudio.SAMPLE_RATE,
+        )
+
+        // The second onward, not the eleven seconds the window covers.
+        assertEquals(10 * SherpaLongAudio.SAMPLE_RATE, newRegion.size)
+    }
+
+    /**
+     * Scripts written without spaces. Every transcript is one "word" on each
+     * side of the seam, so the word matcher never fires: the overlap is written
+     * twice with a space wedged into a script that does not use spaces. iOS has
+     * had a bounded character path; this is Android's.
+     */
+    @Test
+    fun `an unspaced script has its overlap removed without a separator`() {
+        assertEquals(
+            "你好世界再见",
+            SherpaTranscriptMerger.append("你好世界", "世界再见"),
+        )
+        assertEquals(
+            "こんにちは世界",
+            SherpaTranscriptMerger.append("こんにちは", "にちは世界"),
+        )
+    }
+
+    @Test
+    fun `an unspaced repeat wider than the audio overlap is preserved`() {
+        // Seven characters is more than half a second of speech can hold, so it
+        // is repetition the speaker produced rather than duplicated audio.
+        assertEquals(
+            "一二三四五六七一二三四五六七",
+            SherpaTranscriptMerger.append("一二三四五六七", "一二三四五六七"),
+        )
+    }
+
+    @Test
+    fun `a translated unspaced seam is never deduplicated`() {
+        assertEquals(
+            "你好世界 世界再见",
+            SherpaTranscriptMerger.append("你好世界", "世界再见", deduplicateOverlap = false),
+        )
+    }
+
     @Test
     fun `overlapped words are merged once`() {
         assertEquals(

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
@@ -193,6 +193,26 @@ class SherpaLongAudioTest {
         assertEquals(listOf(48_000, 48_000, 64_000, 28_000, 28_000), decodedSizes)
     }
 
+    /**
+     * The extra rungs are for short speech. A long first chunk with nothing
+     * decoded ahead of it is still a long window: repeating it and padding it
+     * costs two whole further decodes and recovers what the split already does.
+     */
+    @Test
+    fun `a long window keeps the split ladder even with nothing decoded before it`() {
+        val decodedSizes = mutableListOf<Int>()
+        SherpaEmptyChunkRecovery.decode(
+            samples = FloatArray(10 * SherpaLongAudio.SAMPLE_RATE) { 0.2f },
+            recoverAudibleShortInput = true,
+            decodeOnce = { samples ->
+                decodedSizes += samples.size
+                SherpaTranscript.EMPTY
+            },
+        )
+
+        assertEquals(listOf(160_000, 84_000, 84_000), decodedSizes)
+    }
+
     @Test
     fun `the recovery split never decodes the whole waveform twice`() {
         val decodedSizes = mutableListOf<Int>()

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
@@ -278,18 +278,40 @@ class SherpaLongAudioTest {
 
         assertFalse(
             SherpaLongAudio.carriesRecoverableSpeech(
-                overlapOnly, SherpaLongAudio.loudestFrame(overlapOnly), 0.4,
+                overlapOnly, true, SherpaLongAudio.loudestFrame(overlapOnly), 0.4,
             ),
         )
         assertTrue(
             SherpaLongAudio.carriesRecoverableSpeech(
-                newSpeech, SherpaLongAudio.loudestFrame(newSpeech), 0.4,
+                newSpeech, true, SherpaLongAudio.loudestFrame(newSpeech), 0.4,
             ),
         )
         // Past the overlap but not speech next to what has already been heard.
         assertFalse(
             SherpaLongAudio.carriesRecoverableSpeech(
-                roomTone, SherpaLongAudio.loudestFrame(roomTone), 0.4,
+                roomTone, true, SherpaLongAudio.loudestFrame(roomTone), 0.4,
+            ),
+        )
+    }
+
+    /**
+     * The length bar is for telling new audio apart from retained overlap, so it
+     * cannot apply where nothing was retained. A one-word dictation is short
+     * because that is all there was to say, and it was never decoded before.
+     */
+    @Test
+    fun `a sole window shorter than the overlap is still recoverable`() {
+        val oneWord = FloatArray(SherpaLongAudio.SAMPLE_RATE / 4) { 0.4f }
+
+        assertTrue(
+            SherpaLongAudio.carriesRecoverableSpeech(
+                oneWord, false, SherpaLongAudio.loudestFrame(oneWord), 0.0,
+            ),
+        )
+        // The same audio arriving as a tail behind a decoded window is not.
+        assertFalse(
+            SherpaLongAudio.carriesRecoverableSpeech(
+                oneWord, true, SherpaLongAudio.loudestFrame(oneWord), 0.4,
             ),
         )
     }

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
@@ -143,6 +143,23 @@ class SherpaLongAudioTest {
     }
 
     @Test
+    fun `an audible complete short recording gets a bounded fresh-stream retry`() {
+        val decodedSizes = mutableListOf<Int>()
+        var attempts = 0
+        val transcript = SherpaEmptyChunkRecovery.decode(
+            samples = FloatArray(5 * SherpaLongAudio.SAMPLE_RATE) { 0.2f },
+            recoverAudibleShortInput = true,
+            decodeOnce = { samples ->
+                decodedSizes += samples.size
+                SherpaTranscript(if (attempts++ == 1) "recovered" else "")
+            },
+        )
+
+        assertEquals("recovered", transcript.text)
+        assertEquals(listOf(80_000, 80_000), decodedSizes)
+    }
+
+    @Test
     fun `a silent chunk is never retried`() {
         val decodedSizes = mutableListOf<Int>()
         SherpaEmptyChunkRecovery.decode(

--- a/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/local/SherpaLongAudioTest.kt
@@ -160,17 +160,73 @@ class SherpaLongAudioTest {
     }
 
     @Test
-    fun `a silent chunk is never retried`() {
+    fun `a silent chunk is never decoded at all`() {
         val decodedSizes = mutableListOf<Int>()
         SherpaEmptyChunkRecovery.decode(
             samples = FloatArray(10 * SherpaLongAudio.SAMPLE_RATE),
+            recoverAudibleShortInput = true,
             decodeOnce = { samples ->
                 decodedSizes += samples.size
                 SherpaTranscript.EMPTY
             },
         )
 
-        assertEquals(listOf(160_000), decodedSizes)
+        // Room tone answering with nothing is the correct answer, and the scan
+        // that says so is cheaper than the decode that would agree with it.
+        assertTrue(decodedSizes.isEmpty())
+    }
+
+    @Test
+    fun `a short recording still empty on a fresh stream is padded then split`() {
+        val decodedSizes = mutableListOf<Int>()
+        SherpaEmptyChunkRecovery.decode(
+            samples = FloatArray(3 * SherpaLongAudio.SAMPLE_RATE) { 0.2f },
+            recoverAudibleShortInput = true,
+            decodeOnce = { samples ->
+                decodedSizes += samples.size
+                SherpaTranscript.EMPTY
+            },
+        )
+
+        // Whole, whole again, padded half a second either side, then the two
+        // halves. The ladder is fixed-length: it never subdivides again.
+        assertEquals(listOf(48_000, 48_000, 64_000, 28_000, 28_000), decodedSizes)
+    }
+
+    @Test
+    fun `the recovery split never decodes the whole waveform twice`() {
+        val decodedSizes = mutableListOf<Int>()
+        SherpaEmptyChunkRecovery.decode(
+            samples = FloatArray(SherpaLongAudio.SAMPLE_RATE / 4) { 0.2f },
+            recoverAudibleShortInput = true,
+            decodeOnce = { samples ->
+                decodedSizes += samples.size
+                SherpaTranscript.EMPTY
+            },
+        )
+
+        assertTrue(decodedSizes.takeLast(2).all { it < SherpaLongAudio.SAMPLE_RATE / 4 })
+    }
+
+    /**
+     * Translated windows are joined verbatim: the same audio does not come back
+     * as the same words, so nothing can pair the repeat the split creates.
+     */
+    @Test
+    fun `a translated recovery split is never text deduplicated`() {
+        val transcript = SherpaEmptyChunkRecovery.decode(
+            samples = FloatArray(10 * SherpaLongAudio.SAMPLE_RATE) { 0.2f },
+            deduplicateOverlap = false,
+            decodeOnce = { samples ->
+                if (samples.size > 6 * SherpaLongAudio.SAMPLE_RATE) {
+                    SherpaTranscript.EMPTY
+                } else {
+                    SherpaTranscript("to the shop")
+                }
+            },
+        )
+
+        assertEquals("to the shop to the shop", transcript.text)
     }
 
     @Test

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		3BC9D24EF0E08132FFB24481 /* SherpaOnnxBridge.c in Sources */ = {isa = PBXBuildFile; fileRef = 4DF09BE84EE712784C57BC12 /* SherpaOnnxBridge.c */; };
 		3C4DE9EF77062407F71ACDCB /* LanguageMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C45D98EAFE18C689DC7551E9 /* LanguageMenuTests.swift */; };
 		3D08A881E95118E5B57E9FCD /* TranscriptSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B121356A503DF83BFA0E0D0C /* TranscriptSanitizer.swift */; };
+		3E4A55C0E40176FC61E4105C /* SherpaDecodeOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EFEBD6293F9649D551A9014 /* SherpaDecodeOutcome.swift */; };
 		3E812EB0A69DFF8CC9A7CA6E /* ModelTranslationSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7235E2DEF5A0082A417E3E /* ModelTranslationSupport.swift */; };
 		3EF8AE348290CBB5FE45BD11 /* ModelLanguageSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */; };
 		3F3E17AFAAE8EB6B79A872BE /* SessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */; };
@@ -168,6 +169,7 @@
 		7E26A729562A6F474635AFEC /* TranscriptStylerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45A3914F898AD0570486806 /* TranscriptStylerTests.swift */; };
 		7E28776EDC2BD3E8A8AFCED9 /* TypingPrivacyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05735C847A47FF442B4FB21A /* TypingPrivacyTests.swift */; };
 		7E3D8E857A83184E74B15433 /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */; };
+		7E7D3327C8DF767DD960ECE9 /* SherpaDecodeOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EFEBD6293F9649D551A9014 /* SherpaDecodeOutcome.swift */; };
 		81131D34DE3F3CBDBA61BE4E /* SwipeTrailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */; };
 		81BFE90A24876CEE127974AE /* TypingFieldPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2CD13AAF5FDF79DD5D0075 /* TypingFieldPolicy.swift */; };
 		81DDEADAD62C978ED52AAE90 /* SentencePunctuation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AF826E0D2C7820CBB4B78C /* SentencePunctuation.swift */; };
@@ -216,6 +218,7 @@
 		A0B8569F3B1A3F72EAC9C1DB /* TranscriptionQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E2BF42CAC209DA12464566 /* TranscriptionQuality.swift */; };
 		A0C4342BED6EC86029B3C492 /* SwipeTrailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */; };
 		A2112E100F4277466EA8DD4F /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */; };
+		A2BD20604DA50ECB8AE82BC0 /* SherpaDecodeOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EFEBD6293F9649D551A9014 /* SherpaDecodeOutcome.swift */; };
 		A568F548D639C064CDA86F0D /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */; };
 		A59723F937FABF80B8158883 /* RecordingSoundFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0187C986535C090BEE7EFD8 /* RecordingSoundFeedback.swift */; };
 		A5E6BD7DC01FF42503792DCB /* KeyboardGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FED099938C2E7D091FFE2BD /* KeyboardGeometryTests.swift */; };
@@ -248,6 +251,7 @@
 		B81AE1A8CE67BD8B31DBB97D /* OnboardingPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D34E7E54437AFA69FDC2848 /* OnboardingPresentation.swift */; };
 		BA66A26AC92DB96524E13AF5 /* TypingWordList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6743BB4173E2F719E3D8CB /* TypingWordList.swift */; };
 		BA7DED07F63C388ADD4EC07A /* KeyboardURLLauncher.m in Sources */ = {isa = PBXBuildFile; fileRef = 88548183D3F0AD213E2268E1 /* KeyboardURLLauncher.m */; };
+		BAC41603698247ACC791848E /* SherpaDecodeOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EFEBD6293F9649D551A9014 /* SherpaDecodeOutcome.swift */; };
 		BAEC1D5BFECB17B9B28BD780 /* TypingWordListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 867A5BD6049E4D6788DB704C /* TypingWordListTests.swift */; };
 		BB97658DE518187ABA47D495 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = F2228242333B1BBC848C90DA /* PrivacyInfo.xcprivacy */; };
 		BBEEC542D1574BF6C8DF319B /* BrandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9711C18238B39EA2E842C0F /* BrandPalette.swift */; };
@@ -428,6 +432,7 @@
 		48D9836F52892447650F0375 /* TelemetryStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryStats.swift; sourceTree = "<group>"; };
 		491DFC2F5F017E14BF64E308 /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
 		4DF09BE84EE712784C57BC12 /* SherpaOnnxBridge.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = SherpaOnnxBridge.c; sourceTree = "<group>"; };
+		4EFEBD6293F9649D551A9014 /* SherpaDecodeOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaDecodeOutcome.swift; sourceTree = "<group>"; };
 		5118F8CFAAE127CD5FF92076 /* KeyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyView.swift; sourceTree = "<group>"; };
 		52F3A6E7B826D1389D462944 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechAudioConditioning.swift; sourceTree = "<group>"; };
@@ -678,6 +683,7 @@
 				78AF826E0D2C7820CBB4B78C /* SentencePunctuation.swift */,
 				36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */,
 				7948F8C6C72A8D7A16C18562 /* SharedStore.swift */,
+				4EFEBD6293F9649D551A9014 /* SherpaDecodeOutcome.swift */,
 				BF256CF6ED209E00193BF135 /* SherpaEmptyChunkRecovery.swift */,
 				7083ED482761906EE2589E97 /* SherpaFeatureDither.swift */,
 				D41205764F091734B2DE6D02 /* SherpaIncrementalSession.swift */,
@@ -1113,6 +1119,7 @@
 				81DDEADAD62C978ED52AAE90 /* SentencePunctuation.swift in Sources */,
 				36295638EAABF35D05369EB0 /* SessionRecord.swift in Sources */,
 				A794CD8D0B445E5118500EC3 /* SharedStore.swift in Sources */,
+				BAC41603698247ACC791848E /* SherpaDecodeOutcome.swift in Sources */,
 				C2930E7FD81AF00E3553F79C /* SherpaEmptyChunkRecovery.swift in Sources */,
 				C9A6096B1D7A0603AE6810C3 /* SherpaFeatureDither.swift in Sources */,
 				503DA76554CDB360C2E32566 /* SherpaIncrementalSession.swift in Sources */,
@@ -1202,6 +1209,7 @@
 				366E7DFAD5B2666FC1FF9FB3 /* SetupStatus.swift in Sources */,
 				0D07EBF90CE481AE0C1976CF /* SetupView.swift in Sources */,
 				D9811B8978380027BF95D0D5 /* SharedStore.swift in Sources */,
+				A2BD20604DA50ECB8AE82BC0 /* SherpaDecodeOutcome.swift in Sources */,
 				FCE1FDC346554C0EE93845F0 /* SherpaEmptyChunkRecovery.swift in Sources */,
 				672274A22E384A0FBA495455 /* SherpaFeatureDither.swift in Sources */,
 				82A1659A07D52F972E9010DD /* SherpaIncrementalSession.swift in Sources */,
@@ -1270,6 +1278,7 @@
 				54A3525CD8F0DFA70980501B /* SentencePunctuation.swift in Sources */,
 				3F3E17AFAAE8EB6B79A872BE /* SessionRecord.swift in Sources */,
 				B2406DA05AE90DDB7EED6246 /* SharedStore.swift in Sources */,
+				3E4A55C0E40176FC61E4105C /* SherpaDecodeOutcome.swift in Sources */,
 				49305C17EF54D17EE77251F0 /* SherpaEmptyChunkRecovery.swift in Sources */,
 				F27B90FB1C64EFADECCDAC7A /* SherpaFeatureDither.swift in Sources */,
 				F0EC49ECABE510B52F876C8F /* SherpaIncrementalSession.swift in Sources */,
@@ -1359,6 +1368,7 @@
 				3219DC5DD26E1998A7A0CD5C /* SetupStatus.swift in Sources */,
 				1B72FBEA5D41DB51B82A1305 /* SetupStatusTests.swift in Sources */,
 				5A151959ABCE2ADE4646A79D /* SharedStore.swift in Sources */,
+				7E7D3327C8DF767DD960ECE9 /* SherpaDecodeOutcome.swift in Sources */,
 				F69EAE4A82B9ACE347EA0D77 /* SherpaDecodingMethodTests.swift in Sources */,
 				E5983EF5CBB205F7FBBB03B1 /* SherpaEmptyChunkRecovery.swift in Sources */,
 				9A89862335FDE367954EF77B /* SherpaFeatureDither.swift in Sources */,

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		45AB9DD91FB8969A4BB19A60 /* TranscriptRetention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6FFEA14B55E6F6C61FBAC /* TranscriptRetention.swift */; };
 		4700DB7F7BE95078E7A8A563 /* TypingFieldPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBE3CB8FFE4DDA7B459C2A7 /* TypingFieldPolicyTests.swift */; };
 		482A8494DA8A03BDB5DF1B0E /* LocalTranscriptionPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FF1A5ABC4220C886291309 /* LocalTranscriptionPreferences.swift */; };
+		49305C17EF54D17EE77251F0 /* SherpaEmptyChunkRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF256CF6ED209E00193BF135 /* SherpaEmptyChunkRecovery.swift */; };
 		4BF2126048D9E40C8999241D /* KeyboardHapticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97639A09609D9E6E76153CDB /* KeyboardHapticsTests.swift */; };
 		4C26EF1A498140E6AEE51D86 /* en-bigrams.txt in Resources */ = {isa = PBXBuildFile; fileRef = DC98427A2C06BE9FD63CACF1 /* en-bigrams.txt */; };
 		4C8B6E06406E63E122F9CBD1 /* KeyLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87128326897BFA30E7B2038 /* KeyLayout.swift */; };
@@ -142,6 +143,7 @@
 		63835D9307A147564F896FB5 /* SmartPunctuation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07178E9C6A3CF354CD83A2C1 /* SmartPunctuation.swift */; };
 		63BC0E226633FBBE88C60EBE /* SmartPunctuationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8CE24C7BC4F4CA618F4B79 /* SmartPunctuationTests.swift */; };
 		6565BFD7DC56DDCECDBC0D7C /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */; };
+		672274A22E384A0FBA495455 /* SherpaFeatureDither.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7083ED482761906EE2589E97 /* SherpaFeatureDither.swift */; };
 		67883BFA07C1D055BF00E118 /* ModelTranslationSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA1F0347FCF246193F6CF96 /* ModelTranslationSupportTests.swift */; };
 		67B842A93BF69D4542744655 /* DictatedTranscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F810558C0B42C924BC6CF21 /* DictatedTranscriptTests.swift */; };
 		68E7553DB227208E27DF3A8F /* KeyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5118F8CFAAE127CD5FF92076 /* KeyView.swift */; };
@@ -202,6 +204,7 @@
 		966E2D9A6D13630E7A2122A6 /* KeyLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87128326897BFA30E7B2038 /* KeyLayout.swift */; };
 		97EE4663316E8CF2EAE9761A /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */; };
 		98AE213452E133E22550785B /* KeyboardHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858088F81E12EC57E13F9492 /* KeyboardHaptics.swift */; };
+		9A89862335FDE367954EF77B /* SherpaFeatureDither.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7083ED482761906EE2589E97 /* SherpaFeatureDither.swift */; };
 		9AE625A9A97E5A57DC6520E9 /* TelemetryStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D9836F52892447650F0375 /* TelemetryStats.swift */; };
 		9B5622A66F2595319CE5825E /* SentencePunctuation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AF826E0D2C7820CBB4B78C /* SentencePunctuation.swift */; };
 		9C3766171C286926385A9F1E /* SpokenNumbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E590CFC53039DA367280B8CD /* SpokenNumbers.swift */; };
@@ -253,6 +256,7 @@
 		BD67C86E9CCCEEBB2ABC845A /* TypingCandidates.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAA4440B24071020CD693DB /* TypingCandidates.swift */; };
 		BF1BF9FEBFC0373AE2C4187D /* DarwinNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3498C523755A678225152570 /* DarwinNotifications.swift */; };
 		BF22B8C9A4943F8B06F74216 /* DictationBarComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FD84E65614D9F94D8EF0AC /* DictationBarComponents.swift */; };
+		C2930E7FD81AF00E3553F79C /* SherpaEmptyChunkRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF256CF6ED209E00193BF135 /* SherpaEmptyChunkRecovery.swift */; };
 		C2C99C66A00384823A3A0A22 /* SherpaLongAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */; };
 		C334F6DF0A4A34FC9A80B6CB /* LocalModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473A608BF3F8827B3D3842B0 /* LocalModelCatalog.swift */; };
 		C37AC6FC3CBF2147D8A50DDA /* SemanticPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B395C37266816A19C38B59 /* SemanticPaletteTests.swift */; };
@@ -265,6 +269,7 @@
 		C80FCACABE7FF798EFD1EB61 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894063AE1B3DDA92C529268D /* AppConfiguration.swift */; };
 		C845C02425BC2788BABB26C2 /* SpeechAudioConditioningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59DB522E7DFDE3B3E009AFD /* SpeechAudioConditioningTests.swift */; };
 		C958410A61E962F39B4F5E4D /* LearnedWords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */; };
+		C9A6096B1D7A0603AE6810C3 /* SherpaFeatureDither.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7083ED482761906EE2589E97 /* SherpaFeatureDither.swift */; };
 		C9A65099749EC5AB021FCC1C /* SherpaLongAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */; };
 		CA31A30F8E764B891884324F /* TranscriptStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DBF47C7F5E5B13752056CB /* TranscriptStyler.swift */; };
 		CD600A39A4DFB39AD6F0E5E1 /* EmojiSuggestionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C0A3D1DBF6BCF25C37CF24 /* EmojiSuggestionsTests.swift */; };
@@ -302,6 +307,7 @@
 		E4162282629880D2A33913CA /* KeyGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF7CAC171521FC372DF2BF0 /* KeyGridView.swift */; };
 		E4187B9A8DA6FBBA6DE095AC /* DictationPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCCE5FE1A8242B96B8CA9FD /* DictationPresentation.swift */; };
 		E5595FE143CBC103B6DAE2C8 /* TypingWordList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6743BB4173E2F719E3D8CB /* TypingWordList.swift */; };
+		E5983EF5CBB205F7FBBB03B1 /* SherpaEmptyChunkRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF256CF6ED209E00193BF135 /* SherpaEmptyChunkRecovery.swift */; };
 		E5CA31ED8B208F173ACDA3EF /* TranscriptRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */; };
 		E5EAD40641B38DDA0CCA0300 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894063AE1B3DDA92C529268D /* AppConfiguration.swift */; };
 		E6FDBF8529AEB00D2CFB245E /* UsageReportingCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AA42EFADB6B77B0C9A5E44 /* UsageReportingCopy.swift */; };
@@ -317,6 +323,7 @@
 		F1E23C92AD4C90D424DB84D9 /* LocalModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473A608BF3F8827B3D3842B0 /* LocalModelCatalog.swift */; };
 		F1EC3EE86C05A57F3A42EFF1 /* DownloadReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF56F0E966D9AECA1DCFF65E /* DownloadReadiness.swift */; };
 		F231FFC3DFB742B826516E5E /* ProtectedSpans.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57FC525B204634FF41CDCDA /* ProtectedSpans.swift */; };
+		F27B90FB1C64EFADECCDAC7A /* SherpaFeatureDither.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7083ED482761906EE2589E97 /* SherpaFeatureDither.swift */; };
 		F37F68399E06B767B5D6ACC7 /* KeyGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF7CAC171521FC372DF2BF0 /* KeyGridView.swift */; };
 		F3A845A38CC7840D2877FD26 /* KeyAlternatives.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0EBA8DE4056FCA3CB7F093C /* KeyAlternatives.swift */; };
 		F426CFBED733974D61FDB432 /* ModelLanguageSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41EF03C8A4F930315EFE77 /* ModelLanguageSupportTests.swift */; };
@@ -331,6 +338,8 @@
 		F9BE6A9D183361BABE1E286E /* TranscriptionSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B154124C04655D1A36F1B4E4 /* TranscriptionSourceTests.swift */; };
 		FAD55FD707FD21407E0980FA /* PairingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFB4BB0345784837C629340 /* PairingPayload.swift */; };
 		FC7578BC51E4E30002077CAC /* TypingCandidatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B31528AA0DAB644EFBBE967 /* TypingCandidatesTests.swift */; };
+		FCE1FDC346554C0EE93845F0 /* SherpaEmptyChunkRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF256CF6ED209E00193BF135 /* SherpaEmptyChunkRecovery.swift */; };
+		FD06CBDABE4EA9640EECF39C /* SherpaLongAudioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C2BEEA5195CB9CB5A38CA /* SherpaLongAudioTests.swift */; };
 		FDBB4DF9D4816CD646C1644D /* TypingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B9027C03A87FBC74CE1130 /* TypingEngine.swift */; };
 /* End PBXBuildFile section */
 
@@ -435,6 +444,7 @@
 		653FBC305F7EB4B9F7EB354B /* UsageReportingViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageReportingViews.swift; sourceTree = "<group>"; };
 		6B6743BB4173E2F719E3D8CB /* TypingWordList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingWordList.swift; sourceTree = "<group>"; };
 		6CF871FC84B4C6B2627A43C2 /* RecordingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingCoordinator.swift; sourceTree = "<group>"; };
+		7083ED482761906EE2589E97 /* SherpaFeatureDither.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaFeatureDither.swift; sourceTree = "<group>"; };
 		70B3F1DBA8332A13B095E4BA /* PairingScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScannerView.swift; sourceTree = "<group>"; };
 		70CAE08F934281250A314597 /* PreviewMatrix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewMatrix.swift; sourceTree = "<group>"; };
 		71DC06463C8AA4C516363157 /* TranscriptRepairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptRepairTests.swift; sourceTree = "<group>"; };
@@ -499,6 +509,7 @@
 		B854354D06D0111DEB123E7A /* SessionRecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRecordTests.swift; sourceTree = "<group>"; };
 		B87128326897BFA30E7B2038 /* KeyLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyLayout.swift; sourceTree = "<group>"; };
 		B8D81AEA9FD59906139F273D /* TelemetryFailureMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryFailureMapping.swift; sourceTree = "<group>"; };
+		B90C2BEEA5195CB9CB5A38CA /* SherpaLongAudioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaLongAudioTests.swift; sourceTree = "<group>"; };
 		B9B9027C03A87FBC74CE1130 /* TypingEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingEngine.swift; sourceTree = "<group>"; };
 		B9BB34E20645F3D8C78A0363 /* Telemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Telemetry.swift; sourceTree = "<group>"; };
 		BA0A732D03A2951F028DDF6E /* SherpaIncrementalSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaIncrementalSessionTests.swift; sourceTree = "<group>"; };
@@ -508,6 +519,7 @@
 		BD7C720E296C2265F0174573 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		BE0BE99770A5F7F08891E2BD /* KeyboardURLLauncher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeyboardURLLauncher.h; sourceTree = "<group>"; };
 		BE3489C985467C23EB6A90AD /* DictationBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarView.swift; sourceTree = "<group>"; };
+		BF256CF6ED209E00193BF135 /* SherpaEmptyChunkRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaEmptyChunkRecovery.swift; sourceTree = "<group>"; };
 		C304CF763960E5F1D8F76B2B /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
 		C3D3E1455AD292ED6DA1DFAC /* VocaPhoneLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocaPhoneLiveActivity.swift; sourceTree = "<group>"; };
 		C4211FAA8E574AEF57D788FA /* GatewayClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayClient.swift; sourceTree = "<group>"; };
@@ -666,6 +678,8 @@
 				78AF826E0D2C7820CBB4B78C /* SentencePunctuation.swift */,
 				36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */,
 				7948F8C6C72A8D7A16C18562 /* SharedStore.swift */,
+				BF256CF6ED209E00193BF135 /* SherpaEmptyChunkRecovery.swift */,
+				7083ED482761906EE2589E97 /* SherpaFeatureDither.swift */,
 				D41205764F091734B2DE6D02 /* SherpaIncrementalSession.swift */,
 				054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */,
 				5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */,
@@ -803,6 +817,7 @@
 				EA031D86C1DE3C2F8B047308 /* SetupStatusTests.swift */,
 				20F3E310970DBFA3822A4D19 /* SherpaDecodingMethodTests.swift */,
 				BA0A732D03A2951F028DDF6E /* SherpaIncrementalSessionTests.swift */,
+				B90C2BEEA5195CB9CB5A38CA /* SherpaLongAudioTests.swift */,
 				3E3E4382E021BE30F6D687A7 /* SherpaTranscriptTests.swift */,
 				8F8CE24C7BC4F4CA618F4B79 /* SmartPunctuationTests.swift */,
 				A59DB522E7DFDE3B3E009AFD /* SpeechAudioConditioningTests.swift */,
@@ -1098,6 +1113,8 @@
 				81DDEADAD62C978ED52AAE90 /* SentencePunctuation.swift in Sources */,
 				36295638EAABF35D05369EB0 /* SessionRecord.swift in Sources */,
 				A794CD8D0B445E5118500EC3 /* SharedStore.swift in Sources */,
+				C2930E7FD81AF00E3553F79C /* SherpaEmptyChunkRecovery.swift in Sources */,
+				C9A6096B1D7A0603AE6810C3 /* SherpaFeatureDither.swift in Sources */,
 				503DA76554CDB360C2E32566 /* SherpaIncrementalSession.swift in Sources */,
 				C2C99C66A00384823A3A0A22 /* SherpaLongAudio.swift in Sources */,
 				35136B012E8D8B8D720B569A /* SmartPunctuation.swift in Sources */,
@@ -1185,6 +1202,8 @@
 				366E7DFAD5B2666FC1FF9FB3 /* SetupStatus.swift in Sources */,
 				0D07EBF90CE481AE0C1976CF /* SetupView.swift in Sources */,
 				D9811B8978380027BF95D0D5 /* SharedStore.swift in Sources */,
+				FCE1FDC346554C0EE93845F0 /* SherpaEmptyChunkRecovery.swift in Sources */,
+				672274A22E384A0FBA495455 /* SherpaFeatureDither.swift in Sources */,
 				82A1659A07D52F972E9010DD /* SherpaIncrementalSession.swift in Sources */,
 				79D51827CA805EB6D890699C /* SherpaLongAudio.swift in Sources */,
 				3BC9D24EF0E08132FFB24481 /* SherpaOnnxBridge.c in Sources */,
@@ -1251,6 +1270,8 @@
 				54A3525CD8F0DFA70980501B /* SentencePunctuation.swift in Sources */,
 				3F3E17AFAAE8EB6B79A872BE /* SessionRecord.swift in Sources */,
 				B2406DA05AE90DDB7EED6246 /* SharedStore.swift in Sources */,
+				49305C17EF54D17EE77251F0 /* SherpaEmptyChunkRecovery.swift in Sources */,
+				F27B90FB1C64EFADECCDAC7A /* SherpaFeatureDither.swift in Sources */,
 				F0EC49ECABE510B52F876C8F /* SherpaIncrementalSession.swift in Sources */,
 				214B0AB3D2362EC3EE656E53 /* SherpaLongAudio.swift in Sources */,
 				91EA8108C4C2D6C4EF5CF3F1 /* SpeechAudioConditioning.swift in Sources */,
@@ -1339,9 +1360,12 @@
 				1B72FBEA5D41DB51B82A1305 /* SetupStatusTests.swift in Sources */,
 				5A151959ABCE2ADE4646A79D /* SharedStore.swift in Sources */,
 				F69EAE4A82B9ACE347EA0D77 /* SherpaDecodingMethodTests.swift in Sources */,
+				E5983EF5CBB205F7FBBB03B1 /* SherpaEmptyChunkRecovery.swift in Sources */,
+				9A89862335FDE367954EF77B /* SherpaFeatureDither.swift in Sources */,
 				DC775A81F32818BCC08CA795 /* SherpaIncrementalSession.swift in Sources */,
 				C6E529713960996E85EFD275 /* SherpaIncrementalSessionTests.swift in Sources */,
 				C9A65099749EC5AB021FCC1C /* SherpaLongAudio.swift in Sources */,
+				FD06CBDABE4EA9640EECF39C /* SherpaLongAudioTests.swift in Sources */,
 				332424547CBE2483FE24C975 /* SherpaTranscriptTests.swift in Sources */,
 				63835D9307A147564F896FB5 /* SmartPunctuation.swift in Sources */,
 				63BC0E226633FBBE88C60EBE /* SmartPunctuationTests.swift in Sources */,

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -696,6 +696,23 @@ struct TranscriptionSettingsView: View {
 
     private var source: TranscriptionSourceStatus { coordinator.transcriptionSource }
 
+    /// The engine the accuracy control is currently describing. Whisper is the
+    /// safe default: it is the engine the setting has always applied to.
+    private var selectedLocalEngine: LocalModelEngine {
+        LocalTranscriptionPreferences.modelIdentifier
+            .flatMap(LocalModelCatalog.descriptor(for:))?
+            .engine ?? .whisperKit
+    }
+
+    /// Whether changing accuracy would build a different recognizer at all.
+    private var selectedLocalEngineVariesWithQuality: Bool {
+        guard let descriptor = LocalTranscriptionPreferences.modelIdentifier
+            .flatMap(LocalModelCatalog.descriptor(for:))
+        else { return true }
+        guard descriptor.engine == .sherpaOnnx else { return true }
+        return descriptor.sherpaFamily?.nativeConfigVariesWithQuality ?? true
+    }
+
     var body: some View {
         List {
             routeSection
@@ -774,7 +791,13 @@ struct TranscriptionSettingsView: View {
                 }
             }
             .pickerStyle(.segmented)
-            .onChange(of: transcriptionQualityRawValue) { _, _ in reloadLocalEngine() }
+            .onChange(of: transcriptionQualityRawValue) { _, _ in
+                // Only where the setting reaches the native config. Rebuilding a
+                // several-hundred-megabyte graph to produce a byte-identical one
+                // is a long "Loading…" and a peak-memory spike for nothing.
+                guard selectedLocalEngineVariesWithQuality else { return }
+                reloadLocalEngine()
+            }
             if let loading = coordinator.localModels.loadingMessage {
                 Text(loading).foregroundStyle(.secondary)
             }
@@ -788,7 +811,7 @@ struct TranscriptionSettingsView: View {
             Text("Accuracy")
         } footer: {
             VStack(alignment: .leading, spacing: VocaMetrics.related) {
-                Text(selectedTranscriptionQuality.detail)
+                Text(selectedTranscriptionQuality.detail(for: selectedLocalEngine))
                 Text(
                     "This governs models running on this iPhone. Transcription on "
                         + "your gateway is unaffected."

--- a/ios/VocaPhoneApp/Models/LocalModelIntegrity.swift
+++ b/ios/VocaPhoneApp/Models/LocalModelIntegrity.swift
@@ -205,6 +205,12 @@ enum LocalModelManagerError: LocalizedError, Equatable {
     case insufficientMemory(requiredGB: Int)
     case insufficientStorage(freeBytes: Int64, requiredBytes: Int64)
     case engineLoadFailed(String)
+    /// The native engine failed to answer at all — see `SherpaNativeFailure`.
+    /// Separate from `emptyTranscript` because the two need different fixes and
+    /// a device report that cannot tell them apart cannot say which one landed.
+    case engineDecodeFailed(String)
+    /// The model was asked and returned no tokens, after the recovery ladder.
+    case emptyTranscript
     case downloadFailed(path: String, statusCode: Int?)
 
     var errorDescription: String? {
@@ -218,6 +224,10 @@ enum LocalModelManagerError: LocalizedError, Equatable {
         case let .integrityUnverified(name):
             "\(name) has not been verified on this device. Download it again."
         case let .modelNotDownloaded(id): "Download \(id) before using on-device transcription."
+        case .engineDecodeFailed:
+            "The on-device model could not run. The recording is preserved; try again."
+        case .emptyTranscript:
+            "The on-device model found no speech in this recording."
         case .noModelContainer: "The app's model directory is unavailable."
         case let .insufficientMemory(requiredGB):
             "This model needs a device with at least \(requiredGB) GB of memory."

--- a/ios/VocaPhoneApp/Models/LocalModelManager.swift
+++ b/ios/VocaPhoneApp/Models/LocalModelManager.swift
@@ -1450,7 +1450,7 @@ final class LocalModelManager {
             let text = results.map(\.text).joined(separator: " ")
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else {
-                throw LocalModelManagerError.modelNotDownloaded("empty transcript")
+                throw LocalModelManagerError.emptyTranscript
             }
             // Detection is meaningful only for Automatic. With an explicit
             // selection, the user's requested output language remains the
@@ -1472,11 +1472,19 @@ final class LocalModelManager {
                 folder: folder,
                 resolvedLanguage: resolvedLanguage
             )
-            let decoded = await Task.detached(priority: .userInitiated) {
+            let outcome = await Task.detached(priority: .userInitiated) {
                 sherpaRecognizer.transcribe(samples)
             }.value
+            // Told apart deliberately. A recognizer that would not open a stream
+            // and a model that heard no speech both arrive here with no text,
+            // and reporting them as one thing is what made a device report
+            // unable to say whether the empty-result repair is working.
+            if let failure = outcome.nativeFailure {
+                throw LocalModelManagerError.engineDecodeFailed(failure.rawValue)
+            }
+            let decoded = outcome.transcriptOrEmpty
             guard !decoded.text.isEmpty else {
-                throw LocalModelManagerError.modelNotDownloaded("empty transcript")
+                throw LocalModelManagerError.emptyTranscript
             }
             return LocalTranscription(
                 text: decoded.text,
@@ -1534,8 +1542,13 @@ final class LocalModelManager {
         let files = try LocalModelIntegrity.sherpaModel(for: descriptor.id).files
         try LocalModelIntegrity.verifySizes(in: folder, files: files)
         // Sherpa bakes the decoding method into the recognizer, so a change of
-        // quality means building a new one.
-        let quality = LocalTranscriptionPreferences.quality
+        // quality means building a new one — but only where the two fields it
+        // reaches actually differ. Every bundled family is on greedy search
+        // today, so this normalises to one value and the accuracy control stops
+        // rebuilding a large model to produce an identical one.
+        let quality = descriptor.sherpaFamily?
+            .effectiveQuality(LocalTranscriptionPreferences.quality)
+            ?? LocalTranscriptionPreferences.quality
         // Resolved from the catalog rather than trusted from a caller, so a
         // target picked under Canary and still stored after a switch to
         // Parakeet can never reach an engine that would misread it.

--- a/ios/VocaPhoneApp/Models/SherpaOnnxBridge.c
+++ b/ios/VocaPhoneApp/Models/SherpaOnnxBridge.c
@@ -15,10 +15,18 @@ static int copy_text(
     char *output,
     int32_t output_capacity
 ) {
-    if (output == NULL || output_capacity <= 0) return -1;
+    if (output == NULL || output_capacity <= 0) {
+        return VocaPhoneSherpaDecodeInvalidArgument;
+    }
     if (text == NULL) text = "";
     int written = snprintf(output, (size_t)output_capacity, "%s", text);
-    return written < 0 || written >= output_capacity ? -1 : written;
+    // snprintf reports what it *would* have written, so a return at or past the
+    // capacity means the transcript was cut. Saying so is the point: a truncated
+    // decode and an empty one are opposite failures, and only one is worth
+    // retrying a smaller window for.
+    if (written < 0) return VocaPhoneSherpaDecodeInvalidArgument;
+    if (written >= output_capacity) return VocaPhoneSherpaDecodeOutputTruncated;
+    return written;
 }
 
 VocaPhoneSherpaRecognizer VocaPhoneSherpaCreate(
@@ -122,11 +130,11 @@ int VocaPhoneSherpaDecode(
         (struct VocaPhoneSherpaContext *)recognizer;
     if (context == NULL || context->recognizer == NULL ||
         samples == NULL || sample_count <= 0) {
-        return -1;
+        return VocaPhoneSherpaDecodeInvalidArgument;
     }
     const SherpaOnnxOfflineStream *stream =
         SherpaOnnxCreateOfflineStream(context->recognizer);
-    if (stream == NULL) return -1;
+    if (stream == NULL) return VocaPhoneSherpaDecodeStreamUnavailable;
 
     SherpaOnnxAcceptWaveformOffline(
         stream, 16000, samples, sample_count);
@@ -134,7 +142,7 @@ int VocaPhoneSherpaDecode(
     const SherpaOnnxOfflineRecognizerResult *result =
         SherpaOnnxGetOfflineStreamResult(stream);
     int copied = result == NULL
-        ? -1
+        ? VocaPhoneSherpaDecodeResultMissing
         : copy_text(result->text, output, output_capacity);
     if (result != NULL) {
         // Optional in the struct and left null by every family except

--- a/ios/VocaPhoneApp/Models/SherpaOnnxBridge.h
+++ b/ios/VocaPhoneApp/Models/SherpaOnnxBridge.h
@@ -34,6 +34,29 @@ VocaPhoneSherpaRecognizer VocaPhoneSherpaCreate(
     int32_t max_active_paths
 );
 
+/// What a decode did, for the negative half of `VocaPhoneSherpaDecode`.
+///
+/// A decode that produces no tokens is a *success* returning zero characters:
+/// the model was asked and answered nothing, which for a pause is the right
+/// answer and for speech is the failure the recovery ladder exists to retry.
+/// Everything below is the engine failing to answer at all, and retrying one of
+/// these decodes the same broken state again for the same result — so the
+/// caller must tell them apart before it spends inference on a retry.
+enum VocaPhoneSherpaDecodeStatus {
+    /// A null or already-destroyed recognizer, or no samples to decode.
+    VocaPhoneSherpaDecodeInvalidArgument = -1,
+    /// sherpa-onnx would not create an offline stream for this recognizer.
+    VocaPhoneSherpaDecodeStreamUnavailable = -2,
+    /// The stream decoded but carried no result object.
+    VocaPhoneSherpaDecodeResultMissing = -3,
+    /// The transcript did not fit the caller's output buffer. Distinct from an
+    /// empty answer in exactly the way that matters: text was produced and lost.
+    VocaPhoneSherpaDecodeOutputTruncated = -4,
+};
+
+/// Returns the number of characters written to `output` — zero being a genuine
+/// empty result — or one of `VocaPhoneSherpaDecodeStatus` on failure.
+///
 /// `language` receives the model's own language label when it reports one — of
 /// the families VocaPhone ships, only SenseVoice does, as a `<|en|>`-style tag.
 /// It is set to an empty string otherwise, and may be NULL if not wanted.

--- a/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
+++ b/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
@@ -161,6 +161,7 @@ final class SherpaRecognizer: @unchecked Sendable {
             let newRegionLevel = SherpaLongAudio.loudestFrame(newRegion)
             let carriesNewSpeech = SherpaLongAudio.carriesRecoverableSpeech(
                 newRegion: newRegion,
+                inheritsAudio: chunk.overlapsPrevious,
                 loudestFrame: newRegionLevel,
                 loudestFrameSoFar: loudestSoFar
             )

--- a/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
+++ b/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
@@ -141,42 +141,58 @@ final class SherpaRecognizer: @unchecked Sendable {
     /// A boundary the silence search found is already cut clean here, so only
     /// a guessed one carries audio across, and while translating that seam is
     /// left as it decoded rather than merged by matching words.
-    func transcribe(_ samples: [Float]) -> SherpaTranscript {
+    func transcribe(_ samples: [Float]) -> SherpaDecodeOutcome {
         var transcript = SherpaTranscript.empty
+        var previousEnd = 0
+        var loudestSoFar = 0.0
         for chunk in SherpaLongAudio.chunks(samples) {
             let bounded = Array(samples[chunk.start..<chunk.endExclusive])
-            // Whether a short empty answer is ordinary depends on what came
-            // before it, not on how long the window is. A short window that
-            // follows text is the retained overlap a recording ending just
-            // after a boundary leaves behind, and an empty answer for it is
-            // correct. A short window with nothing decoded ahead of it is the
-            // whole of what the user said so far — the reported failure — and
-            // it earns the bounded recovery ladder however short it is.
-            let nothingDecodedYet = transcript.text.isEmpty
-            let decoded = SherpaEmptyChunkRecovery.decode(
+            // Whether a short empty answer is ordinary is a question about the
+            // audio this window did not inherit from the one before it. A final
+            // window that is only the retained overlap has nothing new in it,
+            // and an empty answer there is correct. A final window carrying a
+            // whole further sentence is the reported failure, and it is that
+            // whether or not an earlier window already produced text — judging
+            // it by the transcript so far is what let a closing sentence
+            // disappear behind a successful opening one.
+            let newRegion = SherpaLongAudio.newRegion(
+                of: samples, chunk: chunk, previousEnd: previousEnd
+            )
+            let newRegionLevel = SherpaLongAudio.loudestFrame(newRegion)
+            let carriesNewSpeech = SherpaLongAudio.carriesRecoverableSpeech(
+                newRegion: newRegion,
+                loudestFrame: newRegionLevel,
+                loudestFrameSoFar: loudestSoFar
+            )
+            let outcome = SherpaEmptyChunkRecovery.decode(
                 samples: bounded,
                 decodeOnce: decode,
                 deduplicateOverlap: !translating,
-                recoverAudibleShortInput: nothingDecodedYet
+                recoverAudibleShortInput: carriesNewSpeech
             )
+            guard case let .decoded(decoded) = outcome else { return outcome }
+            loudestSoFar = max(loudestSoFar, newRegionLevel)
+            previousEnd = chunk.endExclusive
             transcript = transcript.appending(
                 decoded, deduplicateOverlap: chunk.overlapsPrevious && !translating
             )
         }
-        return SherpaTranscript(
-            text: transcript.text.trimmingCharacters(in: .whitespacesAndNewlines),
-            language: transcript.language
+        return .decoded(
+            SherpaTranscript(
+                text: transcript.text.trimmingCharacters(in: .whitespacesAndNewlines),
+                language: transcript.language
+            )
         )
     }
 
-    func transcribeChunk(_ samples: [Float]) -> SherpaTranscript {
+    func transcribeChunk(_ samples: [Float]) -> SherpaDecodeOutcome {
         SherpaEmptyChunkRecovery.decode(
             samples: samples, decodeOnce: decode, deduplicateOverlap: !translating
         )
     }
 
-    private func decode(_ samples: [Float]) -> SherpaTranscript {
-        guard !samples.isEmpty else { return .empty }
+    private func decode(_ samples: [Float]) -> SherpaDecodeOutcome {
+        guard !samples.isEmpty else { return .failed(.invalidArgument) }
         let samples = SherpaFeatureDither.applied(to: samples, dither: featureDither)
         decodeLock.lock()
         defer { decodeLock.unlock() }
@@ -198,10 +214,14 @@ final class SherpaRecognizer: @unchecked Sendable {
                 }
             }
         }
-        guard result >= 0 else { return .empty }
-        return SherpaTranscript(
-            text: Self.string(from: output),
-            language: SherpaTranscript.languageCode(Self.string(from: languageOutput))
+        // A negative status is the engine failing to answer, and it must never
+        // reach the caller looking like a model that answered nothing.
+        guard result >= 0 else { return .failed(.forStatus(result)) }
+        return .decoded(
+            SherpaTranscript(
+                text: Self.string(from: output),
+                language: SherpaTranscript.languageCode(Self.string(from: languageOutput))
+            )
         )
     }
 

--- a/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
+++ b/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
@@ -5,6 +5,11 @@ import Foundation
 /// VocaPhone needs.
 final class SherpaRecognizer: @unchecked Sendable {
     private let native: UnsafeMutableRawPointer
+    /// sherpa-onnx recognizers are mutable native objects. Incremental decoding
+    /// runs off the main actor while a retry or settings preparation can also
+    /// reach this instance, so one recognizer must never decode two streams at
+    /// once.
+    private let decodeLock = NSLock()
     /// Whether this recognizer was built to translate, which changes how a
     /// recording too long for one decode is put back together. See `transcribe`.
     private let translating: Bool
@@ -127,14 +132,23 @@ final class SherpaRecognizer: @unchecked Sendable {
     /// a guessed one carries audio across, and while translating that seam is
     /// left as it decoded rather than merged by matching words.
     func transcribe(_ samples: [Float]) -> SherpaTranscript {
-        let transcript = SherpaLongAudio.chunks(samples)
-            .reduce(into: SherpaTranscript.empty) { transcript, chunk in
-                let bounded = Array(samples[chunk.start..<chunk.endExclusive])
-                let decoded = SherpaEmptyChunkRecovery.decode(samples: bounded, decodeOnce: decode)
-                transcript = transcript.appending(
-                    decoded, deduplicateOverlap: chunk.overlapsPrevious && !translating
-                )
-            }
+        let chunks = SherpaLongAudio.chunks(samples)
+        var transcript = SherpaTranscript.empty
+        for chunk in chunks {
+            let bounded = Array(samples[chunk.start..<chunk.endExclusive])
+            let decoded = SherpaEmptyChunkRecovery.decode(
+                samples: bounded,
+                decodeOnce: decode,
+                deduplicateOverlap: !translating,
+                // A short final overlap is routinely empty; a short *complete*
+                // dictation with audible speech is the reported failure and
+                // deserves one bounded recovery ladder.
+                recoverAudibleShortInput: chunks.count == 1
+            )
+            transcript = transcript.appending(
+                decoded, deduplicateOverlap: chunk.overlapsPrevious && !translating
+            )
+        }
         return SherpaTranscript(
             text: transcript.text.trimmingCharacters(in: .whitespacesAndNewlines),
             language: transcript.language
@@ -142,11 +156,15 @@ final class SherpaRecognizer: @unchecked Sendable {
     }
 
     func transcribeChunk(_ samples: [Float]) -> SherpaTranscript {
-        SherpaEmptyChunkRecovery.decode(samples: samples, decodeOnce: decode)
+        SherpaEmptyChunkRecovery.decode(
+            samples: samples, decodeOnce: decode, deduplicateOverlap: !translating
+        )
     }
 
     private func decode(_ samples: [Float]) -> SherpaTranscript {
         guard !samples.isEmpty else { return .empty }
+        decodeLock.lock()
+        defer { decodeLock.unlock() }
         var output = [CChar](repeating: 0, count: 131_072)
         // Only ever holds a short tag such as "<|en|>".
         var languageOutput = [CChar](repeating: 0, count: 32)
@@ -193,7 +211,10 @@ private extension SherpaFamily {
 
 private enum SherpaEmptyChunkRecovery {
     static func decode(
-        samples: [Float], decodeOnce: ([Float]) -> SherpaTranscript
+        samples: [Float],
+        decodeOnce: ([Float]) -> SherpaTranscript,
+        deduplicateOverlap: Bool,
+        recoverAudibleShortInput: Bool = false
     ) -> SherpaTranscript {
         guard !SherpaLongAudio.isEffectivelySilent(samples) else { return .empty }
         let attempt = decodeOnce(samples)
@@ -201,12 +222,30 @@ private enum SherpaEmptyChunkRecovery {
             text: attempt.text.trimmingCharacters(in: .whitespacesAndNewlines),
             language: attempt.language
         )
-        guard first.text.isEmpty,
-              samples.count > SherpaLongAudio.minimumSuspectChunkSamples
+        guard first.text.isEmpty else { return first }
+        guard recoverAudibleShortInput || samples.count > SherpaLongAudio.minimumSuspectChunkSamples
         else { return first }
+
+        // Very short speech can begin or end too close to the encoder context.
+        // A fresh stream and bounded padding are only worthwhile for a complete
+        // short recording; lengthy windows keep the established split ladder.
+        if recoverAudibleShortInput {
+            let repeated = decodeOnce(samples)
+            if !repeated.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return repeated
+            }
+            let padding = [Float](repeating: 0, count: SherpaLongAudio.sampleRate / 2)
+            let padded = decodeOnce(padding + samples + padding)
+            if !padded.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return padded
+            }
+        }
+
         let midpoint = samples.count / 2
-        return decodeOnce(Array(samples[..<midpoint]))
-            .appending(decodeOnce(Array(samples[midpoint...])), deduplicateOverlap: false)
+        let overlap = min(SherpaLongAudio.overlapSamples, midpoint / 2)
+        let left = decodeOnce(Array(samples[..<min(samples.count, midpoint + overlap)]))
+        let right = decodeOnce(Array(samples[max(0, midpoint - overlap)...]))
+        return left.appending(right, deduplicateOverlap: deduplicateOverlap)
     }
 }
 

--- a/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
+++ b/ios/VocaPhoneApp/Models/SherpaRecognizer.swift
@@ -13,10 +13,19 @@ final class SherpaRecognizer: @unchecked Sendable {
     /// Whether this recognizer was built to translate, which changes how a
     /// recording too long for one decode is put back together. See `transcribe`.
     private let translating: Bool
+    /// The feature noise this family needs, applied to the waveform because the
+    /// pinned runtime has no `dither` field to ask for it. See
+    /// `SherpaFeatureDither` and `SherpaFamily.featureDither`.
+    private let featureDither: Float
 
-    private init(native: UnsafeMutableRawPointer, translating: Bool = false) {
+    private init(
+        native: UnsafeMutableRawPointer,
+        translating: Bool = false,
+        featureDither: Float = 0
+    ) {
         self.native = native
         self.translating = translating
+        self.featureDither = featureDither
     }
 
     deinit {
@@ -113,7 +122,8 @@ final class SherpaRecognizer: @unchecked Sendable {
         // the caller asked for.
         return SherpaRecognizer(
             native: native,
-            translating: family.acceptsLanguage && !translateTo.isEmpty
+            translating: family.acceptsLanguage && !translateTo.isEmpty,
+            featureDither: family.featureDither
         )
     }
 
@@ -132,18 +142,22 @@ final class SherpaRecognizer: @unchecked Sendable {
     /// a guessed one carries audio across, and while translating that seam is
     /// left as it decoded rather than merged by matching words.
     func transcribe(_ samples: [Float]) -> SherpaTranscript {
-        let chunks = SherpaLongAudio.chunks(samples)
         var transcript = SherpaTranscript.empty
-        for chunk in chunks {
+        for chunk in SherpaLongAudio.chunks(samples) {
             let bounded = Array(samples[chunk.start..<chunk.endExclusive])
+            // Whether a short empty answer is ordinary depends on what came
+            // before it, not on how long the window is. A short window that
+            // follows text is the retained overlap a recording ending just
+            // after a boundary leaves behind, and an empty answer for it is
+            // correct. A short window with nothing decoded ahead of it is the
+            // whole of what the user said so far — the reported failure — and
+            // it earns the bounded recovery ladder however short it is.
+            let nothingDecodedYet = transcript.text.isEmpty
             let decoded = SherpaEmptyChunkRecovery.decode(
                 samples: bounded,
                 decodeOnce: decode,
                 deduplicateOverlap: !translating,
-                // A short final overlap is routinely empty; a short *complete*
-                // dictation with audible speech is the reported failure and
-                // deserves one bounded recovery ladder.
-                recoverAudibleShortInput: chunks.count == 1
+                recoverAudibleShortInput: nothingDecodedYet
             )
             transcript = transcript.appending(
                 decoded, deduplicateOverlap: chunk.overlapsPrevious && !translating
@@ -163,6 +177,7 @@ final class SherpaRecognizer: @unchecked Sendable {
 
     private func decode(_ samples: [Float]) -> SherpaTranscript {
         guard !samples.isEmpty else { return .empty }
+        let samples = SherpaFeatureDither.applied(to: samples, dither: featureDither)
         decodeLock.lock()
         defer { decodeLock.unlock() }
         var output = [CChar](repeating: 0, count: 131_072)
@@ -206,46 +221,6 @@ private extension SherpaFamily {
         case .nemoCtc: 5
         case .paraformer: 6
         }
-    }
-}
-
-private enum SherpaEmptyChunkRecovery {
-    static func decode(
-        samples: [Float],
-        decodeOnce: ([Float]) -> SherpaTranscript,
-        deduplicateOverlap: Bool,
-        recoverAudibleShortInput: Bool = false
-    ) -> SherpaTranscript {
-        guard !SherpaLongAudio.isEffectivelySilent(samples) else { return .empty }
-        let attempt = decodeOnce(samples)
-        let first = SherpaTranscript(
-            text: attempt.text.trimmingCharacters(in: .whitespacesAndNewlines),
-            language: attempt.language
-        )
-        guard first.text.isEmpty else { return first }
-        guard recoverAudibleShortInput || samples.count > SherpaLongAudio.minimumSuspectChunkSamples
-        else { return first }
-
-        // Very short speech can begin or end too close to the encoder context.
-        // A fresh stream and bounded padding are only worthwhile for a complete
-        // short recording; lengthy windows keep the established split ladder.
-        if recoverAudibleShortInput {
-            let repeated = decodeOnce(samples)
-            if !repeated.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                return repeated
-            }
-            let padding = [Float](repeating: 0, count: SherpaLongAudio.sampleRate / 2)
-            let padded = decodeOnce(padding + samples + padding)
-            if !padded.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                return padded
-            }
-        }
-
-        let midpoint = samples.count / 2
-        let overlap = min(SherpaLongAudio.overlapSamples, midpoint / 2)
-        let left = decodeOnce(Array(samples[..<min(samples.count, midpoint + overlap)]))
-        let right = decodeOnce(Array(samples[max(0, midpoint - overlap)...]))
-        return left.appending(right, deduplicateOverlap: deduplicateOverlap)
     }
 }
 

--- a/ios/VocaPhoneShared/LocalModelCatalog.swift
+++ b/ios/VocaPhoneShared/LocalModelCatalog.swift
@@ -14,11 +14,36 @@ enum SherpaFamily: String, Codable, Sendable {
     case nemoCtc
     case paraformer
 
-    /// NeMo TDT accepts `modified_beam_search`, but current sherpa-onnx builds
-    /// intermittently emit empty or hallucinated text with it. Keep every
-    /// bundled family on greedy decoding until a fixed runtime is shipped and
-    /// exercised on phones.
+    /// Whether this family can safely use `modified_beam_search`.
+    ///
+    /// This is not a preference, and it is false for two separate reasons that
+    /// both have to stay written down.
+    ///
+    /// sherpa-onnx validates the decoding method when the recognizer is built,
+    /// and every family except the transducer answers an unsupported one with
+    /// `exit(-1)` — not an exception, not an error return, but the process
+    /// gone. So the method can never be taken from the user's setting alone.
+    ///
+    /// NeMo TDT does accept the value, but its implementation in the bundled
+    /// runtimes can intermittently emit empty or hallucinated text (upstream
+    /// #3267; its proposed fix #3657 is not merged). That keeps the transducer
+    /// false too, until a fixed native runtime is pinned and exercised on a
+    /// phone. Both halves are load-bearing: restoring the transducer here is
+    /// only ever safe for the transducer.
     var supportsBeamSearch: Bool { false }
+
+    /// Tiny feature noise used only where zero dither can collapse valid speech.
+    ///
+    /// Kaldi's `dither=1` on int16 audio is approximately `1 / 32768` in the
+    /// float scale VocaPhone captures at. It is the upstream workaround for
+    /// Parakeet returning no tokens on valid audio with an all-zero dither
+    /// setting (sherpa-onnx #2258), and matches the Android client exactly.
+    ///
+    /// Android passes this into `FeatureConfig.dither`. The pinned iOS runtime
+    /// (v1.12.34) has no `dither` field on `SherpaOnnxFeatureConfig` at all, so
+    /// `SherpaFeatureDither` reproduces its effect on the waveform instead. Move
+    /// this to `config.feat_config.dither` once the runtime upgrade lands.
+    var featureDither: Float { self == .nemoTransducer ? 0.00003 : 0 }
 
     /// Whether the recognizer config for this family has a language field at all.
     ///

--- a/ios/VocaPhoneShared/LocalModelCatalog.swift
+++ b/ios/VocaPhoneShared/LocalModelCatalog.swift
@@ -57,6 +57,22 @@ enum SherpaFamily: String, Codable, Sendable {
 
     static let greedySearch = "greedy_search"
 
+    /// Whether the accuracy setting changes the recognizer this family builds.
+    ///
+    /// It changes exactly two config fields, and greedy search reads neither:
+    /// `decoding_method` is pinned, and `max_active_paths` is the beam width a
+    /// beam search would have used. So while `supportsBeamSearch` is false the
+    /// three accuracy settings produce a byte-identical recognizer — and
+    /// treating quality as part of this family's cached identity rebuilds a
+    /// several-hundred-megabyte ONNX graph to arrive at the one already loaded.
+    var nativeConfigVariesWithQuality: Bool { supportsBeamSearch }
+
+    /// The quality this family's recognizer is actually built at, so a cache key
+    /// cannot record a distinction the native config does not have.
+    func effectiveQuality(_ quality: TranscriptionQuality) -> TranscriptionQuality {
+        nativeConfigVariesWithQuality ? quality : .default
+    }
+
     /// The only safe way to turn a quality setting into a decoding method.
     func decodingMethod(for quality: TranscriptionQuality) -> String {
         supportsBeamSearch ? quality.sherpaDecodingMethod : Self.greedySearch

--- a/ios/VocaPhoneShared/LocalModelCatalog.swift
+++ b/ios/VocaPhoneShared/LocalModelCatalog.swift
@@ -14,14 +14,11 @@ enum SherpaFamily: String, Codable, Sendable {
     case nemoCtc
     case paraformer
 
-    /// Whether this family accepts `modified_beam_search`.
-    ///
-    /// This is not a preference. sherpa-onnx validates the decoding method when
-    /// the recognizer is built, and every family except the transducer answers
-    /// an unsupported one with `exit(-1)` — not an exception, not an error
-    /// return, but the process gone. So the method has to be decided from the
-    /// family and never from the user's setting alone.
-    var supportsBeamSearch: Bool { self == .nemoTransducer }
+    /// NeMo TDT accepts `modified_beam_search`, but current sherpa-onnx builds
+    /// intermittently emit empty or hallucinated text with it. Keep every
+    /// bundled family on greedy decoding until a fixed runtime is shipped and
+    /// exercised on phones.
+    var supportsBeamSearch: Bool { false }
 
     /// Whether the recognizer config for this family has a language field at all.
     ///

--- a/ios/VocaPhoneShared/SherpaDecodeOutcome.swift
+++ b/ios/VocaPhoneShared/SherpaDecodeOutcome.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Why a native decode produced no transcript.
+///
+/// These are the engine failing to answer, not the model answering nothing.
+/// The distinction is the whole point of the type: the recovery ladder exists
+/// to re-ask a model that returned no tokens for audible speech, and re-asking
+/// a recognizer whose stream would not open, or whose context is already gone,
+/// spends a decode to be told the same thing again.
+enum SherpaNativeFailure: String, Sendable, Equatable {
+    /// A null or already-destroyed recognizer, or no samples to decode.
+    case invalidArgument
+    /// sherpa-onnx would not create an offline stream for this recognizer.
+    case streamUnavailable
+    /// The stream decoded but carried no result object.
+    case resultMissing
+    /// Text was produced and did not fit the output buffer. The opposite failure
+    /// to an empty answer, and the one a smaller window would actually help.
+    case outputTruncated
+    /// A negative status the bridge does not name. Kept so a future code cannot
+    /// be silently read as a successful empty decode.
+    case unknown
+
+    /// Maps `VocaPhoneSherpaDecodeStatus`. Lives here rather than at the call
+    /// site so the shared target — and its tests — can reason about the values
+    /// without importing the bridge.
+    static func forStatus(_ status: Int32) -> SherpaNativeFailure {
+        switch status {
+        case -1: .invalidArgument
+        case -2: .streamUnavailable
+        case -3: .resultMissing
+        case -4: .outputTruncated
+        default: .unknown
+        }
+    }
+}
+
+/// What one native decode call did.
+///
+/// `decoded` covers a genuine empty result: the model was asked and answered
+/// nothing. That is an ordinary answer for a pause and the reported failure for
+/// speech, and either way it is the model's answer rather than the engine's
+/// absence.
+enum SherpaDecodeOutcome: Sendable, Equatable {
+    case decoded(SherpaTranscript)
+    case failed(SherpaNativeFailure)
+
+    static let empty = SherpaDecodeOutcome.decoded(.empty)
+
+    /// The transcript, or an empty one for a failure.
+    ///
+    /// Only for the paths that genuinely cannot act on the difference. Anything
+    /// that decides whether to retry, or what to tell the user, must match on
+    /// the case instead — collapsing the two here is the bug this type replaces.
+    var transcriptOrEmpty: SherpaTranscript {
+        switch self {
+        case let .decoded(transcript): transcript
+        case .failed: .empty
+        }
+    }
+
+    var nativeFailure: SherpaNativeFailure? {
+        switch self {
+        case .decoded: nil
+        case let .failed(failure): failure
+        }
+    }
+}

--- a/ios/VocaPhoneShared/SherpaEmptyChunkRecovery.swift
+++ b/ios/VocaPhoneShared/SherpaEmptyChunkRecovery.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Recovers a window that decoded to nothing but demonstrably carried speech.
+///
+/// Some attention-based models occasionally return no tokens for a waveform
+/// even though shorter speech from the same recording is recognized. This lives
+/// in the shared target rather than beside the recognizer so the ladder can be
+/// exercised without the native engine, exactly as Android's is.
+enum SherpaEmptyChunkRecovery {
+
+    /// - Parameters:
+    ///   - deduplicateOverlap: false when the caller is translating. The two
+    ///     halves overlap so the word crossing the centre survives, and matching
+    ///     the repeat back out only works when the same audio returns the same
+    ///     words — which is exactly what a translator does not promise.
+    ///   - recoverAudibleShortInput: true when an empty answer here cannot be
+    ///     the ordinary short trailing overlap. See `SherpaRecognizer.transcribe`
+    ///     for how that is decided.
+    static func decode(
+        samples: [Float],
+        decodeOnce: ([Float]) -> SherpaTranscript,
+        deduplicateOverlap: Bool,
+        recoverAudibleShortInput: Bool = false
+    ) -> SherpaTranscript {
+        // Room tone is the ordinary reason for an empty answer, and the cheapest
+        // thing to rule out before spending more decodes: the scan costs a pass
+        // over the samples, a retry costs inference.
+        guard !SherpaLongAudio.isEffectivelySilent(samples) else { return .empty }
+        let first = trimmed(decodeOnce(samples))
+        guard first.text.isEmpty else { return first }
+        // Length is what the split recovers from, so a window not long enough to
+        // have been dropped for its length has nothing there to recover — unless
+        // the caller has already established that this window is the recording.
+        guard recoverAudibleShortInput || samples.count > SherpaLongAudio.minimumSuspectChunkSamples
+        else { return first }
+
+        if recoverAudibleShortInput {
+            // A fresh offline stream can recover a nondeterministic no-token
+            // answer. Long windows keep the established split ladder and its
+            // predictable latency.
+            let repeated = trimmed(decodeOnce(samples))
+            if !repeated.text.isEmpty { return repeated }
+            // Very short speech can begin or end too close to the encoder
+            // context. Half a second either side is enough to move it inside,
+            // and is bounded so a recording cannot grow its own decode cost.
+            let padding = [Float](repeating: 0, count: SherpaLongAudio.sampleRate / 2)
+            let padded = trimmed(decodeOnce(padding + samples + padding))
+            if !padded.text.isEmpty { return padded }
+        }
+
+        // Retain context on both sides of the recovery boundary. A plain
+        // midpoint split could rescue an empty window while still deleting the
+        // word crossing its exact centre. One split and no more: a half-length
+        // window that is still empty is not being lost to its length, and
+        // subdividing again multiplies the decodes for nothing.
+        //
+        // Half the boundary overlap on each side, so the halves share exactly
+        // the interval a chunk boundary retains and the merger is never asked
+        // to match more repetition than the audio can account for. Clamped so a
+        // very short recording does not hand both halves the whole waveform.
+        let midpoint = samples.count / 2
+        let overlap = min(SherpaLongAudio.overlapSamples / 2, midpoint / 2)
+        let left = decodeOnce(Array(samples[..<min(samples.count, midpoint + overlap)]))
+        let right = decodeOnce(Array(samples[max(0, midpoint - overlap)...]))
+        return left.appending(right, deduplicateOverlap: deduplicateOverlap)
+    }
+
+    private static func trimmed(_ transcript: SherpaTranscript) -> SherpaTranscript {
+        SherpaTranscript(
+            text: transcript.text.trimmingCharacters(in: .whitespacesAndNewlines),
+            language: transcript.language
+        )
+    }
+}

--- a/ios/VocaPhoneShared/SherpaEmptyChunkRecovery.swift
+++ b/ios/VocaPhoneShared/SherpaEmptyChunkRecovery.swift
@@ -31,13 +31,17 @@ enum SherpaEmptyChunkRecovery {
         // Length is what the split recovers from, so a window not long enough to
         // have been dropped for its length has nothing there to recover — unless
         // the caller has already established that this window is the recording.
-        guard recoverAudibleShortInput || samples.count > SherpaLongAudio.minimumSuspectChunkSamples
-        else { return first }
+        let short = samples.count <= SherpaLongAudio.minimumSuspectChunkSamples
+        guard recoverAudibleShortInput || !short else { return first }
 
-        if recoverAudibleShortInput {
+        // The two extra rungs are for short speech and stay there. A ten-second
+        // window is already the length the split recovers from, and padding it
+        // by half a second either side buys nothing for the cost of a whole
+        // further decode — so a long window keeps the established ladder and its
+        // predictable latency however little has been decoded before it.
+        if short {
             // A fresh offline stream can recover a nondeterministic no-token
-            // answer. Long windows keep the established split ladder and its
-            // predictable latency.
+            // answer.
             let repeated = trimmed(decodeOnce(samples))
             if !repeated.text.isEmpty { return repeated }
             // Very short speech can begin or end too close to the encoder

--- a/ios/VocaPhoneShared/SherpaEmptyChunkRecovery.swift
+++ b/ios/VocaPhoneShared/SherpaEmptyChunkRecovery.swift
@@ -6,6 +6,11 @@ import Foundation
 /// even though shorter speech from the same recording is recognized. This lives
 /// in the shared target rather than beside the recognizer so the ladder can be
 /// exercised without the native engine, exactly as Android's is.
+///
+/// Every rung re-asks the model. That is only ever worth a decode when the model
+/// answered, so a native failure leaves the ladder at once and is handed back
+/// for the caller to report as an engine failure — retrying a recognizer whose
+/// stream would not open produces the same non-answer at the same price.
 enum SherpaEmptyChunkRecovery {
 
     /// - Parameters:
@@ -18,21 +23,25 @@ enum SherpaEmptyChunkRecovery {
     ///     for how that is decided.
     static func decode(
         samples: [Float],
-        decodeOnce: ([Float]) -> SherpaTranscript,
+        decodeOnce: ([Float]) -> SherpaDecodeOutcome,
         deduplicateOverlap: Bool,
         recoverAudibleShortInput: Bool = false
-    ) -> SherpaTranscript {
+    ) -> SherpaDecodeOutcome {
         // Room tone is the ordinary reason for an empty answer, and the cheapest
         // thing to rule out before spending more decodes: the scan costs a pass
         // over the samples, a retry costs inference.
         guard !SherpaLongAudio.isEffectivelySilent(samples) else { return .empty }
-        let first = trimmed(decodeOnce(samples))
-        guard first.text.isEmpty else { return first }
+
+        let attempt = decodeOnce(samples)
+        guard case let .decoded(raw) = attempt else { return attempt }
+        let first = trimmed(raw)
+        guard first.text.isEmpty else { return .decoded(first) }
+
         // Length is what the split recovers from, so a window not long enough to
         // have been dropped for its length has nothing there to recover — unless
-        // the caller has already established that this window is the recording.
+        // the caller has already established that this window is new speech.
         let short = samples.count <= SherpaLongAudio.minimumSuspectChunkSamples
-        guard recoverAudibleShortInput || !short else { return first }
+        guard recoverAudibleShortInput || !short else { return .decoded(first) }
 
         // The two extra rungs are for short speech and stay there. A ten-second
         // window is already the length the split recovers from, and padding it
@@ -42,14 +51,22 @@ enum SherpaEmptyChunkRecovery {
         if short {
             // A fresh offline stream can recover a nondeterministic no-token
             // answer.
-            let repeated = trimmed(decodeOnce(samples))
-            if !repeated.text.isEmpty { return repeated }
+            switch decodeOnce(samples) {
+            case let .failed(failure): return .failed(failure)
+            case let .decoded(repeated) where !trimmed(repeated).text.isEmpty:
+                return .decoded(trimmed(repeated))
+            case .decoded: break
+            }
             // Very short speech can begin or end too close to the encoder
             // context. Half a second either side is enough to move it inside,
             // and is bounded so a recording cannot grow its own decode cost.
             let padding = [Float](repeating: 0, count: SherpaLongAudio.sampleRate / 2)
-            let padded = trimmed(decodeOnce(padding + samples + padding))
-            if !padded.text.isEmpty { return padded }
+            switch decodeOnce(padding + samples + padding) {
+            case let .failed(failure): return .failed(failure)
+            case let .decoded(padded) where !trimmed(padded).text.isEmpty:
+                return .decoded(trimmed(padded))
+            case .decoded: break
+            }
         }
 
         // Retain context on both sides of the recovery boundary. A plain
@@ -64,9 +81,11 @@ enum SherpaEmptyChunkRecovery {
         // very short recording does not hand both halves the whole waveform.
         let midpoint = samples.count / 2
         let overlap = min(SherpaLongAudio.overlapSamples / 2, midpoint / 2)
-        let left = decodeOnce(Array(samples[..<min(samples.count, midpoint + overlap)]))
-        let right = decodeOnce(Array(samples[max(0, midpoint - overlap)...]))
-        return left.appending(right, deduplicateOverlap: deduplicateOverlap)
+        let leftOutcome = decodeOnce(Array(samples[..<min(samples.count, midpoint + overlap)]))
+        guard case let .decoded(left) = leftOutcome else { return leftOutcome }
+        let rightOutcome = decodeOnce(Array(samples[max(0, midpoint - overlap)...]))
+        guard case let .decoded(right) = rightOutcome else { return rightOutcome }
+        return .decoded(left.appending(right, deduplicateOverlap: deduplicateOverlap))
     }
 
     private static func trimmed(_ transcript: SherpaTranscript) -> SherpaTranscript {

--- a/ios/VocaPhoneShared/SherpaFeatureDither.swift
+++ b/ios/VocaPhoneShared/SherpaFeatureDither.swift
@@ -26,9 +26,17 @@ enum SherpaFeatureDither {
     ///
     /// A non-positive `dither` returns the samples untouched, so the families
     /// that do not need this pay one comparison and no copy.
+    ///
+    /// The noise is drawn fresh on every call, as Kaldi's is. That is what makes
+    /// the recovery ladder's second attempt a real second attempt: the runtime
+    /// dithers a Parakeet decode differently each time it runs, so re-deciding
+    /// the same waveform is not guaranteed to reproduce the same no-token
+    /// answer. Seeding this identically each call would hand the model
+    /// byte-identical features and make that rung of the ladder cost a decode
+    /// to learn nothing.
     static func applied(to samples: [Float], dither: Float) -> [Float] {
         guard dither > 0, !samples.isEmpty else { return samples }
-        var generator = SherpaDitherGenerator(seed: 0x9E37_79B9_7F4A_7C15)
+        var generator = SherpaDitherGenerator(seed: UInt64.random(in: UInt64.min...UInt64.max))
         var result = samples
         var index = 0
         // Box-Muller returns two independent normals per pair of uniforms, so
@@ -45,12 +53,15 @@ enum SherpaFeatureDither {
     }
 }
 
-/// A small deterministic generator so a decode is reproducible across attempts.
+/// SplitMix64, and a Box-Muller pair on top of it.
 ///
-/// The recovery ladder decodes the same waveform twice on purpose, and the
-/// point of the repeat is a fresh native stream rather than fresh noise. Seeding
-/// this identically each call keeps the difference between the two attempts on
-/// the side being tested.
+/// Every step of the uniform is computed in `Double` and bounded to `(0, 1]` by
+/// construction. Doing it in `Float` is what a `Float` cannot survive here: a
+/// 53-bit draw rounds up to exactly 1 once in about 2^24 values, one nudge past
+/// that makes `log` positive, and the square root of the negative that follows
+/// is a `NaN` written straight into the waveform. At 16 kHz that is a coin flip
+/// every couple of decodes, and a single `NaN` sample is an empty transcript —
+/// the failure this file exists to prevent.
 private struct SherpaDitherGenerator {
     private var state: UInt64
 
@@ -64,14 +75,16 @@ private struct SherpaDitherGenerator {
         return z ^ (z >> 31)
     }
 
-    /// A uniform in `(0, 1]`. Never zero, which `log` could not survive.
-    private mutating func nextUnitInterval() -> Float {
-        Float(next() >> 11) / Float(UInt64(1) << 53) + Float.ulpOfOne
+    /// A uniform in `(0, 1]`, exactly. 52 bits leaves `Double` a spare bit, so
+    /// `bits + 1` is exact and the largest result is 1 rather than a hair above.
+    private mutating func nextUnitInterval() -> Double {
+        (Double(next() >> 12) + 1) / Double(UInt64(1) << 52)
     }
 
     mutating func nextNormalPair() -> (Float, Float) {
-        let magnitude = (-2 * log(nextUnitInterval())).squareRoot()
-        let angle = 2 * Float.pi * nextUnitInterval()
-        return (magnitude * cos(angle), magnitude * sin(angle))
+        // `log(1)` is 0, which is a magnitude of zero and not a special case.
+        let magnitude = (-2 * Foundation.log(nextUnitInterval())).squareRoot()
+        let angle = 2 * Double.pi * nextUnitInterval()
+        return (Float(magnitude * cos(angle)), Float(magnitude * sin(angle)))
     }
 }

--- a/ios/VocaPhoneShared/SherpaFeatureDither.swift
+++ b/ios/VocaPhoneShared/SherpaFeatureDither.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Adds the tiny feature noise that keeps a zero-dither Parakeet from answering
+/// valid speech with no tokens at all.
+///
+/// Kaldi's feature extractor adds `dither * RandGauss()` to every waveform
+/// sample before framing. Its purpose is not audible: an exactly-constant
+/// window — digital silence, a clipped plateau, a synthetic pad — makes the log
+/// energy of that frame collapse, and NeMo TDT has been observed to return an
+/// empty result for a whole recording because of it (sherpa-onnx #2258).
+///
+/// The Android client asks the runtime for this by setting
+/// `FeatureConfig.dither`. The pinned iOS runtime (sherpa-onnx v1.12.34) has no
+/// `dither` field on `SherpaOnnxFeatureConfig`, so there is nothing to set;
+/// applying the same Gaussian to the samples on the way in is numerically the
+/// same thing one stage earlier, and is what keeps the two platforms honest
+/// until the runtime upgrade is evaluated on its own.
+///
+/// This matters most for the empty-result recovery ladder, which pads a short
+/// recording with silence. Without dither that padding is a run of exact zeros
+/// — precisely the input #2258 describes — so the retry meant to rescue the
+/// recording would be the attempt least likely to succeed.
+enum SherpaFeatureDither {
+
+    /// Returns `samples` with Gaussian noise of standard deviation `dither`.
+    ///
+    /// A non-positive `dither` returns the samples untouched, so the families
+    /// that do not need this pay one comparison and no copy.
+    static func applied(to samples: [Float], dither: Float) -> [Float] {
+        guard dither > 0, !samples.isEmpty else { return samples }
+        var generator = SherpaDitherGenerator(seed: 0x9E37_79B9_7F4A_7C15)
+        var result = samples
+        var index = 0
+        // Box-Muller returns two independent normals per pair of uniforms, so
+        // the transcendentals cost half of what a per-sample draw would.
+        while index < result.count {
+            let (first, second) = generator.nextNormalPair()
+            result[index] += dither * first
+            if index + 1 < result.count {
+                result[index + 1] += dither * second
+            }
+            index += 2
+        }
+        return result
+    }
+}
+
+/// A small deterministic generator so a decode is reproducible across attempts.
+///
+/// The recovery ladder decodes the same waveform twice on purpose, and the
+/// point of the repeat is a fresh native stream rather than fresh noise. Seeding
+/// this identically each call keeps the difference between the two attempts on
+/// the side being tested.
+private struct SherpaDitherGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) { state = seed }
+
+    private mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+
+    /// A uniform in `(0, 1]`. Never zero, which `log` could not survive.
+    private mutating func nextUnitInterval() -> Float {
+        Float(next() >> 11) / Float(UInt64(1) << 53) + Float.ulpOfOne
+    }
+
+    mutating func nextNormalPair() -> (Float, Float) {
+        let magnitude = (-2 * log(nextUnitInterval())).squareRoot()
+        let angle = 2 * Float.pi * nextUnitInterval()
+        return (magnitude * cos(angle), magnitude * sin(angle))
+    }
+}

--- a/ios/VocaPhoneShared/SherpaFeatureDither.swift
+++ b/ios/VocaPhoneShared/SherpaFeatureDither.swift
@@ -11,10 +11,16 @@ import Foundation
 ///
 /// The Android client asks the runtime for this by setting
 /// `FeatureConfig.dither`. The pinned iOS runtime (sherpa-onnx v1.12.34) has no
-/// `dither` field on `SherpaOnnxFeatureConfig`, so there is nothing to set;
-/// applying the same Gaussian to the samples on the way in is numerically the
-/// same thing one stage earlier, and is what keeps the two platforms honest
-/// until the runtime upgrade is evaluated on its own.
+/// `dither` field on `SherpaOnnxFeatureConfig`, so there is nothing to set, and
+/// the same Gaussian is applied to the samples one stage earlier instead.
+///
+/// That is an approximation rather than the same computation. Kaldi dithers
+/// inside each extracted frame, and frames overlap — a 25 ms window every
+/// 10 ms — so a sample that appears in two or three frames is given independent
+/// noise in each. Dithering the waveform gives every frame the same noise for
+/// that sample. It breaks the constant windows this exists for, which is what
+/// #2258 turns on, but it is not bit-equivalent to the native path and should
+/// be replaced by the config field when a runtime that has one is evaluated.
 ///
 /// This matters most for the empty-result recovery ladder, which pads a short
 /// recording with silence. Without dither that padding is a run of exact zeros
@@ -59,10 +65,12 @@ enum SherpaFeatureDither {
 /// construction. Doing it in `Float` is what a `Float` cannot survive here: a
 /// 53-bit draw rounds up to exactly 1 once in about 2^24 values, one nudge past
 /// that makes `log` positive, and the square root of the negative that follows
-/// is a `NaN` written straight into the waveform. At 16 kHz that is a coin flip
-/// every couple of decodes, and a single `NaN` sample is an empty transcript —
-/// the failure this file exists to prevent.
-private struct SherpaDitherGenerator {
+/// is a `NaN` written straight into the waveform. Only the magnitude's draw can
+/// do it, so a ten second decode risks it eighty thousand times — on the order
+/// of one recording in two hundred. Rare enough to survive a test suite, often
+/// enough to be seen on a phone, and a single `NaN` sample is an empty
+/// transcript: the failure this file exists to prevent.
+struct SherpaDitherGenerator {
     private var state: UInt64
 
     init(seed: UInt64) { state = seed }
@@ -77,8 +85,17 @@ private struct SherpaDitherGenerator {
 
     /// A uniform in `(0, 1]`, exactly. 52 bits leaves `Double` a spare bit, so
     /// `bits + 1` is exact and the largest result is 1 rather than a hair above.
+    ///
+    /// Split out from the draw so the boundary can be asserted directly. Feeding
+    /// a generator and hoping it reaches the top of its range is how the first
+    /// version of this test passed against the implementation that produced the
+    /// `NaN`: one in 2^24 is not something a test suite finds by sampling.
+    static func unitInterval(bits: UInt64) -> Double {
+        (Double(bits >> 12) + 1) / Double(UInt64(1) << 52)
+    }
+
     private mutating func nextUnitInterval() -> Double {
-        (Double(next() >> 12) + 1) / Double(UInt64(1) << 52)
+        Self.unitInterval(bits: next())
     }
 
     mutating func nextNormalPair() -> (Float, Float) {

--- a/ios/VocaPhoneShared/SherpaIncrementalSession.swift
+++ b/ios/VocaPhoneShared/SherpaIncrementalSession.swift
@@ -39,7 +39,10 @@ final class SherpaIncrementalSession: @unchecked Sendable {
     /// `decode` is handed one complete chunk at a time and must be safe to call
     /// off the main actor; the recognizer overload in the app target supplies
     /// the real one.
-    init(chunks: AsyncStream<Data>, decode: @escaping @Sendable ([Float]) -> SherpaTranscript) {
+    init(
+        chunks: AsyncStream<Data>,
+        decode: @escaping @Sendable ([Float]) -> SherpaDecodeOutcome
+    ) {
         task = Task.detached(priority: .userInitiated) {
             await Self.transcribe(chunks: chunks, decode: decode)
         }
@@ -51,7 +54,7 @@ final class SherpaIncrementalSession: @unchecked Sendable {
 
     private static func transcribe(
         chunks: AsyncStream<Data>,
-        decode: @Sendable ([Float]) -> SherpaTranscript
+        decode: @Sendable ([Float]) -> SherpaDecodeOutcome
     ) async -> SherpaIncrementalResult {
         var samples: [Float] = []
         samples.reserveCapacity(
@@ -72,6 +75,10 @@ final class SherpaIncrementalSession: @unchecked Sendable {
         // to it, so a pause is compared with the speech around it and never
         // with itself.
         var loudestFrame = 0.0
+        // How much of the front of the next chunk the previous split already
+        // decoded. Everything a window can lose sits after it, so it is what
+        // the emptiness of its answer is judged on.
+        var retainedHead = 0
 
         func consume(_ chunk: [Float]) {
             // Silence is judged on the capture as it arrived. The levelling
@@ -83,18 +90,30 @@ final class SherpaIncrementalSession: @unchecked Sendable {
             let level = SherpaLongAudio.loudestFrame(chunk)
             guard !SherpaLongAudio.isEffectivelySilent(loudestFrame: level) else { return }
             let levelled = SpeechAudioConditioning.condition(chunk, peak: peak)
-            let decoded = decode(levelled)
-            // Only a chunk long enough that the recovery has already tried and
-            // failed, and loud enough next to the rest of the recording to have
-            // held speech, is a hole worth re-reading the file for. Below those
-            // bars an empty answer is routine — the retained overlap, the
-            // fragment of a word a recording ending just after a boundary
-            // leaves, the room tone while someone pauses to think — and
-            // treating it as a loss spends a second pass over the whole
-            // recording to find out it was right the first time.
+            let outcome = decode(levelled)
+            // The engine failing to answer is not the model answering nothing.
+            // Either way the seconds are missing from the transcript, so the
+            // whole-file pass has to run — but it is recorded as a loss without
+            // pretending the audio was examined and found empty.
+            guard case let .decoded(decoded) = outcome else {
+                droppedAudibleChunk = true
+                return
+            }
+            // Judged on what this window did not inherit from the one before
+            // it. A window that is mostly retained overlap can be six seconds
+            // long and carry half a second of new speech, and asking whether
+            // the *chunk* was long enough is what let that half second vanish
+            // without the file ever being re-read. Below the bar an empty
+            // answer is routine — the retained overlap itself, a fragment of a
+            // word, the room tone while someone pauses to think — and treating
+            // it as a loss spends a second pass to find out it was right.
+            let newRegion = Array(chunk[min(retainedHead, chunk.count)...])
             if decoded.text.isEmpty,
-               chunk.count > SherpaLongAudio.minimumSuspectChunkSamples,
-               SherpaLongAudio.carriesSpeech(loudestFrame: level, loudestFrameSoFar: loudestFrame)
+               SherpaLongAudio.carriesRecoverableSpeech(
+                   newRegion: newRegion,
+                   loudestFrame: SherpaLongAudio.loudestFrame(newRegion),
+                   loudestFrameSoFar: loudestFrame
+               )
             {
                 droppedAudibleChunk = true
             }
@@ -122,6 +141,7 @@ final class SherpaIncrementalSession: @unchecked Sendable {
                 consume(Array(samples[..<split.endExclusive]))
                 samples.removeFirst(split.nextStart)
                 overlapsPrevious = split.nextStart < split.endExclusive
+                retainedHead = split.endExclusive - split.nextStart
             }
         }
 

--- a/ios/VocaPhoneShared/SherpaIncrementalSession.swift
+++ b/ios/VocaPhoneShared/SherpaIncrementalSession.swift
@@ -111,6 +111,7 @@ final class SherpaIncrementalSession: @unchecked Sendable {
             if decoded.text.isEmpty,
                SherpaLongAudio.carriesRecoverableSpeech(
                    newRegion: newRegion,
+                   inheritsAudio: retainedHead > 0,
                    loudestFrame: SherpaLongAudio.loudestFrame(newRegion),
                    loudestFrameSoFar: loudestFrame
                )

--- a/ios/VocaPhoneShared/SherpaLongAudio.swift
+++ b/ios/VocaPhoneShared/SherpaLongAudio.swift
@@ -172,16 +172,25 @@ enum SherpaLongAudio {
     /// Whether an empty answer for `newRegion` is a loss worth spending decodes
     /// on, rather than the ordinary silence at the end of a recording.
     ///
-    /// Two things have to hold. The region must be longer than the widest
-    /// overlap the chunker ever retains, because below that it cannot be told
-    /// apart from that overlap — a recording ending just after a boundary leaves
-    /// exactly such a tail, and it is a fragment of a word at best. And it must
-    /// carry speech next to what the recording has already been heard to
+    /// It must carry speech next to what the recording has already been heard to
     /// contain, so a trailing pause is not amplified into a retry.
+    ///
+    /// `inheritsAudio` is what the length bar is for, and why it does not always
+    /// apply. A window that begins inside the one before it has to be told apart
+    /// from that retained overlap, and below the widest overlap the chunker ever
+    /// retains it cannot be — a recording ending just after a boundary leaves
+    /// exactly such a tail, a fragment of a word at best. A window that inherited
+    /// nothing has no overlap to be confused with: it is the whole of what the
+    /// user has said, and a two-word dictation is short precisely because that is
+    /// all there was to say. Applying the bar there was what stopped "yes" from
+    /// ever being retried.
     static func carriesRecoverableSpeech(
-        newRegion: [Float], loudestFrame: Double, loudestFrameSoFar: Double
+        newRegion: [Float],
+        inheritsAudio: Bool,
+        loudestFrame: Double,
+        loudestFrameSoFar: Double
     ) -> Bool {
-        guard newRegion.count > overlapSamples else { return false }
+        guard !inheritsAudio || newRegion.count > overlapSamples else { return false }
         return carriesSpeech(loudestFrame: loudestFrame, loudestFrameSoFar: loudestFrameSoFar)
     }
 

--- a/ios/VocaPhoneShared/SherpaLongAudio.swift
+++ b/ios/VocaPhoneShared/SherpaLongAudio.swift
@@ -159,6 +159,32 @@ enum SherpaLongAudio {
         loudestFrame < silentFrameRMS
     }
 
+    /// The part of `chunk` that is not inherited from the window before it.
+    ///
+    /// A chunk that overlaps its predecessor begins with audio that predecessor
+    /// already decoded. Everything a later window can *lose* is what comes after
+    /// that, so it is what the emptiness of its answer has to be judged on.
+    static func newRegion(of samples: [Float], chunk: Chunk, previousEnd: Int) -> [Float] {
+        let start = min(max(chunk.start, previousEnd), chunk.endExclusive)
+        return Array(samples[start..<chunk.endExclusive])
+    }
+
+    /// Whether an empty answer for `newRegion` is a loss worth spending decodes
+    /// on, rather than the ordinary silence at the end of a recording.
+    ///
+    /// Two things have to hold. The region must be longer than the widest
+    /// overlap the chunker ever retains, because below that it cannot be told
+    /// apart from that overlap — a recording ending just after a boundary leaves
+    /// exactly such a tail, and it is a fragment of a word at best. And it must
+    /// carry speech next to what the recording has already been heard to
+    /// contain, so a trailing pause is not amplified into a retry.
+    static func carriesRecoverableSpeech(
+        newRegion: [Float], loudestFrame: Double, loudestFrameSoFar: Double
+    ) -> Bool {
+        guard newRegion.count > overlapSamples else { return false }
+        return carriesSpeech(loudestFrame: loudestFrame, loudestFrameSoFar: loudestFrameSoFar)
+    }
+
     /// Whether `samples` carries speech rather than the room between sentences.
     ///
     /// `loudestFrameSoFar` is the loudest frame heard earlier in the same

--- a/ios/VocaPhoneShared/SherpaLongAudio.swift
+++ b/ios/VocaPhoneShared/SherpaLongAudio.swift
@@ -220,7 +220,15 @@ struct SherpaTranscript: Sendable, Equatable {
 
 /// Joins text from overlapped chunks without writing the repeated boundary words.
 enum SherpaTranscriptMerger {
-    private static let maximumOverlapWords = 12
+    // The audio overlap is half a second at most, whether it came from a chunk
+    // boundary or from the recovery split. A wider text match than that half
+    // second can hold cannot be duplicated audio; it can only be a phrase the
+    // speaker genuinely repeated, and deleting it is the worse error. Android's
+    // `SherpaTranscriptMerger` uses the same bound for the same reason.
+    private static let maximumOverlapWords = 4
+    /// The same bound for scripts written without spaces, where half a second
+    /// of speech is a few characters rather than a few words.
+    private static let maximumOverlapCharacters = 6
 
     static func append(existing: String, next: String, deduplicateOverlap: Bool = true) -> String {
         let left = existing.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -246,7 +254,9 @@ enum SherpaTranscriptMerger {
 
         let leftCharacters = Array(left)
         let rightCharacters = Array(right)
-        let maximum = min(12, leftCharacters.count, rightCharacters.count)
+        let maximum = min(
+            maximumOverlapCharacters, leftCharacters.count, rightCharacters.count
+        )
         let overlap = maximum > 0
             ? stride(from: maximum, through: 1, by: -1).first { count in
                 Array(leftCharacters.suffix(count)) == Array(rightCharacters.prefix(count))

--- a/ios/VocaPhoneShared/SherpaLongAudio.swift
+++ b/ios/VocaPhoneShared/SherpaLongAudio.swift
@@ -1,14 +1,15 @@
 import Foundation
 
 /// Keeps offline encoders away from unbounded long-recording sequences. The
-/// boundary search prefers a quiet 100 ms frame around ten seconds and retains
-/// a short overlap when continuous speech cannot be split cleanly.
+/// boundary search prefers a sustained quiet run around ten seconds and retains
+/// context on every boundary so low-energy phonemes are not lost.
 enum SherpaLongAudio {
     static let sampleRate = 16_000
     static let longAudioThresholdSeconds = 12
     static let targetChunkSeconds = 10
     static let maxChunkSeconds = 14
     static let overlapSamples = sampleRate / 2
+    static let silenceOverlapSamples = sampleRate / 5
     /// A chunk shorter than this answering with no tokens is ordinary rather
     /// than a loss: it is the half second of retained overlap a recording that
     /// ends just after a boundary leaves behind, or a fragment of a word.
@@ -30,6 +31,7 @@ enum SherpaLongAudio {
     }
 
     private static let silenceFrameSamples = sampleRate / 10
+    private static let silenceRunFrames = 3
     private static let silenceSearchSamples = sampleRate * 2
     private static let minChunkSamples = sampleRate * 4
     private static let minSilenceRMS = 0.0125
@@ -62,10 +64,10 @@ enum SherpaLongAudio {
                 maxEnd: min(start + maximum, samples.count - minChunkSamples)
             )
             let end = silence ?? idealEnd
-            let useOverlap = silence == nil
+            let retainedSamples = silence == nil ? overlapSamples : silenceOverlapSamples
             result.append(Chunk(start: start, endExclusive: end, overlapsPrevious: overlapsPrevious))
-            start = useOverlap ? max(end - overlapSamples, start + 1) : end
-            overlapsPrevious = useOverlap
+            start = max(end - retainedSamples, start + 1)
+            overlapsPrevious = true
         }
         return result
     }
@@ -83,10 +85,8 @@ enum SherpaLongAudio {
             maxEnd: streamingWindowSeconds * sampleRate
         )
         let end = silence ?? target
-        return StreamingSplit(
-            endExclusive: end,
-            nextStart: silence == nil ? end - overlapSamples : end
-        )
+        let retainedSamples = silence == nil ? overlapSamples : silenceOverlapSamples
+        return StreamingSplit(endExclusive: end, nextStart: max(end - retainedSamples, 1))
     }
 
     private static func findSilenceBoundary(
@@ -98,22 +98,27 @@ enum SherpaLongAudio {
             / silenceFrameSamples * silenceFrameSamples
         guard first <= last else { return nil }
 
+        var levels: [(Int, Double)] = []
         var peak = 0.0
-        var lowest = Double.greatestFiniteMagnitude
-        var quietStart = -1
         var frame = first
         while frame <= last {
             let value = rms(samples, start: frame, endExclusive: frame + silenceFrameSamples)
             peak = max(peak, value)
-            if value < lowest {
-                lowest = value
-                quietStart = frame
-            }
+            levels.append((frame, value))
             frame += silenceFrameSamples
         }
         let threshold = max(minSilenceRMS, peak * silenceRMSRatio)
-        guard quietStart >= 0, lowest <= threshold else { return nil }
-        return min(max(quietStart + silenceFrameSamples / 2, minEnd), maxEnd)
+        var best: Int?
+        guard levels.count >= silenceRunFrames else { return nil }
+        for start in 0...(levels.count - silenceRunFrames) {
+            let run = levels[start..<(start + silenceRunFrames)]
+            guard run.allSatisfy({ $0.1 <= threshold }) else { continue }
+            let boundary = run.first!.0 + silenceFrameSamples * silenceRunFrames / 2
+            if best == nil || abs(boundary - idealEnd) < abs(best! - idealEnd) {
+                best = boundary
+            }
+        }
+        return best.map { min(max($0, minEnd), maxEnd) }
     }
 
     private static func rms(_ samples: [Float], start: Int, endExclusive: Int) -> Double {

--- a/ios/VocaPhoneShared/TranscriptionQuality.swift
+++ b/ios/VocaPhoneShared/TranscriptionQuality.swift
@@ -25,21 +25,34 @@ enum TranscriptionQuality: String, Codable, CaseIterable, Identifiable, Sendable
         }
     }
 
-    /// No local engine on this platform searches wider than greedy, so nothing
-    /// here may promise that it does. WhisperKit has no beam search at all, and
-    /// every bundled sherpa family is pinned to `greedy_search` — see
-    /// `SherpaFamily.supportsBeamSearch`. What the setting actually buys on iOS
-    /// is re-decoding: how many times a window that came back wrong is tried
-    /// again. Revisit this copy if beam search is ever restored.
-    var detail: String {
-        switch self {
-        case .fast:
-            "Quickest result. Skips the retries that rescue a hard passage."
-        case .balanced:
-            "Retries a window that comes back empty or looks wrong."
-        case .accurate:
-            "Retries hardest before giving up. Noticeably slower on older iPhones."
+    /// What this setting buys, for the engine it is being shown next to.
+    ///
+    /// No local engine on this platform searches wider than greedy — WhisperKit
+    /// has no beam search at all, and every bundled sherpa family is pinned to
+    /// `greedy_search`, see `SherpaFamily.supportsBeamSearch` — so nothing here
+    /// may promise that it does. What is left is re-decoding, and that is where
+    /// the two engines part company: Whisper re-runs a degenerate window at a
+    /// raised temperature and the count comes from this setting, while sherpa's
+    /// empty-result recovery is a fixed ladder that does not consult it. Saying
+    /// otherwise for sherpa describes a control that currently does nothing.
+    func detail(for engine: LocalModelEngine) -> String {
+        switch engine {
+        case .whisperKit: whisperKitDetail
+        case .sherpaOnnx: sherpaDetail
         }
+    }
+
+    private var whisperKitDetail: String {
+        switch self {
+        case .fast: "Quickest result. Skips the retries that rescue a hard passage."
+        case .balanced: "Retries a window that comes back empty or looks wrong."
+        case .accurate: "Retries hardest before giving up. Noticeably slower on older iPhones."
+        }
+    }
+
+    private var sherpaDetail: String {
+        "This model runs one safe decoding mode, so the accuracy setting does "
+            + "not change its result. It applies to Whisper models."
     }
 
     /// How many times a window whose result looks degenerate — too repetitive,

--- a/ios/VocaPhoneShared/TranscriptionQuality.swift
+++ b/ios/VocaPhoneShared/TranscriptionQuality.swift
@@ -25,14 +25,20 @@ enum TranscriptionQuality: String, Codable, CaseIterable, Identifiable, Sendable
         }
     }
 
+    /// No local engine on this platform searches wider than greedy, so nothing
+    /// here may promise that it does. WhisperKit has no beam search at all, and
+    /// every bundled sherpa family is pinned to `greedy_search` — see
+    /// `SherpaFamily.supportsBeamSearch`. What the setting actually buys on iOS
+    /// is re-decoding: how many times a window that came back wrong is tried
+    /// again. Revisit this copy if beam search is ever restored.
     var detail: String {
         switch self {
         case .fast:
             "Quickest result. Skips the retries that rescue a hard passage."
         case .balanced:
-            "Beam search where it is cheap, and a retry when a window looks wrong."
+            "Retries a window that comes back empty or looks wrong."
         case .accurate:
-            "Widest search on every model. Noticeably slower on older iPhones."
+            "Retries hardest before giving up. Noticeably slower on older iPhones."
         }
     }
 
@@ -62,6 +68,10 @@ enum TranscriptionQuality: String, Codable, CaseIterable, Identifiable, Sendable
     }
 
     /// What to ask a sherpa model for *if its family supports beam search*.
+    ///
+    /// No family currently does, so this is unreachable in practice. It stays
+    /// because the mapping is the thing to restore once a fixed runtime is
+    /// pinned, and because deleting it would leave nothing to restore.
     ///
     /// Never pass this to a recognizer without checking
     /// `SherpaFamily.supportsBeamSearch` first: the families that do not

--- a/ios/VocaPhoneTests/SherpaDecodingMethodTests.swift
+++ b/ios/VocaPhoneTests/SherpaDecodingMethodTests.swift
@@ -9,8 +9,8 @@ struct SherpaDecodingMethodTests {
         .nemoTransducer, .senseVoice, .moonshine, .dolphinCtc, .canary, .nemoCtc, .paraformer
     ]
 
-    @Test func onlyTheTransducerFamilyMayBeAskedForBeamSearch() {
-        for family in Self.families where family != .nemoTransducer {
+    @Test func everyBundledFamilyStaysOnGreedySearch() {
+        for family in Self.families {
             for quality in TranscriptionQuality.allCases {
                 #expect(
                     family.decodingMethod(for: quality) == SherpaFamily.greedySearch,
@@ -20,10 +20,10 @@ struct SherpaDecodingMethodTests {
         }
     }
 
-    @Test func theTransducerStillWidensItsSearchWhenQualityAsksForIt() {
+    @Test func parakeetNeverEntersTheUnstableNeMoTDTBeamDecoder() {
         #expect(SherpaFamily.nemoTransducer.decodingMethod(for: .fast) == "greedy_search")
-        #expect(SherpaFamily.nemoTransducer.decodingMethod(for: .balanced) == "modified_beam_search")
-        #expect(SherpaFamily.nemoTransducer.decodingMethod(for: .accurate) == "modified_beam_search")
+        #expect(SherpaFamily.nemoTransducer.decodingMethod(for: .balanced) == "greedy_search")
+        #expect(SherpaFamily.nemoTransducer.decodingMethod(for: .accurate) == "greedy_search")
     }
 
     @Test func everyModelInTheCatalogResolvesToAMethodItsFamilySurvives() {

--- a/ios/VocaPhoneTests/SherpaDecodingMethodTests.swift
+++ b/ios/VocaPhoneTests/SherpaDecodingMethodTests.swift
@@ -76,6 +76,35 @@ struct SherpaDecodingMethodTests {
         #expect(stayedInaudible, "dither must stay inaudible")
     }
 
+    /// Box-Muller reaches for `log` of a uniform, and a uniform built in `Float`
+    /// rounds up to just past 1 about once in every 2^24 draws — one negative
+    /// square root, one `NaN` sample, one empty transcript. At 16 kHz a ten
+    /// second decode draws eighty thousand times, so "rare" is every couple of
+    /// recordings. Far more draws than that, and every one has to be finite.
+    @Test func theDitherNeverWritesANaNIntoTheWaveform() {
+        let dither = SherpaFamily.nemoTransducer.featureDither
+        for _ in 0..<20 {
+            let block = SherpaFeatureDither.applied(
+                to: [Float](repeating: 0, count: 100_000), dither: dither
+            )
+            let allFinite = block.allSatisfy(\.isFinite)
+            #expect(allFinite, "a dithered sample must always be a number")
+        }
+    }
+
+    /// The runtime dithers each decode differently, which is what makes the
+    /// recovery ladder's second attempt worth its inference. Identical noise
+    /// would hand the model identical features and learn nothing.
+    @Test func theDitherIsDrawnFreshForEveryDecode() {
+        let silence = [Float](repeating: 0, count: 4_096)
+        let dither = SherpaFamily.nemoTransducer.featureDither
+
+        let first = SherpaFeatureDither.applied(to: silence, dither: dither)
+        let second = SherpaFeatureDither.applied(to: silence, dither: dither)
+
+        #expect(first != second)
+    }
+
     @Test func aFamilyWithoutDitherIsHandedItsSamplesUntouched() {
         let samples: [Float] = [0.1, -0.2, 0.3, 0]
         #expect(SherpaFeatureDither.applied(to: samples, dither: 0) == samples)

--- a/ios/VocaPhoneTests/SherpaDecodingMethodTests.swift
+++ b/ios/VocaPhoneTests/SherpaDecodingMethodTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 /// sherpa-onnx answers an unsupported decoding method with `exit(-1)`, so a
@@ -78,18 +79,45 @@ struct SherpaDecodingMethodTests {
 
     /// Box-Muller reaches for `log` of a uniform, and a uniform built in `Float`
     /// rounds up to just past 1 about once in every 2^24 draws — one negative
-    /// square root, one `NaN` sample, one empty transcript. At 16 kHz a ten
-    /// second decode draws eighty thousand times, so "rare" is every couple of
-    /// recordings. Far more draws than that, and every one has to be finite.
-    @Test func theDitherNeverWritesANaNIntoTheWaveform() {
-        let dither = SherpaFamily.nemoTransducer.featureDither
-        for _ in 0..<20 {
-            let block = SherpaFeatureDither.applied(
-                to: [Float](repeating: 0, count: 100_000), dither: dither
-            )
-            let allFinite = block.allSatisfy(\.isFinite)
-            #expect(allFinite, "a dithered sample must always be a number")
+    /// square root, one `NaN` sample, one empty transcript.
+    ///
+    /// Asserted at the boundary rather than by sampling. One in 2^24 is not
+    /// something a test suite finds by drawing: an earlier version of this test
+    /// ran twenty blocks of a hundred thousand samples and passed against the
+    /// implementation that produced the `NaN`, because the generator it fed was
+    /// re-seeded identically each call and never left the same safe prefix.
+    @Test func theUniformStaysInsideItsIntervalAtEveryBoundary() {
+        let extremes: [UInt64] = [
+            0, 1, UInt64.max, UInt64.max - 1,
+            // The draw that used to round to exactly 1 in `Float`.
+            (1 << 53) - 1, 1 << 53, ((1 << 53) - 1) << 11,
+            // And the top of each field the shift can expose.
+            (1 << 52) - 1, 1 << 52, ((1 << 52) - 1) << 12, UInt64.max >> 1,
+        ]
+
+        for bits in extremes {
+            let value = SherpaDitherGenerator.unitInterval(bits: bits)
+            #expect(value > 0, "log of \(value) would not be finite")
+            #expect(value <= 1, "\(bits) escaped the interval as \(value)")
+            #expect((-2 * Foundation.log(value)).squareRoot().isFinite)
         }
+    }
+
+    /// The largest draw lands exactly on 1, where `log` is 0 — a magnitude of
+    /// zero, not a special case, and specifically not a hair above 1.
+    @Test func theLargestDrawIsExactlyOne() {
+        #expect(SherpaDitherGenerator.unitInterval(bits: UInt64.max) == 1)
+    }
+
+    /// And the end-to-end guarantee the production path actually needs.
+    @Test func theDitherNeverWritesANaNIntoTheWaveform() {
+        let block = SherpaFeatureDither.applied(
+            to: [Float](repeating: 0, count: 200_000),
+            dither: SherpaFamily.nemoTransducer.featureDither
+        )
+        let allFinite = block.allSatisfy(\.isFinite)
+
+        #expect(allFinite, "a dithered sample must always be a number")
     }
 
     /// The runtime dithers each decode differently, which is what makes the

--- a/ios/VocaPhoneTests/SherpaDecodingMethodTests.swift
+++ b/ios/VocaPhoneTests/SherpaDecodingMethodTests.swift
@@ -36,11 +36,48 @@ struct SherpaDecodingMethodTests {
             }
             for quality in TranscriptionQuality.allCases {
                 let method = family.decodingMethod(for: quality)
+                // Not `method == greedy || family.supportsBeamSearch`: with the
+                // flag false everywhere that reduces to the first clause and
+                // stops asserting anything. What has to hold is that a family
+                // is only ever sent a method it can survive, which for anything
+                // but the transducer means greedy and nothing else.
+                let survivable = family == .nemoTransducer
+                    ? [SherpaFamily.greedySearch, "modified_beam_search"]
+                    : [SherpaFamily.greedySearch]
+                let accepted = survivable.contains(method)
                 #expect(
-                    method == SherpaFamily.greedySearch || family.supportsBeamSearch,
+                    accepted,
                     "\(model.id) would be sent \(method), which \(family) cannot accept"
                 )
             }
         }
+    }
+
+    /// Parakeet's empty-result workaround, and the reason the padded recovery
+    /// retry is not a run of exact zeros into a zero-dither feature extractor.
+    @Test func onlyParakeetCarriesTheUpstreamEmptyResultDither() {
+        #expect(SherpaFamily.nemoTransducer.featureDither == 0.00003)
+        for family in Self.families where family != .nemoTransducer {
+            #expect(family.featureDither == 0, "\(family) does not need dither")
+        }
+    }
+
+    /// The value has to reach the samples, not just sit in the catalog: the
+    /// pinned runtime has no `feat_config.dither` to pass it to.
+    @Test func theDitherActuallyReachesTheWaveform() {
+        let silence = [Float](repeating: 0, count: 640)
+        let dithered = SherpaFeatureDither.applied(
+            to: silence, dither: SherpaFamily.nemoTransducer.featureDither
+        )
+        let movedSomething = dithered.contains { $0 != 0 }
+        let stayedInaudible = dithered.allSatisfy { abs($0) < 0.001 }
+
+        #expect(movedSomething, "a constant window must not stay constant")
+        #expect(stayedInaudible, "dither must stay inaudible")
+    }
+
+    @Test func aFamilyWithoutDitherIsHandedItsSamplesUntouched() {
+        let samples: [Float] = [0.1, -0.2, 0.3, 0]
+        #expect(SherpaFeatureDither.applied(to: samples, dither: 0) == samples)
     }
 }

--- a/ios/VocaPhoneTests/SherpaIncrementalSessionTests.swift
+++ b/ios/VocaPhoneTests/SherpaIncrementalSessionTests.swift
@@ -179,6 +179,7 @@ struct SherpaIncrementalSessionTests {
 
         #expect(!SherpaLongAudio.carriesRecoverableSpeech(
             newRegion: overlapOnly,
+            inheritsAudio: true,
             loudestFrame: SherpaLongAudio.loudestFrame(overlapOnly),
             loudestFrameSoFar: 0.4
         ))
@@ -191,6 +192,7 @@ struct SherpaIncrementalSessionTests {
 
         #expect(SherpaLongAudio.carriesRecoverableSpeech(
             newRegion: region,
+            inheritsAudio: true,
             loudestFrame: SherpaLongAudio.loudestFrame(region),
             loudestFrameSoFar: 0.4
         ))
@@ -203,7 +205,29 @@ struct SherpaIncrementalSessionTests {
 
         #expect(!SherpaLongAudio.carriesRecoverableSpeech(
             newRegion: region,
+            inheritsAudio: true,
             loudestFrame: SherpaLongAudio.loudestFrame(region),
+            loudestFrameSoFar: 0.4
+        ))
+    }
+
+    /// The length bar is for telling new audio apart from retained overlap, so
+    /// it cannot apply where nothing was retained. A one-word dictation is short
+    /// because that is all there was to say, and it was never decoded before.
+    @Test func aSoleWindowShorterThanTheOverlapIsStillRecoverable() {
+        let oneWord = [Float](repeating: 0.4, count: SherpaLongAudio.sampleRate / 4)
+
+        #expect(SherpaLongAudio.carriesRecoverableSpeech(
+            newRegion: oneWord,
+            inheritsAudio: false,
+            loudestFrame: SherpaLongAudio.loudestFrame(oneWord),
+            loudestFrameSoFar: 0
+        ))
+        // The same audio arriving as a tail behind a decoded window is not.
+        #expect(!SherpaLongAudio.carriesRecoverableSpeech(
+            newRegion: oneWord,
+            inheritsAudio: true,
+            loudestFrame: SherpaLongAudio.loudestFrame(oneWord),
             loudestFrameSoFar: 0.4
         ))
     }

--- a/ios/VocaPhoneTests/SherpaIncrementalSessionTests.swift
+++ b/ios/VocaPhoneTests/SherpaIncrementalSessionTests.swift
@@ -41,9 +41,9 @@ struct SherpaIncrementalSessionTests {
     /// What a transducer does: words for a chunk with speech in it, nothing for
     /// a chunk of room tone. Reads the levelled audio the session hands over,
     /// where speech has been brought to the 0.85 target and a pause has not.
-    private static func healthyModel(_ chunk: [Float]) -> SherpaTranscript {
+    private static func healthyModel(_ chunk: [Float]) -> SherpaDecodeOutcome {
         let peak = chunk.reduce(Float(0)) { max($0, abs($1)) }
-        return SherpaTranscript(text: peak > 0.3 ? "spoken" : "")
+        return .decoded(SherpaTranscript(text: peak > 0.3 ? "spoken" : ""))
     }
 
     @Test func aHealthyModelNeverPaysForASecondPass() async {
@@ -81,7 +81,7 @@ struct SherpaIncrementalSessionTests {
             // Exactly the failure this exists for: the first long chunk comes
             // back empty and every later one succeeds, so the merged text reads
             // as a whole sentence that starts ten seconds in.
-            decoded.increment() == 1 ? SherpaTranscript(text: "") : SherpaTranscript(text: "later")
+            decoded.increment() == 1 ? .decoded(SherpaTranscript(text: "")) : .decoded(SherpaTranscript(text: "later"))
         }
         let result = await session.finish()
 
@@ -93,7 +93,7 @@ struct SherpaIncrementalSessionTests {
     @Test func aCompleteRunReportsNothingDropped() async {
         let session = SherpaIncrementalSession(
             chunks: Self.stream(Self.tone(seconds: 25, amplitude: 0.4))
-        ) { _ in SherpaTranscript(text: "spoken") }
+        ) { _ in .decoded(SherpaTranscript(text: "spoken")) }
         let result = await session.finish()
 
         #expect(!result.droppedAudibleChunk)
@@ -103,7 +103,7 @@ struct SherpaIncrementalSessionTests {
     @Test func silenceIsNotMistakenForADroppedChunk() async {
         let session = SherpaIncrementalSession(
             chunks: Self.stream([Float](repeating: 0, count: Self.sampleRate * 25))
-        ) { _ in SherpaTranscript(text: "") }
+        ) { _ in .decoded(SherpaTranscript(text: "")) }
         let result = await session.finish()
 
         // Nothing was said, so nothing was lost, and a whole-file retry of the
@@ -118,7 +118,7 @@ struct SherpaIncrementalSessionTests {
             chunks: Self.stream(Self.tone(seconds: 25, amplitude: 0.05))
         ) { samples in
             peaks.record(samples.reduce(Float(0)) { max($0, abs($1)) })
-            return SherpaTranscript(text: "spoken")
+            return .decoded(SherpaTranscript(text: "spoken"))
         }
         _ = await session.finish()
 
@@ -135,7 +135,7 @@ struct SherpaIncrementalSessionTests {
         let peaks = OSAllocatedPeaks()
         let session = SherpaIncrementalSession(chunks: Self.stream(samples)) { chunk in
             peaks.record(chunk.reduce(Float(0)) { max($0, abs($1)) })
-            return SherpaTranscript(text: "spoken")
+            return .decoded(SherpaTranscript(text: "spoken"))
         }
         _ = await session.finish()
 
@@ -147,25 +147,78 @@ struct SherpaIncrementalSessionTests {
         #expect(peaks.recorded.last! < 0.1)
     }
 
-    @Test func aShortTailThatDecodesToNothingIsNotADroppedChunk() async {
+    /// The bug a chunk-length bar hid. A window can be well under the suspect
+    /// length and still be the last two seconds of the recording: the tail after
+    /// a split is never smaller than the streaming window minus what it
+    /// retained. Asking whether the *chunk* was long enough let a closing
+    /// sentence vanish with nothing downstream able to tell.
+    @Test func aShortTailCarryingNewSpeechIsADroppedChunk() async {
         let sizes = RecordedSizes()
         let session = SherpaIncrementalSession(
             chunks: Self.stream(Self.tone(seconds: 22, amplitude: 0.4))
         ) { samples in
             sizes.record(samples.count)
-            // A recording that ends just after a boundary leaves the half
-            // second of retained overlap and a fragment of a word behind, and
-            // that answers with no tokens all the time.
             return samples.count < 6 * Self.sampleRate
-                ? SherpaTranscript(text: "")
-                : SherpaTranscript(text: "spoken")
+                ? .decoded(SherpaTranscript(text: ""))
+                : .decoded(SherpaTranscript(text: "spoken"))
         }
         let result = await session.finish()
 
         #expect(sizes.recorded.last! < 6 * Self.sampleRate)
-        // Calling that a loss re-runs the whole recording through the model at
-        // finish, which is the exact wait the streaming path exists to remove.
-        #expect(!result.droppedAudibleChunk)
+        #expect(result.droppedAudibleChunk)
+    }
+
+    /// The tail that stays ignorable, stated as the rule the session applies.
+    /// A recording ending just after a boundary leaves the retained overlap
+    /// behind and nothing else, and an empty answer for audio the previous
+    /// window already decoded is not a loss — calling it one re-runs the whole
+    /// recording through the model at finish, which is the exact wait the
+    /// streaming path exists to remove.
+    @Test func aTailThatIsOnlyRetainedOverlapIsNotADroppedChunk() {
+        let overlapOnly = [Float](repeating: 0.4, count: SherpaLongAudio.overlapSamples)
+
+        #expect(!SherpaLongAudio.carriesRecoverableSpeech(
+            newRegion: overlapOnly,
+            loudestFrame: SherpaLongAudio.loudestFrame(overlapOnly),
+            loudestFrameSoFar: 0.4
+        ))
+    }
+
+    /// And the same rule the other way: new audio past the overlap, at the level
+    /// of the speech around it, is a loss whatever the window's total length.
+    @Test func newAudioPastTheOverlapIsRecoverable() {
+        let region = [Float](repeating: 0.4, count: 2 * SherpaLongAudio.sampleRate)
+
+        #expect(SherpaLongAudio.carriesRecoverableSpeech(
+            newRegion: region,
+            loudestFrame: SherpaLongAudio.loudestFrame(region),
+            loudestFrameSoFar: 0.4
+        ))
+    }
+
+    /// Room tone past the overlap is still not a loss: the bar is the level of
+    /// the speech already heard, not merely the presence of samples.
+    @Test func roomTonePastTheOverlapIsNotRecoverable() {
+        let region = [Float](repeating: 0.01, count: 2 * SherpaLongAudio.sampleRate)
+
+        #expect(!SherpaLongAudio.carriesRecoverableSpeech(
+            newRegion: region,
+            loudestFrame: SherpaLongAudio.loudestFrame(region),
+            loudestFrameSoFar: 0.4
+        ))
+    }
+
+    /// A native failure is not a model that heard nothing, but the seconds are
+    /// missing either way, so the whole-file pass still has to run.
+    @Test func aNativeFailureIsCountedAsALossRatherThanAnEmptyAnswer() async {
+        let session = SherpaIncrementalSession(
+            chunks: Self.stream(Self.tone(seconds: 22, amplitude: 0.4))
+        ) { _ in .failed(.streamUnavailable) }
+
+        let result = await session.finish()
+
+        #expect(result.transcript.text.isEmpty)
+        #expect(result.droppedAudibleChunk)
     }
 
     @Test func aPauseInTheMiddleOfARecordingIsNotADroppedChunk() async {
@@ -179,8 +232,8 @@ struct SherpaIncrementalSessionTests {
         let session = SherpaIncrementalSession(chunks: Self.stream(samples)) { chunk in
             decoded.record(chunk.count)
             return decoded.recorded.count > 2
-                ? SherpaTranscript(text: "")
-                : SherpaTranscript(text: "spoken")
+                ? .decoded(SherpaTranscript(text: ""))
+                : .decoded(SherpaTranscript(text: "spoken"))
         }
         let result = await session.finish()
 
@@ -210,8 +263,8 @@ struct SherpaIncrementalSessionTests {
         let session = SherpaIncrementalSession(chunks: Self.stream(samples)) { chunk in
             decoded.record(chunk.count)
             return decoded.recorded.count > 2
-                ? SherpaTranscript(text: "")
-                : SherpaTranscript(text: "spoken")
+                ? .decoded(SherpaTranscript(text: ""))
+                : .decoded(SherpaTranscript(text: "spoken"))
         }
         let result = await session.finish()
 

--- a/ios/VocaPhoneTests/SherpaLongAudioTests.swift
+++ b/ios/VocaPhoneTests/SherpaLongAudioTests.swift
@@ -1,0 +1,298 @@
+import Testing
+
+/// The iOS half of the chunking and empty-result contract.
+///
+/// Every test here has a counterpart in Android's `SherpaLongAudioTest`, with
+/// the same fixtures and the same expected sample counts. The two platforms
+/// drifted apart once already — iOS cut at the single quietest frame and
+/// surrendered its overlap where Android required a sustained quiet run and
+/// kept context either way — and nothing failed to say so. These are what
+/// notice next time.
+struct SherpaLongAudioTests {
+    private static let rate = SherpaLongAudio.sampleRate
+
+    private static func tone(seconds: Int, amplitude: Float = 0.2) -> [Float] {
+        [Float](repeating: amplitude, count: seconds * rate)
+    }
+
+    // MARK: - Chunk ranges
+
+    @Test func shortAudioKeepsOneDecodeRange() {
+        let chunks = SherpaLongAudio.chunks(Self.tone(seconds: 12, amplitude: 0))
+
+        #expect(chunks.count == 1)
+        #expect(chunks[0].start == 0)
+        #expect(chunks[0].endExclusive == 192_000)
+        #expect(chunks[0].overlapsPrevious == false)
+    }
+
+    @Test func continuousLongAudioIsBoundedAndOverlapsEveryBoundary() {
+        let samples = Self.tone(seconds: 52)
+
+        let chunks = SherpaLongAudio.chunks(samples)
+
+        let bounded = chunks.allSatisfy { $0.endExclusive - $0.start <= 14 * Self.rate }
+        let everyBoundaryOverlaps = chunks.dropFirst().allSatisfy(\.overlapsPrevious)
+        let contiguous = zip(chunks, chunks.dropFirst()).allSatisfy { $1.start < $0.endExclusive }
+
+        #expect(chunks.count >= 3)
+        #expect(bounded)
+        #expect(everyBoundaryOverlaps)
+        #expect(contiguous)
+        #expect(chunks.last?.endExclusive == samples.count)
+    }
+
+    @Test func theEighteenSecondDeviceRegressionIsNeverOneDecode() {
+        let samples = Self.tone(seconds: 18)
+
+        let chunks = SherpaLongAudio.chunks(samples)
+
+        let bounded = chunks.allSatisfy { $0.endExclusive - $0.start <= 12 * Self.rate }
+
+        #expect(chunks.count >= 2)
+        #expect(bounded)
+        #expect(chunks.last?.endExclusive == samples.count)
+    }
+
+    // MARK: - Boundary evidence and overlap
+
+    @Test func aQuietBoundaryIsPreferredWithoutSurrenderingOverlap() {
+        var samples = Self.tone(seconds: 52)
+        let silenceStart = 9 * Self.rate
+        let silenceEnd = silenceStart + Self.rate
+        for index in silenceStart..<silenceEnd { samples[index] = 0 }
+
+        let chunks = SherpaLongAudio.chunks(samples)
+
+        #expect(chunks[0].overlapsPrevious == false)
+        #expect((silenceStart...silenceEnd).contains(chunks[0].endExclusive))
+        #expect(chunks[1].overlapsPrevious)
+        // A found quiet run still hands context to the next chunk, just less of
+        // it than a guessed boundary needs.
+        #expect(chunks[1].start == chunks[0].endExclusive - SherpaLongAudio.silenceOverlapSamples)
+    }
+
+    @Test func aGuessedBoundaryKeepsTheWiderOverlap() {
+        let chunks = SherpaLongAudio.chunks(Self.tone(seconds: 52))
+
+        #expect(chunks[1].start == chunks[0].endExclusive - SherpaLongAudio.overlapSamples)
+    }
+
+    /// The bug the sustained-run requirement exists for: a single quiet 100 ms
+    /// frame is a low-energy phoneme as often as it is a pause, and cutting
+    /// there loses the word around it.
+    @Test func oneQuietFrameInsideSpeechIsNotTrustedAsABoundary() {
+        var samples = Self.tone(seconds: 30)
+        let gap = 10 * Self.rate
+        for index in gap..<(gap + Self.rate / 10) { samples[index] = 0 }
+
+        let chunks = SherpaLongAudio.chunks(samples)
+
+        #expect(chunks[0].endExclusive == 10 * Self.rate)
+    }
+
+    @Test func streamingSplitReleasesABoundedPrefixWithOverlap() {
+        let split = SherpaLongAudio.nextStreamingSplit(
+            Self.tone(seconds: SherpaLongAudio.streamingWindowSeconds)
+        )
+
+        #expect(split?.endExclusive == 10 * Self.rate)
+        #expect(split?.nextStart == 10 * Self.rate - SherpaLongAudio.overlapSamples)
+    }
+
+    /// The streaming path retains context at a found boundary too, which is
+    /// what makes `overlapsPrevious` true for the chunk after it.
+    @Test func aStreamingQuietBoundaryStillRetainsContext() {
+        var samples = Self.tone(seconds: SherpaLongAudio.streamingWindowSeconds)
+        let silenceStart = 9 * Self.rate
+        for index in silenceStart..<(silenceStart + Self.rate) { samples[index] = 0 }
+
+        guard let split = SherpaLongAudio.nextStreamingSplit(samples) else {
+            Issue.record("a full streaming window should always split")
+            return
+        }
+
+        #expect(split.nextStart < split.endExclusive)
+        #expect(split.nextStart == split.endExclusive - SherpaLongAudio.silenceOverlapSamples)
+    }
+
+    // MARK: - Empty-result recovery
+
+    @Test func anEmptyLongChunkRetriesAsOverlappingShortDecodes() {
+        var decodedSizes: [Int] = []
+        var shortResult = 0
+
+        let transcript = SherpaEmptyChunkRecovery.decode(
+            samples: Self.tone(seconds: 10),
+            decodeOnce: { samples in
+                decodedSizes.append(samples.count)
+                if samples.count > SherpaLongAudio.minimumSuspectChunkSamples {
+                    return .empty
+                }
+                defer { shortResult += 1 }
+                return SherpaTranscript(text: shortResult == 0 ? "first half" : "second half")
+            },
+            deduplicateOverlap: true
+        )
+
+        #expect(transcript.text == "first half second half")
+        // Half the boundary overlap on each side, exactly as Android splits.
+        #expect(decodedSizes == [160_000, 84_000, 84_000])
+    }
+
+    @Test func anEmptyShortChunkIsNotWorthARetry() {
+        var decodedSizes: [Int] = []
+
+        _ = SherpaEmptyChunkRecovery.decode(
+            samples: Self.tone(seconds: 5),
+            decodeOnce: { samples in
+                decodedSizes.append(samples.count)
+                return .empty
+            },
+            deduplicateOverlap: true
+        )
+
+        // Below the suspect bar an empty answer is ordinary — a fragment of a
+        // word, or the retained overlap a recording ending just after a
+        // boundary leaves — and length is not what dropped it.
+        #expect(decodedSizes == [80_000])
+    }
+
+    @Test func anAudibleCompleteShortRecordingGetsABoundedFreshStreamRetry() {
+        var decodedSizes: [Int] = []
+        var attempts = 0
+
+        let transcript = SherpaEmptyChunkRecovery.decode(
+            samples: Self.tone(seconds: 5),
+            decodeOnce: { samples in
+                decodedSizes.append(samples.count)
+                defer { attempts += 1 }
+                return SherpaTranscript(text: attempts == 1 ? "recovered" : "")
+            },
+            deduplicateOverlap: true,
+            recoverAudibleShortInput: true
+        )
+
+        #expect(transcript.text == "recovered")
+        #expect(decodedSizes == [80_000, 80_000])
+    }
+
+    @Test func aShortRecordingStillEmptyOnAFreshStreamIsPaddedThenSplit() {
+        var decodedSizes: [Int] = []
+
+        _ = SherpaEmptyChunkRecovery.decode(
+            samples: Self.tone(seconds: 3),
+            decodeOnce: { samples in
+                decodedSizes.append(samples.count)
+                return .empty
+            },
+            deduplicateOverlap: true,
+            recoverAudibleShortInput: true
+        )
+
+        // Whole, whole again, padded half a second either side, then the two
+        // halves. The ladder is fixed-length: it never subdivides again.
+        #expect(decodedSizes == [48_000, 48_000, 64_000, 28_000, 28_000])
+    }
+
+    /// A very short recording must not hand both halves the whole waveform.
+    @Test func theRecoverySplitNeverDecodesTheWholeWaveformTwice() {
+        var decodedSizes: [Int] = []
+
+        _ = SherpaEmptyChunkRecovery.decode(
+            samples: [Float](repeating: 0.2, count: Self.rate / 4),
+            decodeOnce: { samples in
+                decodedSizes.append(samples.count)
+                return .empty
+            },
+            deduplicateOverlap: true,
+            recoverAudibleShortInput: true
+        )
+
+        let bothHalvesAreSmaller = decodedSizes.suffix(2).allSatisfy { $0 < Self.rate / 4 }
+        #expect(bothHalvesAreSmaller)
+    }
+
+    @Test func aSilentChunkIsNeverRetried() {
+        var decodedSizes: [Int] = []
+
+        _ = SherpaEmptyChunkRecovery.decode(
+            samples: Self.tone(seconds: 10, amplitude: 0),
+            decodeOnce: { samples in
+                decodedSizes.append(samples.count)
+                return .empty
+            },
+            deduplicateOverlap: true,
+            recoverAudibleShortInput: true
+        )
+
+        // Not one decode: room tone answering with nothing is the right answer,
+        // and it is ruled out before any inference is spent.
+        #expect(decodedSizes.isEmpty)
+    }
+
+    @Test func aHalfThatIsStillEmptyIsNotSubdividedAgain() {
+        var decodedSizes: [Int] = []
+
+        _ = SherpaEmptyChunkRecovery.decode(
+            samples: Self.tone(seconds: 14),
+            decodeOnce: { samples in
+                decodedSizes.append(samples.count)
+                return .empty
+            },
+            deduplicateOverlap: true
+        )
+
+        #expect(decodedSizes == [224_000, 116_000, 116_000])
+    }
+
+    /// Translated windows are joined verbatim: the same audio does not come
+    /// back as the same words, so nothing can pair the repeat.
+    @Test func aTranslatedRecoverySplitIsNeverTextDeduplicated() {
+        let transcript = SherpaEmptyChunkRecovery.decode(
+            samples: Self.tone(seconds: 10),
+            decodeOnce: { samples in
+                samples.count > SherpaLongAudio.minimumSuspectChunkSamples
+                    ? .empty
+                    : SherpaTranscript(text: "to the shop")
+            },
+            deduplicateOverlap: false
+        )
+
+        #expect(transcript.text == "to the shop to the shop")
+    }
+
+    // MARK: - Merge width
+
+    @Test func overlappedWordsAreMergedOnce() {
+        #expect(SherpaTranscriptMerger.append(existing: "hello world", next: "world again")
+            == "hello world again")
+        #expect(SherpaTranscriptMerger.append(existing: "Hello", next: "Hello, there.")
+            == "Hello, there.")
+        #expect(SherpaTranscriptMerger.append(
+            existing: "yes", next: "yes", deduplicateOverlap: false
+        ) == "yes yes")
+    }
+
+    /// The audio overlap is half a second at most, so a match wider than that
+    /// can only be a phrase the speaker genuinely repeated. Deleting it is the
+    /// worse error, and iOS used to allow a match three times too wide.
+    @Test func aPhraseWiderThanTheAudioOverlapIsPreservedAsRepetition() {
+        #expect(SherpaTranscriptMerger.append(
+            existing: "start one two three four five",
+            next: "one two three four five end"
+        ) == "start one two three four five one two three four five end")
+    }
+
+    @Test func deduplicationRemovesARepetitionThatTranslatingMustKeep() {
+        let left = "I went to the shop"
+        let right = "to the shop and then home"
+
+        #expect(SherpaTranscriptMerger.append(
+            existing: left, next: right, deduplicateOverlap: true
+        ) == "I went to the shop and then home")
+        #expect(SherpaTranscriptMerger.append(
+            existing: left, next: right, deduplicateOverlap: false
+        ) == "I went to the shop to the shop and then home")
+    }
+}

--- a/ios/VocaPhoneTests/SherpaLongAudioTests.swift
+++ b/ios/VocaPhoneTests/SherpaLongAudioTests.swift
@@ -195,6 +195,25 @@ struct SherpaLongAudioTests {
         #expect(decodedSizes == [48_000, 48_000, 64_000, 28_000, 28_000])
     }
 
+    /// The extra rungs are for short speech. A long first chunk with nothing
+    /// decoded ahead of it is still a long window: repeating it and padding it
+    /// costs two whole further decodes and recovers what the split already does.
+    @Test func aLongWindowKeepsTheSplitLadderEvenWithNothingDecodedBeforeIt() {
+        var decodedSizes: [Int] = []
+
+        _ = SherpaEmptyChunkRecovery.decode(
+            samples: Self.tone(seconds: 10),
+            decodeOnce: { samples in
+                decodedSizes.append(samples.count)
+                return .empty
+            },
+            deduplicateOverlap: true,
+            recoverAudibleShortInput: true
+        )
+
+        #expect(decodedSizes == [160_000, 84_000, 84_000])
+    }
+
     /// A very short recording must not hand both halves the whole waveform.
     @Test func theRecoverySplitNeverDecodesTheWholeWaveformTwice() {
         var decodedSizes: [Int] = []

--- a/ios/VocaPhoneTests/SherpaLongAudioTests.swift
+++ b/ios/VocaPhoneTests/SherpaLongAudioTests.swift
@@ -130,12 +130,14 @@ struct SherpaLongAudioTests {
                     return .empty
                 }
                 defer { shortResult += 1 }
-                return SherpaTranscript(text: shortResult == 0 ? "first half" : "second half")
+                return .decoded(
+                    SherpaTranscript(text: shortResult == 0 ? "first half" : "second half")
+                )
             },
             deduplicateOverlap: true
         )
 
-        #expect(transcript.text == "first half second half")
+        #expect(transcript.transcriptOrEmpty.text == "first half second half")
         // Half the boundary overlap on each side, exactly as Android splits.
         #expect(decodedSizes == [160_000, 84_000, 84_000])
     }
@@ -167,13 +169,13 @@ struct SherpaLongAudioTests {
             decodeOnce: { samples in
                 decodedSizes.append(samples.count)
                 defer { attempts += 1 }
-                return SherpaTranscript(text: attempts == 1 ? "recovered" : "")
+                return .decoded(SherpaTranscript(text: attempts == 1 ? "recovered" : ""))
             },
             deduplicateOverlap: true,
             recoverAudibleShortInput: true
         )
 
-        #expect(transcript.text == "recovered")
+        #expect(transcript.transcriptOrEmpty.text == "recovered")
         #expect(decodedSizes == [80_000, 80_000])
     }
 
@@ -273,12 +275,65 @@ struct SherpaLongAudioTests {
             decodeOnce: { samples in
                 samples.count > SherpaLongAudio.minimumSuspectChunkSamples
                     ? .empty
-                    : SherpaTranscript(text: "to the shop")
+                    : .decoded(SherpaTranscript(text: "to the shop"))
             },
             deduplicateOverlap: false
         )
 
-        #expect(transcript.text == "to the shop to the shop")
+        #expect(transcript.transcriptOrEmpty.text == "to the shop to the shop")
+    }
+
+    // MARK: - Native failures never enter the ladder
+
+    /// The amplification the typed outcome removes. A recognizer that will not
+    /// open a stream answers with no text, and the ladder used to read that as
+    /// a model with nothing to say — spending four more decodes on the same
+    /// broken state and then reporting it as an empty transcript.
+    @Test func aNativeFailureStopsTheLadderAtOnce() {
+        var attempts = 0
+
+        let outcome = SherpaEmptyChunkRecovery.decode(
+            samples: Self.tone(seconds: 3),
+            decodeOnce: { _ in
+                attempts += 1
+                return .failed(.streamUnavailable)
+            },
+            deduplicateOverlap: true,
+            recoverAudibleShortInput: true
+        )
+
+        #expect(attempts == 1)
+        #expect(outcome.nativeFailure == .streamUnavailable)
+    }
+
+    /// Including partway up the ladder: the first decode can answer and a later
+    /// rung still find the engine gone.
+    @Test func aNativeFailureOnARetryIsNotReadAsAnEmptyResult() {
+        var attempts = 0
+
+        let outcome = SherpaEmptyChunkRecovery.decode(
+            samples: Self.tone(seconds: 3),
+            decodeOnce: { _ in
+                attempts += 1
+                return attempts == 1 ? .empty : .failed(.resultMissing)
+            },
+            deduplicateOverlap: true,
+            recoverAudibleShortInput: true
+        )
+
+        #expect(attempts == 2)
+        #expect(outcome.nativeFailure == .resultMissing)
+    }
+
+    /// A truncated transcript is the opposite failure to an empty one — text was
+    /// produced and lost — and must never be reported as no speech.
+    @Test func everyBridgeStatusMapsToItsOwnFailure() {
+        #expect(SherpaNativeFailure.forStatus(-1) == .invalidArgument)
+        #expect(SherpaNativeFailure.forStatus(-2) == .streamUnavailable)
+        #expect(SherpaNativeFailure.forStatus(-3) == .resultMissing)
+        #expect(SherpaNativeFailure.forStatus(-4) == .outputTruncated)
+        // A status the bridge grows later must not read as a successful decode.
+        #expect(SherpaNativeFailure.forStatus(-99) == .unknown)
     }
 
     // MARK: - Merge width


### PR DESCRIPTION
## Summary

- Makes on-device Sherpa transcription and translation recover reliably when an audible recording initially returns no text.
- Keeps every bundled Sherpa family on greedy decoding while the upstream NeMo TDT beam issue remains unresolved.

## Problem

Canary, Moonshine, and Parakeet could intermittently fail with an empty transcript. Parakeet used the unstable NeMo TDT beam decoder on iOS; a complete short recording had no recovery path; and iOS chunks could cut low-energy speech at a quiet boundary without retained context.

## Changes

- Serialize iOS native recognizer decodes and retain overlap around sustained-quiet chunk boundaries.
- Retry a complete, audible short recording with a fresh stream and bounded padding before the existing split recovery.
- Apply the bounded short-recording recovery on Android, preserving translation-safe non-deduplicated seams.

## Verification

- [x] `just ios ci` (559 tests)
- [x] `just android ci` (unit tests, lint, full debug APK, 16 KB native alignment)
- [x] Gateway changes: N/A; no gateway changes
- [ ] Physical-device test: not run; validate Canary, Moonshine, and Parakeet transcription/translation on iOS and Android

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated: N/A; no data-flow, permission, retention, or network change