### PR TITLE
fix(ios): let the keyboard run at the panel's full refresh rate

### DIFF
--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		AF3CF11CC0E9E65B026EBEF8 /* TranscriptRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */; };
 		B063AE9288450BE04769F7DD /* TypingCandidates.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAA4440B24071020CD693DB /* TypingCandidates.swift */; };
 		B0DF0FF5821BD7E8C839065C /* GatewayClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4211FAA8E574AEF57D788FA /* GatewayClient.swift */; };
+		B1A1053055864F55448F5FED /* ProMotionOptInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4529D7325A4F1D2340C306FD /* ProMotionOptInTests.swift */; };
 		B1D4DE96B74C3327DA6A0FAD /* SwipeTrailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */; };
 		B2406DA05AE90DDB7EED6246 /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
 		B4213158A69A8307967F0845 /* KeyboardHandoffPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75D17831C48C07141D7066C /* KeyboardHandoffPresentationTests.swift */; };
@@ -442,6 +443,7 @@
 		406B0C287866B36EF3109238 /* LocalModelPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelPicker.swift; sourceTree = "<group>"; };
 		41C0A3D1DBF6BCF25C37CF24 /* EmojiSuggestionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiSuggestionsTests.swift; sourceTree = "<group>"; };
 		4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnedWords.swift; sourceTree = "<group>"; };
+		4529D7325A4F1D2340C306FD /* ProMotionOptInTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProMotionOptInTests.swift; sourceTree = "<group>"; };
 		46CC84644E8CF9B1E83696D3 /* KeyPreviewRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPreviewRenderTests.swift; sourceTree = "<group>"; };
 		46E8BCA13C319737A50B7CE9 /* KeyboardHandoffPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHandoffPresentation.swift; sourceTree = "<group>"; };
 		473A608BF3F8827B3D3842B0 /* LocalModelCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelCatalog.swift; sourceTree = "<group>"; };
@@ -842,6 +844,7 @@
 				CDA1F0347FCF246193F6CF96 /* ModelTranslationSupportTests.swift */,
 				F8348F9E480C0343CD38657B /* OnboardingPresentationTests.swift */,
 				7E9E5CE913B4FA5EF8EECD4E /* PairingPayloadTests.swift */,
+				4529D7325A4F1D2340C306FD /* ProMotionOptInTests.swift */,
 				7B5877B4AB653982A0433A37 /* ReliabilityFeatureTests.swift */,
 				B6B395C37266816A19C38B59 /* SemanticPaletteTests.swift */,
 				B854354D06D0111DEB123E7A /* SessionRecordTests.swift */,
@@ -1394,6 +1397,7 @@
 				9F93D09F955DA7B5CC65F058 /* OnboardingPresentationTests.swift in Sources */,
 				2E93E016656B5EA74568DD4F /* PairingPayload.swift in Sources */,
 				DCF552B58B7A7A12C517C17B /* PairingPayloadTests.swift in Sources */,
+				B1A1053055864F55448F5FED /* ProMotionOptInTests.swift in Sources */,
 				D37101A845F65CA081F8B6E4 /* ProtectedSpans.swift in Sources */,
 				BCB8CA3BAACE6280D9ED4B22 /* QuickDictationAvailability.swift in Sources */,
 				15E349A8DDDFD47EFA7EE2FA /* ReliabilityFeatureTests.swift in Sources */,

--- a/ios/VocaPhoneApp/Info.plist
+++ b/ios/VocaPhoneApp/Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <!-- ProMotion is opt-in per bundle, and this is a keyboard: every animation
+       it has is a direct response to a finger. Without this key iOS clamps
+       Core Animation and every CADisplayLink in the process to 60Hz on an
+       iPhone, which silently ignored the trail's own request for the panel's
+       full rate. -->
+  <key>CADisableMinimumFrameDurationOnPhone</key>
+  <true/>
   <key>CFBundleDisplayName</key>
   <string>vocaphone</string>
   <key>CFBundleExecutable</key>

