### PR TITLE
fix(ios): stop the Dynamic Island from turning Quick Dictation off for good

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ the active cursor. A gateway is never required for on-device mode.
 > iOS keyboard extensions cannot access the microphone. VocaPhone records in
 > the containing app, shares only versioned session state with the keyboard, and
 > then inserts through `UITextDocumentProxy`. Quick Dictation can keep that app
-> ready for up to 10 minutes so most later dictations do not require another app
-> switch. The speech-to-text model still runs on the iPhone in on-device mode.
+> ready — for 10 or 20 minutes, or until you close the app — so most later
+> dictations do not require another app switch. The speech-to-text model still runs on the iPhone in on-device mode.
 
 ## Highlights
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,12 +57,16 @@ the gateway wire format changed.
 9. The keyboard verifies its session context, persists `inserting`, calls
    `insertText`, then persists `inserted` and `completed`.
 
-After Finish, the app can rearm a 10-minute Quick Dictation window without
-tearing down its `AVAudioEngine`. The same input tap writes buffers only while a
-dictation is active and deliberately discards every standby buffer. The shared
-availability file contains only activation and expiry timestamps. It is cleared
-before active recording, on expiry, on audio failure, or when the user turns the
-feature off.
+After Finish, the app can rearm a Quick Dictation window without
+tearing down its `AVAudioEngine`. The window length is a preference — 10
+minutes, 20 minutes, or "until I close vocaphone", which takes a short lease the
+standby heartbeat keeps renewing so a killed process cannot leave a marker that
+never expires. The same input tap writes buffers only while a dictation is
+active and deliberately discards every standby buffer. The shared availability
+file contains only activation and expiry timestamps. It is cleared before active
+recording, on expiry, on audio failure, when the user turns the feature off, and
+when the Live Activity's Pause button ends the current window. Pausing sets a
+flag that the next foreground clears; only the Settings toggle is durable.
 
 Persisting `inserting` before touching the document intentionally favors
 avoiding duplicate text if the extension terminates at the worst moment.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -69,7 +69,7 @@ These are changeable implementation defaults, not confirmed product decisions:
 | --- | --- | --- |
 | Minimum iOS | iOS 17.0 | Supports the chosen SwiftUI and audio APIs |
 | Recording | WAV from one persistent `AVAudioEngine` input | Avoids losing background microphone readiness between dictations; FFmpeg normalizes it on the Mac |
-| Quick Dictation | Enabled; ready window of 10 minutes (default), 20 minutes, or until the app is closed | Reduces app switching while bounding battery and microphone exposure. The Live Activity's stop button pauses the current window only; the next launch arms a new one |
+| Quick Dictation | Enabled; ready window of 10 minutes (default), 20 minutes, or until the app is closed | Reduces app switching while bounding battery and microphone exposure. The Live Activity's stop button pauses the current window only; the next launch arms a new one. Installs that arrive with it already off — which an older build could do on one tap — are asked once on Home, never switched back on silently |
 | Language | Automatic plus Arabic, English, Spanish, Japanese, Korean, Mandarin Chinese, Ukrainian, Russian, and Vietnamese | Automatic follows the selected gateway model; explicit choices must match it |
 | Output mode | Raw | Avoids unconfirmed cleanup by default |
 | Audio retention | Delete on success; keep failures 24 hours | Privacy with retry recovery |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -69,7 +69,7 @@ These are changeable implementation defaults, not confirmed product decisions:
 | --- | --- | --- |
 | Minimum iOS | iOS 17.0 | Supports the chosen SwiftUI and audio APIs |
 | Recording | WAV from one persistent `AVAudioEngine` input | Avoids losing background microphone readiness between dictations; FFmpeg normalizes it on the Mac |
-| Quick Dictation | Enabled, 10-minute ready window | Reduces app switching while bounding battery and microphone exposure |
+| Quick Dictation | Enabled; ready window of 10 minutes (default), 20 minutes, or until the app is closed | Reduces app switching while bounding battery and microphone exposure. The Live Activity's stop button pauses the current window only; the next launch arms a new one |
 | Language | Automatic plus Arabic, English, Spanish, Japanese, Korean, Mandarin Chinese, Ukrainian, Russian, and Vietnamese | Automatic follows the selected gateway model; explicit choices must match it |
 | Output mode | Raw | Avoids unconfirmed cleanup by default |
 | Audio retention | Delete on success; keep failures 24 hours | Privacy with retry recovery |

--- a/docs/device-setup.md
+++ b/docs/device-setup.md
@@ -32,8 +32,10 @@ and on-device installation have been exercised with the current checkout.
 ## On-device setup
 
 1. Open vocaphone and grant microphone permission.
-2. Leave “Keep Quick Dictation ready for 10 minutes” enabled. Confirm the app
-   shows Quick Dictation as Ready and iOS displays its microphone indicator.
+2. Leave “Keep Quick Dictation ready” enabled. Confirm the app shows Quick
+   Dictation as Ready and iOS displays its microphone indicator. **Stay ready
+   for** picks the window: 10 minutes (default), 20 minutes, or until vocaphone
+   is closed.
 3. Choose a transcription source. Either path completes the step on its own:
    - **On this iPhone** — under **Settings → Transcription**, pick **On this
      iPhone** and download a speech-to-text model. Wait for it to report
@@ -137,9 +139,14 @@ Run these checks on a physical iPhone after changing audio or App Group code:
 
 - Start and finish from the keyboard several times. Recording and transcript
   states should update immediately; the slower polling path is only a fallback.
-- Expand the standby Dynamic Island and tap **Turn off Quick Dictation**. The
+- Expand the standby Dynamic Island and tap **Pause Quick Dictation**. The
   Live Activity and orange microphone indicator must disappear without opening
-  vocaphone, and the next keyboard dictation must open the app.
+  vocaphone, and the next keyboard dictation must open the app. Then reopen
+  vocaphone: standby must arm again on its own, and the Settings toggle must
+  still read as on — a pause is not a preference change.
+- Set **Stay ready for** to *Until I close vocaphone*, background the app, and
+  confirm standby is still Ready well past 10 minutes. Force-quit vocaphone and
+  confirm the keyboard falls back to opening the app.
 - Force-quit vocaphone while Quick Dictation is ready, wait at least 7 seconds,
   and tap Dictate. The keyboard must treat the heartbeat as stale and open the
   app instead of claiming that standby is ready.

--- a/docs/device-setup.md
+++ b/docs/device-setup.md
@@ -147,6 +147,9 @@ Run these checks on a physical iPhone after changing audio or App Group code:
 - Set **Stay ready for** to *Until I close vocaphone*, background the app, and
   confirm standby is still Ready well past 10 minutes. Force-quit vocaphone and
   confirm the keyboard falls back to opening the app.
+- Upgrading with Quick Dictation already off must show the one-time card on
+  Home offering to turn it back on, and must not arm the microphone until that
+  card is answered. **Not now** has to keep it off and never ask again.
 - Force-quit vocaphone while Quick Dictation is ready, wait at least 7 seconds,
   and tap Dictate. The keyboard must treat the heartbeat as stale and open the
   app instead of claiming that standby is ready.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -9,11 +9,14 @@ after a transcript is safely stored. HTTPS or an encrypted private network is
 recommended so the recording and token are protected in transit.
 
 When Quick Dictation is enabled, the containing app may keep microphone input
-active for up to 10 minutes so later keyboard actions do not need another app
-handoff. The system's orange microphone indicator remains visible. Audio buffers
+active so later keyboard actions do not need another app handoff. The window is
+the user's choice — 10 minutes by default, 20 minutes, or until vocaphone is
+closed. The system's orange microphone indicator remains visible. Audio buffers
 captured while waiting are discarded in memory: they are not written to disk,
 placed in shared state, or uploaded. Only audio after an explicit Dictate action
-is saved for transcription. The user can turn Quick Dictation off in the app.
+is saved for transcription. The user can turn Quick Dictation off in the app,
+or pause the current window from the Live Activity without changing the
+setting.
 
 The gateway host stores randomized audio names under its private data directory.
 On success, original and normalized audio are deleted by default. Failed and

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		28F0EDCC20383E5A9FEB5B42 /* WordComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9859ACCB32CD57E4F3E4D46A /* WordComposerTests.swift */; };
 		2912856F09ED7566DB955AF9 /* InsertionTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A53786C8D2346452C69A748 /* InsertionTargetTests.swift */; };
 		29D15EC565FE20FEE4FFE469 /* TranscriptRetention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6FFEA14B55E6F6C61FBAC /* TranscriptRetention.swift */; };
+		2B102E6B9DACF6787D86C68F /* QuickDictationRecoveryOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B433665FF81481E6CD0E1612 /* QuickDictationRecoveryOffer.swift */; };
 		2C1B81951562FBD7FF87662D /* TelemetryRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27748467103CFAD3F6A2F603 /* TelemetryRecord.swift */; };
 		2C362C9B71AA6A93A6D7E4DB /* SessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */; };
 		2CB5468923B46D6ACAE60BE2 /* TranscriptSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E491E7E805F47388A668E1 /* TranscriptSanitizerTests.swift */; };
