### PR TITLE
fix(ios): make keyboard feedback feel native

### DIFF
--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		3219DC5DD26E1998A7A0CD5C /* SetupStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342F2B3B437269514C969C77 /* SetupStatus.swift */; };
 		3226364FB9F43F49B12FE2A6 /* DictationBarLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA83B914C241E5F8BF8F32AC /* DictationBarLayoutTests.swift */; };
 		324811B86570CBD6C1C1FCFC /* SherpaRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0358A093FE299D51D513BC30 /* SherpaRecognizer.swift */; };
+		3263EFE959E452C5427EF549 /* KeyHitMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91ACC58FF89C43C9BD2D9F6 /* KeyHitMap.swift */; };
 		33049B8AD2490B0F8D0A9E0F /* SwipeRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C4BD2142E9377F123A8848 /* SwipeRecognizer.swift */; };
 		332424547CBE2483FE24C975 /* SherpaTranscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3E4382E021BE30F6D687A7 /* SherpaTranscriptTests.swift */; };
 		33A2193E058E05B4B4FB3860 /* ModelLanguageSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */; };
@@ -127,6 +128,7 @@
 		53A1176717AEAE72A1F5B9F1 /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
 		54A3525CD8F0DFA70980501B /* SentencePunctuation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AF826E0D2C7820CBB4B78C /* SentencePunctuation.swift */; };
 		5634120C15A37F9E2C0FF2C0 /* LearnedWords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */; };
+		565E52EE8369B8FE02E572CA /* KeyHitMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91ACC58FF89C43C9BD2D9F6 /* KeyHitMap.swift */; };
 		5673DF7E07F7F800FB847C2A /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */; };
 		56783518C221839DE432BCC7 /* DesignSystemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755A4279065D41A705E1F19D /* DesignSystemTests.swift */; };
 		5769EF4A106AFBD7B375DC5D /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */; };
@@ -222,6 +224,7 @@
 		A0420E3166FF08AE5059A805 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9BB34E20645F3D8C78A0363 /* Telemetry.swift */; };
 		A0B8569F3B1A3F72EAC9C1DB /* TranscriptionQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E2BF42CAC209DA12464566 /* TranscriptionQuality.swift */; };
 		A0C4342BED6EC86029B3C492 /* SwipeTrailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */; };
+		A201DF59DBFB56276A6D5A00 /* KeyHitMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91ACC58FF89C43C9BD2D9F6 /* KeyHitMap.swift */; };
 		A2112E100F4277466EA8DD4F /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */; };
 		A2BD20604DA50ECB8AE82BC0 /* SherpaDecodeOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EFEBD6293F9649D551A9014 /* SherpaDecodeOutcome.swift */; };
 		A568F548D639C064CDA86F0D /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */; };
@@ -322,6 +325,7 @@
 		E5983EF5CBB205F7FBBB03B1 /* SherpaEmptyChunkRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF256CF6ED209E00193BF135 /* SherpaEmptyChunkRecovery.swift */; };
 		E5CA31ED8B208F173ACDA3EF /* TranscriptRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */; };
 		E5EAD40641B38DDA0CCA0300 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894063AE1B3DDA92C529268D /* AppConfiguration.swift */; };
+		E67DEFF4A0E71720898B15E6 /* KeyHitMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC704CBD16EF6C7FCCBC6D6 /* KeyHitMapTests.swift */; };
 		E6FDBF8529AEB00D2CFB245E /* UsageReportingCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AA42EFADB6B77B0C9A5E44 /* UsageReportingCopy.swift */; };
 		E9C82042A1155CC1E50BF2B6 /* StartDictationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A7126FEDA473D8C112A397 /* StartDictationIntent.swift */; };
 		E9E86F6940BDB4381A8C9FF5 /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C304CF763960E5F1D8F76B2B /* LiveActivityManager.swift */; };
@@ -459,6 +463,7 @@
 		629821E8C5C22C9824A13665 /* LocalModelIntegrity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelIntegrity.swift; sourceTree = "<group>"; };
 		653FBC305F7EB4B9F7EB354B /* UsageReportingViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageReportingViews.swift; sourceTree = "<group>"; };
 		69943FB61027DEE31DA51705 /* Snippet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snippet.swift; sourceTree = "<group>"; };
+		6AC704CBD16EF6C7FCCBC6D6 /* KeyHitMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyHitMapTests.swift; sourceTree = "<group>"; };
 		6B6743BB4173E2F719E3D8CB /* TypingWordList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingWordList.swift; sourceTree = "<group>"; };
 		6CF871FC84B4C6B2627A43C2 /* RecordingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingCoordinator.swift; sourceTree = "<group>"; };
 		7083ED482761906EE2589E97 /* SherpaFeatureDither.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaFeatureDither.swift; sourceTree = "<group>"; };
@@ -573,6 +578,7 @@
 		F2228242333B1BBC848C90DA /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		F72772F0CCE3BA274182C5F4 /* HomePresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePresentationTests.swift; sourceTree = "<group>"; };
 		F8348F9E480C0343CD38657B /* OnboardingPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPresentationTests.swift; sourceTree = "<group>"; };
+		F91ACC58FF89C43C9BD2D9F6 /* KeyHitMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyHitMap.swift; sourceTree = "<group>"; };
 		FA83B914C241E5F8BF8F32AC /* DictationBarLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarLayoutTests.swift; sourceTree = "<group>"; };
 		FC2CD13AAF5FDF79DD5D0075 /* TypingFieldPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingFieldPolicy.swift; sourceTree = "<group>"; };
 		FCAE41267FF8113463CFFF96 /* TranscriptionQualityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionQualityTests.swift; sourceTree = "<group>"; };
@@ -640,6 +646,7 @@
 				98325CD266139FCDEE156D8F /* KeyboardViewController.swift */,
 				8F8E5D91EDE2C0E67DFC0250 /* KeyboardViewPreview.swift */,
 				8BF7CAC171521FC372DF2BF0 /* KeyGridView.swift */,
+				F91ACC58FF89C43C9BD2D9F6 /* KeyHitMap.swift */,
 				B87128326897BFA30E7B2038 /* KeyLayout.swift */,
 				5118F8CFAAE127CD5FF92076 /* KeyView.swift */,
 				06FC8DDB89A55103E29C10D3 /* PrivacyInfo.xcprivacy */,
@@ -825,6 +832,7 @@
 				B75D17831C48C07141D7066C /* KeyboardHandoffPresentationTests.swift */,
 				97639A09609D9E6E76153CDB /* KeyboardHapticsTests.swift */,
 				3EC2C1575D306E7683092FBA /* KeyGridLayoutTests.swift */,
+				6AC704CBD16EF6C7FCCBC6D6 /* KeyHitMapTests.swift */,
 				C45D98EAFE18C689DC7551E9 /* LanguageMenuTests.swift */,
 				FF28F6F60B7FDEA4EB183B6F /* LocalModelCatalogTests.swift */,
 				EE41EF03C8A4F930315EFE77 /* ModelLanguageSupportTests.swift */,
@@ -1114,6 +1122,7 @@
 				7E3D8E857A83184E74B15433 /* GatewayEndpoint.swift in Sources */,
 				771730250FDC04B40A57E462 /* KeyAlternatives.swift in Sources */,
 				E4162282629880D2A33913CA /* KeyGridView.swift in Sources */,
+				565E52EE8369B8FE02E572CA /* KeyHitMap.swift in Sources */,
 				4C8B6E06406E63E122F9CBD1 /* KeyLayout.swift in Sources */,
 				68E7553DB227208E27DF3A8F /* KeyView.swift in Sources */,
 				1A55285B353E4AE5D1B6D967 /* KeyboardHaptics.swift in Sources */,
@@ -1190,6 +1199,7 @@
 				F11A2E1FF01BA4115116AFB5 /* HomePresentation.swift in Sources */,
 				4E4687E35DB482CFC5EB37F9 /* KeyAlternatives.swift in Sources */,
 				F37F68399E06B767B5D6ACC7 /* KeyGridView.swift in Sources */,
+				A201DF59DBFB56276A6D5A00 /* KeyHitMap.swift in Sources */,
 				5C558BDC79705E089820562F /* KeyLayout.swift in Sources */,
 				400FC934DB32BD708B5D23A9 /* KeyView.swift in Sources */,
 				1A5451979B0206365EE36D5E /* KeyboardHandoffPresentation.swift in Sources */,
@@ -1355,6 +1365,8 @@
 				6BF87A2C089381E060D13D22 /* KeyAlternativesTests.swift in Sources */,
 				62F20884ED82C44DD050F3E5 /* KeyGridLayoutTests.swift in Sources */,
 				F859CEA335A920156C89478F /* KeyGridView.swift in Sources */,
+				3263EFE959E452C5427EF549 /* KeyHitMap.swift in Sources */,
+				E67DEFF4A0E71720898B15E6 /* KeyHitMapTests.swift in Sources */,
 				966E2D9A6D13630E7A2122A6 /* KeyLayout.swift in Sources */,
 				BC36D829FEE2BEC0A6BC30C2 /* KeyView.swift in Sources */,
 				A5E6BD7DC01FF42503792DCB /* KeyboardGeometryTests.swift in Sources */,

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -332,6 +332,7 @@
 		ED04BFBB1AB30BB6226D77B3 /* TranscriptRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */; };
 		EE7A49C4F95388AF42E1B30C /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
 		EF4B66CAC02A63D743384B49 /* DownloadReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF56F0E966D9AECA1DCFF65E /* DownloadReadiness.swift */; };
+		EF977715FB417ABD32BB2E7A /* KeyPreviewRenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CC84644E8CF9B1E83696D3 /* KeyPreviewRenderTests.swift */; };
 		EFEB53E947DAF4C77FE5E059 /* DictatedTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575BDB070A428051B623F095 /* DictatedTranscript.swift */; };
 		F0EC49ECABE510B52F876C8F /* SherpaIncrementalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41205764F091734B2DE6D02 /* SherpaIncrementalSession.swift */; };
 		F11A2E1FF01BA4115116AFB5 /* HomePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C96151B8C8ECE035FF0D8F /* HomePresentation.swift */; };
@@ -441,6 +442,7 @@
 		406B0C287866B36EF3109238 /* LocalModelPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelPicker.swift; sourceTree = "<group>"; };
 		41C0A3D1DBF6BCF25C37CF24 /* EmojiSuggestionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiSuggestionsTests.swift; sourceTree = "<group>"; };
 		4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnedWords.swift; sourceTree = "<group>"; };
+		46CC84644E8CF9B1E83696D3 /* KeyPreviewRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPreviewRenderTests.swift; sourceTree = "<group>"; };
 		46E8BCA13C319737A50B7CE9 /* KeyboardHandoffPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHandoffPresentation.swift; sourceTree = "<group>"; };
 		473A608BF3F8827B3D3842B0 /* LocalModelCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelCatalog.swift; sourceTree = "<group>"; };
 		4871EA8AAF829D7979EC9587 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -833,6 +835,7 @@
 				97639A09609D9E6E76153CDB /* KeyboardHapticsTests.swift */,
 				3EC2C1575D306E7683092FBA /* KeyGridLayoutTests.swift */,
 				6AC704CBD16EF6C7FCCBC6D6 /* KeyHitMapTests.swift */,
+				46CC84644E8CF9B1E83696D3 /* KeyPreviewRenderTests.swift */,
 				C45D98EAFE18C689DC7551E9 /* LanguageMenuTests.swift */,
 				FF28F6F60B7FDEA4EB183B6F /* LocalModelCatalogTests.swift */,
 				EE41EF03C8A4F930315EFE77 /* ModelLanguageSupportTests.swift */,
@@ -1368,6 +1371,7 @@
 				3263EFE959E452C5427EF549 /* KeyHitMap.swift in Sources */,
 				E67DEFF4A0E71720898B15E6 /* KeyHitMapTests.swift in Sources */,
 				966E2D9A6D13630E7A2122A6 /* KeyLayout.swift in Sources */,
