### PR TITLE
fix(ios): keep fast keystrokes on the key they pressed

### DIFF
--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -145,7 +145,9 @@ final class KeyGridView: UIView {
         var isEngaged = true
         /// Set when a plane switch under another finger took this touch's
         /// keyboard away. It keeps the key it pressed and still commits it on
-        /// lift, but there is no map left to re-target it against.
+        /// lift, but `keyIndex` now points into a `keyViews` that has been
+        /// replaced, so nothing may re-target it — which is why `touchesMoved`
+        /// leaves a pinned touch alone entirely.
         var isPinned = false
         /// Whether the finger may leave this key and type the one it lands on.
         /// Characters always may. So do Shift and the plane key, because iOS
@@ -494,9 +496,13 @@ final class KeyGridView: UIView {
         swipeTrail.cancel()
         for item in tracked {
             // The popover and the balloon are both anchored to a plane that is
-            // going away, and a trace across a plane change means nothing.
+            // going away.
             item.longPressTimer?.invalidate()
             item.longPressTimer = nil
+            // A trace in flight commits nothing at all: its path crossed a
+            // plane that has gone, and the one letter the finger happens to
+            // have stopped over is not the word it was drawing.
+            if item.isSwiping { item.isEngaged = false }
             item.isSwiping = false
             item.swipePath = []
             item.isPinned = true
@@ -710,8 +716,9 @@ final class KeyGridView: UIView {
 
     private func finish(_ touches: Set<UITouch>, commit: Bool) {
         // Applied after the loop: restoring the plane rebuilds the grid and
-        // releases every tracked touch, which would strand the other fingers
-        // of a multi-touch batch before they have been read.
+        // pins every tracked touch, which would freeze the other fingers of a
+        // multi-touch batch — clearing their previews and stopping them
+        // tracking — before they have been read.
         var planeToRestore: KeyPlane?
         for touch in touches.sorted(by: { $0.timestamp < $1.timestamp }) {
             if planeHoldTouch === touch { cancelPlaneHold() }
@@ -1078,9 +1085,9 @@ final class KeyGridView: UIView {
     /// Distinct fingers on the grid.
     ///
     /// A slide off the plane key re-registers the same `UITouch` under a second
-    /// `TrackedTouch`, and today only the `releaseTouches` inside the plane
-    /// switch keeps the first from outliving it. Counting distinct touches
-    /// rather than entries means this stays right if that ordering ever moves.
+    /// `TrackedTouch`, and it is only the explicit removal of the first in
+    /// `touchesBegan` that stops the two coexisting. Counting distinct touches
+    /// rather than entries means this stays right if that ever slips.
     private var activeTouchCount: Int {
         var count = 0
         for (position, item) in tracked.enumerated()

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -143,6 +143,10 @@ final class KeyGridView: UIView {
         /// clear the highlight the first was still relying on — a dropped
         /// keystroke that only ever showed up at speed.
         var isEngaged = true
+        /// Set when a plane switch under another finger took this touch's
+        /// keyboard away. It keeps the key it pressed and still commits it on
+        /// lift, but there is no map left to re-target it against.
+        var isPinned = false
         /// Whether the finger may leave this key and type the one it lands on.
         /// Characters always may. So do Shift and the plane key, because iOS
         /// lets a press on either slide onto a letter or symbol, type it, and
@@ -419,7 +423,7 @@ final class KeyGridView: UIView {
         // touch resolve old target indices against the new plane's views.
         hitMap = KeyHitMap(targets: [])
         endDeleteRepeat()
-        releaseTouches()
+        pinTouchesToTheirKeys()
         keyViews.forEach { $0.isHidden = true }
 
         let entry: (rows: [KeyRow], views: [KeyView])
@@ -473,6 +477,34 @@ final class KeyGridView: UIView {
         endDeleteRepeat()
         cancelPlaneHold()
         releaseTouches()
+    }
+
+    /// Freezes every touch in flight on the key it is already holding.
+    ///
+    /// A plane switch replaces `keyViews` and the hit map, so a finger that was
+    /// down when another thumb tapped `123` has nothing left to slide across.
+    /// It used to be dropped outright, which is a keystroke the user typed and
+    /// never saw: two-thumb typists hit `123` with one thumb while the other is
+    /// still on a letter all the time. `KeyView` carries its own spec, so the
+    /// pinned touch can still commit that letter when it lifts even though the
+    /// view behind it now belongs to a plane that is no longer on screen.
+    private func pinTouchesToTheirKeys() {
+        spaceTrackpadTimer?.invalidate()
+        spaceTrackpadTimer = nil
+        swipeTrail.cancel()
+        for item in tracked {
+            // The popover and the balloon are both anchored to a plane that is
+            // going away, and a trace across a plane change means nothing.
+            item.longPressTimer?.invalidate()
+            item.longPressTimer = nil
+            item.isSwiping = false
+            item.swipePath = []
+            item.isPinned = true
+            item.key.isHighlighted = false
+            recycle(item.preview)
+            item.preview = nil
+        }
+        dismissAlternatives()
     }
 
     private func releaseTouches() {
@@ -529,23 +561,26 @@ final class KeyGridView: UIView {
             if key.spec.cap.actsOnTouchDown {
                 let planeBefore = plane
                 performTouchDownAction(for: key, event: event)
-                // Switching planes rebuilds the grid and releases every touch,
-                // this one included. Re-register it against the plane the
-                // finger is now looking at, so it can slide onto a symbol and
-                // type it on lift the way the system keyboard does.
-                if case .plane = key.spec.cap, plane != planeBefore,
-                   let landedIndex = self.keyIndex(at: point, characterOnly: false)
-                {
-                    let landed = keyViews[landedIndex]
-                    let slide = TrackedTouch(
-                        touch: touch,
-                        key: landed,
-                        keyIndex: landedIndex,
-                        initialPoint: point,
-                        planeToRestore: planeBefore
-                    )
-                    tracked.append(slide)
-                    landed.isHighlighted = true
+                // Switching planes rebuilds the grid and pins every touch,
+                // this one included. Unlike the other fingers it has nothing
+                // worth committing — a plane key types nothing — so drop its
+                // entry and re-register it against the plane the finger is now
+                // looking at, letting it slide onto a symbol and type that on
+                // lift the way the system keyboard does.
+                if case .plane = key.spec.cap, plane != planeBefore {
+                    tracked.removeAll { $0 === item }
+                    if let landedIndex = self.keyIndex(at: point, characterOnly: false) {
+                        let landed = keyViews[landedIndex]
+                        let slide = TrackedTouch(
+                            touch: touch,
+                            key: landed,
+                            keyIndex: landedIndex,
+                            initialPoint: point,
+                            planeToRestore: planeBefore
+                        )
+                        tracked.append(slide)
+                        landed.isHighlighted = true
+                    }
                 }
             }
         }
@@ -560,6 +595,9 @@ final class KeyGridView: UIView {
                 if hypot(point.x - origin.x, point.y - origin.y) > 12 { cancelPlaneHold() }
             }
             guard let item = tracked.first(where: { $0.touch === touch }) else { continue }
+            // Pinned by a plane switch: the keys it was moving over are gone, so
+            // it waits for the lift that commits what it pressed.
+            guard !item.isPinned else { continue }
             let point = touch.location(in: self)
 
             if item.isChoosingAlternative {

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -112,7 +112,7 @@ final class KeyGridView: UIView {
     private var alternativesView: KeyAlternativesView?
     /// Rebuilt by layout from the same frames that are rendered. Touches never
     /// scan UIKit subviews directly, so a gutter boundary has one stable owner.
-    private var hitMap = KeyHitMap(targets: [])
+    private(set) var hitMap = KeyHitMap(targets: [])
     private var tracked: [TrackedTouch] = []
     /// The plane key's hold-for-emoji gesture. Owned by the grid rather than by
     /// a `TrackedTouch`, because the plane switch it rides on releases those.
@@ -124,10 +124,25 @@ final class KeyGridView: UIView {
     private var spaceTrackpadTimer: Timer?
     private var deleteRepeatCount = 0
     private var lastShiftTapAt: Date?
+    /// When the run of fast typing this keyboard is in last produced a letter,
+    /// or `nil` if it is not in one. See ``isInFastTyping``.
+    private var lastLetterCommitAt: Date?
 
     private final class TrackedTouch: @unchecked Sendable {
         let touch: UITouch
-        var key: KeyView
+        private(set) var key: KeyView
+        /// The key's position in `keyViews`, which is also its index in the hit
+        /// map. Kept beside the view so a move event can ask the map to
+        /// re-target without first searching the subviews for the current key.
+        private(set) var keyIndex: Int
+        /// Whether this finger would still commit if it lifted now.
+        ///
+        /// Distinct from `key.isHighlighted`, which belongs to the *view*: two
+        /// fingers can be on one key when a fast typist re-presses a letter
+        /// before the first press has lifted, and the second one lifting used to
+        /// clear the highlight the first was still relying on — a dropped
+        /// keystroke that only ever showed up at speed.
+        var isEngaged = true
         /// Whether the finger may leave this key and type the one it lands on.
         /// Characters always may. So do Shift and the plane key, because iOS
         /// lets a press on either slide onto a letter or symbol, type it, and
@@ -161,16 +176,23 @@ final class KeyGridView: UIView {
         init(
             touch: UITouch,
             key: KeyView,
+            keyIndex: Int,
             initialPoint: CGPoint,
             planeToRestore: KeyPlane? = nil
         ) {
             self.touch = touch
             self.key = key
+            self.keyIndex = keyIndex
             self.initialPoint = initialPoint
             self.planeToRestore = planeToRestore
             startedOnShift = key.spec.cap == .shift
             allowsSwipe = key.spec.cap.isCharacter
             allowsSlide = key.spec.cap.isCharacter || startedOnShift || planeToRestore != nil
+        }
+
+        func retarget(to index: Int, view: KeyView) {
+            keyIndex = index
+            key = view
         }
     }
 
@@ -212,6 +234,11 @@ final class KeyGridView: UIView {
             hitMap = KeyHitMap(targets: [])
             return
         }
+        // Android's 8dp is measured against its ~40dp key; expressing it as a
+        // share of this keyboard's own column keeps the same feel at every
+        // height preference and on iPad, where a fixed 8pt would be a much
+        // smaller part of a 56pt key.
+        let hysteresis = max(unit * 0.2, metrics.columnGap)
 
         var keyIndex = 0
         var targets: [KeyHitMap.Target] = []
@@ -265,7 +292,7 @@ final class KeyGridView: UIView {
             y += metrics.keyHeight + metrics.rowGap
         }
 
-        hitMap = KeyHitMap(targets: targets)
+        hitMap = KeyHitMap(targets: targets, hysteresis: hysteresis)
     }
 
     /// The native letters plane leaves a larger visual moat around Shift and
@@ -477,11 +504,15 @@ final class KeyGridView: UIView {
     // MARK: - Touch tracking
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        for touch in touches {
+        // Sorted, because `Set` has no order and two thumbs landing inside one
+        // event would otherwise type in whichever order the set happened to
+        // hash — the letters of a fast word arriving transposed.
+        for touch in touches.sorted(by: { $0.timestamp < $1.timestamp }) {
             let point = touch.location(in: self)
-            guard let key = key(at: point, characterOnly: false)
+            guard let index = keyIndex(at: point, characterOnly: false)
             else { continue }
-            let item = TrackedTouch(touch: touch, key: key, initialPoint: point)
+            let key = keyViews[index]
+            let item = TrackedTouch(touch: touch, key: key, keyIndex: index, initialPoint: point)
             tracked.append(item)
             key.isHighlighted = true
             // The click belongs to the press, not to the commit: the system
@@ -503,11 +534,13 @@ final class KeyGridView: UIView {
                 // finger is now looking at, so it can slide onto a symbol and
                 // type it on lift the way the system keyboard does.
                 if case .plane = key.spec.cap, plane != planeBefore,
-                   let landed = self.key(at: point, characterOnly: false)
+                   let landedIndex = self.keyIndex(at: point, characterOnly: false)
                 {
+                    let landed = keyViews[landedIndex]
                     let slide = TrackedTouch(
                         touch: touch,
                         key: landed,
+                        keyIndex: landedIndex,
                         initialPoint: point,
                         planeToRestore: planeBefore
                     )
@@ -553,8 +586,9 @@ final class KeyGridView: UIView {
                 // the finger wanders off, so a drag away cancels instead of
                 // firing something the user no longer intends.
                 let isInside = item.key.hitRect.contains(point)
-                guard item.key.isHighlighted != isInside else { continue }
-                item.key.isHighlighted = isInside
+                guard item.isEngaged != isInside else { continue }
+                item.isEngaged = isInside
+                setHighlight(isInside, on: item.key)
                 if item.key.spec.cap == .delete {
                     isInside ? startDeleteTimer() : endDeleteRepeat()
                 }
@@ -566,7 +600,9 @@ final class KeyGridView: UIView {
                     point.x - item.initialPoint.x,
                     point.y - item.initialPoint.y
                 )
-                if !item.isSwiping, travelled > SwipeRecognizer.activationDistance {
+                if !item.isSwiping, activeTouchCount == 1,
+                   travelled > swipeActivationDistance
+                {
                     // Only now is this a swipe. Below the threshold it is the
                     // slide-to-correct-a-target gesture the keyboard already
                     // had, and stealing that would break ordinary typing.
@@ -585,19 +621,43 @@ final class KeyGridView: UIView {
                 if item.isSwiping {
                     item.swipePath.append(point)
                     swipeTrail.extend(to: point)
-                    if let key = key(at: point, characterOnly: true), key !== item.key {
-                        item.key.isHighlighted = false
-                        item.key = key
-                        key.isHighlighted = true
+                    // A trace is meant to run across keys, so it re-targets on
+                    // the boundary with no hysteresis at all.
+                    if let index = keyIndex(at: point, characterOnly: true),
+                       index != item.keyIndex
+                    {
+                        let previous = item.key
+                        item.retarget(to: index, view: keyViews[index])
+                        setHighlight(false, on: previous)
+                        setHighlight(true, on: item.key)
                     }
                     continue
                 }
             }
 
-            guard let key = key(at: point, characterOnly: true), key !== item.key else { continue }
-            item.key.isHighlighted = false
-            item.key = key
-            key.isHighlighted = true
+            // Past here the finger is correcting its target rather than tracing,
+            // and both reasons a *fast* keystroke lands on the wrong letter are
+            // decided in this step.
+            //
+            // The first is that another finger is already down. Typing at speed
+            // overlaps the strokes, and panels report two close contacts noisily
+            // — the finger that is lifting reads as a slide. Android pins the key
+            // in exactly this case ("if there are currently multiple touches,
+            // register the key even if the finger slides off the key"), with the
+            // same carve-out for a modifier being chorded into a letter.
+            guard activeTouchCount == 1 || item.isModifierSlide else { continue }
+
+            // The second is the boundary, which the hit map now holds the finger
+            // back from until it has genuinely left the key it pressed.
+            guard let index = hitMap.retargetIndex(
+                from: item.keyIndex,
+                at: point,
+                characterOnly: true
+            ), keyViews.indices.contains(index) else { continue }
+            let previous = item.key
+            item.retarget(to: index, view: keyViews[index])
+            setHighlight(false, on: previous)
+            setHighlight(true, on: item.key)
             showPreview(for: item)
         }
     }
@@ -615,7 +675,7 @@ final class KeyGridView: UIView {
         // releases every tracked touch, which would strand the other fingers
         // of a multi-touch batch before they have been read.
         var planeToRestore: KeyPlane?
-        for touch in touches {
+        for touch in touches.sorted(by: { $0.timestamp < $1.timestamp }) {
             if planeHoldTouch === touch { cancelPlaneHold() }
             guard let index = tracked.firstIndex(where: { $0.touch === touch }) else { continue }
             let item = tracked.remove(at: index)
@@ -625,7 +685,7 @@ final class KeyGridView: UIView {
             }
             item.longPressTimer?.invalidate()
             item.longPressTimer = nil
-            var shouldCommit = commit && item.key.isHighlighted && !item.isCursorTracking
+            var shouldCommit = commit && item.isEngaged && !item.isCursorTracking
             // A slide that began on Shift or the plane key tracks characters
             // only, so sliding back onto the modifier leaves `item.key` on the
             // letter it passed over. Lifting there must type nothing.
@@ -634,18 +694,22 @@ final class KeyGridView: UIView {
             {
                 shouldCommit = false
             }
-            item.key.isHighlighted = false
+            item.isEngaged = false
+            setHighlight(false, on: item.key)
             recycle(item.preview)
             item.preview = nil
             if item.key.spec.cap == .delete { endDeleteRepeat() }
             if item.isSwiping {
-                item.key.isHighlighted = false
                 let path = item.swipePath
                 item.swipePath = []
                 item.isSwiping = false
                 // A committed swipe lets its trail fade out under the word that
                 // just appeared; a cancelled one takes the trail with it.
                 if commit {
+                    // A traced word is not typing, so it closes the window
+                    // rather than extending it — the same reason Android's
+                    // recorder treats a batch input as ending the run.
+                    lastLetterCommitAt = nil
                     swipeTrail.end()
                     commitSwipe(path)
                 } else {
@@ -680,8 +744,9 @@ final class KeyGridView: UIView {
     func completeKeyInteraction(_ key: KeyView, shouldCommit: Bool) -> Bool {
         guard shouldCommit else { return false }
         switch key.spec.cap {
-        case .character:
+        case let .character(base):
             guard let text = key.previewText else { return false }
+            recordTyping(isLetter: base.first?.isLetter == true)
             feedback.textCommitted()
             delegate?.keyGrid(self, didProduce: .text(text))
             // Also what ends a slide off Shift: one capital, then back to
@@ -689,6 +754,7 @@ final class KeyGridView: UIView {
             if shiftState == .on { shiftState = .off }
             return true
         case .space:
+            recordTyping(isLetter: false)
             feedback.textCommitted()
             delegate?.keyGrid(self, didProduce: .space)
             return true
@@ -727,7 +793,7 @@ final class KeyGridView: UIView {
                 guard let self,
                       let item,
                       self.tracked.contains(where: { $0 === item }),
-                      item.key.isHighlighted
+                      item.isEngaged
                 else { return }
                 item.isCursorTracking = true
                 item.lastCursorStep = 0
@@ -744,11 +810,13 @@ final class KeyGridView: UIView {
                 spaceTrackpadTimer?.invalidate()
                 spaceTrackpadTimer = nil
             }
-            item.key.isHighlighted = item.key.hitRect.contains(point)
+            item.isEngaged = item.key.hitRect.contains(point)
+            setHighlight(item.isEngaged, on: item.key)
             return
         }
 
-        item.key.isHighlighted = true
+        item.isEngaged = true
+        setHighlight(true, on: item.key)
         let step = CursorTrackpad.step(
             forHorizontalTranslation: point.x - item.initialPoint.x
         )
@@ -758,7 +826,42 @@ final class KeyGridView: UIView {
         delegate?.keyGrid(self, didProduce: .moveCursor(delta))
     }
 
+    // MARK: - Fast typing
+
+    /// How long after a letter the keyboard still counts as being typed at
+    /// speed. Android's `config_gesture_static_time_threshold_after_fast_typing`
+    /// to the millisecond.
+    private static let fastTypingWindow: TimeInterval = 0.5
+
+    /// Whether the last letter is recent enough that this touch is part of a
+    /// run rather than a considered single press.
+    private var isInFastTyping: Bool {
+        guard let lastLetterCommitAt else { return false }
+        return Date().timeIntervalSince(lastLetterCommitAt) < Self.fastTypingWindow
+    }
+
+    /// Mirrors Android's `TypingTimeRecorder`: a letter always opens or extends
+    /// the window, and a non-letter only extends one that is already open — so a
+    /// full stop at the end of a sentence does not reopen it a second later.
+    private func recordTyping(isLetter: Bool) {
+        if isLetter || isInFastTyping { lastLetterCommitAt = Date() }
+    }
+
     // MARK: - Swipe
+
+    /// How far a finger must leave its key before this becomes a trace.
+    ///
+    /// Doubled inside the fast typing window, because a keystroke at speed
+    /// skids far enough to look like the start of one and a swipe fired by
+    /// accident replaces a whole word. Android answers the same problem by
+    /// raising its gesture threshold for half a second after the last letter;
+    /// raising the distance rather than refusing outright keeps a deliberate
+    /// swipe mid-sentence available.
+    private var swipeActivationDistance: CGFloat {
+        isInFastTyping
+            ? SwipeRecognizer.activationDistance * 2
+            : SwipeRecognizer.activationDistance
+    }
 
     private var swipeTypingIsAvailable: Bool {
         KeyboardPreferences.swipeTypingEnabled
@@ -859,7 +962,7 @@ final class KeyGridView: UIView {
                 guard let self,
                       let item,
                       self.tracked.contains(where: { $0 === item }),
-                      item.key.isHighlighted
+                      item.isEngaged
                 else { return }
                 self.presentAlternatives(for: item)
             }
@@ -923,10 +1026,41 @@ final class KeyGridView: UIView {
     }
 
     func key(at point: CGPoint, characterOnly: Bool) -> KeyView? {
+        guard let index = keyIndex(at: point, characterOnly: characterOnly) else { return nil }
+        return keyViews[index]
+    }
+
+    private func keyIndex(at point: CGPoint, characterOnly: Bool) -> Int? {
         guard let index = hitMap.targetIndex(at: point, characterOnly: characterOnly),
               keyViews.indices.contains(index)
         else { return nil }
-        return keyViews[index]
+        return index
+    }
+
+    /// Distinct fingers on the grid.
+    ///
+    /// A slide off the plane key re-registers the same `UITouch` under a second
+    /// `TrackedTouch`, and today only the `releaseTouches` inside the plane
+    /// switch keeps the first from outliving it. Counting distinct touches
+    /// rather than entries means this stays right if that ordering ever moves.
+    private var activeTouchCount: Int {
+        var count = 0
+        for (position, item) in tracked.enumerated()
+        where !tracked[..<position].contains(where: { $0.touch === item.touch }) {
+            count += 1
+        }
+        return count
+    }
+
+    /// Highlighting belongs to the key view, which two tracked touches can
+    /// share. Only the last of them to let go may turn it off.
+    private func setHighlight(_ isHighlighted: Bool, on key: KeyView) {
+        if isHighlighted {
+            key.isHighlighted = true
+            return
+        }
+        guard !tracked.contains(where: { $0.isEngaged && $0.key === key }) else { return }
+        key.isHighlighted = false
     }
 
     // MARK: - Delete repeat
@@ -1047,9 +1181,13 @@ final class KeyGridView: UIView {
     /// The throwaway `TrackedTouch` is deliberately not added to `tracked`: it
     /// carries no real `UITouch`, and live touch tracking must never see one.
     /// `showPreview` only reads the item, and the balloon it dequeues is a
-    /// subview of the grid, so it survives for the render either way.
+    /// subview of the grid, so it survives for the render either way. Its
+    /// `keyIndex` is deliberately out of range for the same reason: nothing
+    /// will ever ask the hit map to re-target it.
     func previewKeyForRendering(_ key: KeyView) {
-        showPreview(for: TrackedTouch(touch: UITouch(), key: key, initialPoint: .zero))
+        showPreview(
+            for: TrackedTouch(touch: UITouch(), key: key, keyIndex: -1, initialPoint: .zero)
+        )
     }
 #endif
 

--- a/ios/VocaPhoneKeyboard/KeyHitMap.swift
+++ b/ios/VocaPhoneKeyboard/KeyHitMap.swift
@@ -19,6 +19,26 @@ struct KeyHitMap {
 
     let targets: [Target]
 
+    /// How far past the edge of the key it is already on a finger must travel
+    /// before the grid hands the touch to a neighbour.
+    ///
+    /// Without this a boundary is a knife edge: a finger that lands two points
+    /// inside `d` and rolls six points right as it lifts — which is what every
+    /// fast keystroke does — leaves with `f`. The system keyboards do not
+    /// re-target on the boundary either. Android's is the published one:
+    /// `config_key_hysteresis_distance` is 8dp measured from the *edge of the
+    /// current key*, and `PointerTracker.isMajorEnoughMoveToBeOnNewKey` refuses
+    /// the new key until the finger clears it.
+    ///
+    /// Zero restores the knife edge, and is only the default so that callers
+    /// building a map for a query that has no current key need not supply one.
+    let hysteresis: CGFloat
+
+    init(targets: [Target], hysteresis: CGFloat = 0) {
+        self.targets = targets
+        self.hysteresis = hysteresis
+    }
+
     /// The nearest visible centre among the targets claiming `point`.
     ///
     /// A gutter can land exactly on the midpoint between two keys. `targets` is
@@ -46,5 +66,32 @@ struct KeyHitMap {
         }
 
         return winner?.index
+    }
+
+    /// The target a finger already on `currentIndex` should move to, or `nil`
+    /// to stay where it is.
+    ///
+    /// Distance is measured from the current key's layout slot rather than from
+    /// its effective target, because the effective targets tile the plane: they
+    /// meet at the middle of the gutter, so measuring from them would give a
+    /// key at the edge of the keyboard — whose target runs out to the bounds —
+    /// far more protection than one in the middle of a row.
+    func retargetIndex(from currentIndex: Int, at point: CGPoint, characterOnly: Bool) -> Int? {
+        guard let candidate = targetIndex(at: point, characterOnly: characterOnly),
+              candidate != currentIndex
+        else { return nil }
+        guard let current = targets.first(where: { $0.index == currentIndex }) else {
+            return candidate
+        }
+        guard Self.distance(from: current.frame, to: point) >= hysteresis else { return nil }
+        return candidate
+    }
+
+    /// How far `point` lies outside `rect`; zero anywhere inside it.
+    static func distance(from rect: CGRect, to point: CGPoint) -> CGFloat {
+        hypot(
+            max(rect.minX - point.x, 0, point.x - rect.maxX),
+            max(rect.minY - point.y, 0, point.y - rect.maxY)
+        )
     }
 }

--- a/ios/VocaPhoneTests/KeyHitMapTests.swift
+++ b/ios/VocaPhoneTests/KeyHitMapTests.swift
@@ -114,6 +114,143 @@ struct KeyHitMapTests {
         #expect(grid.hitMap.retargetIndex(from: index, at: rolled, characterOnly: true) == nil)
     }
 
+    /// Two-thumb typists tap `123` with one thumb while the other is still on a
+    /// letter. The switch used to release every tracked touch, so that letter
+    /// was a keystroke the user typed and never saw.
+    @Test func aPlaneSwitchKeepsTheFingerAlreadyDownOnALetter() throws {
+        let delegate = KeyGridDelegateSpy()
+        let grid = Self.makeLaidOutGrid(delegate: delegate)
+
+        let q = try #require(grid.keyViews.first { $0.spec.cap == .character("q") })
+        let planeKey = try #require(grid.keyViews.first { $0.spec.cap == .plane(.numbers) })
+
+        let letter = StubTouch(at: q.frame.center)
+        grid.touchesBegan([letter], with: nil)
+        grid.touchesBegan([StubTouch(at: planeKey.frame.center)], with: nil)
+        #expect(grid.plane == .numbers)
+
+        grid.touchesEnded([letter], with: nil)
+        #expect(delegate.insertedText == ["q"])
+    }
+
+    /// Pinned means frozen, not merely un-slidable: the plane it was moving
+    /// across is gone, so a drag can no longer pick up whatever digit happens to
+    /// have taken that spot.
+    @Test func aPinnedFingerCommitsWhatItPressedAndIgnoresTheDrag() throws {
+        let delegate = KeyGridDelegateSpy()
+        let grid = Self.makeLaidOutGrid(delegate: delegate)
+
+        let q = try #require(grid.keyViews.first { $0.spec.cap == .character("q") })
+        let w = try #require(grid.keyViews.first { $0.spec.cap == .character("w") })
+        let planeKey = try #require(grid.keyViews.first { $0.spec.cap == .plane(.numbers) })
+
+        let letter = StubTouch(at: q.frame.center)
+        grid.touchesBegan([letter], with: nil)
+        grid.touchesBegan([StubTouch(at: planeKey.frame.center)], with: nil)
+
+        letter.move(to: w.frame.center)
+        grid.touchesMoved([letter], with: nil)
+        grid.touchesEnded([letter], with: nil)
+
+        #expect(delegate.insertedText == ["q"])
+    }
+
+    /// The finger that pressed `123` is pinned by its own switch like every
+    /// other, but a plane key types nothing, so it must be replaced rather than
+    /// left behind — otherwise its lift consumes the slide's entry and the
+    /// symbol the finger slid onto never arrives.
+    @Test func theFingerThatSwitchedPlanesStillSlidesOntoASymbol() throws {
+        let delegate = KeyGridDelegateSpy()
+        let grid = Self.makeLaidOutGrid(delegate: delegate)
+
+        let planeKey = try #require(grid.keyViews.first { $0.spec.cap == .plane(.numbers) })
+        let touch = StubTouch(at: planeKey.frame.center)
+        grid.touchesBegan([touch], with: nil)
+
+        let four = try #require(grid.keyViews.first { $0.spec.cap == .character("4") })
+        touch.move(to: four.frame.center)
+        grid.touchesMoved([touch], with: nil)
+        grid.touchesEnded([touch], with: nil)
+
+        #expect(delegate.insertedText == ["4"])
+        // Typing a symbol this way returns to the plane the finger came from.
+        #expect(grid.plane == .letters)
+    }
+
+    /// The reported bug, driven through the real touch path: a finger that
+    /// presses `d` near its edge and skids as it lifts — every keystroke at
+    /// speed — used to type `f`.
+    @Test func aKeystrokeThatRollsOffTheEdgeStillTypesItsOwnLetter() throws {
+        let delegate = KeyGridDelegateSpy()
+        let grid = Self.makeLaidOutGrid(delegate: delegate)
+        let d = try #require(grid.keyViews.first { $0.spec.cap == .character("d") })
+
+        let touch = StubTouch(at: CGPoint(x: d.frame.maxX - 2, y: d.frame.midY))
+        grid.touchesBegan([touch], with: nil)
+        touch.move(to: CGPoint(x: d.frame.maxX + 4, y: d.frame.midY))
+        grid.touchesMoved([touch], with: nil)
+        grid.touchesEnded([touch], with: nil)
+
+        #expect(delegate.insertedText == ["d"])
+    }
+
+    /// A deliberate slide to the next letter is a gesture people use to fix a
+    /// target, and the hysteresis must not have eaten it.
+    @Test func aDeliberateSlideToTheNextLetterStillRetargets() throws {
+        let delegate = KeyGridDelegateSpy()
+        let grid = Self.makeLaidOutGrid(delegate: delegate)
+        let d = try #require(grid.keyViews.first { $0.spec.cap == .character("d") })
+        let f = try #require(grid.keyViews.first { $0.spec.cap == .character("f") })
+
+        let touch = StubTouch(at: d.frame.center)
+        grid.touchesBegan([touch], with: nil)
+        touch.move(to: f.frame.center)
+        grid.touchesMoved([touch], with: nil)
+        grid.touchesEnded([touch], with: nil)
+
+        #expect(delegate.insertedText == ["f"])
+    }
+
+    /// With a second finger down the grid stops following a drag at all, because
+    /// panels report two close contacts noisily and the finger that is lifting
+    /// reads as a slide. Both fingers type what they pressed.
+    @Test func aSecondFingerDownPinsBothToTheKeysTheyPressed() throws {
+        let delegate = KeyGridDelegateSpy()
+        let grid = Self.makeLaidOutGrid(delegate: delegate)
+        let d = try #require(grid.keyViews.first { $0.spec.cap == .character("d") })
+        let f = try #require(grid.keyViews.first { $0.spec.cap == .character("f") })
+        let k = try #require(grid.keyViews.first { $0.spec.cap == .character("k") })
+
+        let first = StubTouch(at: d.frame.center)
+        let second = StubTouch(at: k.frame.center)
+        grid.touchesBegan([first], with: nil)
+        grid.touchesBegan([second], with: nil)
+
+        // Far enough that a single finger would certainly have re-targeted.
+        first.move(to: f.frame.center)
+        grid.touchesMoved([first], with: nil)
+        grid.touchesEnded([first], with: nil)
+        grid.touchesEnded([second], with: nil)
+
+        #expect(delegate.insertedText == ["d", "k"])
+    }
+
+    private static func makeLaidOutGrid(delegate: KeyGridDelegateSpy) -> KeyGridView {
+        let metrics = KeyboardMetrics.resolved(for: UITraitCollection {
+            $0.verticalSizeClass = .regular
+        })
+        let grid = KeyGridView(
+            metrics: metrics,
+            palette: KeyboardPalette(isDark: false),
+            feedback: KeyboardFeedbackSpy()
+        )
+        grid.delegate = delegate
+        grid.shiftState = .off
+        grid.frame = CGRect(x: 0, y: 0, width: 393, height: metrics.gridHeight)
+        grid.layoutIfNeeded()
+        return grid
+    }
+
     @Test func pointsOutsideEveryEffectiveTargetDoNotResolve() {
         #expect(map.targetIndex(at: CGPoint(x: -1, y: 20), characterOnly: false) == nil)
         #expect(map.targetIndex(at: CGPoint(x: 200, y: 20), characterOnly: false) == nil)
@@ -330,6 +467,22 @@ private final class KeyGridDelegateSpy: KeyGridViewDelegate {
 
 private extension CGRect {
     var center: CGPoint { CGPoint(x: midX, y: midY) }
+}
+
+/// A `UITouch` that reports a location. UIKit only ever hands out real ones, and
+/// the grid reads nothing from a touch but its identity, its timestamp and where
+/// it is — so the touch paths can be driven end to end without a device.
+private final class StubTouch: UITouch {
+    private var point: CGPoint
+
+    init(at point: CGPoint) {
+        self.point = point
+        super.init()
+    }
+
+    func move(to point: CGPoint) { self.point = point }
+
+    override func location(in view: UIView?) -> CGPoint { point }
 }
 
 private extension KeyHitMap {

--- a/ios/VocaPhoneTests/KeyHitMapTests.swift
+++ b/ios/VocaPhoneTests/KeyHitMapTests.swift
@@ -41,6 +41,79 @@ struct KeyHitMapTests {
         #expect(map.targetIndex(at: CGPoint(x: 110, y: 20), characterOnly: true) == nil)
     }
 
+    /// A finger that lands near the edge of a key and rolls as it lifts — which
+    /// is what typing at speed looks like — used to leave with the neighbour,
+    /// because the effective targets meet on a knife edge. It now has to clear
+    /// the key it pressed before the grid will hand it over.
+    @Test func aRollWithinTheHysteresisKeepsTheKeyItPressed() {
+        let hysteretic = KeyHitMap(targets: map.targets, hysteresis: 8)
+        // 41 is already inside key 1's effective target, but only 1pt outside
+        // key 0's slot.
+        #expect(hysteretic.retarget(from: 0, at: 41) == nil)
+        #expect(hysteretic.retarget(from: 0, at: 47) == nil)
+    }
+
+    /// A deliberate slide still lands: past the hysteresis the neighbour wins,
+    /// which is the slide-to-correct gesture the keyboard has always had.
+    @Test func aSlideBeyondTheHysteresisTakesTheNeighbour() {
+        let hysteretic = KeyHitMap(targets: map.targets, hysteresis: 8)
+        #expect(hysteretic.retarget(from: 0, at: 48) == 1)
+    }
+
+    /// Hysteresis is measured from the current key alone. Coming back onto the
+    /// key the finger started on is never a re-target, however far it went.
+    @Test func returningToTheOriginalKeyIsNotARetarget() {
+        let hysteretic = KeyHitMap(targets: map.targets, hysteresis: 8)
+        #expect(hysteretic.retarget(from: 0, at: 20) == nil)
+    }
+
+    /// The distance is to the nearest edge, so it is zero everywhere inside the
+    /// key and grows in whichever direction the finger actually left.
+    @Test func distanceToASlotIsZeroInsideItAndGrowsOutside() {
+        let slot = CGRect(x: 0, y: 0, width: 40, height: 40)
+        #expect(KeyHitMap.distance(from: slot, to: CGPoint(x: 20, y: 20)) == 0)
+        #expect(KeyHitMap.distance(from: slot, to: CGPoint(x: 46, y: 20)) == 6)
+        #expect(KeyHitMap.distance(from: slot, to: CGPoint(x: 20, y: -5)) == 5)
+    }
+
+    /// The hysteresis has to scale with the keys: a value that protects a 34pt
+    /// portrait column would be a much smaller share of a 56pt iPad one, and
+    /// the same roll would still slip through there.
+    @Test func layoutDerivesAHysteresisFromItsOwnColumnWidth() {
+        let metrics = KeyboardMetrics.resolved(for: UITraitCollection {
+            $0.verticalSizeClass = .regular
+        })
+        let grid = KeyGridView(metrics: metrics, palette: KeyboardPalette(isDark: false))
+        grid.frame = CGRect(x: 0, y: 0, width: 393, height: metrics.gridHeight)
+        grid.layoutIfNeeded()
+
+        // Wide enough that a keystroke's roll stays on its key, and narrow
+        // enough that a deliberate slide to the next letter still arrives.
+        #expect(grid.hitMap.hysteresis > metrics.columnGap)
+        #expect(grid.hitMap.hysteresis < 12)
+    }
+
+    /// The whole point, in the geometry people actually type on: a finger that
+    /// presses `d` a couple of points from its edge and skids six more must
+    /// still produce `d`.
+    @Test func aRollOffTheEdgeOfALetterStillTypesThatLetter() throws {
+        let metrics = KeyboardMetrics.resolved(for: UITraitCollection {
+            $0.verticalSizeClass = .regular
+        })
+        let grid = KeyGridView(metrics: metrics, palette: KeyboardPalette(isDark: false))
+        grid.frame = CGRect(x: 0, y: 0, width: 393, height: metrics.gridHeight)
+        grid.layoutIfNeeded()
+
+        let d = try #require(grid.keyViews.first { $0.spec.cap == .character("d") })
+        let index = try #require(grid.keyViews.firstIndex(of: d))
+        let rolled = CGPoint(x: d.frame.maxX + 4, y: d.frame.midY)
+
+        // The effective targets alone have already given the point away.
+        #expect(grid.key(at: rolled, characterOnly: true)?.spec.cap == .character("f"))
+        // The finger that pressed `d` keeps it.
+        #expect(grid.hitMap.retargetIndex(from: index, at: rolled, characterOnly: true) == nil)
+    }
+
     @Test func pointsOutsideEveryEffectiveTargetDoNotResolve() {
         #expect(map.targetIndex(at: CGPoint(x: -1, y: 20), characterOnly: false) == nil)
         #expect(map.targetIndex(at: CGPoint(x: 200, y: 20), characterOnly: false) == nil)
@@ -257,4 +330,12 @@ private final class KeyGridDelegateSpy: KeyGridViewDelegate {
 
 private extension CGRect {
     var center: CGPoint { CGPoint(x: midX, y: midY) }
+}
+
+private extension KeyHitMap {
+    /// The three-target fixture is one row 40pt tall, so every case in it varies
+    /// only in x. Naming that keeps the assertions to the number under test.
+    func retarget(from currentIndex: Int, at x: CGFloat) -> Int? {
+        retargetIndex(from: currentIndex, at: CGPoint(x: x, y: 20), characterOnly: false)
+    }
 }


### PR DESCRIPTION
Follow-up to #231. Typing at speed on this keyboard landed on neighbouring letters in a way the system keyboard does not.

## It was not the geometry

At 393pt a column here is 33.8pt wide with a 39.8pt effective target, against roughly 34.7pt and 41pt on Apple's — the layout was already measured against iOS 26 and is right. What was missing was the touch *dynamics*. Android's LatinIME is the published implementation of all three mechanisms below; Apple's behaves the same way.

## Key hysteresis

`PointerTracker.isMajorEnoughMoveToBeOnNewKey` refuses to hand a moving finger to a neighbour until it has cleared the edge of *the key it pressed* by `config_key_hysteresis_distance`, 8dp:

```java
final int distanceFromKeyEdgeSquared = curKey.squaredDistanceToEdge(x, y);
if (distanceFromKeyEdgeSquared >= keyHysteresisDistanceSquared) { return true; }
```

Here the effective targets tile the plane — each claims half the gutter — so the boundary was a knife edge three points outside the visible key. Land two points inside `d`, roll six as you lift, which is what every fast keystroke does, and you left with `f`.

`KeyHitMap` now owns the rule as `retargetIndex(from:at:characterOnly:)`. It measures from the layout **slot** rather than the effective target: the targets meet in the middle of the gutter, so measuring from them would give a key at the edge of the keyboard, whose target runs out to the bounds, far more protection than one mid-row. The distance is 0.2 of a column — Android's ratio against its own ~40dp key — so it holds at every height preference and on iPad, where a fixed 8pt would be a much smaller share of a 56pt key.

Swipes still re-target on the boundary with no hysteresis; a trace is meant to run across keys.

## Multi-touch pinning

Typing at speed overlaps the strokes, and panels report two close contacts noisily — the finger that is lifting reads as a slide. Android pins the key in exactly this case, with the same carve-out for a modifier being chorded into a letter:

> HACK: If there are currently multiple touches, register the key even if the finger slides off the key. This defends against noise from some touch panels when there are close multiple touches. Caveat: When in chording input mode with a modifier key, we don't use this hack.

## Fast-typing gesture suppression

A keystroke at speed skids far enough to look like the start of a trace, and a swipe fired by accident replaces a whole word. Android raises its gesture threshold for `config_gesture_static_time_threshold_after_fast_typing` — 500ms — after the last letter. The swipe activation distance now doubles inside that window, which keeps a deliberate swipe mid-sentence available in a way that refusing outright would not, and no swipe starts while a second finger is down.

The window opens and extends on `TypingTimeRecorder`'s rule: a letter always, a non-letter only if one is already open — so a full stop at the end of a sentence does not reopen it a second later — and a committed trace closes it.

## Three more dropped-keystroke bugs in the same path

**A plane switch cancelled the other finger.** `activatePlane` replaces `keyViews` and the hit map, so it released every touch in flight — and two-thumb typists tap `123` with one thumb while the other is still on a letter constantly. Those touches are now *pinned* rather than dropped: `KeyView` carries its own spec and shift state, so a touch frozen on the key it pressed still commits exactly the character it was showing when the finger landed, even though the view behind it now belongs to a plane that is off screen. A pinned touch ignores movement outright, since following the drag would pick up whichever digit had taken that spot. The finger that pressed `123` is pinned by its own switch like every other, but a plane key types nothing, so it is dropped and re-registered against the new plane — otherwise its lift would consume the slide's entry and the symbol it slid onto would never arrive.

**Two fingers on one key.** Commit tested `key.isHighlighted`, which belongs to the *view*. Re-press a letter before the first press has lifted and the second finger lifting cleared the highlight the first still needed. Each `TrackedTouch` now carries its own `isEngaged`, and a highlight is only cleared by the last finger holding it.

**Transposed letters.** `touchesBegan` and `finish` walked an unordered `Set<UITouch>`, so two thumbs landing inside one event typed in whatever order the set happened to hash. Both sort by `timestamp`.

## Testing

`just ios::ci` — build and 641 tests pass.

The tests add a `StubTouch` that reports a location, which lets the touch paths be driven end to end for the first time, so the important cases are covered as *typing* rather than as geometry:

- pressing `d` 2pt from its edge and skidding 4pt past it types `d` — this is the reported bug, and it produces `f` with the hysteresis removed
- a deliberate slide from `d` to `f` still types `f`, so slide-to-correct is intact
- two fingers down, one dragged across two keys, still types both keys as pressed
- a finger on a letter when another taps `123` still types the letter
- the finger that pressed `123` still slides onto `4` and returns to letters

Each was checked against the fix backed out, to confirm it fails for the reason claimed. The existing slide, shift-slide and plane-slide tests are unchanged and still pass.