@@ -97,6 +98,7 @@
 		3C4DE9EF77062407F71ACDCB /* LanguageMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C45D98EAFE18C689DC7551E9 /* LanguageMenuTests.swift */; };
 		3D08A881E95118E5B57E9FCD /* TranscriptSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B121356A503DF83BFA0E0D0C /* TranscriptSanitizer.swift */; };
 		3E4A55C0E40176FC61E4105C /* SherpaDecodeOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EFEBD6293F9649D551A9014 /* SherpaDecodeOutcome.swift */; };
+		3E6B0A4C52A07940D9E96A11 /* QuickDictationRecoveryOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B433665FF81481E6CD0E1612 /* QuickDictationRecoveryOffer.swift */; };
 		3E812EB0A69DFF8CC9A7CA6E /* ModelTranslationSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7235E2DEF5A0082A417E3E /* ModelTranslationSupport.swift */; };
 		3EF8AE348290CBB5FE45BD11 /* ModelLanguageSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */; };
 		3F3E17AFAAE8EB6B79A872BE /* SessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */; };
@@ -547,6 +549,7 @@
 		B121356A503DF83BFA0E0D0C /* TranscriptSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSanitizer.swift; sourceTree = "<group>"; };
 		B154124C04655D1A36F1B4E4 /* TranscriptionSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSourceTests.swift; sourceTree = "<group>"; };
 		B15DE10A5F8F90C87D4BA48A /* AudioCapturePipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCapturePipeline.swift; sourceTree = "<group>"; };
+		B433665FF81481E6CD0E1612 /* QuickDictationRecoveryOffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDictationRecoveryOffer.swift; sourceTree = "<group>"; };
 		B67629F24A2CF6C990BA991A /* en.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = en.txt; sourceTree = "<group>"; };
 		B6B395C37266816A19C38B59 /* SemanticPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticPaletteTests.swift; sourceTree = "<group>"; };
 		B7028AF4B134C7EDD726891E /* VocaPhoneKeyboard.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = VocaPhoneKeyboard.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -933,6 +936,7 @@
 				406B0C287866B36EF3109238 /* LocalModelPicker.swift */,
 				2D34E7E54437AFA69FDC2848 /* OnboardingPresentation.swift */,
 				70B3F1DBA8332A13B095E4BA /* PairingScannerView.swift */,
+				B433665FF81481E6CD0E1612 /* QuickDictationRecoveryOffer.swift */,
 				87F5D76EB1E944F3A323006D /* SettingsView.swift */,
 				342F2B3B437269514C969C77 /* SetupStatus.swift */,
 				346B6558EE5557A35C916067 /* SetupView.swift */,
@@ -1266,6 +1270,7 @@
 				C7ADFFD337103F3F6CF7BBA6 /* ProtectedSpans.swift in Sources */,
 				B4EE97A67B156A6D5BA0D258 /* QuickDictationAvailability.swift in Sources */,
 				FF899AF5E59FAA55FDA261ED /* QuickDictationDuration.swift in Sources */,
+				3E6B0A4C52A07940D9E96A11 /* QuickDictationRecoveryOffer.swift in Sources */,
 				5D5A394AA7E8170CFE4E128B /* RecordingCoordinator.swift in Sources */,
 				A59723F937FABF80B8158883 /* RecordingSoundFeedback.swift in Sources */,
 				53A1176717AEAE72A1F5B9F1 /* SemanticPalette.swift in Sources */,
@@ -1440,6 +1445,7 @@
 				D37101A845F65CA081F8B6E4 /* ProtectedSpans.swift in Sources */,
 				BCB8CA3BAACE6280D9ED4B22 /* QuickDictationAvailability.swift in Sources */,
 				7F4E5E2A734F31B916574879 /* QuickDictationDuration.swift in Sources */,
+				2B102E6B9DACF6787D86C68F /* QuickDictationRecoveryOffer.swift in Sources */,
 				15E349A8DDDFD47EFA7EE2FA /* ReliabilityFeatureTests.swift in Sources */,
 				6CEF2A686643F72F4BCDD51D /* SemanticPalette.swift in Sources */,
 				C37AC6FC3CBF2147D8A50DDA /* SemanticPaletteTests.swift in Sources */,

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 		7E28776EDC2BD3E8A8AFCED9 /* TypingPrivacyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05735C847A47FF442B4FB21A /* TypingPrivacyTests.swift */; };
 		7E3D8E857A83184E74B15433 /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */; };
 		7E7D3327C8DF767DD960ECE9 /* SherpaDecodeOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EFEBD6293F9649D551A9014 /* SherpaDecodeOutcome.swift */; };
+		7F4E5E2A734F31B916574879 /* QuickDictationDuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783E7FC5F9553FD419487180 /* QuickDictationDuration.swift */; };
 		81131D34DE3F3CBDBA61BE4E /* SwipeTrailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */; };
 		81BFE90A24876CEE127974AE /* TypingFieldPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2CD13AAF5FDF79DD5D0075 /* TypingFieldPolicy.swift */; };
 		81DDEADAD62C978ED52AAE90 /* SentencePunctuation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AF826E0D2C7820CBB4B78C /* SentencePunctuation.swift */; };
@@ -229,6 +230,7 @@
 		9C6AF2EE68EB7AA4D4CF0F61 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA135DE504590121F6D8843 /* DiagnosticLog.swift */; };
 		9EE31A21EE5F9D71A15404DA /* SpellChecking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4BE75828FCA9C70DFEDC96 /* SpellChecking.swift */; };
 		9F93D09F955DA7B5CC65F058 /* OnboardingPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8348F9E480C0343CD38657B /* OnboardingPresentationTests.swift */; };
+		9FAAEF705B6D4575B72F2D07 /* QuickDictationDuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783E7FC5F9553FD419487180 /* QuickDictationDuration.swift */; };
 		A018E5851AAB98E42FBBB65A /* DictationPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCCE5FE1A8242B96B8CA9FD /* DictationPresentation.swift */; };
 		A0420E3166FF08AE5059A805 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9BB34E20645F3D8C78A0363 /* Telemetry.swift */; };
 		A0B8569F3B1A3F72EAC9C1DB /* TranscriptionQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E2BF42CAC209DA12464566 /* TranscriptionQuality.swift */; };
@@ -312,6 +314,7 @@
 		D4FEC9D26550CB1696FDF424 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */; };
 		D6533E4D830A06E9845CE624 /* KeyboardViewPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8E5D91EDE2C0E67DFC0250 /* KeyboardViewPreview.swift */; };
 		D7038E651848C4EE6B0F722A /* TypingStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AA0EB543777294237739CF /* TypingStripView.swift */; };
+		D73776692116A07EF59C6496 /* QuickDictationDuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783E7FC5F9553FD419487180 /* QuickDictationDuration.swift */; };
 		D7CC096732C721CE14B5F682 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */; };
 		D8EE8A829E13191046F3F183 /* WordComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A6EEE8C98BCBF8D1D70D44 /* WordComposer.swift */; };
 		D9811B8978380027BF95D0D5 /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
@@ -372,6 +375,7 @@
 		FCE1FDC346554C0EE93845F0 /* SherpaEmptyChunkRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF256CF6ED209E00193BF135 /* SherpaEmptyChunkRecovery.swift */; };
 		FD06CBDABE4EA9640EECF39C /* SherpaLongAudioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C2BEEA5195CB9CB5A38CA /* SherpaLongAudioTests.swift */; };
 		FDBB4DF9D4816CD646C1644D /* TypingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B9027C03A87FBC74CE1130 /* TypingEngine.swift */; };
+		FF899AF5E59FAA55FDA261ED /* QuickDictationDuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783E7FC5F9553FD419487180 /* QuickDictationDuration.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -490,6 +494,7 @@
 		71DC06463C8AA4C516363157 /* TranscriptRepairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptRepairTests.swift; sourceTree = "<group>"; };
 		755A4279065D41A705E1F19D /* DesignSystemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemTests.swift; sourceTree = "<group>"; };
 		75FD84E65614D9F94D8EF0AC /* DictationBarComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarComponents.swift; sourceTree = "<group>"; };
+		783E7FC5F9553FD419487180 /* QuickDictationDuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDictationDuration.swift; sourceTree = "<group>"; };
 		786DEF44BDB4C70935762971 /* VocaPhoneLiveActivity.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VocaPhoneLiveActivity.entitlements; sourceTree = "<group>"; };
 		78AF826E0D2C7820CBB4B78C /* SentencePunctuation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentencePunctuation.swift; sourceTree = "<group>"; };
 		7948F8C6C72A8D7A16C18562 /* SharedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStore.swift; sourceTree = "<group>"; };
@@ -721,6 +726,7 @@
 				DBFB4BB0345784837C629340 /* PairingPayload.swift */,
 				D57FC525B204634FF41CDCDA /* ProtectedSpans.swift */,
 				0AB84927D76F9C32C4BE1547 /* QuickDictationAvailability.swift */,
+				783E7FC5F9553FD419487180 /* QuickDictationDuration.swift */,
 				AF6C44F954E7A62974C66109 /* SemanticPalette.swift */,
 				78AF826E0D2C7820CBB4B78C /* SentencePunctuation.swift */,
 				36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */,
@@ -1167,6 +1173,7 @@
 				FAD55FD707FD21407E0980FA /* PairingPayload.swift in Sources */,
 				1D8B94886C8506BB36C1887C /* ProtectedSpans.swift in Sources */,
 				6192C923119F158CCE94B48E /* QuickDictationAvailability.swift in Sources */,
