### PR TITLE
feat(android): write dictated numbers as digits

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/core/DictatedTranscript.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/DictatedTranscript.kt
@@ -18,9 +18,8 @@ package com.vocahq.vocaphone.core
  * 3. Style — but only for transcripts produced on this device. A gateway has
  *    already applied the writing style the session asked for, and applying it
  *    twice is how "Hello." becomes "Hello.." on one route and not the other.
- *
- * Mirrors the iOS client's `DictatedTranscript`, minus the digits step, which
- * only that platform has.
+ * 4. Digits — after styling, so sentence capitalization can still see the
+ *    first word; never before snippet expansion, which happens in delivery.
  */
 object DictatedTranscript {
     fun finished(
@@ -29,6 +28,7 @@ object DictatedTranscript {
         language: String = "auto",
         styledUpstream: Boolean = false,
         repairSpeech: Boolean,
+        numbersAsDigits: Boolean = false,
     ): String {
         val cleaned = TranscriptSanitizer.clean(raw)
         val repaired = if (repairSpeech && style != WritingStyle.RAW) {
@@ -36,6 +36,7 @@ object DictatedTranscript {
         } else {
             cleaned
         }
-        return if (styledUpstream) repaired else TranscriptStyler.apply(repaired, style, language)
+        val styled = if (styledUpstream) repaired else TranscriptStyler.apply(repaired, style, language)
+        return if (numbersAsDigits) SpokenNumbers.digitsIn(styled) else styled
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/DictatedTranscript.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/DictatedTranscript.kt
@@ -19,7 +19,8 @@ package com.vocahq.vocaphone.core
  *    already applied the writing style the session asked for, and applying it
  *    twice is how "Hello." becomes "Hello.." on one route and not the other.
  * 4. Digits — after styling, so sentence capitalization can still see the
- *    first word; never before snippet expansion, which happens in delivery.
+ *    first word. Matching snippets are protected so a number-word trigger
+ *    still expands literally after digit conversion finishes.
  */
 object DictatedTranscript {
     fun finished(
@@ -29,6 +30,7 @@ object DictatedTranscript {
         styledUpstream: Boolean = false,
         repairSpeech: Boolean,
         numbersAsDigits: Boolean = false,
+        snippets: List<Snippet> = emptyList(),
     ): String {
         val cleaned = TranscriptSanitizer.clean(raw)
         val repaired = if (repairSpeech && style != WritingStyle.RAW) {
@@ -37,6 +39,9 @@ object DictatedTranscript {
             cleaned
         }
         val styled = if (styledUpstream) repaired else TranscriptStyler.apply(repaired, style, language)
-        return if (numbersAsDigits) SpokenNumbers.digitsIn(styled) else styled
+        if (!numbersAsDigits) return SnippetExpander.expand(styled, snippets)
+
+        val protected = SnippetExpander.protect(styled, snippets)
+        return protected.restore(SpokenNumbers.digitsIn(protected.text))
     }
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/SnippetExpander.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/SnippetExpander.kt
@@ -5,11 +5,11 @@ import java.util.regex.Pattern
 /**
  * Expands snippet triggers into their literal expansion text.
  *
- * Runs after [DictatedTranscript.finished], never before: the writing style
- * capitalizes sentence starts and would otherwise rewrite a snippet's literal
- * expansion (an email trigger must not come out "Me@example.com"). Matching
- * itself is case-insensitive, so capitalizing the source text first does not
- * break it.
+ * Matching runs after writing style: capitalization cannot rewrite a snippet's
+ * literal expansion (an email trigger must not come out "Me@example.com"), and
+ * case-insensitive matching still finds a capitalized trigger. When digit
+ * conversion is on, [DictatedTranscript] protects a matched expansion while it
+ * converts the surrounding text, then restores the literal expansion last.
  *
  * One combined regex over every trigger rather than a snippet-by-snippet
  * loop, so an expansion that happens to contain another trigger is never
@@ -19,6 +19,51 @@ import java.util.regex.Pattern
 object SnippetExpander {
 
     fun expand(text: String, snippets: List<Snippet>): String {
+        val matches = matchingExpansions(text, snippets)
+        if (matches.isEmpty()) return text
+
+        val result = StringBuilder(text)
+        for (match in matches.asReversed()) {
+            result.replace(match.start, match.end, match.expansion)
+        }
+        return result.toString()
+    }
+
+    /**
+     * Matches snippet triggers before another text stage rewrites them, while
+     * keeping the user's expansion opaque to that stage. The restored text is
+     * exactly the literal expansion, as though [expand] had run last.
+     */
+    fun protect(text: String, snippets: List<Snippet>): ProtectedExpansions {
+        val matches = matchingExpansions(text, snippets)
+        if (matches.isEmpty()) return ProtectedExpansions(text, emptyList())
+
+        val expansions = matches.map { it.expansion }
+        val result = StringBuilder(text)
+        for (index in matches.indices.reversed()) {
+            val match = matches[index]
+            result.replace(match.start, match.end, "$OPEN$index$CLOSE")
+        }
+        return ProtectedExpansions(result.toString(), expansions)
+    }
+
+    class ProtectedExpansions internal constructor(
+        val text: String,
+        private val expansions: List<String>,
+    ) {
+        fun restore(text: String): String = PLACEHOLDER.replace(text) { match ->
+            val index = match.groupValues[1].toIntOrNull() ?: return@replace match.value
+            expansions.getOrNull(index) ?: match.value
+        }
+    }
+
+    private data class ExpansionMatch(
+        val start: Int,
+        val end: Int,
+        val expansion: String,
+    )
+
+    private fun matchingExpansions(text: String, snippets: List<Snippet>): List<ExpansionMatch> {
         // A blank expansion is skipped rather than applied: settings will not
         // save one, and a stored one would quietly delete its trigger from
         // every transcript, which is never what an empty field meant.
@@ -28,7 +73,7 @@ object SnippetExpander {
             // Longer, more specific triggers win over a shorter one that could
             // be a substring of it ("my email" before "email").
             .sortedByDescending { it.trigger.length }
-        if (active.isEmpty()) return text
+        if (active.isEmpty()) return emptyList()
 
         // A trigger that cannot be compiled must cost the user the expansion,
         // not the dictation: without this the throw propagates out of deliver()
@@ -38,23 +83,21 @@ object SnippetExpander {
                 active.joinToString("|") { "(${boundaryPattern(it.trigger)})" },
                 Pattern.CASE_INSENSITIVE or Pattern.UNICODE_CASE,
             )
-        }.getOrNull() ?: return text
+        }.getOrNull() ?: return emptyList()
         val matcher = pattern.matcher(text)
-        val matches = mutableListOf<Triple<Int, Int, Int>>()
+        val matches = mutableListOf<ExpansionMatch>()
         while (matcher.find()) {
             // Exactly one branch of the alternation can have matched, but skip
             // rather than throw if that ever stops holding: this runs inside
             // delivery, where an exception costs the whole transcript.
             val groupIndex = (1..active.size).firstOrNull { matcher.group(it) != null } ?: continue
-            matches += Triple(matcher.start(), matcher.end(), groupIndex - 1)
+            matches += ExpansionMatch(
+                start = matcher.start(),
+                end = matcher.end(),
+                expansion = active[groupIndex - 1].expansion,
+            )
         }
-        if (matches.isEmpty()) return text
-
-        val result = StringBuilder(text)
-        for ((start, end, index) in matches.asReversed()) {
-            result.replace(start, end, active[index].expansion)
-        }
-        return result.toString()
+        return matches
     }
 
     /**
@@ -80,4 +123,7 @@ object SnippetExpander {
 
     /** Letters and digits in any script, plus the underscore. */
     private const val WORD = "[\\p{L}\\p{N}_]"
+    private const val OPEN = "\uE100"
+    private const val CLOSE = "\uE101"
+    private val PLACEHOLDER = Regex("$OPEN(\\d+)$CLOSE")
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/SpokenNumbers.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/SpokenNumbers.kt
@@ -1,0 +1,245 @@
+package com.vocahq.vocaphone.core
+
+import java.util.Locale
+
+/**
+ * Rewrites dictated English number words as digits: "six pm at the office"
+ * becomes "6 pm at the office".
+ *
+ * This is deliberately conservative. Adjacent number words convert only when
+ * the complete run is one valid number; a lone "one" needs a following unit;
+ * and ordinals and spoken times stay exactly as the user said them. The word
+ * lists are English-only, so text in other languages passes through unchanged.
+ */
+object SpokenNumbers {
+    const val MAXIMUM = 999_999_999_999L
+
+    private val quantifyingUnits = setOf(
+        "am", "pm", "o'clock", "oclock",
+        "hour", "hours", "hr", "hrs",
+        "minute", "minutes", "min", "mins",
+        "second", "seconds", "sec", "secs",
+        "percent",
+        "dollar", "dollars", "rupee", "rupees", "euro", "euros",
+        "pound", "pounds", "cent", "cents",
+        "kg", "kilo", "kilos", "kilogram", "kilograms",
+        "gram", "grams", "km", "kilometre", "kilometres", "kilometer", "kilometers",
+        "mile", "miles", "metre", "metres", "meter", "meters",
+        "litre", "litres", "liter", "liters", "ml",
+        "degree", "degrees", "star", "stars",
+        "kb", "mb", "gb", "tb", "mph", "kmph",
+    )
+
+    private val ordinalWords = setOf(
+        "first", "third", "fourth", "fifth", "sixth", "seventh", "eighth",
+        "ninth", "tenth", "eleventh", "twelfth", "thirteenth", "fourteenth",
+        "fifteenth", "sixteenth", "seventeenth", "eighteenth", "nineteenth",
+        "twentieth", "thirtieth", "fortieth", "fiftieth", "sixtieth",
+        "seventieth", "eightieth", "ninetieth", "hundredth", "thousandth", "millionth",
+    )
+
+    private val wordPattern = Regex("[A-Za-z]+(?:['’][A-Za-z]+)*")
+
+    /** Converts only number phrases that can be parsed without guessing. */
+    fun digitsIn(text: String): String {
+        if (text.isEmpty()) return text
+        val words = wordPattern.findAll(text).toList()
+        if (words.isEmpty()) return text
+
+        val result = StringBuilder()
+        var copied = 0
+        var index = 0
+        while (index < words.size) {
+            val first = wordFor(words[index].value)
+            if (first?.opensANumber != true) {
+                index += 1
+                continue
+            }
+
+            val tokens = mutableListOf(first)
+            var last = index
+            while (
+                last + 1 < words.size &&
+                isJoiner(last, words, text)
+            ) {
+                val next = wordFor(words[last + 1].value) ?: break
+                if (!next.mayExtend(tokens)) break
+                tokens += next
+                last += 1
+            }
+            while (tokens.lastOrNull()?.isConnector == true) {
+                tokens.removeAt(tokens.lastIndex)
+                last -= 1
+            }
+
+            val phrase = tokens.takeIf { it.isNotEmpty() }?.let(::parse)
+            if (phrase == null || !isWorthConverting(tokens, last, words, text)) {
+                // Keep an invalid run whole rather than converting pieces of it.
+                index = last + 1
+                continue
+            }
+
+            result.append(text, copied, words[index].range.first)
+            result.append(phrase.formatted)
+            copied = words[last].range.last + 1
+            index = last + 1
+        }
+        result.append(text, copied, text.length)
+        return result.toString()
+    }
+
+    private fun isWorthConverting(
+        tokens: List<Token>,
+        last: Int,
+        words: List<MatchResult>,
+        text: String,
+    ): Boolean {
+        val following = words.getOrNull(last + 1)?.let { next ->
+            next.value.lowercase(Locale.ROOT) to text.substring(words[last].range.last + 1, next.range.first)
+        }
+        if (following != null && following.second in setOf(" ", "-", "‑") &&
+            following.first in ordinalWords
+        ) return false
+
+        if (tokens != listOf(UnitValue(1))) return true
+        return following?.let { (word, gap) -> gap == " " && word in quantifyingUnits } == true
+    }
+
+    private fun isJoiner(index: Int, words: List<MatchResult>, text: String): Boolean {
+        val gap = text.substring(words[index].range.last + 1, words[index + 1].range.first)
+        return gap == " " || gap == "-" || gap == "‑"
+    }
+
+    private sealed interface Token {
+        val opensANumber: Boolean
+        val isConnector: Boolean get() = false
+        fun mayExtend(tokens: List<Token>): Boolean = when (this) {
+            And -> tokens.lastOrNull() is Hundred || tokens.lastOrNull() is Scale
+            Point -> tokens.lastOrNull()?.isConnector == false
+            else -> true
+        }
+    }
+
+    private data class UnitValue(val value: Int) : Token { override val opensANumber = true }
+    private data class Teen(val value: Int) : Token { override val opensANumber = true }
+    private data class Tens(val value: Int) : Token { override val opensANumber = true }
+    private data object Hundred : Token { override val opensANumber = false }
+    private data class Scale(val value: Long) : Token { override val opensANumber = false }
+    private data object And : Token {
+        override val opensANumber = false
+        override val isConnector = true
+    }
+    private data object Point : Token {
+        override val opensANumber = false
+        override val isConnector = true
+    }
+
+    private data class Phrase(val value: Long, val decimals: String) {
+        val formatted: String get() = if (decimals.isEmpty()) "$value" else "$value.$decimals"
+    }
+
+    private fun wordFor(text: String): Token? = when (text.lowercase(Locale.ROOT)) {
+        "zero" -> UnitValue(0)
+        "one" -> UnitValue(1)
+        "two" -> UnitValue(2)
+        "three" -> UnitValue(3)
+        "four" -> UnitValue(4)
+        "five" -> UnitValue(5)
+        "six" -> UnitValue(6)
+        "seven" -> UnitValue(7)
+        "eight" -> UnitValue(8)
+        "nine" -> UnitValue(9)
+        "ten" -> Teen(10)
+        "eleven" -> Teen(11)
+        "twelve" -> Teen(12)
+        "thirteen" -> Teen(13)
+        "fourteen" -> Teen(14)
+        "fifteen" -> Teen(15)
+        "sixteen" -> Teen(16)
+        "seventeen" -> Teen(17)
+        "eighteen" -> Teen(18)
+        "nineteen" -> Teen(19)
+        "twenty" -> Tens(20)
+        "thirty" -> Tens(30)
+        "forty", "fourty" -> Tens(40)
+        "fifty" -> Tens(50)
+        "sixty" -> Tens(60)
+        "seventy" -> Tens(70)
+        "eighty" -> Tens(80)
+        "ninety" -> Tens(90)
+        "hundred" -> Hundred
+        "thousand" -> Scale(1_000)
+        "million" -> Scale(1_000_000)
+        "billion" -> Scale(1_000_000_000)
+        "and" -> And
+        "point" -> Point
+        else -> null
+    }
+
+    private fun parse(tokens: List<Token>): Phrase? {
+        var total = 0L
+        var group = 0L
+        val decimals = StringBuilder()
+        var isDecimal = false
+        var smallestScale = Long.MAX_VALUE
+        var previous: Token? = null
+
+        for (token in tokens) {
+            if (!mayFollow(previous, token, isDecimal)) return null
+            when (token) {
+                is UnitValue -> if (isDecimal) decimals.append(token.value) else group += token.value
+                is Teen -> group += token.value
+                is Tens -> group += token.value
+                Hundred -> group *= 100
+                is Scale -> {
+                    if (group <= 0 || token.value >= smallestScale) return null
+                    smallestScale = token.value
+                    total += group * token.value
+                    group = 0
+                }
+                And -> Unit
+                Point -> isDecimal = true
+            }
+            previous = token
+        }
+
+        if (isDecimal && decimals.isEmpty()) return null
+        val value = total + group
+        if (value > MAXIMUM) return null
+        return Phrase(value, decimals.toString())
+    }
+
+    private fun mayFollow(previous: Token?, token: Token, isDecimal: Boolean): Boolean {
+        if (isDecimal) return token is UnitValue
+        return when (previous) {
+            null -> token.opensANumber
+            is UnitValue -> when (token) {
+                Hundred, is Scale -> previous.value > 0
+                Point -> true
+                else -> false
+            }
+            is Teen -> token == Hundred || token is Scale || token == Point
+            is Tens -> when (token) {
+                is UnitValue -> token.value > 0
+                is Scale, Point -> true
+                else -> false
+            }
+            Hundred -> when (token) {
+                is UnitValue -> token.value > 0
+                is Teen, is Tens, is Scale, And, Point -> true
+                else -> false
+            }
+            is Scale -> when (token) {
+                is UnitValue -> token.value > 0
+                is Teen, is Tens, is Scale, And, Point -> true
+                else -> false
+            }
+            And -> when (token) {
+                is UnitValue -> token.value > 0
+                is Teen, is Tens -> true
+                else -> false
+            }
+            Point -> token is UnitValue
+        }
+    }
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -703,6 +703,7 @@ class DictationController(
                 styledUpstream = true,
                 repairSpeech = configuration.repairSpeech,
                 numbersAsDigits = configuration.numbersAsDigits,
+                snippets = configuration.snippets,
             )
             if (transcript != null && cleaned.isEmpty()) {
                 wavFile.delete()
@@ -795,6 +796,7 @@ class DictationController(
                 styledUpstream = true,
                 repairSpeech = configuration.repairSpeech,
                 numbersAsDigits = configuration.numbersAsDigits,
+                snippets = configuration.snippets,
             )
             if (transcript.isEmpty()) {
                 throw GatewayException(
@@ -901,6 +903,7 @@ class DictationController(
         ),
         repairSpeech = configuration.repairSpeech,
         numbersAsDigits = configuration.numbersAsDigits,
+        snippets = configuration.snippets,
     )
 
     private suspend fun deliver(
@@ -909,10 +912,6 @@ class DictationController(
         configuration: VocaPhoneSettings,
         source: DictationSource,
     ) {
-        // After formatting, never before: the writing style's capitalization
-        // must not rewrite a snippet's literal expansion text, and trigger
-        // matching is case-insensitive so this order does not break it.
-        val transcript = SnippetExpander.expand(transcript, configuration.snippets)
         diagnostics.recordTiming("transcript_ready", source.name)
         // Reported here rather than after insertion: the transcript exists and
         // is correct at this point, and whether the keyboard managed to commit

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -702,6 +702,7 @@ class DictationController(
                 language = configuration.effectiveLanguage.wireValue,
                 styledUpstream = true,
                 repairSpeech = configuration.repairSpeech,
+                numbersAsDigits = configuration.numbersAsDigits,
             )
             if (transcript != null && cleaned.isEmpty()) {
                 wavFile.delete()
@@ -793,6 +794,7 @@ class DictationController(
                 language = configuration.effectiveLanguage.wireValue,
                 styledUpstream = true,
                 repairSpeech = configuration.repairSpeech,
+                numbersAsDigits = configuration.numbersAsDigits,
             )
             if (transcript.isEmpty()) {
                 throw GatewayException(
@@ -898,6 +900,7 @@ class DictationController(
             translateTo = configuration.translationTarget,
         ),
         repairSpeech = configuration.repairSpeech,
+        numbersAsDigits = configuration.numbersAsDigits,
     )
 
     private suspend fun deliver(

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -195,13 +195,15 @@ data class VocaPhoneSettings(
      * Whether hesitation sounds, false starts, and missing sentence punctuation
      * are repaired before the writing style is applied.
      *
-     * On by default, and the only dictation setting that changes the words in a
-     * transcript rather than its formatting. It earns that because the words it
-     * removes are not words: "um" is a sound someone makes while deciding what
-     * to say, and nobody dictating meant to type it. Never applied to
-     * [WritingStyle.RAW], which promises the model's own output.
+     * On by default, and one of the dictation settings that changes the words
+     * in a transcript rather than its formatting. It earns that because the
+     * words it removes are not words: "um" is a sound someone makes while
+     * deciding what to say, and nobody dictating meant to type it. Never
+     * applied to [WritingStyle.RAW], which promises the model's own output.
      */
     val repairSpeech: Boolean = true,
+    /** Whether dictated English number words are written as digits. Off by default. */
+    val numbersAsDigits: Boolean = false,
     val dictationTone: DictationTone = DictationTone.DEFAULT,
     val microphone: MicrophonePreference = MicrophonePreference.DEFAULT,
     val audioRetention: AudioRetention = AudioRetention.DEFAULT,
@@ -413,6 +415,8 @@ class SettingsRepository(private val context: Context) {
 
     suspend fun setRepairSpeech(enabled: Boolean) = put(Keys.REPAIR_SPEECH, enabled)
 
+    suspend fun setNumbersAsDigits(enabled: Boolean) = put(Keys.NUMBERS_AS_DIGITS, enabled)
+
     suspend fun setNumberRowEnabled(enabled: Boolean) = put(Keys.NUMBER_ROW, enabled)
 
     suspend fun setKeyboardHeight(height: KeyboardHeight) = put(Keys.KEYBOARD_HEIGHT, height.storedValue)
@@ -614,6 +618,7 @@ class SettingsRepository(private val context: Context) {
         customVocabulary = this[Keys.CUSTOM_VOCABULARY].orEmpty(),
         syncWhisperDictionary = this[Keys.SYNC_WHISPER_DICTIONARY] ?: true,
         repairSpeech = this[Keys.REPAIR_SPEECH] ?: true,
+        numbersAsDigits = this[Keys.NUMBERS_AS_DIGITS] ?: false,
         numberRowEnabled = this[Keys.NUMBER_ROW] ?: true,
         keyboardHeight = KeyboardHeight.fromStored(this[Keys.KEYBOARD_HEIGHT]),
         splitKeyboard = SplitKeyboard.fromStored(this[Keys.SPLIT_KEYBOARD]),
@@ -659,6 +664,7 @@ class SettingsRepository(private val context: Context) {
         val CUSTOM_VOCABULARY = stringPreferencesKey("custom_vocabulary")
         val SYNC_WHISPER_DICTIONARY = booleanPreferencesKey("sync_whisper_dictionary")
         val REPAIR_SPEECH = booleanPreferencesKey("repair_speech")
+        val NUMBERS_AS_DIGITS = booleanPreferencesKey("numbers_as_digits")
         val NUMBER_ROW = booleanPreferencesKey("keyboard_number_row")
         val KEYBOARD_HEIGHT = stringPreferencesKey("keyboard_height")
         val SPLIT_KEYBOARD = stringPreferencesKey("keyboard_split")

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
@@ -404,6 +404,7 @@ fun VocaPhoneApp(
                 onTranslateTo = { viewModel.setTranslateTo(it) },
                 onStyle = { viewModel.setStyle(it) },
                 onRepairSpeech = { viewModel.setRepairSpeech(it) },
+                onNumbersAsDigits = { viewModel.setNumbersAsDigits(it) },
                 onDictationTone = { viewModel.setDictationTone(it) },
                 onPreviewDictationTone = { viewModel.toggleDictationTonePreview(it) },
                 tonePreviewListening = tonePreviewListening,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -92,6 +92,7 @@ fun SettingsScreen(
     onTranslateTo: (TranscriptionLanguage) -> Unit,
     onStyle: (WritingStyle) -> Unit,
     onRepairSpeech: (Boolean) -> Unit,
+    onNumbersAsDigits: (Boolean) -> Unit,
     onDictationTone: (DictationTone) -> Unit,
     onPreviewDictationTone: (DictationTone) -> Unit,
     tonePreviewListening: Boolean,
@@ -408,10 +409,9 @@ fun SettingsScreen(
                 }
                 Section(
                     title = "Clean up",
-                    // The one switch on this page that changes words rather
-                    // than formatting, which is why it says so here instead of
-                    // leaving it to be discovered.
-                    supporting = "The only setting that changes your words. " +
+                    // This switch changes spoken filler words rather than just
+                    // transcript formatting, so make that explicit here.
+                    supporting = "Changes your words, not only formatting. " +
                         "Never applied to the Raw writing style.",
                 ) {
                     SettingToggle(
@@ -424,6 +424,18 @@ fun SettingsScreen(
                             "\"uh-huh\", which are answers.",
                         checked = settings.repairSpeech,
                         onCheckedChange = onRepairSpeech,
+                    )
+                }
+                Section(
+                    title = "Numbers",
+                    supporting = "English only. Ordinals and spoken times stay as words.",
+                ) {
+                    SettingToggle(
+                        title = "Write numbers as digits",
+                        detail = "Writes “six pm” as “6 pm” and “twenty three” as “23”. " +
+                            "A lone “one” stays a word unless a unit follows it.",
+                        checked = settings.numbersAsDigits,
+                        onCheckedChange = onNumbersAsDigits,
                     )
                 }
                 Section(

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
@@ -320,6 +320,9 @@ class VocaPhoneViewModel(application: Application) : AndroidViewModel(applicatio
     fun setRepairSpeech(enabled: Boolean) =
         viewModelScope.launch { container.settings.setRepairSpeech(enabled) }
 
+    fun setNumbersAsDigits(enabled: Boolean) =
+        viewModelScope.launch { container.settings.setNumbersAsDigits(enabled) }
+
     fun setDictationTone(tone: DictationTone) {
         _tonePreviewListening.value = false
         viewModelScope.launch { container.settings.setDictationTone(tone) }

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/DictatedTranscriptTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/DictatedTranscriptTest.kt
@@ -5,10 +5,32 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * The order of the three steps is the whole point of the funnel, and each wrong
+ * The order of the four steps is the whole point of the funnel, and each wrong
  * order produces text that looks like a different bug.
  */
 class DictatedTranscriptTest {
+
+    @Test
+    fun `digits run after styling only when enabled`() {
+        assertEquals(
+            "20 people came.",
+            DictatedTranscript.finished(
+                "twenty people came",
+                style = WritingStyle.FORMAL,
+                repairSpeech = false,
+                numbersAsDigits = true,
+            ),
+        )
+        assertEquals(
+            "Twenty people came.",
+            DictatedTranscript.finished(
+                "twenty people came",
+                style = WritingStyle.FORMAL,
+                repairSpeech = false,
+                numbersAsDigits = false,
+            ),
+        )
+    }
 
     /**
      * Sanitizing first, because a model's own annotations are not something to
@@ -17,11 +39,12 @@ class DictatedTranscriptTest {
     @Test
     fun `markers are removed before anything else`() {
         assertEquals(
-            "Five copies please.",
+            "5 copies please.",
             DictatedTranscript.finished(
                 "[BLANK_AUDIO] five copies please",
                 style = WritingStyle.FORMAL,
                 repairSpeech = false,
+                numbersAsDigits = true,
             ),
         )
     }

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/SnippetExpansionIntegrationTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/SnippetExpansionIntegrationTest.kt
@@ -4,11 +4,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * Snippet expansion runs on [DictatedTranscript.finished]'s output, never on
- * its input: the writing style capitalizes sentence starts, and if expansion
- * ran first its literal text would be capitalized right along with it. This
- * mirrors the order [com.vocahq.vocaphone.dictation.DictationController.deliver]
- * uses.
+ * Snippet triggers match after styling, but their literal expansions are
+ * protected from the subsequent number conversion and restored last.
  */
 class SnippetExpansionIntegrationTest {
 
@@ -16,15 +13,12 @@ class SnippetExpansionIntegrationTest {
     fun `formal capitalization does not clobber a snippet's literal expansion`() {
         val snippets = listOf(Snippet("1", "brb", "be right back"))
 
-        val formatted = DictatedTranscript.finished(
+        val expanded = DictatedTranscript.finished(
             "brb getting coffee",
             style = WritingStyle.FORMAL,
             repairSpeech = false,
+            snippets = snippets,
         )
-        // The styler capitalized the sentence start, including the trigger.
-        assertEquals("Brb getting coffee.", formatted)
-
-        val expanded = SnippetExpander.expand(formatted, snippets)
         // Matching is case-insensitive, so "Brb" still triggers, and the
         // expansion is inserted exactly as written rather than capitalized.
         assertEquals("be right back getting coffee.", expanded)
@@ -34,14 +28,28 @@ class SnippetExpansionIntegrationTest {
     fun `an email trigger does not come out capitalized`() {
         val snippets = listOf(Snippet("1", "my email", "kanishk@example.com"))
 
-        val formatted = DictatedTranscript.finished(
+        val expanded = DictatedTranscript.finished(
             "my email is on the form",
             style = WritingStyle.FORMAL,
             repairSpeech = false,
+            snippets = snippets,
         )
-        assertEquals("My email is on the form.", formatted)
-
-        val expanded = SnippetExpander.expand(formatted, snippets)
         assertEquals("kanishk@example.com is on the form.", expanded)
+    }
+
+    @Test
+    fun `a number-word trigger wins over digit conversion and stays literal`() {
+        val snippets = listOf(Snippet("1", "six pm", "six pm on the dot"))
+
+        assertEquals(
+            "5 copies at six pm on the dot.",
+            DictatedTranscript.finished(
+                "five copies at six pm",
+                style = WritingStyle.FORMAL,
+                repairSpeech = false,
+                numbersAsDigits = true,
+                snippets = snippets,
+            ),
+        )
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/SpokenNumbersTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/SpokenNumbersTest.kt
@@ -1,0 +1,115 @@
+package com.vocahq.vocaphone.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The opt-in conversion is intentionally more defined by its refusals than by
+ * the happy path: a wrong digit conversion makes every transcript harder to
+ * trust and undo.
+ */
+class SpokenNumbersTest {
+    private fun converted(text: String): String = SpokenNumbers.digitsIn(text)
+
+    @Test
+    fun `times quantities and compound numbers become digits`() {
+        assertEquals("6 pm at office", converted("six pm at office"))
+        assertEquals("call me at 8 am", converted("call me at eight am"))
+        assertEquals("11 o'clock", converted("eleven o'clock"))
+        assertEquals("I need 5 copies", converted("I need five copies"))
+        assertEquals("0 results", converted("zero results"))
+        assertEquals("19 days later", converted("nineteen days later"))
+        assertEquals("23 people", converted("twenty three people"))
+        assertEquals("23 people", converted("twenty-three people"))
+        assertEquals("250", converted("two hundred and fifty"))
+        assertEquals("2500", converted("twenty five hundred"))
+        assertEquals("2003500", converted("two million three thousand five hundred"))
+    }
+
+    @Test
+    fun `decimals are read digit by digit`() {
+        assertEquals("3.5 hours", converted("three point five hours"))
+        assertEquals("3.14", converted("three point one four"))
+        assertEquals("0.5", converted("zero point five"))
+    }
+
+    @Test
+    fun `case and surrounding punctuation survive`() {
+        assertEquals("20 people came.", converted("Twenty people came."))
+        assertEquals("at 6, then 7.", converted("at six, then seven."))
+        assertEquals("(23)", converted("(twenty three)"))
+        assertEquals("6!", converted("six!"))
+    }
+
+    @Test
+    fun `a lone one is kept as a word unless a quantity unit follows`() {
+        assertEquals("no one came", converted("no one came"))
+        assertEquals("one of them is broken", converted("one of them is broken"))
+        assertEquals("one day I'll get to it", converted("one day I'll get to it"))
+        assertEquals("that's the one", converted("that's the one"))
+        assertEquals("one another", converted("one another"))
+        assertEquals("a one-off thing", converted("a one-off thing"))
+        assertEquals("see you at 1 pm", converted("see you at one pm"))
+        assertEquals("1 hour later", converted("one hour later"))
+        assertEquals("1 percent of them", converted("one percent of them"))
+        assertEquals("1 kg of rice", converted("one kg of rice"))
+        assertEquals("one, pm", converted("one, pm"))
+        assertEquals("one\npm", converted("one\npm"))
+    }
+
+    @Test
+    fun `one within an unambiguous number converts`() {
+        assertEquals("21 people", converted("twenty one people"))
+        assertEquals("1000", converted("one thousand"))
+        assertEquals("101", converted("one hundred and one"))
+    }
+
+    @Test
+    fun `adjacent numbers and spoken times are not guessed`() {
+        assertEquals("six seven", converted("six seven"))
+        assertEquals("one two three four", converted("one two three four"))
+        assertEquals("nineteen eighty four", converted("nineteen eighty four"))
+        assertEquals("twenty twenty five", converted("twenty twenty five"))
+        assertEquals("meet me at seven thirty", converted("meet me at seven thirty"))
+    }
+
+    @Test
+    fun `ordinals and their preceding number stay as spoken`() {
+        assertEquals("first of May", converted("first of May"))
+        assertEquals("second thoughts", converted("second thoughts"))
+        assertEquals("the twenty first", converted("the twenty first"))
+        assertEquals("the twenty-first", converted("the twenty-first"))
+        assertEquals("her thirtieth birthday", converted("her thirtieth birthday"))
+        assertEquals("a 5 second delay", converted("a five second delay"))
+        assertEquals("1 second please", converted("one second please"))
+    }
+
+    @Test
+    fun `connectors and impossible number combinations are kept safely`() {
+        assertEquals("hundreds of people", converted("hundreds of people"))
+        assertEquals("that is the point", converted("that is the point"))
+        assertEquals("you and I", converted("you and I"))
+        assertEquals("between 5 and 10", converted("between five and ten"))
+        assertEquals("2 and 3", converted("two and three"))
+        assertEquals("200 and the rest", converted("two hundred and the rest"))
+        assertEquals("5 point Nemo", converted("five point Nemo"))
+        assertEquals("zero hundred", converted("zero hundred"))
+        assertEquals("twenty hundred", converted("twenty hundred"))
+        assertEquals("three thousand two million", converted("three thousand two million"))
+    }
+
+    @Test
+    fun `the supported maximum converts and other text passes through`() {
+        val largest = "nine hundred ninety nine billion nine hundred ninety nine million " +
+            "nine hundred ninety nine thousand nine hundred ninety nine"
+        assertEquals("999999999999", converted(largest))
+        assertEquals(999_999_999_999L, SpokenNumbers.MAXIMUM)
+        assertEquals("one trillion", converted("one trillion"))
+        assertEquals("call 9876543210 now", converted("call 9876543210 now"))
+        assertEquals("version 2.1 is out", converted("version 2.1 is out"))
+        assertEquals("मुझे तीन कॉपी चाहिए", converted("मुझे तीन कॉपी चाहिए"))
+        assertEquals("necesito cinco copias", converted("necesito cinco copias"))
+        assertEquals("someone told me", converted("someone told me"))
+        assertEquals("20\n3", converted("twenty\nthree"))
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/SettingsChoiceTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/SettingsChoiceTest.kt
@@ -55,6 +55,7 @@ class SettingsChoiceTest {
         assertEquals(5, MicrophonePreference.entries.size)
         assertEquals(KeyboardHeight.DEFAULT, KeyboardHeight.fromStored(null))
         assertEquals(KeyboardHeight.DEFAULT, VocaPhoneSettings().keyboardHeight)
+        assertFalse(VocaPhoneSettings().numbersAsDigits)
         assertEquals(48, KeyboardHeight.DEFAULT.keyHeightDp)
     }
 


### PR DESCRIPTION
## Summary

- add an opt-in **Write numbers as digits** setting to Android, off by default
- mirror the conservative English-only iOS number parser, including ambiguous-number, ordinal, decimal, and lone-"one" safeguards
- apply conversion after transcript styling and before snippet expansion for both on-device and self-hosted gateway routes
- track broader language support separately in #224

## Problem

Android did not have the iOS option for turning dictated English number words such as “six pm” and “twenty three” into `6 pm` and `23`. Users had to reformat these transcripts manually, and the two clients behaved differently.

## Verification

- [ ] `just ios ci` — N/A: Android-only change
- [x] `just android ci`
- [x] Gateway changes — N/A: formatting remains on the phone; no gateway or submodule change
- [ ] Physical-device test — not run because no Android device is attached

Maintainers can comment `/build` on this PR for installable Android/iOS
artifacts (see CONTRIBUTING).

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation reviewed; no data-flow, permission, retention, or network behavior changed