### PR TITLE
fix(ios): improve native keyboard fidelity

### DIFF
--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		6BF87A2C089381E060D13D22 /* KeyAlternativesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0326EF6FB3E96C942C6065 /* KeyAlternativesTests.swift */; };
 		6C48D9ED8AF4FE61AB76AE49 /* StopQuickDictationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332854D2644CFCE5843E3F31 /* StopQuickDictationIntent.swift */; };
 		6CEF2A686643F72F4BCDD51D /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
+		6EAFD2EC2E02A1270A140E47 /* TypingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B9027C03A87FBC74CE1130 /* TypingEngine.swift */; };
 		70232F18D7B4AA7F6BB15C64 /* TelemetrySink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E413C2A7ADDFE5C3B5F27C7 /* TelemetrySink.swift */; };
 		7118F0F04A2C3D94C65EC00D /* TelemetrySink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E413C2A7ADDFE5C3B5F27C7 /* TelemetrySink.swift */; };
 		7280B936E153A21AC6D75B27 /* WordComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A6EEE8C98BCBF8D1D70D44 /* WordComposer.swift */; };
@@ -1489,6 +1490,7 @@
 				F9BE6A9D183361BABE1E286E /* TranscriptionSourceTests.swift in Sources */,
 				AA0483D40117344580501ABD /* TypingCandidates.swift in Sources */,
 				FC7578BC51E4E30002077CAC /* TypingCandidatesTests.swift in Sources */,
+				6EAFD2EC2E02A1270A140E47 /* TypingEngine.swift in Sources */,
 				044611DCE2FFB3B38B4BFACE /* TypingFieldPolicy.swift in Sources */,
 				4700DB7F7BE95078E7A8A563 /* TypingFieldPolicyTests.swift in Sources */,
 				7E28776EDC2BD3E8A8AFCED9 /* TypingPrivacyTests.swift in Sources */,

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		594C4A6790AD798CA3A7D427 /* SpeechAudioConditioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */; };
 		5A151959ABCE2ADE4646A79D /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
 		5ADC4420E2E23403BFC8716D /* TranscriptRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */; };
+		5C0F524206C9335BC0C4C672 /* KeyboardStatusPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549656C750D0C8EF3F25E17C /* KeyboardStatusPublication.swift */; };
 		5C558BDC79705E089820562F /* KeyLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87128326897BFA30E7B2038 /* KeyLayout.swift */; };
 		5D5A394AA7E8170CFE4E128B /* RecordingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF871FC84B4C6B2627A43C2 /* RecordingCoordinator.swift */; };
 		5E7C819783E63C4FC95E706B /* TelemetryFailureMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D81AEA9FD59906139F273D /* TelemetryFailureMapping.swift */; };
@@ -163,6 +164,7 @@
 		7118F0F04A2C3D94C65EC00D /* TelemetrySink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E413C2A7ADDFE5C3B5F27C7 /* TelemetrySink.swift */; };
 		7280B936E153A21AC6D75B27 /* WordComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A6EEE8C98BCBF8D1D70D44 /* WordComposer.swift */; };
 		7466C707EC283E26021BB710 /* sherpa_model_pins.json in Resources */ = {isa = PBXBuildFile; fileRef = 00FA1D26F8C2CDC36BEBB95A /* sherpa_model_pins.json */; };
+		75A2C56534698189538C7B87 /* KeyboardStatusPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549656C750D0C8EF3F25E17C /* KeyboardStatusPublication.swift */; };
 		75EC59510885420249491B03 /* EmojiSuggestions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136E505E4C5668F9ACCD30C5 /* EmojiSuggestions.swift */; };
 		767A30103B5B432E7D497A72 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9BB34E20645F3D8C78A0363 /* Telemetry.swift */; };
 		76E660378F845C250AEA0673 /* AudioCapturePipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15DE10A5F8F90C87D4BA48A /* AudioCapturePipeline.swift */; };
@@ -172,6 +174,7 @@
 		79D51827CA805EB6D890699C /* SherpaLongAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */; };
 		7AE5598954918484EE8BB6B9 /* KeyboardHandoffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E5F9C1D93EF4EFB2AF5EA7 /* KeyboardHandoffView.swift */; };
 		7B0D3581B262BEB5AC561C23 /* TelemetryStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D9836F52892447650F0375 /* TelemetryStats.swift */; };
+		7B571D68CCB37D4C3FCEE258 /* KeyboardStatusPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549656C750D0C8EF3F25E17C /* KeyboardStatusPublication.swift */; };
 		7C304FFA51BC372F267CC729 /* Snippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69943FB61027DEE31DA51705 /* Snippet.swift */; };
 		7E26A729562A6F474635AFEC /* TranscriptStylerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45A3914F898AD0570486806 /* TranscriptStylerTests.swift */; };
 		7E28776EDC2BD3E8A8AFCED9 /* TypingPrivacyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05735C847A47FF442B4FB21A /* TypingPrivacyTests.swift */; };
@@ -198,6 +201,7 @@
 		8D3596587AE7568FDB37C147 /* onnxruntime.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 796D6FA2FF5B98026FAA85AD /* onnxruntime.xcframework */; };
 		8DD5E5E2B734765883552523 /* DictationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3489C985467C23EB6A90AD /* DictationBarView.swift */; };
 		8F8E3C14AAC6A4F1DF144AD3 /* OnboardingPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D34E7E54437AFA69FDC2848 /* OnboardingPresentation.swift */; };
+		8FADF6C970427AFDEDCB45C4 /* KeyboardStatusPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549656C750D0C8EF3F25E17C /* KeyboardStatusPublication.swift */; };
 		90F0433AE6FE139E90D62F9A /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */; };
 		9137DE19695E0CADB0EFBFB0 /* TranscriptRetention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6FFEA14B55E6F6C61FBAC /* TranscriptRetention.swift */; };
 		91C1D5BB9A998A47DFF79A52 /* DictationBarComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FD84E65614D9F94D8EF0AC /* DictationBarComponents.swift */; };
@@ -234,6 +238,7 @@
 		A794CD8D0B445E5118500EC3 /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
 		A79BA8A795F60838D96EDFAA /* VocaPhoneLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D3E1455AD292ED6DA1DFAC /* VocaPhoneLiveActivity.swift */; };
 		A86F678EFECCEA8BA246778C /* UsageReportingViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653FBC305F7EB4B9F7EB354B /* UsageReportingViews.swift */; };
+		A8E7D7F8F6BE5CED2509C07F /* KeyboardStatusPublicationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D68C853A7603A9B3224B3C /* KeyboardStatusPublicationTests.swift */; };
 		AA0483D40117344580501ABD /* TypingCandidates.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAA4440B24071020CD693DB /* TypingCandidates.swift */; };
 		AA2103E195D36B18D25CBF86 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA135DE504590121F6D8843 /* DiagnosticLog.swift */; };
 		AAD8F3868CD1C6C2338CDA74 /* DownloadReadinessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9500368520DA46E5DE55186E /* DownloadReadinessTests.swift */; };
@@ -419,6 +424,7 @@
 		1CF82ECCA1F28AB94B4142DE /* SwipeAlternatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeAlternatesTests.swift; sourceTree = "<group>"; };
 		20F3E310970DBFA3822A4D19 /* SherpaDecodingMethodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaDecodingMethodTests.swift; sourceTree = "<group>"; };
 		22AA42EFADB6B77B0C9A5E44 /* UsageReportingCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageReportingCopy.swift; sourceTree = "<group>"; };
+		22D68C853A7603A9B3224B3C /* KeyboardStatusPublicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardStatusPublicationTests.swift; sourceTree = "<group>"; };
 		2678D836274997421A54E901 /* AudioCaptureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCaptureTests.swift; sourceTree = "<group>"; };
 		2730948940D555163E520926 /* SnippetExpanderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetExpanderTests.swift; sourceTree = "<group>"; };
 		27748467103CFAD3F6A2F603 /* TelemetryRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryRecord.swift; sourceTree = "<group>"; };
@@ -454,6 +460,7 @@
 		4EFEBD6293F9649D551A9014 /* SherpaDecodeOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaDecodeOutcome.swift; sourceTree = "<group>"; };
 		5118F8CFAAE127CD5FF92076 /* KeyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyView.swift; sourceTree = "<group>"; };
 		52F3A6E7B826D1389D462944 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		549656C750D0C8EF3F25E17C /* KeyboardStatusPublication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardStatusPublication.swift; sourceTree = "<group>"; };
 		5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechAudioConditioning.swift; sourceTree = "<group>"; };
 		55A7126FEDA473D8C112A397 /* StartDictationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartDictationIntent.swift; sourceTree = "<group>"; };
 		56047A6705008B5F17F003CE /* DictationPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationPresentationTests.swift; sourceTree = "<group>"; };
@@ -694,6 +701,7 @@
 				9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */,
 				9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */,
 				A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */,
+				549656C750D0C8EF3F25E17C /* KeyboardStatusPublication.swift */,
 				4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */,
 				473A608BF3F8827B3D3842B0 /* LocalModelCatalog.swift */,
 				13FF1A5ABC4220C886291309 /* LocalTranscriptionPreferences.swift */,
@@ -835,6 +843,7 @@
 				7FED099938C2E7D091FFE2BD /* KeyboardGeometryTests.swift */,
 				B75D17831C48C07141D7066C /* KeyboardHandoffPresentationTests.swift */,
 				97639A09609D9E6E76153CDB /* KeyboardHapticsTests.swift */,
+				22D68C853A7603A9B3224B3C /* KeyboardStatusPublicationTests.swift */,
 				3EC2C1575D306E7683092FBA /* KeyGridLayoutTests.swift */,
 				6AC704CBD16EF6C7FCCBC6D6 /* KeyHitMapTests.swift */,
 				46CC84644E8CF9B1E83696D3 /* KeyPreviewRenderTests.swift */,
@@ -1134,6 +1143,7 @@
 				1A55285B353E4AE5D1B6D967 /* KeyboardHaptics.swift in Sources */,
 				97EE4663316E8CF2EAE9761A /* KeyboardPreferences.swift in Sources */,
 				6565BFD7DC56DDCECDBC0D7C /* KeyboardStatus.swift in Sources */,
+				5C0F524206C9335BC0C4C672 /* KeyboardStatusPublication.swift in Sources */,
 				BA7DED07F63C388ADD4EC07A /* KeyboardURLLauncher.m in Sources */,
 				31D729EBEF69158BAAFE66D0 /* KeyboardViewController.swift in Sources */,
 				044D82D7CA0E7563552B563A /* KeyboardViewPreview.swift in Sources */,
@@ -1214,6 +1224,7 @@
 				A568F548D639C064CDA86F0D /* KeyboardPreferences.swift in Sources */,
 				F7432B1674EF3B6924FB89B1 /* KeyboardPreview.swift in Sources */,
 				61D705F2D38349B0A9667F2E /* KeyboardStatus.swift in Sources */,
+				8FADF6C970427AFDEDCB45C4 /* KeyboardStatusPublication.swift in Sources */,
 				D6533E4D830A06E9845CE624 /* KeyboardViewPreview.swift in Sources */,
 				8468AAFD83E231AD9BB99792 /* KeychainStore.swift in Sources */,
 				4CAE7CAEAD36C1567BFB1D81 /* LearnedWords.swift in Sources */,
@@ -1301,6 +1312,7 @@
 				1D96E4B5456A18FA04F5F15D /* GatewayEndpoint.swift in Sources */,
 				5769EF4A106AFBD7B375DC5D /* KeyboardPreferences.swift in Sources */,
 				582C18BD155158A79ADCBB5A /* KeyboardStatus.swift in Sources */,
+				7B571D68CCB37D4C3FCEE258 /* KeyboardStatusPublication.swift in Sources */,
 				5634120C15A37F9E2C0FF2C0 /* LearnedWords.swift in Sources */,
 				C334F6DF0A4A34FC9A80B6CB /* LocalModelCatalog.swift in Sources */,
 				396330316A5B80A3884BE142 /* LocalTranscriptionPreferences.swift in Sources */,
@@ -1383,6 +1395,8 @@
 				4BF2126048D9E40C8999241D /* KeyboardHapticsTests.swift in Sources */,
 				90F0433AE6FE139E90D62F9A /* KeyboardPreferences.swift in Sources */,
 				5673DF7E07F7F800FB847C2A /* KeyboardStatus.swift in Sources */,
+				75A2C56534698189538C7B87 /* KeyboardStatusPublication.swift in Sources */,
+				A8E7D7F8F6BE5CED2509C07F /* KeyboardStatusPublicationTests.swift in Sources */,
 				52151816E957DE430B67B9F8 /* KeyboardViewPreview.swift in Sources */,
 				3C4DE9EF77062407F71ACDCB /* LanguageMenuTests.swift in Sources */,
 				D0E6AF99E65342BE66CF809A /* LearnedWords.swift in Sources */,

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		1D8B94886C8506BB36C1887C /* ProtectedSpans.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57FC525B204634FF41CDCDA /* ProtectedSpans.swift */; };
 		1D96E4B5456A18FA04F5F15D /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */; };
 		1EE70552DF2972DCE328ED01 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA135DE504590121F6D8843 /* DiagnosticLog.swift */; };
+		1EF1A5CDD042058766DFCA5D /* KeyProximity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B90ACCDCBABF9F7412EE906 /* KeyProximity.swift */; };
 		1F45494DE6D2E1E471D446B5 /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11816AC1A2219D15E870CE3E /* EmojiCatalog.swift */; };
 		214B0AB3D2362EC3EE656E53 /* SherpaLongAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */; };
 		21FF5DE4F40DB8D70AC170E2 /* CustomVocabulary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AA9291707DE7366D08EB0C /* CustomVocabulary.swift */; };
@@ -106,6 +107,7 @@
 		414B7AB5FBA938C804977DAE /* SpellChecking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4BE75828FCA9C70DFEDC96 /* SpellChecking.swift */; };
 		41FC2CCC3EA684B6256AE6A3 /* SnippetExpander.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1247ACC1CA43648BE4449042 /* SnippetExpander.swift */; };
 		4217DD7E4261F3B917A4FD81 /* SwipeTrailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DFD83D2BCB84400E7981A4B /* SwipeTrailTests.swift */; };
+		43F839BD8D7441028A781D11 /* ShortWordCorrections.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEF2896D6B013414A340977 /* ShortWordCorrections.swift */; };
 		444F9DFC10831BE9150988A6 /* TranscriptionQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E2BF42CAC209DA12464566 /* TranscriptionQuality.swift */; };
 		445497F26F783CF512F605AD /* SwipeAlternates.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1F0FABCAE6669D0EB07FC3 /* SwipeAlternates.swift */; };
 		45AB9DD91FB8969A4BB19A60 /* TranscriptRetention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6FFEA14B55E6F6C61FBAC /* TranscriptRetention.swift */; };
@@ -194,6 +196,7 @@
 		84EB79403F7CED013A82334F /* PairingScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B3F1DBA8332A13B095E4BA /* PairingScannerView.swift */; };
 		84F2FD89DD3C1EB490E86A73 /* FinishRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B19321866AE8083C78C2B7F /* FinishRecordingIntent.swift */; };
 		867671B90E038F77BE36A4E6 /* DarwinNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3498C523755A678225152570 /* DarwinNotifications.swift */; };
+		883C67CC3B4BBDA22771637A /* KeyProximity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B90ACCDCBABF9F7412EE906 /* KeyProximity.swift */; };
 		89A73E55E01C0814D465824C /* sherpa-onnx.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1582F900473255CD64DC8C2A /* sherpa-onnx.xcframework */; };
 		89E3D47D85EBD6AD5A093813 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */; };
 		8A69E16ABEF642C3D68FADD5 /* TranscriptHistoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A89F2BEC08F07614372D84D /* TranscriptHistoryModel.swift */; };
@@ -205,6 +208,7 @@
 		90F0433AE6FE139E90D62F9A /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */; };
 		9137DE19695E0CADB0EFBFB0 /* TranscriptRetention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6FFEA14B55E6F6C61FBAC /* TranscriptRetention.swift */; };
 		91C1D5BB9A998A47DFF79A52 /* DictationBarComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FD84E65614D9F94D8EF0AC /* DictationBarComponents.swift */; };
+		91C72A4719D529180BBAEB0F /* ShortWordCorrections.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEF2896D6B013414A340977 /* ShortWordCorrections.swift */; };
 		91EA8108C4C2D6C4EF5CF3F1 /* SpeechAudioConditioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */; };
 		9282771B81021A932B1C6EA1 /* DictatedTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575BDB070A428051B623F095 /* DictatedTranscript.swift */; };
 		930EDA1E5ADC03BD11074B04 /* NetworkConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD99C2A5EC13AD2F181A10F /* NetworkConditions.swift */; };
@@ -235,6 +239,7 @@
 		A59723F937FABF80B8158883 /* RecordingSoundFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0187C986535C090BEE7EFD8 /* RecordingSoundFeedback.swift */; };
 		A5E6BD7DC01FF42503792DCB /* KeyboardGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FED099938C2E7D091FFE2BD /* KeyboardGeometryTests.swift */; };
 		A7216F1D388DBC1B95658666 /* SwipeBackCoach.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BAEF22ED143D3569B005C88 /* SwipeBackCoach.swift */; };
+		A745962F725F14ECF4639938 /* ShortWordCorrections.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEF2896D6B013414A340977 /* ShortWordCorrections.swift */; };
 		A794CD8D0B445E5118500EC3 /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
 		A79BA8A795F60838D96EDFAA /* VocaPhoneLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D3E1455AD292ED6DA1DFAC /* VocaPhoneLiveActivity.swift */; };
 		A86F678EFECCEA8BA246778C /* UsageReportingViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653FBC305F7EB4B9F7EB354B /* UsageReportingViews.swift */; };
@@ -289,6 +294,7 @@
 		C7ADFFD337103F3F6CF7BBA6 /* ProtectedSpans.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57FC525B204634FF41CDCDA /* ProtectedSpans.swift */; };
 		C80FCACABE7FF798EFD1EB61 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894063AE1B3DDA92C529268D /* AppConfiguration.swift */; };
 		C845C02425BC2788BABB26C2 /* SpeechAudioConditioningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59DB522E7DFDE3B3E009AFD /* SpeechAudioConditioningTests.swift */; };
+		C8A3486459DEF9BE777C3ED6 /* KeyProximity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B90ACCDCBABF9F7412EE906 /* KeyProximity.swift */; };
 		C958410A61E962F39B4F5E4D /* LearnedWords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */; };
 		C9A6096B1D7A0603AE6810C3 /* SherpaFeatureDither.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7083ED482761906EE2589E97 /* SherpaFeatureDither.swift */; };
 		C9A65099749EC5AB021FCC1C /* SherpaLongAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */; };
@@ -518,6 +524,7 @@
 		9859ACCB32CD57E4F3E4D46A /* WordComposerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordComposerTests.swift; sourceTree = "<group>"; };
 		991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptRepair.swift; sourceTree = "<group>"; };
 		9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayEndpoint.swift; sourceTree = "<group>"; };
+		9B90ACCDCBABF9F7412EE906 /* KeyProximity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyProximity.swift; sourceTree = "<group>"; };
 		9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPreferences.swift; sourceTree = "<group>"; };
 		9DCCE5FE1A8242B96B8CA9FD /* DictationPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationPresentation.swift; sourceTree = "<group>"; };
 		A0EBA8DE4056FCA3CB7F093C /* KeyAlternatives.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyAlternatives.swift; sourceTree = "<group>"; };
@@ -575,6 +582,7 @@
 		DBAE2B11D3A27A798D0F39ED /* local_model_pins.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = local_model_pins.json; sourceTree = "<group>"; };
 		DBFB4BB0345784837C629340 /* PairingPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingPayload.swift; sourceTree = "<group>"; };
 		DC98427A2C06BE9FD63CACF1 /* en-bigrams.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "en-bigrams.txt"; sourceTree = "<group>"; };
+		DDEF2896D6B013414A340977 /* ShortWordCorrections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortWordCorrections.swift; sourceTree = "<group>"; };
 		DEAA4440B24071020CD693DB /* TypingCandidates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingCandidates.swift; sourceTree = "<group>"; };
 		DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeTrailView.swift; sourceTree = "<group>"; };
 		E0187C986535C090BEE7EFD8 /* RecordingSoundFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSoundFeedback.swift; sourceTree = "<group>"; };
@@ -659,8 +667,10 @@
 				8BF7CAC171521FC372DF2BF0 /* KeyGridView.swift */,
 				F91ACC58FF89C43C9BD2D9F6 /* KeyHitMap.swift */,
 				B87128326897BFA30E7B2038 /* KeyLayout.swift */,
+				9B90ACCDCBABF9F7412EE906 /* KeyProximity.swift */,
 				5118F8CFAAE127CD5FF92076 /* KeyView.swift */,
 				06FC8DDB89A55103E29C10D3 /* PrivacyInfo.xcprivacy */,
+				DDEF2896D6B013414A340977 /* ShortWordCorrections.swift */,
 				07178E9C6A3CF354CD83A2C1 /* SmartPunctuation.swift */,
 				3D4BE75828FCA9C70DFEDC96 /* SpellChecking.swift */,
 				BA1F0FABCAE6669D0EB07FC3 /* SwipeAlternates.swift */,
@@ -1139,6 +1149,7 @@
 				E4162282629880D2A33913CA /* KeyGridView.swift in Sources */,
 				565E52EE8369B8FE02E572CA /* KeyHitMap.swift in Sources */,
 				4C8B6E06406E63E122F9CBD1 /* KeyLayout.swift in Sources */,
+				883C67CC3B4BBDA22771637A /* KeyProximity.swift in Sources */,
 				68E7553DB227208E27DF3A8F /* KeyView.swift in Sources */,
 				1A55285B353E4AE5D1B6D967 /* KeyboardHaptics.swift in Sources */,
 				97EE4663316E8CF2EAE9761A /* KeyboardPreferences.swift in Sources */,
@@ -1164,6 +1175,7 @@
 				C9A6096B1D7A0603AE6810C3 /* SherpaFeatureDither.swift in Sources */,
 				503DA76554CDB360C2E32566 /* SherpaIncrementalSession.swift in Sources */,
 				C2C99C66A00384823A3A0A22 /* SherpaLongAudio.swift in Sources */,
+				43F839BD8D7441028A781D11 /* ShortWordCorrections.swift in Sources */,
 				35136B012E8D8B8D720B569A /* SmartPunctuation.swift in Sources */,
 				F3614A472010F224F5DA119F /* Snippet.swift in Sources */,
 				2835994232D6867BC96CD41F /* SnippetExpander.swift in Sources */,
@@ -1217,6 +1229,7 @@
 				F37F68399E06B767B5D6ACC7 /* KeyGridView.swift in Sources */,
 				A201DF59DBFB56276A6D5A00 /* KeyHitMap.swift in Sources */,
 				5C558BDC79705E089820562F /* KeyLayout.swift in Sources */,
+				C8A3486459DEF9BE777C3ED6 /* KeyProximity.swift in Sources */,
 				400FC934DB32BD708B5D23A9 /* KeyView.swift in Sources */,
 				1A5451979B0206365EE36D5E /* KeyboardHandoffPresentation.swift in Sources */,
 				7AE5598954918484EE8BB6B9 /* KeyboardHandoffView.swift in Sources */,
@@ -1260,6 +1273,7 @@
 				79D51827CA805EB6D890699C /* SherpaLongAudio.swift in Sources */,
 				3BC9D24EF0E08132FFB24481 /* SherpaOnnxBridge.c in Sources */,
 				324811B86570CBD6C1C1FCFC /* SherpaRecognizer.swift in Sources */,
+				91C72A4719D529180BBAEB0F /* ShortWordCorrections.swift in Sources */,
 				7C304FFA51BC372F267CC729 /* Snippet.swift in Sources */,
 				0648339909A2715411711B48 /* SnippetExpander.swift in Sources */,
 				594C4A6790AD798CA3A7D427 /* SpeechAudioConditioning.swift in Sources */,
@@ -1387,6 +1401,7 @@
 				E67DEFF4A0E71720898B15E6 /* KeyHitMapTests.swift in Sources */,
 				966E2D9A6D13630E7A2122A6 /* KeyLayout.swift in Sources */,
 				EF977715FB417ABD32BB2E7A /* KeyPreviewRenderTests.swift in Sources */,
+				1EF1A5CDD042058766DFCA5D /* KeyProximity.swift in Sources */,
 				BC36D829FEE2BEC0A6BC30C2 /* KeyView.swift in Sources */,
 				A5E6BD7DC01FF42503792DCB /* KeyboardGeometryTests.swift in Sources */,
 				AEF583A0E9B4984F72636A0A /* KeyboardHandoffPresentation.swift in Sources */,
@@ -1432,6 +1447,7 @@
 				C9A65099749EC5AB021FCC1C /* SherpaLongAudio.swift in Sources */,
 				FD06CBDABE4EA9640EECF39C /* SherpaLongAudioTests.swift in Sources */,
 				332424547CBE2483FE24C975 /* SherpaTranscriptTests.swift in Sources */,
+				A745962F725F14ECF4639938 /* ShortWordCorrections.swift in Sources */,
 				63835D9307A147564F896FB5 /* SmartPunctuation.swift in Sources */,
 				63BC0E226633FBBE88C60EBE /* SmartPunctuationTests.swift in Sources */,
 				C1B1F70A0C28FB9059780143 /* Snippet.swift in Sources */,