--- a/ios/VocaPhoneKeyboard/Info.plist
+++ b/ios/VocaPhoneKeyboard/Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <!-- ProMotion is opt-in per bundle, and this is a keyboard: every animation
+       it has is a direct response to a finger. Without this key iOS clamps
+       Core Animation and every CADisplayLink in the process to 60Hz on an
+       iPhone, which silently ignored the trail's own request for the panel's
+       full rate. -->
+  <key>CADisableMinimumFrameDurationOnPhone</key>
+  <true/>
   <key>CFBundleDisplayName</key>
   <string>vocaphone</string>
   <key>CFBundleExecutable</key>

--- a/ios/VocaPhoneTests/ProMotionOptInTests.swift
+++ b/ios/VocaPhoneTests/ProMotionOptInTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+/// ProMotion is opt-in, per bundle, and silent when it is missing.
+///
+/// `CADisableMinimumFrameDurationOnPhone` is what lets Core Animation and
+/// `CADisplayLink` run above 60Hz on an iPhone. Without it iOS clamps the whole
+/// process and returns no error, so `SwipeTrailView` asking for
+/// `CAFrameRateRange(minimum: 30, maximum: 120, preferred: 120)` was answered at
+/// 60 on a 120Hz panel and nothing said so.
+///
+/// The keyboard runs in its own process, so its own `Info.plist` has to carry
+/// the key — inheriting the containing app's would not have helped it. That is
+/// the part easiest to drop, which is why it is pinned here rather than left to
+/// be noticed on a device.
+struct ProMotionOptInTests {
+    @Test(arguments: ["VocaPhoneApp", "VocaPhoneKeyboard"])
+    func everyBundleThatDrawsOptsIntoTheFullFrameRate(target: String) throws {
+        let plist = Self.iosDirectory
+            .appendingPathComponent(target)
+            .appendingPathComponent("Info.plist")
+        let contents = try Data(contentsOf: plist)
+        let parsed = try PropertyListSerialization.propertyList(
+            from: contents,
+            format: nil
+        ) as? [String: Any]
+
+        #expect(parsed?["CADisableMinimumFrameDurationOnPhone"] as? Bool == true)
+    }
+
+    private static var iosDirectory: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+}


### PR DESCRIPTION
Reported on an iPhone 14 Pro: the keyboard does not feel like it is running at 120Hz. It wasn't. Neither bundle opted into ProMotion, so iOS was clamping both to 60.

## What was happening

`SwipeTrailView` already asks for the display's full rate:

```swift
link.preferredFrameRateRange = CAFrameRateRange(minimum: 30, maximum: 120, preferred: 120)
```

On an iPhone that request is answered at 60 unless the bundle sets `CADisableMinimumFrameDurationOnPhone`. Apple made high refresh rates opt-in per bundle for battery reasons, and the clamp is applied to Core Animation and to every `CADisplayLink` in the process. There is no error, no warning, and no API that reports it — `UIScreen.maximumFramesPerSecond` still says 120 — which is why this survived a keyboard that was otherwise written for the full rate.

## Both bundles

The keyboard extension runs in its own process, so the containing app's opt-in does nothing for it. The extension is the target that actually matters here: every animation it has — the swipe trail, the press state, the preview balloon — is a direct response to a finger, and 60Hz on a 120Hz panel is the difference the finger feels. The app gets it too.

Verified in the built products rather than only in source:

```
$ plutil -extract CADisableMinimumFrameDurationOnPhone raw VocaPhoneKeyboard.appex/Info.plist
true
$ plutil -extract CADisableMinimumFrameDurationOnPhone raw VocaPhoneApp.app/Info.plist
true
```

## Side effect on the dictation waveform

`DictationBarComponents` deliberately asks for `CAFrameRateRange(minimum: 20, maximum: 30, preferred: 30)`. Under the clamp that request could not be honoured either, so the waveform was running faster than it asked to. It can now actually go slow, which is where it wanted to be.

## Testing

`just ios::ci` — build and 630 tests pass.

`ProMotionOptInTests` reads both `Info.plist` files and asserts the key, checked against the key removed to confirm it fails for the right reason. This is pinned by a test rather than left to be noticed on a device precisely because the failure mode is silence: the key is easy to drop in a plist rewrite, and neither a build nor the simulator would ever report its absence.

**Device check still wanted.** CI and the simulator cannot observe a 120Hz panel, so the frame rate itself is not something this PR can prove. Worth a swipe on the 14 Pro before merging.