+				D73776692116A07EF59C6496 /* QuickDictationDuration.swift in Sources */,
 				EE7A49C4F95388AF42E1B30C /* SemanticPalette.swift in Sources */,
 				81DDEADAD62C978ED52AAE90 /* SentencePunctuation.swift in Sources */,
 				36295638EAABF35D05369EB0 /* SessionRecord.swift in Sources */,
@@ -1258,6 +1265,7 @@
 				2F1F7D8997BCA83AF5334382 /* PreviewMatrix.swift in Sources */,
 				C7ADFFD337103F3F6CF7BBA6 /* ProtectedSpans.swift in Sources */,
 				B4EE97A67B156A6D5BA0D258 /* QuickDictationAvailability.swift in Sources */,
+				FF899AF5E59FAA55FDA261ED /* QuickDictationDuration.swift in Sources */,
 				5D5A394AA7E8170CFE4E128B /* RecordingCoordinator.swift in Sources */,
 				A59723F937FABF80B8158883 /* RecordingSoundFeedback.swift in Sources */,
 				53A1176717AEAE72A1F5B9F1 /* SemanticPalette.swift in Sources */,
@@ -1336,6 +1344,7 @@
 				364C315F292BA4BD66E23C2A /* PairingPayload.swift in Sources */,
 				F231FFC3DFB742B826516E5E /* ProtectedSpans.swift in Sources */,
 				58CDCA65875E94B8F7BE0101 /* QuickDictationAvailability.swift in Sources */,
+				9FAAEF705B6D4575B72F2D07 /* QuickDictationDuration.swift in Sources */,
 				F4E8B1A9D00B14184B01B223 /* SemanticPalette.swift in Sources */,
 				54A3525CD8F0DFA70980501B /* SentencePunctuation.swift in Sources */,
 				3F3E17AFAAE8EB6B79A872BE /* SessionRecord.swift in Sources */,
@@ -1430,6 +1439,7 @@
 				B1A1053055864F55448F5FED /* ProMotionOptInTests.swift in Sources */,
 				D37101A845F65CA081F8B6E4 /* ProtectedSpans.swift in Sources */,
 				BCB8CA3BAACE6280D9ED4B22 /* QuickDictationAvailability.swift in Sources */,
+				7F4E5E2A734F31B916574879 /* QuickDictationDuration.swift in Sources */,
 				15E349A8DDDFD47EFA7EE2FA /* ReliabilityFeatureTests.swift in Sources */,
 				6CEF2A686643F72F4BCDD51D /* SemanticPalette.swift in Sources */,
 				C37AC6FC3CBF2147D8A50DDA /* SemanticPaletteTests.swift in Sources */,

--- a/ios/VocaPhoneActivityShared/StopQuickDictationIntent.swift
+++ b/ios/VocaPhoneActivityShared/StopQuickDictationIntent.swift
@@ -5,21 +5,26 @@ import Foundation
 /// Runs from the Live Activity without opening VocaPhone. The App Group write
 /// makes the command durable, while the Darwin ping tells the still-running
 /// containing app to release its audio engine immediately.
+///
+/// This is a pause, not a settings change. Somebody reaching for it wants the
+/// microphone released now — from a button that offers no way to undo itself —
+/// not to be sent hunting through Settings the next time they dictate. The next
+/// launch of vocaphone clears the pause and arms a fresh window.
 struct StopQuickDictationIntent: LiveActivityIntent {
-    static let title: LocalizedStringResource = "Turn off Quick Dictation"
+    static let title: LocalizedStringResource = "Pause Quick Dictation"
     static let description = IntentDescription(
-        "Stops VocaPhone standby and releases the microphone."
+        "Ends this VocaPhone standby window and releases the microphone. Reopening VocaPhone starts a new one."
     )
 
     func perform() async throws -> some IntentResult {
-        KeyboardPreferences.quickDictationEnabled = false
+        KeyboardPreferences.quickDictationPausedUntilRelaunch = true
         try? SharedStore.shared.clearQuickDictationAvailability()
         DiagnosticLog.record(.stopQuickDictationRequested)
         VocaPhoneDarwinCenter.post(.stopQuickDictationRequested)
 
         let content = ActivityContent(
             state: VocaPhoneActivityAttributes.ContentState(
-                status: "Quick Dictation off",
+                status: "Quick Dictation paused",
                 canFinish: false,
                 phase: .finished
             ),

--- a/ios/VocaPhoneApp/App/ContentView.swift
+++ b/ios/VocaPhoneApp/App/ContentView.swift
@@ -26,6 +26,14 @@ struct ContentView: View {
         KeyboardPreferences.keyboardPracticeKey,
         store: KeyboardPreferences.defaults
     ) private var hasCompletedKeyboardPractice = false
+    @AppStorage(
+        KeyboardPreferences.quickDictationKey,
+        store: KeyboardPreferences.defaults
+    ) private var quickDictationEnabled = true
+    @AppStorage(
+        KeyboardPreferences.quickDictationRecoveryOfferKey,
+        store: KeyboardPreferences.defaults
+    ) private var quickDictationOfferPending = false
     @State private var testText = ""
     @State private var isShowingSourceDetail = false
     @FocusState private var diagFocused: Bool
@@ -35,6 +43,7 @@ struct ContentView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: VocaMetrics.grouping) {
                     attentionCard
+                    quickDictationOfferCard
                     sessionCard
                     practiceCard
                     sourceRow
@@ -122,6 +131,40 @@ struct ContentView: View {
                 }
             }
             .buttonStyle(.plain)
+        }
+    }
+
+    /// Sits below the setup card, which still owns the top slot: an unfinished
+    /// setup blocks dictation outright, while this only costs an app switch.
+    @ViewBuilder private var quickDictationOfferCard: some View {
+        if let offer = QuickDictationRecoveryOffer.make(
+            isPending: quickDictationOfferPending,
+            isEnabled: quickDictationEnabled
+        ) {
+            VocaCard {
+                VStack(alignment: .leading, spacing: VocaMetrics.padding - 2) {
+                    VocaStatusLine(
+                        status: .inactive,
+                        title: offer.title,
+                        detail: offer.detail
+                    )
+                    // The coordinator owns both keys this card reads, and
+                    // `@AppStorage` is watching the same suite, so one call
+                    // turns the feature on, answers the offer, and takes the
+                    // card off screen.
+                    VocaPrimaryButton(title: offer.confirm, symbol: "mic.fill") {
+                        coordinator.setQuickDictationEnabled(true)
+                    }
+                    // Taken as final. The card exists to undo a decision the
+                    // user may never have made knowingly; asking twice would
+                    // make it the nag it is trying not to be.
+                    Button(offer.dismiss) {
+                        quickDictationOfferPending = false
+                    }
+                    .frame(maxWidth: .infinity)
+                    .font(.subheadline)
+                }
+            }
         }
     }
 

--- a/ios/VocaPhoneApp/App/ContentView.swift
+++ b/ios/VocaPhoneApp/App/ContentView.swift
@@ -68,6 +68,9 @@ struct ContentView: View {
                     isShowingSetup = true
                 }
                 coordinator.refreshSetupStatus()
+                // `scenePhase` does not change on a cold launch, so the pause a
+                // previous run left behind is cleared here too.
+                coordinator.endQuickDictationPause()
                 await coordinator.recoverRecentSession()
                 coordinator.prepareQuickDictationIfEnabled()
                 await coordinator.refreshGatewayHealth()
