### PR TITLE
Align iPhone meta and Gateway links with the product site

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -667,7 +667,7 @@
               No. Download an on-device model once and VocaPhone can transcribe
               without a gateway, account, or network connection. If you want larger
               models, more engines, or shared hardware, you can self-host
-              <a href="https://github.com/VocaHQ/vocagateway">VocaGateway</a> on a
+              <a href="https://vocagateway.vocahq.com">VocaGateway</a> on a
               Mac, Linux machine, or home server and pair your phone by QR.
             </p>
           </details>
@@ -813,7 +813,7 @@
         <div>
           <p>resources</p>
           <a href="https://github.com/VocaHQ/vocaphone">GitHub</a>
-          <a href="https://github.com/VocaHQ/vocagateway">VocaGateway</a>
+          <a href="https://vocagateway.vocahq.com">VocaGateway</a>
           <a href="/privacy/">privacy</a>
           <a href="https://github.com/VocaHQ/vocaphone/blob/main/SUPPORT.md">support</a>
         </div>

--- a/web/iphone/index.html
+++ b/web/iphone/index.html
@@ -35,7 +35,7 @@
     <meta name="twitter:title" content="Install VocaPhone on iPhone" />
     <meta
       name="twitter:description"
-      content="Join the public TestFlight, or build from source, then install the private keyboard and run speech-to-text on your iPhone."
+      content="Join the public TestFlight, or build from source, then install the keyboard and run speech-to-text on your iPhone."
     />
     <meta name="twitter:image" content="https://vocaphone.vocahq.com/assets/og-image.png" />
     <meta

--- a/web/iphone/index.html
+++ b/web/iphone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Build and install VocaPhone on an iPhone, choose an on-device speech-to-text model, and enable the private voice keyboard."
+      content="Join the public TestFlight, or build from source, then install the keyboard and run speech-to-text on your iPhone."
     />
     <meta name="theme-color" content="#f4f1e8" />
     <meta name="robots" content="index, follow" />
@@ -180,9 +180,14 @@ git lfs pull</code></pre>
               encrypted network, or HTTPS.
             </p>
           </div>
-          <a class="button button-secondary" href="https://github.com/VocaHQ/vocagateway">
-            explore VocaGateway <span aria-hidden="true">↗</span>
-          </a>
+          <div class="gateway-actions">
+            <a class="button gateway-button" href="https://vocagateway.vocahq.com">
+              explore VocaGateway <span aria-hidden="true">↗</span>
+            </a>
+            <a class="button button-secondary" href="https://github.com/VocaHQ/vocagateway">
+              view on GitHub <span aria-hidden="true">↗</span>
+            </a>
+          </div>
         </aside>
 
         <div class="guide-source-links">

--- a/web/privacy/index.html
+++ b/web/privacy/index.html
@@ -133,9 +133,14 @@
               traffic.
             </p>
           </div>
-          <a class="button button-secondary" href="https://github.com/VocaHQ/vocagateway">
-            explore VocaGateway <span aria-hidden="true">↗</span>
-          </a>
+          <div class="gateway-actions">
+            <a class="button gateway-button" href="https://vocagateway.vocahq.com">
+              explore VocaGateway <span aria-hidden="true">↗</span>
+            </a>
+            <a class="button button-secondary" href="https://github.com/VocaHQ/vocagateway">
+              view on GitHub <span aria-hidden="true">↗</span>
+            </a>
+          </div>
         </aside>
 
         <div class="guide-intro">

--- a/web/styles.css
+++ b/web/styles.css
@@ -2911,6 +2911,11 @@ svg {
   background: #24523f;
 }
 
+.guide-callout .gateway-actions {
+  flex-direction: column;
+  align-items: stretch;
+}
+
 .guide-callout + .guide-intro {
   margin-top: 90px;
   margin-bottom: 0;

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -132,7 +132,7 @@ test("production metadata is complete", () => {
     /property="og:image:alt"\s+content="VocaPhone on Android and iPhone, on-device first with an optional self-hosted gateway"/,
     /property="og:description"\s+content="Join the public TestFlight, or build from source, then install the keyboard and run speech-to-text on your iPhone\."/,
     /name="twitter:title" content="Install VocaPhone on iPhone"/,
-    /name="twitter:description"\s+content="Join the public TestFlight, or build from source, then install the private keyboard and run speech-to-text on your iPhone\."/,
+    /name="twitter:description"\s+content="Join the public TestFlight, or build from source, then install the keyboard and run speech-to-text on your iPhone\."/,
     /name="twitter:image" content="https:\/\/vocaphone\.vocahq\.com\/assets\/og-image\.png"/,
     /name="twitter:image:alt"\s+content="VocaPhone on Android and iPhone, on-device first with an optional self-hosted gateway"/,
   ]) {

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -68,6 +68,15 @@ test("VocaGateway is presented as an explicit optional path", () => {
   assert.match(html, /trusted LAN, an encrypted private\s+network, or HTTPS/i);
   assert.match(html, /href="https:\/\/vocagateway\.vocahq\.com"/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocagateway"/);
+  assert.match(
+    html,
+    /self-host\s+<a href="https:\/\/vocagateway\.vocahq\.com">VocaGateway<\/a>/,
+  );
+  assert.match(html, /<a href="https:\/\/vocagateway\.vocahq\.com">VocaGateway<\/a>/);
+  assert.doesNotMatch(
+    html,
+    /<a href="https:\/\/github\.com\/VocaHQ\/vocagateway">VocaGateway<\/a>/,
+  );
   assert.doesNotMatch(html, /no gateway\. no catch/i);
   assert.doesNotMatch(html, />no gateway needed</i);
 });
@@ -119,6 +128,7 @@ test("production metadata is complete", () => {
     /property="og:image:type" content="image\/png"/,
     /property="og:image:width" content="1200"/,
     /property="og:image:height" content="630"/,
+    /name="description"\s+content="Join the public TestFlight, or build from source, then install the keyboard and run speech-to-text on your iPhone\."/,
     /property="og:image:alt"\s+content="VocaPhone on Android and iPhone, on-device first with an optional self-hosted gateway"/,
     /property="og:description"\s+content="Join the public TestFlight, or build from source, then install the keyboard and run speech-to-text on your iPhone\."/,
     /name="twitter:title" content="Install VocaPhone on iPhone"/,
@@ -343,6 +353,21 @@ test("the iPhone gateway callout uses a dark-surface button", () => {
     css,
     /\.guide-callout \.button-secondary\s*\{[\s\S]*?background:\s*#17392d;/,
   );
+});
+
+test("iPhone and privacy Gateway CTAs point at the product site", () => {
+  for (const page of [iphoneHtml, privacyHtml]) {
+    assert.match(page, /href="https:\/\/vocagateway\.vocahq\.com"/);
+    assert.match(page, /href="https:\/\/github\.com\/VocaHQ\/vocagateway"/);
+    assert.match(
+      page,
+      /href="https:\/\/vocagateway\.vocahq\.com"[\s\S]*?explore VocaGateway/,
+    );
+    assert.match(
+      page,
+      /href="https:\/\/github\.com\/VocaHQ\/vocagateway"[\s\S]*?view on GitHub/,
+    );
+  }
 });
 
 test("visual treatment stays flat", () => {


### PR DESCRIPTION
iPhone meta now matches the TestFlight-first og line. Gateway explore, FAQ, and footer links go to vocagateway.vocahq.com, with GitHub kept as the secondary callout. Closes #244.