+				EF977715FB417ABD32BB2E7A /* KeyPreviewRenderTests.swift in Sources */,
 				BC36D829FEE2BEC0A6BC30C2 /* KeyView.swift in Sources */,
 				A5E6BD7DC01FF42503792DCB /* KeyboardGeometryTests.swift in Sources */,
 				AEF583A0E9B4984F72636A0A /* KeyboardHandoffPresentation.swift in Sources */,

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -324,9 +324,9 @@ struct KeyboardSettingsView: View {
                 )
                 Text(
                     "Typing haptics are off by default. Keyboard clicks follow "
-                    + "the iPhone's Keyboard Clicks setting. Custom haptics "
-                        + "need Full Access and text haptics play only after text "
-                        + "is entered."
+                        + "the iPhone's Keyboard Clicks setting. When enabled, "
+                        + "custom haptics confirm committed typing and occasional "
+                        + "keyboard actions."
                 )
                 Text(
                     "Swipe to type is new and off by default. Slide from letter to "

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -164,9 +164,9 @@ struct KeyboardSettingsView: View {
         store: KeyboardPreferences.defaults
     ) private var smartPunctuationEnabled = true
     @AppStorage(
-        KeyboardPreferences.keyboardHapticsKey,
+        KeyboardPreferences.typingHapticsKey,
         store: KeyboardPreferences.defaults
-    ) private var hapticsEnabled = true
+    ) private var typingHapticsEnabled = false
     @AppStorage(
         KeyboardPreferences.emojiSuggestionsKey,
         store: KeyboardPreferences.defaults
@@ -306,7 +306,7 @@ struct KeyboardSettingsView: View {
         Section {
             Toggle("Smart punctuation", isOn: $smartPunctuationEnabled)
             Toggle("Emoji suggestions", isOn: $emojiSuggestionsEnabled)
-            Toggle("Keyboard haptics", isOn: $hapticsEnabled)
+            Toggle("Typing haptics", isOn: $typingHapticsEnabled)
             Toggle("Swipe to type", isOn: $swipeTypingEnabled)
         } footer: {
             VStack(alignment: .leading, spacing: VocaMetrics.related) {
@@ -322,12 +322,11 @@ struct KeyboardSettingsView: View {
                         + "suggestion's place, and words without an obvious emoji "
                         + "get none."
                 )
-                // Said plainly rather than leaving people to wonder why their
-                // keyboard is silent.
                 Text(
-                    "Keyboard haptics need Full Access. Without it iOS gives the "
-                        + "keyboard no way to reach the Taptic Engine, and this "
-                        + "switch does nothing."
+                    "Typing haptics are off by default. Keyboard clicks follow "
+                    + "the iPhone's Keyboard Clicks setting. Custom haptics "
+                        + "need Full Access and text haptics play only after text "
+                        + "is entered."
                 )
                 Text(
                     "Swipe to type is new and off by default. Slide from letter to "

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -328,6 +328,15 @@ struct KeyboardSettingsView: View {
                         + "custom haptics confirm committed typing and occasional "
                         + "keyboard actions."
                 )
+                // Said plainly rather than leaving people to wonder why their
+                // keyboard is silent: the switch really does nothing without
+                // Full Access, whatever it is set to.
+                Text(
+                    "Typing haptics also need Full Access. Without it iOS gives "
+                        + "the keyboard no way to reach the Taptic Engine, and "
+                        + "this switch does nothing. Keyboard clicks are "
+                        + "unaffected."
+                )
                 Text(
                     "Swipe to type is new and off by default. Slide from letter to "
                         + "letter without lifting; alternatives appear in the "

--- a/ios/VocaPhoneApp/App/VocaPhoneApp.swift
+++ b/ios/VocaPhoneApp/App/VocaPhoneApp.swift
@@ -68,6 +68,7 @@ struct VocaPhoneApp: App {
                 .onOpenURL { coordinator.handleDeepLink($0) }
                 .onAppear {
                     KeyboardPreferences.containingAppIsForeground = true
+                    KeyboardPreferences.migrateTypingHapticsIfNeeded()
                     Telemetry.shared.appFirstOpen()
                     // Started once here rather than lazily from the setup card:
                     // the first path update has to have landed by the time that

--- a/ios/VocaPhoneApp/Audio/AudioRecorder.swift
+++ b/ios/VocaPhoneApp/Audio/AudioRecorder.swift
@@ -333,6 +333,17 @@ final class AudioRecorder: NSObject {
             mode: .default,
             options: categoryOptions
         )
+        // iOS mutes system sounds and haptics for the whole device while a
+        // session is using audio input, so the Taptic Engine cannot buzz into
+        // the microphone. It defaults to off, and Quick Dictation holds the
+        // input open for ten minutes at a time — which silently killed keyboard
+        // haptics everywhere, in Apple's keyboards as much as this one, for the
+        // whole standby window.
+        //
+        // A dictation app that keeps the microphone warm has to ask for them
+        // back. Failing is not worth abandoning the recording over: the cost is
+        // the feedback, not the audio.
+        try? audioSession.setAllowHapticsAndSystemSoundsDuringRecording(true)
         do {
             try audioSession.setActive(true)
             try selectPreferredInput(in: audioSession)

--- a/ios/VocaPhoneKeyboard/EmojiPanelView.swift
+++ b/ios/VocaPhoneKeyboard/EmojiPanelView.swift
@@ -262,17 +262,17 @@ final class EmojiPanelView: UIView {
     }
 
     @objc private func spaceTapped() {
-        KeyboardHaptics.shared.keyPress()
+        KeyboardHaptics.shared.textCommitted()
         delegate?.emojiPanelDidRequestSpace(self)
     }
 
     @objc private func deleteTapped() {
-        KeyboardHaptics.shared.keyPress()
+        KeyboardHaptics.shared.keyActionCommitted()
         delegate?.emojiPanelDidRequestDelete(self)
     }
 
     @objc private func returnTapped() {
-        KeyboardHaptics.shared.keyPress()
+        KeyboardHaptics.shared.textCommitted()
         delegate?.emojiPanelDidRequestReturn(self)
     }
 }
@@ -305,7 +305,7 @@ extension EmojiPanelView: UICollectionViewDataSource, UICollectionViewDelegateFl
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard indexPath.item < glyphs.count else { return }
         let glyph = glyphs[indexPath.item]
-        KeyboardHaptics.shared.keyPress()
+        KeyboardHaptics.shared.textCommitted()
         EmojiRecents.note(glyph)
         delegate?.emojiPanel(self, didChoose: glyph)
     }

--- a/ios/VocaPhoneKeyboard/EmojiPanelView.swift
+++ b/ios/VocaPhoneKeyboard/EmojiPanelView.swift
@@ -18,6 +18,7 @@ protocol EmojiPanelViewDelegate: AnyObject {
 /// never becomes a place you can get stuck.
 final class EmojiPanelView: UIView {
     weak var delegate: (any EmojiPanelViewDelegate)?
+    private let feedback: any KeyboardFeedbackProviding
 
     var palette: KeyboardPalette {
         didSet {
@@ -60,9 +61,14 @@ final class EmojiPanelView: UIView {
     }()
     private let bottomRow = UIStackView()
 
-    init(palette: KeyboardPalette, metrics: KeyboardMetrics) {
+    init(
+        palette: KeyboardPalette,
+        metrics: KeyboardMetrics,
+        feedback: any KeyboardFeedbackProviding = KeyboardHaptics.shared
+    ) {
         self.palette = palette
         self.metrics = metrics
+        self.feedback = feedback
         super.init(frame: .zero)
         configure()
         applyPalette()
@@ -175,6 +181,7 @@ final class EmojiPanelView: UIView {
             button.layer.cornerRadius = 8
             button.layer.cornerCurve = .continuous
             button.accessibilityLabel = category.label
+            button.addTarget(self, action: #selector(keyPressed), for: .touchDown)
             button.addTarget(self, action: #selector(categoryTapped), for: .touchUpInside)
             categoryRow.addArrangedSubview(button)
             button.widthAnchor.constraint(equalToConstant: 40).isActive = true
@@ -218,6 +225,7 @@ final class EmojiPanelView: UIView {
         button.titleLabel?.font = .systemFont(ofSize: metrics.functionFontSize, weight: .medium)
         button.layer.cornerRadius = metrics.cornerRadius
         button.layer.cornerCurve = .continuous
+        button.addTarget(self, action: #selector(keyPressed), for: .touchDown)
         button.addTarget(self, action: action, for: .touchUpInside)
         return button
     }
@@ -237,6 +245,14 @@ final class EmojiPanelView: UIView {
 
     // MARK: - Actions
 
+    /// The panel's controls are `UIButton`s and collection cells rather than the
+    /// grid's own hit-tested keys, so the click has to be hung off touch-down
+    /// explicitly. Without it the panel would sound a beat later than the
+    /// keyboard the user just came from.
+    @objc private func keyPressed() {
+        feedback.keyPressed()
+    }
+
     @objc private func searchChanged() {
         query = searchField.text ?? ""
         reload()
@@ -244,7 +260,7 @@ final class EmojiPanelView: UIView {
 
     @objc private func categoryTapped(_ sender: UIButton) {
         guard sender.tag < EmojiCategory.allCases.count else { return }
-        KeyboardHaptics.shared.selectionChanged()
+        feedback.selectionChanged()
         category = EmojiCategory.allCases[sender.tag]
         query = ""
         searchField.text = ""
@@ -257,22 +273,22 @@ final class EmojiPanelView: UIView {
     // they tap back the same way. A panel that goes silent the moment it opens
     // reads as a keyboard that has stopped responding.
     @objc private func lettersTapped() {
-        KeyboardHaptics.shared.selectionChanged()
+        feedback.selectionChanged()
         delegate?.emojiPanelDidRequestLetters(self)
     }
 
     @objc private func spaceTapped() {
-        KeyboardHaptics.shared.textCommitted()
+        feedback.textCommitted()
         delegate?.emojiPanelDidRequestSpace(self)
     }
 
     @objc private func deleteTapped() {
-        KeyboardHaptics.shared.keyActionCommitted()
+        feedback.keyActionCommitted()
         delegate?.emojiPanelDidRequestDelete(self)
     }
 
     @objc private func returnTapped() {
-        KeyboardHaptics.shared.textCommitted()
+        feedback.textCommitted()
         delegate?.emojiPanelDidRequestReturn(self)
     }
 }
@@ -302,10 +318,15 @@ extension EmojiPanelView: UICollectionViewDataSource, UICollectionViewDelegateFl
         itemSize
     }
 
+    func collectionView(_ collectionView: UICollectionView, didHighlightItemAt indexPath: IndexPath) {
+        // Highlight is the cell's touch-down, which is where a key clicks.
+        feedback.keyPressed()
+    }
+
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard indexPath.item < glyphs.count else { return }
         let glyph = glyphs[indexPath.item]
-        KeyboardHaptics.shared.textCommitted()
+        feedback.textCommitted()
         EmojiRecents.note(glyph)
         delegate?.emojiPanel(self, didChoose: glyph)
     }

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -114,6 +114,12 @@ final class KeyGridView: UIView {
     /// scan UIKit subviews directly, so a gutter boundary has one stable owner.
     private var hitMap = KeyHitMap(targets: [])
     private var tracked: [TrackedTouch] = []
+    /// The plane key's hold-for-emoji gesture. Owned by the grid rather than by
+    /// a `TrackedTouch`, because the plane switch it rides on releases those.
+    private var planeHoldTimer: Timer?
+    private weak var planeHoldTouch: UITouch?
+    private var planeHoldOrigin: KeyPlane?
+    private var planeHoldPoint: CGPoint?
     private var deleteTimer: Timer?
     private var spaceTrackpadTimer: Timer?
     private var deleteRepeatCount = 0
@@ -334,6 +340,7 @@ final class KeyGridView: UIView {
     private func rebuild() {
         hitMap = KeyHitMap(targets: [])
         endDeleteRepeat()
+        cancelPlaneHold()
         releaseTouches()
         for (_, plane) in planeCache {
             plane.views.forEach { $0.removeFromSuperview() }
@@ -349,8 +356,8 @@ final class KeyGridView: UIView {
     }
 
     private func activatePlane() {
-        // `setNeedsLayout()` is deferred. Never let touches arriving in that
-        // window resolve old target indices against the new plane's views.
+        // Cleared here and rebuilt before this method returns: never let a
+        // touch resolve old target indices against the new plane's views.
         hitMap = KeyHitMap(targets: [])
         endDeleteRepeat()
         releaseTouches()
@@ -392,6 +399,11 @@ final class KeyGridView: UIView {
         updateKeys()
         invalidateIntrinsicContentSize()
         setNeedsLayout()
+        // `setNeedsLayout()` alone defers the new geometry to the next layout
+        // pass, and `touchesBegan` walks an unordered set: a second finger
+        // landing in the same event as a plane switch would resolve against an
+        // empty map and be silently dropped. Two-thumb typists hit that.
+        layoutIfNeeded()
     }
 
     /// Abandons everything in flight — held keys, delete repeat, an open accent
@@ -400,6 +412,7 @@ final class KeyGridView: UIView {
     /// dismissed, and a popover left behind reappears over the next field.
     func endActiveInteractions() {
         endDeleteRepeat()
+        cancelPlaneHold()
         releaseTouches()
     }
 
@@ -439,10 +452,17 @@ final class KeyGridView: UIView {
             let item = TrackedTouch(touch: touch, key: key, initialPoint: point)
             tracked.append(item)
             key.isHighlighted = true
+            // The click belongs to the press, not to the commit: the system
+            // keyboard sounds a key as the finger lands, and every key here
+            // does the same so the rhythm never depends on which key it was.
+            feedback.keyPressed()
             showPreview(for: item)
             if key.spec.cap == .space { scheduleSpaceTrackpad(for: item) }
             scheduleAlternatives(for: item)
-            schedulePlaneLongPress(for: item)
+            if case .plane = key.spec.cap {
+                beginPlaneHold(at: point)
+                planeHoldTouch = touch
+            }
             if key.spec.cap.actsOnTouchDown {
                 performTouchDownAction(for: key, event: event)
             }
@@ -451,6 +471,12 @@ final class KeyGridView: UIView {
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
         for touch in touches {
+            if planeHoldTouch === touch, let origin = planeHoldPoint {
+                let point = touch.location(in: self)
+                // Sliding off the plane key is a change of mind about the key,
+                // not a hold — the same 12pt slack the accent popover allows.
+                if hypot(point.x - origin.x, point.y - origin.y) > 12 { cancelPlaneHold() }
+            }
             guard let item = tracked.first(where: { $0.touch === touch }) else { continue }
             let point = touch.location(in: self)
 
@@ -537,6 +563,7 @@ final class KeyGridView: UIView {
 
     private func finish(_ touches: Set<UITouch>, commit: Bool) {
         for touch in touches {
+            if planeHoldTouch === touch { cancelPlaneHold() }
             guard let index = tracked.firstIndex(where: { $0.touch === touch }) else { continue }
             let item = tracked.remove(at: index)
             if item.key.spec.cap == .space {
@@ -707,27 +734,45 @@ final class KeyGridView: UIView {
     /// focus model has no finger to hold, and the alternatives are reachable
     /// through the key's accessibility custom actions instead — see
     /// ``KeyView/refresh()``.
-    /// Holding the plane key opens the emoji panel. Armed separately from the
-    /// accent popover, because the plane key is not a character key.
-    private func schedulePlaneLongPress(for item: TrackedTouch) {
-        guard case .plane = item.key.spec.cap, !UIAccessibility.isVoiceOverRunning else { return }
-        item.longPressTimer?.invalidate()
-        item.longPressTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) {
-            [weak self, weak item] _ in
-            MainActor.assumeIsolated {
-                guard let self,
-                      let item,
-                      self.tracked.contains(where: { $0 === item })
-                else { return }
-                item.longPressTimer = nil
-                item.key.isHighlighted = false
-                // The touch is consumed: lifting must not also switch planes,
-                // which is what the same key does on a tap.
-                self.tracked.removeAll { $0 === item }
-                self.feedback.selectionChanged()
-                self.delegate?.keyGrid(self, didProduce: .emojiPanel)
-            }
+    /// Holding the plane key opens the emoji panel.
+    ///
+    /// The hold cannot hang off the `TrackedTouch` the way the accent popover
+    /// does. The plane key acts on touch-down, and switching planes rebuilds
+    /// the grid and releases every tracked touch — which invalidated this very
+    /// timer before it could ever fire, leaving the gesture unreachable. The
+    /// grid owns it instead, and remembers the plane the hold started from so
+    /// reaching the panel does not also leave a plane switch behind it.
+    /// Arms the hold, remembering the plane it started from. Split from touch
+    /// handling — and from the touch's own identity — so the gesture the plane
+    /// switch used to swallow can be tested without a UIKit-owned `UITouch`.
+    func beginPlaneHold(at point: CGPoint) {
+        guard !UIAccessibility.isVoiceOverRunning else { return }
+        cancelPlaneHold()
+        planeHoldOrigin = plane
+        planeHoldPoint = point
+        planeHoldTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) {
+            [weak self] _ in
+            MainActor.assumeIsolated { self?.completePlaneHold() }
         }
+    }
+
+    func completePlaneHold() {
+        guard let origin = planeHoldOrigin else { return }
+        cancelPlaneHold()
+        // The tap already switched planes as the finger landed. A hold means
+        // the panel was wanted instead, so the switch is undone rather than
+        // left waiting underneath it.
+        plane = origin
+        feedback.selectionChanged()
+        delegate?.keyGrid(self, didProduce: .emojiPanel)
+    }
+
+    private func cancelPlaneHold() {
+        planeHoldTimer?.invalidate()
+        planeHoldTimer = nil
+        planeHoldTouch = nil
+        planeHoldOrigin = nil
+        planeHoldPoint = nil
     }
 
     private func scheduleAlternatives(for item: TrackedTouch) {
@@ -840,8 +885,9 @@ final class KeyGridView: UIView {
     }
 
     /// One repeat at a time, rescheduled at the ramped interval — a repeating
-    /// timer cannot change its own period.
-    private func scheduleNextDelete() {
+    /// timer cannot change its own period. Not private, so a test can step the
+    /// ramp without waiting out real seconds of held Delete.
+    func scheduleNextDelete() {
         deleteTimer?.invalidate()
         guard delegate?.keyGridShouldContinueDeleting(self) ?? true else {
             // The start of a line. Stopping here is what keeps a held Delete
@@ -854,6 +900,7 @@ final class KeyGridView: UIView {
         let output: KeyboardOutput = deleteRepeatCount > Self.deleteWordThreshold
             ? .deleteWord
             : .deleteBackward
+        feedback.deleteRepeated()
         delegate?.keyGrid(self, didProduce: output)
 
         // Eased from slow to fast over the first dozen repeats.

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -195,9 +195,20 @@ final class KeyGridView: UIView {
 
             for (column, width) in widths.enumerated() {
                 let key = keyViews[keyIndex]
-                key.frame = CGRect(x: x, y: y, width: width, height: metrics.keyHeight)
+                let slotFrame = CGRect(
+                    x: x,
+                    y: y,
+                    width: width,
+                    height: metrics.keyHeight
+                )
+                key.frame = visibleFrame(
+                    for: slotFrame,
+                    key: key,
+                    row: row,
+                    unit: unit
+                )
                 key.hitRect = hitRect(
-                    for: key.frame,
+                    for: slotFrame,
                     isLeading: column == 0,
                     isTrailing: column == widths.count - 1,
                     isTopRow: rowIndex == 0,
@@ -217,6 +228,38 @@ final class KeyGridView: UIView {
                 isCharacter: key.spec.cap.isCharacter
             )
         })
+    }
+
+    /// The native letters plane leaves a larger visual moat around Shift and
+    /// Delete without sacrificing their touch targets. Keep the original slot
+    /// for hit testing, and only inset the rendered key toward the outside.
+    private func visibleFrame(
+        for slotFrame: CGRect,
+        key: KeyView,
+        row: KeyRow,
+        unit: CGFloat
+    ) -> CGRect {
+        guard row.keys.first?.cap == .shift else { return slotFrame }
+        let nativeModifierWidth = unit + 12
+        let inset = max(slotFrame.width - nativeModifierWidth, 0)
+        switch key.spec.cap {
+        case .shift:
+            return CGRect(
+                x: slotFrame.minX,
+                y: slotFrame.minY,
+                width: slotFrame.width - inset,
+                height: slotFrame.height
+            )
+        case .delete:
+            return CGRect(
+                x: slotFrame.minX + inset,
+                y: slotFrame.minY,
+                width: slotFrame.width - inset,
+                height: slotFrame.height
+            )
+        default:
+            return slotFrame
+        }
     }
 
     private func resolvedWidths(

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -109,6 +109,9 @@ final class KeyGridView: UIView {
     /// any interaction that makes sense, and allocating a view per long press
     /// would churn labels the pool exists to avoid.
     private var alternativesView: KeyAlternativesView?
+    /// Rebuilt by layout from the same frames that are rendered. Touches never
+    /// scan UIKit subviews directly, so a gutter boundary has one stable owner.
+    private var hitMap = KeyHitMap(targets: [])
     private var tracked: [TrackedTouch] = []
     private var deleteTimer: Timer?
     private var spaceTrackpadTimer: Timer?
@@ -169,7 +172,10 @@ final class KeyGridView: UIView {
         // Every row resolves against the width of one letter column from the
         // ten-key reference row, which is what keeps columns aligned vertically.
         let unit = (available - 9 * metrics.columnGap) / 10
-        guard unit > 0 else { return }
+        guard unit > 0 else {
+            hitMap = KeyHitMap(targets: [])
+            return
+        }
 
         var keyIndex = 0
         var y: CGFloat = 0
@@ -196,6 +202,15 @@ final class KeyGridView: UIView {
             }
             y += metrics.keyHeight + metrics.rowGap
         }
+
+        hitMap = KeyHitMap(targets: keyViews.enumerated().map { index, key in
+            KeyHitMap.Target(
+                index: index,
+                frame: key.frame,
+                hitRect: key.hitRect,
+                isCharacter: key.spec.cap.isCharacter
+            )
+        })
     }
 
     private func resolvedWidths(
@@ -371,7 +386,6 @@ final class KeyGridView: UIView {
             let item = TrackedTouch(touch: touch, key: key, initialPoint: point)
             tracked.append(item)
             key.isHighlighted = true
-            KeyboardHaptics.shared.keyPress()
             showPreview(for: item)
             if key.spec.cap == .space { scheduleSpaceTrackpad(for: item) }
             scheduleAlternatives(for: item)
@@ -502,6 +516,7 @@ final class KeyGridView: UIView {
                 let choice = alternativesView?.highlightedOption
                 dismissAlternatives()
                 guard commit, let choice else { continue }
+                KeyboardHaptics.shared.textCommitted()
                 delegate?.keyGrid(self, didProduce: .text(choice))
                 if shiftState == .on { shiftState = .off }
                 continue
@@ -512,6 +527,7 @@ final class KeyGridView: UIView {
     }
 
     private func commitKey(_ key: KeyView) {
+        KeyboardHaptics.shared.textCommitted()
         switch key.spec.cap {
         case .character:
             guard let text = key.previewText else { return }
@@ -527,6 +543,7 @@ final class KeyGridView: UIView {
     }
 
     private func performTouchDownAction(for key: KeyView, event: UIEvent?) {
+        KeyboardHaptics.shared.keyActionCommitted()
         switch key.spec.cap {
         case .delete:
             delegate?.keyGrid(self, didProduce: .deleteBackward)
@@ -729,19 +746,10 @@ final class KeyGridView: UIView {
     }
 
     private func key(at point: CGPoint, characterOnly: Bool) -> KeyView? {
-        var closest: KeyView?
-        var shortestDistance = CGFloat.greatestFiniteMagnitude
-        for key in keyViews {
-            if characterOnly, !key.spec.cap.isCharacter { continue }
-            guard key.hitRect.contains(point) else { continue }
-            // Gutters belong to both neighbours, so ties go to the nearer centre.
-            let distance = hypot(point.x - key.frame.midX, point.y - key.frame.midY)
-            if distance < shortestDistance {
-                shortestDistance = distance
-                closest = key
-            }
-        }
-        return closest
+        guard let index = hitMap.targetIndex(at: point, characterOnly: characterOnly),
+              keyViews.indices.contains(index)
+        else { return nil }
+        return keyViews[index]
     }
 
     // MARK: - Delete repeat

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -128,7 +128,23 @@ final class KeyGridView: UIView {
     private final class TrackedTouch: @unchecked Sendable {
         let touch: UITouch
         var key: KeyView
+        /// Whether the finger may leave this key and type the one it lands on.
+        /// Characters always may. So do Shift and the plane key, because iOS
+        /// lets a press on either slide onto a letter or symbol, type it, and
+        /// drop the modifier — one of the gestures people type by reflex.
         let allowsSlide: Bool
+        /// Only a touch that began on a character may become a traced word. A
+        /// slide off Shift travels just as far and must not be read as one.
+        let allowsSwipe: Bool
+        /// Set when this touch began on the plane key: the plane to return to
+        /// once the slide has typed something. A plain tap leaves it nil, so
+        /// tapping `123` stays on the numbers plane the way it should.
+        let planeToRestore: KeyPlane?
+        /// A slide that started on a modifier only commits while the finger is
+        /// still over the key it landed on — sliding back to the modifier and
+        /// lifting types nothing, as on iOS.
+        var isModifierSlide: Bool { planeToRestore != nil || startedOnShift }
+        private let startedOnShift: Bool
         var preview: KeyPreviewView?
         let initialPoint: CGPoint
         var lastCursorStep = 0
@@ -142,11 +158,19 @@ final class KeyGridView: UIView {
         var swipePath: [CGPoint] = []
         var isSwiping = false
 
-        init(touch: UITouch, key: KeyView, initialPoint: CGPoint) {
+        init(
+            touch: UITouch,
+            key: KeyView,
+            initialPoint: CGPoint,
+            planeToRestore: KeyPlane? = nil
+        ) {
             self.touch = touch
             self.key = key
             self.initialPoint = initialPoint
-            allowsSlide = key.spec.cap.isCharacter
+            self.planeToRestore = planeToRestore
+            startedOnShift = key.spec.cap == .shift
+            allowsSwipe = key.spec.cap.isCharacter
+            allowsSlide = key.spec.cap.isCharacter || startedOnShift || planeToRestore != nil
         }
     }
 
@@ -190,6 +214,8 @@ final class KeyGridView: UIView {
         }
 
         var keyIndex = 0
+        var targets: [KeyHitMap.Target] = []
+        targets.reserveCapacity(keyViews.count)
         var y: CGFloat = 0
         for (rowIndex, row) in rows.enumerated() {
             let widths = resolvedWidths(for: row, unit: unit, available: available)
@@ -220,20 +246,26 @@ final class KeyGridView: UIView {
                     isTopRow: rowIndex == 0,
                     isBottomRow: rowIndex == rows.count - 1
                 )
+                // The slot, not `key.frame`: Shift and Delete render inset to
+                // leave the native moat around them, and measuring from the
+                // shrunken visual centre would hand their share of the gutter
+                // to the neighbouring letter — losing the touch target the
+                // inset was written to preserve.
+                targets.append(
+                    KeyHitMap.Target(
+                        index: keyIndex,
+                        frame: slotFrame,
+                        hitRect: key.hitRect,
+                        isCharacter: key.spec.cap.isCharacter
+                    )
+                )
                 x += width + metrics.columnGap
                 keyIndex += 1
             }
             y += metrics.keyHeight + metrics.rowGap
         }
 
-        hitMap = KeyHitMap(targets: keyViews.enumerated().map { index, key in
-            KeyHitMap.Target(
-                index: index,
-                frame: key.frame,
-                hitRect: key.hitRect,
-                isCharacter: key.spec.cap.isCharacter
-            )
-        })
+        hitMap = KeyHitMap(targets: targets)
     }
 
     /// The native letters plane leaves a larger visual moat around Shift and
@@ -464,7 +496,24 @@ final class KeyGridView: UIView {
                 planeHoldTouch = touch
             }
             if key.spec.cap.actsOnTouchDown {
+                let planeBefore = plane
                 performTouchDownAction(for: key, event: event)
+                // Switching planes rebuilds the grid and releases every touch,
+                // this one included. Re-register it against the plane the
+                // finger is now looking at, so it can slide onto a symbol and
+                // type it on lift the way the system keyboard does.
+                if case .plane = key.spec.cap, plane != planeBefore,
+                   let landed = self.key(at: point, characterOnly: false)
+                {
+                    let slide = TrackedTouch(
+                        touch: touch,
+                        key: landed,
+                        initialPoint: point,
+                        planeToRestore: planeBefore
+                    )
+                    tracked.append(slide)
+                    landed.isHighlighted = true
+                }
             }
         }
     }
@@ -512,7 +561,7 @@ final class KeyGridView: UIView {
                 continue
             }
 
-            if swipeTypingIsAvailable, item.allowsSlide {
+            if swipeTypingIsAvailable, item.allowsSwipe {
                 let travelled = hypot(
                     point.x - item.initialPoint.x,
                     point.y - item.initialPoint.y
@@ -562,6 +611,10 @@ final class KeyGridView: UIView {
     }
 
     private func finish(_ touches: Set<UITouch>, commit: Bool) {
+        // Applied after the loop: restoring the plane rebuilds the grid and
+        // releases every tracked touch, which would strand the other fingers
+        // of a multi-touch batch before they have been read.
+        var planeToRestore: KeyPlane?
         for touch in touches {
             if planeHoldTouch === touch { cancelPlaneHold() }
             guard let index = tracked.firstIndex(where: { $0.touch === touch }) else { continue }
@@ -572,7 +625,15 @@ final class KeyGridView: UIView {
             }
             item.longPressTimer?.invalidate()
             item.longPressTimer = nil
-            let shouldCommit = commit && item.key.isHighlighted && !item.isCursorTracking
+            var shouldCommit = commit && item.key.isHighlighted && !item.isCursorTracking
+            // A slide that began on Shift or the plane key tracks characters
+            // only, so sliding back onto the modifier leaves `item.key` on the
+            // letter it passed over. Lifting there must type nothing.
+            if item.isModifierSlide,
+               !item.key.hitRect.contains(touch.location(in: self))
+            {
+                shouldCommit = false
+            }
             item.key.isHighlighted = false
             recycle(item.preview)
             item.preview = nil
@@ -601,32 +662,42 @@ final class KeyGridView: UIView {
                 if shiftState == .on { shiftState = .off }
                 continue
             }
-            completeKeyInteraction(
+            let didCommit = completeKeyInteraction(
                 item.key,
                 shouldCommit: shouldCommit && !item.key.spec.cap.actsOnTouchDown
             )
+            // Typing a symbol this way returns to the plane the finger came
+            // from; lifting on the plane key itself commits nothing and stays.
+            if didCommit, let origin = item.planeToRestore { planeToRestore = origin }
         }
+        if let planeToRestore { plane = planeToRestore }
     }
 
     /// The single completion boundary for ordinary taps and slide correction.
     /// Keeping the commit decision here makes cancellation testable without
     /// constructing UIKit-owned `UITouch` instances.
-    func completeKeyInteraction(_ key: KeyView, shouldCommit: Bool) {
-        guard shouldCommit else { return }
+    @discardableResult
+    func completeKeyInteraction(_ key: KeyView, shouldCommit: Bool) -> Bool {
+        guard shouldCommit else { return false }
         switch key.spec.cap {
         case .character:
-            guard let text = key.previewText else { return }
+            guard let text = key.previewText else { return false }
             feedback.textCommitted()
             delegate?.keyGrid(self, didProduce: .text(text))
+            // Also what ends a slide off Shift: one capital, then back to
+            // lowercase. A locked Shift is a deliberate state and outranks it.
             if shiftState == .on { shiftState = .off }
+            return true
         case .space:
             feedback.textCommitted()
             delegate?.keyGrid(self, didProduce: .space)
+            return true
         case .newline:
             feedback.textCommitted()
             delegate?.keyGrid(self, didProduce: .newline)
+            return true
         default:
-            break
+            return false
         }
     }
 
@@ -866,9 +937,14 @@ final class KeyGridView: UIView {
     /// faster than the system keyboard at the start — so a hold meant to remove
     /// two letters removed five — and slower than it once a long deletion is
     /// genuinely under way.
-    private static let deleteInitialDelay: TimeInterval = 0.45
+    ///
+    /// The floor is the part that has to stay honest. iOS settles at roughly
+    /// ten characters a second and holds there; ramping to 0.045 s was more
+    /// than twice that, which is how a hold meant to clear a word clears the
+    /// sentence before the finger lifts.
+    private static let deleteInitialDelay: TimeInterval = 0.5
     private static let deleteSlowestInterval: TimeInterval = 0.16
-    private static let deleteFastestInterval: TimeInterval = 0.045
+    private static let deleteFastestInterval: TimeInterval = 0.09
     /// After this many repeats a hold is clearly a bulk deletion, and whole
     /// words go rather than letters.
     private static let deleteWordThreshold = 16
@@ -938,15 +1014,44 @@ final class KeyGridView: UIView {
             preview = dequeuePreview()
             item.preview = preview
         }
-        preview.show(text)
-
         let frame = item.key.frame
         let width = max(frame.width * 1.5, frame.width + 22)
-        let height = frame.height * 1.25
+        let balloonHeight = frame.height * 1.25
         let x = min(max(frame.midX - width / 2, 2), bounds.width - width - 2)
-        preview.frame = CGRect(x: x, y: frame.minY - height - 6, width: width, height: height)
+        // The preview reaches down over the key rather than floating above a
+        // gap: the neck is what joins the two on the system keyboard, and the
+        // gap is the tell that gives a third-party keyboard away.
+        preview.frame = CGRect(
+            x: x,
+            y: frame.minY - balloonHeight,
+            width: width,
+            height: balloonHeight + frame.height
+        )
+        preview.show(
+            text,
+            balloonHeight: balloonHeight,
+            neck: CGRect(
+                x: frame.minX - x,
+                y: balloonHeight,
+                width: frame.width,
+                height: frame.height
+            )
+        )
         bringSubviewToFront(preview)
     }
+
+#if DEBUG
+    /// Shows a key's preview with no touch behind it, so the balloon can be
+    /// rendered and looked at without installing the keyboard on a device.
+    ///
+    /// The throwaway `TrackedTouch` is deliberately not added to `tracked`: it
+    /// carries no real `UITouch`, and live touch tracking must never see one.
+    /// `showPreview` only reads the item, and the balloon it dequeues is a
+    /// subview of the grid, so it survives for the render either way.
+    func previewKeyForRendering(_ key: KeyView) {
+        showPreview(for: TrackedTouch(touch: UITouch(), key: key, initialPoint: .zero))
+    }
+#endif
 
     /// Reused rather than allocated per touch; a fast typist would otherwise
     /// create and discard a view for every keystroke.

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -44,6 +44,7 @@ protocol KeyGridViewDelegate: AnyObject {
 /// per key reacting to `touchUpInside`.
 final class KeyGridView: UIView {
     weak var delegate: (any KeyGridViewDelegate)?
+    private let feedback: any KeyboardFeedbackProviding
 
     var metrics: KeyboardMetrics {
         didSet { if metrics != oldValue { rebuild() } }
@@ -143,9 +144,14 @@ final class KeyGridView: UIView {
         }
     }
 
-    init(metrics: KeyboardMetrics, palette: KeyboardPalette) {
+    init(
+        metrics: KeyboardMetrics,
+        palette: KeyboardPalette,
+        feedback: any KeyboardFeedbackProviding = KeyboardHaptics.shared
+    ) {
         self.metrics = metrics
         self.palette = palette
+        self.feedback = feedback
         super.init(frame: .zero)
         isMultipleTouchEnabled = true
         // Previews for the top row rise above the grid's own bounds.
@@ -283,6 +289,7 @@ final class KeyGridView: UIView {
     /// Discards every cached plane. Only geometry or colour changes need this;
     /// a plane switch goes through `activatePlane`.
     private func rebuild() {
+        hitMap = KeyHitMap(targets: [])
         endDeleteRepeat()
         releaseTouches()
         for (_, plane) in planeCache {
@@ -299,6 +306,9 @@ final class KeyGridView: UIView {
     }
 
     private func activatePlane() {
+        // `setNeedsLayout()` is deferred. Never let touches arriving in that
+        // window resolve old target indices against the new plane's views.
+        hitMap = KeyHitMap(targets: [])
         endDeleteRepeat()
         releaseTouches()
         keyViews.forEach { $0.isHidden = true }
@@ -452,7 +462,7 @@ final class KeyGridView: UIView {
                     // mid-air would look like a dropped frame.
                     swipeTrail.begin(at: item.initialPoint)
                     bringSubviewToFront(swipeTrail)
-                    KeyboardHaptics.shared.swipeBegan()
+                    feedback.swipeBegan()
                 }
                 if item.isSwiping {
                     item.swipePath.append(point)
@@ -516,26 +526,34 @@ final class KeyGridView: UIView {
                 let choice = alternativesView?.highlightedOption
                 dismissAlternatives()
                 guard commit, let choice else { continue }
-                KeyboardHaptics.shared.textCommitted()
+                feedback.textCommitted()
                 delegate?.keyGrid(self, didProduce: .text(choice))
                 if shiftState == .on { shiftState = .off }
                 continue
             }
-            guard shouldCommit, !item.key.spec.cap.actsOnTouchDown else { continue }
-            commitKey(item.key)
+            completeKeyInteraction(
+                item.key,
+                shouldCommit: shouldCommit && !item.key.spec.cap.actsOnTouchDown
+            )
         }
     }
 
-    private func commitKey(_ key: KeyView) {
-        KeyboardHaptics.shared.textCommitted()
+    /// The single completion boundary for ordinary taps and slide correction.
+    /// Keeping the commit decision here makes cancellation testable without
+    /// constructing UIKit-owned `UITouch` instances.
+    func completeKeyInteraction(_ key: KeyView, shouldCommit: Bool) {
+        guard shouldCommit else { return }
         switch key.spec.cap {
         case .character:
             guard let text = key.previewText else { return }
+            feedback.textCommitted()
             delegate?.keyGrid(self, didProduce: .text(text))
             if shiftState == .on { shiftState = .off }
         case .space:
+            feedback.textCommitted()
             delegate?.keyGrid(self, didProduce: .space)
         case .newline:
+            feedback.textCommitted()
             delegate?.keyGrid(self, didProduce: .newline)
         default:
             break
@@ -543,7 +561,7 @@ final class KeyGridView: UIView {
     }
 
     private func performTouchDownAction(for key: KeyView, event: UIEvent?) {
-        KeyboardHaptics.shared.keyActionCommitted()
+        feedback.keyActionCommitted()
         switch key.spec.cap {
         case .delete:
             delegate?.keyGrid(self, didProduce: .deleteBackward)
@@ -572,7 +590,7 @@ final class KeyGridView: UIView {
                 else { return }
                 item.isCursorTracking = true
                 item.lastCursorStep = 0
-                KeyboardHaptics.shared.selectionChanged()
+                self.feedback.selectionChanged()
                 UIAccessibility.post(notification: .announcement, argument: "Cursor control")
             }
         }
@@ -630,7 +648,7 @@ final class KeyGridView: UIView {
         let trace = recognizer.trace(path)
         let candidates = recognizer.candidates(for: trace, in: wordList)
         guard let best = candidates.first else { return }
-        KeyboardHaptics.shared.swipeCommitted()
+        feedback.swipeCommitted()
         delegate?.keyGrid(
             self,
             didProduce: .swipeWord(best, alternates: Array(candidates.dropFirst()))
@@ -663,7 +681,7 @@ final class KeyGridView: UIView {
                 // The touch is consumed: lifting must not also switch planes,
                 // which is what the same key does on a tap.
                 self.tracked.removeAll { $0 === item }
-                KeyboardHaptics.shared.selectionChanged()
+                self.feedback.selectionChanged()
                 self.delegate?.keyGrid(self, didProduce: .emojiPanel)
             }
         }
@@ -722,14 +740,14 @@ final class KeyGridView: UIView {
 
         item.isChoosingAlternative = true
         item.longPressTimer = nil
-        KeyboardHaptics.shared.selectionChanged()
+        feedback.selectionChanged()
     }
 
     private func handleAlternativeMovement(_ item: TrackedTouch, point: CGPoint) {
         guard let popover = alternativesView else { return }
         let local = convert(point, to: popover)
         if popover.highlightOption(atX: local.x) {
-            KeyboardHaptics.shared.selectionChanged()
+            feedback.selectionChanged()
         }
     }
 
@@ -745,7 +763,7 @@ final class KeyGridView: UIView {
         shiftState = isDoubleTap ? .locked : (shiftState == .off ? .on : .off)
     }
 
-    private func key(at point: CGPoint, characterOnly: Bool) -> KeyView? {
+    func key(at point: CGPoint, characterOnly: Bool) -> KeyView? {
         guard let index = hitMap.targetIndex(at: point, characterOnly: characterOnly),
               keyViews.indices.contains(index)
         else { return nil }

--- a/ios/VocaPhoneKeyboard/KeyHitMap.swift
+++ b/ios/VocaPhoneKeyboard/KeyHitMap.swift
@@ -1,0 +1,55 @@
+import CoreGraphics
+
+/// The effective targets for one laid-out keyboard plane.
+///
+/// Keys can visually leave a gutter between them while still claiming that
+/// space for touch input. Keeping the selection rule separate from `UIView`
+/// traversal makes that rule deterministic, testable, and shared by every
+/// touch path. The visible geometry remains the source of truth; this type does
+/// not invent personalised or language-aware correction.
+struct KeyHitMap {
+    struct Target: Equatable {
+        /// Stable layout order, used only when a point is exactly equidistant
+        /// from two visual centres.
+        let index: Int
+        let frame: CGRect
+        let hitRect: CGRect
+        let isCharacter: Bool
+    }
+
+    let targets: [Target]
+
+    func targetIndex(at point: CGPoint, characterOnly: Bool) -> Int? {
+        var winner: Target?
+        var shortestDistance = CGFloat.greatestFiniteMagnitude
+
+        for target in targets {
+            guard (!characterOnly || target.isCharacter), target.hitRect.contains(point) else {
+                continue
+            }
+
+            let distance = hypot(
+                point.x - target.frame.midX,
+                point.y - target.frame.midY
+            )
+            if distance < shortestDistance {
+                winner = target
+                shortestDistance = distance
+                continue
+            }
+
+            // A gutter can be exactly on the midpoint between two keys. The
+            // previous implementation happened to use subview iteration order;
+            // layout order states that tie-break explicitly and keeps it stable
+            // if the view hierarchy changes for previews or accessibility.
+            if distance == shortestDistance,
+               let currentWinner = winner,
+               target.index < currentWinner.index
+            {
+                winner = target
+            }
+        }
+
+        return winner?.index
+    }
+}

--- a/ios/VocaPhoneKeyboard/KeyHitMap.swift
+++ b/ios/VocaPhoneKeyboard/KeyHitMap.swift
@@ -19,6 +19,13 @@ struct KeyHitMap {
 
     let targets: [Target]
 
+    /// The nearest visible centre among the targets claiming `point`.
+    ///
+    /// A gutter can land exactly on the midpoint between two keys. `targets` is
+    /// in layout order and the comparison is strictly closer, so such a tie
+    /// goes to the earlier key — the leftmost on a row — rather than to
+    /// whatever order the view hierarchy happens to be in after previews and
+    /// accessibility have moved subviews around.
     func targetIndex(at point: CGPoint, characterOnly: Bool) -> Int? {
         var winner: Target?
         var shortestDistance = CGFloat.greatestFiniteMagnitude
@@ -35,18 +42,6 @@ struct KeyHitMap {
             if distance < shortestDistance {
                 winner = target
                 shortestDistance = distance
-                continue
-            }
-
-            // A gutter can be exactly on the midpoint between two keys. The
-            // previous implementation happened to use subview iteration order;
-            // layout order states that tie-break explicitly and keeps it stable
-            // if the view hierarchy changes for previews or accessibility.
-            if distance == shortestDistance,
-               let currentWinner = winner,
-               target.index < currentWinner.index
-            {
-                winner = target
             }
         }
 

--- a/ios/VocaPhoneKeyboard/KeyLayout.swift
+++ b/ios/VocaPhoneKeyboard/KeyLayout.swift
@@ -169,10 +169,10 @@ enum KeyLayout {
         }
     }
 
-    /// The narrowest the return key may become. Below this "Continue" and
-    /// "Emergency" stop fitting, and the row's most-used non-space target starts
-    /// reading as an afterthought.
-    static let minimumReturnColumns: CGFloat = 1.75
+    /// Apple's iPhone bottom row gives Return two and a half letter columns.
+    /// Besides matching its visual weight, this keeps longer return labels such
+    /// as "Continue" from becoming a much smaller target than users expect.
+    static let minimumReturnColumns: CGFloat = 2.5
 
     /// Column widths that put the spacebar's visible centre on the keyboard's
     /// centre.
@@ -198,25 +198,21 @@ enum KeyLayout {
         var centreOffset: CGFloat { (leading - trailing) / 2 }
 
         static func resolved(includesGlobe: Bool, includesPunctuation: Bool) -> BottomRowColumns {
-            let punctuation: CGFloat? = includesPunctuation ? 1 : nil
-            var columns = BottomRowColumns(
-                planeSwitch: 1.25,
+            // Measured on Apple's iOS 26 keyboard at the same 402pt width:
+            //   plain:  2.5 |       5       | 2.5
+            //   globe:  1.25 | 1.25 | 5     | 2.5
+            //   email:  1.25 | 1.25 | 2.5 | 1.25 | 1.25 | 2.5
+            // iOS sometimes supplies the globe in its own row below the
+            // extension. In that case 123 occupies the two native leading
+            // slots instead of leaving Space unnaturally wide.
+            let punctuation: CGFloat? = includesPunctuation ? 1.25 : nil
+            return BottomRowColumns(
+                planeSwitch: includesGlobe ? 1.25 : 2.5,
                 globe: includesGlobe ? 1.25 : nil,
                 punctuation: punctuation,
                 period: punctuation,
-                newline: 0
+                newline: minimumReturnColumns
             )
-            // Return absorbs the difference, because it is the one key on this
-            // row with no fixed idea of how wide it should be.
-            columns.newline = columns.leading - columns.trailing
-            guard columns.newline < minimumReturnColumns else { return columns }
-            // Without a globe key the leading group is too light to balance a
-            // usable return, so the plane switch takes the slack instead. That
-            // is the rare case — iOS requires the globe on a third-party
-            // keyboard almost everywhere — and a wider "123" costs nothing.
-            columns.newline = minimumReturnColumns
-            columns.planeSwitch += columns.trailing - columns.leading
-            return columns
         }
     }
 
@@ -241,11 +237,21 @@ enum KeyLayout {
             keys.append(KeySpec(cap: .globe, width: .multiple(globe), style: .function))
         }
         if let punctuation {
-            keys.append(KeySpec(cap: .character(punctuation)))
+            keys.append(
+                KeySpec(
+                    cap: .character(punctuation),
+                    width: .multiple(columns.punctuation ?? 1)
+                )
+            )
         }
         keys.append(KeySpec(cap: .space, width: .fill))
         if punctuation != nil {
-            keys.append(KeySpec(cap: .character(".")))
+            keys.append(
+                KeySpec(
+                    cap: .character("."),
+                    width: .multiple(columns.period ?? 1)
+                )
+            )
         }
         keys.append(
             KeySpec(
@@ -323,9 +329,9 @@ struct KeyboardMetrics: Equatable {
         case .compact:
             return KeyboardMetrics(
                 keyHeight: 39,
-                rowGap: 8,
+                rowGap: 9,
                 columnGap: 6,
-                sideInset: 4,
+                sideInset: 2 / 3,
                 letterFontSize: 21,
                 functionFontSize: 15,
                 cornerRadius: 6
@@ -333,9 +339,9 @@ struct KeyboardMetrics: Equatable {
         case .standard:
             return KeyboardMetrics(
                 keyHeight: 43,
-                rowGap: 10,
+                rowGap: 11,
                 columnGap: 6,
-                sideInset: 4,
+                sideInset: 2 / 3,
                 letterFontSize: 22,
                 functionFontSize: 16,
                 cornerRadius: 6
@@ -343,9 +349,9 @@ struct KeyboardMetrics: Equatable {
         case .tall:
             return KeyboardMetrics(
                 keyHeight: 49,
-                rowGap: 11,
+                rowGap: 12,
                 columnGap: 6,
-                sideInset: 4,
+                sideInset: 2 / 3,
                 letterFontSize: 23,
                 functionFontSize: 16,
                 cornerRadius: 7
@@ -361,15 +367,25 @@ struct KeyboardMetrics: Equatable {
 /// The keys stay close to the system keyboard's luminance rather than adopting
 /// the app's warm paper canvas: a keyboard is a high-frequency input surface
 /// that has to read as part of iOS, not as the marketing site. What the brand
-/// contributes here is the *accent* — an engaged shift, an editor-prominent
-/// return — and nothing else.
+/// contributes here is the *accent* — an editor-prominent return and the swipe
+/// trail — and nothing else.
 struct KeyboardPalette: Equatable {
     let isDark: Bool
+
+    private var usesUnifiedSystemKeyFill: Bool {
+        if #available(iOS 26.0, *) { return true }
+        return false
+    }
 
     /// Neutral charcoal in dark, neutral grey in light. Both were previously
     /// tinted toward blue, which is the drift the design standard names.
     var background: UIColor {
-        isDark ? UIColor(white: 0.086, alpha: 1) : UIColor(white: 0.827, alpha: 1)
+        if usesUnifiedSystemKeyFill {
+            return isDark
+                ? UIColor(white: 23 / 255, alpha: 1)
+                : UIColor(red: 226 / 255, green: 228 / 255, blue: 232 / 255, alpha: 1)
+        }
+        return isDark ? UIColor(white: 0.086, alpha: 1) : UIColor(white: 0.827, alpha: 1)
     }
 
     var cardBorder: UIColor {
@@ -381,17 +397,23 @@ struct KeyboardPalette: Equatable {
     /// The brightest key in either appearance, because a character key is what
     /// the eye should land on first.
     var standardKey: UIColor {
-        isDark ? UIColor(white: 0.29, alpha: 1) : .white
+        if usesUnifiedSystemKeyFill {
+            return isDark ? UIColor(white: 61 / 255, alpha: 1) : .white
+        }
+        return isDark ? UIColor(white: 0.29, alpha: 1) : .white
     }
 
     /// Visibly a step down from ``standardKey``, and neutral — a muddy or blue
     /// function key is what made the old palette read as someone else's product.
     var functionKey: UIColor {
-        isDark ? UIColor(white: 0.184, alpha: 1) : UIColor(white: 0.686, alpha: 1)
+        if usesUnifiedSystemKeyFill { return standardKey }
+        return isDark
+            ? UIColor(white: 0.184, alpha: 1)
+            : UIColor(white: 0.686, alpha: 1)
     }
 
-    /// The product accent, used only where a key is genuinely *engaged* or
-    /// *prominent*: caps lock, an active shift, a Send/Search return.
+    /// The product accent, used only where a key is genuinely prominent, such
+    /// as a Send/Search return, or for the swipe trail.
     var accentKey: UIColor { BrandPalette.accent(isDark: isDark) }
 
     var keyForeground: UIColor { isDark ? .white : .black }
@@ -414,7 +436,7 @@ struct KeyboardPalette: Equatable {
     }
 
     func background(for style: KeyStyle) -> UIColor {
-        switch style {
+        return switch style {
         case .standard: standardKey
         case .function: functionKey
         case .accent: accentKey
@@ -427,11 +449,17 @@ struct KeyboardPalette: Equatable {
         style == .accent ? ContrastMath.legibleLabel(on: accentKey) : keyForeground
     }
 
-    /// Pressed function keys swap to the standard key colour and pressed
-    /// standard keys swap to the function colour, so a press always reads as a
-    /// change even when no preview is shown. No glow: the swap *is* the signal.
+    /// A press always reads as a change even when no preview is shown. Unified
+    /// iOS 26 keys darken or lighten; earlier palettes swap their two neutral
+    /// fills. No glow: the fill change is the signal.
     func pressedBackground(for style: KeyStyle) -> UIColor {
-        switch style {
+        if usesUnifiedSystemKeyFill, style != .accent {
+            return background(for: style).blended(
+                with: isDark ? .white : .black,
+                amount: 0.16
+            )
+        }
+        return switch style {
         case .standard: functionKey
         case .function: standardKey
         // Shifting toward the appearance's own extreme rather than fading, so a

--- a/ios/VocaPhoneKeyboard/KeyView.swift
+++ b/ios/VocaPhoneKeyboard/KeyView.swift
@@ -258,20 +258,35 @@ final class KeyView: UIView {
 
 /// The magnified glyph shown above a pressed character key. The system keyboard
 /// relies on this to confirm what was typed while the fingertip covers the key.
+///
+/// Drawn as one path rather than a floating rounded rectangle. iOS joins the
+/// balloon to the key with a tapered neck, and a bubble hovering over a gap is
+/// the detail that gives a third-party keyboard away at a glance. The view
+/// therefore spans from the top of the balloon down to the bottom of the key,
+/// and ``show(_:balloonHeight:neck:)`` is told where the key sits inside it.
 final class KeyPreviewView: UIView {
     private let label = UILabel()
+    private let shape = CAShapeLayer()
+    private let keyCornerRadius: CGFloat
+    private let balloonCornerRadius: CGFloat
+    private var balloonHeight: CGFloat = 0
+    private var neck: CGRect = .zero
 
     init(palette: KeyboardPalette, metrics: KeyboardMetrics) {
+        keyCornerRadius = metrics.cornerRadius
+        balloonCornerRadius = metrics.cornerRadius + 4
         super.init(frame: .zero)
         isUserInteractionEnabled = false
         isAccessibilityElement = false
-        backgroundColor = palette.standardKey
-        layer.cornerRadius = metrics.cornerRadius + 4
-        layer.cornerCurve = .continuous
-        layer.shadowColor = UIColor.black.cgColor
-        layer.shadowOpacity = 0.22
-        layer.shadowRadius = 5
-        layer.shadowOffset = CGSize(width: 0, height: 3)
+        // The shape carries the fill and the shadow; the view itself must not
+        // paint a rectangle behind it.
+        backgroundColor = .clear
+        shape.fillColor = palette.standardKey.cgColor
+        shape.shadowColor = UIColor.black.cgColor
+        shape.shadowOpacity = 0.22
+        shape.shadowRadius = 5
+        shape.shadowOffset = CGSize(width: 0, height: 3)
+        layer.addSublayer(shape)
 
         label.textAlignment = .center
         label.adjustsFontSizeToFitWidth = true
@@ -291,14 +306,92 @@ final class KeyPreviewView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        label.frame = bounds
-        layer.shadowPath = UIBezierPath(
-            roundedRect: bounds,
-            cornerRadius: layer.cornerRadius
-        ).cgPath
+        // Geometry changes here are driven by the finger, so the implicit
+        // animation on a shape layer's path would smear the glyph across the
+        // keyboard as the touch slides between keys.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        shape.frame = bounds
+        let path = outline().cgPath
+        shape.path = path
+        shape.shadowPath = path
+        CATransaction.commit()
+        // The glyph belongs in the balloon, not centred over the whole view —
+        // the neck is the key the finger is already covering.
+        label.frame = CGRect(x: 0, y: 0, width: bounds.width, height: balloonHeight)
     }
 
-    func show(_ text: String) {
+    func show(_ text: String, balloonHeight: CGFloat, neck: CGRect) {
         label.text = text
+        self.balloonHeight = balloonHeight
+        self.neck = neck
+        setNeedsLayout()
+    }
+
+    /// The balloon, the tapered shoulders, and the neck over the key, as one
+    /// closed path drawn clockwise from the balloon's top-left corner.
+    private func outline() -> UIBezierPath {
+        let width = bounds.width
+        let height = bounds.height
+        let balloonBottom = balloonHeight
+        // A neck wider than the balloon, or one that has not been set yet,
+        // would fold the path inside out. Fall back to the plain balloon.
+        let minX = max(neck.minX, 0)
+        let maxX = min(neck.maxX, width)
+        guard balloonBottom > 0, height > balloonBottom, maxX - minX > 0, minX > 0 || maxX < width
+        else {
+            return UIBezierPath(
+                roundedRect: CGRect(x: 0, y: 0, width: width, height: max(height, 1)),
+                cornerRadius: balloonCornerRadius
+            )
+        }
+
+        let corner = min(balloonCornerRadius, width / 2, balloonBottom / 2)
+        let keyCorner = min(keyCornerRadius, (maxX - minX) / 2)
+        // How far the taper runs up into the balloon, and how far it runs down
+        // past the balloon before the neck settles vertical. The curve between
+        // them is cubic with both control points on the verticals it joins, so
+        // the shoulder leaves the balloon and meets the neck without a corner —
+        // the long concave sweep is most of what makes the system's preview
+        // read as one moulded shape rather than a box on a stick.
+        let shoulder = min(balloonBottom * 0.45, 20)
+        let drop = min((height - balloonBottom) * 0.35, 14)
+
+        let path = UIBezierPath()
+        path.move(to: CGPoint(x: corner, y: 0))
+        path.addLine(to: CGPoint(x: width - corner, y: 0))
+        path.addQuadCurve(
+            to: CGPoint(x: width, y: corner),
+            controlPoint: CGPoint(x: width, y: 0)
+        )
+        path.addLine(to: CGPoint(x: width, y: balloonBottom - shoulder))
+        path.addCurve(
+            to: CGPoint(x: maxX, y: balloonBottom + drop),
+            controlPoint1: CGPoint(x: width, y: balloonBottom + drop * 0.55),
+            controlPoint2: CGPoint(x: maxX, y: balloonBottom - shoulder * 0.55)
+        )
+        path.addLine(to: CGPoint(x: maxX, y: height - keyCorner))
+        path.addQuadCurve(
+            to: CGPoint(x: maxX - keyCorner, y: height),
+            controlPoint: CGPoint(x: maxX, y: height)
+        )
+        path.addLine(to: CGPoint(x: minX + keyCorner, y: height))
+        path.addQuadCurve(
+            to: CGPoint(x: minX, y: height - keyCorner),
+            controlPoint: CGPoint(x: minX, y: height)
+        )
+        path.addLine(to: CGPoint(x: minX, y: balloonBottom + drop))
+        path.addCurve(
+            to: CGPoint(x: 0, y: balloonBottom - shoulder),
+            controlPoint1: CGPoint(x: minX, y: balloonBottom - shoulder * 0.55),
+            controlPoint2: CGPoint(x: 0, y: balloonBottom + drop * 0.55)
+        )
+        path.addLine(to: CGPoint(x: 0, y: corner))
+        path.addQuadCurve(
+            to: CGPoint(x: corner, y: 0),
+            controlPoint: CGPoint(x: 0, y: 0)
+        )
+        path.close()
+        return path
     }
 }

--- a/ios/VocaPhoneKeyboard/KeyView.swift
+++ b/ios/VocaPhoneKeyboard/KeyView.swift
@@ -149,16 +149,25 @@ final class KeyView: UIView {
                 withConfiguration: symbolConfiguration
             )
         case .space:
-            titleLabel.text = "space"
-            titleLabel.font = functionFont
+            // The system spacebar is visually blank; its name remains available
+            // through the key's accessibility label.
+            titleLabel.text = nil
             symbolView.image = nil
         case .newline:
-            titleLabel.text = returnTitle
-            titleLabel.font = functionFont
-            symbolView.image = nil
+            if returnTitle == "return" {
+                titleLabel.text = nil
+                symbolView.image = UIImage(
+                    systemName: "return",
+                    withConfiguration: symbolConfiguration
+                )
+            } else {
+                titleLabel.text = returnTitle
+                titleLabel.font = functionFont
+                symbolView.image = nil
+            }
         case let .plane(plane):
             titleLabel.text = KeyLayout.planeTitle(plane)
-            titleLabel.font = functionFont
+            titleLabel.font = planeFont
             symbolView.image = nil
         }
 
@@ -218,6 +227,13 @@ final class KeyView: UIView {
         )
     }
 
+    private var planeFont: UIFont {
+        KeyFont.scaled(
+            metrics.functionFontSize + 4,
+            maximum: metrics.functionFontSize + 6
+        )
+    }
+
     private var shiftSymbolName: String {
         switch shift {
         case .off: "shift"
@@ -227,11 +243,11 @@ final class KeyView: UIView {
     }
 
     private func applyColors() {
-        // An engaged shift reads as a selected control rather than a pressed
-        // one, so it keeps the accent fill until the user turns it off.
-        let isShiftEngaged = spec.cap == .shift && shift != .off
-        let style: KeyStyle = isShiftEngaged ? .accent : spec.style
-        backgroundColor = isHighlighted && !isShiftEngaged
+        // Apple's Shift stays on the neutral key surface; its filled Shift or
+        // Caps Lock glyph carries the state. A persistent mint key made the
+        // resting keyboard look active and unlike the keyboard users know.
+        let style = spec.style
+        backgroundColor = isHighlighted
             ? palette.pressedBackground(for: style)
             : palette.background(for: style)
         let foreground = palette.foreground(for: style)

--- a/ios/VocaPhoneKeyboard/KeyboardHaptics.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardHaptics.swift
@@ -80,9 +80,11 @@ enum KeyboardFeedbackPolicy {
 /// A standard keyboard click is audio feedback controlled by iOS Settings. It
 /// is not a haptic, must not be disabled by VocaPhone's optional tactile
 /// preference, and is played on touch-down because that is when the system
-/// keyboard plays it. Custom haptics are deliberately opt-in, wait for the
-/// interaction to commit, and use restrained intensities because typing is the
-/// keyboard's highest-frequency action.
+/// keyboard plays it. Custom haptics are deliberately opt-in and wait for the
+/// interaction to commit. Typing is played at full strength on the crispest
+/// style, because a key is a hard, short click and anything softer reads as
+/// weaker than every other keyboard on the phone. The rarer events vary against
+/// that reference rather than sitting below it.
 @MainActor
 final class KeyboardHaptics: KeyboardFeedbackProviding {
     static let shared = KeyboardHaptics()
@@ -144,8 +146,8 @@ final class KeyboardHaptics: KeyboardFeedbackProviding {
     /// problem this whole type exists to avoid.
     func warmUp() {
         guard allowsHaptics else { return }
-        impact(&keyTapGenerator, style: .light).prepare()
-        impact(&actionGenerator, style: .soft).prepare()
+        keyTapImpact().prepare()
+        actionImpact().prepare()
         selection().prepare()
     }
 
@@ -221,24 +223,33 @@ final class KeyboardHaptics: KeyboardFeedbackProviding {
             case .inputClick:
                 UIDevice.current.playInputClick()
             case .typingHaptic:
-                let generator = impact(&keyTapGenerator, style: .light)
-                generator.impactOccurred(intensity: 0.35)
+                // `.rigid` rather than `.light`: a key is a hard, short click,
+                // and `.light` is the softest and most diffuse of the styles —
+                // it reads as a nudge where the system keyboard reads as a
+                // press. Full intensity because a third of the engine's power
+                // is exactly what made this feel weaker than every other
+                // keyboard on the phone.
+                let generator = keyTapImpact()
+                generator.impactOccurred(intensity: 1)
                 generator.prepare()
             case .selectionHaptic:
                 let generator = selection()
                 generator.selectionChanged()
                 generator.prepare()
             case .actionHaptic:
-                let generator = impact(&actionGenerator, style: .soft)
+                let generator = actionImpact()
                 generator.impactOccurred()
                 generator.prepare()
             case .swipeBeganHaptic:
-                let generator = impact(&keyTapGenerator, style: .light)
-                generator.impactOccurred(intensity: 0.25)
+                // The same instrument as a keystroke, played softer: the
+                // gesture is still in flight, so it should register as related
+                // to typing but plainly not a committed character.
+                let generator = keyTapImpact()
+                generator.impactOccurred(intensity: 0.5)
                 generator.prepare()
             case .swipeCommittedHaptic:
-                let generator = impact(&actionGenerator, style: .soft)
-                generator.impactOccurred(intensity: 0.5)
+                let generator = actionImpact()
+                generator.impactOccurred(intensity: 0.8)
                 generator.prepare()
             }
         }
@@ -246,8 +257,22 @@ final class KeyboardHaptics: KeyboardFeedbackProviding {
 
     // MARK: - Generators
 
-    /// The stored generator for a role, made on first use and kept afterwards.
-    private func impact(
+    /// The keystroke generator: crisp and short, like a key.
+    ///
+    /// A generator's style is fixed when it is built, so each role owns its
+    /// style rather than taking it as an argument. Passing one to a cached
+    /// generator would have been silently ignored, leaving the keyboard playing
+    /// whichever texture happened to be requested first.
+    private func keyTapImpact() -> UIImpactFeedbackGenerator {
+        cached(&keyTapGenerator, style: .rigid)
+    }
+
+    /// The generator for rare, weightier events: softer and more diffuse.
+    private func actionImpact() -> UIImpactFeedbackGenerator {
+        cached(&actionGenerator, style: .soft)
+    }
+
+    private func cached(
         _ generator: inout UIImpactFeedbackGenerator?,
         style: UIImpactFeedbackGenerator.FeedbackStyle
     ) -> UIImpactFeedbackGenerator {

--- a/ios/VocaPhoneKeyboard/KeyboardHaptics.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardHaptics.swift
@@ -1,5 +1,15 @@
 import UIKit
 
+@MainActor
+protocol KeyboardFeedbackProviding: AnyObject {
+    func textCommitted()
+    func keyActionCommitted()
+    func selectionChanged()
+    func action()
+    func swipeBegan()
+    func swipeCommitted()
+}
+
 /// The semantic feedback a keyboard interaction may produce. Keeping this as
 /// data lets tests prove that a cancelled touch cannot buzz or click, without
 /// pretending the simulator has a Taptic Engine.
@@ -56,7 +66,7 @@ enum KeyboardFeedbackPolicy {
 /// interaction has committed, and use restrained intensities because typing is
 /// the keyboard's highest-frequency action.
 @MainActor
-final class KeyboardHaptics {
+final class KeyboardHaptics: KeyboardFeedbackProviding {
     static let shared = KeyboardHaptics()
 
     /// Whether the extension can reach the Taptic Engine at all. Only the

--- a/ios/VocaPhoneKeyboard/KeyboardHaptics.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardHaptics.swift
@@ -2,8 +2,10 @@ import UIKit
 
 @MainActor
 protocol KeyboardFeedbackProviding: AnyObject {
+    func keyPressed()
     func textCommitted()
     func keyActionCommitted()
+    func deleteRepeated()
     func selectionChanged()
     func action()
     func swipeBegan()
@@ -23,8 +25,10 @@ enum KeyboardFeedbackEvent: Equatable {
 }
 
 enum KeyboardFeedbackInteraction {
+    case keyPressed
     case committedText
     case committedKeyAction
+    case deleteRepeated
     case selectionChanged
     case dictationAction
     case swipeBegan
@@ -39,13 +43,26 @@ enum KeyboardFeedbackPolicy {
     ) -> [KeyboardFeedbackEvent] {
         let allowsHaptics = typingHapticsEnabled && hasFullAccess
         switch interaction {
-        case .committedText:
-            return [.inputClick] + (allowsHaptics ? [.typingHaptic] : [])
-        case .committedKeyAction:
-            // Shift, Delete, plane switching, and the globe act immediately;
-            // their visible state change is feedback enough. They still get the
-            // standard click so the custom keyboard keeps the iOS convention.
+        case .keyPressed:
+            // The system keyboard clicks the instant a finger lands, not when
+            // it lifts. Feedback that waits for the commit arrives after the
+            // key has already animated, which is what reads as "not native".
             return [.inputClick]
+        case .committedText:
+            // The click has already been played on touch-down. What waits for
+            // the commit is the tactile confirmation, so a cancelled or
+            // slid-away touch never buzzes for a character it did not insert.
+            return allowsHaptics ? [.typingHaptic] : []
+        case .committedKeyAction:
+            // Shift, Delete, plane switching and the globe resolve on
+            // touch-down, so their haptic lands with the same press that
+            // already clicked.
+            return allowsHaptics ? [.typingHaptic] : []
+        case .deleteRepeated:
+            // A held Delete is a stream of separate deletions, and the system
+            // keyboard sounds each one. Silence here makes a hold feel like it
+            // has stopped working.
+            return [.inputClick] + (allowsHaptics ? [.typingHaptic] : [])
         case .selectionChanged:
             return allowsHaptics ? [.selectionHaptic] : []
         case .dictationAction:
@@ -61,10 +78,11 @@ enum KeyboardFeedbackPolicy {
 /// Every buzz and click the keyboard makes, in one place.
 ///
 /// A standard keyboard click is audio feedback controlled by iOS Settings. It
-/// is not a haptic and must not be disabled by VocaPhone's optional tactile
-/// preference. Custom haptics are deliberately opt-in, occur only after an
-/// interaction has committed, and use restrained intensities because typing is
-/// the keyboard's highest-frequency action.
+/// is not a haptic, must not be disabled by VocaPhone's optional tactile
+/// preference, and is played on touch-down because that is when the system
+/// keyboard plays it. Custom haptics are deliberately opt-in, wait for the
+/// interaction to commit, and use restrained intensities because typing is the
+/// keyboard's highest-frequency action.
 @MainActor
 final class KeyboardHaptics: KeyboardFeedbackProviding {
     static let shared = KeyboardHaptics()
@@ -119,9 +137,15 @@ final class KeyboardHaptics: KeyboardFeedbackProviding {
 
     /// Wakes the engine so the *next* event lands immediately. Cheap, and a
     /// no-op when the keyboard cannot use haptics anyway.
+    ///
+    /// Every generator is warmed, not just the typing one: a dictation action
+    /// and a committed swipe are exactly the rare events that would otherwise
+    /// pay the wake-up cost on their first use, which is the late-first-haptic
+    /// problem this whole type exists to avoid.
     func warmUp() {
         guard allowsHaptics else { return }
         impact(&keyTapGenerator, style: .light).prepare()
+        impact(&actionGenerator, style: .soft).prepare()
         selection().prepare()
     }
 
@@ -136,6 +160,14 @@ final class KeyboardHaptics: KeyboardFeedbackProviding {
 
     // MARK: - Events
 
+    /// A finger has landed on a key. This is the click, and it is deliberately
+    /// not deferred: the system keyboard sounds a key as it goes down, and
+    /// feedback that waits for the lift arrives after the key has finished
+    /// animating.
+    func keyPressed() {
+        perform(.keyPressed)
+    }
+
     /// A character, space, Return, or emoji that has actually inserted. Calling
     /// this only after target resolution prevents a missed or cancelled touch
     /// from confirming the wrong key in the person's hand.
@@ -144,10 +176,14 @@ final class KeyboardHaptics: KeyboardFeedbackProviding {
     }
 
     /// An immediate keyboard control such as Shift, Delete, plane switching, or
-    /// the globe. These controls retain standard input-click feedback without
-    /// adding a custom impact to every tap.
+    /// the globe. Their press already clicked; this is the tactile half.
     func keyActionCommitted() {
         perform(.committedKeyAction)
+    }
+
+    /// One character removed by a held Delete, rather than by its first press.
+    func deleteRepeated() {
+        perform(.deleteRepeated)
     }
 
     /// Moving between accent options, entering cursor control, opening the emoji
@@ -162,8 +198,9 @@ final class KeyboardHaptics: KeyboardFeedbackProviding {
         perform(.dictationAction)
     }
 
-    /// The moment a slide becomes a swipe. Light, because the gesture is still
-    /// in flight — this says "I am tracing now", not "I typed something".
+    /// The moment a slide becomes a swipe. Lighter than a keystroke, because
+    /// the gesture is still in flight — this says "I am tracing now", not
+    /// "I typed something".
     func swipeBegan() {
         perform(.swipeBegan)
     }
@@ -197,7 +234,7 @@ final class KeyboardHaptics: KeyboardFeedbackProviding {
                 generator.prepare()
             case .swipeBeganHaptic:
                 let generator = impact(&keyTapGenerator, style: .light)
-                generator.impactOccurred(intensity: 0.35)
+                generator.impactOccurred(intensity: 0.25)
                 generator.prepare()
             case .swipeCommittedHaptic:
                 let generator = impact(&actionGenerator, style: .soft)

--- a/ios/VocaPhoneKeyboard/KeyboardHaptics.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardHaptics.swift
@@ -1,27 +1,60 @@
 import UIKit
 
+/// The semantic feedback a keyboard interaction may produce. Keeping this as
+/// data lets tests prove that a cancelled touch cannot buzz or click, without
+/// pretending the simulator has a Taptic Engine.
+enum KeyboardFeedbackEvent: Equatable {
+    case inputClick
+    case typingHaptic
+    case selectionHaptic
+    case actionHaptic
+    case swipeBeganHaptic
+    case swipeCommittedHaptic
+}
+
+enum KeyboardFeedbackInteraction {
+    case committedText
+    case committedKeyAction
+    case selectionChanged
+    case dictationAction
+    case swipeBegan
+    case swipeCommitted
+}
+
+enum KeyboardFeedbackPolicy {
+    static func events(
+        for interaction: KeyboardFeedbackInteraction,
+        typingHapticsEnabled: Bool,
+        hasFullAccess: Bool
+    ) -> [KeyboardFeedbackEvent] {
+        let allowsHaptics = typingHapticsEnabled && hasFullAccess
+        switch interaction {
+        case .committedText:
+            return [.inputClick] + (allowsHaptics ? [.typingHaptic] : [])
+        case .committedKeyAction:
+            // Shift, Delete, plane switching, and the globe act immediately;
+            // their visible state change is feedback enough. They still get the
+            // standard click so the custom keyboard keeps the iOS convention.
+            return [.inputClick]
+        case .selectionChanged:
+            return allowsHaptics ? [.selectionHaptic] : []
+        case .dictationAction:
+            return allowsHaptics ? [.actionHaptic] : []
+        case .swipeBegan:
+            return allowsHaptics ? [.swipeBeganHaptic] : []
+        case .swipeCommitted:
+            return allowsHaptics ? [.swipeCommittedHaptic] : []
+        }
+    }
+}
+
 /// Every buzz and click the keyboard makes, in one place.
 ///
-/// The keyboard used to ask for feedback at each call site, and got almost none
-/// of it:
-///
-/// * A key press called `UIDevice.playInputClick()`, which is the keyboard
-///   *click sound* and has never produced a haptic. Typing — the one gesture
-///   that happens hundreds of times a minute — was therefore the only
-///   interaction with no feedback at all.
-/// * Everywhere else built a `UIFeedbackGenerator` and fired it in the same
-///   statement. A generator that has not been prepared has to wake the Taptic
-///   Engine first, so the first tap produces nothing and the ones after it
-///   arrive late — which reads as "the haptics are broken", because from the
-///   user's side they are.
-///
-/// So the generators live as long as the keyboard does, are prepared before
-/// they are needed, and are re-prepared after each event while a burst of
-/// typing keeps them warm.
-///
-/// Haptics also need Full Access: an extension without it cannot reach the
-/// engine, and firing into that is how a preference ends up looking like a lie.
-/// The click *sound* does not, so it is gated on the preference alone.
+/// A standard keyboard click is audio feedback controlled by iOS Settings. It
+/// is not a haptic and must not be disabled by VocaPhone's optional tactile
+/// preference. Custom haptics are deliberately opt-in, occur only after an
+/// interaction has committed, and use restrained intensities because typing is
+/// the keyboard's highest-frequency action.
 @MainActor
 final class KeyboardHaptics {
     static let shared = KeyboardHaptics()
@@ -49,7 +82,7 @@ final class KeyboardHaptics {
 
     private var allowsHaptics: Bool {
         Self.allowsHaptics(
-            preferenceEnabled: KeyboardPreferences.keyboardHapticsEnabled,
+            preferenceEnabled: KeyboardPreferences.typingHapticsEnabled,
             hasFullAccess: hasFullAccess
         )
     }
@@ -93,58 +126,75 @@ final class KeyboardHaptics {
 
     // MARK: - Events
 
-    /// A character, space or return. The click sound and the tap together, which
-    /// is what the system keyboard does.
-    ///
-    /// `intensity` is a little under full: a key is the most repeated event on
-    /// the keyboard, and one at full strength turns a sentence into a rattle.
-    func keyPress() {
-        guard KeyboardPreferences.keyboardHapticsEnabled else { return }
-        // Sound needs no Full Access, so it stays available to keyboards that
-        // have not granted it.
-        UIDevice.current.playInputClick()
-        guard allowsHaptics else { return }
-        let generator = impact(&keyTapGenerator, style: .light)
-        generator.impactOccurred(intensity: 0.7)
-        // Prepared again immediately: a typist's next key is milliseconds away,
-        // and this is what keeps the engine warm through a burst.
-        generator.prepare()
+    /// A character, space, Return, or emoji that has actually inserted. Calling
+    /// this only after target resolution prevents a missed or cancelled touch
+    /// from confirming the wrong key in the person's hand.
+    func textCommitted() {
+        perform(.committedText)
+    }
+
+    /// An immediate keyboard control such as Shift, Delete, plane switching, or
+    /// the globe. These controls retain standard input-click feedback without
+    /// adding a custom impact to every tap.
+    func keyActionCommitted() {
+        perform(.committedKeyAction)
     }
 
     /// Moving between accent options, entering cursor control, opening the emoji
     /// panel: the user is choosing rather than committing.
     func selectionChanged() {
-        guard allowsHaptics else { return }
-        let generator = selection()
-        generator.selectionChanged()
-        generator.prepare()
+        perform(.selectionChanged)
     }
 
     /// A bar button — start, insert, cancel. Weightier than a key because it is
     /// rare and consequential.
     func action() {
-        guard allowsHaptics else { return }
-        let generator = impact(&actionGenerator, style: .soft)
-        generator.impactOccurred()
-        generator.prepare()
+        perform(.dictationAction)
     }
 
     /// The moment a slide becomes a swipe. Light, because the gesture is still
     /// in flight — this says "I am tracing now", not "I typed something".
     func swipeBegan() {
-        guard allowsHaptics else { return }
-        let generator = impact(&keyTapGenerator, style: .light)
-        generator.impactOccurred(intensity: 0.45)
-        generator.prepare()
+        perform(.swipeBegan)
     }
 
     /// A traced word has been committed. Firmer than the start: a whole word
     /// just landed, and the user's eyes are on the strip rather than the keys.
     func swipeCommitted() {
-        guard allowsHaptics else { return }
-        let generator = impact(&actionGenerator, style: .soft)
-        generator.impactOccurred(intensity: 0.8)
-        generator.prepare()
+        perform(.swipeCommitted)
+    }
+
+    private func perform(_ interaction: KeyboardFeedbackInteraction) {
+        for event in KeyboardFeedbackPolicy.events(
+            for: interaction,
+            typingHapticsEnabled: KeyboardPreferences.typingHapticsEnabled,
+            hasFullAccess: hasFullAccess
+        ) {
+            switch event {
+            case .inputClick:
+                UIDevice.current.playInputClick()
+            case .typingHaptic:
+                let generator = impact(&keyTapGenerator, style: .light)
+                generator.impactOccurred(intensity: 0.35)
+                generator.prepare()
+            case .selectionHaptic:
+                let generator = selection()
+                generator.selectionChanged()
+                generator.prepare()
+            case .actionHaptic:
+                let generator = impact(&actionGenerator, style: .soft)
+                generator.impactOccurred()
+                generator.prepare()
+            case .swipeBeganHaptic:
+                let generator = impact(&keyTapGenerator, style: .light)
+                generator.impactOccurred(intensity: 0.35)
+                generator.prepare()
+            case .swipeCommittedHaptic:
+                let generator = impact(&actionGenerator, style: .soft)
+                generator.impactOccurred(intensity: 0.5)
+                generator.prepare()
+            }
+        }
     }
 
     // MARK: - Generators

--- a/ios/VocaPhoneKeyboard/TypingStripView.swift
+++ b/ios/VocaPhoneKeyboard/TypingStripView.swift
@@ -20,6 +20,7 @@ protocol TypingStripViewDelegate: AnyObject {
 /// pushed up against the left edge.
 final class TypingStripView: UIScrollView {
     weak var chipDelegate: (any TypingStripViewDelegate)?
+    private let feedback: any KeyboardFeedbackProviding
 
     var palette: KeyboardPalette {
         didSet {
@@ -58,9 +59,14 @@ final class TypingStripView: UIScrollView {
     private static let minimumGlyphChipWidth: CGFloat = 48
     private static let chipTextInset: CGFloat = 14
 
-    init(palette: KeyboardPalette, metrics: DictationBarMetrics) {
+    init(
+        palette: KeyboardPalette,
+        metrics: DictationBarMetrics,
+        feedback: any KeyboardFeedbackProviding = KeyboardHaptics.shared
+    ) {
         self.palette = palette
         self.metrics = metrics
+        self.feedback = feedback
         super.init(frame: .zero)
         showsHorizontalScrollIndicator = false
         showsVerticalScrollIndicator = false
@@ -242,7 +248,7 @@ final class TypingStripView: UIScrollView {
         // A chip replaces a whole word, which is a bigger edit than any key
         // makes. Silence here, next to keys that tap back, reads as a chip that
         // did not register.
-        KeyboardHaptics.shared.selectionChanged()
+        feedback.selectionChanged()
         chipDelegate?.typingStrip(self, didChoose: candidates[sender.tag])
     }
 }

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -264,7 +264,15 @@ enum KeyboardPreferences {
     static let learnAsITypeKey = "learnAsITypeEnabled"
     static let smartPunctuationKey = "smartPunctuationEnabled"
     static let emojiSuggestionsKey = "emojiSuggestionsEnabled"
-    static let keyboardHapticsKey = "keyboardHapticsEnabled"
+    /// Custom tactile feedback for committed typing. Input clicks are governed
+    /// by iOS's Keyboard Clicks setting and deliberately do not share this
+    /// preference.
+    static let typingHapticsKey = "typingHapticsEnabled"
+    /// Marks the release that stopped treating the old, default-on keyboard
+    /// haptic setting as a user's affirmative choice. We cannot distinguish an
+    /// inherited default from an explicit toggle, so the one-time migration
+    /// picks the quieter default and leaves the new control opt-in.
+    static let typingHapticsMigrationKey = "typingHapticsMigrationV1"
     static let swipeTypingKey = "swipeTypingEnabled"
     static let numberRowKey = "numberRowEnabled"
     static let quickDictationKey = "quickDictationEnabled"
@@ -384,12 +392,25 @@ enum KeyboardPreferences {
         set { defaults?.set(newValue, forKey: emojiSuggestionsKey) }
     }
 
-    /// A no-op without Full Access, because a keyboard extension cannot reach
-    /// the haptic engine without it. The Keyboard settings screen says so
-    /// rather than leaving people to wonder why their keyboard is silent.
-    static var keyboardHapticsEnabled: Bool {
-        get { boolean(keyboardHapticsKey, default: true) }
-        set { defaults?.set(newValue, forKey: keyboardHapticsKey) }
+    /// Custom per-key haptics are opt-in. The standard keyboard input click is
+    /// still available whenever iOS Keyboard Clicks are enabled, with or
+    /// without Full Access.
+    static var typingHapticsEnabled: Bool {
+        get { boolean(typingHapticsKey, default: false) }
+        set { defaults?.set(newValue, forKey: typingHapticsKey) }
+    }
+
+    /// Existing releases stored a default-on `keyboardHapticsEnabled` value,
+    /// but that key did not tell us whether a person had ever chosen it. A
+    /// strong buzz on every character is disruptive enough that preserving the
+    /// old default would be worse than asking an interested person to opt in
+    /// again. Calling this repeatedly is safe for the app and keyboard.
+    static func migrateTypingHapticsIfNeeded() {
+        guard let defaults,
+              defaults.object(forKey: typingHapticsMigrationKey) == nil
+        else { return }
+        defaults.set(false, forKey: typingHapticsKey)
+        defaults.set(true, forKey: typingHapticsMigrationKey)
     }
 
     /// Off until device QA says the recogniser has earned it. A swipe engine

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -268,6 +268,9 @@ enum KeyboardPreferences {
     /// by iOS's Keyboard Clicks setting and deliberately do not share this
     /// preference.
     static let typingHapticsKey = "typingHapticsEnabled"
+    /// The default-on switch this preference replaced. Kept only so the
+    /// migration below has a name to clear; nothing reads its value.
+    static let legacyKeyboardHapticsKey = "keyboardHapticsEnabled"
     /// Marks the release that stopped treating the old, default-on keyboard
     /// haptic setting as a user's affirmative choice. We cannot distinguish an
     /// inherited default from an explicit toggle, so the one-time migration
@@ -401,15 +404,17 @@ enum KeyboardPreferences {
     }
 
     /// Existing releases stored a default-on `keyboardHapticsEnabled` value,
-    /// but that key did not tell us whether a person had ever chosen it. A
-    /// strong buzz on every character is disruptive enough that preserving the
-    /// old default would be worse than asking an interested person to opt in
-    /// again. Calling this repeatedly is safe for the app and keyboard.
+    /// but that key did not tell us whether a person had ever chosen it. A buzz
+    /// on every character is disruptive enough that preserving the old default
+    /// would be worse than asking an interested person to opt in again, so the
+    /// stale value is discarded rather than carried over — `typingHapticsKey`
+    /// already defaults to off, and writing that default explicitly would say
+    /// nothing the getter does not. Calling this repeatedly is safe.
     static func migrateTypingHapticsIfNeeded() {
         guard let defaults,
               defaults.object(forKey: typingHapticsMigrationKey) == nil
         else { return }
-        defaults.set(false, forKey: typingHapticsKey)
+        defaults.removeObject(forKey: legacyKeyboardHapticsKey)
         defaults.set(true, forKey: typingHapticsMigrationKey)
     }
 

--- a/ios/VocaPhoneTests/KeyGridLayoutTests.swift
+++ b/ios/VocaPhoneTests/KeyGridLayoutTests.swift
@@ -61,9 +61,9 @@ struct KeyGridLayoutTests {
         #expect(abs(indent - trailing) < 0.5)
     }
 
-    /// Shift and delete absorb whatever the seven letters leave, which is what
-    /// keeps the third row aligned with the ten-key row above it.
-    @Test func modifierKeysAbsorbTheRemainderOfTheirRow() {
+    /// Shift and Delete keep the native visual width while their invisible
+    /// target slots still absorb the remainder and tile the entire row.
+    @Test func letterModifiersUseNativeVisualWidthsAndFullHitTargets() {
         let grid = Self.makeGrid()
         let row = Self.rowsByPosition(in: grid)[2]
         let shift = row.first!
@@ -72,6 +72,8 @@ struct KeyGridLayoutTests {
         #expect(delete.spec.cap == .delete)
         #expect(abs(shift.frame.width - delete.frame.width) < 0.5)
         #expect(shift.frame.width > row[1].frame.width)
+        #expect(shift.hitRect.maxX >= row[1].hitRect.minX)
+        #expect(delete.hitRect.minX <= row[row.count - 2].hitRect.maxX)
     }
 
     @Test func hitTargetsCoverTheGuttersWithoutGaps() {

--- a/ios/VocaPhoneTests/KeyHitMapTests.swift
+++ b/ios/VocaPhoneTests/KeyHitMapTests.swift
@@ -100,6 +100,81 @@ struct KeyHitMapTests {
         grid.endActiveInteractions()
     }
 
+    /// Shift and Delete render inset to leave the native moat around them. The
+    /// moat is cosmetic: every point out to the slot boundary still belongs to
+    /// the modifier, which is what `visibleFrame` promises and what a thumb
+    /// aiming at the edge of Shift depends on.
+    @Test func theMoatAroundShiftIsCosmeticAndKeepsItsTouchTarget() throws {
+        let metrics = KeyboardMetrics.resolved(for: UITraitCollection {
+            $0.verticalSizeClass = .regular
+        })
+        let grid = KeyGridView(metrics: metrics, palette: KeyboardPalette(isDark: false))
+        grid.frame = CGRect(x: 0, y: 0, width: 393, height: metrics.gridHeight)
+        grid.layoutIfNeeded()
+
+        let shift = try #require(grid.keyViews.first { $0.spec.cap == .shift })
+        // Without an inset there is no moat and nothing to protect.
+        #expect(shift.frame.width < shift.hitRect.width - metrics.columnGap)
+
+        let y = shift.frame.midY
+        var x = shift.frame.maxX + 0.5
+        while x < shift.hitRect.maxX {
+            #expect(grid.key(at: CGPoint(x: x, y: y), characterOnly: false)?.spec.cap == .shift)
+            x += 0.5
+        }
+    }
+
+    /// Where two effective targets genuinely overlap, the winner is decided by
+    /// the layout slot rather than the shrunken visual frame — otherwise a key
+    /// that renders inset would be aimed at as though it were smaller than the
+    /// area it actually claims.
+    @Test func overlappingTargetsResolveByTheLayoutSlot() {
+        let inset = KeyHitMap(targets: [
+            // A modifier whose slot spans 0...60 but which renders 0...40.
+            KeyHitMap.Target(
+                index: 0,
+                frame: CGRect(x: 0, y: 0, width: 60, height: 40),
+                hitRect: CGRect(x: 0, y: 0, width: 70, height: 40),
+                isCharacter: false
+            ),
+            KeyHitMap.Target(
+                index: 1,
+                frame: CGRect(x: 66, y: 0, width: 34, height: 40),
+                hitRect: CGRect(x: 50, y: 0, width: 50, height: 40),
+                isCharacter: true
+            ),
+        ])
+        // 54 lies inside both hit rects. Measured from the slot centres, 30 and
+        // 83, the modifier is nearer; measured from a 0...40 visual centre of
+        // 20 it would lose the point to its neighbour.
+        #expect(inset.targetIndex(at: CGPoint(x: 54, y: 20), characterOnly: false) == 0)
+    }
+
+    /// Sliding off Shift onto a letter types one capital and returns to
+    /// lowercase — the reflex gesture the system keyboard has always had.
+    @Test func slidingOffShiftTypesOneCapitalThenReleasesShift() throws {
+        let feedback = KeyboardFeedbackSpy()
+        let delegate = KeyGridDelegateSpy()
+        let grid = Self.makeGrid(feedback: feedback, delegate: delegate)
+        grid.shiftState = .on
+
+        let landed = try #require(grid.keyViews.first { $0.spec.cap == KeyCap.character("q") })
+        #expect(grid.completeKeyInteraction(landed, shouldCommit: true))
+
+        #expect(delegate.insertedText == ["Q"])
+        #expect(grid.shiftState == .off)
+    }
+
+    /// A locked Shift is a deliberate state, so a slide off it does not undo it.
+    @Test func slidingOffALockedShiftKeepsCapsLock() throws {
+        let grid = Self.makeGrid(feedback: KeyboardFeedbackSpy(), delegate: KeyGridDelegateSpy())
+        grid.shiftState = .locked
+
+        let landed = try #require(grid.keyViews.first { $0.spec.cap == KeyCap.character("q") })
+        #expect(grid.completeKeyInteraction(landed, shouldCommit: true))
+        #expect(grid.shiftState == .locked)
+    }
+
     private static func makeGrid(
         feedback: KeyboardFeedbackSpy,
         delegate: KeyGridDelegateSpy

--- a/ios/VocaPhoneTests/KeyHitMapTests.swift
+++ b/ios/VocaPhoneTests/KeyHitMapTests.swift
@@ -30,7 +30,9 @@ struct KeyHitMapTests {
     }
 
     @Test func exactBoundaryTieUsesStableLayoutOrder() {
-        // Both targets claim 42.5 and their centres are equally distant.
+        // Both targets claim 42.5 and their centres are equally distant, so the
+        // earlier key in layout order wins rather than whichever subview the
+        // hierarchy happened to hold last.
         #expect(map.targetIndex(at: CGPoint(x: 42.5, y: 20), characterOnly: false) == 0)
     }
 
@@ -44,7 +46,11 @@ struct KeyHitMapTests {
         #expect(map.targetIndex(at: CGPoint(x: 200, y: 20), characterOnly: false) == nil)
     }
 
-    @Test func changingPlanesInvalidatesTargetsUntilTheNewLayoutExists() throws {
+    /// `touchesBegan` walks an unordered set, so a second finger can land in the
+    /// same event that switched planes. If the switch left the map empty until
+    /// the next layout pass, that keystroke would resolve to nothing and be
+    /// silently dropped — which is what two-thumb typing looks like.
+    @Test func changingPlanesResolvesTheNewLayoutImmediately() throws {
         let metrics = KeyboardMetrics.resolved(for: UITraitCollection {
             $0.verticalSizeClass = .regular
         })
@@ -57,10 +63,57 @@ struct KeyHitMapTests {
         #expect(grid.key(at: oldPoint, characterOnly: false)?.spec.cap == .character("q"))
 
         grid.plane = .numbers
-        #expect(grid.key(at: oldPoint, characterOnly: false) == nil)
-
-        grid.layoutIfNeeded()
         #expect(grid.key(at: oldPoint, characterOnly: false)?.spec.cap == .character("1"))
+    }
+
+    /// The plane key acts on touch-down, and the switch releases every tracked
+    /// touch. The hold used to hang off that touch, so it was cancelled before
+    /// it could ever fire and the panel was unreachable by its own gesture.
+    @Test func holdingThePlaneKeyOpensTheEmojiPanelAndUndoesTheSwitch() {
+        let feedback = KeyboardFeedbackSpy()
+        let delegate = KeyGridDelegateSpy()
+        let grid = Self.makeGrid(feedback: feedback, delegate: delegate)
+
+        grid.plane = .letters
+        grid.beginPlaneHold(at: .zero)
+        // What the touch-down action does the instant the finger lands.
+        grid.plane = .numbers
+        grid.completePlaneHold()
+
+        #expect(grid.plane == .letters)
+        #expect(delegate.outputs == ["emojiPanel"])
+        #expect(feedback.events == [.selectionChanged])
+    }
+
+    /// A held Delete is a stream of deletions. Sounding only the first press
+    /// makes a long hold read as a keyboard that has stopped responding.
+    @Test func everyDeleteRepeatReportsItsOwnFeedback() {
+        let feedback = KeyboardFeedbackSpy()
+        let delegate = KeyGridDelegateSpy()
+        let grid = Self.makeGrid(feedback: feedback, delegate: delegate)
+
+        grid.scheduleNextDelete()
+        grid.scheduleNextDelete()
+
+        #expect(feedback.events == [.deleteRepeated, .deleteRepeated])
+        #expect(delegate.outputs == ["deleteBackward", "deleteBackward"])
+        grid.endActiveInteractions()
+    }
+
+    private static func makeGrid(
+        feedback: KeyboardFeedbackSpy,
+        delegate: KeyGridDelegateSpy
+    ) -> KeyGridView {
+        let metrics = KeyboardMetrics.resolved(for: UITraitCollection {
+            $0.verticalSizeClass = .regular
+        })
+        let grid = KeyGridView(
+            metrics: metrics,
+            palette: KeyboardPalette(isDark: false),
+            feedback: feedback
+        )
+        grid.delegate = delegate
+        return grid
     }
 
     @Test func cancelledAndSlideCorrectedKeysReportOnlyTheFinalCommit() throws {
@@ -90,13 +143,21 @@ struct KeyHitMapTests {
 }
 
 private final class KeyboardFeedbackSpy: KeyboardFeedbackProviding {
-    enum Event: Equatable { case textCommitted }
+    enum Event: Equatable {
+        case keyPressed
+        case textCommitted
+        case keyActionCommitted
+        case deleteRepeated
+        case selectionChanged
+    }
 
     private(set) var events: [Event] = []
 
+    func keyPressed() { events.append(.keyPressed) }
     func textCommitted() { events.append(.textCommitted) }
-    func keyActionCommitted() {}
-    func selectionChanged() {}
+    func keyActionCommitted() { events.append(.keyActionCommitted) }
+    func deleteRepeated() { events.append(.deleteRepeated) }
+    func selectionChanged() { events.append(.selectionChanged) }
     func action() {}
     func swipeBegan() {}
     func swipeCommitted() {}
@@ -104,13 +165,19 @@ private final class KeyboardFeedbackSpy: KeyboardFeedbackProviding {
 
 private final class KeyGridDelegateSpy: KeyGridViewDelegate {
     private(set) var insertedText: [String] = []
+    private(set) var outputs: [String] = []
 
     func keyGrid(_ grid: KeyGridView, didProduce output: KeyboardOutput) {
         if case let .text(text) = output { insertedText.append(text) }
+        switch output {
+        case .emojiPanel: outputs.append("emojiPanel")
+        case .deleteBackward: outputs.append("deleteBackward")
+        default: break
+        }
     }
 
     func keyGridDidChangeShift(_ grid: KeyGridView) {}
-    func keyGridShouldContinueDeleting(_ grid: KeyGridView) -> Bool { false }
+    func keyGridShouldContinueDeleting(_ grid: KeyGridView) -> Bool { true }
 }
 
 private extension CGRect {

--- a/ios/VocaPhoneTests/KeyHitMapTests.swift
+++ b/ios/VocaPhoneTests/KeyHitMapTests.swift
@@ -43,4 +43,76 @@ struct KeyHitMapTests {
         #expect(map.targetIndex(at: CGPoint(x: -1, y: 20), characterOnly: false) == nil)
         #expect(map.targetIndex(at: CGPoint(x: 200, y: 20), characterOnly: false) == nil)
     }
+
+    @Test func changingPlanesInvalidatesTargetsUntilTheNewLayoutExists() throws {
+        let metrics = KeyboardMetrics.resolved(for: UITraitCollection {
+            $0.verticalSizeClass = .regular
+        })
+        let grid = KeyGridView(metrics: metrics, palette: KeyboardPalette(isDark: false))
+        grid.frame = CGRect(x: 0, y: 0, width: 393, height: metrics.gridHeight)
+        grid.layoutIfNeeded()
+
+        let oldKey = try #require(grid.keyViews.first { $0.spec.cap == .character("q") })
+        let oldPoint = oldKey.frame.center
+        #expect(grid.key(at: oldPoint, characterOnly: false)?.spec.cap == .character("q"))
+
+        grid.plane = .numbers
+        #expect(grid.key(at: oldPoint, characterOnly: false) == nil)
+
+        grid.layoutIfNeeded()
+        #expect(grid.key(at: oldPoint, characterOnly: false)?.spec.cap == .character("1"))
+    }
+
+    @Test func cancelledAndSlideCorrectedKeysReportOnlyTheFinalCommit() throws {
+        let feedback = KeyboardFeedbackSpy()
+        let delegate = KeyGridDelegateSpy()
+        let metrics = KeyboardMetrics.resolved(for: UITraitCollection {
+            $0.verticalSizeClass = .regular
+        })
+        let grid = KeyGridView(
+            metrics: metrics,
+            palette: KeyboardPalette(isDark: false),
+            feedback: feedback
+        )
+        grid.delegate = delegate
+        grid.shiftState = .off
+
+        let initial = try #require(grid.keyViews.first { $0.spec.cap == .character("q") })
+        let corrected = try #require(grid.keyViews.first { $0.spec.cap == .character("w") })
+        grid.completeKeyInteraction(initial, shouldCommit: false)
+        #expect(feedback.events.isEmpty)
+        #expect(delegate.insertedText.isEmpty)
+
+        grid.completeKeyInteraction(corrected, shouldCommit: true)
+        #expect(feedback.events == [.textCommitted])
+        #expect(delegate.insertedText == ["w"])
+    }
+}
+
+private final class KeyboardFeedbackSpy: KeyboardFeedbackProviding {
+    enum Event: Equatable { case textCommitted }
+
+    private(set) var events: [Event] = []
+
+    func textCommitted() { events.append(.textCommitted) }
+    func keyActionCommitted() {}
+    func selectionChanged() {}
+    func action() {}
+    func swipeBegan() {}
+    func swipeCommitted() {}
+}
+
+private final class KeyGridDelegateSpy: KeyGridViewDelegate {
+    private(set) var insertedText: [String] = []
+
+    func keyGrid(_ grid: KeyGridView, didProduce output: KeyboardOutput) {
+        if case let .text(text) = output { insertedText.append(text) }
+    }
+
+    func keyGridDidChangeShift(_ grid: KeyGridView) {}
+    func keyGridShouldContinueDeleting(_ grid: KeyGridView) -> Bool { false }
+}
+
+private extension CGRect {
+    var center: CGPoint { CGPoint(x: midX, y: midY) }
 }

--- a/ios/VocaPhoneTests/KeyHitMapTests.swift
+++ b/ios/VocaPhoneTests/KeyHitMapTests.swift
@@ -1,0 +1,46 @@
+import Testing
+import UIKit
+
+@MainActor
+struct KeyHitMapTests {
+    private let map = KeyHitMap(targets: [
+        KeyHitMap.Target(
+            index: 0,
+            frame: CGRect(x: 0, y: 0, width: 40, height: 40),
+            hitRect: CGRect(x: 0, y: 0, width: 45, height: 40),
+            isCharacter: true
+        ),
+        KeyHitMap.Target(
+            index: 1,
+            frame: CGRect(x: 45, y: 0, width: 40, height: 40),
+            hitRect: CGRect(x: 40, y: 0, width: 45, height: 40),
+            isCharacter: true
+        ),
+        KeyHitMap.Target(
+            index: 2,
+            frame: CGRect(x: 90, y: 0, width: 40, height: 40),
+            hitRect: CGRect(x: 85, y: 0, width: 45, height: 40),
+            isCharacter: false
+        ),
+    ])
+
+    @Test func gutterBelongsToTheNearestVisibleCentre() {
+        #expect(map.targetIndex(at: CGPoint(x: 41, y: 20), characterOnly: false) == 0)
+        #expect(map.targetIndex(at: CGPoint(x: 44, y: 20), characterOnly: false) == 1)
+    }
+
+    @Test func exactBoundaryTieUsesStableLayoutOrder() {
+        // Both targets claim 42.5 and their centres are equally distant.
+        #expect(map.targetIndex(at: CGPoint(x: 42.5, y: 20), characterOnly: false) == 0)
+    }
+
+    @Test func characterOnlyQueriesNeverResolveAFunctionKey() {
+        #expect(map.targetIndex(at: CGPoint(x: 110, y: 20), characterOnly: false) == 2)
+        #expect(map.targetIndex(at: CGPoint(x: 110, y: 20), characterOnly: true) == nil)
+    }
+
+    @Test func pointsOutsideEveryEffectiveTargetDoNotResolve() {
+        #expect(map.targetIndex(at: CGPoint(x: -1, y: 20), characterOnly: false) == nil)
+        #expect(map.targetIndex(at: CGPoint(x: 200, y: 20), characterOnly: false) == nil)
+    }
+}

--- a/ios/VocaPhoneTests/KeyPreviewRenderTests.swift
+++ b/ios/VocaPhoneTests/KeyPreviewRenderTests.swift
@@ -1,0 +1,52 @@
+#if DEBUG
+import Testing
+import UIKit
+
+/// Not an assertion suite: it writes the pressed-key preview to a PNG so the
+/// balloon, its taper and the neck over the key can be looked at without
+/// installing the keyboard on a device. Set VOCA_RENDER_DIR to collect them.
+@MainActor
+struct KeyPreviewRenderTests {
+    @Test func renderPressedKeyPreview() throws {
+        guard let directory = ProcessInfo.processInfo.environment["VOCA_RENDER_DIR"] else { return }
+
+        let metrics = KeyboardMetrics.resolved(for: UITraitCollection {
+            $0.verticalSizeClass = .regular
+        })
+        for (name, isDark) in [("preview-light", false), ("preview-dark", true)] {
+            let palette = KeyboardPalette(isDark: isDark)
+            let grid = KeyGridView(metrics: metrics, palette: palette)
+            let canvas = UIView(
+                frame: CGRect(x: 0, y: 0, width: 393, height: metrics.gridHeight + 60)
+            )
+            canvas.backgroundColor = palette.background
+            grid.frame = CGRect(
+                x: 0,
+                y: 60,
+                width: 393,
+                height: metrics.gridHeight
+            )
+            canvas.addSubview(grid)
+            canvas.layoutIfNeeded()
+
+            // Press one key in the middle of the row and one against the left
+            // edge, where the balloon is clamped and the neck sits off-centre.
+            for letter in ["g", "q"] {
+                guard let key = grid.keyViews.first(where: { $0.spec.cap == KeyCap.character(letter) })
+                else { continue }
+                key.isHighlighted = true
+                grid.previewKeyForRendering(key)
+            }
+            canvas.layoutIfNeeded()
+
+            // `drawHierarchy` renders nothing for a view that was never in a
+            // window, which is every view in a unit test.
+            let image = UIGraphicsImageRenderer(bounds: canvas.bounds).image { context in
+                canvas.layer.render(in: context.cgContext)
+            }
+            let url = URL(fileURLWithPath: directory).appendingPathComponent("\(name).png")
+            try #require(image.pngData()).write(to: url)
+        }
+    }
+}
+#endif

--- a/ios/VocaPhoneTests/KeyboardGeometryTests.swift
+++ b/ios/VocaPhoneTests/KeyboardGeometryTests.swift
@@ -52,12 +52,46 @@ struct KeyboardGeometryTests {
         #expect(allShowPreviews)
     }
 
-    /// Standard is what every existing install already draws, so adopting the
-    /// preference must change nothing for someone who never opens the setting.
-    @Test func standardReproducesTheShippedGeometry() {
+    /// The default uses the same vertical rhythm measured from Apple's iOS 26
+    /// keyboard, including the full-height bottom row.
+    @Test func standardUsesTheNativeVerticalRhythm() {
         let standard = KeyboardMetrics.resolved(for: Self.portrait, preference: .standard)
         #expect(standard.keyHeight == 43)
-        #expect(standard.rowGap == 10)
+        #expect(standard.rowGap == 11)
+        #expect(standard.gridHeight == 205)
+    }
+
+    /// Reference measurements come from the Apple keyboard on the same 402pt
+    /// iPhone 17 simulator. The extension receives 390pt after its 6pt chrome
+    /// inset on each side, so screen coordinates below add that inset back.
+    @Test func defaultPortraitMatchesTheIPhone17SystemKeyboard() {
+        let chromeInset: CGFloat = 6
+        let grid = Self.makeGrid(width: 390, includesGlobe: false)
+        let rows = Self.rows(in: grid)
+        let q = rows[0][0]
+        let a = rows[1][0]
+        let shift = rows[2][0]
+        let delete = rows[2].last!
+        let plane = rows[3][0]
+        let space = rows[3][1]
+        let newline = rows[3][2]
+
+        // Apple: Q x 6.67, width 33.33; A x 26.33; Shift/Delete width 45.33.
+        #expect(abs(q.frame.minX + chromeInset - 6.67) < 0.75)
+        #expect(abs(q.frame.width - 33.33) < 0.75)
+        #expect(abs(a.frame.minX + chromeInset - 26.33) < 0.75)
+        #expect(abs(shift.frame.width - 45.33) < 0.75)
+        #expect(abs(delete.frame.width - 45.33) < 0.75)
+
+        // Apple: four 43pt rows separated by 11pt gaps.
+        #expect(rows.map { $0[0].frame.minY } == [0, 54, 108, 162])
+        #expect(rows.map { $0[0].frame.height } == [43, 43, 43, 43])
+
+        // With the globe in iOS's lower system row, Apple uses 2.5 / 5 / 2.5
+        // columns here instead of shrinking both modifiers around a huge Space.
+        #expect(abs(plane.frame.width - 92.67) < 0.75)
+        #expect(abs(space.frame.width - 191.33) < 0.75)
+        #expect(abs(newline.frame.width - 92.67) < 0.75)
     }
 
     /// Whatever the preference, the whole keyboard has to fit a phone. The
@@ -129,11 +163,11 @@ struct KeyboardGeometryTests {
         }
 
         // The pinned reference for the default: 6pt inset twice, a 54pt strip,
-        // 7pt of spacing and a 202pt grid.
+        // 7pt of spacing and the native-rhythm 205pt grid.
         let standardGrid = KeyboardMetrics.resolved(for: Self.portrait, preference: .standard)
         let standardBar = DictationBarMetrics.resolved(for: Self.portrait, preference: .standard)
         #expect(standardBar.stripHeight == 54)
-        #expect(chrome + standardBar.stripHeight + standardGrid.gridHeight == 275)
+        #expect(chrome + standardBar.stripHeight + standardGrid.gridHeight == 278)
     }
 
     /// The strip is the shortest of the three bar shapes, in every orientation

--- a/ios/VocaPhoneTests/KeyboardHapticsTests.swift
+++ b/ios/VocaPhoneTests/KeyboardHapticsTests.swift
@@ -15,42 +15,70 @@ struct KeyboardHapticsTests {
         #expect(!KeyboardHaptics.allowsHaptics(preferenceEnabled: false, hasFullAccess: false))
     }
 
-    @Test func committedTextAlwaysUsesTheSystemClick() {
-        #expect(
-            KeyboardFeedbackPolicy.events(
-                for: .committedText,
-                typingHapticsEnabled: false,
-                hasFullAccess: false
-            ) == [.inputClick]
-        )
-        #expect(
-            KeyboardFeedbackPolicy.events(
-                for: .committedText,
-                typingHapticsEnabled: false,
-                hasFullAccess: true
-            ) == [.inputClick]
-        )
-        #expect(
-            KeyboardFeedbackPolicy.events(
-                for: .committedText,
-                typingHapticsEnabled: true,
-                hasFullAccess: true
-            ) == [.inputClick, .typingHaptic]
-        )
-    }
-
-    @Test func immediateKeyboardControlsClickWithoutAddingATypingImpact() {
+    /// The click is the press, not the commit — the system keyboard sounds a
+    /// key as the finger lands — and it never depends on the haptic preference.
+    @Test func pressingAKeyAlwaysClicksAndOnlyClicks() {
         for preferenceEnabled in [false, true] {
             for hasFullAccess in [false, true] {
                 #expect(
                     KeyboardFeedbackPolicy.events(
-                        for: .committedKeyAction,
+                        for: .keyPressed,
                         typingHapticsEnabled: preferenceEnabled,
                         hasFullAccess: hasFullAccess
                     ) == [.inputClick]
                 )
             }
         }
+    }
+
+    /// Committing adds only the tactile half: clicking again on lift would
+    /// double every keystroke.
+    @Test func committingCarriesTheHapticButNotASecondClick() {
+        for interaction in [
+            KeyboardFeedbackInteraction.committedText,
+            .committedKeyAction,
+        ] {
+            #expect(
+                KeyboardFeedbackPolicy.events(
+                    for: interaction,
+                    typingHapticsEnabled: false,
+                    hasFullAccess: true
+                ).isEmpty
+            )
+            #expect(
+                KeyboardFeedbackPolicy.events(
+                    for: interaction,
+                    typingHapticsEnabled: true,
+                    hasFullAccess: false
+                ).isEmpty
+            )
+            #expect(
+                KeyboardFeedbackPolicy.events(
+                    for: interaction,
+                    typingHapticsEnabled: true,
+                    hasFullAccess: true
+                ) == [.typingHaptic]
+            )
+        }
+    }
+
+    /// A held Delete is a stream of separate deletions, and each one sounds —
+    /// otherwise a hold reads as a keyboard that has stopped responding.
+    @Test func eachDeleteRepeatSoundsLikeItsOwnKeystroke() {
+        #expect(
+            KeyboardFeedbackPolicy.events(
+                for: .deleteRepeated,
+                typingHapticsEnabled: false,
+                hasFullAccess: true
+            ) == [.inputClick]
+        )
+        #expect(
+            KeyboardFeedbackPolicy.events(
+                for: .deleteRepeated,
+                typingHapticsEnabled: true,
+                hasFullAccess: true
+            ) == [.inputClick, .typingHaptic]
+        )
     }
 
     @Test func optionalHapticsAreSilentWithoutBothPermissions() {
@@ -95,8 +123,10 @@ struct KeyboardHapticsTests {
     @Test func everyEventIsSafeWithoutAnEngine() {
         let haptics = KeyboardHaptics.shared
         haptics.attach(to: UIView(), hasFullAccess: false)
+        haptics.keyPressed()
         haptics.textCommitted()
         haptics.keyActionCommitted()
+        haptics.deleteRepeated()
         haptics.selectionChanged()
         haptics.action()
         haptics.swipeBegan()

--- a/ios/VocaPhoneTests/KeyboardHapticsTests.swift
+++ b/ios/VocaPhoneTests/KeyboardHapticsTests.swift
@@ -1,11 +1,9 @@
 import Testing
 import UIKit
 
-/// Whether the keyboard is allowed to buzz is a rule with two owners, and both
-/// halves of it have been wrong in shipped builds: the preference was read and
-/// the platform's answer was not, so a keyboard without Full Access fired into
-/// an engine it could not reach and looked broken to the person who had turned
-/// the setting on.
+/// The standard keyboard click and optional custom haptics have different
+/// owners. A click follows iOS Keyboard Clicks; a custom haptic needs both the
+/// explicit VocaPhone preference and Full Access.
 @MainActor
 struct KeyboardHapticsTests {
     @Test func hapticsNeedBothThePreferenceAndFullAccess() {
@@ -15,6 +13,68 @@ struct KeyboardHapticsTests {
         // Keyboard settings screen explains rather than leaving silent.
         #expect(!KeyboardHaptics.allowsHaptics(preferenceEnabled: true, hasFullAccess: false))
         #expect(!KeyboardHaptics.allowsHaptics(preferenceEnabled: false, hasFullAccess: false))
+    }
+
+    @Test func committedTextAlwaysUsesTheSystemClick() {
+        #expect(
+            KeyboardFeedbackPolicy.events(
+                for: .committedText,
+                typingHapticsEnabled: false,
+                hasFullAccess: false
+            ) == [.inputClick]
+        )
+        #expect(
+            KeyboardFeedbackPolicy.events(
+                for: .committedText,
+                typingHapticsEnabled: false,
+                hasFullAccess: true
+            ) == [.inputClick]
+        )
+        #expect(
+            KeyboardFeedbackPolicy.events(
+                for: .committedText,
+                typingHapticsEnabled: true,
+                hasFullAccess: true
+            ) == [.inputClick, .typingHaptic]
+        )
+    }
+
+    @Test func immediateKeyboardControlsClickWithoutAddingATypingImpact() {
+        for preferenceEnabled in [false, true] {
+            for hasFullAccess in [false, true] {
+                #expect(
+                    KeyboardFeedbackPolicy.events(
+                        for: .committedKeyAction,
+                        typingHapticsEnabled: preferenceEnabled,
+                        hasFullAccess: hasFullAccess
+                    ) == [.inputClick]
+                )
+            }
+        }
+    }
+
+    @Test func optionalHapticsAreSilentWithoutBothPermissions() {
+        for interaction in [
+            KeyboardFeedbackInteraction.selectionChanged,
+            .dictationAction,
+            .swipeBegan,
+            .swipeCommitted,
+        ] {
+            #expect(
+                KeyboardFeedbackPolicy.events(
+                    for: interaction,
+                    typingHapticsEnabled: false,
+                    hasFullAccess: true
+                ).isEmpty
+            )
+            #expect(
+                KeyboardFeedbackPolicy.events(
+                    for: interaction,
+                    typingHapticsEnabled: true,
+                    hasFullAccess: false
+                ).isEmpty
+            )
+        }
     }
 
     /// Full Access can be revoked in Settings while an extension instance lives
@@ -35,7 +95,8 @@ struct KeyboardHapticsTests {
     @Test func everyEventIsSafeWithoutAnEngine() {
         let haptics = KeyboardHaptics.shared
         haptics.attach(to: UIView(), hasFullAccess: false)
-        haptics.keyPress()
+        haptics.textCommitted()
+        haptics.keyActionCommitted()
         haptics.selectionChanged()
         haptics.action()
         haptics.swipeBegan()

--- a/ios/VocaPhoneTests/SemanticPaletteTests.swift
+++ b/ios/VocaPhoneTests/SemanticPaletteTests.swift
@@ -4,6 +4,7 @@ import UIKit
 /// The palette carries product claims, not just taste: an amber that has drifted
 /// into the recording red says a wait is a capture, and a brand green that has
 /// moved says this is a different product.
+@MainActor
 struct SemanticPaletteTests {
     private func contrast(_ first: UIColor, _ second: UIColor) -> CGFloat {
         ContrastMath.ratio(first, second)
@@ -149,17 +150,57 @@ struct SemanticPaletteTests {
 
     // MARK: - Keyboard
 
-    /// A character key is what the eye should land on first, so it stays the
-    /// brightest key in the light palette and the lightest in the dark one.
-    @Test func standardKeysAreTheBrightestKeysInBothAppearances() {
+    /// iOS 26 unifies character and function fills. Earlier systems retain the
+    /// stepped palette their native keyboard used.
+    @Test func keyFillHierarchyMatchesTheRunningSystem() {
         for isDark in [true, false] {
             let palette = KeyboardPalette(isDark: isDark)
             let standard = ContrastMath.relativeLuminance(palette.standardKey)
             let function = ContrastMath.relativeLuminance(palette.functionKey)
             let background = ContrastMath.relativeLuminance(palette.background)
-            #expect(standard > function)
-            #expect(isDark ? function > background : function < background)
+            if #available(iOS 26.0, *) {
+                #expect(standard == function)
+                #expect(standard > background)
+            } else {
+                #expect(standard > function)
+                #expect(isDark ? function > background : function < background)
+            }
         }
+    }
+
+    @Test func ios26KeyboardSurfacesMatchMeasuredSystemPixels() {
+        guard #available(iOS 26.0, *) else { return }
+        #expect(Self.rgb(KeyboardPalette(isDark: false).background) == (226, 228, 232))
+        #expect(Self.rgb(KeyboardPalette(isDark: false).standardKey) == (255, 255, 255))
+        #expect(Self.rgb(KeyboardPalette(isDark: true).background) == (23, 23, 23))
+        #expect(Self.rgb(KeyboardPalette(isDark: true).standardKey) == (61, 61, 61))
+    }
+
+    @Test func engagedShiftUsesTheNativeNeutralSurface() {
+        let palette = KeyboardPalette(isDark: false)
+        let metrics = KeyboardMetrics.resolved(
+            for: UITraitCollection { $0.verticalSizeClass = .regular }
+        )
+        let shift = KeyView(
+            spec: KeySpec(cap: .shift, width: .fill, style: .function),
+            metrics: metrics,
+            palette: palette
+        )
+        shift.update(metrics: metrics, palette: palette, shift: .on, returnTitle: "return")
+        #expect(shift.backgroundColor == palette.functionKey)
+    }
+
+    private static func rgb(_ color: UIColor) -> (Int, Int, Int) {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        _ = color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return (
+            Int((red * 255).rounded()),
+            Int((green * 255).rounded()),
+            Int((blue * 255).rounded())
+        )
     }
 
     /// Every key label, on every fill it can be drawn on, including the pressed

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -30,6 +30,7 @@ targets:
       # The controller stays out: it is a `UIInputViewController` and has no
       # meaning outside the extension.
       - path: VocaPhoneKeyboard/KeyLayout.swift
+      - path: VocaPhoneKeyboard/KeyHitMap.swift
       - path: VocaPhoneKeyboard/KeyView.swift
       - path: VocaPhoneKeyboard/KeyGridView.swift
       - path: VocaPhoneKeyboard/KeyAlternatives.swift
@@ -128,6 +129,7 @@ targets:
       # Key geometry is worth regression tests; the controller itself needs a
       # host extension and stays out of the test target.
       - path: VocaPhoneKeyboard/KeyLayout.swift
+      - path: VocaPhoneKeyboard/KeyHitMap.swift
       - path: VocaPhoneKeyboard/KeyView.swift
       - path: VocaPhoneKeyboard/KeyGridView.swift
       # The trail's ageing and taper is pure arithmetic over sampled points, and


### PR DESCRIPTION
## Problem

The iOS keyboard could feel unlike the native keyboard in two independent ways: feedback fired too aggressively, and the visible typing surface did not match Apple's default iPhone geometry. The old layout had a tighter vertical rhythm, larger outer inset, oversized Shift/Delete slots, narrow bottom modifiers, non-system iOS 26 colours, and a permanently accented Shift state.

## Summary

- separate standard iOS keyboard clicks from optional custom typing haptics
- default custom typing haptics off and migrate existing installs to the calmer setting
- emit typing feedback only for the final committed character, Space, Return, or emoji
- add a deterministic hit map with stable gutter ownership and invalidate it during deferred plane relayouts
- add injectable feedback plus cancellation, slide-correction, plane-transition, and policy regression coverage
- match Apple's measured iPhone portrait geometry: 43 pt keys, 11 pt row gaps, 6 pt column gaps, native edge/home-row positions, and native-width Shift/Delete keys
- preserve full invisible touch slots around the narrower Shift/Delete visuals
- match Apple's default 2.5 / 5 / 2.5 bottom-row proportions when iOS supplies the globe below the extension
- use the iOS 26 system keyboard surface colours in light and dark appearances
- keep Shift neutral, leave Space visually blank, and use the system Return glyph for the default return action
- update Keyboard Settings copy without making an unverified Full Access claim

## Verification

- [x] `just ios ci` — preview isolation, simulator build, project staleness check, and all 621 tests pass
- [x] iPhone 17 simulator on iOS 26.5 — captured and measured Apple's keyboard, then compared VocaPhone in light and dark appearances; key frames and surface colours match the measured references
- [ ] `just android ci` — N/A; iOS-only change
- [ ] Gateway changes — N/A; no gateway or submodule changes
- [ ] Physical-device test — not run; keyboard feel, clicks, optional haptics, rapid two-thumb typing, plane switching, and insertion still require an iPhone pass

Maintainers can comment `/build` on this PR for installable Android/iOS artifacts (see CONTRIBUTING).

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation update not required; no data-flow, permission, retention, microphone, or network behavior changed
