### PR TITLE
Bump Android to 0.1.6

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.vocahq.vocaphone"
         minSdk = 33
         targetSdk = 36
-        versionCode = 26
-        versionName = "0.1.5"
+        versionCode = 27
+        versionName = "0.1.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/docs/play-store.md
+++ b/docs/play-store.md
@@ -28,8 +28,8 @@ Upload the full AAB only. Never upload the fdroid APK or an fdroid bundle to
 Play. The fdroid flavour drops prebuilt sherpa-onnx / ONNX Runtime so F-Droid
 can rebuild from source; Play testers should get the full catalog.
 
-Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 26,
-`versionName` `0.1.5`. Keep that until the next Play-bound tag needs a bump;
+Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 27,
+`versionName` `0.1.6`. Keep that until the next Play-bound tag needs a bump;
 the release workflow refuses to publish when the tag is not `android/v$versionName`.
 
 `dependenciesInfo.includeInApk` / `includeInBundle` stay `false` so AGP does

--- a/fastlane/metadata/android/en-US/changelogs/27.txt
+++ b/fastlane/metadata/android/en-US/changelogs/27.txt
@@ -1,0 +1,1 @@
+Dictate a short trigger and it expands to the longer text you saved. Spoken English numbers can land as digits: twenty three becomes 23, six pm becomes 6 pm. A lone one stays a word. Download progress stays on the model card you tapped.

--- a/fdroid/com.vocahq.vocaphone.yml
+++ b/fdroid/com.vocahq.vocaphone.yml
@@ -37,9 +37,9 @@ Binaries:
   https://github.com/VocaHQ/vocaphone/releases/download/android/v%v/vocaphone-fdroid.apk
 
 Builds:
-  - versionName: 0.1.5
-    versionCode: 26
-    commit: android/v0.1.5
+  - versionName: 0.1.6
+    versionCode: 27
+    commit: android/v0.1.6
     subdir: android/app
     submodules: true
     gradle:
@@ -59,5 +59,5 @@ AllowedAPKSigningKeys: e6131446f8afeff13516f78036db9ea26aaa16e01b39f37182bf262cc
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags ^android/v[0-9.]+$
-CurrentVersion: 0.1.5
-CurrentVersionCode: 26
+CurrentVersion: 0.1.6
+CurrentVersionCode: 27

--- a/web/README.md
+++ b/web/README.md
@@ -13,7 +13,7 @@ Then open `http://127.0.0.1:4173/`. The iPhone setup guide is available at
 `http://127.0.0.1:4173/privacy/`.
 
 The site uses only local brand assets and system fonts. The Android install and
-download CTAs point at a pinned release tag (`android/v0.1.5`), where the release
+download CTAs point at a pinned release tag (`android/v0.1.6`), where the release
 includes the APK and its verification files. New Android tags are `android/v*`;
 **move the pin when you cut the next Android release people should install**
 (see [releasing.md](../docs/releasing.md)). `npm run check` asserts the tag the

--- a/web/index.html
+++ b/web/index.html
@@ -161,7 +161,7 @@
           <div class="hero-actions">
             <a
               class="button button-primary"
-              href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.5"
+              href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.6"
             >
               <svg class="mark-solid" aria-hidden="true"><use href="#mark-android" /></svg>
               get the android beta
@@ -602,7 +602,7 @@
             </div>
             <p>Native whisper.cpp and sherpa-onnx models run inside the Android phone and insert text directly.</p>
             <div class="platform-card-actions">
-              <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.5">
+              <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.6">
                 <svg class="mark-solid" aria-hidden="true"><use href="#mark-android" /></svg>
                 get the beta <span aria-hidden="true">↗</span>
               </a>
@@ -734,16 +734,16 @@
             <ul class="install-facts">
               <li><b>Requires</b><span>Android 13 or newer</span></li>
               <li><b>Install</b><span>Download and sideload the signed APK</span></li>
-              <li><b>Latest</b><span>v0.1.5</span></li>
+              <li><b>Latest</b><span>v0.1.6</span></li>
               <li><b>Privacy</b><span>On-device model or optional gateway</span></li>
             </ul>
             <p class="install-note">
               Uninstall <code>io.github.mrsunglasses.localflow</code> before
               sideloading if that older Local Flow build is still installed.
             </p>
-            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.5">
+            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.6">
               <svg class="mark-solid" aria-hidden="true"><use href="#mark-android" /></svg>
-              open v0.1.5 <span aria-hidden="true">↗</span>
+              open v0.1.6 <span aria-hidden="true">↗</span>
             </a>
             <p class="install-note">
               Download <code>vocaphone.apk</code> from that tag and verify it with
@@ -790,7 +790,7 @@
           <h2 id="download-title">say less.<br />type more.</h2>
           <p>Download a model to your phone and turn speech into text without sending your voice anywhere.</p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.5"><svg class="mark-solid" aria-hidden="true"><use href="#mark-android" /></svg>get Android beta v0.1.5 <span aria-hidden="true">↗</span></a>
+            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.6"><svg class="mark-solid" aria-hidden="true"><use href="#mark-android" /></svg>get Android beta v0.1.6 <span aria-hidden="true">↗</span></a>
             <a class="button button-primary" href="https://testflight.apple.com/join/wd85wQ3W"><svg class="mark-solid" aria-hidden="true"><use href="#mark-apple" /></svg>join the iPhone TestFlight <span aria-hidden="true">↗</span></a>
           </div>
           <span class="download-fineprint">no gateway required · free &amp; open source · AGPL-3.0</span>
@@ -808,7 +808,7 @@
           <p>product</p>
           <a href="#why">why VocaPhone</a>
           <a href="#how">how it works</a>
-          <a href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.5">releases</a>
+          <a href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.6">releases</a>
         </div>
         <div>
           <p>resources</p>

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -202,9 +202,9 @@ test("availability and install paths are honest", () => {
   assert.match(html, /There is\s+no App Store release yet/);
   assert.match(
     html,
-    /href="https:\/\/github\.com\/VocaHQ\/vocaphone\/releases\/tag\/android\/v0\.1\.5"/,
+    /href="https:\/\/github\.com\/VocaHQ\/vocaphone\/releases\/tag\/android\/v0\.1\.6"/,
   );
-  assert.match(html, /v0\.1\.5/);
+  assert.match(html, /v0\.1\.6/);
   assert.match(html, /io\.github\.mrsunglasses\.localflow/);
   assert.match(html, /href="\/iphone\/"/);
   assert.match(html, /SHA256SUMS\.txt/);
@@ -230,14 +230,14 @@ test("availability and install paths are honest", () => {
   assert.match(hero, /<use href="#mark-android"/);
   assert.match(hero, /<use href="#mark-apple"/);
   assert.ok(
-    hero.includes("https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.5"),
+    hero.includes("https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.6"),
     "hero is missing the Android release link",
   );
 
   const androidCard = androidInstallBlock(html);
   const uninstallAt = androidCard.indexOf("io.github.mrsunglasses.localflow");
   const tagHrefAt = androidCard.indexOf(
-    "https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.5",
+    "https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.6",
   );
   const checksumAt = androidCard.indexOf("SHA256SUMS.txt");
   assert.ok(uninstallAt !== -1, "uninstall note missing from Android install block");


### PR DESCRIPTION
Cuts Android 0.1.6 (versionCode 27). Play Internal already has 0.1.5 as 26, so this is the next AAB it will take. Testers already walked snippets, spoken digits, and download percent on a debug sideload. Website pin, Play notes, F-Droid metadata, and changelog 27.txt move with the bump. iOS is unchanged. After merge, tag android/v0.1.6.