### PR TITLE
fix(android): show download percent on the card that starts the download

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/LocalModelPicker.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/LocalModelPicker.kt
@@ -1213,6 +1213,14 @@ private fun ModelActions(
                 progress = { state.progress / 100f },
                 modifier = Modifier.fillMaxWidth(),
             )
+            // The recommended card and the detail sheet suppress the busy
+            // banner while they are the thing being downloaded, so without
+            // this the bar is the only feedback and reads as stuck.
+            Text(
+                downloadProgressLine(state),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
         model.id !in state.downloaded -> PrimaryButton(
             text = downloadLabel,


### PR DESCRIPTION
A user on Android reported that the model download shows no percentage. It turned out the percentage exists, but not on the surface they were looking at.

## What was wrong

The picker has three places that render a running download:

| Surface | Before |
| --- | --- |
| `ModelBusyBanner` | `38% · 254 MB of 670 MB · about 3 minutes left` |
| `ModelTile` (grid) | `Downloading 38%` |
| `ModelActions` (recommended card + detail sheet) | bare progress bar, no numbers |

`showPickerBusyBanner` deliberately suppresses the banner while the model being downloaded *is* the recommended one, so the card would not say the same thing twice (`ModelCatalogQueryTest.recommendedDownloadDoesNotAlsoShowTheBusyBanner`). But the card never carried the numbers in the first place — so on the onboarding path, the one a first-time user actually watches, a 670 MB download was a moving bar and nothing else. iOS shows the percent plus size and estimate in every case.

## The change

`ModelActions` now renders the shared `downloadProgressLine(state)` under its bar — the same string the banner uses, so all three surfaces read alike and match iOS. One file, nine lines, no state or manager changes.

## Testing

- `./gradlew testFullDebugUnitTest lintFullDebug` — passing
- Not yet exercised on a device; the string and its inputs are unchanged from the banner, which is already shipping.