### PR TITLE
fix(ios): restore the shipping App Group, and pin it to the entitlements

### DIFF
--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		84E419209B93E8F1B50FEE4E /* DictationBarStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7842B22D05FB171B261101A /* DictationBarStyle.swift */; };
 		84EB79403F7CED013A82334F /* PairingScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B3F1DBA8332A13B095E4BA /* PairingScannerView.swift */; };
 		84F2FD89DD3C1EB490E86A73 /* FinishRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B19321866AE8083C78C2B7F /* FinishRecordingIntent.swift */; };
+		85207216B77DE9C92D5E0519 /* AppGroupEntitlementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49565018533AF6A394F9C24 /* AppGroupEntitlementTests.swift */; };
 		867671B90E038F77BE36A4E6 /* DarwinNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3498C523755A678225152570 /* DarwinNotifications.swift */; };
 		883C67CC3B4BBDA22771637A /* KeyProximity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B90ACCDCBABF9F7412EE906 /* KeyProximity.swift */; };
 		89A73E55E01C0814D465824C /* sherpa-onnx.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1582F900473255CD64DC8C2A /* sherpa-onnx.xcframework */; };
@@ -587,6 +588,7 @@
 		DEAA4440B24071020CD693DB /* TypingCandidates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingCandidates.swift; sourceTree = "<group>"; };
 		DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeTrailView.swift; sourceTree = "<group>"; };
 		E0187C986535C090BEE7EFD8 /* RecordingSoundFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSoundFeedback.swift; sourceTree = "<group>"; };
+		E49565018533AF6A394F9C24 /* AppGroupEntitlementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupEntitlementTests.swift; sourceTree = "<group>"; };
 		E590CFC53039DA367280B8CD /* SpokenNumbers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpokenNumbers.swift; sourceTree = "<group>"; };
 		E8847DC87DD10F359C6005C5 /* LocalModelManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelManager.swift; sourceTree = "<group>"; };
 		E9559007A45749959AF9D10C /* TelemetryEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryEvent.swift; sourceTree = "<group>"; };
@@ -838,6 +840,7 @@
 		933CC6C800F854E14554ACCA /* VocaPhoneTests */ = {
 			isa = PBXGroup;
 			children = (
+				E49565018533AF6A394F9C24 /* AppGroupEntitlementTests.swift */,
 				2678D836274997421A54E901 /* AudioCaptureTests.swift */,
 				EF0D852E37E341D37CCB4DB2 /* CustomVocabularyTests.swift */,
 				755A4279065D41A705E1F19D /* DesignSystemTests.swift */,
@@ -1366,6 +1369,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E5EAD40641B38DDA0CCA0300 /* AppConfiguration.swift in Sources */,
+				85207216B77DE9C92D5E0519 /* AppGroupEntitlementTests.swift in Sources */,
 				76E660378F845C250AEA0673 /* AudioCapturePipeline.swift in Sources */,
 				F6901AAB3D79295B2F40E436 /* AudioCaptureTests.swift in Sources */,
 				BBEEC542D1574BF6C8DF319B /* BrandPalette.swift in Sources */,

--- a/ios/VocaPhoneShared/AppConfiguration.swift
+++ b/ios/VocaPhoneShared/AppConfiguration.swift
@@ -1,7 +1,14 @@
 import Foundation
 
 enum AppConfiguration {
-    static let appGroupIdentifier = "group.dev.kanishkpachauri.vocaphone"
+    /// Must match the `com.apple.security.application-groups` entitlement of
+    /// all three targets, which is what the App Store profile is minted
+    /// against. A value that only exists in this file is not a smaller mistake
+    /// than a missing entitlement: the container this names is the only channel
+    /// the keyboard and the app have, so drift takes dictation out entirely
+    /// rather than degrading it. See ``appGroupMatchesEntitlements`` — the test
+    /// that reads the entitlement files rather than trusting this line.
+    static let appGroupIdentifier = "group.com.vocahq"
     /// The identifier the app ships under. Only a fallback for when the running
     /// bundle declines to name itself, which is what a unit-test host does.
     static let shippingAppBundleIdentifier = "com.vocahq.vocaphone"

--- a/ios/VocaPhoneTests/AppGroupEntitlementTests.swift
+++ b/ios/VocaPhoneTests/AppGroupEntitlementTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+
+/// The App Group is the only channel the keyboard and the containing app have.
+///
+/// It is named twice: in three `.entitlements` files, which is what the App
+/// Store profile is minted against, and in `AppConfiguration`, which is what
+/// the running code asks for. Nothing in the build makes those agree — an
+/// archive whose entitlement grants one group while the code opens another
+/// signs, uploads and installs perfectly, and then cannot reach its own shared
+/// container: no session records, no transcript ever leaves the keyboard.
+/// Dictation does not degrade, it stops.
+///
+/// This has happened. A local development group was committed into
+/// `AppConfiguration` alongside an unrelated keyboard change and reached main,
+/// where the release workflow's own check could not see it — that check greps
+/// the entitlements, which were right, and never reads the Swift constant.
+///
+/// So the constant is checked against the files rather than against another
+/// copy of itself, and all three targets are checked, because an extension that
+/// is missing the group is exactly as broken as a wrong one.
+struct AppGroupEntitlementTests {
+    @Test(
+        arguments: [
+            "VocaPhoneApp/VocaPhoneApp.entitlements",
+            "VocaPhoneKeyboard/VocaPhoneKeyboard.entitlements",
+            "VocaPhoneLiveActivity/VocaPhoneLiveActivity.entitlements",
+        ]
+    )
+    func everyTargetGrantsTheGroupTheCodeOpens(entitlementPath: String) throws {
+        let url = Self.iosDirectory.appendingPathComponent(entitlementPath)
+        let parsed = try PropertyListSerialization.propertyList(
+            from: try Data(contentsOf: url),
+            format: nil
+        ) as? [String: Any]
+        let groups = parsed?["com.apple.security.application-groups"] as? [String]
+
+        #expect(groups?.contains(AppConfiguration.appGroupIdentifier) == true)
+    }
+
+    /// The identifier a release is actually signed for. Pinned as a literal so
+    /// that changing `AppConfiguration` alone — the exact shape of the incident
+    /// above — fails here instead of at a user's cursor.
+    @Test func theSharedContainerIsTheOneRegisteredToTheShippingTeam() {
+        #expect(AppConfiguration.appGroupIdentifier == "group.com.vocahq")
+    }
+
+    private static var iosDirectory: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+}


### PR DESCRIPTION
## What is wrong on `main`

`AppConfiguration.appGroupIdentifier` currently reads `group.dev.kanishkpachauri.vocaphone`. All three `.entitlements` files grant `group.com.vocahq` — the value #97 moved everything to, and the one the App Store profile is minted against.

Those have to name the same container.

## How it got there

#97 ("Move iOS signing to team 92962VK378 and group.com.vocahq") changed the entitlements **and** the constant together, correctly.

**#234** (`7e3bd62`, the current tip of main) then changed the constant back to a local development group. It is one line inside a 33-file keyboard-fidelity change, in the same hunk as a deliberate rewrite of `keyboardBundleIdentifier` directly below it, which is why it read as intentional.

## What it would have cost

Nothing has shipped: no tag contains `7e3bd62`, and `ios/v1.0.25` predates it.

The next release would not have failed loudly. `containerURL(forSecurityApplicationGroupIdentifier:)` returns nil for a group the entitlement does not grant, so the archive signs, uploads, installs and launches — and then cannot open its own App Group. No session record reaches the keyboard, no transcript reaches a text field. Dictation does not degrade, it stops.

The release workflow could not have caught it either: `ios-release.yml` greps the built bundle's entitlements for `group.com.vocahq`, which were right the whole time, and never reads the Swift constant.

## The guard

The constant is restored, and `AppGroupEntitlementTests` now parses all three entitlement files and asserts each grants the group the code actually opens — checking the constant against the files rather than against another copy of itself — plus the literal a release is signed for. All three targets are covered, because an extension missing the group is exactly as broken as a wrong one.

Verified by reverting the constant to the value this PR removes: four cases fail. Full suite green (695).

## Note for reviewers

Local device testing needs a different App Group and team, and the shape of this bug is exactly a local override reaching `main`. Keep those edits in the working tree — `git add` explicit paths rather than `-A` — and this test will fail loudly in CI if one is ever committed again.