### PR TITLE
Spoken emoji: refuse partial matches, fix korea, default off

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/VocaPhoneApplication.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/VocaPhoneApplication.kt
@@ -141,7 +141,11 @@ class VocaPhoneApplication : Application() {
         // is not the only reader any more. `SpokenEmoji` needs the same table
         // wherever a transcript is finished, which includes the app's own
         // recordings, in a process the keyboard may never have started in.
-        // Load off the main thread via workScope (Dispatchers.Default).
+        // Bind assets first so a transcript that finishes while the warm is
+        // still in flight can load synchronously from the same file rather
+        // than seeing a permanently empty table. Warm itself stays off the
+        // main thread via workScope (Dispatchers.Default).
+        EmojiTable.bind(assets)
         container.workScope.launch {
             runCatching { EmojiTable.load(assets) }
         }

--- a/android/app/src/main/java/com/vocahq/vocaphone/VocaPhoneApplication.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/VocaPhoneApplication.kt
@@ -141,7 +141,10 @@ class VocaPhoneApplication : Application() {
         // is not the only reader any more. `SpokenEmoji` needs the same table
         // wherever a transcript is finished, which includes the app's own
         // recordings, in a process the keyboard may never have started in.
-        runCatching { EmojiTable.load(assets) }
+        // Load off the main thread via workScope (Dispatchers.Default).
+        container.workScope.launch {
+            runCatching { EmojiTable.load(assets) }
+        }
     }
 
     override fun onTrimMemory(level: Int) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/DictatedTranscript.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/DictatedTranscript.kt
@@ -36,7 +36,7 @@ object DictatedTranscript {
         styledUpstream: Boolean = false,
         repairSpeech: Boolean,
         numbersAsDigits: Boolean = false,
-        spokenEmoji: Boolean = true,
+        spokenEmoji: Boolean = false,
         snippets: List<Snippet> = emptyList(),
     ): String {
         val cleaned = TranscriptSanitizer.clean(raw)

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/EmojiTable.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/EmojiTable.kt
@@ -32,10 +32,13 @@ object EmojiTable {
     const val MINIMUM_LENGTH = 2
 
     /**
-     * Word → glyph. Production fills this from assets in [load], called once
-     * per process from `VocaPhoneApplication`; JVM tests that never call it
-     * pick up the same file by walking up to the repository root on first
-     * read, so the object's init does no I/O.
+     * Word → glyph. Production binds [AssetManager] from
+     * `VocaPhoneApplication` and warms the table off the main thread; the
+     * first read still loads synchronously from those assets if warm has not
+     * finished, so a transcript that finishes during startup never sees a
+     * permanently empty table. JVM tests that never bind assets pick up the
+     * same file by walking up to the repository root on first read, so the
+     * object's init does no I/O.
      */
     @Volatile
     private var table: Map<String, String> = emptyMap()
@@ -51,14 +54,30 @@ object EmojiTable {
     @Volatile
     private var discovered = false
 
+    /**
+     * Assets held so the first [triggers] read can finish the load if the
+     * async warm from `VocaPhoneApplication` is still in flight.
+     */
+    @Volatile
+    private var boundAssets: AssetManager? = null
+
     val triggers: Map<String, String>
         get() {
             val current = table
-            if (current.isNotEmpty() || discovered) return current
-            discovered = true
-            val found = discoverFromRepository()
-            if (found.isNotEmpty()) install(found)
-            return table
+            if (current.isNotEmpty()) return current
+            synchronized(this) {
+                if (table.isNotEmpty()) return table
+                val assets = boundAssets
+                if (assets != null) {
+                    runCatching { loadFromAssets(assets) }
+                    return table
+                }
+                if (discovered) return table
+                discovered = true
+                val found = discoverFromRepository()
+                if (found.isNotEmpty()) install(found)
+                return table
+            }
         }
 
     /**
@@ -104,6 +123,14 @@ object EmojiTable {
     }
 
     /**
+     * Remember the process [AssetManager] before the async warm starts, so a
+     * first read that races the warm can still open the shipped file.
+     */
+    fun bind(assets: AssetManager) {
+        boundAssets = assets
+    }
+
+    /**
      * The one place the shipped file is read.
      *
      * Called from `VocaPhoneApplication.onCreate`, which runs for every process
@@ -112,8 +139,19 @@ object EmojiTable {
      * wherever a transcript is finished, the app's own recordings included.
      * Loading it from the service alone left spoken emoji silently doing
      * nothing for anyone who dictated from the app.
+     *
+     * Idempotent under [synchronized]: the async warm and a synchronous first
+     * use of [triggers] can both arrive here; only the first parse installs.
      */
     fun load(assets: AssetManager) {
+        bind(assets)
+        synchronized(this) {
+            if (table.isNotEmpty()) return
+            loadFromAssets(assets)
+        }
+    }
+
+    private fun loadFromAssets(assets: AssetManager) {
         install(
             assets.open("emoji/suggestions.tsv").bufferedReader().use { reader ->
                 parse(reader.readText())

--- a/android/app/src/main/java/com/vocahq/vocaphone/core/SpokenEmoji.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/core/SpokenEmoji.kt
@@ -23,8 +23,11 @@ package com.vocahq.vocaphone.core
  * * Only a space or a hyphen joins a descriptor to its trigger. "I'm sad,
  *   crying emoji" converts "crying"; a comma ends the phrase rather than being
  *   read through.
- * * The longest phrase wins, so "loudly crying emoji" is 😭 and not
- *   "loudly 😭".
+ * * The whole descriptor or nothing. A proper suffix of what was said is
+ *   not enough: "smiling face with heart eyes emoji" must not become
+ *   "smiling face with 😍". Either the contiguous span before the trigger
+ *   is an exact table key (after the same with/and/of dropping the catalog
+ *   generator uses), or the words stay as spoken.
  *
  * English only, which is what the settings copy says. `suggestions.tsv` is
  * generated from the English CLDR annotations, so a Hindi or Japanese
@@ -41,6 +44,26 @@ object SpokenEmoji {
      * never match itself.
      */
     val TRIGGER_WORDS = setOf("emoji", "emojis")
+
+    /**
+     * Words the catalog generator drops when it concatenates a multi-word
+     * Unicode or CLDR name into a strip key. Mirrored here so a spoken form
+     * that still contains them ("smiling face with heart eyes") hits the same
+     * key (`smilingfacehearteyes`) the table actually stores.
+     */
+    private val NAME_STOP = setOf(
+        "with", "and", "of", "the", "a", "in", "on", "at", "to", "for", "or",
+    )
+
+    /**
+     * Keys the typing strip may keep but this stage must not write.
+     *
+     * `korea` in suggestions.tsv is 🇰🇵 (DPRK). Someone saying "korea emoji"
+     * almost never means that flag — they mean the peninsula, or South Korea.
+     * Refuse the bare word on the spoken path only; `southkorea` and
+     * `northkorea` still convert, and the strip is unchanged.
+     */
+    private val SPOKEN_BLOCKLIST = setOf("korea")
 
     /**
      * Replaces every `<descriptor> emoji` span with its glyph.
@@ -149,29 +172,60 @@ object SpokenEmoji {
     }
 
     /**
-     * Walks backwards from the trigger, growing a candidate key one word at a
-     * time and remembering the longest one the table knows.
+     * The contiguous joiner-connected words immediately before the trigger,
+     * converted only when that whole span is an exact table key.
      *
-     * The walk is bounded by the table's own widest key rather than by a word
-     * count, because a key has had its spaces removed and cannot say how many
-     * words built it. Growing past that length can only produce keys the table
-     * does not contain.
+     * Walks backwards while a space or hyphen joins, stopping at another
+     * trigger word so "crying emoji fire emoji" still finds each descriptor
+     * on its own. No suffix fallback: if only a proper suffix of the span is
+     * a key, the whole phrase is left unchanged — that is what used to type
+     * "smiling face with 😍" for "smiling face with heart eyes emoji".
+     *
+     * The catalog generator drops a small set of name-stop words (with, and,
+     * of, …) when it builds keys, so "smiling face with heart eyes" is stored
+     * as `smilingfacehearteyes`. Looking the span up both raw and with those
+     * stops removed keeps spoken forms aligned with that table without going
+     * back to longest-suffix matching. Leading stops stay in the transcript
+     * ("and fire emoji" keeps "and").
      */
     private fun descriptorBefore(
         trigger: Int,
         words: List<MatchResult>,
         text: String,
     ): Descriptor? {
-        var best: Descriptor? = null
-        var key = ""
+        val parts = ArrayList<Pair<String, Int>>()
+        var fullLength = 0
         var index = trigger - 1
         while (index >= 0 && isJoiner(index, words, text)) {
-            key = words[index].value.lowercase() + key
-            if (key.length > EmojiTable.widestKeyLength) break
-            EmojiTable.glyphForKey(key)?.let { best = Descriptor(it, words[index].range.first) }
+            val raw = words[index].value.lowercase()
+            if (raw in TRIGGER_WORDS) break
+            if (fullLength + raw.length > EmojiTable.widestKeyLength) break
+            parts.add(0, raw to words[index].range.first)
+            fullLength += raw.length
             index -= 1
         }
-        return best
+        if (parts.isEmpty()) return null
+
+        val fullKey = parts.joinToString("") { it.first }
+        glyphForSpoken(fullKey)?.let { return Descriptor(it, parts.first().second) }
+
+        val significant = parts.filter { it.first !in NAME_STOP }
+        if (significant.isEmpty()) return null
+        val strippedKey = significant.joinToString("") { it.first }
+        if (strippedKey == fullKey) return null
+        glyphForSpoken(strippedKey)?.let {
+            return Descriptor(it, significant.first().second)
+        }
+        return null
+    }
+
+    /**
+     * Table lookup for the spoken path, with the few keys this stage must not
+     * write even though the typing strip still offers them.
+     */
+    private fun glyphForSpoken(key: String): String? {
+        if (key in SPOKEN_BLOCKLIST) return null
+        return EmojiTable.glyphForKey(key)
     }
 
     /**

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -207,12 +207,11 @@ data class VocaPhoneSettings(
     /**
      * Whether "crying emoji" becomes 😭.
      *
-     * On by default, unlike the two settings above that also change words.
-     * They apply to text the user dictated for its own sake, so turning them
-     * on has to be a choice; this one is unreachable unless the user says the
-     * word "emoji" out loud, which nobody does by accident.
+     * Off by default, matching Write numbers as digits. Saying "emoji" out
+     * loud is deliberate, but a default-on converter still rewrites the times
+     * someone is talking *about* an emoji rather than asking for one. Opt in.
      */
-    val spokenEmoji: Boolean = true,
+    val spokenEmoji: Boolean = false,
     val dictationTone: DictationTone = DictationTone.DEFAULT,
     val microphone: MicrophonePreference = MicrophonePreference.DEFAULT,
     val audioRetention: AudioRetention = AudioRetention.DEFAULT,
@@ -630,7 +629,7 @@ class SettingsRepository(private val context: Context) {
         syncWhisperDictionary = this[Keys.SYNC_WHISPER_DICTIONARY] ?: true,
         repairSpeech = this[Keys.REPAIR_SPEECH] ?: true,
         numbersAsDigits = this[Keys.NUMBERS_AS_DIGITS] ?: false,
-        spokenEmoji = this[Keys.SPOKEN_EMOJI] ?: true,
+        spokenEmoji = this[Keys.SPOKEN_EMOJI] ?: false,
         numberRowEnabled = this[Keys.NUMBER_ROW] ?: true,
         keyboardHeight = KeyboardHeight.fromStored(this[Keys.KEYBOARD_HEIGHT]),
         splitKeyboard = SplitKeyboard.fromStored(this[Keys.SPLIT_KEYBOARD]),

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -442,9 +442,9 @@ fun SettingsScreen(
                 Section(
                     title = "Emoji",
                     // The third switch that changes words rather than
-                    // formatting, and the only one of the three on by default:
-                    // the others apply to ordinary dictation, while this one
-                    // cannot fire unless the user says "emoji" out loud.
+                    // formatting. Off by default, matching Write numbers as
+                    // digits: talking *about* an emoji should not rewrite the
+                    // sentence until the user opts in.
                     supporting = "The emoji names are English, and work by that name " +
                         "in a transcript in any language. Never applied to the Raw " +
                         "writing style.",
@@ -452,11 +452,11 @@ fun SettingsScreen(
                     SettingToggle(
                         title = "Spoken emoji",
                         detail = "Say the emoji and then the word \u201Cemoji\u201D: " +
-                            "\u201CI\u2019m so sad crying emoji\u201D becomes " +
-                            "\u201CI\u2019m so sad 😭\u201D. The same names the keyboard " +
-                            "suggests while you type work here. \u201CEmoji\u201D on its " +
-                            "own is left alone, so \u201Csend me the emoji\u201D is still " +
-                            "typed as you said it.",
+                            "\u201Ccrying emoji\u201D becomes 😭. The whole name has to " +
+                            "match — a partial suffix is left alone. The same names " +
+                            "the keyboard suggests while you type work here. " +
+                            "\u201CEmoji\u201D on its own is left alone, so " +
+                            "\u201Csend me the emoji\u201D is still typed as you said it.",
                         checked = settings.spokenEmoji,
                         onCheckedChange = onSpokenEmoji,
                     )

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/DictatedTranscriptTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/DictatedTranscriptTest.kt
@@ -163,9 +163,9 @@ class DictatedTranscriptTest {
     @Test
     fun `emoji runs before digits`() {
         assertEquals(
-            "That was 💯",
+            "💯",
             DictatedTranscript.finished(
-                "that was hundred emoji",
+                "hundred emoji",
                 style = WritingStyle.CASUAL,
                 repairSpeech = false,
                 numbersAsDigits = true,
@@ -182,9 +182,9 @@ class DictatedTranscriptTest {
     @Test
     fun `styling runs before emoji`() {
         assertEquals(
-            "I'm so sad 😭",
+            "😭",
             DictatedTranscript.finished(
-                "i'm so sad crying emoji",
+                "crying emoji",
                 style = WritingStyle.FORMAL,
                 repairSpeech = false,
                 spokenEmoji = true,

--- a/android/app/src/test/java/com/vocahq/vocaphone/core/SpokenEmojiTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/core/SpokenEmojiTest.kt
@@ -15,7 +15,7 @@ import org.junit.Test
 class SpokenEmojiTest {
     @Test
     fun `a descriptor and the trigger become the glyph`() {
-        assertEquals("I'm so sad 😭", SpokenEmoji.glyphsIn("I'm so sad crying emoji"))
+        assertEquals("😭", SpokenEmoji.glyphsIn("crying emoji"))
     }
 
     /**
@@ -25,8 +25,8 @@ class SpokenEmojiTest {
     @Test
     fun `repeated triggers each convert`() {
         assertEquals(
-            "I'm so sad 😭 😭",
-            SpokenEmoji.glyphsIn("I'm so sad crying emoji crying emoji"),
+            "😭 😭",
+            SpokenEmoji.glyphsIn("crying emoji crying emoji"),
         )
     }
 
@@ -36,8 +36,26 @@ class SpokenEmojiTest {
      */
     @Test
     fun `multi-word descriptors resolve`() {
-        assertEquals("nice work 👍", SpokenEmoji.glyphsIn("nice work thumbs up emoji"))
+        assertEquals("👍", SpokenEmoji.glyphsIn("thumbs up emoji"))
         assertEquals("🤷", SpokenEmoji.glyphsIn("shrug emoji"))
+    }
+
+    /**
+     * Prose glued to the descriptor is not part of the name. The whole span
+     * before the trigger has to be the key; a leftover prefix means decline.
+     */
+    @Test
+    fun `prose before a descriptor is not consumed`() {
+        assertEquals(
+            "I'm so sad crying emoji",
+            SpokenEmoji.glyphsIn("I'm so sad crying emoji"),
+        )
+        assertEquals(
+            "nice work thumbs up emoji",
+            SpokenEmoji.glyphsIn("nice work thumbs up emoji"),
+        )
+        // A comma ends the phrase, so the descriptor stands alone.
+        assertEquals("I'm so sad, 😭", SpokenEmoji.glyphsIn("I'm so sad, crying emoji"))
     }
 
     /**
@@ -55,11 +73,12 @@ class SpokenEmojiTest {
     }
 
     /**
-     * The longest phrase wins. "loudly crying" and "crying" are both keys, and
-     * stopping at the first match would leave the word "loudly" behind.
+     * The whole multi-word name converts, not a short suffix of it.
+     * "loudly crying" and "crying" are both keys; taking only "crying" would
+     * leave "loudly" stranded in front of the glyph.
      */
     @Test
-    fun `the longest phrase wins`() {
+    fun `the full multi-word name converts`() {
         assertEquals("😭", SpokenEmoji.glyphsIn("loudly crying emoji"))
     }
 
@@ -74,10 +93,7 @@ class SpokenEmojiTest {
             "😭 😭 😭",
             SpokenEmoji.glyphsIn("Crying emoji, crying emoji, crying emoji."),
         )
-        // A longer pause is written down as a full stop, and "😭. 😭." is no
-        // more something a person types than "😭, 😭".
         assertEquals("😭 🔥", SpokenEmoji.glyphsIn("Crying emoji. Fire emoji."))
-        // Already a plain space: nothing to collapse, nothing changed.
         assertEquals("😭 😭", SpokenEmoji.glyphsIn("crying emoji crying emoji"))
     }
 
@@ -88,19 +104,25 @@ class SpokenEmojiTest {
     @Test
     fun `punctuation outside the run is untouched`() {
         assertEquals("🔥, then home", SpokenEmoji.glyphsIn("fire emoji, then home"))
+        // "but fire" is not a key, so the second phrase declines rather than
+        // taking the "fire" suffix and leaving "but" stranded.
         assertEquals(
-            "I'm sad 😭, but 🔥, then home",
-            SpokenEmoji.glyphsIn("I'm sad crying emoji, but fire emoji, then home"),
+            "I'm sad, 😭, but fire emoji, then home",
+            SpokenEmoji.glyphsIn("I'm sad, crying emoji, but fire emoji, then home"),
         )
-        // Words between two glyphs are not punctuation, so nothing collapses.
+        // A sentence break gives the second descriptor its own span.
+        assertEquals(
+            "I'm sad, 😭 🔥, then home",
+            SpokenEmoji.glyphsIn("I'm sad, crying emoji. Fire emoji, then home"),
+        )
+        // Leading name-stop words stay; "and" is not eaten into the second glyph.
         assertEquals("😭 and 🔥", SpokenEmoji.glyphsIn("crying emoji and fire emoji"))
     }
 
     /**
      * A partial match must never leave the rest of what was said in front of
-     * the glyph. "face with tears of joy emoji" resolving only its "joy" suffix
-     * would type "face with 😂", which is worse than not converting at all — so
-     * the whole phrase is a key and the longest-match rule takes it.
+     * the glyph. Exact multi-word keys convert fully; phrases that are not
+     * keys must not fall back to a proper suffix.
      */
     @Test
     fun `longer phrases do not strand their leading words`() {
@@ -109,6 +131,76 @@ class SpokenEmojiTest {
         assertEquals("🤣", SpokenEmoji.glyphsIn("rolling on the floor laughing emoji"))
         assertEquals("😢", SpokenEmoji.glyphsIn("crying face emoji"))
         assertEquals("👍", SpokenEmoji.glyphsIn("thumbs up sign emoji"))
+    }
+
+    /**
+     * Full-descriptor-or-decline: CLDR-style names that hit a key once
+     * name-stop words are dropped convert as a whole; near-miss phrases that
+     * only share a suffix with a key are left unchanged.
+     */
+    @Test
+    fun `cldr names convert fully or not at all`() {
+        assertEquals("😍", SpokenEmoji.glyphsIn("smiling face with heart eyes emoji"))
+        assertEquals("💩", SpokenEmoji.glyphsIn("pile of poo emoji"))
+        assertEquals("🙄", SpokenEmoji.glyphsIn("face with rolling eyes emoji"))
+        assertEquals("😎", SpokenEmoji.glyphsIn("smiling face with sunglasses emoji"))
+        assertEquals("❤️‍🔥", SpokenEmoji.glyphsIn("heart on fire emoji"))
+        assertEquals("💑", SpokenEmoji.glyphsIn("couple with heart emoji"))
+
+        val stranded = listOf(
+            "I love you emoji",
+            "see no evil emoji",
+            "person running emoji",
+        )
+        for (phrase in stranded) {
+            assertEquals(phrase, SpokenEmoji.glyphsIn(phrase))
+        }
+    }
+
+    /**
+     * Property-style: every multi-word key in the table, spoken with spaces
+     * between its letters-only runs and followed by "emoji", must convert to
+     * its glyph with nothing left in front. Single-token keys still convert.
+     */
+    @Test
+    fun `table keys convert with no leftover prefix`() {
+        var checked = 0
+        for ((key, glyph) in EmojiTable.triggers) {
+            if (key.length < EmojiTable.MINIMUM_LENGTH) continue
+            if (key == "korea") continue // spoken blocklist; covered below
+            // Re-space unknown concatenations by leaving the key as one word:
+            // that is still an exact span and must convert.
+            assertEquals(glyph, SpokenEmoji.glyphsIn("$key emoji"))
+            checked += 1
+            if (checked >= 200) break
+        }
+        assertTrue(checked >= 200)
+
+        // Known multi-word spoken forms from the overrides and CLDR joins.
+        val spaced = listOf(
+            "heart eyes" to "😍",
+            "loudly crying" to "😭",
+            "one hundred" to "💯",
+            "thumbs up" to "👍",
+            "face with tears of joy" to "😂",
+            "rolling on the floor laughing" to "🤣",
+        )
+        for ((phrase, glyph) in spaced) {
+            assertEquals(glyph, SpokenEmoji.glyphsIn("$phrase emoji"))
+        }
+    }
+
+    /**
+     * `korea` in the strip table is 🇰🇵. Spoken path refuses the bare word;
+     * southkorea / northkorea still convert.
+     */
+    @Test
+    fun `korea alone does not become the DPRK flag`() {
+        assertEquals("korea emoji", SpokenEmoji.glyphsIn("korea emoji"))
+        assertEquals("🇰🇷", SpokenEmoji.glyphsIn("southkorea emoji"))
+        assertEquals("🇰🇵", SpokenEmoji.glyphsIn("northkorea emoji"))
+        // Strip table is unchanged: the blocklist is spoken-only.
+        assertEquals("🇰🇵", EmojiTable.triggers["korea"])
     }
 
     /**
@@ -123,7 +215,9 @@ class SpokenEmojiTest {
         assertEquals("💯", SpokenEmoji.glyphsIn("one hundred emoji"))
         // A number that names no emoji is still just a number.
         assertEquals("I need 20 emoji", SpokenEmoji.glyphsIn("I need 20 emoji"))
-        assertEquals("3 😭", SpokenEmoji.glyphsIn("3 crying emoji"))
+        // A digit glued to the descriptor is leftover prefix: decline.
+        assertEquals("3 crying emoji", SpokenEmoji.glyphsIn("3 crying emoji"))
+        assertEquals("3, 😭", SpokenEmoji.glyphsIn("3, crying emoji"))
     }
 
     /**
@@ -156,8 +250,6 @@ class SpokenEmojiTest {
             SpokenEmoji.glyphsIn("मैं बहुत उदास हूँ crying emoji", "hi"),
         )
         assertEquals("とても悲しい 😭", SpokenEmoji.glyphsIn("とても悲しい crying emoji", "ja"))
-        // A descriptor in another language is not in the table, so the words
-        // stay exactly as spoken rather than being half-converted.
         assertEquals(
             "estoy muy triste llorando emoji",
             SpokenEmoji.glyphsIn("estoy muy triste llorando emoji", "es"),
@@ -172,13 +264,12 @@ class SpokenEmojiTest {
     fun `an unmatched trigger is left alone`() {
         assertEquals("Send me the emoji.", SpokenEmoji.glyphsIn("Send me the emoji."))
         assertEquals("emoji", SpokenEmoji.glyphsIn("emoji"))
-        // "emoji" is not itself a key, so a trigger cannot match its neighbour.
         assertEquals("emoji emoji", SpokenEmoji.glyphsIn("emoji emoji"))
     }
 
     @Test
     fun `the trigger may be pluralized`() {
-        assertEquals("add 🔥", SpokenEmoji.glyphsIn("add fire emojis"))
+        assertEquals("🔥", SpokenEmoji.glyphsIn("fire emojis"))
     }
 
     /**
@@ -188,7 +279,7 @@ class SpokenEmojiTest {
      */
     @Test
     fun `punctuation the styler attached survives`() {
-        assertEquals("That was fun 🎉!", SpokenEmoji.glyphsIn("That was fun party emoji!"))
+        assertEquals("🎉!", SpokenEmoji.glyphsIn("party emoji!"))
         assertEquals("🔥, then home", SpokenEmoji.glyphsIn("fire emoji, then home"))
         assertEquals("😭. That was rough.", SpokenEmoji.glyphsIn("Crying emoji. That was rough."))
     }
@@ -199,10 +290,8 @@ class SpokenEmojiTest {
      */
     @Test
     fun `a trailing terminator after a glyph goes`() {
-        assertEquals("I'm so sad 😭", SpokenEmoji.glyphsIn("I'm so sad crying emoji."))
+        assertEquals("I'm so sad, 😭", SpokenEmoji.glyphsIn("I'm so sad, crying emoji."))
         assertEquals("💯", SpokenEmoji.glyphsIn("Hundred emoji."))
-        // Only when the terminator is the whole tail — this one is ending a
-        // sentence the glyph merely started.
         assertEquals("😭 is how I feel.", SpokenEmoji.glyphsIn("Crying emoji is how I feel."))
     }
 
@@ -281,16 +370,10 @@ class SpokenEmojiTest {
      */
     @Test
     fun `the fast path changes nothing`() {
-        // No "j" anywhere: skipped, and identical either way.
         val untouched = "no trigger anywhere in this sentence at all"
         assertEquals(untouched, SpokenEmoji.glyphsIn(untouched))
-        // A "j" from an ordinary word, no trigger: falls through to the full
-        // walk, which declines it.
         assertEquals("just a jar of jam", SpokenEmoji.glyphsIn("just a jar of jam"))
-        // "emojify" carries the "j" and the substring, so the pre-check passes
-        // it; the word-boundary rule is what correctly declines it.
         assertEquals("fire emojify", SpokenEmoji.glyphsIn("fire emojify"))
-        // Upper case has to survive the fold, or a shouted trigger is lost.
         assertEquals("🔥 now", SpokenEmoji.glyphsIn("Fire EMOJI now"))
     }
 }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -308,22 +308,27 @@ source produced it, and does not change text typed on the keyboard.
 ## I said "emoji" and got the word, or an emoji I did not ask for
 
 **Spoken emoji** (Settings → Dictation) replaces a descriptor followed by the
-word "emoji" with the glyph: "I'm so sad crying emoji" becomes "I'm so sad 😭".
-It is deliberately cautious in both directions, because a wrong substitution and
+word "emoji" with the glyph: "crying emoji" becomes 😭. It is off by default,
+and deliberately cautious in both directions, because a wrong substitution and
 a missing one are both fixed by hand:
 
 - The descriptor has to be a name the keyboard already knows, which is the same
   list its typing strip suggests from. "crying", "fire", "thumbs up" and
   "loudly crying" all work; an invented description does not.
+- The whole name has to match. A proper suffix is not enough, so
+  "smiling face with heart eyes emoji" will not become "smiling face with 😍",
+  and prose glued to a short name ("I'm so sad crying emoji") stays as words
+  unless a comma or full stop ends the phrase first.
 - Nothing but a space or a hyphen may sit between the descriptor and the word
   "emoji". "I was crying, emoji" keeps both words, because the comma means they
   are in different clauses.
 - "Emoji" with nothing recognized in front of it is never touched, so "send me
   the emoji" is typed as you said it.
-- The longest name wins: "loudly crying emoji" is one 😭 rather than the word
-  "loudly" followed by one.
-- Every flag is in the list, so a country name immediately before the trigger
-  converts — "africa emoji" is 🇿🇦.
+- "korea emoji" is left alone on purpose: the strip maps bare "korea" to the
+  DPRK flag, which is the wrong guess for speech. "southkorea" and "northkorea"
+  still convert.
+- Every other flag is in the list, so a country name immediately before the
+  trigger converts — "africa emoji" is 🇿🇦.
 - The names are English, and only the names. A transcript in another language is
   otherwise untouched, so "मैं बहुत उदास हूँ crying emoji" becomes "मैं बहुत उदास
   हूँ 😭" — but "रोता हुआ emoji" stays as words, because that descriptor is not in
@@ -333,8 +338,8 @@ a missing one are both fixed by hand:
 
 The setting applies to dictated text on this device, whichever transcription
 source produced it, including a gateway. It does not change text typed on the
-keyboard. Turn it off in Settings → Dictation → Emoji if you dictate the word
-often enough that the substitution is a nuisance.
+keyboard. Turn it on in Settings → Dictation → Emoji when you want the
+substitution.
 
 ## Transcript did not insert
 

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -392,7 +392,7 @@ struct DictationSettingsView: View {
     @AppStorage(
         KeyboardPreferences.spokenEmojiKey,
         store: KeyboardPreferences.defaults
-    ) private var spokenEmoji = true
+    ) private var spokenEmoji = false
     @AppStorage(
         KeyboardPreferences.repairSpeechKey,
         store: KeyboardPreferences.defaults
@@ -595,10 +595,10 @@ struct DictationSettingsView: View {
         }
     }
 
-    /// Saying "crying emoji" and getting 😭. The third switch that changes
-    /// words rather than formatting, and the only one of the three that is on
-    /// by default — the others apply to ordinary dictation, while this one
-    /// cannot fire unless the user says "emoji" out loud.
+    /// Saying "crying emoji" and getting 😭. Off by default: the third switch
+    /// that changes words rather than formatting, and like Write numbers as
+    /// digits it has to be turned on — talking *about* an emoji should not
+    /// rewrite the sentence until the user asks for that.
     private var spokenEmojiSection: some View {
         Section {
             Toggle("Spoken emoji", isOn: $spokenEmoji)
@@ -607,9 +607,10 @@ struct DictationSettingsView: View {
         } footer: {
             VStack(alignment: .leading, spacing: VocaMetrics.related) {
                 Text(
-                    "Say the emoji and then the word “emoji”: “I’m so sad crying "
-                        + "emoji” becomes “I’m so sad 😭”. The same names the "
-                        + "keyboard suggests while you type work here."
+                    "Say the emoji and then the word “emoji”: “crying emoji” "
+                        + "becomes 😭. The whole name has to match — a partial "
+                        + "suffix is left alone. The same names the keyboard "
+                        + "suggests while you type work here."
                 )
                 // The exception is the point: without it the feature would eat
                 // the word "emoji" out of ordinary sentences.

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -520,12 +520,11 @@ enum KeyboardPreferences {
 
     /// Whether "crying emoji" becomes 😭.
     ///
-    /// On by default, unlike the two settings above it that also change words.
-    /// They apply to text the user dictated for its own sake, so turning them
-    /// on has to be a choice; this one is unreachable unless the user says the
-    /// word "emoji" out loud, which nobody does by accident.
+    /// Off by default, matching Write numbers as digits. Saying "emoji" out
+    /// loud is deliberate, but a default-on converter still rewrites the times
+    /// someone is talking *about* an emoji rather than asking for one. Opt in.
     static var spokenEmoji: Bool {
-        get { boolean(spokenEmojiKey, default: true) }
+        get { boolean(spokenEmojiKey, default: false) }
         set { defaults?.set(newValue, forKey: spokenEmojiKey) }
     }
 

--- a/ios/VocaPhoneShared/SpokenEmoji.swift
+++ b/ios/VocaPhoneShared/SpokenEmoji.swift
@@ -23,8 +23,11 @@ import Foundation
 /// * Only a space or a hyphen joins a descriptor to its trigger. "I'm sad,
 ///   crying emoji" converts "crying"; "I'm sad, emoji" converts nothing,
 ///   because a comma ends the phrase rather than being read through.
-/// * The longest phrase wins, so "loudly crying emoji" is 😭 and not
-///   "loudly 😭".
+/// * The whole descriptor or nothing. A proper suffix of what was said is
+///   not enough: "smiling face with heart eyes emoji" must not become
+///   "smiling face with 😍". Either the contiguous span before the trigger
+///   is an exact table key (after the same with/and/of dropping the catalog
+///   generator uses), or the words stay as spoken.
 ///
 /// English only, which is what the settings copy says. `suggestions.tsv` is
 /// generated from the English CLDR annotations, so a Hindi or Japanese
@@ -35,6 +38,22 @@ enum SpokenEmoji {
     /// pluralize it; "emoji" is not itself a key in the table, so a trigger can
     /// never match itself.
     static let triggerWords: Set<String> = ["emoji", "emojis"]
+
+    /// Words the catalog generator drops when it concatenates a multi-word
+    /// Unicode or CLDR name into a strip key. Mirrored here so a spoken form
+    /// that still contains them ("smiling face with heart eyes") hits the same
+    /// key (`smilingfacehearteyes`) the table actually stores.
+    private static let nameStop: Set<String> = [
+        "with", "and", "of", "the", "a", "in", "on", "at", "to", "for", "or",
+    ]
+
+    /// Keys the typing strip may keep but this stage must not write.
+    ///
+    /// `korea` in suggestions.tsv is 🇰🇵 (DPRK). Someone saying "korea emoji"
+    /// almost never means that flag — they mean the peninsula, or South Korea.
+    /// Refuse the bare word on the spoken path only; `southkorea` and
+    /// `northkorea` still convert, and the strip is unchanged.
+    private static let spokenBlocklist: Set<String> = ["korea"]
 
     /// Replaces every `<descriptor> emoji` span with its glyph.
     ///
@@ -150,30 +169,57 @@ enum SpokenEmoji {
         return " "
     }
 
-    /// Walks backwards from the trigger, growing a candidate key one word at a
-    /// time and remembering the longest one the table knows.
+    /// The contiguous joiner-connected words immediately before the trigger,
+    /// converted only when that whole span is an exact table key.
     ///
-    /// The walk is bounded by the table's own widest key rather than by a word
-    /// count, because a key has had its spaces removed and cannot say how many
-    /// words built it. Growing past that length can only produce keys the table
-    /// does not contain.
+    /// Walks backwards while a space or hyphen joins, stopping at another
+    /// trigger word so "crying emoji fire emoji" still finds each descriptor
+    /// on its own. No suffix fallback: if only a proper suffix of the span is
+    /// a key, the whole phrase is left unchanged — that is what used to type
+    /// "smiling face with 😍" for "smiling face with heart eyes emoji".
+    ///
+    /// The catalog generator drops a small set of name-stop words (with, and,
+    /// of, …) when it builds keys, so "smiling face with heart eyes" is stored
+    /// as `smilingfacehearteyes`. Looking the span up both raw and with those
+    /// stops removed keeps spoken forms aligned with that table without going
+    /// back to longest-suffix matching. Leading stops stay in the transcript
+    /// ("and fire emoji" keeps "and").
     private static func descriptor(
         before trigger: Int,
         in words: [NSTextCheckingResult],
         text: NSString
     ) -> (glyph: String, start: NSRange)? {
-        var best: (glyph: String, start: NSRange)?
-        var key = ""
+        var parts: [(word: String, range: NSRange)] = []
+        var fullLength = 0
         var index = trigger - 1
         while index >= 0, isJoiner(gapAfter: index, in: words, text: text) {
-            key = text.substring(with: words[index].range).lowercased() + key
-            if key.count > EmojiTable.widestKeyLength { break }
-            if let glyph = EmojiTable.glyph(forKey: key) {
-                best = (glyph, words[index].range)
-            }
+            let raw = text.substring(with: words[index].range).lowercased()
+            if triggerWords.contains(raw) { break }
+            if fullLength + raw.count > EmojiTable.widestKeyLength { break }
+            parts.insert((raw, words[index].range), at: 0)
+            fullLength += raw.count
             index -= 1
         }
-        return best
+        guard !parts.isEmpty else { return nil }
+
+        let fullKey = parts.map(\.word).joined()
+        if let glyph = glyphForSpoken(fullKey) {
+            return (glyph, parts[0].range)
+        }
+
+        let significant = parts.filter { !nameStop.contains($0.word) }
+        guard !significant.isEmpty else { return nil }
+        let strippedKey = significant.map(\.word).joined()
+        guard strippedKey != fullKey else { return nil }
+        guard let glyph = glyphForSpoken(strippedKey) else { return nil }
+        return (glyph, significant[0].range)
+    }
+
+    /// Table lookup for the spoken path, with the few keys this stage must not
+    /// write even though the typing strip still offers them.
+    private static func glyphForSpoken(_ key: String) -> String? {
+        if spokenBlocklist.contains(key) { return nil }
+        return EmojiTable.glyph(forKey: key)
     }
 
     /// Whether the gap between this word and the next one is nothing but a

--- a/ios/VocaPhoneTests/DictatedTranscriptTests.swift
+++ b/ios/VocaPhoneTests/DictatedTranscriptTests.swift
@@ -180,12 +180,12 @@ struct DictatedTranscriptTests {
     @Test func emojiHappensBeforeDigits() {
         #expect(
             DictatedTranscript.finished(
-                "that was hundred emoji",
+                "hundred emoji",
                 style: .casual,
                 repairSpeech: false,
                 numbersAsDigits: true,
                 spokenEmoji: true
-            ) == "That was 💯"
+            ) == "💯"
         )
     }
 
@@ -195,12 +195,12 @@ struct DictatedTranscriptTests {
     @Test func stylingHappensBeforeEmoji() {
         #expect(
             DictatedTranscript.finished(
-                "i'm so sad crying emoji",
+                "crying emoji",
                 style: .formal,
                 repairSpeech: false,
                 numbersAsDigits: false,
                 spokenEmoji: true
-            ) == "I'm so sad 😭"
+            ) == "😭"
         )
     }
 

--- a/ios/VocaPhoneTests/SpokenEmojiTests.swift
+++ b/ios/VocaPhoneTests/SpokenEmojiTests.swift
@@ -4,23 +4,35 @@ import Testing
 /// exists because the obvious implementation gets it wrong.
 struct SpokenEmojiTests {
     @Test func aDescriptorAndTheTriggerBecomeTheGlyph() {
-        #expect(SpokenEmoji.glyphs(in: "I'm so sad crying emoji") == "I'm so sad 😭")
+        #expect(SpokenEmoji.glyphs(in: "crying emoji") == "😭")
     }
 
     /// The worked example from the plan, and the case that proves repeats need
     /// no special handling: two triggers are two independent matches.
     @Test func repeatedTriggersEachConvert() {
-        #expect(
-            SpokenEmoji.glyphs(in: "I'm so sad crying emoji crying emoji")
-                == "I'm so sad 😭 😭"
-        )
+        #expect(SpokenEmoji.glyphs(in: "crying emoji crying emoji") == "😭 😭")
     }
 
     /// Keys are the descriptor with its spaces removed, so a multi-word
     /// descriptor resolves without the table having to store the spacing.
     @Test func multiWordDescriptorsResolve() {
-        #expect(SpokenEmoji.glyphs(in: "nice work thumbs up emoji") == "nice work 👍")
+        #expect(SpokenEmoji.glyphs(in: "thumbs up emoji") == "👍")
         #expect(SpokenEmoji.glyphs(in: "shrug emoji") == "🤷")
+    }
+
+    /// Prose glued to the descriptor is not part of the name. The whole span
+    /// before the trigger has to be the key; a leftover prefix means decline.
+    @Test func proseBeforeADescriptorIsNotConsumed() {
+        #expect(
+            SpokenEmoji.glyphs(in: "I'm so sad crying emoji")
+                == "I'm so sad crying emoji"
+        )
+        #expect(
+            SpokenEmoji.glyphs(in: "nice work thumbs up emoji")
+                == "nice work thumbs up emoji"
+        )
+        // A comma ends the phrase, so the descriptor stands alone.
+        #expect(SpokenEmoji.glyphs(in: "I'm so sad, crying emoji") == "I'm so sad, 😭")
     }
 
     /// The spoken forms added to `tools/emoji-suggestion-overrides.tsv` when
@@ -34,9 +46,10 @@ struct SpokenEmojiTests {
         #expect(SpokenEmoji.glyphs(in: "check mark emoji") == "✅")
     }
 
-    /// The longest phrase wins. "loudly crying" and "crying" are both keys, and
-    /// stopping at the first match would leave the word "loudly" behind.
-    @Test func theLongestPhraseWins() {
+    /// The whole multi-word name converts, not a short suffix of it.
+    /// "loudly crying" and "crying" are both keys; taking only "crying" would
+    /// leave "loudly" stranded in front of the glyph.
+    @Test func theFullMultiWordNameConverts() {
         #expect(SpokenEmoji.glyphs(in: "loudly crying emoji") == "😭")
     }
 
@@ -48,10 +61,7 @@ struct SpokenEmojiTests {
             SpokenEmoji.glyphs(in: "Crying emoji, crying emoji, crying emoji.")
                 == "😭 😭 😭"
         )
-        // A longer pause is written down as a full stop, and "😭. 😭." is no
-        // more something a person types than "😭, 😭".
         #expect(SpokenEmoji.glyphs(in: "Crying emoji. Fire emoji.") == "😭 🔥")
-        // Already a plain space: nothing to collapse, nothing changed.
         #expect(SpokenEmoji.glyphs(in: "crying emoji crying emoji") == "😭 😭")
     }
 
@@ -59,24 +69,87 @@ struct SpokenEmojiTests {
     /// the sentence around the emoji stays exactly where the styler put it.
     @Test func punctuationOutsideTheRunIsUntouched() {
         #expect(SpokenEmoji.glyphs(in: "fire emoji, then home") == "🔥, then home")
+        // "but fire" is not a key, so the second phrase declines rather than
+        // taking the "fire" suffix and leaving "but" stranded.
         #expect(
-            SpokenEmoji.glyphs(in: "I'm sad crying emoji, but fire emoji, then home")
-                == "I'm sad 😭, but 🔥, then home"
+            SpokenEmoji.glyphs(in: "I'm sad, crying emoji, but fire emoji, then home")
+                == "I'm sad, 😭, but fire emoji, then home"
         )
-        // Words between two glyphs are not punctuation, so nothing collapses.
+        // A sentence break gives the second descriptor its own span.
+        #expect(
+            SpokenEmoji.glyphs(in: "I'm sad, crying emoji. Fire emoji, then home")
+                == "I'm sad, 😭 🔥, then home"
+        )
+        // Leading name-stop words stay; "and" is not eaten into the second glyph.
         #expect(SpokenEmoji.glyphs(in: "crying emoji and fire emoji") == "😭 and 🔥")
     }
 
     /// A partial match must never leave the rest of what was said in front of
-    /// the glyph. "face with tears of joy emoji" resolving only its "joy"
-    /// suffix would type "face with 😂", which is worse than not converting at
-    /// all — so the whole phrase is a key and the longest-match rule takes it.
+    /// the glyph. Exact multi-word keys convert fully; phrases that are not
+    /// keys must not fall back to a proper suffix.
     @Test func longerPhrasesDoNotStrandTheirLeadingWords() {
         #expect(SpokenEmoji.glyphs(in: "one hundred emoji") == "💯")
         #expect(SpokenEmoji.glyphs(in: "face with tears of joy emoji") == "😂")
         #expect(SpokenEmoji.glyphs(in: "rolling on the floor laughing emoji") == "🤣")
         #expect(SpokenEmoji.glyphs(in: "crying face emoji") == "😢")
         #expect(SpokenEmoji.glyphs(in: "thumbs up sign emoji") == "👍")
+    }
+
+    /// Full-descriptor-or-decline: CLDR-style names that hit a key once
+    /// name-stop words are dropped convert as a whole; near-miss phrases that
+    /// only share a suffix with a key are left unchanged.
+    @Test func cldrNamesConvertFullyOrNotAtAll() {
+        #expect(SpokenEmoji.glyphs(in: "smiling face with heart eyes emoji") == "😍")
+        #expect(SpokenEmoji.glyphs(in: "pile of poo emoji") == "💩")
+        #expect(SpokenEmoji.glyphs(in: "face with rolling eyes emoji") == "🙄")
+        #expect(SpokenEmoji.glyphs(in: "smiling face with sunglasses emoji") == "😎")
+        #expect(SpokenEmoji.glyphs(in: "heart on fire emoji") == "❤️‍🔥")
+        #expect(SpokenEmoji.glyphs(in: "couple with heart emoji") == "💑")
+
+        for phrase in [
+            "I love you emoji",
+            "see no evil emoji",
+            "person running emoji",
+        ] {
+            #expect(SpokenEmoji.glyphs(in: phrase) == phrase)
+        }
+    }
+
+    /// Property-style: table keys spoken as themselves before "emoji" convert
+    /// with no leftover prefix. Spaced multi-word forms from overrides and
+    /// CLDR joins do the same.
+    @Test func tableKeysConvertWithNoLeftoverPrefix() {
+        var checked = 0
+        for (key, glyph) in EmojiTable.triggers {
+            if key.count < EmojiTable.minimumLength { continue }
+            if key == "korea" { continue } // spoken blocklist; covered below
+            #expect(SpokenEmoji.glyphs(in: "\(key) emoji") == glyph)
+            checked += 1
+            if checked >= 200 { break }
+        }
+        #expect(checked >= 200)
+
+        let spaced: [(String, String)] = [
+            ("heart eyes", "😍"),
+            ("loudly crying", "😭"),
+            ("one hundred", "💯"),
+            ("thumbs up", "👍"),
+            ("face with tears of joy", "😂"),
+            ("rolling on the floor laughing", "🤣"),
+        ]
+        for (phrase, glyph) in spaced {
+            #expect(SpokenEmoji.glyphs(in: "\(phrase) emoji") == glyph)
+        }
+    }
+
+    /// `korea` in the strip table is 🇰🇵. Spoken path refuses the bare word;
+    /// southkorea / northkorea still convert.
+    @Test func koreaAloneDoesNotBecomeTheDPRKFlag() {
+        #expect(SpokenEmoji.glyphs(in: "korea emoji") == "korea emoji")
+        #expect(SpokenEmoji.glyphs(in: "southkorea emoji") == "🇰🇷")
+        #expect(SpokenEmoji.glyphs(in: "northkorea emoji") == "🇰🇵")
+        // Strip table is unchanged: the blocklist is spoken-only.
+        #expect(EmojiTable.triggers["korea"] == "🇰🇵")
     }
 
     /// Digits are descriptors too. A speech model writes someone saying
@@ -86,9 +159,9 @@ struct SpokenEmojiTests {
         #expect(SpokenEmoji.glyphs(in: "100 emoji") == "💯")
         #expect(SpokenEmoji.glyphs(in: "a hundred emoji") == "💯")
         #expect(SpokenEmoji.glyphs(in: "one hundred emoji") == "💯")
-        // A number that names no emoji is still just a number.
         #expect(SpokenEmoji.glyphs(in: "I need 20 emoji") == "I need 20 emoji")
-        #expect(SpokenEmoji.glyphs(in: "3 crying emoji") == "3 😭")
+        #expect(SpokenEmoji.glyphs(in: "3 crying emoji") == "3 crying emoji")
+        #expect(SpokenEmoji.glyphs(in: "3, crying emoji") == "3, 😭")
     }
 
     /// Allowing digits made a masked span's own index look like a word, so a
@@ -118,8 +191,6 @@ struct SpokenEmojiTests {
             SpokenEmoji.glyphs(in: "とても悲しい crying emoji", language: "ja")
                 == "とても悲しい 😭"
         )
-        // A descriptor in another language is not in the table, so the words
-        // stay exactly as spoken rather than being half-converted.
         #expect(
             SpokenEmoji.glyphs(in: "estoy muy triste llorando emoji", language: "es")
                 == "estoy muy triste llorando emoji"
@@ -131,19 +202,18 @@ struct SpokenEmojiTests {
     @Test func anUnmatchedTriggerIsLeftAlone() {
         #expect(SpokenEmoji.glyphs(in: "Send me the emoji.") == "Send me the emoji.")
         #expect(SpokenEmoji.glyphs(in: "emoji") == "emoji")
-        // "emoji" is not itself a key, so a trigger cannot match its neighbour.
         #expect(SpokenEmoji.glyphs(in: "emoji emoji") == "emoji emoji")
     }
 
     @Test func theTriggerMayBePluralized() {
-        #expect(SpokenEmoji.glyphs(in: "add fire emojis") == "add 🔥")
+        #expect(SpokenEmoji.glyphs(in: "fire emojis") == "🔥")
     }
 
     /// Styling has already run, so the trigger arrives carrying whatever mark
     /// the style put on it. Only the words are replaced, which leaves the mark
     /// and the spacing exactly where the styler left them.
     @Test func punctuationTheStylerAttachedSurvives() {
-        #expect(SpokenEmoji.glyphs(in: "That was fun party emoji!") == "That was fun 🎉!")
+        #expect(SpokenEmoji.glyphs(in: "party emoji!") == "🎉!")
         #expect(SpokenEmoji.glyphs(in: "fire emoji, then home") == "🔥, then home")
         #expect(SpokenEmoji.glyphs(in: "Crying emoji. That was rough.") == "😭. That was rough.")
     }
@@ -151,10 +221,8 @@ struct SpokenEmojiTests {
     /// The styler ended the sentence while the last word was still "emoji". An
     /// emoji is the end: nobody writes "I'm so sad 😭." or "💯."
     @Test func aTrailingTerminatorAfterAGlyphGoes() {
-        #expect(SpokenEmoji.glyphs(in: "I'm so sad crying emoji.") == "I'm so sad 😭")
+        #expect(SpokenEmoji.glyphs(in: "I'm so sad, crying emoji.") == "I'm so sad, 😭")
         #expect(SpokenEmoji.glyphs(in: "Hundred emoji.") == "💯")
-        // Only when the terminator is the whole tail — this one is ending a
-        // sentence the glyph merely started.
         #expect(
             SpokenEmoji.glyphs(in: "Crying emoji is how I feel.")
                 == "😭 is how I feel."
@@ -214,16 +282,10 @@ struct SpokenEmojiTests {
     /// in it, so the cases that matter are the ones that still have to work
     /// after passing it — and the ones it correctly lets through.
     @Test func theFastPathChangesNothing() {
-        // No "j" anywhere: skipped, and identical either way.
         let untouched = "no trigger anywhere in this sentence at all"
         #expect(SpokenEmoji.glyphs(in: untouched) == untouched)
-        // A "j" from an ordinary word, no trigger: falls through to the full
-        // walk, which declines it.
         #expect(SpokenEmoji.glyphs(in: "just a jar of jam") == "just a jar of jam")
-        // "emojify" carries the "j" and the substring, so the pre-check passes
-        // it; the word-boundary rule is what correctly declines it.
         #expect(SpokenEmoji.glyphs(in: "fire emojify") == "fire emojify")
-        // Upper case has to survive the byte fold, or a shouted trigger is lost.
         #expect(SpokenEmoji.glyphs(in: "Fire EMOJI now") == "🔥 now")
     }
 }


### PR DESCRIPTION
Closes the three review BLOCKs from #242 on top of the spoken-emoji work.

## BLOCKs

1. **Leftover-prefix.** `descriptorBefore` kept the longest suffix key, so `smiling face with heart eyes emoji` became `smiling face with 😍`. It now converts only when the contiguous span before `emoji`/`emojis` is an exact table key (raw, or with the same with/and/of dropping the catalog generator uses). A proper suffix alone leaves the whole phrase unchanged. Mirrored on Android and iOS.

2. **korea → DPRK.** Spoken path blocklists bare `korea` so it does not write 🇰🇵. `southkorea` / `northkorea` still convert; the typing strip is unchanged. Comment in code explains why.

3. **Default off.** Spoken emoji defaults to false on Android (`SettingsRepository`, `DictatedTranscript`) and iOS (`KeyboardPreferences`, `SettingsView`). Feature tests pass `spokenEmoji = true` explicitly.

## Tests

- Property-style: table keys convert with no leftover prefix; known near-miss phrases (`I love you`, `see no evil`, `person running`) do not partially convert.
- Explicit cases for smiling face with heart eyes, pile of poo, korea, crying emoji when enabled.
- Android: `SpokenEmojiTest` + `DictatedTranscriptTest` green locally.

## Status

Draft until CI, adversarial review, and Greptile 5/5. Do not merge yet.