--- a/ios/VocaPhoneApp/App/SetupStatus.swift
+++ b/ios/VocaPhoneApp/App/SetupStatus.swift
@@ -58,9 +58,16 @@ enum InstalledKeyboards {
 
     /// Entries carry trailing layout options, so the bundle identifier is
     /// matched as a substring rather than compared whole.
-    static func includesVocaPhone(_ identifiers: [String]?) -> Bool? {
+    ///
+    /// `keyboard` is injectable because the identifier is derived from the
+    /// running bundle, and a test bundle is not the app — without it a test can
+    /// only ever check the matching against whatever the *test host* is called.
+    static func includesVocaPhone(
+        _ identifiers: [String]?,
+        keyboard: String = AppConfiguration.keyboardBundleIdentifier
+    ) -> Bool? {
         identifiers.map { entries in
-            entries.contains { $0.contains(AppConfiguration.keyboardBundleIdentifier) }
+            entries.contains { $0.contains(keyboard) }
         }
     }
 }

--- a/ios/VocaPhoneKeyboard/DictationBarView.swift
+++ b/ios/VocaPhoneKeyboard/DictationBarView.swift
@@ -178,6 +178,26 @@ final class DictationBarView: UIView, TypingStripViewDelegate {
         configureSecondaries(model.secondaries)
     }
 
+    /// Replaces the chips without touching anything else on the bar.
+    ///
+    /// The strip changes on every keystroke and the rest of the bar does not, so
+    /// going through ``apply(_:animated:)`` for it meant rebuilding a whole
+    /// model — session state, transcript, buttons, accent, layout — to change
+    /// three words. Only valid while the strip is what the bar is actually
+    /// showing, which is the caller's guard to make.
+    /// Reports whether it could: only a bar already showing chips can swap them
+    /// without a crossfade. Arriving *at* the strip from the controls is a
+    /// change of body, and that animation belongs to a full `apply`.
+    @discardableResult
+    func updateCandidates(_ candidates: [TypingCandidate]) -> Bool {
+        guard case .candidates = renderedModel?.body else { return false }
+        // The stored model has to follow, or the next real `apply` will compare
+        // against a body that is no longer on screen and skip the update.
+        renderedModel?.body = .candidates(candidates)
+        setBody(.candidates(candidates), animated: false)
+        return true
+    }
+
     /// The most recent microphone level. Kept separate from `apply` because it
     /// changes on every tick while the model does not.
     func push(meterLevel: Float) {

--- a/ios/VocaPhoneKeyboard/EmojiCatalog.swift
+++ b/ios/VocaPhoneKeyboard/EmojiCatalog.swift
@@ -132,6 +132,56 @@ struct EmojiCatalog: Sendable {
     }
 }
 
+/// The five skin tones an emoji can be asked for, and which emoji can be asked.
+///
+/// Long-pressing a hand or a face on the system keyboard offers these, and a
+/// panel without them quietly excludes most of its users from the emoji they
+/// actually send. The eligibility test is Unicode's own — `isEmojiModifierBase`
+/// is the property that exists to answer exactly this question — rather than a
+/// hand-kept list that would go stale with every emoji release.
+enum EmojiSkinTones {
+    /// Light to dark, the order every keyboard shows them in.
+    static let modifiers: [Unicode.Scalar] = [
+        "\u{1F3FB}", "\u{1F3FC}", "\u{1F3FD}", "\u{1F3FE}", "\u{1F3FF}",
+    ]
+
+    /// The glyph with its skin tone stripped, so a recent emoji already in a
+    /// tone still finds its own variants.
+    static func base(of glyph: String) -> String {
+        String(String.UnicodeScalarView(
+            glyph.unicodeScalars.filter { !modifiers.contains($0) }
+        ))
+    }
+
+    /// The tone variants of `glyph`, default first, or an empty array when the
+    /// emoji has no tones.
+    ///
+    /// Only single-base emoji are offered. A ZWJ sequence — a family, a couple,
+    /// a person with an occupation — takes a modifier on each of its people,
+    /// and a row that changed only the first one would produce a glyph the user
+    /// did not ask for and cannot easily undo.
+    static func variants(of glyph: String) -> [String] {
+        let stripped = base(of: glyph)
+        var scalars = Array(stripped.unicodeScalars)
+        // A trailing variation selector is presentation, not content.
+        if scalars.last == "\u{FE0F}" { scalars.removeLast() }
+        guard scalars.count == 1,
+              let scalar = scalars.first,
+              scalar.properties.isEmojiModifierBase
+        else { return [] }
+        return [stripped] + modifiers.map { modifier in
+            var toned = String.UnicodeScalarView()
+            toned.append(scalar)
+            toned.append(modifier)
+            return String(toned)
+        }
+    }
+
+    static func hasVariants(of glyph: String) -> Bool {
+        !variants(of: glyph).isEmpty
+    }
+}
+
 /// The emoji this user reaches for, most recent first.
 ///
 /// In the App Group so they survive the keyboard being torn down — which iOS

--- a/ios/VocaPhoneKeyboard/EmojiPanelView.swift
+++ b/ios/VocaPhoneKeyboard/EmojiPanelView.swift
@@ -60,6 +60,11 @@ final class EmojiPanelView: UIView {
         return view
     }()
     private let bottomRow = UIStackView()
+    /// The skin-tone row, built on first use. Shares the key grid's popover so a
+    /// long press here looks like a long press on a letter — same corners, same
+    /// shadow, same highlight — rather than like a second design.
+    private var tonesView: KeyAlternativesView?
+    private var toneOptions: [String] = []
 
     init(
         palette: KeyboardPalette,
@@ -189,6 +194,15 @@ final class EmojiPanelView: UIView {
         }
 
         addSubview(collection)
+        // Skin tones. A long press rather than a separate control, because that
+        // is the gesture the system keyboard taught everyone and there is no
+        // room on this panel for a tone picker that is always visible.
+        let hold = UILongPressGestureRecognizer(target: self, action: #selector(toneHold))
+        hold.minimumPressDuration = 0.45
+        // The collection has to keep scrolling normally; the hold only wins once
+        // it has actually been held.
+        hold.delaysTouchesBegan = false
+        collection.addGestureRecognizer(hold)
 
         bottomRow.axis = .horizontal
         bottomRow.spacing = metrics.columnGap
@@ -251,6 +265,68 @@ final class EmojiPanelView: UIView {
     /// keyboard the user just came from.
     @objc private func keyPressed() {
         feedback.keyPressed()
+    }
+
+    /// Long press on an emoji that has skin tones: open the row, track the
+    /// finger along it, commit whatever it is over when it lifts.
+    @objc private func toneHold(_ recognizer: UILongPressGestureRecognizer) {
+        let point = recognizer.location(in: collection)
+        switch recognizer.state {
+        case .began:
+            guard let indexPath = collection.indexPathForItem(at: point),
+                  indexPath.item < glyphs.count
+            else { return }
+            let options = EmojiSkinTones.variants(of: glyphs[indexPath.item])
+            guard options.count > 1 else { return }
+            presentTones(options, over: indexPath)
+        case .changed:
+            guard let tones = tonesView, !tones.isHidden else { return }
+            let local = convert(point, from: collection)
+            if tones.highlightOption(atX: convert(local, to: tones).x) {
+                feedback.selectionChanged()
+            }
+        case .ended:
+            guard let tones = tonesView, !tones.isHidden else { return }
+            let choice = tones.highlightedOption
+            dismissTones()
+            guard let choice else { return }
+            feedback.textCommitted()
+            EmojiRecents.note(choice)
+            delegate?.emojiPanel(self, didChoose: choice)
+        default:
+            dismissTones()
+        }
+    }
+
+    private func presentTones(_ options: [String], over indexPath: IndexPath) {
+        guard let attributes = collection.layoutAttributesForItem(at: indexPath) else { return }
+        let tones = tonesView ?? {
+            let created = KeyAlternativesView(palette: palette, metrics: metrics)
+            addSubview(created)
+            tonesView = created
+            return created
+        }()
+        toneOptions = options
+        tones.show(options, palette: palette, metrics: metrics)
+        let size = tones.size(for: options)
+        let cell = convert(attributes.frame, from: collection)
+        // Nudged inside the panel, so a tone row opened on the first or last
+        // column of the grid does not hang off the edge.
+        let x = min(max(cell.midX - size.width / 2, 2), max(bounds.width - size.width - 2, 2))
+        tones.frame = CGRect(
+            x: x,
+            y: max(cell.minY - size.height - 6, 0),
+            width: size.width,
+            height: size.height
+        )
+        bringSubviewToFront(tones)
+        tones.appear(animated: true)
+        feedback.selectionChanged()
+    }
+
+    private func dismissTones() {
+        tonesView?.disappear(animated: true)
+        toneOptions = []
     }
 
     @objc private func searchChanged() {
@@ -324,6 +400,9 @@ extension EmojiPanelView: UICollectionViewDataSource, UICollectionViewDelegateFl
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        // The tone row owns this touch. Without this the lift that chooses a
+        // tone would also insert the untoned emoji the row was opened from.
+        guard tonesView?.isHidden != false else { return }
         guard indexPath.item < glyphs.count else { return }
         let glyph = glyphs[indexPath.item]
         feedback.textCommitted()

--- a/ios/VocaPhoneKeyboard/KeyAlternatives.swift
+++ b/ios/VocaPhoneKeyboard/KeyAlternatives.swift
@@ -190,6 +190,57 @@ final class KeyAlternativesView: UIView {
         setNeedsLayout()
     }
 
+    /// Opens the row out of the key it was held on.
+    ///
+    /// Same reasoning as ``KeyPreviewView/appear(animated:)``: the system's
+    /// accent row unfolds, and one that is simply *there* on the next frame
+    /// reads as a menu rather than as the key opening up. Called after the
+    /// frame has been set, so the growth is measured against the real size.
+    func appear(animated: Bool) {
+        layer.removeAllAnimations()
+        isHidden = false
+        guard animated, !UIAccessibility.isReduceMotionEnabled else {
+            alpha = 1
+            transform = .identity
+            return
+        }
+        alpha = 0
+        transform = CGAffineTransform(translationX: 0, y: bounds.height * 0.18)
+            .scaledBy(x: 0.88, y: 0.64)
+        UIView.animate(
+            withDuration: 0.13,
+            delay: 0,
+            usingSpringWithDamping: 0.86,
+            initialSpringVelocity: 0,
+            options: [.beginFromCurrentState, .allowUserInteraction]
+        ) {
+            self.alpha = 1
+            self.transform = .identity
+        }
+    }
+
+    func disappear(animated: Bool) {
+        layer.removeAllAnimations()
+        let finish = {
+            self.isHidden = true
+            self.alpha = 1
+            self.transform = .identity
+        }
+        guard animated, !UIAccessibility.isReduceMotionEnabled, !isHidden else {
+            finish()
+            return
+        }
+        UIView.animate(
+            withDuration: 0.1,
+            delay: 0,
+            options: [.beginFromCurrentState, .allowUserInteraction]
+        ) {
+            self.alpha = 0
+        } completion: { _ in
+            finish()
+        }
+    }
+
     /// Moves the selection to whichever option the finger is over, clamped to
     /// the ends so a finger dragged past the edge keeps the nearest option
     /// rather than losing the selection entirely.

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -7,6 +7,12 @@ enum KeyboardOutput {
     case deleteBackward
     case deleteWord
     case moveCursor(Int)
+    /// Move the cursor up or down whole lines, keeping its column.
+    ///
+    /// Separate from ``moveCursor(_:)`` because a keyboard extension can only
+    /// move by *characters*: how many characters a line is worth is a question
+    /// about the document, and only the controller can see it.
+    case moveCursorLine(Int)
     /// A traced word and the alternates that lost to it, for the strip.
     case swipeWord(String, alternates: [String])
     /// Hold the plane key to reach the emoji panel.
@@ -23,9 +29,20 @@ enum KeyboardOutput {
 
 enum CursorTrackpad {
     static let pointsPerCharacter: CGFloat = 10
+    /// How far the finger travels for one line.
+    ///
+    /// Deliberately more than twice the horizontal step. The gesture is mostly
+    /// used to nudge along a line, and a vertical threshold close to the
+    /// horizontal one turns every slightly sloped drag into a jump to another
+    /// line — which loses the user the place they were trying to reach.
+    static let pointsPerLine: CGFloat = 26
 
     static func step(forHorizontalTranslation translation: CGFloat) -> Int {
         Int(translation / pointsPerCharacter)
+    }
+
+    static func line(forVerticalTranslation translation: CGFloat) -> Int {
+        Int(translation / pointsPerLine)
     }
 }
 
@@ -72,8 +89,32 @@ final class KeyGridView: UIView {
 
     /// The punctuation pair on the letters plane, or `nil` for none — which is
     /// the plain QWERTY case, matching the system keyboard.
-    var leadingPunctuation: String? {
-        didSet { if leadingPunctuation != oldValue { rebuild() } }
+    var punctuation: KeyLayout.BottomRowPunctuation? {
+        didSet { if punctuation != oldValue { rebuild() } }
+    }
+
+    /// Whether Return does anything. Fields that set
+    /// `enablesReturnKeyAutomatically` expect it dimmed and inert until there is
+    /// something to send, and a Send button that fires on an empty message is a
+    /// message the user did not write.
+    var returnKeyIsEnabled = true {
+        didSet { if returnKeyIsEnabled != oldValue { updateKeys() } }
+    }
+
+    /// How likely each letter is to be typed next, from the language model.
+    ///
+    /// Handed straight to the hit map, which grows an expected key's invisible
+    /// target by a bounded fraction of the hysteresis distance. This is the
+    /// piece the geometry alone could not supply, and it is why the system
+    /// keyboard forgives a finger that lands in the gutter between two keys.
+    ///
+    /// Assigned rather than rebuilt: the targets belong to the layout and change
+    /// when the keyboard is re-laid out, while this changes on every keystroke.
+    var nextCharacterLikelihood: [Character: Double] = [:] {
+        didSet {
+            guard nextCharacterLikelihood != oldValue else { return }
+            hitMap.likelihood = nextCharacterLikelihood
+        }
     }
 
     /// The word list the swipe recogniser ranks against. Set by the controller
@@ -169,6 +210,7 @@ final class KeyGridView: UIView {
         var preview: KeyPreviewView?
         let initialPoint: CGPoint
         var lastCursorStep = 0
+        var lastCursorLine = 0
         var isCursorTracking = false
         /// Fires the accent popover if the finger is still on the key. Cancelled
         /// by movement, by lifting, and by anything that tears the grid down.
@@ -284,21 +326,32 @@ final class KeyGridView: UIView {
                 // shrunken visual centre would hand their share of the gutter
                 // to the neighbouring letter — losing the touch target the
                 // inset was written to preserve.
-                targets.append(
-                    KeyHitMap.Target(
-                        index: keyIndex,
-                        frame: slotFrame,
-                        hitRect: key.hitRect,
-                        isCharacter: key.spec.cap.isCharacter
+                // A blank claims no space at all. It is a hole in the keypad,
+                // and letting it own a hit rect would put a dead zone beside the
+                // zero where the neighbouring keys should reach.
+                if key.spec.cap.isInteractive {
+                    targets.append(
+                        KeyHitMap.Target(
+                            index: keyIndex,
+                            frame: slotFrame,
+                            hitRect: key.hitRect,
+                            isCharacter: key.spec.cap.isCharacter,
+                            character: key.spec.cap.resolvedText(shift: .off)
+                                .flatMap { $0.count == 1 ? $0.lowercased().first : nil }
+                        )
                     )
-                )
+                }
                 x += width + metrics.columnGap
                 keyIndex += 1
             }
             y += metrics.keyHeight + metrics.rowGap
         }
 
-        hitMap = KeyHitMap(targets: targets, hysteresis: hysteresis)
+        hitMap = KeyHitMap(
+            targets: targets,
+            hysteresis: hysteresis,
+            likelihood: nextCharacterLikelihood
+        )
     }
 
     /// The native letters plane leaves a larger visual moat around Shift and
@@ -436,7 +489,7 @@ final class KeyGridView: UIView {
                 for: plane,
                 includesGlobe: showsGlobeKey,
                 returnIsProminent: returnKeyIsProminent,
-                leadingPunctuation: leadingPunctuation
+                punctuation: punctuation
             )
             var views: [KeyView] = []
             views.reserveCapacity(built.reduce(0) { $0 + $1.keys.count })
@@ -536,6 +589,7 @@ final class KeyGridView: UIView {
                 shift: shiftState,
                 returnTitle: returnKeyTitle
             )
+            if key.spec.cap == .newline { key.isEnabled = returnKeyIsEnabled }
         }
     }
 
@@ -550,6 +604,9 @@ final class KeyGridView: UIView {
             guard let index = keyIndex(at: point, characterOnly: false)
             else { continue }
             let key = keyViews[index]
+            // A dimmed Return takes no touch at all — not the highlight and not
+            // the click, both of which would promise something it will not do.
+            if key.spec.cap == .newline, !returnKeyIsEnabled { continue }
             let item = TrackedTouch(touch: touch, key: key, keyIndex: index, initialPoint: point)
             tracked.append(item)
             key.isHighlighted = true
@@ -663,8 +720,16 @@ final class KeyGridView: UIView {
                     feedback.swipeBegan()
                 }
                 if item.isSwiping {
-                    item.swipePath.append(point)
-                    swipeTrail.extend(to: point)
+                    // Every sample the panel actually took, not just the one
+                    // that survived to this frame. At 120Hz UIKit delivers
+                    // several touches per display refresh and collapses them
+                    // into one `touchesMoved`; taking only the last threw away
+                    // most of the curve, which cost the recogniser the shape it
+                    // scores against and left the trail visibly polygonal.
+                    for sample in coalescedPoints(for: touch, in: event) {
+                        item.swipePath.append(sample)
+                        swipeTrail.extend(to: sample)
+                    }
                     // A trace is meant to run across keys, so it re-targets on
                     // the boundary with no hysteresis at all.
                     if let index = keyIndex(at: point, characterOnly: true),
@@ -704,6 +769,15 @@ final class KeyGridView: UIView {
             setHighlight(true, on: item.key)
             showPreview(for: item)
         }
+    }
+
+    /// Every position the panel reported for this touch since the last event,
+    /// oldest first — or just the current one if coalescing is unavailable.
+    private func coalescedPoints(for touch: UITouch, in event: UIEvent?) -> [CGPoint] {
+        guard let coalesced = event?.coalescedTouches(for: touch), !coalesced.isEmpty else {
+            return [touch.location(in: self)]
+        }
+        return coalesced.map { $0.location(in: self) }
     }
 
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -804,6 +878,10 @@ final class KeyGridView: UIView {
             delegate?.keyGrid(self, didProduce: .space)
             return true
         case .newline:
+            // A field that asked for `enablesReturnKeyAutomatically` has said
+            // there is nothing to send yet. The key is drawn dimmed; it has to
+            // act dimmed too, or the dimming is decoration.
+            guard returnKeyIsEnabled else { return false }
             feedback.textCommitted()
             delegate?.keyGrid(self, didProduce: .newline)
             return true
@@ -832,19 +910,17 @@ final class KeyGridView: UIView {
     private func scheduleSpaceTrackpad(for item: TrackedTouch) {
         guard !UIAccessibility.isVoiceOverRunning else { return }
         spaceTrackpadTimer?.invalidate()
-        spaceTrackpadTimer = Timer.scheduledTimer(withTimeInterval: 0.32, repeats: false) {
-            [weak self, weak item] _ in
-            MainActor.assumeIsolated {
-                guard let self,
-                      let item,
-                      self.tracked.contains(where: { $0 === item }),
-                      item.isEngaged
-                else { return }
-                item.isCursorTracking = true
-                item.lastCursorStep = 0
-                self.feedback.selectionChanged()
-                UIAccessibility.post(notification: .announcement, argument: "Cursor control")
-            }
+        spaceTrackpadTimer = Self.scheduleTimer(after: 0.32) { [weak self, weak item] in
+            guard let self,
+                  let item,
+                  self.tracked.contains(where: { $0 === item }),
+                  item.isEngaged
+            else { return }
+            item.isCursorTracking = true
+            item.lastCursorStep = 0
+            item.lastCursorLine = 0
+            self.feedback.selectionChanged()
+            UIAccessibility.post(notification: .announcement, argument: "Cursor control")
         }
     }
 
@@ -862,6 +938,20 @@ final class KeyGridView: UIView {
 
         item.isEngaged = true
         setHighlight(true, on: item.key)
+
+        // Lines first. A drag that has crossed into another line is a drag about
+        // *which* line, and applying the horizontal component in the same turn
+        // would land the cursor a few characters away from the column the finger
+        // is actually over.
+        let line = CursorTrackpad.line(
+            forVerticalTranslation: point.y - item.initialPoint.y
+        )
+        let lineDelta = line - item.lastCursorLine
+        if lineDelta != 0 {
+            item.lastCursorLine = line
+            delegate?.keyGrid(self, didProduce: .moveCursorLine(lineDelta))
+        }
+
         let step = CursorTrackpad.step(
             forHorizontalTranslation: point.x - item.initialPoint.x
         )
@@ -910,6 +1000,10 @@ final class KeyGridView: UIView {
 
     private var swipeTypingIsAvailable: Bool {
         KeyboardPreferences.swipeTypingEnabled
+            // Only where there are letters to trace across. On the numbers and
+            // symbols planes, and on the numeric keypads, a long drag is a
+            // finger changing its mind about a key.
+            && plane == .letters
             && swipeWordList?.isEmpty == false
             && !UIAccessibility.isVoiceOverRunning
     }
@@ -969,9 +1063,8 @@ final class KeyGridView: UIView {
         cancelPlaneHold()
         planeHoldOrigin = plane
         planeHoldPoint = point
-        planeHoldTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) {
-            [weak self] _ in
-            MainActor.assumeIsolated { self?.completePlaneHold() }
+        planeHoldTimer = Self.scheduleTimer(after: 0.5) { [weak self] in
+            self?.completePlaneHold()
         }
     }
 
@@ -1001,16 +1094,13 @@ final class KeyGridView: UIView {
               KeyAlternatives.hasOptions(for: base, keyboardType: keyboardType)
         else { return }
         item.longPressTimer?.invalidate()
-        item.longPressTimer = Timer.scheduledTimer(withTimeInterval: 0.45, repeats: false) {
-            [weak self, weak item] _ in
-            MainActor.assumeIsolated {
-                guard let self,
-                      let item,
-                      self.tracked.contains(where: { $0 === item }),
-                      item.isEngaged
-                else { return }
-                self.presentAlternatives(for: item)
-            }
+        item.longPressTimer = Self.scheduleTimer(after: 0.45) { [weak self, weak item] in
+            guard let self,
+                  let item,
+                  self.tracked.contains(where: { $0 === item }),
+                  item.isEngaged
+            else { return }
+            self.presentAlternatives(for: item)
         }
     }
 
@@ -1034,7 +1124,6 @@ final class KeyGridView: UIView {
             alternativesView = created
             return created
         }()
-        popover.isHidden = false
         popover.show(options, palette: palette, metrics: metrics)
 
         let size = popover.size(for: options)
@@ -1044,6 +1133,7 @@ final class KeyGridView: UIView {
         let x = min(max(frame.midX - size.width / 2, 2), max(bounds.width - size.width - 2, 2))
         popover.frame = CGRect(x: x, y: frame.minY - size.height - 6, width: size.width, height: size.height)
         bringSubviewToFront(popover)
+        popover.appear(animated: true)
 
         item.isChoosingAlternative = true
         item.longPressTimer = nil
@@ -1059,7 +1149,7 @@ final class KeyGridView: UIView {
     }
 
     private func dismissAlternatives() {
-        alternativesView?.isHidden = true
+        alternativesView?.disappear(animated: true)
         for item in tracked { item.isChoosingAlternative = false }
     }
 
@@ -1108,6 +1198,29 @@ final class KeyGridView: UIView {
         key.isHighlighted = false
     }
 
+    // MARK: - Timers
+
+    /// One-shot timer on the *common* run loop modes.
+    ///
+    /// `Timer.scheduledTimer` installs into `.default` only, which stops firing
+    /// the moment UIKit enters tracking mode — which it does whenever a scroll
+    /// view anywhere in this process is being dragged, the typing strip and the
+    /// emoji panel included. Every interaction timer in this view is armed by a
+    /// finger, so a held Delete that quietly stopped repeating, or an accent
+    /// popover that never opened, is a keyboard that has frozen as far as the
+    /// person holding it is concerned. The session poller was already given
+    /// `.common` for this exact reason; these are the timers that needed it more.
+    static func scheduleTimer(
+        after interval: TimeInterval,
+        _ body: @escaping @MainActor () -> Void
+    ) -> Timer {
+        let timer = Timer(timeInterval: interval, repeats: false) { _ in
+            MainActor.assumeIsolated { body() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        return timer
+    }
+
     // MARK: - Delete repeat
 
     /// The first repeat waits; the ones after it accelerate.
@@ -1131,11 +1244,8 @@ final class KeyGridView: UIView {
     private func startDeleteTimer() {
         deleteTimer?.invalidate()
         deleteRepeatCount = 0
-        deleteTimer = Timer.scheduledTimer(
-            withTimeInterval: Self.deleteInitialDelay,
-            repeats: false
-        ) { [weak self] _ in
-            MainActor.assumeIsolated { self?.scheduleNextDelete() }
+        deleteTimer = Self.scheduleTimer(after: Self.deleteInitialDelay) { [weak self] in
+            self?.scheduleNextDelete()
         }
     }
 
@@ -1162,9 +1272,8 @@ final class KeyGridView: UIView {
         let progress = min(CGFloat(deleteRepeatCount) / 12, 1)
         let interval = Self.deleteSlowestInterval
             - (Self.deleteSlowestInterval - Self.deleteFastestInterval) * Double(progress)
-        deleteTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) {
-            [weak self] _ in
-            MainActor.assumeIsolated { self?.scheduleNextDelete() }
+        deleteTimer = Self.scheduleTimer(after: interval) { [weak self] in
+            self?.scheduleNextDelete()
         }
     }
 
@@ -1187,11 +1296,14 @@ final class KeyGridView: UIView {
         }
 
         let preview: KeyPreviewView
+        let isNew: Bool
         if let existing = item.preview {
             preview = existing
+            isNew = false
         } else {
             preview = dequeuePreview()
             item.preview = preview
+            isNew = true
         }
         let frame = item.key.frame
         let width = max(frame.width * 1.5, frame.width + 22)
@@ -1217,6 +1329,10 @@ final class KeyGridView: UIView {
             )
         )
         bringSubviewToFront(preview)
+        // Only the first appearance grows. Sliding from one key to the next
+        // moves the same balloon, and re-animating it there would be the glyph
+        // pulsing under a finger that is simply correcting its aim.
+        if isNew { preview.appear(animated: true) }
     }
 
 #if DEBUG
@@ -1248,15 +1364,24 @@ final class KeyGridView: UIView {
         return preview
     }
 
+    /// Fades the balloon back into its key and returns it to the pool.
+    ///
+    /// The view is pooled only once the fade has finished. A preview handed back
+    /// mid-animation would be dequeued by the next keystroke while still
+    /// shrinking, and the letter after it would appear half transparent —
+    /// `appear(animated:)` resets both, but the pool is the honest place to draw
+    /// the line.
     private func recycle(_ preview: KeyPreviewView?) {
         guard let preview else { return }
-        preview.isHidden = true
-        // Two covers two-thumb typing; holding more would just retain views.
-        guard previewPool.count < 2 else {
-            preview.removeFromSuperview()
-            return
+        preview.disappear(animated: metrics.showsPreview) { [weak self, weak preview] in
+            guard let self, let preview else { return }
+            // Two covers two-thumb typing; holding more would just retain views.
+            guard previewPool.count < 2, preview.superview === self else {
+                preview.removeFromSuperview()
+                return
+            }
+            previewPool.append(preview)
         }
-        previewPool.append(preview)
     }
 }
 
@@ -1277,7 +1402,10 @@ private extension KeyCap {
     var actsOnTouchDown: Bool {
         switch self {
         case .delete, .shift, .plane, .globe: true
-        case .character, .space, .newline: false
+        // A blank never reaches here — it owns no hit target — but saying so
+        // explicitly is what stops the next cap added to the enum from
+        // defaulting into firing on touch-down.
+        case .character, .space, .newline, .blank: false
         }
     }
 }

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -464,7 +464,14 @@ final class KeyGridView: UIView {
             plane.views.forEach { $0.removeFromSuperview() }
         }
         planeCache.removeAll()
-        previewPool.forEach { $0.removeFromSuperview() }
+        // Every balloon, not just the pooled ones. `releaseTouches` above starts
+        // a *fade* rather than hiding outright, so a preview that is still
+        // fading is in neither the pool nor any tracked touch — it used to
+        // survive the rebuild and then hand itself back to the fresh pool,
+        // carrying the palette and metrics it was built with. The next
+        // keystroke after a theme or height change dequeued it and drew the
+        // previous appearance's colours.
+        subviews.compactMap { $0 as? KeyPreviewView }.forEach { $0.removeFromSuperview() }
         previewPool.removeAll()
         alternativesView?.removeFromSuperview()
         alternativesView = nil

--- a/ios/VocaPhoneKeyboard/KeyHitMap.swift
+++ b/ios/VocaPhoneKeyboard/KeyHitMap.swift
@@ -5,8 +5,9 @@ import CoreGraphics
 /// Keys can visually leave a gutter between them while still claiming that
 /// space for touch input. Keeping the selection rule separate from `UIView`
 /// traversal makes that rule deterministic, testable, and shared by every
-/// touch path. The visible geometry remains the source of truth; this type does
-/// not invent personalised or language-aware correction.
+/// touch path. The visible geometry remains the source of truth; what the
+/// language model contributes is a bounded nudge at the boundaries — see
+/// ``likelihood``.
 struct KeyHitMap {
     struct Target: Equatable {
         /// Stable layout order, used only when a point is exactly equidistant
@@ -15,6 +16,25 @@ struct KeyHitMap {
         let frame: CGRect
         let hitRect: CGRect
         let isCharacter: Bool
+        /// The lowercase letter this key types, for keys that type one. This is
+        /// what ``likelihood`` is keyed by, so a plane change or a re-layout
+        /// does not invalidate a prediction that is about letters rather than
+        /// about positions.
+        var character: Character?
+
+        init(
+            index: Int,
+            frame: CGRect,
+            hitRect: CGRect,
+            isCharacter: Bool,
+            character: Character? = nil
+        ) {
+            self.index = index
+            self.frame = frame
+            self.hitRect = hitRect
+            self.isCharacter = isCharacter
+            self.character = character
+        }
     }
 
     let targets: [Target]
@@ -34,9 +54,48 @@ struct KeyHitMap {
     /// building a map for a query that has no current key need not supply one.
     let hysteresis: CGFloat
 
-    init(targets: [Target], hysteresis: CGFloat = 0) {
+    /// How likely each letter is to be the next one typed, from 0 to 1.
+    ///
+    /// This is the half of the touch model that geometry cannot supply. The
+    /// system keyboard grows a key's *invisible* target when the language
+    /// expects that letter — after "th", "e" claims more of the gutter than the
+    /// "w" beside it — and it is a large part of why a finger landing between
+    /// two keys is forgiven there and was not here.
+    ///
+    /// Deliberately a separate stored property rather than something baked into
+    /// the targets: the targets change on layout, this changes on every
+    /// keystroke, and rebuilding thirty frames per letter to carry a number
+    /// would cost more than the correction is worth.
+    var likelihood: [Character: Double] = [:]
+
+    /// The most a fully expected letter may claim beyond its own boundary, as a
+    /// share of the hysteresis distance.
+    ///
+    /// Small on purpose, and bounded by the same number that already decides how
+    /// far a finger must travel to change keys. A prediction is allowed to
+    /// settle a genuinely marginal touch; it is never allowed to take a touch
+    /// that plainly landed on the neighbour, because a keyboard that types a
+    /// letter the user can see they did not press is worse than one that is
+    /// merely unforgiving.
+    static let maximumBiasShare: CGFloat = 0.5
+
+    init(targets: [Target], hysteresis: CGFloat = 0, likelihood: [Character: Double] = [:]) {
         self.targets = targets
         self.hysteresis = hysteresis
+        self.likelihood = likelihood
+    }
+
+    /// How strongly this key is expected, from 0 (no opinion) to 1.
+    func weight(of target: Target) -> Double {
+        guard let character = target.character, !likelihood.isEmpty else { return 0 }
+        return min(max(likelihood[character] ?? 0, 0), 1)
+    }
+
+    /// The target's claimed area, grown by however much the language expects it.
+    func effectiveRect(of target: Target) -> CGRect {
+        let grow = hysteresis * Self.maximumBiasShare * CGFloat(weight(of: target))
+        guard grow > 0 else { return target.hitRect }
+        return target.hitRect.insetBy(dx: -grow, dy: -grow)
     }
 
     /// The nearest visible centre among the targets claiming `point`.
@@ -46,19 +105,24 @@ struct KeyHitMap {
     /// goes to the earlier key — the leftmost on a row — rather than to
     /// whatever order the view hierarchy happens to be in after previews and
     /// accessibility have moved subviews around.
+    ///
+    /// Expanded targets overlap, which is the point: where two keys both claim a
+    /// point, the distance to each centre is scaled by how much the language
+    /// expects it, and the expected one wins a contest it would otherwise have
+    /// lost by a point or two.
     func targetIndex(at point: CGPoint, characterOnly: Bool) -> Int? {
         var winner: Target?
         var shortestDistance = CGFloat.greatestFiniteMagnitude
 
         for target in targets {
-            guard (!characterOnly || target.isCharacter), target.hitRect.contains(point) else {
-                continue
-            }
+            guard (!characterOnly || target.isCharacter),
+                  effectiveRect(of: target).contains(point)
+            else { continue }
 
             let distance = hypot(
                 point.x - target.frame.midX,
                 point.y - target.frame.midY
-            )
+            ) / (1 + CGFloat(weight(of: target)) * 0.12)
             if distance < shortestDistance {
                 winner = target
                 shortestDistance = distance
@@ -83,7 +147,17 @@ struct KeyHitMap {
         guard let current = targets.first(where: { $0.index == currentIndex }) else {
             return candidate
         }
-        guard Self.distance(from: current.frame, to: point) >= hysteresis else { return nil }
+        // Leaving a key the language expects takes a little more travel; landing
+        // on one takes a little less. The same bounded nudge as the expanded
+        // target, expressed against the distance the finger has to clear.
+        var required = hysteresis
+        if !likelihood.isEmpty,
+           let candidateTarget = targets.first(where: { $0.index == candidate })
+        {
+            let difference = weight(of: current) - weight(of: candidateTarget)
+            required *= max(0, 1 + CGFloat(difference) * Self.maximumBiasShare)
+        }
+        guard Self.distance(from: current.frame, to: point) >= required else { return nil }
         return candidate
     }
 

--- a/ios/VocaPhoneKeyboard/KeyLayout.swift
+++ b/ios/VocaPhoneKeyboard/KeyLayout.swift
@@ -318,38 +318,44 @@ enum KeyLayout {
     /// the system keypad does — a stretched `0` there would be a target people
     /// hit by accident reaching for nothing.
     static func keypadRows(for plane: KeyPlane, includesGlobe: Bool) -> [KeyRow] {
-        // Three columns in every row, including the last. The system keypad is a
-        // regular block and reads as one; a bottom row of four keys under three
-        // is a grid that has come apart.
+        // Three columns in every row. The system keypad is a regular block and
+        // reads as one; a bottom row of four keys under three is a grid that has
+        // come apart.
         //
-        // The corner slot goes to whichever of these the field actually needs:
-        // the globe where iOS demands one, the decimal separator on a decimal
-        // pad, the "+" a dialable number can start with on a phone pad, and
-        // otherwise nothing at all — which is what the system keypad leaves
-        // there, rather than stretching the zero across a target nobody is
-        // aiming at.
-        let corner: KeyCap = if includesGlobe {
-            .globe
-        } else {
-            switch plane {
-            case .decimalPad: .character(".")
-            case .phonePad: .character("+")
-            default: .blank
-            }
+        // The bottom row is the exception, and only where it has to be. A
+        // decimal pad's "." and a phone pad's "+" are the *only* way to type
+        // those characters — these layouts have no second plane and no duplicate
+        // key — so when iOS also demands a globe there are four things that must
+        // be reachable and three slots. Giving the corner to the globe left a
+        // decimal pad that could not type a decimal point, which is not a
+        // narrower keyboard, it is a broken one. The row takes a fourth key
+        // instead; the digits above it stay on three.
+        var last: [KeySpec] = []
+        if includesGlobe {
+            last.append(KeySpec(cap: .globe, width: .multiple(keypadColumns), style: .function))
         }
-        let cornerStyle: KeyStyle = corner == .globe ? .function : .standard
+        switch plane {
+        case .decimalPad:
+            last.append(KeySpec(cap: .character("."), width: .multiple(keypadColumns)))
+        case .phonePad:
+            last.append(KeySpec(cap: .character("+"), width: .multiple(keypadColumns)))
+        default:
+            break
+        }
+        // A plain number pad with no globe has nothing for the corner, and iOS
+        // leaves it genuinely empty rather than stretching the zero across it —
+        // a target people would hit reaching for nothing.
+        if last.isEmpty {
+            last.append(KeySpec(cap: .blank, width: .multiple(keypadColumns)))
+        }
+        last.append(KeySpec(cap: .character("0"), width: .multiple(keypadColumns)))
+        last.append(KeySpec(cap: .delete, width: .multiple(keypadColumns), style: .function))
+
         return [
             keypadRow("123"),
             keypadRow("456"),
             keypadRow("789"),
-            KeyRow(
-                keys: [
-                    KeySpec(cap: corner, width: .multiple(keypadColumns), style: cornerStyle),
-                    KeySpec(cap: .character("0"), width: .multiple(keypadColumns)),
-                    KeySpec(cap: .delete, width: .multiple(keypadColumns), style: .function),
-                ],
-                alignment: .centered
-            ),
+            KeyRow(keys: last, alignment: .centered),
         ]
     }
 

--- a/ios/VocaPhoneKeyboard/KeyLayout.swift
+++ b/ios/VocaPhoneKeyboard/KeyLayout.swift
@@ -4,6 +4,25 @@ enum KeyPlane: Equatable {
     case letters
     case numbers
     case symbols
+    /// The three numeric layouts iOS gives a field that asks for one.
+    ///
+    /// These are not "the numbers plane with a different starting point", which
+    /// is what a `.numberPad` field used to get: a full QWERTY symbols row
+    /// reading `-/:;()$&@"` above a phone-number box does not read as a
+    /// variant, it reads as a keyboard that has not noticed where it is. They
+    /// have no plane switch, because there is nowhere else for them to go.
+    case numberPad
+    case phonePad
+    case decimalPad
+
+    /// Whether this plane is one of the numeric keypads, which share a shape
+    /// and share the rule that the user cannot leave them.
+    var isKeypad: Bool {
+        switch self {
+        case .numberPad, .phonePad, .decimalPad: true
+        case .letters, .numbers, .symbols: false
+        }
+    }
 }
 
 enum KeyCap: Equatable {
@@ -16,6 +35,10 @@ enum KeyCap: Equatable {
     case newline
     case plane(KeyPlane)
     case globe
+    /// A hole in the grid. The numeric keypads are a 3x4 block with one empty
+    /// corner, and iOS leaves that corner genuinely empty rather than
+    /// stretching its neighbours across it.
+    case blank
 
     /// Character keys are the only ones that show a preview and accept a finger
     /// sliding in from a neighbour, matching the system keyboard.
@@ -23,6 +46,10 @@ enum KeyCap: Equatable {
         if case .character = self { return true }
         return false
     }
+
+    /// Whether this key can be pressed at all. A blank is laid out and drawn as
+    /// nothing, and must never take a touch from the keys either side of it.
+    var isInteractive: Bool { self != .blank }
 
     func resolvedText(shift: ShiftState) -> String? {
         guard case let .character(value) = self else { return nil }
@@ -38,11 +65,13 @@ enum KeyCap: Equatable {
         case .space: return "Space"
         case .newline: return "Return"
         case .globe: return "Next keyboard"
+        case .blank: return ""
         case let .plane(plane):
             switch plane {
             case .letters: return "Letters"
             case .numbers: return "Numbers"
             case .symbols: return "Symbols"
+            case .numberPad, .phonePad, .decimalPad: return "Numbers"
             }
         }
     }
@@ -117,9 +146,11 @@ enum KeyLayout {
         for plane: KeyPlane,
         includesGlobe: Bool,
         returnIsProminent: Bool,
-        leadingPunctuation: String? = nil
+        punctuation: BottomRowPunctuation? = nil
     ) -> [KeyRow] {
         switch plane {
+        case .numberPad, .phonePad, .decimalPad:
+            return keypadRows(for: plane, includesGlobe: includesGlobe)
         case .letters:
             return [
                 KeyRow(keys: map("qwertyuiop")),
@@ -129,7 +160,7 @@ enum KeyLayout {
                     + [KeySpec(cap: .delete, width: .fill, style: .function)]),
                 bottomRow(
                     planeSwitch: .numbers,
-                    punctuation: leadingPunctuation,
+                    punctuation: punctuation,
                     includesGlobe: includesGlobe,
                     returnIsProminent: returnIsProminent
                 ),
@@ -184,6 +215,20 @@ enum KeyLayout {
     /// spacebar is centred exactly when **the column totals either side of it
     /// are equal**. That identity is the whole calculation; it holds at every
     /// width, which point-based nudging never did.
+    /// The two punctuation keys iOS adds to the bottom row in the handful of
+    /// field types that earn them.
+    ///
+    /// A pair rather than a single leading key, because the second slot is not
+    /// always a full stop: a `.twitter` field gets `@` and `#`, which are the
+    /// two characters that field is *for*, and hard-coding "." there was why it
+    /// could not be offered.
+    struct BottomRowPunctuation: Equatable {
+        let leading: String
+        let trailing: String
+
+        static let period = BottomRowPunctuation(leading: ",", trailing: ".")
+    }
+
     struct BottomRowColumns: Equatable {
         var planeSwitch: CGFloat
         var globe: CGFloat?
@@ -218,7 +263,7 @@ enum KeyLayout {
 
     private static func bottomRow(
         planeSwitch: KeyPlane,
-        punctuation: String?,
+        punctuation: BottomRowPunctuation?,
         includesGlobe: Bool,
         returnIsProminent: Bool
     ) -> KeyRow {
@@ -239,16 +284,16 @@ enum KeyLayout {
         if let punctuation {
             keys.append(
                 KeySpec(
-                    cap: .character(punctuation),
+                    cap: .character(punctuation.leading),
                     width: .multiple(columns.punctuation ?? 1)
                 )
             )
         }
         keys.append(KeySpec(cap: .space, width: .fill))
-        if punctuation != nil {
+        if let punctuation {
             keys.append(
                 KeySpec(
-                    cap: .character("."),
+                    cap: .character(punctuation.trailing),
                     width: .multiple(columns.period ?? 1)
                 )
             )
@@ -263,6 +308,67 @@ enum KeyLayout {
         return KeyRow(keys: keys)
     }
 
+    /// The three-column numeric block iOS shows for a `.numberPad`,
+    /// `.phonePad` or `.decimalPad` field.
+    ///
+    /// Four rows, so it occupies exactly the height the letters plane does and
+    /// the keyboard does not resize under the user when the cursor moves from a
+    /// name field to a phone-number one. The bottom-left slot carries the globe
+    /// where iOS asks for one and is genuinely empty otherwise, which is what
+    /// the system keypad does — a stretched `0` there would be a target people
+    /// hit by accident reaching for nothing.
+    static func keypadRows(for plane: KeyPlane, includesGlobe: Bool) -> [KeyRow] {
+        // Three columns in every row, including the last. The system keypad is a
+        // regular block and reads as one; a bottom row of four keys under three
+        // is a grid that has come apart.
+        //
+        // The corner slot goes to whichever of these the field actually needs:
+        // the globe where iOS demands one, the decimal separator on a decimal
+        // pad, the "+" a dialable number can start with on a phone pad, and
+        // otherwise nothing at all — which is what the system keypad leaves
+        // there, rather than stretching the zero across a target nobody is
+        // aiming at.
+        let corner: KeyCap = if includesGlobe {
+            .globe
+        } else {
+            switch plane {
+            case .decimalPad: .character(".")
+            case .phonePad: .character("+")
+            default: .blank
+            }
+        }
+        let cornerStyle: KeyStyle = corner == .globe ? .function : .standard
+        return [
+            keypadRow("123"),
+            keypadRow("456"),
+            keypadRow("789"),
+            KeyRow(
+                keys: [
+                    KeySpec(cap: corner, width: .multiple(keypadColumns), style: cornerStyle),
+                    KeySpec(cap: .character("0"), width: .multiple(keypadColumns)),
+                    KeySpec(cap: .delete, width: .multiple(keypadColumns), style: .function),
+                ],
+                alignment: .centered
+            ),
+        ]
+    }
+
+    /// How wide one keypad key is, in letter columns. Three of them plus their
+    /// gaps come to a little over two thirds of the keyboard, which is where the
+    /// system keypad sits: wide enough to be unmissable, narrow enough that the
+    /// block still reads as a keypad rather than as a stretched row.
+    static let keypadColumns: CGFloat = 2.4
+
+    private static func keypadRow(_ digits: String) -> KeyRow {
+        KeyRow(keys: keypadSpecs(digits), alignment: .centered)
+    }
+
+    private static func keypadSpecs(_ digits: String) -> [KeySpec] {
+        digits.map {
+            KeySpec(cap: .character(String($0)), width: .multiple(keypadColumns))
+        }
+    }
+
     private static func map(_ characters: String) -> [KeySpec] {
         characters.map { KeySpec.letter(String($0)) }
     }
@@ -273,6 +379,9 @@ enum KeyLayout {
         case .letters: "ABC"
         case .numbers: "123"
         case .symbols: "#+="
+        // The keypads have no plane key to put a title on; the case exists so
+        // adding a plane later cannot silently inherit the wrong label.
+        case .numberPad, .phonePad, .decimalPad: "123"
         }
     }
 }

--- a/ios/VocaPhoneKeyboard/KeyProximity.swift
+++ b/ios/VocaPhoneKeyboard/KeyProximity.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+/// Which letters sit under neighbouring keys, and what that costs a correction.
+///
+/// The system checker ranks its guesses by spelling alone: "hekki" and "hexxo"
+/// are the same distance from "hello" as far as Levenshtein is concerned, but
+/// only one of them is a hand that drifted one key right. A keyboard knows
+/// something the dictionary does not — where the fingers were — and folding that
+/// in is most of what separates a correction that lands from one that reads as
+/// the keyboard guessing.
+///
+/// Adjacency is taken from the QWERTY layout rather than from the live key
+/// frames on purpose. The rows are the same shape at every key height and on
+/// every device, so a static table gives the same answer as measured geometry
+/// while staying pure, cheap and testable — and it keeps working on the numbers
+/// and symbols planes, where the letters are not on screen at all.
+enum KeyProximity {
+    /// The three letter rows, as laid out by ``KeyLayout``.
+    private static let rows = ["qwertyuiop", "asdfghjkl", "zxcvbnm"]
+
+    /// How far the lower rows are indented, in key columns. The home row sits
+    /// half a column in and the bottom row a full column, which is what makes
+    /// "s" a neighbour of both "w" and "x" but not of "q".
+    private static let rowOffsets: [Double] = [0, 0.5, 1.0]
+
+    /// Column position of every letter, so adjacency is measured rather than
+    /// enumerated by hand — a hand-written table of a hundred and some pairs is
+    /// a place for exactly one typo to hide forever.
+    private static let positions: [Character: (row: Int, column: Double)] = {
+        var positions: [Character: (row: Int, column: Double)] = [:]
+        for (rowIndex, row) in rows.enumerated() {
+            for (columnIndex, character) in row.enumerated() {
+                positions[character] = (rowIndex, Double(columnIndex) + rowOffsets[rowIndex])
+            }
+        }
+        return positions
+    }()
+
+    /// Keys within one column and one row of each other.
+    ///
+    /// Built once. `neighbours(of:)` is asked several times per candidate word
+    /// during a correction, and rebuilding the set each time turned a cheap
+    /// lookup into the most expensive part of ranking.
+    private static let adjacency: [Character: Set<Character>] = {
+        var adjacency: [Character: Set<Character>] = [:]
+        for (character, position) in positions {
+            var neighbours: Set<Character> = []
+            for (other, otherPosition) in positions where other != character {
+                guard abs(otherPosition.row - position.row) <= 1,
+                      abs(otherPosition.column - position.column) <= 1.05
+                else { continue }
+                neighbours.insert(other)
+            }
+            adjacency[character] = neighbours
+        }
+        return adjacency
+    }()
+
+    static func neighbours(of character: Character) -> Set<Character> {
+        adjacency[Character(String(character).lowercased())] ?? []
+    }
+
+    static func areAdjacent(_ left: Character, _ right: Character) -> Bool {
+        guard left != right else { return false }
+        return neighbours(of: left).contains(Character(String(right).lowercased()))
+    }
+
+    /// What it costs to say the user meant `intended` where they typed `typed`.
+    ///
+    /// A neighbouring key is the overwhelmingly common single-character error,
+    /// so it costs less than half a full substitution. Anything else is a
+    /// different letter entirely, and paying full price for it is what stops
+    /// "cat" being offered for "bat" as readily as "hello" for "hwllo".
+    static func substitutionCost(typed: Character, intended: Character) -> Double {
+        if typed == intended { return 0 }
+        let lowerTyped = Character(String(typed).lowercased())
+        let lowerIntended = Character(String(intended).lowercased())
+        if lowerTyped == lowerIntended { return 0 }
+        return areAdjacent(lowerTyped, lowerIntended) ? 0.4 : 1
+    }
+
+    /// Damerau-Levenshtein with the substitution cost above, bounded.
+    ///
+    /// The same shape as ``TypingCandidates/editDistance(_:_:maximum:)`` — which
+    /// stays, because the *unweighted* answer is still what the "is this a typo
+    /// at all" threshold should be measured against — but the costs are real
+    /// numbers, so a two-key drift can rank ahead of a one-key change to a
+    /// letter on the other side of the keyboard.
+    static func weightedDistance(_ left: String, _ right: String, maximum: Double) -> Double {
+        if left == right { return 0 }
+        let a = Array(left)
+        let b = Array(right)
+        // Insertions and deletions still cost one each, so a length gap alone
+        // can already exceed the bound.
+        if Double(abs(a.count - b.count)) > maximum { return maximum + 1 }
+        if a.isEmpty { return min(Double(b.count), maximum + 1) }
+        if b.isEmpty { return min(Double(a.count), maximum + 1) }
+
+        var previousPrevious = [Double](repeating: 0, count: b.count + 1)
+        var previous = (0...b.count).map(Double.init)
+        var current = [Double](repeating: 0, count: b.count + 1)
+
+        for i in 1...a.count {
+            current[0] = Double(i)
+            var rowMinimum = current[0]
+            for j in 1...b.count {
+                let substitution = substitutionCost(typed: a[i - 1], intended: b[j - 1])
+                var value = min(
+                    previous[j] + 1,
+                    current[j - 1] + 1,
+                    previous[j - 1] + substitution
+                )
+                // Two fingers arriving in the wrong order. Cheap because it is
+                // the one error class with no competing explanation.
+                if i > 1, j > 1, a[i - 1] == b[j - 2], a[i - 2] == b[j - 1] {
+                    value = min(value, previousPrevious[j - 2] + 0.8)
+                }
+                current[j] = value
+                rowMinimum = min(rowMinimum, value)
+            }
+            if rowMinimum > maximum { return maximum + 1 }
+            swap(&previousPrevious, &previous)
+            swap(&previous, &current)
+        }
+        return previous[b.count]
+    }
+}

--- a/ios/VocaPhoneKeyboard/KeyView.swift
+++ b/ios/VocaPhoneKeyboard/KeyView.swift
@@ -31,7 +31,20 @@ final class KeyView: UIView {
     var isHighlighted = false {
         didSet {
             guard isHighlighted != oldValue else { return }
+            applyColors(animated: !isHighlighted)
+        }
+    }
+
+    /// Whether this key does anything when pressed. Only Return uses it, for
+    /// the fields that set `enablesReturnKeyAutomatically` and expect the key to
+    /// sit dimmed until there is something to send.
+    var isEnabled = true {
+        didSet {
+            guard isEnabled != oldValue else { return }
             applyColors()
+            accessibilityTraits = isEnabled
+                ? .keyboardKey
+                : [.keyboardKey, .notEnabled]
         }
     }
 
@@ -65,8 +78,13 @@ final class KeyView: UIView {
         addSubview(titleLabel)
         addSubview(symbolView)
 
-        isAccessibilityElement = true
+        // A blank is a hole in the grid, not a control: it takes no touch, so it
+        // must not be somewhere VoiceOver can land either.
+        isAccessibilityElement = spec.cap.isInteractive
         accessibilityTraits = .keyboardKey
+        if !spec.cap.isInteractive {
+            layer.shadowOpacity = 0
+        }
         refresh()
     }
 
@@ -169,6 +187,9 @@ final class KeyView: UIView {
             titleLabel.text = KeyLayout.planeTitle(plane)
             titleLabel.font = planeFont
             symbolView.image = nil
+        case .blank:
+            titleLabel.text = nil
+            symbolView.image = nil
         }
 
         accessibilityLabel = spec.cap.accessibilityLabel(shift: shift)
@@ -242,17 +263,49 @@ final class KeyView: UIView {
         }
     }
 
-    private func applyColors() {
-        // Apple's Shift stays on the neutral key surface; its filled Shift or
-        // Caps Lock glyph carries the state. A persistent mint key made the
-        // resting keyboard look active and unlike the keyboard users know.
-        let style = spec.style
-        backgroundColor = isHighlighted
+    /// The style this key is actually drawn in right now.
+    ///
+    /// An active Shift is drawn on the *standard* key surface rather than the
+    /// function one. That is the system keyboard's own behaviour and the reason
+    /// it is legible at a glance: the filled glyph alone is a small difference
+    /// to spot mid-sentence, and the lifted surface is what says "the next
+    /// letter is a capital" without being read.
+    ///
+    /// The brand accent stays out of it. A mint Shift made the resting keyboard
+    /// look like something was running.
+    private var renderedStyle: KeyStyle {
+        guard spec.cap == .shift, shift.isUppercase else { return spec.style }
+        return .standard
+    }
+
+    private func applyColors(animated: Bool = false) {
+        let style = renderedStyle
+        let background = isHighlighted
             ? palette.pressedBackground(for: style)
             : palette.background(for: style)
         let foreground = palette.foreground(for: style)
-        titleLabel.textColor = foreground
-        symbolView.tintColor = foreground
+        let apply = {
+            self.backgroundColor = self.spec.cap.isInteractive ? background : .clear
+            self.titleLabel.textColor = foreground
+            self.symbolView.tintColor = foreground
+            // Dimmed rather than hidden: a Return that vanishes when the field
+            // is empty is a keyboard that has lost a key.
+            self.alpha = self.isEnabled ? 1 : 0.4
+        }
+        // Pressing is instant — the finger is already there and any delay reads
+        // as lag. Releasing fades, because the system keyboard's key settles
+        // back rather than snapping, and an instant restore under a fast typist
+        // is a strobe.
+        guard animated, !UIAccessibility.isReduceMotionEnabled else {
+            apply()
+            return
+        }
+        UIView.animate(
+            withDuration: 0.11,
+            delay: 0,
+            options: [.beginFromCurrentState, .allowUserInteraction],
+            animations: apply
+        )
     }
 }
 
@@ -326,6 +379,78 @@ final class KeyPreviewView: UIView {
         self.balloonHeight = balloonHeight
         self.neck = neck
         setNeedsLayout()
+    }
+
+    /// Grows the balloon out of the key it belongs to.
+    ///
+    /// The system keyboard's preview does not simply exist: it swells from the
+    /// key under the finger in about a frame and a half. Appearing fully formed
+    /// is the single clearest tell that a keyboard is not the system one — it
+    /// reads as a tooltip rather than as the key itself lifting — and it costs
+    /// one short animation to fix.
+    ///
+    /// The anchor is the bottom of the view, which is the bottom of the *key*,
+    /// so the growth runs upward out of what the finger is covering.
+    func appear(animated: Bool) {
+        layer.removeAllAnimations()
+        isHidden = false
+        guard animated, !UIAccessibility.isReduceMotionEnabled else {
+            alpha = 1
+            transform = .identity
+            return
+        }
+        alpha = 0
+        transform = Self.growth(from: 0.82, 0.62, in: bounds)
+        UIView.animate(
+            withDuration: 0.09,
+            delay: 0,
+            options: [.beginFromCurrentState, .allowUserInteraction]
+        ) {
+            self.alpha = 1
+            self.transform = .identity
+        }
+    }
+
+    /// Settles the balloon back into the key and hands the view back.
+    ///
+    /// `completion` runs whether or not the fade finished, so a pooled preview
+    /// is never left half-transparent for the next keystroke to dequeue.
+    func disappear(animated: Bool, completion: @escaping () -> Void) {
+        layer.removeAllAnimations()
+        let finish = {
+            self.isHidden = true
+            self.alpha = 1
+            self.transform = .identity
+            completion()
+        }
+        guard animated, !UIAccessibility.isReduceMotionEnabled else {
+            finish()
+            return
+        }
+        UIView.animate(
+            withDuration: 0.08,
+            delay: 0,
+            options: [.beginFromCurrentState, .allowUserInteraction]
+        ) {
+            self.alpha = 0
+            self.transform = Self.growth(from: 0.9, 0.75, in: self.bounds)
+        } completion: { _ in
+            finish()
+        }
+    }
+
+    /// A scale about the view's *bottom* edge, expressed as an ordinary
+    /// transform.
+    ///
+    /// The bottom of this view is the bottom of the key, so scaling there is
+    /// what makes the balloon look like it grew out of what the finger is
+    /// covering. Done with a translation rather than by moving `layer.anchorPoint`
+    /// — an anchor point that is not the centre silently changes what setting
+    /// `frame` means, and this view's frame is rewritten on every slide between
+    /// keys.
+    private static func growth(from scaleX: CGFloat, _ scaleY: CGFloat, in bounds: CGRect) -> CGAffineTransform {
+        CGAffineTransform(translationX: 0, y: bounds.height * (1 - scaleY) / 2)
+            .scaledBy(x: scaleX, y: scaleY)
     }
 
     /// The balloon, the tapered shoulders, and the neck over the key, as one

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -270,11 +270,14 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
     override func textDidChange(_ textInput: (any UITextInput)?) {
         super.textDidChange(textInput)
-        // Re-read once here and let everything below share it. This runs after
-        // every insertion this keyboard makes, so it is the single hottest place
-        // in the extension for a redundant hop into the host process.
-        let snapshot = refreshDocument()
-        defer { currentDocument = nil }
+        documentEvent { handleTextChange() }
+    }
+
+    /// Runs after every insertion this keyboard makes, which makes it the single
+    /// hottest place in the extension for a redundant hop into the host process.
+    /// One snapshot, shared by everything below.
+    private func handleTextChange() {
+        let snapshot = document
         // Moving to a different field brings different traits with it, and the
         // plane should reset so a number pad never leaves the user on letters.
         let documentID = currentDocumentID
@@ -385,11 +388,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     // MARK: - Typing
 
     func keyGrid(_ grid: KeyGridView, didProduce output: KeyboardOutput) {
-        // One read for the whole event. Established here rather than on first
-        // use, and cleared on the way out so the next event starts from what the
-        // document actually says then.
-        currentDocument = readDocument()
-        defer { currentDocument = nil }
+        documentEvent { handle(output) }
+    }
+
+    private func handle(_ output: KeyboardOutput) {
         switch output {
         case let .text(text):
             if let substitution = SmartPunctuation.substitution(
@@ -534,6 +536,22 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// on the way out.
     private var document: DocumentSnapshot {
         currentDocument ?? readDocument()
+    }
+
+    /// Runs `body` as one document event: one snapshot taken at the start,
+    /// released at the end.
+    ///
+    /// A helper rather than a `defer` written out at each entry point, because
+    /// writing it out is exactly what gets forgotten. `applyDocumentTraits` did,
+    /// and left a snapshot from `viewWillAppear` for the next keystroke to read
+    /// as though it described the document now; the emoji panel's handlers did
+    /// too, and left one from the emoji they had just inserted. Both are the
+    /// same mistake, and neither is possible through here.
+    @discardableResult
+    private func documentEvent<T>(_ body: () -> T) -> T {
+        currentDocument = readDocument()
+        defer { currentDocument = nil }
+        return body()
     }
 
     /// Re-reads the document after this keyboard has changed it. The insertion
@@ -1411,25 +1429,31 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
 extension KeyboardViewController: EmojiPanelViewDelegate {
     func emojiPanel(_ panel: EmojiPanelView, didChoose glyph: String) {
-        textDocumentProxy.insertText(glyph)
-        // An emoji ends a word as surely as a space does, and it is never
-        // something to autocorrect.
-        typing.resetComposition(origin: .suggestion, document: refreshDocument())
-        releaseUndoIfDetached()
+        documentEvent {
+            textDocumentProxy.insertText(glyph)
+            // An emoji ends a word as surely as a space does, and it is never
+            // something to autocorrect.
+            typing.resetComposition(origin: .suggestion, document: refreshDocument())
+            releaseUndoIfDetached()
+        }
     }
 
     func emojiPanelDidRequestDelete(_ panel: EmojiPanelView) {
-        deleteBackward()
-        releaseUndoIfDetached()
+        documentEvent {
+            deleteBackward()
+            releaseUndoIfDetached()
+        }
     }
 
     func emojiPanelDidRequestReturn(_ panel: EmojiPanelView) {
-        commitComposition(followedBy: "\n")
-        releaseUndoIfDetached()
+        documentEvent {
+            commitComposition(followedBy: "\n")
+            releaseUndoIfDetached()
+        }
     }
 
     func emojiPanelDidRequestSpace(_ panel: EmojiPanelView) {
-        insertSpace()
+        documentEvent { insertSpace() }
     }
 
     func emojiPanelDidRequestLetters(_ panel: EmojiPanelView) {
@@ -1461,8 +1485,10 @@ extension KeyboardViewController: DictationBarViewDelegate {
     /// the literal means nothing to it at all.
     func dictationBar(_ bar: DictationBarView, didChoose candidate: TypingCandidate) {
         guard !isPerformingInsertion else { return }
-        currentDocument = readDocument()
-        defer { currentDocument = nil }
+        documentEvent { apply(candidate) }
+    }
+
+    private func apply(_ candidate: TypingCandidate) {
         switch candidate.kind {
         case .literal:
             // The user's own spelling, asserted. Nothing is rewritten — the

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -626,7 +626,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// so the strip is the surface this keyboard can honestly put it on.
     @discardableResult
     private func revertPendingCorrection() -> Bool {
-        guard let revert = typing.takeRevert() else { return false }
+        guard let revert = typing.takeRevert(documentBefore: document.before) else { return false }
         let removals = revert.replacement.count + revert.boundary.count
         for _ in 0..<removals { textDocumentProxy.deleteBackward() }
         textDocumentProxy.insertText(revert.typed + revert.boundary)

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -205,6 +205,11 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        // UIKit can finalize a changed Full Access setting after the earlier
+        // appearance callbacks. This is the last lifecycle point before guided
+        // setup expects the extension to prove its state.
+        publishKeyboardStatus()
+        KeyboardHaptics.shared.attach(to: view, hasFullAccess: hasFullAccess)
         // A session found before the keyboard is on screen is work already in
         // flight being restored, not something that just happened to the user,
         // and it must not arrive as a buzz in their hand.

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -385,8 +385,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     // MARK: - Typing
 
     func keyGrid(_ grid: KeyGridView, didProduce output: KeyboardOutput) {
-        // One read for the whole event. Cleared on the way out so the next one
-        // starts from what the document actually says now.
+        // One read for the whole event. Established here rather than on first
+        // use, and cleared on the way out so the next event starts from what the
+        // document actually says then.
+        currentDocument = readDocument()
         defer { currentDocument = nil }
         switch output {
         case let .text(text):
@@ -520,11 +522,18 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// keystroke: stale context here is a wrong autocorrect, not a slow one.
     private var currentDocument: DocumentSnapshot?
 
+    /// The event's snapshot if one has been established, and a fresh read
+    /// otherwise.
+    ///
+    /// Deliberately does *not* cache. It used to, which meant any caller
+    /// anywhere could quietly establish an event snapshot — and
+    /// `applyDocumentTraits`, reached from `viewWillAppear`, is not inside an
+    /// event and has no `defer` to clear one. The snapshot it left behind was
+    /// then reused by the next keystroke as though it described the document
+    /// now. Only the entry points below may set it, and each of them clears it
+    /// on the way out.
     private var document: DocumentSnapshot {
-        if let currentDocument { return currentDocument }
-        let snapshot = readDocument()
-        currentDocument = snapshot
-        return snapshot
+        currentDocument ?? readDocument()
     }
 
     /// Re-reads the document after this keyboard has changed it. The insertion
@@ -1306,7 +1315,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             keyGrid.returnKeyIsEnabled = true
             return
         }
-        let resolved = snapshot ?? document
+        // Read fresh when no event snapshot was handed in: this is reached from
+        // `viewWillAppear`, which is not inside an event.
+        let resolved = snapshot ?? readDocument()
         // The proxy answers with nothing while the keyboard is loading, which is
         // not the same as an empty field. Dimming Return on that would grey out
         // the Send button over a message the user has already written.
@@ -1386,26 +1397,15 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// field asks for none, and forcing sentence case there produced input the
     /// user had to correct on every word.
     private func updateAutomaticShift(for snapshot: DocumentSnapshot? = nil) {
-        let proxy = textDocumentProxy
-        let requested = proxy.autocapitalizationType ?? .sentences
-        guard requested != .allCharacters else {
-            keyGrid.shiftState = .locked
-            return
-        }
-        // A user-engaged caps lock outranks any automatic decision.
-        guard keyGrid.shiftState != .locked else { return }
-
-        let before = (snapshot ?? document).before ?? ""
-        switch requested {
-        case .none:
-            keyGrid.shiftState = .off
-        case .words:
-            keyGrid.shiftState = before.isEmpty || before.last?.isWhitespace == true ? .on : .off
-        default:
-            // "e.g. ", "Mr. " and "3. " all end in a full stop and none of them
-            // ends a sentence. See `SentenceBoundary`.
-            keyGrid.shiftState = SentenceBoundary.endsSentence(before) ? .on : .off
-        }
+        // `nil` means leave the shift key alone, which is the answer whenever
+        // the host declined to say what the document contains. See
+        // ``AutomaticShift``.
+        guard let state = AutomaticShift.state(
+            documentBefore: (snapshot ?? document).before,
+            autocapitalization: textDocumentProxy.autocapitalizationType ?? .sentences,
+            current: keyGrid.shiftState
+        ) else { return }
+        keyGrid.shiftState = state
     }
 }
 
@@ -1461,6 +1461,7 @@ extension KeyboardViewController: DictationBarViewDelegate {
     /// the literal means nothing to it at all.
     func dictationBar(_ bar: DictationBarView, didChoose candidate: TypingCandidate) {
         guard !isPerformingInsertion else { return }
+        currentDocument = readDocument()
         defer { currentDocument = nil }
         switch candidate.kind {
         case .literal:

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -110,13 +110,18 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             controller.applyLayoutMetrics()
         }
         publishKeyboardStatus()
-        typing.onStrip = { [weak self] _ in
+        typing.onStrip = { [weak self] strip in
             guard let self else { return }
-            render(lastRecord)
+            renderStrip(strip)
             noteAvailableMemory(.firstCandidates)
         }
         typing.onWordListLoaded = { [weak self] list in
             self?.keyGrid.swipeWordList = list
+        }
+        // The language half of the touch model. Straight through to the grid,
+        // which hands it to the hit map — nothing here interprets it.
+        typing.onNextCharacters = { [weak self] weights in
+            self?.keyGrid.nextCharacterLikelihood = weights
         }
         // The user's own text replacements and contact names. Requested once per
         // instance; if Full Access is off it simply comes back empty.
@@ -260,6 +265,11 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
     override func textDidChange(_ textInput: (any UITextInput)?) {
         super.textDidChange(textInput)
+        // Re-read once here and let everything below share it. This runs after
+        // every insertion this keyboard makes, so it is the single hottest place
+        // in the extension for a redundant hop into the host process.
+        let snapshot = refreshDocument()
+        defer { currentDocument = nil }
         // Moving to a different field brings different traits with it, and the
         // plane should reset so a number pad never leaves the user on letters.
         let documentID = currentDocumentID
@@ -267,9 +277,6 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             lastDocumentID = documentID
             lastSpaceInsertedAt = nil
             applyDocumentTraits()
-            keyGrid.plane = Self.initialPlane(
-                for: textDocumentProxy.keyboardType ?? .default
-            )
             // A waiting transcript parks itself when the cursor leaves its field
             // and re-arms when it comes back. Both were left to the next poll,
             // so the bar could still offer Insert for a field the user had
@@ -279,9 +286,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         } else {
             // Same field, but something moved the cursor or edited the text
             // without going through this keyboard. The document wins.
-            typing.reconcile(documentBefore: textDocumentProxy.documentContextBeforeInput)
+            typing.reconcile(document: snapshot)
         }
-        updateAutomaticShift()
+        updateReturnKeyEnablement(for: snapshot)
+        updateAutomaticShift(for: snapshot)
     }
 
     // MARK: - Dictation actions
@@ -372,21 +380,24 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     // MARK: - Typing
 
     func keyGrid(_ grid: KeyGridView, didProduce output: KeyboardOutput) {
+        // One read for the whole event. Cleared on the way out so the next one
+        // starts from what the document actually says now.
+        defer { currentDocument = nil }
         switch output {
         case let .text(text):
             if let substitution = SmartPunctuation.substitution(
                 for: text,
-                before: documentBefore ?? "",
+                before: document.before ?? "",
                 traits: smartPunctuation
             ) {
                 for _ in 0..<substitution.deletions { textDocumentProxy.deleteBackward() }
                 textDocumentProxy.insertText(substitution.insertion)
-                typing.insert(substitution.insertion, documentBefore: documentBefore)
+                typing.insert(substitution.insertion, document: refreshDocument())
             } else if Self.isBoundary(text) {
                 commitComposition(followedBy: text)
             } else {
                 textDocumentProxy.insertText(text)
-                typing.insert(text, documentBefore: documentBefore)
+                typing.insert(text, document: refreshDocument())
             }
             lastSpaceInsertedAt = nil
             releaseUndoIfDetached()
@@ -402,7 +413,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             releaseUndoIfDetached()
         case .deleteWord:
             deleteWordBackward()
-            typing.resetComposition(documentBefore: documentBefore)
+            typing.resetComposition(document: refreshDocument())
             releaseUndoIfDetached()
         case .emojiPanel:
             showEmojiPanel(true)
@@ -414,6 +425,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
                 ? word.prefix(1).uppercased() + word.dropFirst()
                 : word
             textDocumentProxy.insertText(cased + " ")
+            refreshDocument()
             typing.noteSwipeWord(cased, alternates: alternates)
             lastSpaceInsertedAt = nil
             releaseUndoIfDetached()
@@ -423,7 +435,12 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             lastSpaceInsertedAt = nil
             // The cursor is somewhere else now, so whatever was being composed
             // belongs to a different part of the document.
-            typing.reconcile(documentBefore: documentBefore)
+            typing.reconcile(document: refreshDocument())
+            releaseUndoIfDetached()
+        case let .moveCursorLine(lines):
+            moveCursorByLines(lines)
+            lastSpaceInsertedAt = nil
+            typing.reconcile(document: refreshDocument())
             releaseUndoIfDetached()
         case let .nextInputMode(anchor, event):
             // `handleInputModeList` also drives the long-press keyboard picker,
@@ -475,8 +492,44 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         return panel
     }
 
-    private var documentBefore: String? {
-        textDocumentProxy.documentContextBeforeInput
+    /// The text either side of the cursor, read once and reused for the rest of
+    /// the event.
+    ///
+    /// Every read of `documentContextBeforeInput` is a synchronous hop into the
+    /// host application. A single keystroke used to make six or seven of them:
+    /// smart punctuation, the composer, the undo check, then `textDidChange`
+    /// coming back for the document identifier, the composer again, and
+    /// autocapitalization. On a slow host that is most of a frame spent asking
+    /// the same question.
+    private func readDocument() -> DocumentSnapshot {
+        DocumentSnapshot(
+            before: textDocumentProxy.documentContextBeforeInput,
+            after: textDocumentProxy.documentContextAfterInput
+        )
+    }
+
+    /// The snapshot taken at the start of the event currently being handled.
+    ///
+    /// Held for the duration of one call into this controller and cleared after
+    /// it, so nothing can accidentally read a snapshot from the *previous*
+    /// keystroke: stale context here is a wrong autocorrect, not a slow one.
+    private var currentDocument: DocumentSnapshot?
+
+    private var document: DocumentSnapshot {
+        if let currentDocument { return currentDocument }
+        let snapshot = readDocument()
+        currentDocument = snapshot
+        return snapshot
+    }
+
+    /// Re-reads the document after this keyboard has changed it. The insertion
+    /// has already happened, so the cached snapshot no longer describes what the
+    /// composer is looking at.
+    @discardableResult
+    private func refreshDocument() -> DocumentSnapshot {
+        let snapshot = readDocument()
+        currentDocument = snapshot
+        return snapshot
     }
 
     /// Re-read per keystroke rather than cached: the field can change its own
@@ -516,8 +569,14 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             let rewrite = typing.composer.rewrite(to: replacement)
             for _ in 0..<rewrite.deletions { textDocumentProxy.deleteBackward() }
             textDocumentProxy.insertText(rewrite.insertion + boundary)
+            // Order matters and used to be the other way round. Feeding the
+            // boundary through the engine clears any pending revert, so noting
+            // the correction first meant it was wiped by the very space that
+            // applied it — Delete had nothing to restore, and undo-autocorrect,
+            // the behaviour people rely on without knowing its name, silently
+            // did nothing at all.
+            typing.insert(boundary, document: refreshDocument())
             typing.noteCorrection(typed: typed, replacement: replacement, boundary: boundary)
-            typing.insert(boundary, documentBefore: documentBefore)
             // The correction is the one keyboard action a user may not have
             // noticed, so it announces itself — and only it.
             UIAccessibility.post(
@@ -528,7 +587,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         }
         if !boundary.isEmpty { textDocumentProxy.insertText(boundary) }
         if !typed.isEmpty { typing.noteCompletedWord(typed) }
-        typing.insert(boundary.isEmpty ? " " : boundary, documentBefore: documentBefore)
+        typing.insert(boundary.isEmpty ? " " : boundary, document: refreshDocument())
     }
 
     /// Delete, which is also how an autocorrect is undone.
@@ -538,26 +597,38 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// document. This is the behaviour people rely on without knowing its name,
     /// and getting it wrong is how a keyboard becomes something to fight.
     private func deleteBackward() {
-        if let revert = typing.takeRevert() {
-            let removals = revert.replacement.count + revert.boundary.count
-            for _ in 0..<removals { textDocumentProxy.deleteBackward() }
-            textDocumentProxy.insertText(revert.typed + revert.boundary)
-            typing.reconcile(documentBefore: documentBefore)
-            UIAccessibility.post(
-                notification: .announcement,
-                argument: "Restored \(revert.typed)"
-            )
-            return
-        }
+        guard !revertPendingCorrection() else { return }
         textDocumentProxy.deleteBackward()
-        typing.deleteBackward(documentBefore: documentBefore)
+        typing.deleteBackward(document: refreshDocument())
+    }
+
+    /// Puts back exactly what the user typed, if an autocorrect is still
+    /// standing. Reports whether it did.
+    ///
+    /// Reached two ways, which is the point of it being one function: pressing
+    /// Delete as the very next action, and tapping the chip the strip offers
+    /// right afterwards. The system keyboard draws that offer as a bubble under
+    /// the word itself; an extension is never told where the word is on screen,
+    /// so the strip is the surface this keyboard can honestly put it on.
+    @discardableResult
+    private func revertPendingCorrection() -> Bool {
+        guard let revert = typing.takeRevert() else { return false }
+        let removals = revert.replacement.count + revert.boundary.count
+        for _ in 0..<removals { textDocumentProxy.deleteBackward() }
+        textDocumentProxy.insertText(revert.typed + revert.boundary)
+        typing.reconcile(document: refreshDocument())
+        UIAccessibility.post(
+            notification: .announcement,
+            argument: "Restored \(revert.typed)"
+        )
+        return true
     }
 
     func keyGridDidChangeShift(_ grid: KeyGridView) {}
 
     private func insertSpace() {
         let proxy = textDocumentProxy
-        let before = proxy.documentContextBeforeInput ?? ""
+        let before = document.before ?? ""
         // A second space closes the sentence instead of doubling the gap, which
         // is the iOS behaviour people type by reflex. It can never coincide with
         // a pending correction: the previous space already ended that word.
@@ -571,7 +642,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             proxy.deleteBackward()
             proxy.insertText(". ")
             lastSpaceInsertedAt = nil
-            typing.insert(". ", documentBefore: documentBefore)
+            typing.insert(". ", document: refreshDocument())
         } else {
             commitComposition(followedBy: " ")
             lastSpaceInsertedAt = Date()
@@ -579,9 +650,65 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         releaseUndoIfDetached()
     }
 
+    /// Moves the cursor a whole line up or down, keeping its column.
+    ///
+    /// A keyboard extension can only `adjustTextPosition(byCharacterOffset:)`,
+    /// so "one line" has to be counted out in characters from the document
+    /// context — which is why this lives here rather than in the grid: the grid
+    /// knows the finger moved, and only the controller can see the text.
+    ///
+    /// Clamped to the ends. Off the top or bottom of the visible context the
+    /// cursor goes to the start or end of it rather than nowhere, which is what
+    /// the user is reaching for anyway.
+    private func moveCursorByLines(_ lines: Int) {
+        guard lines != 0 else { return }
+        let snapshot = document
+        let beforeLines = (snapshot.before ?? "").components(separatedBy: "\n")
+        let afterLines = (snapshot.after ?? "").components(separatedBy: "\n")
+        // How far into its own line the cursor sits. The last element of the
+        // leading context is the part of the current line behind the cursor.
+        let column = beforeLines.last?.count ?? 0
+        let proxy = textDocumentProxy
+
+        if lines < 0 {
+            // Nothing above in the visible context: the start of this line is
+            // the nearest thing to what was asked for, and it is where a finger
+            // dragged off the top is reaching anyway.
+            guard beforeLines.count > 1 else {
+                if column > 0 { proxy.adjustTextPosition(byCharacterOffset: -column) }
+                return
+            }
+            let steps = min(-lines, beforeLines.count - 1)
+            let target = beforeLines.count - 1 - steps
+            // Back to the start of the current line, then over each line
+            // skipped along with the break that ended it.
+            var offset = -column
+            for index in stride(from: beforeLines.count - 2, through: target, by: -1) {
+                offset -= 1 + beforeLines[index].count
+            }
+            // Forward into the target line, clamped to its end so a short line
+            // keeps the cursor on it rather than past it.
+            offset += min(column, beforeLines[target].count)
+            proxy.adjustTextPosition(byCharacterOffset: offset)
+        } else {
+            guard afterLines.count > 1 else {
+                let tail = afterLines.first?.count ?? 0
+                if tail > 0 { proxy.adjustTextPosition(byCharacterOffset: tail) }
+                return
+            }
+            let steps = min(lines, afterLines.count - 1)
+            var offset = afterLines[0].count
+            for index in 1..<steps {
+                offset += 1 + afterLines[index].count
+            }
+            offset += 1 + min(column, afterLines[steps].count)
+            proxy.adjustTextPosition(byCharacterOffset: offset)
+        }
+    }
+
     private func deleteWordBackward() {
         let proxy = textDocumentProxy
-        guard let before = proxy.documentContextBeforeInput, !before.isEmpty else {
+        guard let before = document.before, !before.isEmpty else {
             proxy.deleteBackward()
             return
         }
@@ -601,7 +728,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// that would delete the wrong characters.
     private func releaseUndoIfDetached() {
         guard let inserted = lastInsertedText,
-              textDocumentProxy.documentContextBeforeInput?.hasSuffix(inserted) != true
+              document.before?.hasSuffix(inserted) != true
         else { return }
         lastInsertedText = nil
         refresh()
@@ -713,7 +840,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             // A transcript arrives as finished text. It never becomes a
             // composition and is never autocorrected: the model that produced it
             // already had its say.
-            typing.resetComposition(origin: .dictated, documentBefore: nil)
+            typing.resetComposition(origin: .dictated, document: .unknown)
             try record.transition(to: .inserted)
             try store.save(record)
             try record.transition(to: .completed)
@@ -941,6 +1068,36 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         render(record)
     }
 
+    /// A strip update, and only a strip update.
+    ///
+    /// This runs on every keystroke, and it used to go through the full
+    /// ``render(_:)`` — rebuilding the entire dictation bar model from the
+    /// session record, the preference state and the transcript, re-deriving the
+    /// bar's layout and height, and re-running the preference controls — to
+    /// change three words in a row of chips. The bar's own `apply` bails on an
+    /// unchanged model, but everything upstream of that comparison had already
+    /// been paid for.
+    ///
+    /// The fast path is only taken when the bar is genuinely showing the strip.
+    /// A recording or a waiting transcript owns the bar, and its candidates are
+    /// empty by construction — those go through the full render, where they
+    /// belong.
+    private func renderStrip(_ strip: TypingStrip) {
+        // An empty strip means the bar goes back to its controls, which is a
+        // change of body rather than a change of chips — that belongs to the
+        // full render, which owns the crossfade between the two.
+        guard barLayout == .strip,
+              !strip.candidates.isEmpty,
+              lastRecord == nil || lastRecord?.state == .idle
+        else {
+            render(lastRecord)
+            return
+        }
+        // The bar may still be showing its controls, in which case arriving at
+        // the strip is a change of body and the full render owns the crossfade.
+        if !dictationBar.updateCandidates(strip.candidates) { render(lastRecord) }
+    }
+
     private func render(_ record: SessionRecord?) {
         lastRecord = record
         updatePolling(for: record)
@@ -1122,9 +1279,38 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         let returnKeyType = proxy.returnKeyType ?? .default
         keyGrid.returnKeyTitle = Self.returnKeyTitle(for: returnKeyType)
         keyGrid.returnKeyIsProminent = returnKeyType != .default
-        keyGrid.leadingPunctuation = Self.leadingPunctuation(for: proxy.keyboardType ?? .default)
-        keyGrid.keyboardType = proxy.keyboardType ?? .default
+        let keyboardType = proxy.keyboardType ?? .default
+        keyGrid.punctuation = Self.punctuation(for: keyboardType)
+        keyGrid.keyboardType = keyboardType
+        // The plane belongs to the field, not to wherever the last one left it.
+        // A phone-number field has to arrive on its keypad, and it has nowhere
+        // else to go once it is there.
+        keyGrid.plane = Self.initialPlane(for: keyboardType)
+        updateReturnKeyEnablement()
         applyTheme()
+    }
+
+    /// Dims Return in the fields that asked for it.
+    ///
+    /// `enablesReturnKeyAutomatically` is a field saying "there is nothing to
+    /// send until something has been typed", and the system keyboard answers it
+    /// by greying the key out. Ignoring it meant a Send button that looked live
+    /// over an empty message and fired on an empty message.
+    private func updateReturnKeyEnablement(for snapshot: DocumentSnapshot? = nil) {
+        guard textDocumentProxy.enablesReturnKeyAutomatically == true else {
+            keyGrid.returnKeyIsEnabled = true
+            return
+        }
+        let resolved = snapshot ?? document
+        // The proxy answers with nothing while the keyboard is loading, which is
+        // not the same as an empty field. Dimming Return on that would grey out
+        // the Send button over a message the user has already written.
+        guard resolved.before != nil || resolved.after != nil else {
+            keyGrid.returnKeyIsEnabled = true
+            return
+        }
+        keyGrid.returnKeyIsEnabled = !(resolved.before ?? "").isEmpty
+            || !(resolved.after ?? "").isEmpty
     }
 
     private static func returnKeyTitle(for type: UIReturnKeyType) -> String {
@@ -1147,20 +1333,29 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// the way the system keyboard does. A plain iPhone QWERTY has `123`, the
     /// globe, space and return on that row and nothing else; the comma and full
     /// stop this used to add were two keys the spacebar could have been.
-    private static func leadingPunctuation(for type: UIKeyboardType) -> String? {
+    private static func punctuation(for type: UIKeyboardType) -> KeyLayout.BottomRowPunctuation? {
         switch type {
-        case .emailAddress: "@"
-        case .URL, .webSearch: "/"
+        case .emailAddress: KeyLayout.BottomRowPunctuation(leading: "@", trailing: ".")
+        case .URL, .webSearch: KeyLayout.BottomRowPunctuation(leading: "/", trailing: ".")
+        // The two characters a Twitter-style field is for. iOS puts both on the
+        // bottom row here, and the pair used to be unreachable because the
+        // trailing slot was hardcoded to a full stop.
+        case .twitter: KeyLayout.BottomRowPunctuation(leading: "@", trailing: "#")
         default: nil
         }
     }
 
     private static func initialPlane(for type: UIKeyboardType) -> KeyPlane {
         switch type {
-        case .numberPad, .phonePad, .decimalPad, .asciiCapableNumberPad, .numbersAndPunctuation:
-            .numbers
-        default:
-            .letters
+        // A real keypad, not the symbols plane wearing a hat. A verification
+        // code or a phone number typed against `-/:;()$&@"` is a keyboard that
+        // has not noticed where it is.
+        case .numberPad, .asciiCapableNumberPad: .numberPad
+        case .phonePad: .phonePad
+        case .decimalPad: .decimalPad
+        // Punctuation is the point of this one, so it keeps the full plane.
+        case .numbersAndPunctuation: .numbers
+        default: .letters
         }
     }
 
@@ -1185,7 +1380,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// Autocapitalization follows the field's own request. A username or URL
     /// field asks for none, and forcing sentence case there produced input the
     /// user had to correct on every word.
-    private func updateAutomaticShift() {
+    private func updateAutomaticShift(for snapshot: DocumentSnapshot? = nil) {
         let proxy = textDocumentProxy
         let requested = proxy.autocapitalizationType ?? .sentences
         guard requested != .allCharacters else {
@@ -1195,7 +1390,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // A user-engaged caps lock outranks any automatic decision.
         guard keyGrid.shiftState != .locked else { return }
 
-        let before = proxy.documentContextBeforeInput ?? ""
+        let before = (snapshot ?? document).before ?? ""
         switch requested {
         case .none:
             keyGrid.shiftState = .off
@@ -1214,7 +1409,7 @@ extension KeyboardViewController: EmojiPanelViewDelegate {
         textDocumentProxy.insertText(glyph)
         // An emoji ends a word as surely as a space does, and it is never
         // something to autocorrect.
-        typing.resetComposition(origin: .suggestion, documentBefore: documentBefore)
+        typing.resetComposition(origin: .suggestion, document: refreshDocument())
         releaseUndoIfDetached()
     }
 
@@ -1243,7 +1438,7 @@ extension KeyboardViewController: KeyGridViewDelegate {
     /// fresh press, which is what keeps one long hold from swallowing the
     /// paragraph above the one being edited.
     func keyGridShouldContinueDeleting(_ grid: KeyGridView) -> Bool {
-        guard let before = textDocumentProxy.documentContextBeforeInput else { return true }
+        guard let before = readDocument().before else { return true }
         return !before.isEmpty && !before.hasSuffix("\n")
     }
 }
@@ -1261,6 +1456,7 @@ extension KeyboardViewController: DictationBarViewDelegate {
     /// the literal means nothing to it at all.
     func dictationBar(_ bar: DictationBarView, didChoose candidate: TypingCandidate) {
         guard !isPerformingInsertion else { return }
+        defer { currentDocument = nil }
         switch candidate.kind {
         case .literal:
             // The user's own spelling, asserted. Nothing is rewritten — the
@@ -1268,15 +1464,20 @@ extension KeyboardViewController: DictationBarViewDelegate {
             // stops being corrected, and the keyboard learns it.
             typing.assert(candidate.text)
             render(lastRecord)
+        case .revert:
+            // The correction has already gone into the document. Taking it back
+            // is the same operation Delete performs, and it asserts the word so
+            // the keyboard does not simply do it again on the next sentence.
+            revertPendingCorrection()
         case .completion, .correction:
             let typed = typing.composer.text
             for _ in 0..<typed.count { textDocumentProxy.deleteBackward() }
             textDocumentProxy.insertText(candidate.text + " ")
             typing.noteCompletedWord(candidate.text)
-            typing.resetComposition(origin: .suggestion, documentBefore: documentBefore)
+            typing.resetComposition(origin: .suggestion, document: refreshDocument())
         case .prediction:
             textDocumentProxy.insertText(candidate.text + " ")
-            typing.resetComposition(origin: .suggestion, documentBefore: documentBefore)
+            typing.resetComposition(origin: .suggestion, document: refreshDocument())
         case .swipeAlternate:
             // The swiped word is already in the document with the space that
             // followed it, so the replacement covers both and puts a space
@@ -1288,7 +1489,7 @@ extension KeyboardViewController: DictationBarViewDelegate {
             // subsystem, and a replacement that cannot see the word it is
             // replacing must not delete four characters on faith.
             guard let swiped = typing.pendingSwipeWord,
-                  SwipeAlternates.isArmed(word: swiped, documentBefore: documentBefore)
+                  SwipeAlternates.isArmed(word: swiped, documentBefore: document.before)
             else { break }
             let alternates = SwipeAlternates.alternates(
                 after: candidate.text,
@@ -1299,6 +1500,7 @@ extension KeyboardViewController: DictationBarViewDelegate {
                 textDocumentProxy.deleteBackward()
             }
             textDocumentProxy.insertText(candidate.text + " ")
+            refreshDocument()
             // Re-armed on the new word, so a second thought is another tap
             // rather than a retype.
             typing.noteSwipeWord(candidate.text, alternates: alternates)
@@ -1311,7 +1513,7 @@ extension KeyboardViewController: DictationBarViewDelegate {
             // Deliberately not learned. `noteCompletedWord` teaches the
             // keyboard vocabulary, and an emoji is not a word it should start
             // completing letters into.
-            typing.resetComposition(origin: .suggestion, documentBefore: documentBefore)
+            typing.resetComposition(origin: .suggestion, document: refreshDocument())
         }
         lastSpaceInsertedAt = nil
         releaseUndoIfDetached()

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -19,6 +19,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     private var hasRendered = false
     private var announcesStateChanges = false
     private var lastPublishedAt: Date?
+    private var lastPublishedFullAccess: Bool?
     private static let statusRepublishInterval: TimeInterval = 10
     private var isBarExpanded = false
     private var barLayout = DictationBarLayout.status
@@ -237,12 +238,17 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// that returning to the keyboard repeatedly is not a stream of file writes.
     private func publishKeyboardStatus() {
         let now = Date()
-        if let lastPublishedAt,
-           now.timeIntervalSince(lastPublishedAt) < Self.statusRepublishInterval
-        {
+        guard KeyboardStatusPublication.shouldPublish(
+            lastPublishedAt: lastPublishedAt,
+            lastPublishedFullAccess: lastPublishedFullAccess,
+            fullAccess: hasFullAccess,
+            now: now,
+            minimumInterval: Self.statusRepublishInterval
+        ) else {
             return
         }
         lastPublishedAt = now
+        lastPublishedFullAccess = hasFullAccess
         try? store.saveKeyboardStatus(
             KeyboardStatus(lastSeenAt: now, hasFullAccess: hasFullAccess)
         )

--- a/ios/VocaPhoneKeyboard/ShortWordCorrections.swift
+++ b/ios/VocaPhoneKeyboard/ShortWordCorrections.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// The corrections a spell checker will never make, because nothing is
+/// misspelled.
+///
+/// ``TypingCandidates/autocorrection(_:)`` refuses anything shorter than three
+/// letters, anything the checker recognises, and anything that only changes
+/// case — three rules that are each individually right and that together
+/// silently disable the corrections people notice first. "i" is a word. "im",
+/// "dont", "cant" and "youre" are all either real words or close enough that
+/// the checker declines to guess. So the keyboard typed exactly what the user
+/// pressed, forever, while the system keyboard beside it fixed all of them.
+///
+/// This is the curated answer: a small table, applied ahead of the general
+/// path, holding only substitutions where there is no second reading. It stops
+/// well short of a style guide — "ok" stays "ok", "thru" stays "thru" — because
+/// the moment a table like this starts having opinions it becomes something to
+/// fight.
+enum ShortWordCorrections {
+    /// Lowercase typed form to replacement. The replacement carries its own
+    /// capitalization, which is the point for the "I" family.
+    static let table: [String: String] = [
+        // The one every user notices in the first minute.
+        "i": "I",
+        "im": "I'm",
+        "id": "I'd",
+        "ill": "I'll",
+        "ive": "I've",
+
+        // Contractions the checker either recognises as other words or has no
+        // confident guess for.
+        "dont": "don't",
+        "doesnt": "doesn't",
+        "didnt": "didn't",
+        "cant": "can't",
+        "couldnt": "couldn't",
+        "shouldnt": "shouldn't",
+        "wouldnt": "wouldn't",
+        "wont": "won't",
+        "isnt": "isn't",
+        "arent": "aren't",
+        "wasnt": "wasn't",
+        "werent": "weren't",
+        "hasnt": "hasn't",
+        "havent": "haven't",
+        "hadnt": "hadn't",
+        "youre": "you're",
+        "youve": "you've",
+        "youll": "you'll",
+        "youd": "you'd",
+        "theyre": "they're",
+        "theyve": "they've",
+        "theyll": "they'll",
+        "theyd": "they'd",
+        "weve": "we've",
+        "whats": "what's",
+        "thats": "that's",
+        "wheres": "where's",
+        "hows": "how's",
+        "whos": "who's",
+        "lets": "let's",
+        "aint": "ain't",
+        "oclock": "o'clock",
+    ]
+
+    /// Words deliberately absent, and why, so nobody adds them back:
+    ///
+    /// - "its" and "it's" are different words and only grammar can tell them
+    ///   apart. Correcting either way is wrong half the time.
+    /// - "were", "well", "hell", "shell" and "wed" are all ordinary words in
+    ///   their own right, and far too common to spend on a contraction.
+    ///   "cant" is borderline and kept, because "can't" wins overwhelmingly.
+    /// - "shes", "hes" both map to a possessive reading often enough to leave.
+    ///
+    /// Kept as prose rather than a set: this is a note to the next person, not
+    /// a lookup anything performs.
+    static func replacement(for typed: String) -> String? {
+        table[typed.lowercased()]
+    }
+
+    /// Whether this word has an entry at all, which is also the reason the
+    /// general path must not run on it: the table's answer is better than
+    /// anything the checker would offer.
+    static func hasReplacement(for typed: String) -> Bool {
+        table[typed.lowercased()] != nil
+    }
+}

--- a/ios/VocaPhoneKeyboard/SmartPunctuation.swift
+++ b/ios/VocaPhoneKeyboard/SmartPunctuation.swift
@@ -109,6 +109,56 @@ enum SmartPunctuation {
     }
 }
 
+/// Whether the shift key should turn itself on, given what the document says.
+///
+/// Pure, and separated from the controller for one reason: the decision has a
+/// third answer. As well as "on" and "off" there is **"do not touch it"**, and
+/// collapsing that into one of the other two is what produced capital letters in
+/// the middle of words.
+///
+/// `UITextDocumentProxy` returns `nil` for its context whenever the host has not
+/// answered — while the keyboard is loading, and transiently while the host is
+/// mid-update. This code used to read that as `""`, and an empty document is the
+/// start of a sentence, so Shift came on. The host answers on most keystrokes
+/// and not on others, so the capital landed on whichever letter happened to
+/// follow a read the host skipped: "how Are you", "I am The good". Nothing about
+/// it looked like a rule, which is exactly why it read as random.
+///
+/// The rest of this file already knew better — ``WordComposer/reconcile(documentBefore:)``
+/// guards on the same `nil` and says so in its own comment. This is the one
+/// place that did not.
+enum AutomaticShift {
+    /// The state to move to, or `nil` to leave the shift key exactly as it is.
+    static func state(
+        documentBefore: String?,
+        autocapitalization: UITextAutocapitalizationType,
+        current: ShiftState
+    ) -> ShiftState? {
+        // The field wants everything capitalised, which it can say without the
+        // keyboard knowing a thing about the document.
+        if autocapitalization == .allCharacters { return .locked }
+        // A user-engaged caps lock outranks any automatic decision.
+        guard current != .locked else { return nil }
+        // The host did not answer. Not an empty document — no information at
+        // all — so the last decision, which was made from a context the host
+        // *did* answer, stands.
+        guard let documentBefore else { return nil }
+
+        switch autocapitalization {
+        case .none:
+            return .off
+        case .words:
+            return documentBefore.isEmpty || documentBefore.last?.isWhitespace == true
+                ? .on
+                : .off
+        default:
+            // "e.g. ", "Mr. " and "3. " all end in a full stop and none of them
+            // ends a sentence. See `SentenceBoundary`.
+            return SentenceBoundary.endsSentence(documentBefore) ? .on : .off
+        }
+    }
+}
+
 /// Sentence capitalization that knows an abbreviation from a full stop.
 ///
 /// `updateAutomaticShift` treats ". " as the end of a sentence. So does "e.g. ",

--- a/ios/VocaPhoneKeyboard/SpellChecking.swift
+++ b/ios/VocaPhoneKeyboard/SpellChecking.swift
@@ -108,6 +108,15 @@ struct SuggestionCache {
         var completions: [String]
         var guesses: [String]
         var isKnown: Bool
+        /// Near-matches from the shipped word list.
+        ///
+        /// Cached here rather than recomputed per keystroke, which is what it
+        /// used to be: `similarWords` scans the list computing edit distances,
+        /// it runs on the main actor, and it ran on the *cache hit* path too —
+        /// so the cache that exists to keep the checker off the keystroke was
+        /// letting an equally expensive scan straight through it. Typing a name,
+        /// which is exactly when nothing is in the list, was the worst case.
+        var similar: [String] = []
     }
 
     private var storage: [Key: Value] = [:]

--- a/ios/VocaPhoneKeyboard/SwipeRecognizer.swift
+++ b/ios/VocaPhoneKeyboard/SwipeRecognizer.swift
@@ -25,17 +25,44 @@ struct SwipeRecognizer {
     static let activationDistance: CGFloat = 26
 
     private let keys: [Key]
+    /// Centre by character. Sampling a word's ideal path looks up twelve points
+    /// per candidate, and doing that with a linear scan over `keys` made the
+    /// lookup itself the dominant cost of scoring.
+    private let centres: [Character: CGPoint]
     /// Derived from the keys themselves rather than assumed: a Compact keyboard
     /// on a 320pt phone has very different spacing from a Tall one on a Max.
     private let neighbourRadius: CGFloat
+    /// Neighbour sets for every key, resolved once. `candidates` asks for the
+    /// first and last key's neighbours, and `medianPitch` has already paid for
+    /// the distances.
+    private let neighbourCache: [Character: Set<Character>]
 
     init(keys: [Key]) {
         self.keys = keys
+        var centres: [Character: CGPoint] = [:]
+        centres.reserveCapacity(keys.count)
+        for key in keys where centres[key.character] == nil {
+            centres[key.character] = key.centre
+        }
+        self.centres = centres
         // 1.4 × the typical column pitch: far enough to include the keys either
         // side and the ones above and below, not so far as to include a third
         // of the alphabet.
         let pitch = Self.medianPitch(of: keys)
-        neighbourRadius = pitch * 1.4
+        let radius = pitch * 1.4
+        neighbourRadius = radius
+        var neighbourCache: [Character: Set<Character>] = [:]
+        for key in keys {
+            neighbourCache[key.character] = Set(
+                keys
+                    .filter {
+                        $0.character != key.character
+                            && Self.distance($0.centre, key.centre) < radius
+                    }
+                    .map(\.character)
+            )
+        }
+        self.neighbourCache = neighbourCache
     }
 
     var isUsable: Bool { keys.count > 10 }
@@ -56,22 +83,25 @@ struct SwipeRecognizer {
     }
 
     func nearestKey(to point: CGPoint) -> Key? {
-        keys.min { first, second in
-            Self.distance(first.centre, point) < Self.distance(second.centre, point)
+        var nearest: Key?
+        var shortest = CGFloat.greatestFiniteMagnitude
+        for key in keys {
+            // Squared distance: the ordering is the same and the square root
+            // was being taken once per key per sampled point of the trace.
+            let dx = key.centre.x - point.x
+            let dy = key.centre.y - point.y
+            let squared = dx * dx + dy * dy
+            if squared < shortest {
+                shortest = squared
+                nearest = key
+            }
         }
+        return nearest
     }
 
     /// Letters whose keys sit within a finger's slop of this one.
     func neighbours(of character: Character) -> Set<Character> {
-        guard let origin = keys.first(where: { $0.character == character }) else { return [] }
-        return Set(
-            keys
-                .filter {
-                    $0.character != character
-                        && Self.distance($0.centre, origin.centre) < neighbourRadius
-                }
-                .map(\.character)
-        )
+        neighbourCache[character] ?? []
     }
 
     // MARK: - Matching
@@ -90,9 +120,20 @@ struct SwipeRecognizer {
         let starts = neighbours(of: first).union([first])
         let ends = neighbours(of: last).union([last])
 
+        // The collapsed forms come from the list, which built them once when it
+        // loaded. The cheap tests — first key, last key, subsequence — run
+        // before any scoring, so the expensive shape comparison only ever sees
+        // the handful of words a trace could plausibly be.
+        let words = wordList.rankedWords
+        let collapsed = wordList.collapsedWords
+        // The traced path's own samples and length do not change from one
+        // candidate to the next, and `shapeDistance` was re-deriving both for
+        // every word it scored.
+        let tracedSamples = sample(path)
+        let tracedLength = pathLength(path)
         var scored: [(word: String, score: CGFloat)] = []
-        for (rank, word) in wordList.rankedWords.enumerated() {
-            let compact = Self.collapsed(word)
+        for rank in words.indices {
+            let compact = collapsed[rank]
             guard compact.count >= 2,
                   let wordFirst = compact.first,
                   let wordLast = compact.last,
@@ -103,7 +144,16 @@ struct SwipeRecognizer {
                   // word containing one.
                   Self.isSubsequence(compact, of: path)
             else { continue }
-            scored.append((word, score(path: path, word: compact, frequencyRank: rank)))
+            scored.append((
+                words[rank],
+                score(
+                    path: path,
+                    tracedSamples: tracedSamples,
+                    tracedLength: tracedLength,
+                    word: compact,
+                    frequencyRank: rank
+                )
+            ))
         }
         return scored
             .sorted { $0.score > $1.score }
@@ -115,8 +165,26 @@ struct SwipeRecognizer {
     /// whose ends do not match the trace's ends is penalised heavily — those
     /// are the two keys the user was most deliberate about.
     func score(path: String, word: String, frequencyRank: Int) -> CGFloat {
-        let shape = shapeDistance(path: path, word: word)
-        let lengthGap = abs(pathLength(path) - pathLength(word))
+        score(
+            path: path,
+            tracedSamples: sample(path),
+            tracedLength: pathLength(path),
+            word: word,
+            frequencyRank: frequencyRank
+        )
+    }
+
+    /// The same score with the traced path's samples and length supplied, so a
+    /// run over the word list derives them once rather than ten thousand times.
+    func score(
+        path: String,
+        tracedSamples: [CGPoint],
+        tracedLength: CGFloat,
+        word: String,
+        frequencyRank: Int
+    ) -> CGFloat {
+        let shape = shapeDistance(traced: tracedSamples, word: word)
+        let lengthGap = abs(tracedLength - pathLength(word))
         let endPenalty = (word.first == path.first ? 0 : 0.7)
             + (word.last == path.last ? 0 : 0.7)
         let frequency = 1 / (1 + CGFloat(frequencyRank) / 400)
@@ -132,7 +200,10 @@ struct SwipeRecognizer {
     /// Mean distance between the traced path and the ideal one through the
     /// word's keys, both resampled to the same number of points.
     func shapeDistance(path: String, word: String) -> CGFloat {
-        let traced = sample(path)
+        shapeDistance(traced: sample(path), word: word)
+    }
+
+    func shapeDistance(traced: [CGPoint], word: String) -> CGFloat {
         let ideal = sample(word)
         guard !traced.isEmpty, ideal.count == traced.count else { return .greatestFiniteMagnitude }
         let total = zip(traced, ideal).reduce(CGFloat.zero) { $0 + Self.distance($1.0, $1.1) }
@@ -144,9 +215,7 @@ struct SwipeRecognizer {
     /// Resamples the polyline through a string's key centres at even spacing,
     /// which is what makes two paths of different lengths comparable.
     func sample(_ letters: String) -> [CGPoint] {
-        let points = letters.compactMap { character in
-            keys.first { $0.character == character }?.centre
-        }
+        let points = letters.compactMap { centres[$0] }
         guard !points.isEmpty else { return [] }
         guard points.count > 1 else {
             return Array(repeating: points[0], count: Self.samplePoints)
@@ -170,9 +239,7 @@ struct SwipeRecognizer {
     }
 
     private func pathLength(_ letters: String) -> CGFloat {
-        let points = letters.compactMap { character in
-            keys.first { $0.character == character }?.centre
-        }
+        let points = letters.compactMap { centres[$0] }
         guard points.count > 1 else { return 0 }
         return (1..<points.count).reduce(CGFloat.zero) {
             $0 + Self.distance(points[$1 - 1], points[$1])

--- a/ios/VocaPhoneKeyboard/TypingCandidates.swift
+++ b/ios/VocaPhoneKeyboard/TypingCandidates.swift
@@ -279,8 +279,19 @@ enum TypingCandidates {
         // only a case and apostrophe away from nothing the checker will guess —
         // and refusing them is what made this keyboard visibly worse than the
         // system one at the corrections people notice first.
-        // Exact comparison here, and here it *is* the whole point: "i" → "I" is a
-        // case-only change, which is precisely what the general path below
+        // Acronyms stand. "WIP" is not a misspelling of "wip", and "DONT"
+        // typed with caps lock on is not asking to become "don't" — someone
+        // shouting has still chosen their letters.
+        //
+        // Above the curated table rather than below it, which is where this
+        // check used to sit: the table would otherwise rewrite a shouted
+        // contraction before the acronym rule ever ran. Deliberately *below*
+        // the lexicon, because a text replacement is an instruction the user
+        // configured, and "OMW" should expand whatever case it is typed in.
+        guard !isAllCaps(typed) else { return nil }
+
+        // Exact comparison here, and here it *is* the whole point: "i" → "I" is
+        // a case-only change, which is precisely what the general path below
         // refuses and precisely what this table exists to allow.
         //
         // Safe here and not for the lexicon above because this table is
@@ -321,9 +332,6 @@ enum TypingCandidates {
         guard typed.allSatisfy({ $0.isLetter || $0 == "'" || $0 == "\u{2019}" }) else {
             return nil
         }
-
-        // Acronyms stand. "WIP" is not a misspelling of "wip".
-        guard !isAllCaps(typed) else { return nil }
 
         let guesses = context.systemGuesses.filter {
             $0.caseInsensitiveCompare(typed) != .orderedSame

--- a/ios/VocaPhoneKeyboard/TypingCandidates.swift
+++ b/ios/VocaPhoneKeyboard/TypingCandidates.swift
@@ -19,6 +19,16 @@ struct TypingCandidate: Equatable {
         /// Distinct from ``correction`` because replacing it has to take the
         /// space the swipe inserted with it — see ``SwipeAlternates``.
         case swipeAlternate
+        /// The word the user actually typed, offered back immediately after an
+        /// autocorrect replaced it.
+        ///
+        /// The system keyboard draws a small bubble under the corrected word
+        /// carrying the original. An extension cannot: the word is in the host
+        /// app's text view, in another process, at coordinates this keyboard is
+        /// never told. The strip is the surface this keyboard does own, so the
+        /// offer goes there — visible for exactly as long as the correction is
+        /// still the last thing that happened.
+        case revert
     }
 
     let text: String
@@ -69,6 +79,22 @@ enum TypingCandidates {
         var systemGuesses: [String] = []
         var listCompletions: [String] = []
         var predictions: [String] = []
+        /// What usually follows ``precedingWord``. Distinct from ``predictions``
+        /// — which is the same data used to fill an *empty* strip — because here
+        /// it is evidence about the word being typed rather than a guess about
+        /// the next one. "I'll be there son" and "sooner" are the same distance
+        /// from "son"; only "be there" says which.
+        var contextualFollowers: [String] = []
+
+        /// The user's own text replacement for exactly this input, if they have
+        /// one. iOS hands keyboards the lexicon specifically so that "omw" can
+        /// mean what its owner told Settings it means.
+        var lexiconExpansion: String?
+
+        /// Whether the cursor sits inside a longer word rather than at the end
+        /// of one. Nothing may be replaced there: the composition is a prefix of
+        /// a word the keyboard can only see half of.
+        var isMidWord = false
 
         /// Whether the system checker recognises the composition.
         var isKnownToChecker = false
@@ -132,6 +158,17 @@ enum TypingCandidates {
         return TypingStrip(
             candidates: appendingEmoji(to: candidates, context: context),
             autocorrection: correction
+        )
+    }
+
+    /// The strip shown for as long as a just-applied autocorrect can still be
+    /// taken back — the extension's stand-in for the system keyboard's revert
+    /// bubble, which needs coordinates in the host app that no extension is
+    /// given. One chip, carrying what the user actually typed.
+    static func revertStrip(typed: String) -> TypingStrip {
+        TypingStrip(
+            candidates: [TypingCandidate(text: typed, kind: .revert)],
+            autocorrection: nil
         )
     }
 
@@ -199,17 +236,52 @@ enum TypingCandidates {
         // suggestion were all chosen by something the user saw.
         guard context.origin == .typed else { return nil }
 
+        // The cursor is inside a longer word. The keyboard is holding a prefix
+        // of something it cannot see the end of, and rewriting that prefix
+        // corrupts a word the user never finished typing in the first place.
+        guard !context.isMidWord else { return nil }
+
         let typed = context.composition
+        guard !typed.isEmpty else { return nil }
+
+        // The user's own assertion outranks every source below, including the
+        // curated table: someone who put their spelling back once has answered
+        // this question already.
+        guard !contains(context.customWords, typed),
+              !contains(context.learnedWords, typed),
+              !context.assertedWords.contains(typed.lowercased())
+        else { return nil }
+
+        // A text replacement the user configured in Settings. Highest priority
+        // of anything here — it is not a guess at all, it is an instruction.
+        // Compared exactly, not case-insensitively. A replacement that differs
+        // only in case is still a replacement the user asked for.
+        if let expansion = context.lexiconExpansion, expansion != typed {
+            return expansion
+        }
+
+        // The curated short-word table, ahead of every guard below it. Each of
+        // those guards would refuse these words — "i" is too short, "dont" is
+        // only a case and apostrophe away from nothing the checker will guess —
+        // and refusing them is what made this keyboard visibly worse than the
+        // system one at the corrections people notice first.
+        // Exact comparison again, and here it is the whole point: "i" → "I" is a
+        // case-only change, which is precisely what the general path below
+        // refuses and precisely what this table exists to allow.
+        if let replacement = ShortWordCorrections.replacement(for: typed),
+           replacement != typed
+        {
+            return replacement
+        }
+
         // Two-letter words are mostly deliberate, and the shorter the word the
-        // more words sit within one edit of it.
+        // more words sit within one edit of it. Anything genuinely worth fixing
+        // at that length is in the table above.
         guard typed.count >= 3 else { return nil }
 
         // Anything the user or the language already recognises stands.
         guard !context.isKnownToChecker,
-              !context.isInWordList,
-              !contains(context.customWords, typed),
-              !contains(context.learnedWords, typed),
-              !context.assertedWords.contains(typed.lowercased())
+              !context.isInWordList
         else { return nil }
 
         // A word this keyboard has a curated emoji for is a word people type on
@@ -237,34 +309,98 @@ enum TypingCandidates {
         let guesses = context.systemGuesses.filter {
             $0.caseInsensitiveCompare(typed) != .orderedSame
         }
-        guard let best = guesses.first else { return nil }
+        guard !guesses.isEmpty else { return nil }
 
-        // Close enough to be a typo rather than a different word.
-        let bestDistance = editDistance(typed.lowercased(), best.lowercased(), maximum: 2)
-        guard bestDistance <= 2 else { return nil }
-
-        // A comfortable margin over the runner-up. Two equally close guesses
-        // means the checker does not know which either, and picking one is a
-        // coin toss played with the user's sentence — "hend" is as near to
-        // "hand" as it is to "bend", and only the user knows which.
+        // Re-ranked rather than taken in the order the checker offered them.
         //
-        // A transposition is the exception, because it is the one typo class
-        // with no ambiguity: "teh" is "the" with two keys swapped, and no
-        // competing guess explains the letters as well. Without this exception
-        // the most famous typo in English would go uncorrected.
-        if guesses.count > 1 {
-            let second = editDistance(typed.lowercased(), guesses[1].lowercased(), maximum: 3)
-            let hasMargin = bestDistance < second
-            guard hasMargin || isTransposition(typed.lowercased(), best.lowercased()) else {
-                return nil
-            }
+        // `UITextChecker` ranks by spelling alone, which is the one thing a
+        // keyboard can improve on: it knows where the fingers were, and it knows
+        // what word came before. Both are folded into a single cost here, so the
+        // margin rule below compares like with like.
+        let scored = guesses
+            .map { (word: $0, cost: correctionCost(typed: typed, candidate: $0, context: context)) }
+            .sorted { $0.cost < $1.cost }
+        guard let best = scored.first else { return nil }
+
+        // Close enough to be a typo rather than a different word. Measured
+        // unweighted, because "is this a typo at all" is a question about how
+        // many characters moved, not about which keys they were near.
+        let bestEdits = editDistance(typed.lowercased(), best.word.lowercased(), maximum: 2)
+        guard bestEdits <= 2 else { return nil }
+
+        // A comfortable margin over the runner-up. Two equally good guesses
+        // means nothing here knows which either, and picking one is a coin toss
+        // played with the user's sentence — "hend" is as near to "hand" as it is
+        // to "bend", and only the user knows which.
+        //
+        // Two exceptions, both cases where the ambiguity is only apparent:
+        //
+        // - A transposition. "teh" is "the" with two keys swapped, and no
+        //   competing guess explains the letters as well. Without this the most
+        //   famous typo in English would go uncorrected.
+        // - A word the preceding word actually predicts. "be there son" and
+        //   "be there soon" are the same edit from "son"; the bigram is the
+        //   evidence that breaks the tie, and it is evidence the checker never
+        //   had.
+        if scored.count > 1 {
+            // Two margins, and either one is enough.
+            //
+            // Spelling first: a runner-up that needs strictly more edits is
+            // plainly the worse reading, whatever the fingers were doing. This
+            // is the rule that was here before proximity weighting, and it has
+            // to stay — weighted costs compress the range, so "hand" (one
+            // substitution) and "blend" (an insertion *and* a substitution) came
+            // out only 0.4 apart and the obvious correction stopped firing.
+            //
+            // Proximity second, and only by a wide gap. Being near the key the
+            // finger actually hit is evidence, not proof: it should settle a
+            // contest between two readings the dictionary rates the same, and
+            // never manufacture a winner where there genuinely is not one.
+            // "hend" is one edit from "hand" and one from "bend", and no amount
+            // of knowing that "b" is under "h" makes that a question the
+            // keyboard is entitled to answer.
+            let secondEdits = editDistance(
+                typed.lowercased(),
+                scored[1].word.lowercased(),
+                maximum: 3
+            )
+            let hasSpellingMargin = secondEdits > bestEdits
+            let hasProximityMargin = scored[1].cost - best.cost >= 0.7
+            let isContextual = contains(context.contextualFollowers, best.word)
+            guard hasSpellingMargin
+                || hasProximityMargin
+                || isContextual
+                || isTransposition(typed.lowercased(), best.word.lowercased())
+            else { return nil }
         }
 
         // Capitalization is `updateAutomaticShift`'s job. An autocorrect that
         // only changes case is the keyboard fighting the shift key.
-        guard best.lowercased() != typed.lowercased() else { return nil }
+        guard best.word.lowercased() != typed.lowercased() else { return nil }
 
-        return best
+        return best.word
+    }
+
+    /// How reluctant the keyboard should be to replace `typed` with `candidate`.
+    /// Lower is better; the units are edits, so the margin threshold above means
+    /// something concrete.
+    static func correctionCost(typed: String, candidate: String, context: Context) -> Double {
+        var cost = KeyProximity.weightedDistance(
+            typed.lowercased(),
+            candidate.lowercased(),
+            maximum: 3
+        )
+        // The preceding word predicts this one. Worth about half an edit: enough
+        // to settle a tie, never enough to beat a plainly closer spelling.
+        // Worth more than a neighbouring-key substitution discount, and
+        // deliberately so: which word the sentence wants is better evidence than
+        // which key the finger was near. Not enough to beat a plainly closer
+        // spelling, which the margin rule above still requires.
+        if contains(context.contextualFollowers, candidate) { cost -= 0.7 }
+        // The shipped list is frequency-ordered and the checker is not, so a
+        // guess the list knows is the more likely reading of the two.
+        if contains(context.listCompletions, candidate) { cost -= 0.1 }
+        return cost
     }
 
     // MARK: - Helpers
@@ -296,9 +432,21 @@ enum TypingCandidates {
     /// "Teh" gives "The" rather than "the".
     static func matchingCase(of typed: String, applyingTo replacement: String) -> String {
         guard let first = typed.first else { return replacement }
+        // A replacement that carries its own capitalization is not a spelling of
+        // the typed word — it is a substitution the keyboard was told to make.
+        // "omw" must not become "ON MY WAY!" because the user happened to have
+        // caps lock on, and "i" must stay "I" rather than being lowercased back.
+        guard !carriesOwnCase(replacement) else { return replacement }
         if isAllCaps(typed), typed.count > 1 { return replacement.uppercased() }
         if first.isUppercase { return replacement.prefix(1).uppercased() + replacement.dropFirst() }
         return replacement
+    }
+
+    /// Whether a replacement's capitalization is deliberate: a text replacement,
+    /// a phrase, or anything already carrying an uppercase letter.
+    static func carriesOwnCase(_ replacement: String) -> Bool {
+        replacement.contains(where: \.isWhitespace)
+            || replacement.contains(where: \.isUppercase)
     }
 
     /// Concatenates without duplicates, keeping the first occurrence's order.

--- a/ios/VocaPhoneKeyboard/TypingCandidates.swift
+++ b/ios/VocaPhoneKeyboard/TypingCandidates.swift
@@ -252,11 +252,25 @@ enum TypingCandidates {
               !context.assertedWords.contains(typed.lowercased())
         else { return nil }
 
-        // A text replacement the user configured in Settings. Highest priority
-        // of anything here — it is not a guess at all, it is an instruction.
-        // Compared exactly, not case-insensitively. A replacement that differs
-        // only in case is still a replacement the user asked for.
-        if let expansion = context.lexiconExpansion, expansion != typed {
+        // A text replacement the user configured in Settings. Not a guess — an
+        // instruction — which is why it outranks everything below it.
+        //
+        // But it has to be a real *expansion*. `UILexicon` is not just the
+        // shortcuts someone typed into Settings: it also carries names from
+        // Contacts and the system's own proper nouns, as a lowercase
+        // `userInput` mapped to a properly-cased `documentText` — "world" to
+        // "World", "iphone" to "iPhone". Applying those on an exact match meant
+        // any ordinary word that happened to be in the user's address book was
+        // silently capitalised mid-sentence, with no way to tell which words
+        // would do it. That is the same thing the case-only guard further down
+        // exists to prevent, and this path was walking straight past it.
+        //
+        // A case-only lexicon entry is still *offered*: it reaches the strip
+        // through `lexiconEntries`, at the top of `rankedSuggestions`. Offering
+        // it is right. Imposing it is not.
+        if let expansion = context.lexiconExpansion,
+           expansion.lowercased() != typed.lowercased()
+        {
             return expansion
         }
 
@@ -265,9 +279,14 @@ enum TypingCandidates {
         // only a case and apostrophe away from nothing the checker will guess —
         // and refusing them is what made this keyboard visibly worse than the
         // system one at the corrections people notice first.
-        // Exact comparison again, and here it is the whole point: "i" → "I" is a
+        // Exact comparison here, and here it *is* the whole point: "i" → "I" is a
         // case-only change, which is precisely what the general path below
         // refuses and precisely what this table exists to allow.
+        //
+        // Safe here and not for the lexicon above because this table is
+        // curated: thirty-odd entries, each one a word whose capital is
+        // unambiguous in English. The lexicon is whatever happens to be in
+        // someone's contacts.
         if let replacement = ShortWordCorrections.replacement(for: typed),
            replacement != typed
         {

--- a/ios/VocaPhoneKeyboard/TypingEngine.swift
+++ b/ios/VocaPhoneKeyboard/TypingEngine.swift
@@ -29,6 +29,10 @@ final class TypingEngine {
     /// Handed the word list once it has parsed, so the swipe recogniser has
     /// something to rank against.
     var onWordListLoaded: ((TypingWordList) -> Void)?
+    /// How likely each letter is to be typed next, for the key grid's hit map.
+    /// Published on every composition change, including the empty one that
+    /// clears it.
+    var onNextCharacters: (([Character: Double]) -> Void)?
 
     private(set) var composer = WordComposer()
     private(set) var policy = TypingFieldPolicy.allowed
@@ -145,42 +149,46 @@ final class TypingEngine {
     /// Reconciles the composition against what the document says, then
     /// recomputes. Called after a cursor move, a dictation insertion, or any
     /// edit this keyboard did not make itself.
-    func reconcile(documentBefore: String?) {
-        composer.reconcile(documentBefore: documentBefore)
+    func reconcile(document: DocumentSnapshot) {
+        isMidWord = document.isMidWord
+        composer.reconcile(documentBefore: document.before)
         // The swipe's own insertion is what triggers the first of these. The
         // word is still the tail of the document, so its alternates stand —
         // reconciling the composer to an empty composition must not take them
         // down with it.
         if let pendingSwipe,
-           SwipeAlternates.isArmed(word: pendingSwipe.word, documentBefore: documentBefore)
+           SwipeAlternates.isArmed(word: pendingSwipe.word, documentBefore: document.before)
         {
             publishSwipeAlternates()
             return
         }
         pendingSwipe = nil
-        refresh(documentBefore: documentBefore)
+        refresh(document: document)
     }
 
     // MARK: - Typing
 
-    func insert(_ text: String, origin: WordComposer.Origin = .typed, documentBefore: String?) {
+    func insert(_ text: String, origin: WordComposer.Origin = .typed, document: DocumentSnapshot) {
         pendingRevert = nil
         pendingSwipe = nil
+        isMidWord = document.isMidWord
         composer.insert(text, origin: origin)
-        refresh(documentBefore: documentBefore)
+        refresh(document: document)
     }
 
-    func deleteBackward(documentBefore: String?) {
+    func deleteBackward(document: DocumentSnapshot) {
         pendingRevert = nil
         pendingSwipe = nil
+        isMidWord = document.isMidWord
         composer.deleteBackward()
-        refresh(documentBefore: documentBefore)
+        refresh(document: document)
     }
 
-    func resetComposition(origin: WordComposer.Origin = .typed, documentBefore: String?) {
+    func resetComposition(origin: WordComposer.Origin = .typed, document: DocumentSnapshot) {
         pendingSwipe = nil
+        isMidWord = document.isMidWord
         composer.reset(origin: origin)
-        refresh(documentBefore: documentBefore)
+        refresh(document: document)
     }
 
     /// The word the user asserted by tapping their own spelling. It stops being
@@ -192,13 +200,21 @@ final class TypingEngine {
         learned.update { $0.learn(word) }
     }
 
-    /// Records that an autocorrect was applied, so the next Delete can undo it.
+    /// Records that an autocorrect was applied, so the next Delete can undo it
+    /// and the strip can offer the original back.
+    ///
+    /// Must be called *after* the boundary has been fed through ``insert(_:origin:document:)``,
+    /// not before: every insertion clears the pending revert, so a correction
+    /// noted first was wiped by the space that applied it — which left Delete
+    /// with nothing to restore and the feature switched off in practice.
     func noteCorrection(typed: String, replacement: String, boundary: String) {
         pendingRevert = AppliedCorrection(
             typed: typed,
             replacement: replacement,
             boundary: boundary
         )
+        guard policy.allowsTypingIntelligence else { return }
+        publish(TypingCandidates.revertStrip(typed: typed))
     }
 
     /// Consumes the pending revert. Asserting the restored word is the point:
@@ -206,6 +222,7 @@ final class TypingEngine {
     func takeRevert() -> AppliedCorrection? {
         guard let pendingRevert else { return nil }
         self.pendingRevert = nil
+        publish(.none)
         assertedWords.insert(pendingRevert.typed.lowercased())
         if KeyboardPreferences.learnAsITypeEnabled {
             learned.update { $0.learn(pendingRevert.typed) }
@@ -320,7 +337,8 @@ final class TypingEngine {
 
     // MARK: - Computation
 
-    private func refresh(documentBefore: String?) {
+    private func refresh(document: DocumentSnapshot) {
+        publishNextCharacters()
         guard KeyboardPreferences.typingSuggestionsEnabled, policy.allowsTypingIntelligence
         else {
             publish(.none)
@@ -332,7 +350,7 @@ final class TypingEngine {
         let composition = composer.text
         if !composition.isEmpty { ensureLoaded() }
         let origin = composer.origin
-        let preceding = PrecedingWord.lastWord(in: documentBefore)
+        let preceding = PrecedingWord.lastWord(in: document.before)
 
         // Nothing being composed: prediction needs no checker, so it renders on
         // this turn rather than costing a hop.
@@ -367,7 +385,10 @@ final class TypingEngine {
             let value = SuggestionCache.Value(
                 completions: self.checker.completions(for: composition, language: self.language),
                 guesses: self.checker.guesses(for: composition, language: self.language),
-                isKnown: self.checker.isKnown(composition, language: self.language)
+                isKnown: self.checker.isKnown(composition, language: self.language),
+                // Computed here, on the later turn, rather than inside
+                // `context` — which the cache-hit path also runs.
+                similar: self.wordList.similarWords(to: composition, limit: 2)
             )
             // Checked again: the user may have typed on while this task waited
             // its turn, and a strip two keystrokes behind is worse than none.
@@ -397,12 +418,18 @@ final class TypingEngine {
         context.composition = composition
         context.origin = origin
         context.precedingWord = preceding
+        let lowered = composition.lowercased()
         context.lexiconEntries = lexiconEntries
-            .filter {
-                !composition.isEmpty
-                    && $0.userInput.lowercased().hasPrefix(composition.lowercased())
-            }
+            .filter { !composition.isEmpty && $0.userInput.lowercased().hasPrefix(lowered) }
             .map(\.documentText)
+        // An *exact* match is an instruction rather than a suggestion: the user
+        // told Settings that "omw" means something, and iOS hands keyboards the
+        // lexicon precisely so it can be honoured. It used to reach the strip as
+        // a chip and stop there, so the expansion only ever happened if the user
+        // noticed it and tapped.
+        context.lexiconExpansion = lexiconEntries
+            .first { $0.userInput.lowercased() == lowered && !$0.documentText.isEmpty }?
+            .documentText
         context.customWords = customWords.filter {
             !composition.isEmpty && $0.lowercased().hasPrefix(composition.lowercased())
         }
@@ -412,10 +439,17 @@ final class TypingEngine {
         // together they still answer when either one draws a blank.
         context.systemGuesses = TypingCandidates.merged(
             Array((checked?.guesses ?? []).prefix(4)),
-            wordList.similarWords(to: composition, limit: 2)
+            checked?.similar ?? []
         )
         context.listCompletions = wordList.completions(for: composition, limit: 3)
         context.predictions = preceding.map { wordList.nextWords(after: $0, limit: 3) } ?? []
+        // The same bigrams, but as evidence about the word being typed rather
+        // than a guess about the next one. A wider window than the strip shows,
+        // because this only has to contain the right answer, not display it.
+        context.contextualFollowers = preceding.map {
+            wordList.nextWords(after: $0, limit: 12)
+        } ?? []
+        context.isMidWord = isMidWord
         context.isKnownToChecker = checked?.isKnown ?? false
         context.isInWordList = wordList.contains(composition)
         context.assertedWords = assertedWords
@@ -429,6 +463,40 @@ final class TypingEngine {
         context.allowsTypingIntelligence = policy.allowsTypingIntelligence
         return context
     }
+
+    /// The touch model's language half, recomputed whenever the composition
+    /// moves.
+    ///
+    /// Guarded by the same policy as everything else here: a password field gets
+    /// no prediction, which means its keys get no bias either. Bounded scan, so
+    /// this stays affordable on the keystroke path — see
+    /// ``TypingWordList/nextCharacterWeights(after:scanLimit:)``.
+    private func publishNextCharacters() {
+        guard let onNextCharacters else { return }
+        let composition = composer.text
+        guard policy.allowsTypingIntelligence, !composition.isEmpty, hasLoaded else {
+            if !lastNextCharacters.isEmpty {
+                lastNextCharacters = [:]
+                onNextCharacters([:])
+            }
+            return
+        }
+        let weights = wordList.nextCharacterWeights(after: composition)
+        guard weights != lastNextCharacters else { return }
+        lastNextCharacters = weights
+        onNextCharacters(weights)
+    }
+
+    private var lastNextCharacters: [Character: Double] = [:]
+
+    /// Whether the cursor sits inside a word rather than at the end of one.
+    ///
+    /// Set from the document's *trailing* context, which is the piece this
+    /// subsystem never read. Without it, tapping into the middle of
+    /// "helloworld" after "hello" left a composition of "hello" that the next
+    /// space would happily autocorrect — rewriting the first half of a word the
+    /// keyboard could only see half of.
+    private var isMidWord = false
 
     private func publish(_ newStrip: TypingStrip) {
         guard newStrip != strip else { return }

--- a/ios/VocaPhoneKeyboard/TypingEngine.swift
+++ b/ios/VocaPhoneKeyboard/TypingEngine.swift
@@ -53,6 +53,24 @@ final class TypingEngine {
         /// that back too, or the sentence loses its spacing along with its
         /// correction.
         let boundary: String
+
+        /// Whether the correction is still the text immediately before the
+        /// cursor.
+        ///
+        /// A revert deletes a fixed number of characters and types the original
+        /// in their place, which is only meaningful where the replacement
+        /// actually is. Once the cursor has moved, those characters belong to
+        /// something else — and reverting there would delete four characters of
+        /// unrelated text and insert a word the user typed a paragraph ago.
+        ///
+        /// Checked against the document rather than remembered, for the same
+        /// reason ``SwipeAlternates/isArmed(word:documentBefore:)`` is: the
+        /// document is the thing that can be trusted, and a keyboard that
+        /// deletes on faith deletes the wrong thing.
+        func isArmed(documentBefore: String?) -> Bool {
+            guard let documentBefore else { return false }
+            return documentBefore.hasSuffix(replacement + boundary)
+        }
     }
 
     private let checker: any SpellChecking
@@ -219,8 +237,15 @@ final class TypingEngine {
 
     /// Consumes the pending revert. Asserting the restored word is the point:
     /// a user who put their word back once should not have to do it again.
-    func takeRevert() -> AppliedCorrection? {
-        guard let pendingRevert else { return nil }
+    func takeRevert(documentBefore: String?) -> AppliedCorrection? {
+        guard let pendingRevert,
+              pendingRevert.isArmed(documentBefore: documentBefore)
+        else {
+            // Either there was nothing to revert, or the cursor has left the
+            // correction behind. Both mean the offer is over.
+            self.pendingRevert = nil
+            return nil
+        }
         self.pendingRevert = nil
         publish(.none)
         assertedWords.insert(pendingRevert.typed.lowercased())
@@ -342,6 +367,25 @@ final class TypingEngine {
         guard KeyboardPreferences.typingSuggestionsEnabled, policy.allowsTypingIntelligence
         else {
             publish(.none)
+            return
+        }
+
+        // A correction that can still be taken back owns the strip, the same way
+        // a swiped word owns it while its alternates stand.
+        //
+        // This is also what retires the offer. `reconcile` runs on every
+        // keystroke in this field, so clearing the revert there would clear it
+        // on the very keystroke that applied the correction — the boundary key
+        // — and undo would be dead again. Asking the document instead means the
+        // offer survives exactly as long as the correction is still in front of
+        // the cursor, and disarms itself the moment the cursor moves away.
+        if let pendingRevert {
+            guard pendingRevert.isArmed(documentBefore: document.before) else {
+                self.pendingRevert = nil
+                publish(.none)
+                return
+            }
+            publish(TypingCandidates.revertStrip(typed: pendingRevert.typed))
             return
         }
 

--- a/ios/VocaPhoneKeyboard/TypingStripView.swift
+++ b/ios/VocaPhoneKeyboard/TypingStripView.swift
@@ -182,9 +182,16 @@ final class TypingStripView: UIScrollView {
         // The literal is quoted, exactly as the system keyboard quotes the word
         // it is about to take away. The quotes are the affordance: they say
         // "this is what you typed", and iOS has trained everyone to read them.
-        configuration.title = candidate.kind == .literal
-            ? "“\(candidate.text)”"
-            : candidate.text
+        // The literal and the revert are both quoted, exactly as the system
+        // keyboard quotes a word it is about to take away or has just taken.
+        // The revert carries a leading undo arrow as well, because by the time
+        // it appears the replacement is already in the document and the chip has
+        // to say "put it back" rather than "keep this".
+        configuration.title = switch candidate.kind {
+        case .literal: "“\(candidate.text)”"
+        case .revert: "↩ “\(candidate.text)”"
+        default: candidate.text
+        }
         let isEmoji = candidate.kind == .emoji
         configuration.cornerStyle = .capsule
         configuration.contentInsets = NSDirectionalEdgeInsets(
@@ -240,6 +247,7 @@ final class TypingStripView: UIScrollView {
         case .prediction: "Inserts this word next."
         case .emoji: "Replaces the word with this emoji."
         case .swipeAlternate: "Replaces the swiped word."
+        case .revert: "Undoes the autocorrect and restores what you typed."
         }
     }
 

--- a/ios/VocaPhoneKeyboard/TypingWordList.swift
+++ b/ios/VocaPhoneKeyboard/TypingWordList.swift
@@ -21,6 +21,14 @@ struct TypingWordList: Sendable {
     private let ranks: [String: Int]
     private let words: [String]
     private let bigrams: [String: [String]]
+    /// Each word with consecutive repeats removed, in `words` order.
+    ///
+    /// Built once with the list rather than per swipe. The recogniser needs the
+    /// collapsed form of every word to test it against a trace, and deriving
+    /// ten thousand of them inside the gesture meant ten thousand String
+    /// allocations on the main actor at the exact frame the finger lifted — the
+    /// one moment in this keyboard where a hitch is guaranteed to be seen.
+    let collapsedWords: [String]
 
     static let empty = TypingWordList(words: [], bigrams: [:])
 
@@ -33,6 +41,7 @@ struct TypingWordList: Sendable {
             ranks[word] = rank
         }
         self.ranks = ranks
+        collapsedWords = words.map(SwipeRecognizer.collapsed)
     }
 
     var isEmpty: Bool { words.isEmpty }
@@ -91,6 +100,38 @@ struct TypingWordList: Sendable {
             if withinOne.count >= limit { break }
         }
         return Array((withinOne + withinTwo).prefix(limit))
+    }
+
+    /// How likely each letter is to be the next one typed, given the prefix
+    /// already composed. Weights are relative, and the largest is always 1.
+    ///
+    /// This is the language half of the touch model. The system keyboard quietly
+    /// grows a key's *invisible* hit region when the language expects that
+    /// letter — after "th" the "e" claims more of the gutter than the "w" beside
+    /// it — which is a large part of why it forgives a finger that lands between
+    /// two keys and this keyboard did not.
+    ///
+    /// Bounded hard. It runs on the keystroke path, and the answer only has to
+    /// separate "expected" from "not expected": scanning the most common few
+    /// hundred matches gives the same ordering as scanning ten thousand, for a
+    /// fraction of the work.
+    func nextCharacterWeights(after prefix: String, scanLimit: Int = 400) -> [Character: Double] {
+        guard !prefix.isEmpty else { return [:] }
+        let lowered = prefix.lowercased()
+        var weights: [Character: Double] = [:]
+        var matches = 0
+        // `words` is frequency-ordered, so a match found early is a more likely
+        // continuation than one found late — which is exactly the weighting
+        // wanted, and it comes for free from the scan order.
+        for (rank, word) in words.enumerated() {
+            guard word.count > lowered.count, word.hasPrefix(lowered) else { continue }
+            let next = word[word.index(word.startIndex, offsetBy: lowered.count)]
+            weights[next, default: 0] += 1 / (1 + Double(rank) / 500)
+            matches += 1
+            if matches >= scanLimit { break }
+        }
+        guard let peak = weights.values.max(), peak > 0 else { return [:] }
+        return weights.mapValues { $0 / peak }
     }
 
     /// What usually follows `word`.

--- a/ios/VocaPhoneKeyboard/WordComposer.swift
+++ b/ios/VocaPhoneKeyboard/WordComposer.swift
@@ -138,6 +138,49 @@ struct WordComposer: Equatable {
     }
 }
 
+/// What the document says on either side of the cursor, read once per event.
+///
+/// Two reasons this is a type rather than two loose strings.
+///
+/// The first is cost. Every `documentContextBeforeInput` is a synchronous trip
+/// to the host application's process, and a single keystroke used to make six
+/// or seven of them — one for smart punctuation, one for the composer, one to
+/// check the undo offer, then three more once `textDidChange` came back. Reading
+/// the pair once and passing it down is the difference between a keystroke that
+/// costs one round trip and one that costs seven, on a path where the budget is
+/// a display frame.
+///
+/// The second is ``isMidWord``. The trailing context is the piece this keyboard
+/// never read, and it is the only way to tell "the cursor is at the end of the
+/// word I am composing" from "the cursor is halfway through a word I can see
+/// half of" — a distinction that decides whether an autocorrect is a correction
+/// or a corruption.
+struct DocumentSnapshot: Equatable {
+    var before: String?
+    var after: String?
+
+    /// iOS did not answer, which is not the same as an empty document: the proxy
+    /// returns nothing while the keyboard is loading, and treating that as "no
+    /// text" discards a half-typed word.
+    static let unknown = DocumentSnapshot(before: nil, after: nil)
+
+    init(before: String?, after: String? = nil) {
+        self.before = before
+        self.after = after
+    }
+
+    /// Whether a word continues past the cursor.
+    ///
+    /// `nil` trailing context is treated as "not mid-word": the permissive
+    /// answer is the one that keeps autocorrect working in every field that
+    /// declines to answer, and the strict one would silently switch the feature
+    /// off wherever iOS was slow to reply.
+    var isMidWord: Bool {
+        guard let first = after?.first else { return false }
+        return WordComposer.isWordCharacter(first)
+    }
+}
+
 /// The word immediately before the cursor, for next-word prediction.
 ///
 /// Deliberately separate from ``WordComposer``: this one *does* read the

--- a/ios/VocaPhoneShared/AppConfiguration.swift
+++ b/ios/VocaPhoneShared/AppConfiguration.swift
@@ -1,11 +1,50 @@
 import Foundation
 
 enum AppConfiguration {
-    static let appGroupIdentifier = "group.com.vocahq"
-    /// Must match `VocaPhoneKeyboard`'s `PRODUCT_BUNDLE_IDENTIFIER` in
-    /// `project.yml`. Only used to spot the keyboard in the user's enabled
-    /// list, so drift degrades guided setup rather than breaking dictation.
-    static let keyboardBundleIdentifier = "com.vocahq.vocaphone.keyboard"
+    static let appGroupIdentifier = "group.dev.kanishkpachauri.vocaphone"
+    /// The identifier the app ships under. Only a fallback for when the running
+    /// bundle declines to name itself, which is what a unit-test host does.
+    static let shippingAppBundleIdentifier = "com.vocahq.vocaphone"
+
+    /// The keyboard extension's bundle identifier.
+    ///
+    /// Used to spot the keyboard in the user's enabled list, which iOS
+    /// publishes as bundle identifiers under an undocumented key.
+    ///
+    /// Derived from the running bundle rather than written down, because a
+    /// hardcoded one rots silently the moment anyone re-signs under their own
+    /// identifier to test on a device. Everything else gets renamed — the
+    /// targets, the entitlements, the App Group — and this does not, so guided
+    /// setup scans the enabled list for an identifier no installed keyboard
+    /// has, concludes the keyboard is missing, and traps onboarding on the page
+    /// that will not advance until it appears. The keyboard is sitting in the
+    /// list the whole time, working.
+    ///
+    /// The comment this replaces said drift here "degrades guided setup rather
+    /// than breaking dictation". That was too kind: onboarding cannot be walked
+    /// past the keyboard step, so nothing downstream of it happens either.
+    static var keyboardBundleIdentifier: String {
+        keyboardBundleIdentifier(forHostBundle: Bundle.main.bundleIdentifier)
+    }
+
+    /// Split out so the derivation can be checked without a bundle.
+    ///
+    /// `project.yml` builds the extension's identifier as the app's with
+    /// `.keyboard` appended, and that relationship is the whole rule.
+    static func keyboardBundleIdentifier(forHostBundle running: String?) -> String {
+        let host = running ?? shippingAppBundleIdentifier
+        // Asked from inside the keyboard itself, the answer is already in hand.
+        if host.hasSuffix(keyboardSuffix) { return host }
+        // Asked from another extension, strip its own component first so the
+        // sibling is derived from the app rather than from the asker.
+        if host.hasSuffix(liveActivitySuffix) {
+            return String(host.dropLast(liveActivitySuffix.count)) + keyboardSuffix
+        }
+        return host + keyboardSuffix
+    }
+
+    private static let keyboardSuffix = ".keyboard"
+    private static let liveActivitySuffix = ".liveactivity"
     static let urlScheme = "vocaphone"
     /// The manual route to the Full Access switch, written once because the app
     /// and the keyboard both have to give it and they must not disagree.

--- a/ios/VocaPhoneShared/KeyboardStatusPublication.swift
+++ b/ios/VocaPhoneShared/KeyboardStatusPublication.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Decides whether the keyboard should refresh its Full Access proof.
+///
+/// iOS can keep a keyboard extension alive while the user changes Allow Full
+/// Access in Settings. A repeated appearance with the same value can be
+/// throttled, but a changed value must reach guided setup immediately.
+enum KeyboardStatusPublication {
+    static func shouldPublish(
+        lastPublishedAt: Date?,
+        lastPublishedFullAccess: Bool?,
+        fullAccess: Bool,
+        now: Date,
+        minimumInterval: TimeInterval
+    ) -> Bool {
+        guard let lastPublishedAt else { return true }
+        guard lastPublishedFullAccess == fullAccess else { return true }
+        return now.timeIntervalSince(lastPublishedAt) >= minimumInterval
+    }
+}

--- a/ios/VocaPhoneTests/KeyGridLayoutTests.swift
+++ b/ios/VocaPhoneTests/KeyGridLayoutTests.swift
@@ -214,7 +214,27 @@ struct KeypadLayoutTests {
 
     @Test func theGlobeTakesTheEmptyCornerWhenItIsNeeded() {
         let rows = KeyLayout.keypadRows(for: .numberPad, includesGlobe: true)
-        #expect(rows[3].keys.first?.cap == .globe)
+        #expect(rows[3].keys.map(\.cap) == [.globe, .character("0"), .delete])
+    }
+
+    /// The globe must never cost a keypad the only key that types its own
+    /// character: these layouts have no second plane and no duplicate, so a
+    /// displaced "." is a decimal pad that cannot type a decimal point.
+    @Test func theGlobeNeverDisplacesAKeypadsOnlySeparator() {
+        for (plane, required) in [(KeyPlane.decimalPad, "."), (.phonePad, "+")] {
+            for globe in [true, false] {
+                let caps = KeyLayout.keypadRows(for: plane, includesGlobe: globe)
+                    .flatMap(\.keys)
+                    .map(\.cap)
+                #expect(
+                    caps.contains(.character(required)),
+                    "\(plane) with globe=\(globe) lost its \(required)"
+                )
+                #expect(caps.contains(.delete))
+                #expect(caps.contains(.character("0")))
+                #expect(caps.contains(.globe) == globe)
+            }
+        }
     }
 
     @Test func aDecimalPadSpendsTheCornerOnItsSeparator() {
@@ -229,17 +249,20 @@ struct KeypadLayoutTests {
         #expect(rows[3].keys.map(\.cap) == [.character("+"), .character("0"), .delete])
     }
 
-    /// Three columns in every row, the last one included. A bottom row of four
-    /// keys under three is a grid that has come apart.
-    @Test func everyKeypadRowIsThreeColumnsWide() {
+    /// Three columns in every row, and four only where a globe and a required
+    /// separator both have to fit. The digits are always a regular block.
+    @Test func theDigitsAreAlwaysARegularBlock() {
         for plane in [KeyPlane.numberPad, .phonePad, .decimalPad] {
             for globe in [true, false] {
                 let rows = KeyLayout.keypadRows(for: plane, includesGlobe: globe)
+                #expect(rows.count == 4)
                 #expect(
-                    rows.allSatisfy { $0.keys.count == 3 },
-                    "\(plane) with globe=\(globe) is not a regular block"
+                    rows.prefix(3).allSatisfy { $0.keys.count == 3 },
+                    "\(plane) with globe=\(globe) has ragged digits"
                 )
                 #expect(rows.allSatisfy { $0.alignment == .centered })
+                let needsFour = globe && plane != .numberPad
+                #expect(rows[3].keys.count == (needsFour ? 4 : 3))
             }
         }
     }

--- a/ios/VocaPhoneTests/KeyGridLayoutTests.swift
+++ b/ios/VocaPhoneTests/KeyGridLayoutTests.swift
@@ -147,19 +147,31 @@ struct KeyGridLayoutTests {
     @Test func emailAndUrlFieldsGetTheirSeparatorBack() {
         let grid = Self.makeGrid()
 
-        grid.leadingPunctuation = "@"
+        grid.punctuation = KeyLayout.BottomRowPunctuation(leading: "@", trailing: ".")
         var caps = grid.keyViews.map(\.spec.cap)
         #expect(caps.contains(.character("@")))
         #expect(caps.contains(.character(".")))
 
-        grid.leadingPunctuation = "/"
+        grid.punctuation = KeyLayout.BottomRowPunctuation(leading: "/", trailing: ".")
         caps = grid.keyViews.map(\.spec.cap)
         #expect(caps.contains(.character("/")))
         #expect(!caps.contains(.character("@")))
 
-        grid.leadingPunctuation = nil
+        grid.punctuation = nil
         caps = grid.keyViews.map(\.spec.cap)
         #expect(!caps.contains(.character("/")))
+        #expect(!caps.contains(.character(".")))
+    }
+
+    /// A Twitter-style field gets `@` and `#`, which are the two characters it
+    /// exists for. The trailing slot used to be hardcoded to a full stop, so the
+    /// pair could not be expressed at all.
+    @Test func twitterFieldsGetTheHandleAndHashKeys() {
+        let grid = Self.makeGrid()
+        grid.punctuation = KeyLayout.BottomRowPunctuation(leading: "@", trailing: "#")
+        let caps = grid.keyViews.map(\.spec.cap)
+        #expect(caps.contains(.character("@")))
+        #expect(caps.contains(.character("#")))
         #expect(!caps.contains(.character(".")))
     }
 
@@ -176,5 +188,67 @@ struct KeyGridLayoutTests {
         Dictionary(grouping: grid.keyViews) { ($0.frame.minY * 10).rounded() }
             .sorted { $0.key < $1.key }
             .map { $0.value.sorted { $0.frame.minX < $1.frame.minX } }
+    }
+}
+
+/// The numeric keypads, which a `.numberPad` or `.phonePad` field used to be
+/// denied entirely: it got the symbols plane, so a phone number was typed
+/// against `-/:;()$&@"`.
+@MainActor
+struct KeypadLayoutTests {
+    @Test func aNumberPadIsAKeypadRatherThanTheSymbolsPlane() {
+        let rows = KeyLayout.keypadRows(for: .numberPad, includesGlobe: false)
+        #expect(rows.count == 4, "the keypad must occupy the grid's own four rows")
+        #expect(rows[0].keys.map(\.cap) == [
+            .character("1"), .character("2"), .character("3"),
+        ])
+        #expect(rows[2].keys.map(\.cap) == [
+            .character("7"), .character("8"), .character("9"),
+        ])
+        // The empty corner is genuinely empty. Stretching the zero across it
+        // would put a target where the user is reaching for nothing.
+        #expect(rows[3].keys.map(\.cap) == [.blank, .character("0"), .delete])
+        // Nothing on a keypad may leave it: there is no plane key to leave by.
+        #expect(!rows.flatMap(\.keys).contains { if case .plane = $0.cap { true } else { false } })
+    }
+
+    @Test func theGlobeTakesTheEmptyCornerWhenItIsNeeded() {
+        let rows = KeyLayout.keypadRows(for: .numberPad, includesGlobe: true)
+        #expect(rows[3].keys.first?.cap == .globe)
+    }
+
+    @Test func aDecimalPadSpendsTheCornerOnItsSeparator() {
+        let rows = KeyLayout.keypadRows(for: .decimalPad, includesGlobe: false)
+        #expect(rows[3].keys.first?.cap == .character("."))
+    }
+
+    /// A phone pad has to be able to type the characters a dialable number
+    /// contains, so it spends the delete slot on "+" and moves delete up.
+    @Test func aPhonePadSpendsTheCornerOnThePlus() {
+        let rows = KeyLayout.keypadRows(for: .phonePad, includesGlobe: false)
+        #expect(rows[3].keys.map(\.cap) == [.character("+"), .character("0"), .delete])
+    }
+
+    /// Three columns in every row, the last one included. A bottom row of four
+    /// keys under three is a grid that has come apart.
+    @Test func everyKeypadRowIsThreeColumnsWide() {
+        for plane in [KeyPlane.numberPad, .phonePad, .decimalPad] {
+            for globe in [true, false] {
+                let rows = KeyLayout.keypadRows(for: plane, includesGlobe: globe)
+                #expect(
+                    rows.allSatisfy { $0.keys.count == 3 },
+                    "\(plane) with globe=\(globe) is not a regular block"
+                )
+                #expect(rows.allSatisfy { $0.alignment == .centered })
+            }
+        }
+    }
+
+    /// A blank is a hole, not a key. It must never take a touch, show a preview
+    /// or fire on touch-down.
+    @Test func aBlankIsNotInteractive() {
+        #expect(!KeyCap.blank.isInteractive)
+        #expect(!KeyCap.blank.isCharacter)
+        #expect(KeyCap.character("0").isInteractive)
     }
 }

--- a/ios/VocaPhoneTests/KeyHitMapTests.swift
+++ b/ios/VocaPhoneTests/KeyHitMapTests.swift
@@ -492,3 +492,78 @@ private extension KeyHitMap {
         retargetIndex(from: currentIndex, at: CGPoint(x: x, y: 20), characterOnly: false)
     }
 }
+
+/// The language half of the touch model: an expected letter claims a little
+/// more of the gutter than its neighbour, which is what the system keyboard
+/// does and what geometry alone could never supply.
+struct KeyHitMapBiasTests {
+    /// Two 40pt keys side by side with a 10pt gutter between them, tiled the
+    /// way the grid tiles them: each claims to the middle of the gap.
+    private static func pair(likelihood: [Character: Double] = [:]) -> KeyHitMap {
+        let left = KeyHitMap.Target(
+            index: 0,
+            frame: CGRect(x: 0, y: 0, width: 40, height: 40),
+            hitRect: CGRect(x: -5, y: -5, width: 50, height: 50),
+            isCharacter: true,
+            character: "a"
+        )
+        let right = KeyHitMap.Target(
+            index: 1,
+            frame: CGRect(x: 50, y: 0, width: 40, height: 40),
+            hitRect: CGRect(x: 45, y: -5, width: 50, height: 50),
+            isCharacter: true,
+            character: "b"
+        )
+        return KeyHitMap(targets: [left, right], hysteresis: 8, likelihood: likelihood)
+    }
+
+    /// With no opinion the boundary is where the geometry says it is.
+    @Test func withoutAPredictionTheGeometryDecides() {
+        let map = Self.pair()
+        #expect(map.targetIndex(at: CGPoint(x: 44, y: 20), characterOnly: true) == 0)
+        #expect(map.targetIndex(at: CGPoint(x: 46, y: 20), characterOnly: true) == 1)
+    }
+
+    /// A point just inside the left key's half of the gutter goes to the right
+    /// key once the language plainly expects it.
+    @Test func anExpectedLetterClaimsTheGutter() {
+        let map = Self.pair(likelihood: ["b": 1])
+        #expect(map.targetIndex(at: CGPoint(x: 44, y: 20), characterOnly: true) == 1)
+    }
+
+    /// And never more than the gutter. A touch plainly on the other key stays
+    /// there, whatever the model expects — typing a letter the user can see they
+    /// did not press is worse than being unforgiving.
+    @Test func aPredictionCannotTakeATouchThatPlainlyLanded() {
+        let map = Self.pair(likelihood: ["b": 1])
+        #expect(map.targetIndex(at: CGPoint(x: 20, y: 20), characterOnly: true) == 0)
+        #expect(map.targetIndex(at: CGPoint(x: 2, y: 20), characterOnly: true) == 0)
+    }
+
+    /// The bias is bounded by the hysteresis distance, so it scales with the
+    /// key size rather than being a fixed number of points.
+    @Test func theBiasIsBoundedByTheHysteresis() {
+        let map = Self.pair(likelihood: ["b": 1])
+        guard let left = map.targets.first else {
+            Issue.record("missing target")
+            return
+        }
+        let grown = map.effectiveRect(of: map.targets[1])
+        let expected = 8 * KeyHitMap.maximumBiasShare
+        #expect(abs(grown.minX - (map.targets[1].hitRect.minX - expected)) < 0.001)
+        // The unexpected key is not shrunk; it simply does not grow.
+        #expect(map.effectiveRect(of: left) == left.hitRect)
+    }
+
+    /// A half-expected letter gets half the nudge.
+    @Test func theNudgeScalesWithHowExpectedTheLetterIs() {
+        let strong = Self.pair(likelihood: ["b": 1])
+        let weak = Self.pair(likelihood: ["b": 0.25])
+        let strongGrowth = strong.targets[1].hitRect.minX
+            - strong.effectiveRect(of: strong.targets[1]).minX
+        let weakGrowth = weak.targets[1].hitRect.minX
+            - weak.effectiveRect(of: weak.targets[1]).minX
+        #expect(weakGrowth < strongGrowth)
+        #expect(weakGrowth > 0)
+    }
+}

--- a/ios/VocaPhoneTests/KeyboardStatusPublicationTests.swift
+++ b/ios/VocaPhoneTests/KeyboardStatusPublicationTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+struct KeyboardStatusPublicationTests {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test func firstProofIsPublished() {
+        #expect(KeyboardStatusPublication.shouldPublish(
+            lastPublishedAt: nil,
+            lastPublishedFullAccess: nil,
+            fullAccess: false,
+            now: now,
+            minimumInterval: 10
+        ))
+    }
+
+    @Test func identicalProofIsThrottled() {
+        #expect(!KeyboardStatusPublication.shouldPublish(
+            lastPublishedAt: now,
+            lastPublishedFullAccess: true,
+            fullAccess: true,
+            now: now.addingTimeInterval(1),
+            minimumInterval: 10
+        ))
+    }
+
+    @Test func changedFullAccessBypassesTheThrottle() {
+        #expect(KeyboardStatusPublication.shouldPublish(
+            lastPublishedAt: now,
+            lastPublishedFullAccess: false,
+            fullAccess: true,
+            now: now.addingTimeInterval(1),
+            minimumInterval: 10
+        ))
+    }
+}

--- a/ios/VocaPhoneTests/SemanticPaletteTests.swift
+++ b/ios/VocaPhoneTests/SemanticPaletteTests.swift
@@ -176,18 +176,37 @@ struct SemanticPaletteTests {
         #expect(Self.rgb(KeyboardPalette(isDark: true).standardKey) == (61, 61, 61))
     }
 
-    @Test func engagedShiftUsesTheNativeNeutralSurface() {
+    /// An engaged Shift lifts to the *standard* key surface, which is what the
+    /// system keyboard does and what makes the state readable at a glance: a
+    /// filled glyph alone is a small thing to spot mid-sentence, and the lighter
+    /// surface says "the next letter is a capital" without being read.
+    ///
+    /// The point the original test was defending still holds and is asserted
+    /// below: the brand accent stays out of it. A mint Shift made the resting
+    /// keyboard look like something was running.
+    @Test func engagedShiftLiftsToTheStandardSurface() {
         let palette = KeyboardPalette(isDark: false)
         let metrics = KeyboardMetrics.resolved(
             for: UITraitCollection { $0.verticalSizeClass = .regular }
         )
-        let shift = KeyView(
-            spec: KeySpec(cap: .shift, width: .fill, style: .function),
-            metrics: metrics,
-            palette: palette
-        )
-        shift.update(metrics: metrics, palette: palette, shift: .on, returnTitle: "return")
-        #expect(shift.backgroundColor == palette.functionKey)
+        func shiftKey() -> KeyView {
+            KeyView(
+                spec: KeySpec(cap: .shift, width: .fill, style: .function),
+                metrics: metrics,
+                palette: palette
+            )
+        }
+
+        let resting = shiftKey()
+        resting.update(metrics: metrics, palette: palette, shift: .off, returnTitle: "return")
+        #expect(resting.backgroundColor == palette.functionKey)
+
+        for engaged in [ShiftState.on, .locked] {
+            let shift = shiftKey()
+            shift.update(metrics: metrics, palette: palette, shift: engaged, returnTitle: "return")
+            #expect(shift.backgroundColor == palette.standardKey)
+            #expect(shift.backgroundColor != palette.accentKey)
+        }
     }
 
     private static func rgb(_ color: UIColor) -> (Int, Int, Int) {

--- a/ios/VocaPhoneTests/SetupStatusTests.swift
+++ b/ios/VocaPhoneTests/SetupStatusTests.swift
@@ -193,3 +193,69 @@ struct SetupStatusTests {
         #expect(denied.detail(for: .microphone).contains("Settings"))
     }
 }
+
+/// The keyboard's identifier is derived from the running bundle, not written
+/// down. A hardcoded one rots the moment anyone re-signs under their own
+/// identifier for device testing — and because guided setup will not advance
+/// past the keyboard step until it finds that identifier in the enabled list,
+/// the rot is a deadlock rather than a cosmetic wrong answer.
+struct KeyboardBundleIdentifierTests {
+    @Test func theKeyboardIsTheAppsIdentifierPlusItsSuffix() {
+        #expect(
+            AppConfiguration.keyboardBundleIdentifier(forHostBundle: "com.vocahq.vocaphone")
+                == "com.vocahq.vocaphone.keyboard"
+        )
+    }
+
+    /// A locally re-signed build. This is the case that was broken: everything
+    /// else was renamed and the identifier was not.
+    @Test func aLocallyResignedAppFindsItsOwnKeyboard() {
+        let host = "dev.kanishkpachauri.vocaphone"
+        let keyboard = AppConfiguration.keyboardBundleIdentifier(forHostBundle: host)
+        #expect(keyboard == "dev.kanishkpachauri.vocaphone.keyboard")
+        // The enabled-keyboard list carries trailing layout options, which is
+        // why the match is a substring.
+        #expect(
+            InstalledKeyboards.includesVocaPhone(
+                ["\(keyboard)@sw=QWERTY;hw=Automatic"],
+                keyboard: keyboard
+            ) == true
+        )
+        // And the identifier it used to look for is no longer in the list,
+        // which is exactly why guided setup could not find the keyboard.
+        #expect(
+            InstalledKeyboards.includesVocaPhone(
+                ["\(keyboard)@sw=QWERTY;hw=Automatic"],
+                keyboard: "com.vocahq.vocaphone.keyboard"
+            ) == false
+        )
+    }
+
+    /// Asked from inside the keyboard, the answer is already in hand.
+    @Test func theKeyboardDoesNotAppendItsSuffixTwice() {
+        #expect(
+            AppConfiguration.keyboardBundleIdentifier(
+                forHostBundle: "dev.kanishkpachauri.vocaphone.keyboard"
+            ) == "dev.kanishkpachauri.vocaphone.keyboard"
+        )
+    }
+
+    /// Asked from another extension, the sibling is derived from the app rather
+    /// than from the asker.
+    @Test func anotherExtensionDerivesTheSibling() {
+        #expect(
+            AppConfiguration.keyboardBundleIdentifier(
+                forHostBundle: "dev.kanishkpachauri.vocaphone.liveactivity"
+            ) == "dev.kanishkpachauri.vocaphone.keyboard"
+        )
+    }
+
+    /// A bundle that will not name itself falls back to the shipping identifier
+    /// rather than producing ".keyboard" on its own.
+    @Test func anUnnamedBundleFallsBackToTheShippingIdentifier() {
+        #expect(
+            AppConfiguration.keyboardBundleIdentifier(forHostBundle: nil)
+                == "com.vocahq.vocaphone.keyboard"
+        )
+    }
+}

--- a/ios/VocaPhoneTests/SmartPunctuationTests.swift
+++ b/ios/VocaPhoneTests/SmartPunctuationTests.swift
@@ -131,3 +131,119 @@ struct SymbolAlternativesTests {
         #expect(plain.contains("…"))
     }
 }
+
+/// The shift key's third answer.
+///
+/// `UITextDocumentProxy` returns `nil` for its context whenever the host has not
+/// answered. Reading that as an empty document meant "start of a sentence", so
+/// Shift came on — on whichever keystroke the host happened to skip, which is
+/// how a capital letter turned up in the middle of a word.
+struct AutomaticShiftTests {
+    /// The bug, stated directly: mid-sentence, an unanswered read must change
+    /// nothing.
+    @Test func anUnansweredContextLeavesTheShiftKeyAlone() {
+        #expect(
+            AutomaticShift.state(
+                documentBefore: nil,
+                autocapitalization: .sentences,
+                current: .off
+            ) == nil
+        )
+        #expect(
+            AutomaticShift.state(
+                documentBefore: nil,
+                autocapitalization: .words,
+                current: .off
+            ) == nil
+        )
+    }
+
+    /// A genuinely empty document really is the start of a sentence, and that
+    /// behaviour has to survive the fix.
+    @Test func anEmptyDocumentStillStartsASentence() {
+        #expect(
+            AutomaticShift.state(
+                documentBefore: "",
+                autocapitalization: .sentences,
+                current: .off
+            ) == .on
+        )
+    }
+
+    /// The reported case: typing on through a sentence stays lowercase.
+    @Test func typingThroughASentenceStaysLowercase() {
+        for before in ["how ", "how are ", "I am the ", "hello wor"] {
+            #expect(
+                AutomaticShift.state(
+                    documentBefore: before,
+                    autocapitalization: .sentences,
+                    current: .off
+                ) == .off,
+                "\(before) should not capitalise the next letter"
+            )
+        }
+    }
+
+    @Test func aSentenceEndStillCapitalises() {
+        #expect(
+            AutomaticShift.state(
+                documentBefore: "Done. ",
+                autocapitalization: .sentences,
+                current: .off
+            ) == .on
+        )
+        // Abbreviations are not sentence ends, which `SentenceBoundary` owns.
+        #expect(
+            AutomaticShift.state(
+                documentBefore: "Mr. ",
+                autocapitalization: .sentences,
+                current: .off
+            ) == .off
+        )
+    }
+
+    /// A word-capitalising field still capitalises every word, and a field that
+    /// asked for none still gets none.
+    @Test func theFieldsOwnRequestIsHonoured() {
+        #expect(
+            AutomaticShift.state(
+                documentBefore: "John ",
+                autocapitalization: .words,
+                current: .off
+            ) == .on
+        )
+        #expect(
+            AutomaticShift.state(
+                documentBefore: "",
+                autocapitalization: .none,
+                current: .on
+            ) == .off
+        )
+        #expect(
+            AutomaticShift.state(
+                documentBefore: "anything",
+                autocapitalization: .allCharacters,
+                current: .off
+            ) == .locked
+        )
+    }
+
+    /// A caps lock the user engaged outranks every automatic decision, and an
+    /// unanswered read must not quietly cancel it either.
+    @Test func anEngagedCapsLockIsNeverOverridden() {
+        #expect(
+            AutomaticShift.state(
+                documentBefore: "hello ",
+                autocapitalization: .sentences,
+                current: .locked
+            ) == nil
+        )
+        #expect(
+            AutomaticShift.state(
+                documentBefore: nil,
+                autocapitalization: .sentences,
+                current: .locked
+            ) == nil
+        )
+    }
+}

--- a/ios/VocaPhoneTests/TypingCandidatesTests.swift
+++ b/ios/VocaPhoneTests/TypingCandidatesTests.swift
@@ -117,6 +117,68 @@ struct TypingCandidatesTests {
         )
     }
 
+    /// The bug from the recording: typing "world" produced "World".
+    ///
+    /// `UILexicon` is not only the shortcuts someone typed into Settings — it
+    /// also carries Contacts names and system proper nouns as a lowercase
+    /// `userInput` mapped to a properly-cased `documentText`. Applying those on
+    /// an exact match silently capitalised any ordinary word that happened to be
+    /// in the user's address book, mid-sentence, with no way to predict which.
+    @Test func aLexiconEntryNeverAppliesAMereCapitalization() {
+        #expect(
+            TypingCandidates.autocorrection(
+                Self.context(
+                    composition: "world",
+                    isKnownToChecker: true,
+                    expansion: "World"
+                )
+            ) == nil
+        )
+        // The words from the original report, for the same reason.
+        for (typed, cased) in [("are", "Are"), ("the", "The"), ("hello", "Hello")] {
+            #expect(
+                TypingCandidates.autocorrection(
+                    Self.context(composition: typed, isKnownToChecker: true, expansion: cased)
+                ) == nil,
+                "\(typed) must not be capitalised into \(cased)"
+            )
+        }
+    }
+
+    /// A genuine expansion still applies on its own — that is what the lexicon
+    /// is handed to keyboards for.
+    @Test func aGenuineExpansionStillApplies() {
+        #expect(
+            TypingCandidates.autocorrection(
+                Self.context(
+                    composition: "omw",
+                    isKnownToChecker: true,
+                    expansion: "On my way!"
+                )
+            ) == "On my way!"
+        )
+        // A case change *plus* a real edit is an expansion, not a capitalization.
+        #expect(
+            TypingCandidates.autocorrection(
+                Self.context(
+                    composition: "kp",
+                    isKnownToChecker: true,
+                    expansion: "Kanishk"
+                )
+            ) == "Kanishk"
+        )
+    }
+
+    /// The curated table keeps its case-only power, because every entry in it is
+    /// a word whose capital is unambiguous. This is the line between the two.
+    @Test func theCuratedTableStillCapitalisesI() {
+        #expect(
+            TypingCandidates.autocorrection(
+                Self.context(composition: "i", isKnownToChecker: true, isInWordList: true)
+            ) == "I"
+        )
+    }
+
     /// A replacement carrying its own capitalization is a substitution, not a
     /// spelling of the typed word. Caps lock must not shout it.
     @Test func anExpansionKeepsItsOwnCapitalization() {

--- a/ios/VocaPhoneTests/TypingCandidatesTests.swift
+++ b/ios/VocaPhoneTests/TypingCandidatesTests.swift
@@ -24,7 +24,10 @@ struct TypingCandidatesTests {
         suggestions: Bool = true,
         autocorrect: Bool = true,
         prediction: Bool = true,
-        allowed: Bool = true
+        allowed: Bool = true,
+        followers: [String] = [],
+        expansion: String? = nil,
+        isMidWord: Bool = false
     ) -> TypingCandidates.Context {
         var context = TypingCandidates.Context()
         context.composition = composition
@@ -44,7 +47,137 @@ struct TypingCandidatesTests {
         context.autocorrectEnabled = autocorrect
         context.predictionEnabled = prediction
         context.allowsTypingIntelligence = allowed
+        context.contextualFollowers = followers
+        context.lexiconExpansion = expansion
+        context.isMidWord = isMidWord
         return context
+    }
+
+    // MARK: - The touch model
+
+    /// The corrections a spell checker will never make, because nothing is
+    /// misspelled. Every one of these is blocked by a rule that is individually
+    /// right — too short, already a word, case-only — and every one of them is
+    /// something the system keyboard fixes.
+    @Test func theCuratedShortWordsAreCorrected() {
+        let expected = [
+            "i": "I",
+            "im": "I'm",
+            "ive": "I've",
+            "dont": "don't",
+            "cant": "can't",
+            "youre": "you're",
+            "thats": "that's",
+        ]
+        for (typed, replacement) in expected {
+            #expect(
+                TypingCandidates.autocorrection(
+                    Self.context(composition: typed, isKnownToChecker: true, isInWordList: true)
+                ) == replacement,
+                "\(typed) should become \(replacement)"
+            )
+        }
+    }
+
+    /// The words deliberately left out, because only grammar could tell them
+    /// apart and a keyboard has none.
+    @Test func ambiguousContractionsAreLeftAlone() {
+        for token in ["its", "were", "well", "hell", "shell", "wed"] {
+            #expect(
+                TypingCandidates.autocorrection(
+                    Self.context(composition: token, isKnownToChecker: true)
+                ) == nil,
+                "\(token) should stand"
+            )
+        }
+    }
+
+    /// The user's own assertion outranks the table. Someone who put "im" back
+    /// once has answered the question.
+    @Test func anAssertedShortWordIsNotCorrected() {
+        #expect(
+            TypingCandidates.autocorrection(
+                Self.context(composition: "im", asserted: ["im"])
+            ) == nil
+        )
+    }
+
+    /// A text replacement is an instruction, not a guess: the user told Settings
+    /// what "omw" means. It used to reach the strip as a chip and stop there, so
+    /// the expansion only happened if they noticed and tapped it.
+    @Test func aTextReplacementExpandsOnItsOwn() {
+        #expect(
+            TypingCandidates.autocorrection(
+                Self.context(
+                    composition: "omw",
+                    isKnownToChecker: true,
+                    expansion: "On my way!"
+                )
+            ) == "On my way!"
+        )
+    }
+
+    /// A replacement carrying its own capitalization is a substitution, not a
+    /// spelling of the typed word. Caps lock must not shout it.
+    @Test func anExpansionKeepsItsOwnCapitalization() {
+        #expect(
+            TypingCandidates.matchingCase(of: "OMW", applyingTo: "On my way!") == "On my way!"
+        )
+        #expect(TypingCandidates.matchingCase(of: "i", applyingTo: "I") == "I")
+        // An ordinary correction still follows the typed word's case.
+        #expect(TypingCandidates.matchingCase(of: "Teh", applyingTo: "the") == "The")
+    }
+
+    /// Nothing may be replaced when the cursor is inside a longer word: the
+    /// composition is a prefix of something the keyboard can only see half of,
+    /// and rewriting it corrupts a word the user never finished.
+    @Test func nothingIsCorrectedInTheMiddleOfAWord() {
+        #expect(
+            TypingCandidates.autocorrection(
+                Self.context(composition: "teh", guesses: ["the"], isMidWord: true)
+            ) == nil
+        )
+    }
+
+    /// The preceding word is evidence the checker never had. Two guesses the
+    /// same distance away, and the bigram says which one the sentence wants.
+    @Test func contextBreaksATieTheCheckerCannot() {
+        #expect(
+            TypingCandidates.autocorrection(
+                Self.context(
+                    composition: "hend",
+                    guesses: ["hand", "bend"],
+                    preceding: "please",
+                    followers: ["hand"]
+                )
+            ) == "hand"
+        )
+    }
+
+    /// Proximity settles a contest the dictionary rates equally; it never
+    /// manufactures a winner where there genuinely is not one.
+    @Test func proximityBreaksTiesWithoutCreatingThem() {
+        // Adjacent keys cost less than a letter from the other side of the
+        // keyboard: "w" is beside "e", "p" is not.
+        #expect(KeyProximity.areAdjacent("w", "e"))
+        #expect(!KeyProximity.areAdjacent("q", "p"))
+        #expect(
+            KeyProximity.substitutionCost(typed: "w", intended: "e")
+                < KeyProximity.substitutionCost(typed: "q", intended: "p")
+        )
+        // Still no correction when both readings are one plain edit away.
+        #expect(
+            TypingCandidates.autocorrection(
+                Self.context(composition: "hend", guesses: ["hand", "bend"])
+            ) == nil
+        )
+        // But a runner-up needing strictly more edits still loses, which is the
+        // rule proximity weighting must not have taken away.
+        #expect(
+            TypingCandidates.autocorrection(
+                Self.context(composition: "hend", guesses: ["hand", "blend"])
+            ) == "hand"
+        )
     }
 
     // MARK: - Autocorrect rules

--- a/ios/VocaPhoneTests/TypingCandidatesTests.swift
+++ b/ios/VocaPhoneTests/TypingCandidatesTests.swift
@@ -568,3 +568,45 @@ struct TypingCandidatesTests {
         #expect(TypingCandidates.strip(ctx).candidates.isEmpty)
     }
 }
+
+/// A revert deletes a fixed number of characters and types the original in
+/// their place, which is only meaningful where the replacement actually is.
+struct AppliedCorrectionArmingTests {
+    private static let correction = TypingEngine.AppliedCorrection(
+        typed: "teh",
+        replacement: "the",
+        boundary: " "
+    )
+
+    /// Immediately after the correction, with it still in front of the cursor.
+    @Test func aCorrectionInFrontOfTheCursorIsArmed() {
+        #expect(Self.correction.isArmed(documentBefore: "the "))
+        #expect(Self.correction.isArmed(documentBefore: "I saw the "))
+    }
+
+    /// The cursor has moved on. Reverting here would delete four characters of
+    /// unrelated text and insert a word from a paragraph ago.
+    @Test func aCorrectionTheCursorHasLeftIsNotArmed() {
+        #expect(!Self.correction.isArmed(documentBefore: "the quick brown fox"))
+        #expect(!Self.correction.isArmed(documentBefore: "somewhere else entirely"))
+        #expect(!Self.correction.isArmed(documentBefore: ""))
+    }
+
+    /// The host declining to answer is not permission to delete on faith.
+    @Test func anUnansweredContextIsNotArmed() {
+        #expect(!Self.correction.isArmed(documentBefore: nil))
+    }
+
+    /// The boundary counts. "the" alone is a word the user typed, not the
+    /// correction plus the space that applied it.
+    @Test func theBoundaryIsPartOfWhatMustStillBeThere() {
+        #expect(!Self.correction.isArmed(documentBefore: "the"))
+        let punctuated = TypingEngine.AppliedCorrection(
+            typed: "teh",
+            replacement: "the",
+            boundary: "."
+        )
+        #expect(punctuated.isArmed(documentBefore: "the."))
+        #expect(!punctuated.isArmed(documentBefore: "the "))
+    }
+}

--- a/ios/VocaPhoneTests/TypingCandidatesTests.swift
+++ b/ios/VocaPhoneTests/TypingCandidatesTests.swift
@@ -79,6 +79,35 @@ struct TypingCandidatesTests {
         }
     }
 
+    /// Someone shouting has still chosen their letters. The curated table must
+    /// not rewrite a contraction typed with caps lock on, for the same reason
+    /// "WIP" is not a misspelling of "wip".
+    @Test func aShoutedContractionIsNotRewritten() {
+        for token in ["DONT", "CANT", "IM", "YOURE"] {
+            #expect(
+                TypingCandidates.autocorrection(
+                    Self.context(composition: token, isKnownToChecker: true)
+                ) == nil,
+                "\(token) should stand"
+            )
+        }
+    }
+
+    /// A text replacement is an instruction the user configured, so it expands
+    /// whatever case it is typed in. This is the deliberate split from the rule
+    /// above.
+    @Test func aShoutedShortcutStillExpands() {
+        #expect(
+            TypingCandidates.autocorrection(
+                Self.context(
+                    composition: "OMW",
+                    isKnownToChecker: true,
+                    expansion: "On my way!"
+                )
+            ) == "On my way!"
+        )
+    }
+
     /// The words deliberately left out, because only grammar could tell them
     /// apart and a keyboard has none.
     @Test func ambiguousContractionsAreLeftAlone() {

--- a/ios/VocaPhoneTests/TypingWordListTests.swift
+++ b/ios/VocaPhoneTests/TypingWordListTests.swift
@@ -97,3 +97,46 @@ struct TypingWordListTests {
 
     private final class BundleMarker {}
 }
+
+/// The two things the list precomputes so the keystroke and the swipe do not
+/// have to.
+struct TypingWordListPrecomputationTests {
+    private static let list = TypingWordList(
+        words: ["the", "there", "these", "than", "book", "look"],
+        bigrams: [:]
+    )
+
+    /// The collapsed forms come from the list rather than from the gesture.
+    /// Deriving ten thousand of them inside a swipe meant ten thousand String
+    /// allocations on the main actor at the frame the finger lifted.
+    @Test func collapsedFormsAreBuiltWithTheList() {
+        let list = TypingWordList(words: ["hello", "book", "the"], bigrams: [:])
+        #expect(list.collapsedWords == ["helo", "bok", "the"])
+        #expect(list.collapsedWords.count == list.rankedWords.count)
+    }
+
+    /// After "th" the language plainly expects "e", and that is what lets the
+    /// hit map forgive a finger that lands in the gutter beside it.
+    @Test func theExpectedNextLetterLeadsTheWeights() {
+        let weights = Self.list.nextCharacterWeights(after: "th")
+        #expect(weights["e"] == 1, "the peak is always normalised to 1")
+        #expect((weights["a"] ?? 0) > 0)
+        #expect((weights["a"] ?? 0) < 1)
+        // A letter no word continues into gets no opinion at all.
+        #expect(weights["z"] == nil)
+    }
+
+    /// No prefix, no opinion — which is what clears the bias between words.
+    @Test func anEmptyPrefixExpectsNothing() {
+        #expect(Self.list.nextCharacterWeights(after: "").isEmpty)
+        #expect(Self.list.nextCharacterWeights(after: "qqq").isEmpty)
+    }
+
+    /// Frequency order is the weighting: a continuation found early in the list
+    /// is a more likely one than the same letter found late.
+    @Test func earlierWordsWeighMore() {
+        let list = TypingWordList(words: ["ba"] + Array(repeating: "zz", count: 900) + ["bb"], bigrams: [:])
+        let weights = list.nextCharacterWeights(after: "b")
+        #expect((weights["a"] ?? 0) > (weights["b"] ?? 0))
+    }
+}

--- a/ios/VocaPhoneTests/WordComposerTests.swift
+++ b/ios/VocaPhoneTests/WordComposerTests.swift
@@ -224,3 +224,31 @@ struct PrecedingWordTests {
         #expect(PrecedingWord.lastWord(in: "costs 1200 ") == nil)
     }
 }
+
+/// The trailing context, which this subsystem never read.
+struct DocumentSnapshotTests {
+    /// A cursor at the end of a word is the ordinary case, and everything about
+    /// autocorrect depends on it being distinguishable from the other one.
+    @Test func aCursorAtTheEndOfAWordIsNotMidWord() {
+        #expect(!DocumentSnapshot(before: "hello", after: "").isMidWord)
+        #expect(!DocumentSnapshot(before: "hello", after: " world").isMidWord)
+        #expect(!DocumentSnapshot(before: "hello", after: ". Next").isMidWord)
+    }
+
+    /// Tapping into the middle of "helloworld" after "hello" leaves the composer
+    /// holding a prefix of a word it can only see half of. Rewriting that prefix
+    /// corrupts a word the user never finished typing.
+    @Test func aCursorInsideAWordIsMidWord() {
+        #expect(DocumentSnapshot(before: "hello", after: "world").isMidWord)
+        #expect(DocumentSnapshot(before: "hel", after: "lo").isMidWord)
+        #expect(DocumentSnapshot(before: "don", after: "'t").isMidWord)
+    }
+
+    /// iOS answering with nothing is not the same as an empty document. The
+    /// permissive reading keeps autocorrect working in fields that decline to
+    /// answer, rather than silently switching the feature off there.
+    @Test func anUnansweredContextIsNotTreatedAsMidWord() {
+        #expect(!DocumentSnapshot.unknown.isMidWord)
+        #expect(!DocumentSnapshot(before: "hello").isMidWord)
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -155,6 +155,9 @@ targets:
       # misspelled. Small, curated, and exactly the sort of table that needs a
       # test saying which words are deliberately absent.
       - path: VocaPhoneKeyboard/ShortWordCorrections.swift
+      # The correction the next Delete can take back, and the rule that decides
+      # whether it still points at the text it replaced.
+      - path: VocaPhoneKeyboard/TypingEngine.swift
       - path: VocaPhoneKeyboard/SpellChecking.swift
       - path: VocaPhoneKeyboard/SmartPunctuation.swift
       # The word-to-emoji table is the feature worth pinning: which names

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -34,6 +34,8 @@ targets:
       - path: VocaPhoneKeyboard/KeyView.swift
       - path: VocaPhoneKeyboard/KeyGridView.swift
       - path: VocaPhoneKeyboard/KeyAlternatives.swift
+      - path: VocaPhoneKeyboard/KeyProximity.swift
+      - path: VocaPhoneKeyboard/ShortWordCorrections.swift
       # The grid draws a swipe trail and asks for haptics, so the preview needs
       # both to link.
       - path: VocaPhoneKeyboard/SwipeTrailView.swift
@@ -146,6 +148,13 @@ targets:
       - path: VocaPhoneKeyboard/TypingCandidates.swift
       - path: VocaPhoneKeyboard/TypingFieldPolicy.swift
       - path: VocaPhoneKeyboard/TypingWordList.swift
+      # The keyboard's own spatial model: which letters neighbour which, and
+      # what a neighbouring-key typo costs a correction.
+      - path: VocaPhoneKeyboard/KeyProximity.swift
+      # The corrections a spell checker will never make, because nothing is
+      # misspelled. Small, curated, and exactly the sort of table that needs a
+      # test saying which words are deliberately absent.
+      - path: VocaPhoneKeyboard/ShortWordCorrections.swift
       - path: VocaPhoneKeyboard/SpellChecking.swift
       - path: VocaPhoneKeyboard/SmartPunctuation.swift
       # The word-to-emoji table is the feature worth pinning: which names


### PR DESCRIPTION
## Summary

- Improve native keyboard touch targeting, geometry, corrections, suggestions, emoji, and document-context handling.
- Refresh the onboarding Full Access proof immediately when the permission state changes.

## Problem

A warm keyboard extension could suppress its updated Full Access status for up to ten seconds, leaving onboarding with stale permission evidence. The keyboard also needed the pending native-fidelity improvements now included in this focused iOS change.

## Verification

- [x] `just ios ci` — 672 tests across 67 suites
- [x] `git diff --check`
- [x] `just android ci` — N/A; no Android changes
- [ ] Physical-device test — not performed

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation update — N/A; no data-flow, permission semantics, retention, or network behavior changed