@@ -131,6 +134,7 @@ struct ContentView: View {
                 isRecording: coordinator.isRecording,
                 isQuickDictationReady: coordinator.isQuickDictationReady,
                 quickDictationExpiresAt: coordinator.quickDictationExpiresAt,
+                quickDictationDuration: coordinator.quickDictationDuration,
                 processingLocation: coordinator.activeRecord?.processingLocation,
                 transcript: coordinator.transcript,
                 errorMessage: coordinator.hasError ? coordinator.message : nil,

--- a/ios/VocaPhoneApp/App/HomePresentation.swift
+++ b/ios/VocaPhoneApp/App/HomePresentation.swift
@@ -41,6 +41,7 @@ struct HomeSessionCard: Equatable {
         var isRecording = false
         var isQuickDictationReady = false
         var quickDictationExpiresAt: Date?
+        var quickDictationDuration: QuickDictationDuration?
         var processingLocation: SessionProcessingLocation?
         var transcript: String?
         var errorMessage: String?
@@ -78,8 +79,9 @@ struct HomeSessionCard: Equatable {
             // Standby, not recording — and the wording has to make that
             // unmistakable, because the iOS microphone indicator is lit either
             // way. See `QuickDictationAvailability`.
-            detail = "Quick Dictation is on standby until "
-                + expiresAt.formatted(date: .omitted, time: .shortened)
+            let duration = context.quickDictationDuration ?? .tenMinutes
+            detail = "Quick Dictation is on standby "
+                + duration.standbyDescription(expiringAt: expiresAt)
                 + ". Nothing is being recorded."
         } else if !context.isSourceReady {
             detail = "Choose where speech becomes text before dictating."

--- a/ios/VocaPhoneApp/App/QuickDictationRecoveryOffer.swift
+++ b/ios/VocaPhoneApp/App/QuickDictationRecoveryOffer.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// The one-time offer to turn Quick Dictation back on, shown to the people an
+/// older build turned it off for.
+///
+/// Until this release the Live Activity's stop button wrote the durable
+/// preference, so a single tap on a control with no undo left Quick Dictation
+/// off until the user found the switch in Settings. Those installs carry a
+/// stored `false` that is indistinguishable from a deliberate choice, so
+/// nothing here flips it back: re-arming somebody's microphone on their behalf
+/// would be a worse bug than the one being fixed. The app asks instead, once,
+/// and takes either answer as final.
+struct QuickDictationRecoveryOffer: Equatable {
+    var title: String
+    var detail: String
+    var confirm: String
+    var dismiss: String
+
+    /// `nil` whenever there is nothing to ask: the offer was already answered,
+    /// this install was never affected, or Quick Dictation is on — including
+    /// when the user turned it on themselves in Settings before reaching Home.
+    static func make(isPending: Bool, isEnabled: Bool) -> QuickDictationRecoveryOffer? {
+        guard isPending, !isEnabled else { return nil }
+        return QuickDictationRecoveryOffer(
+            title: "Quick Dictation is off",
+            // Names what happened, because the people seeing this card mostly
+            // do not believe they ever turned the feature off.
+            detail: "Stopping it from the Dynamic Island used to switch it off for "
+                + "good — it now only pauses until you reopen vocaphone. Turn it back "
+                + "on to dictate without leaving the app you are in.",
+            confirm: "Turn it back on",
+            dismiss: "Not now"
+        )
+    }
+}

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -378,6 +378,10 @@ struct DictationSettingsView: View {
         store: KeyboardPreferences.defaults
     ) private var quickDictationEnabled = true
     @AppStorage(
+        KeyboardPreferences.quickDictationDurationKey,
+        store: KeyboardPreferences.defaults
+    ) private var quickDictationDurationRawValue = QuickDictationDuration.tenMinutes.rawValue
+    @AppStorage(
         KeyboardPreferences.writingStyleKey,
         store: KeyboardPreferences.defaults
     ) private var writingStyleRawValue = WritingStyle.casual.rawValue
@@ -442,19 +446,35 @@ struct DictationSettingsView: View {
         }
     }
 
+    private var selectedQuickDictationDuration: QuickDictationDuration {
+        QuickDictationDuration(rawValue: quickDictationDurationRawValue) ?? .tenMinutes
+    }
+
     private var quickDictationSection: some View {
         Section {
-            Toggle("Keep Quick Dictation ready for 10 minutes", isOn: $quickDictationEnabled)
+            Toggle("Keep Quick Dictation ready", isOn: $quickDictationEnabled)
                 .onChange(of: quickDictationEnabled) { _, enabled in
                     coordinator.setQuickDictationEnabled(enabled)
                 }
+            // Hidden rather than disabled when the feature is off: a greyed-out
+            // duration for a window that will never open is noise.
+            if quickDictationEnabled {
+                Picker("Stay ready for", selection: $quickDictationDurationRawValue) {
+                    ForEach(QuickDictationDuration.allCases) { duration in
+                        Text(duration.displayName).tag(duration.rawValue)
+                    }
+                }
+                .onChange(of: quickDictationDurationRawValue) { _, rawValue in
+                    guard let duration = QuickDictationDuration(rawValue: rawValue) else { return }
+                    coordinator.setQuickDictationDuration(duration)
+                }
+            }
         } footer: {
             Text(
-                "After vocaphone gets microphone access, it keeps an active background "
-                    + "input for up to 10 minutes so Dictate can start without leaving "
-                    + "the app you are in. Standby audio is discarded and never saved or "
-                    + "uploaded. The orange microphone indicator stays visible while it "
-                    + "is on."
+                quickDictationEnabled
+                    ? selectedQuickDictationDuration.settingsFooter
+                    : "The keyboard's first Dictate tap opens vocaphone to record, then "
+                        + "you swipe back. Turn this on to skip that trip."
             )
         }
     }

--- a/ios/VocaPhoneApp/App/VocaPhoneApp.swift
+++ b/ios/VocaPhoneApp/App/VocaPhoneApp.swift
@@ -91,6 +91,11 @@ struct VocaPhoneApp: App {
                         }
                         return
                     }
+                    // A pause taken from the Live Activity ends here: coming
+                    // back to vocaphone is the "turn it back on" gesture, and
+                    // the alternative is a user hunting through Settings for a
+                    // switch they never knowingly flipped.
+                    coordinator.endQuickDictationPause()
                     Task {
                         await coordinator.recoverRecentSession()
                         coordinator.prepareQuickDictationIfEnabled()

--- a/ios/VocaPhoneApp/App/VocaPhoneApp.swift
+++ b/ios/VocaPhoneApp/App/VocaPhoneApp.swift
@@ -69,6 +69,7 @@ struct VocaPhoneApp: App {
                 .onAppear {
                     KeyboardPreferences.containingAppIsForeground = true
                     KeyboardPreferences.migrateTypingHapticsIfNeeded()
+                    KeyboardPreferences.markQuickDictationRecoveryOfferIfNeeded()
                     Telemetry.shared.appFirstOpen()
                     // Started once here rather than lazily from the setup card:
                     // the first path update has to have landed by the time that

--- a/ios/VocaPhoneApp/Sessions/LiveActivityManager.swift
+++ b/ios/VocaPhoneApp/Sessions/LiveActivityManager.swift
@@ -71,6 +71,45 @@ final class LiveActivityManager: @unchecked Sendable {
         )
     }
 
+    /// How far the stale date has to have moved before it is worth telling the
+    /// system. The standby lease is renewed every couple of seconds, and an
+    /// ActivityKit update per heartbeat would burn the whole day redrawing a
+    /// card whose text never changes. Two minutes still leaves the stale date
+    /// minutes ahead of now, so a live window never renders as stale.
+    private static let standbyRenewalInterval: TimeInterval = 120
+
+    /// Pushes the standby activity's stale date forward for a window the user
+    /// asked to last as long as the app does.
+    ///
+    /// Deliberately not `present`: that requests a new activity when none
+    /// exist, which would resurrect a card the user swiped away and keep
+    /// resurrecting it for as long as standby ran. A renewal updates what is on
+    /// screen or does nothing.
+    func renewStandby(expiresAt: Date) {
+        guard standbyRequested, activeSessionID == nil else { return }
+        if let standbyExpiresAt,
+           expiresAt.timeIntervalSince(standbyExpiresAt) < Self.standbyRenewalInterval
+        {
+            return
+        }
+        standbyExpiresAt = expiresAt
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+
+        let content = ActivityContent(
+            state: VocaPhoneActivityAttributes.ContentState(
+                status: "Quick Dictation on standby",
+                canFinish: false,
+                phase: .standby
+            ),
+            staleDate: expiresAt
+        )
+        enqueueActivityMutation {
+            for activity in Activity<VocaPhoneActivityAttributes>.activities {
+                await activity.update(content)
+            }
+        }
+    }
+
     /// Removes the standby Live Activity when Quick Dictation releases the
     /// microphone. An active recording keeps its own activity until completion.
     func stopStandby() {

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -1329,6 +1329,11 @@ final class RecordingCoordinator {
         }
     }
 
+    /// How far a renewing window's deadline has to move before the observable
+    /// copy is updated. Well under the lease, so the published value is always
+    /// minutes ahead of now.
+    private static let standbyDeadlinePublishInterval: TimeInterval = 60
+
     private func beginQuickDictationWatcher(
         _ availability: QuickDictationAvailability,
         duration: QuickDictationDuration
@@ -1347,11 +1352,20 @@ final class RecordingCoordinator {
                     return
                 }
                 refreshedAvailability = refreshedAvailability.renewingLease(duration)
-                // Only a renewing window has a deadline that moves. Writing the
-                // same date back every two seconds would invalidate the home
-                // card on every heartbeat for nothing.
+                // Only a renewing window has a deadline that moves, and it moves
+                // every two seconds. Publishing each one would re-render the
+                // home card at that rate for the whole life of an all-day
+                // standby — for a card that shows this window no clock time at
+                // all. Publish rarely enough to keep the deadline comfortably
+                // in the future, which is all `isQuickDictationReady` asks, and
+                // no more. `renewStandby` throttles itself the same way.
                 if duration.renewsLease {
-                    self.quickDictationExpiresAt = refreshedAvailability.expiresAt
+                    let published = self.quickDictationExpiresAt ?? .distantPast
+                    if refreshedAvailability.expiresAt.timeIntervalSince(published)
+                        >= Self.standbyDeadlinePublishInterval
+                    {
+                        self.quickDictationExpiresAt = refreshedAvailability.expiresAt
+                    }
                     self.liveActivity.renewStandby(expiresAt: refreshedAvailability.expiresAt)
                 }
                 do {

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -8,6 +8,10 @@ final class RecordingCoordinator {
     private(set) var activeRecord: SessionRecord?
     private(set) var message: String?
     private(set) var quickDictationExpiresAt: Date?
+    /// The window the armed standby is running under, so the home card can say
+    /// "until 4:20 PM" or "until you close vocaphone" without re-reading the
+    /// preference behind the arming.
+    private(set) var quickDictationDuration: QuickDictationDuration?
     private(set) var currentMicrophoneName: String?
     /// Kept separate from `activeRecord` so a level update several times a
     /// second invalidates only the views that draw the meter.
@@ -330,6 +334,7 @@ final class RecordingCoordinator {
         meterLevel: Float = 0,
         isRecording: Bool = false,
         quickDictationExpiresAt: Date? = nil,
+        quickDictationDuration: QuickDictationDuration? = nil,
         microphoneName: String? = nil,
         transcripts: [SessionRecord]? = nil,
         models: LocalModelManager = LocalModelManager(preview: [])
@@ -343,6 +348,8 @@ final class RecordingCoordinator {
         self.message = message
         self.meterLevel = meterLevel
         self.quickDictationExpiresAt = quickDictationExpiresAt
+        self.quickDictationDuration = quickDictationDuration
+            ?? (quickDictationExpiresAt == nil ? nil : .tenMinutes)
         currentMicrophoneName = microphoneName
     }
 #endif
@@ -403,7 +410,7 @@ final class RecordingCoordinator {
             guard let self else { return }
             if granted {
                 self.message = "Microphone permission granted."
-                if KeyboardPreferences.quickDictationEnabled {
+                if KeyboardPreferences.quickDictationArmable {
                     self.armQuickDictation()
                 }
             } else {
@@ -417,10 +424,11 @@ final class RecordingCoordinator {
         guard !isInert else { return }
         debugQuickDictation(
             "prepare enabled=\(KeyboardPreferences.quickDictationEnabled) "
+                + "paused=\(KeyboardPreferences.quickDictationPausedUntilRelaunch) "
                 + "permission=\(recorder.recordPermission.rawValue) "
                 + "recording=\(recorder.isRecording)"
         )
-        guard KeyboardPreferences.quickDictationEnabled,
+        guard KeyboardPreferences.quickDictationArmable,
               audioSessionAvailable,
               recorder.recordPermission == .granted,
               !recorder.isRecording,
@@ -429,9 +437,24 @@ final class RecordingCoordinator {
         armQuickDictation()
     }
 
+    /// Called every time vocaphone reaches the foreground. A pause taken from
+    /// the Live Activity lasts exactly until the user comes back — which is the
+    /// whole point of it being a pause — so this runs before the arming check
+    /// rather than being folded into it.
+    func endQuickDictationPause() {
+        guard !isInert else { return }
+        guard KeyboardPreferences.quickDictationPausedUntilRelaunch else { return }
+        KeyboardPreferences.quickDictationPausedUntilRelaunch = false
+        debugQuickDictation("pause cleared on foreground")
+    }
+
     func setQuickDictationEnabled(_ enabled: Bool) {
         guard !isInert else { return }
         KeyboardPreferences.quickDictationEnabled = enabled
+        // Either way the pause has been overtaken by a deliberate choice: on,
+        // and the user wants it armed now; off, and the durable switch is the
+        // stronger statement.
+        KeyboardPreferences.quickDictationPausedUntilRelaunch = false
         if enabled {
             if recorder.recordPermission == .granted {
                 armQuickDictation()
@@ -439,11 +462,32 @@ final class RecordingCoordinator {
                 requestMicrophonePermission()
             }
         } else {
-            stopQuickDictation()
+            disableQuickDictation()
         }
     }
 
-    func stopQuickDictation() {
+    /// The standby window the user asked for. Changing it re-arms so the new
+    /// window starts now, instead of waiting out the old one.
+    ///
+    /// The preference is assigned rather than compared: Settings binds the
+    /// picker straight to the same App Group key, so by the time this runs the
+    /// stored value is already the new one and an equality check would never
+    /// fire.
+    func setQuickDictationDuration(_ duration: QuickDictationDuration) {
+        guard !isInert else { return }
+        KeyboardPreferences.quickDictationDuration = duration
+        guard quickDictationDuration != duration,
+              KeyboardPreferences.quickDictationArmable,
+              recorder.recordPermission == .granted,
+              !recorder.isRecording,
+              startingSessionID == nil
+        else { return }
+        armQuickDictation()
+    }
+
+    /// The Settings switch turned off: durable, and it stays off until the user
+    /// turns it back on.
+    func disableQuickDictation() {
         guard !isInert else { return }
         KeyboardPreferences.quickDictationEnabled = false
         clearQuickDictationReadiness(deactivateAudioSession: true)
@@ -451,6 +495,19 @@ final class RecordingCoordinator {
         DiagnosticLog.record(
             .quickDictationStopped,
             metadata: .reason(.userRequested)
+        )
+    }
+
+    /// The Live Activity's stop button: this window only. The preference is left
+    /// alone, and the next foreground clears the pause flag the intent set.
+    func pauseQuickDictation() {
+        guard !isInert else { return }
+        KeyboardPreferences.quickDictationPausedUntilRelaunch = true
+        clearQuickDictationReadiness(deactivateAudioSession: true)
+        message = "Quick Dictation is paused. Opening vocaphone starts a new window."
+        DiagnosticLog.record(
+            .quickDictationStopped,
+            metadata: .reason(.pausedUntilRelaunch)
         )
     }
 
@@ -721,7 +778,7 @@ final class RecordingCoordinator {
             guard let latestRecord = try store.load(id),
                   [.launchingApp, .awaitingReturn].contains(latestRecord.state)
             else {
-                if KeyboardPreferences.quickDictationEnabled, audioSessionAvailable {
+                if KeyboardPreferences.quickDictationArmable, audioSessionAvailable {
                     armQuickDictation()
                 } else {
                     recorder.stopStandby(deactivateAudioSession: true)
@@ -1232,30 +1289,30 @@ final class RecordingCoordinator {
     }
 
     private func shouldKeepQuickDictationReady(after record: SessionRecord) -> Bool {
-        KeyboardPreferences.quickDictationEnabled
+        KeyboardPreferences.quickDictationArmable
             && audioSessionAvailable
             && record.sourceDocumentID != "in-app-test"
     }
 
     private func armQuickDictation() {
-        guard KeyboardPreferences.quickDictationEnabled,
+        guard KeyboardPreferences.quickDictationArmable,
               audioSessionAvailable,
               !recorder.isRecording
         else { return }
 
         clearQuickDictationMarker()
+        let duration = KeyboardPreferences.quickDictationDuration
         do {
             try recorder.startStandby()
             let activatedAt = Date()
             let availability = QuickDictationAvailability(
                 activatedAt: activatedAt,
-                expiresAt: activatedAt.addingTimeInterval(
-                    AppConfiguration.quickDictationWindowSeconds
-                )
+                expiresAt: duration.expiry(from: activatedAt)
             )
             try store.saveQuickDictationAvailability(availability)
+            quickDictationDuration = duration
             quickDictationExpiresAt = availability.expiresAt
-            beginQuickDictationWatcher(availability)
+            beginQuickDictationWatcher(availability, duration: duration)
             liveActivity.startStandby(expiresAt: availability.expiresAt)
             DiagnosticLog.record(.quickDictationArmed)
             debugQuickDictation("armed until \(availability.expiresAt)")
@@ -1270,7 +1327,10 @@ final class RecordingCoordinator {
         }
     }
 
-    private func beginQuickDictationWatcher(_ availability: QuickDictationAvailability) {
+    private func beginQuickDictationWatcher(
+        _ availability: QuickDictationAvailability,
+        duration: QuickDictationDuration
+    ) {
         quickDictationWatcherTask?.cancel()
         quickDictationWatcherTask = Task { [weak self] in
             var refreshedAvailability = availability
@@ -1284,7 +1344,14 @@ final class RecordingCoordinator {
                     self.clearQuickDictationReadiness(deactivateAudioSession: true)
                     return
                 }
-                refreshedAvailability = refreshedAvailability.refreshingHeartbeat()
+                refreshedAvailability = refreshedAvailability.renewingLease(duration)
+                // Only a renewing window has a deadline that moves. Writing the
+                // same date back every two seconds would invalidate the home
+                // card on every heartbeat for nothing.
+                if duration.renewsLease {
+                    self.quickDictationExpiresAt = refreshedAvailability.expiresAt
+                    self.liveActivity.renewStandby(expiresAt: refreshedAvailability.expiresAt)
+                }
                 do {
                     try self.store.saveQuickDictationAvailability(
                         refreshedAvailability,
@@ -1311,6 +1378,7 @@ final class RecordingCoordinator {
         quickDictationWatcherTask?.cancel()
         quickDictationWatcherTask = nil
         quickDictationExpiresAt = nil
+        quickDictationDuration = nil
         try? store.clearQuickDictationAvailability()
     }
 
@@ -1350,7 +1418,7 @@ final class RecordingCoordinator {
             VocaPhoneDarwinCenter.observe(.stopQuickDictationRequested) { [weak self] in
                 Task { @MainActor [weak self] in
                     DiagnosticLog.record(.stopQuickDictationRequested)
-                    self?.stopQuickDictation()
+                    self?.pauseQuickDictation()
                 }
             }
         )

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -453,8 +453,10 @@ final class RecordingCoordinator {
         KeyboardPreferences.quickDictationEnabled = enabled
         // Either way the pause has been overtaken by a deliberate choice: on,
         // and the user wants it armed now; off, and the durable switch is the
-        // stronger statement.
+        // stronger statement. The same goes for the recovery offer: the user has
+        // just answered the question it exists to ask.
         KeyboardPreferences.quickDictationPausedUntilRelaunch = false
+        KeyboardPreferences.quickDictationRecoveryOfferPending = false
         if enabled {
             if recorder.recordPermission == .granted {
                 armQuickDictation()

--- a/ios/VocaPhoneLiveActivity/VocaPhoneLiveActivity.swift
+++ b/ios/VocaPhoneLiveActivity/VocaPhoneLiveActivity.swift
@@ -97,7 +97,7 @@ struct VocaPhoneRecordingActivity: Widget {
             .tint(Color.vocaRecording)
         } else if state.effectivePhase == .standby {
             Button(intent: StopQuickDictationIntent()) {
-                Label("Turn off", systemImage: "mic.slash.fill")
+                Label("Pause", systemImage: "mic.slash.fill")
             }
             .buttonStyle(.bordered)
             .tint(.brand)
@@ -118,8 +118,10 @@ struct VocaPhoneRecordingActivity: Widget {
             .buttonStyle(.borderedProminent)
             .tint(Color.vocaRecording)
         } else if state.effectivePhase == .standby {
+            // "Pause", not "Turn off": this button ends the current window and
+            // nothing else. Reopening vocaphone arms a new one.
             Button(intent: StopQuickDictationIntent()) {
-                Label("Turn off Quick Dictation", systemImage: "mic.slash.fill")
+                Label("Pause Quick Dictation", systemImage: "mic.slash.fill")
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.bordered)

--- a/ios/VocaPhoneShared/AppConfiguration.swift
+++ b/ios/VocaPhoneShared/AppConfiguration.swift
@@ -65,7 +65,6 @@ enum AppConfiguration {
     static let fullAccessKeyboardHint =
         "Turn on Allow Full Access under Settings › General › Keyboard."
     static let maximumRecordingSeconds: TimeInterval = 120
-    static let quickDictationWindowSeconds: TimeInterval = 10 * 60
     /// How long the keyboard waits for an unclaimed Quick Dictation request
     /// before falling back to opening vocaphone.
     static let quickDictationLaunchFallbackSeconds: TimeInterval = 1.5

--- a/ios/VocaPhoneShared/DiagnosticLog.swift
+++ b/ios/VocaPhoneShared/DiagnosticLog.swift
@@ -55,6 +55,9 @@ enum DiagnosticEvent: String, Codable, Sendable {
 
 enum DiagnosticReason: String, Codable, Sendable {
     case userRequested
+    /// Quick Dictation was stopped from the Live Activity, which pauses the
+    /// current window instead of changing the durable preference.
+    case pausedUntilRelaunch
     case quickDictationOff
     case sessionFinished
     case processExit

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -285,6 +285,13 @@ enum KeyboardPreferences {
     /// Dictation again. Reopening vocaphone clears it. Kept in the App Group so
     /// the Live Activity's intent, which runs in its own process, can set it.
     static let quickDictationPausedKey = "quickDictationPausedUntilRelaunch"
+    /// Whether Home still owes this install the one-time offer to turn Quick
+    /// Dictation back on. See ``QuickDictationRecoveryOffer``.
+    static let quickDictationRecoveryOfferKey = "quickDictationRecoveryOfferPending"
+    /// Marks the release that stopped letting the Live Activity write the
+    /// durable preference, so the offer above is raised exactly once per
+    /// install rather than every launch.
+    static let quickDictationRecoveryMigrationKey = "quickDictationRecoveryMigrationV1"
     static let writingStyleKey = "writingStyle"
     static let numbersAsDigitsKey = "numbersAsDigitsEnabled"
     static let repairSpeechKey = "speechRepairEnabled"
@@ -368,6 +375,28 @@ enum KeyboardPreferences {
     /// temporary pause together. Every arming path asks this, not the switch.
     static var quickDictationArmable: Bool {
         quickDictationEnabled && !quickDictationPausedUntilRelaunch
+    }
+
+    static var quickDictationRecoveryOfferPending: Bool {
+        get { defaults?.bool(forKey: quickDictationRecoveryOfferKey) ?? false }
+        set { defaults?.set(newValue, forKey: quickDictationRecoveryOfferKey) }
+    }
+
+    /// Queues the recovery offer for installs that arrive at this release with
+    /// Quick Dictation already off, which older builds could do to somebody who
+    /// only meant to release the microphone once.
+    ///
+    /// The stored value is deliberately left alone. It cannot be told apart
+    /// from a deliberate Settings choice, and turning a microphone back on for
+    /// a person who chose to turn it off is not a fix. Running this repeatedly
+    /// is safe, and a user who is already on is never asked anything.
+    static func markQuickDictationRecoveryOfferIfNeeded() {
+        guard let defaults,
+              defaults.object(forKey: quickDictationRecoveryMigrationKey) == nil
+        else { return }
+        defaults.set(true, forKey: quickDictationRecoveryMigrationKey)
+        guard !quickDictationEnabled else { return }
+        quickDictationRecoveryOfferPending = true
     }
 
     /// Defaults to ``KeyboardHeightPreference/standard`` when absent, which is

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -279,6 +279,12 @@ enum KeyboardPreferences {
     static let swipeTypingKey = "swipeTypingEnabled"
     static let numberRowKey = "numberRowEnabled"
     static let quickDictationKey = "quickDictationEnabled"
+    static let quickDictationDurationKey = "quickDictationDuration"
+    /// A stop from the Live Activity is a pause, not a preference change: the
+    /// user is silencing this window, not saying they never want Quick
+    /// Dictation again. Reopening vocaphone clears it. Kept in the App Group so
+    /// the Live Activity's intent, which runs in its own process, can set it.
+    static let quickDictationPausedKey = "quickDictationPausedUntilRelaunch"
     static let writingStyleKey = "writingStyle"
     static let numbersAsDigitsKey = "numbersAsDigitsEnabled"
     static let repairSpeechKey = "speechRepairEnabled"
@@ -323,6 +329,9 @@ enum KeyboardPreferences {
         }
     }
 
+    /// The durable switch. Only the Settings toggle writes it, so a stop from
+    /// the Dynamic Island can never leave a user wondering why Quick Dictation
+    /// stayed off for days.
     static var quickDictationEnabled: Bool {
         get {
             guard let defaults else { return true }
@@ -332,6 +341,33 @@ enum KeyboardPreferences {
         set {
             defaults?.set(newValue, forKey: quickDictationKey)
         }
+    }
+
+    /// Ten minutes for every existing install: the preference is new, and that
+    /// is the window those users already have.
+    static var quickDictationDuration: QuickDictationDuration {
+        get {
+            guard let rawValue = defaults?.string(forKey: quickDictationDurationKey),
+                  let duration = QuickDictationDuration(rawValue: rawValue)
+            else { return .tenMinutes }
+            return duration
+        }
+        set {
+            defaults?.set(newValue.rawValue, forKey: quickDictationDurationKey)
+        }
+    }
+
+    /// Set by the Live Activity's stop button, cleared the next time vocaphone
+    /// comes to the foreground. See ``quickDictationPausedKey``.
+    static var quickDictationPausedUntilRelaunch: Bool {
+        get { defaults?.bool(forKey: quickDictationPausedKey) ?? false }
+        set { defaults?.set(newValue, forKey: quickDictationPausedKey) }
+    }
+
+    /// Whether the app may arm standby right now — the durable switch and the
+    /// temporary pause together. Every arming path asks this, not the switch.
+    static var quickDictationArmable: Bool {
+        quickDictationEnabled && !quickDictationPausedUntilRelaunch
     }
 
     /// Defaults to ``KeyboardHeightPreference/standard`` when absent, which is

--- a/ios/VocaPhoneShared/QuickDictationAvailability.swift
+++ b/ios/VocaPhoneShared/QuickDictationAvailability.swift
@@ -37,6 +37,22 @@ struct QuickDictationAvailability: Codable, Equatable, Sendable {
         )
     }
 
+    /// A heartbeat that also pushes the deadline out, for a window the user
+    /// asked to last as long as the app does. The lease still exists — a
+    /// process killed between heartbeats leaves a marker that expires by
+    /// itself — it is just continuously renewed while the app is alive.
+    func renewingLease(
+        _ duration: QuickDictationDuration,
+        at date: Date = Date()
+    ) -> QuickDictationAvailability {
+        guard duration.renewsLease else { return refreshingHeartbeat(at: date) }
+        return QuickDictationAvailability(
+            activatedAt: activatedAt,
+            expiresAt: duration.expiry(from: date),
+            heartbeatAt: date
+        )
+    }
+
     /// A keyboard request and a standby re-arm can cross in separate processes.
     /// The tiny grace window accepts that in-flight request without adopting an
     /// older abandoned session from before Quick Dictation was available.

--- a/ios/VocaPhoneShared/QuickDictationDuration.swift
+++ b/ios/VocaPhoneShared/QuickDictationDuration.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// How long a Quick Dictation standby window lasts once the app arms it.
+///
+/// Standby is a real, running microphone: it is bounded so a user who forgets
+/// about it does not carry an armed input around all day. The choice exists
+/// because the right bound is personal — someone dictating in bursts across an
+/// afternoon pays the app-switch tax over and over at ten minutes, while
+/// someone who dictates twice a week wants the shortest window that works.
+enum QuickDictationDuration: String, CaseIterable, Codable, Identifiable, Sendable {
+    case tenMinutes
+    case twentyMinutes
+    /// No deadline: standby is re-leased for as long as the app is alive, and
+    /// ends when the user force-quits vocaphone (or iOS reclaims the process).
+    case untilAppCloses
+
+    var id: String { rawValue }
+
+    /// The window a fresh arming gets. ``untilAppCloses`` takes a short lease
+    /// that the standby watcher keeps renewing, so a process that dies without
+    /// running its teardown leaves a marker that expires on its own rather than
+    /// one that claims the microphone is ready forever.
+    var leaseSeconds: TimeInterval {
+        switch self {
+        case .tenMinutes: 10 * 60
+        case .twentyMinutes: 20 * 60
+        case .untilAppCloses: 5 * 60
+        }
+    }
+
+    /// Whether the watcher pushes the deadline forward on every heartbeat.
+    var renewsLease: Bool { self == .untilAppCloses }
+
+    /// The expiry to write for a window armed at `date`.
+    func expiry(from date: Date) -> Date {
+        date.addingTimeInterval(leaseSeconds)
+    }
+
+    /// Settings row title.
+    var displayName: String {
+        switch self {
+        case .tenMinutes: "10 minutes"
+        case .twentyMinutes: "20 minutes"
+        case .untilAppCloses: "Until I close vocaphone"
+        }
+    }
+
+    /// Completes "Quick Dictation is on standby …" on the home card.
+    ///
+    /// A renewing window is given no clock time on purpose: its deadline moves
+    /// every couple of seconds, so any time printed here would be a number the
+    /// user could watch change for no reason. It names the exit instead.
+    func standbyDescription(expiringAt expiresAt: Date) -> String {
+        switch self {
+        case .tenMinutes, .twentyMinutes:
+            "until \(expiresAt.formatted(date: .omitted, time: .shortened))"
+        case .untilAppCloses:
+            "until you close vocaphone"
+        }
+    }
+
+    var settingsFooter: String {
+        let window: String
+        switch self {
+        case .tenMinutes: window = "for up to 10 minutes"
+        case .twentyMinutes: window = "for up to 20 minutes"
+        case .untilAppCloses: window = "until you close vocaphone"
+        }
+        return "After vocaphone gets microphone access, it keeps an active background "
+            + "input \(window) so Dictate can start without leaving the app you are in. "
+            + "Standby audio is discarded and never saved or uploaded. The orange "
+            + "microphone indicator stays visible while it is on. Pausing from the "
+            + "Dynamic Island ends only the current window — reopening vocaphone arms "
+            + "a new one, and this switch stays on."
+    }
+}

--- a/ios/VocaPhoneTests/HomePresentationTests.swift
+++ b/ios/VocaPhoneTests/HomePresentationTests.swift
@@ -10,6 +10,7 @@ struct HomePresentationTests {
         canRetry: Bool = false,
         startedInApp: Bool = true,
         quickDictationReady: Bool = false,
+        quickDictationDuration: QuickDictationDuration = .tenMinutes,
         sourceReady: Bool = true
     ) -> HomeSessionCard {
         HomeSessionCard.make(
@@ -20,6 +21,7 @@ struct HomePresentationTests {
                 quickDictationExpiresAt: quickDictationReady
                     ? Date(timeIntervalSince1970: 1_700_000_000)
                     : nil,
+                quickDictationDuration: quickDictationReady ? quickDictationDuration : nil,
                 processingLocation: location,
                 transcript: transcript,
                 errorMessage: errorMessage,
@@ -70,6 +72,24 @@ struct HomePresentationTests {
         #expect(standby.detail?.contains("standby") == true)
         #expect(standby.detail?.contains("Nothing is being recorded") == true)
         #expect(!standby.showsMeter)
+    }
+
+    /// A window that renews itself every couple of seconds has no clock time
+    /// worth printing, so the card names the exit instead of a deadline that
+    /// keeps moving.
+    @Test func anUnlimitedStandbyNamesTheExitRatherThanAClockTime() {
+        let rolling = Self.card(
+            .idle,
+            quickDictationReady: true,
+            quickDictationDuration: .untilAppCloses
+        )
+
+        #expect(rolling.detail?.contains("until you close vocaphone") == true)
+        #expect(rolling.detail?.contains("Nothing is being recorded") == true)
+
+        let bounded = Self.card(.idle, quickDictationReady: true)
+        #expect(bounded.detail?.contains("until you close vocaphone") == false)
+        #expect(bounded.detail?.contains("standby until") == true)
     }
 
     /// The processing card names the place, or says nothing rather than

--- a/ios/VocaPhoneTests/ReliabilityFeatureTests.swift
+++ b/ios/VocaPhoneTests/ReliabilityFeatureTests.swift
@@ -105,6 +105,119 @@ struct ReliabilityFeatureTests {
         #expect(availability.isReady(at: refreshedAt))
     }
 
+    /// The bug this replaced: stopping standby from the Dynamic Island wrote the
+    /// durable preference, so Quick Dictation stayed off until the user found
+    /// the switch in Settings. The two states are separate now, and every
+    /// arming path asks for both at once through `quickDictationArmable`.
+    @Test func pausingLeavesTheDurablePreferenceOn() {
+        let enabled = KeyboardPreferences.quickDictationEnabled
+        let paused = KeyboardPreferences.quickDictationPausedUntilRelaunch
+        defer {
+            KeyboardPreferences.quickDictationEnabled = enabled
+            KeyboardPreferences.quickDictationPausedUntilRelaunch = paused
+        }
+
+        KeyboardPreferences.quickDictationEnabled = true
+        KeyboardPreferences.quickDictationPausedUntilRelaunch = false
+        #expect(KeyboardPreferences.quickDictationArmable)
+
+        // The Live Activity's Pause button, which is what
+        // `StopQuickDictationIntent` writes.
+        KeyboardPreferences.quickDictationPausedUntilRelaunch = true
+        #expect(!KeyboardPreferences.quickDictationArmable)
+        #expect(KeyboardPreferences.quickDictationEnabled)
+
+        // Reopening vocaphone, which is `endQuickDictationPause`.
+        KeyboardPreferences.quickDictationPausedUntilRelaunch = false
+        #expect(KeyboardPreferences.quickDictationArmable)
+
+        // The Settings switch is the one that persists: clearing the pause does
+        // not undo it.
+        KeyboardPreferences.quickDictationEnabled = false
+        #expect(!KeyboardPreferences.quickDictationArmable)
+        KeyboardPreferences.quickDictationPausedUntilRelaunch = false
+        #expect(!KeyboardPreferences.quickDictationArmable)
+    }
+
+    /// Both new preferences are absent for everyone upgrading, and the defaults
+    /// they fall back to have to be the behaviour those users already have.
+    @Test func newQuickDictationPreferencesDefaultToTodaysBehaviour() {
+        let storedDuration = KeyboardPreferences.defaults?
+            .string(forKey: KeyboardPreferences.quickDictationDurationKey)
+        let paused = KeyboardPreferences.quickDictationPausedUntilRelaunch
+        defer {
+            if let storedDuration {
+                KeyboardPreferences.defaults?
+                    .set(storedDuration, forKey: KeyboardPreferences.quickDictationDurationKey)
+            } else {
+                KeyboardPreferences.defaults?
+                    .removeObject(forKey: KeyboardPreferences.quickDictationDurationKey)
+            }
+            KeyboardPreferences.quickDictationPausedUntilRelaunch = paused
+        }
+
+        KeyboardPreferences.defaults?
+            .removeObject(forKey: KeyboardPreferences.quickDictationDurationKey)
+        KeyboardPreferences.defaults?
+            .removeObject(forKey: KeyboardPreferences.quickDictationPausedKey)
+
+        #expect(KeyboardPreferences.quickDictationDuration == .tenMinutes)
+        #expect(!KeyboardPreferences.quickDictationPausedUntilRelaunch)
+    }
+
+    @Test func standbyWindowsMatchTheDurationTheUserPicked() {
+        let armedAt = Date(timeIntervalSince1970: 10_000)
+
+        #expect(
+            QuickDictationDuration.tenMinutes.expiry(from: armedAt)
+                == armedAt.addingTimeInterval(600)
+        )
+        #expect(
+            QuickDictationDuration.twentyMinutes.expiry(from: armedAt)
+                == armedAt.addingTimeInterval(1_200)
+        )
+        #expect(!QuickDictationDuration.tenMinutes.renewsLease)
+        #expect(!QuickDictationDuration.twentyMinutes.renewsLease)
+        #expect(QuickDictationDuration.untilAppCloses.renewsLease)
+        // An unlimited window still takes a bounded lease, so a process that
+        // dies between heartbeats cannot leave a marker claiming the microphone
+        // is ready forever.
+        #expect(QuickDictationDuration.untilAppCloses.leaseSeconds > 0)
+    }
+
+    /// Every raw value is persisted, so renaming a case silently resets the
+    /// preference for everyone who chose it.
+    @Test func durationRawValuesAreStable() {
+        #expect(QuickDictationDuration.tenMinutes.rawValue == "tenMinutes")
+        #expect(QuickDictationDuration.twentyMinutes.rawValue == "twentyMinutes")
+        #expect(QuickDictationDuration.untilAppCloses.rawValue == "untilAppCloses")
+        #expect(QuickDictationDuration(rawValue: "nonsense") == nil)
+    }
+
+    @Test func onlyAnUnlimitedWindowMovesItsDeadline() {
+        let started = Date(timeIntervalSince1970: 10_000)
+        let bounded = QuickDictationAvailability(
+            activatedAt: started,
+            expiresAt: QuickDictationDuration.tenMinutes.expiry(from: started)
+        )
+        let laterOn = started.addingTimeInterval(120)
+
+        let heldWindow = bounded.renewingLease(.tenMinutes, at: laterOn)
+        #expect(heldWindow.expiresAt == bounded.expiresAt)
+        #expect(heldWindow.heartbeatAt == laterOn)
+        #expect(heldWindow.isReady(at: laterOn))
+
+        let rolling = QuickDictationAvailability(
+            activatedAt: started,
+            expiresAt: QuickDictationDuration.untilAppCloses.expiry(from: started)
+        ).renewingLease(.untilAppCloses, at: laterOn)
+        #expect(rolling.activatedAt == started)
+        #expect(rolling.expiresAt == QuickDictationDuration.untilAppCloses.expiry(from: laterOn))
+        #expect(rolling.isReady(at: laterOn))
+        // And it dies on its own once the heartbeats stop.
+        #expect(!rolling.isReady(at: laterOn.addingTimeInterval(30)))
+    }
+
     @Test func standbyAcceptsARequestThatRacedWithRearming() {
         let started = Date(timeIntervalSince1970: 10_000)
         let availability = QuickDictationAvailability(

--- a/ios/VocaPhoneTests/ReliabilityFeatureTests.swift
+++ b/ios/VocaPhoneTests/ReliabilityFeatureTests.swift
@@ -218,6 +218,61 @@ struct ReliabilityFeatureTests {
         #expect(!rolling.isReady(at: laterOn.addingTimeInterval(30)))
     }
 
+    /// The offer exists for people an older build switched off, and it must not
+    /// reach anybody else — nor reappear after it has been answered.
+    @Test func theRecoveryOfferIsRaisedOnlyForInstallsThatArriveTurnedOff() {
+        #expect(QuickDictationRecoveryOffer.make(isPending: true, isEnabled: false) != nil)
+        // Already on: nothing to ask, whoever turned it on.
+        #expect(QuickDictationRecoveryOffer.make(isPending: true, isEnabled: true) == nil)
+        // Answered, or never affected.
+        #expect(QuickDictationRecoveryOffer.make(isPending: false, isEnabled: false) == nil)
+        #expect(QuickDictationRecoveryOffer.make(isPending: false, isEnabled: true) == nil)
+    }
+
+    /// The migration marks the offer; it must never turn the microphone back on
+    /// by itself, and it must run exactly once so "Not now" stays answered.
+    @Test func theRecoveryMigrationAsksRatherThanReArmingTheMicrophone() {
+        let defaults = KeyboardPreferences.defaults
+        let enabled = KeyboardPreferences.quickDictationEnabled
+        let offer = KeyboardPreferences.quickDictationRecoveryOfferPending
+        let migrated = defaults?
+            .object(forKey: KeyboardPreferences.quickDictationRecoveryMigrationKey)
+        defer {
+            KeyboardPreferences.quickDictationEnabled = enabled
+            KeyboardPreferences.quickDictationRecoveryOfferPending = offer
+            if let migrated {
+                defaults?.set(migrated, forKey: KeyboardPreferences.quickDictationRecoveryMigrationKey)
+            } else {
+                defaults?.removeObject(forKey: KeyboardPreferences.quickDictationRecoveryMigrationKey)
+            }
+        }
+
+        func resetMigration() {
+            defaults?.removeObject(forKey: KeyboardPreferences.quickDictationRecoveryMigrationKey)
+            KeyboardPreferences.quickDictationRecoveryOfferPending = false
+        }
+
+        // An install that arrives with the feature off is asked, and the stored
+        // preference is left exactly as the user's older build left it.
+        resetMigration()
+        KeyboardPreferences.quickDictationEnabled = false
+        KeyboardPreferences.markQuickDictationRecoveryOfferIfNeeded()
+        #expect(KeyboardPreferences.quickDictationRecoveryOfferPending)
+        #expect(!KeyboardPreferences.quickDictationEnabled)
+
+        // Answering it sticks: the migration has already run, so a later launch
+        // does not raise the card again.
+        KeyboardPreferences.quickDictationRecoveryOfferPending = false
+        KeyboardPreferences.markQuickDictationRecoveryOfferIfNeeded()
+        #expect(!KeyboardPreferences.quickDictationRecoveryOfferPending)
+
+        // An install that arrives with the feature on is never asked anything.
+        resetMigration()
+        KeyboardPreferences.quickDictationEnabled = true
+        KeyboardPreferences.markQuickDictationRecoveryOfferIfNeeded()
+        #expect(!KeyboardPreferences.quickDictationRecoveryOfferPending)
+    }
+
     @Test func standbyAcceptsARequestThatRacedWithRearming() {
         let started = Date(timeIntervalSince1970: 10_000)
         let availability = QuickDictationAvailability(

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -181,6 +181,9 @@ targets:
       # reads can be undone from iOS Settings. The model behind it is pure.
       - path: VocaPhoneApp/App/SetupStatus.swift
       - path: VocaPhoneApp/App/OnboardingPresentation.swift
+      # Who gets asked to turn Quick Dictation back on after an older build
+      # switched it off for them, and who is deliberately left alone.
+      - path: VocaPhoneApp/App/QuickDictationRecoveryOffer.swift
       # The external-dictation screen stays truthful through recording,
       # processing, a ready transcript, and recoverable failures.
       - path: VocaPhoneApp/App/KeyboardHandoffPresentation.swift


### PR DESCRIPTION
## The bug

`StopQuickDictationIntent` — the **Turn off** button on the standby Live Activity — wrote `KeyboardPreferences.quickDictationEnabled = false`, the same durable App Group key the Settings toggle owns. One tap on a control that offers no undo disabled Quick Dictation permanently. The only way back was Settings → Dictation, which is not somewhere a user goes looking after tapping a button in the Dynamic Island. `RecordingCoordinator.stopQuickDictation()` did the same thing on the Darwin path.

## Pause is not off

Two states now, instead of one boolean doing both jobs:

- `quickDictationEnabled` — durable, written only by the Settings toggle.
- `quickDictationPausedUntilRelaunch` — new App Group flag, set by the Live Activity's button and cleared the next time vocaphone reaches the foreground (`endQuickDictationPause`, called from the scene-phase change and from `ContentView.task` for a cold launch, which the scene phase never fires for).

Every arming path asks `KeyboardPreferences.quickDictationArmable` (`enabled && !paused`) rather than the switch. `stopQuickDictation()` split into `disableQuickDictation()` (Settings, durable) and `pauseQuickDictation()` (Live Activity, this window only), with a `.pausedUntilRelaunch` diagnostic reason to tell the two apart in a bug report. The button reads **Pause** / **Pause Quick Dictation**, because that is now what it does.

## How long standby stays ready

New `QuickDictationDuration` preference, surfaced as a **Stay ready for** picker under the toggle:

| | |
| --- | --- |
| 10 minutes | default, and what every existing install already has |
| 20 minutes | |
| Until I close vocaphone | ends on force-quit or when iOS reclaims the process |

Changing it re-arms immediately, so the new window starts now instead of waiting out the old one.

The unlimited window does **not** write an unbounded expiry. It takes a five-minute lease that the standby heartbeat renews every two seconds (`QuickDictationAvailability.renewingLease`), so a jetsam kill or a crash leaves a marker that expires on its own rather than one claiming the microphone is ready forever — the keyboard's staleness check stays the fast path, and the lease is the backstop. The Live Activity's stale date is pushed forward roughly every two minutes rather than per heartbeat, through an update-only path: `present` requests a new activity when none exist, which would have resurrected a card the user swiped away and kept resurrecting it all day.

The home card says "on standby until 4:20 PM" for a bounded window and "on standby until you close vocaphone" for a renewing one, whose deadline moves every couple of seconds and has no honest clock time to print.

## Getting the affected users back

Everything above still leaves the people who are complaining exactly where they are: their preference is already stored as `false`, and none of it turns that back on.

It is not migrated. A stored `false` cannot be told apart from somebody who deliberately turned the feature off in Settings — the old button and the old switch wrote the same key — and silently re-arming a microphone for that person would be a worse bug than the one being fixed.

So the app asks, once. The first launch on this release marks installs that arrive with Quick Dictation off (`markQuickDictationRecoveryOfferIfNeeded`, alongside the existing haptics migration), and Home shows them a single card:

> **Quick Dictation is off**
> Stopping it from the Dynamic Island used to switch it off for good — it now only pauses until you reopen vocaphone. Turn it back on to dictate without leaving the app you are in.
> [ Turn it back on ]   Not now

Both answers are final, and so is either direction of the Settings toggle — the user has just answered the question the card exists to ask. It sits below the setup card, which keeps the top slot: unfinished setup blocks dictation outright, while this only costs an app switch. New installs never see it.

## Tests

`just test` — 701 passing. New coverage: the pause leaves the durable preference on (and clearing a pause does not undo a real Settings off), both new preferences default to today's behaviour for upgrades, duration windows and raw values, only a renewing lease moves its deadline while still expiring once heartbeats stop, who the recovery offer reaches, and that the migration marks the offer without ever re-arming the microphone or asking twice.

Home was staged on the simulator with the affected state to check the card renders and reads correctly.

## Device checks

`docs/device-setup.md` gains three gates: pause from the island, reopen the app, confirm standby re-arms on its own and the Settings toggle still reads as on; set *Until I close vocaphone*, background the app, confirm standby is still Ready well past ten minutes, then force-quit and confirm the keyboard falls back to opening the app; and upgrade with Quick Dictation already off, confirming the card appears and that nothing arms the microphone until it is answered.