### PR TITLE
feat(ios): one dictation surface, and keystrokes that land

### DIFF
--- a/.github/workflows/quality-ios.yml
+++ b/.github/workflows/quality-ios.yml
@@ -63,6 +63,19 @@ jobs:
           persist-credentials: false
       - name: Fetch iOS Sherpa ONNX runtime
         run: bash ios/ThirdParty/SherpaOnnx/fetch.sh
+      - name: Select Xcode 26
+        run: |
+          set -euo pipefail
+          # `macos-15` still defaults to Xcode 16.4 / iOS 18.5, and this job
+          # otherwise builds the keyboard against an SDK the project does not
+          # target: `project.yml` asks for Xcode 26 and the release workflow
+          # already selects it here. Anything guarded by `#available(iOS 26, *)`
+          # still fails to *compile* on the older SDK, because a runtime check
+          # cannot conjure a symbol the SDK has never heard of.
+          app="$(printf '%s\n' /Applications/Xcode_26*.app | sort -V | tail -1)"
+          sudo xcode-select -s "$app"
+          xcodebuild -version
+
       - run: brew install xcodegen
       - name: Fail if the checked-in Xcode project is stale
         working-directory: ios

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		06DDF0287EE04B56BDA4C2B5 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = BD7C720E296C2265F0174573 /* PrivacyInfo.xcprivacy */; };
 		07138BD901EA33F72339A4F7 /* TelemetryRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27748467103CFAD3F6A2F603 /* TelemetryRecord.swift */; };
 		07D7CA474CBB8812C0E83D1C /* VocaPhoneActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8988211922DAD4FC77AF89EB /* VocaPhoneActivityAttributes.swift */; };
+		0B1D719C6CC090B5EB1014D9 /* FrameMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B973580E9433CC9EC9A76024 /* FrameMonitor.swift */; };
 		0B939DE9494D3B8F14F18142 /* ModelLanguageSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */; };
 		0D07EBF90CE481AE0C1976CF /* SetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346B6558EE5557A35C916067 /* SetupView.swift */; };
 		0E4F6A827869289078B1F4D5 /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491DFC2F5F017E14BF64E308 /* DesignSystem.swift */; };
@@ -80,6 +81,7 @@
 		3226364FB9F43F49B12FE2A6 /* DictationBarLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA83B914C241E5F8BF8F32AC /* DictationBarLayoutTests.swift */; };
 		324811B86570CBD6C1C1FCFC /* SherpaRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0358A093FE299D51D513BC30 /* SherpaRecognizer.swift */; };
 		3263EFE959E452C5427EF549 /* KeyHitMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91ACC58FF89C43C9BD2D9F6 /* KeyHitMap.swift */; };
+		32ACD083D95E809FF6453331 /* TouchWitness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FABAD2700D5F00046349B21 /* TouchWitness.swift */; };
 		33049B8AD2490B0F8D0A9E0F /* SwipeRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C4BD2142E9377F123A8848 /* SwipeRecognizer.swift */; };
 		332424547CBE2483FE24C975 /* SherpaTranscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3E4382E021BE30F6D687A7 /* SherpaTranscriptTests.swift */; };
 		33A2193E058E05B4B4FB3860 /* ModelLanguageSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C6476FC82C4B74D01F4358 /* ModelLanguageSupport.swift */; };
@@ -140,6 +142,7 @@
 		5673DF7E07F7F800FB847C2A /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */; };
 		56783518C221839DE432BCC7 /* DesignSystemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755A4279065D41A705E1F19D /* DesignSystemTests.swift */; };
 		5769EF4A106AFBD7B375DC5D /* KeyboardPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9571AEC75B1A986C5D3077 /* KeyboardPreferences.swift */; };
+		57E1A4107330DC457108AFEF /* TouchWitness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FABAD2700D5F00046349B21 /* TouchWitness.swift */; };
 		582C18BD155158A79ADCBB5A /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */; };
 		58CDCA65875E94B8F7BE0101 /* QuickDictationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB84927D76F9C32C4BE1547 /* QuickDictationAvailability.swift */; };
 		590AE5D90BD9113ABA4EEF3F /* BrandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9711C18238B39EA2E842C0F /* BrandPalette.swift */; };
@@ -228,6 +231,7 @@
 		939752FDA33E96C811ED23C1 /* LocalTranscriptionPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FF1A5ABC4220C886291309 /* LocalTranscriptionPreferences.swift */; };
 		939ADF1C236F670A3541ACAA /* SwipeAlternates.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1F0FABCAE6669D0EB07FC3 /* SwipeAlternates.swift */; };
 		9418E647BE968A5FC2064D06 /* SpokenNumbersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8201161064874EF522DF3F70 /* SpokenNumbersTests.swift */; };
+		9470DF414CA8F44F2330CC77 /* DictationSurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC10480CFBC7D25599BAD55 /* DictationSurfaceView.swift */; };
 		94B667AC0FFB905D57BE2CA3 /* VocaPhoneLiveActivity.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = CF080065DC31C6DA8E693163 /* VocaPhoneLiveActivity.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		94F7D564583E151ECAF6C33C /* DownloadReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF56F0E966D9AECA1DCFF65E /* DownloadReadiness.swift */; };
 		95A08342703AE27BD09E08AC /* TranscriptStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DBF47C7F5E5B13752056CB /* TranscriptStyler.swift */; };
@@ -280,6 +284,7 @@
 		B48D69BABE8D1FB3D9DE9504 /* LocalModelCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF28F6F60B7FDEA4EB183B6F /* LocalModelCatalogTests.swift */; };
 		B4EE97A67B156A6D5BA0D258 /* QuickDictationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB84927D76F9C32C4BE1547 /* QuickDictationAvailability.swift */; };
 		B61F7C13B4B93422C9BA3680 /* DarwinNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3498C523755A678225152570 /* DarwinNotifications.swift */; };
+		B63E29AFDE681832FA04ECFE /* TouchTrace.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF0FF0280003723E5D64E2A /* TouchTrace.swift */; };
 		B6FC1A52A47686796F30DC57 /* SnippetExpanderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2730948940D555163E520926 /* SnippetExpanderTests.swift */; };
 		B799AC1ACFA93756FA43069D /* TypingStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AA0EB543777294237739CF /* TypingStripView.swift */; };
 		B803C86D8A77C8A2D758DA0A /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C9B64B52A8D28D252CC3A5 /* AudioRecorder.swift */; };
@@ -303,19 +308,23 @@
 		C37AC6FC3CBF2147D8A50DDA /* SemanticPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B395C37266816A19C38B59 /* SemanticPaletteTests.swift */; };
 		C3862F53612AE55F9766E974 /* Snippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69943FB61027DEE31DA51705 /* Snippet.swift */; };
 		C4D64FB835EAB5A67E6CE009 /* AudioCapturePipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15DE10A5F8F90C87D4BA48A /* AudioCapturePipeline.swift */; };
+		C571D55DDA9D6C70259F0236 /* TouchTrace.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF0FF0280003723E5D64E2A /* TouchTrace.swift */; };
 		C5E88735AB4386DEFEBD2075 /* TelemetryFailureMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D81AEA9FD59906139F273D /* TelemetryFailureMapping.swift */; };
 		C63521DE52DC5A8DCD6847AE /* EmojiPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348E2313B75BA61D777FA18B /* EmojiPanelView.swift */; };
+		C6408C0FBE97AC8E61B7A373 /* TouchTrace.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF0FF0280003723E5D64E2A /* TouchTrace.swift */; };
 		C6E529713960996E85EFD275 /* SherpaIncrementalSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0A732D03A2951F028DDF6E /* SherpaIncrementalSessionTests.swift */; };
 		C729D3D95B9B597E56C485E7 /* SpokenNumbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E590CFC53039DA367280B8CD /* SpokenNumbers.swift */; };
 		C7ADFFD337103F3F6CF7BBA6 /* ProtectedSpans.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57FC525B204634FF41CDCDA /* ProtectedSpans.swift */; };
 		C80FCACABE7FF798EFD1EB61 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894063AE1B3DDA92C529268D /* AppConfiguration.swift */; };
 		C845C02425BC2788BABB26C2 /* SpeechAudioConditioningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59DB522E7DFDE3B3E009AFD /* SpeechAudioConditioningTests.swift */; };
+		C8A0B999624A4CA5DFBD8330 /* DictationSurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC10480CFBC7D25599BAD55 /* DictationSurfaceView.swift */; };
 		C8A3486459DEF9BE777C3ED6 /* KeyProximity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B90ACCDCBABF9F7412EE906 /* KeyProximity.swift */; };
 		C958410A61E962F39B4F5E4D /* LearnedWords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */; };
 		C9A6096B1D7A0603AE6810C3 /* SherpaFeatureDither.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7083ED482761906EE2589E97 /* SherpaFeatureDither.swift */; };
 		C9A65099749EC5AB021FCC1C /* SherpaLongAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */; };
 		CA31A30F8E764B891884324F /* TranscriptStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DBF47C7F5E5B13752056CB /* TranscriptStyler.swift */; };
 		CD600A39A4DFB39AD6F0E5E1 /* EmojiSuggestionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C0A3D1DBF6BCF25C37CF24 /* EmojiSuggestionsTests.swift */; };
+		CDFE48F60144A96B1C41080A /* DictationSurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC10480CFBC7D25599BAD55 /* DictationSurfaceView.swift */; };
 		CE9227DEA1DE35F0F9987562 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894063AE1B3DDA92C529268D /* AppConfiguration.swift */; };
 		CFF7A7DC99B4880EB955D603 /* KeyboardHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858088F81E12EC57E13F9492 /* KeyboardHaptics.swift */; };
 		D0E6AF99E65342BE66CF809A /* LearnedWords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */; };
@@ -326,6 +335,7 @@
 		D4CA018F48AA244D322B9156 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F3A6E7B826D1389D462944 /* ContentView.swift */; };
 		D4FEC9D26550CB1696FDF424 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */; };
 		D6533E4D830A06E9845CE624 /* KeyboardViewPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8E5D91EDE2C0E67DFC0250 /* KeyboardViewPreview.swift */; };
+		D6C5C2566FDD55046D16D878 /* FrameMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B973580E9433CC9EC9A76024 /* FrameMonitor.swift */; };
 		D7038E651848C4EE6B0F722A /* TypingStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AA0EB543777294237739CF /* TypingStripView.swift */; };
 		D73776692116A07EF59C6496 /* QuickDictationDuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783E7FC5F9553FD419487180 /* QuickDictationDuration.swift */; };
 		D7CC096732C721CE14B5F682 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */; };
@@ -333,6 +343,7 @@
 		D9811B8978380027BF95D0D5 /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
 		D9D9DB4E8F749BCC02AD0B5B /* PreviewFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9677581A0FA938AD9C520C /* PreviewFixtures.swift */; };
 		DA4C9428C4D3BF5F90F13377 /* TelemetryEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9559007A45749959AF9D10C /* TelemetryEvent.swift */; };
+		DAB0807EB39C3EA6AFEB03F4 /* TouchWitness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FABAD2700D5F00046349B21 /* TouchWitness.swift */; };
 		DC775A81F32818BCC08CA795 /* SherpaIncrementalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41205764F091734B2DE6D02 /* SherpaIncrementalSession.swift */; };
 		DCAAD00B7ED79568106DAD0C /* DictatedTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575BDB070A428051B623F095 /* DictatedTranscript.swift */; };
 		DCF552B58B7A7A12C517C17B /* PairingPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9E5CE913B4FA5EF8EECD4E /* PairingPayloadTests.swift */; };
@@ -376,6 +387,7 @@
 		F37F68399E06B767B5D6ACC7 /* KeyGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF7CAC171521FC372DF2BF0 /* KeyGridView.swift */; };
 		F3A845A38CC7840D2877FD26 /* KeyAlternatives.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0EBA8DE4056FCA3CB7F093C /* KeyAlternatives.swift */; };
 		F426CFBED733974D61FDB432 /* ModelLanguageSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41EF03C8A4F930315EFE77 /* ModelLanguageSupportTests.swift */; };
+		F43318EAC4CF26D8C46ECD19 /* FrameMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B973580E9433CC9EC9A76024 /* FrameMonitor.swift */; };
 		F4E8B1A9D00B14184B01B223 /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
 		F50496BCCFCB73757D3DDF13 /* EmojiCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882F3122E12BD0F2BF44ADC9 /* EmojiCatalogTests.swift */; };
 		F5468739AA5410076BE0C5EF /* SpokenEmojiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6B7EB27436670B0B1EB1D1 /* SpokenEmojiTests.swift */; };
@@ -458,6 +470,7 @@
 		28ECEDA044D2B1021710F205 /* TranscriptHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptHistoryView.swift; sourceTree = "<group>"; };
 		2D34E7E54437AFA69FDC2848 /* OnboardingPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPresentation.swift; sourceTree = "<group>"; };
 		2E6C1FB17BFD787FDDCBBF82 /* SherpaOnnxBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SherpaOnnxBridge.h; sourceTree = "<group>"; };
+		2FABAD2700D5F00046349B21 /* TouchWitness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchWitness.swift; sourceTree = "<group>"; };
 		32BFD71F9D14772A0C7330CD /* DictationBarLabelColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarLabelColorTests.swift; sourceTree = "<group>"; };
 		332854D2644CFCE5843E3F31 /* StopQuickDictationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopQuickDictationIntent.swift; sourceTree = "<group>"; };
 		342F2B3B437269514C969C77 /* SetupStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupStatus.swift; sourceTree = "<group>"; };
@@ -504,6 +517,7 @@
 		69943FB61027DEE31DA51705 /* Snippet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snippet.swift; sourceTree = "<group>"; };
 		6AC704CBD16EF6C7FCCBC6D6 /* KeyHitMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyHitMapTests.swift; sourceTree = "<group>"; };
 		6B6743BB4173E2F719E3D8CB /* TypingWordList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingWordList.swift; sourceTree = "<group>"; };
+		6CC10480CFBC7D25599BAD55 /* DictationSurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationSurfaceView.swift; sourceTree = "<group>"; };
 		6CF871FC84B4C6B2627A43C2 /* RecordingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingCoordinator.swift; sourceTree = "<group>"; };
 		7083ED482761906EE2589E97 /* SherpaFeatureDither.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaFeatureDither.swift; sourceTree = "<group>"; };
 		70B3F1DBA8332A13B095E4BA /* PairingScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScannerView.swift; sourceTree = "<group>"; };
@@ -575,6 +589,7 @@
 		B87128326897BFA30E7B2038 /* KeyLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyLayout.swift; sourceTree = "<group>"; };
 		B8D81AEA9FD59906139F273D /* TelemetryFailureMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryFailureMapping.swift; sourceTree = "<group>"; };
 		B90C2BEEA5195CB9CB5A38CA /* SherpaLongAudioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaLongAudioTests.swift; sourceTree = "<group>"; };
+		B973580E9433CC9EC9A76024 /* FrameMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameMonitor.swift; sourceTree = "<group>"; };
 		B9B9027C03A87FBC74CE1130 /* TypingEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingEngine.swift; sourceTree = "<group>"; };
 		B9BB34E20645F3D8C78A0363 /* Telemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Telemetry.swift; sourceTree = "<group>"; };
 		BA0A732D03A2951F028DDF6E /* SherpaIncrementalSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaIncrementalSessionTests.swift; sourceTree = "<group>"; };
@@ -616,6 +631,7 @@
 		E8847DC87DD10F359C6005C5 /* LocalModelManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelManager.swift; sourceTree = "<group>"; };
 		E9559007A45749959AF9D10C /* TelemetryEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryEvent.swift; sourceTree = "<group>"; };
 		EA031D86C1DE3C2F8B047308 /* SetupStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupStatusTests.swift; sourceTree = "<group>"; };
+		EDF0FF0280003723E5D64E2A /* TouchTrace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchTrace.swift; sourceTree = "<group>"; };
 		EE41EF03C8A4F930315EFE77 /* ModelLanguageSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelLanguageSupportTests.swift; sourceTree = "<group>"; };
 		EF0326EF6FB3E96C942C6065 /* KeyAlternativesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyAlternativesTests.swift; sourceTree = "<group>"; };
 		EF0D852E37E341D37CCB4DB2 /* CustomVocabularyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVocabularyTests.swift; sourceTree = "<group>"; };
@@ -681,9 +697,11 @@
 				C7842B22D05FB171B261101A /* DictationBarStyle.swift */,
 				BE3489C985467C23EB6A90AD /* DictationBarView.swift */,
 				9DCCE5FE1A8242B96B8CA9FD /* DictationPresentation.swift */,
+				6CC10480CFBC7D25599BAD55 /* DictationSurfaceView.swift */,
 				11816AC1A2219D15E870CE3E /* EmojiCatalog.swift */,
 				348E2313B75BA61D777FA18B /* EmojiPanelView.swift */,
 				136E505E4C5668F9ACCD30C5 /* EmojiSuggestions.swift */,
+				B973580E9433CC9EC9A76024 /* FrameMonitor.swift */,
 				3785791C0D9A5ABA2506F1B7 /* Info.plist */,
 				A0EBA8DE4056FCA3CB7F093C /* KeyAlternatives.swift */,
 				858088F81E12EC57E13F9492 /* KeyboardHaptics.swift */,
@@ -703,6 +721,8 @@
 				BA1F0FABCAE6669D0EB07FC3 /* SwipeAlternates.swift */,
 				07C4BD2142E9377F123A8848 /* SwipeRecognizer.swift */,
 				DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */,
+				EDF0FF0280003723E5D64E2A /* TouchTrace.swift */,
+				2FABAD2700D5F00046349B21 /* TouchWitness.swift */,
 				DEAA4440B24071020CD693DB /* TypingCandidates.swift */,
 				B9B9027C03A87FBC74CE1130 /* TypingEngine.swift */,
 				FC2CD13AAF5FDF79DD5D0075 /* TypingFieldPolicy.swift */,
@@ -1177,11 +1197,13 @@
 				2D1CF0D6875DFD7D9BFD10FF /* DictationBarStyle.swift in Sources */,
 				F1CDF580A8C552E1A03524A1 /* DictationBarView.swift in Sources */,
 				E4187B9A8DA6FBBA6DE095AC /* DictationPresentation.swift in Sources */,
+				C8A0B999624A4CA5DFBD8330 /* DictationSurfaceView.swift in Sources */,
 				22916AAC244D261969A38330 /* DownloadReadiness.swift in Sources */,
 				5FD3264678E78B2F180A074A /* EmojiCatalog.swift in Sources */,
 				C63521DE52DC5A8DCD6847AE /* EmojiPanelView.swift in Sources */,
 				40959874C3AE5396E1177CC4 /* EmojiSuggestions.swift in Sources */,
 				3632C1278A31CC6ADBAC33D5 /* EmojiTable.swift in Sources */,
+				D6C5C2566FDD55046D16D878 /* FrameMonitor.swift in Sources */,
 				7E3D8E857A83184E74B15433 /* GatewayEndpoint.swift in Sources */,
 				771730250FDC04B40A57E462 /* KeyAlternatives.swift in Sources */,
 				E4162282629880D2A33913CA /* KeyGridView.swift in Sources */,
@@ -1226,6 +1248,8 @@
 				282E28F25550DF3BFB996429 /* SwipeRecognizer.swift in Sources */,
 				B1D4DE96B74C3327DA6A0FAD /* SwipeTrailView.swift in Sources */,
 				E366EFAD9B70FE3FC43FEBAD /* TextInsertion.swift in Sources */,
+				B63E29AFDE681832FA04ECFE /* TouchTrace.swift in Sources */,
+				57E1A4107330DC457108AFEF /* TouchWitness.swift in Sources */,
 				5ADC4420E2E23403BFC8716D /* TranscriptRepair.swift in Sources */,
 				9137DE19695E0CADB0EFBFB0 /* TranscriptRetention.swift in Sources */,
 				057296EB66A8C88C3B2A762C /* TranscriptSanitizer.swift in Sources */,
@@ -1259,9 +1283,11 @@
 				84E419209B93E8F1B50FEE4E /* DictationBarStyle.swift in Sources */,
 				78D493F3552BE347D8931376 /* DictationBarView.swift in Sources */,
 				A018E5851AAB98E42FBBB65A /* DictationPresentation.swift in Sources */,
+				9470DF414CA8F44F2330CC77 /* DictationSurfaceView.swift in Sources */,
 				94F7D564583E151ECAF6C33C /* DownloadReadiness.swift in Sources */,
 				BBCAD7035421FAF541F20BDD /* EmojiTable.swift in Sources */,
 				84F2FD89DD3C1EB490E86A73 /* FinishRecordingIntent.swift in Sources */,
+				0B1D719C6CC090B5EB1014D9 /* FrameMonitor.swift in Sources */,
 				B0DF0FF5821BD7E8C839065C /* GatewayClient.swift in Sources */,
 				062CD049AAD6768AE5AB3766 /* GatewayEndpoint.swift in Sources */,
 				4016476924F9555E1E861673 /* GatewaySetupView.swift in Sources */,
@@ -1336,6 +1362,8 @@
 				70232F18D7B4AA7F6BB15C64 /* TelemetrySink.swift in Sources */,
 				7B0D3581B262BEB5AC561C23 /* TelemetryStats.swift in Sources */,
 				89E3D47D85EBD6AD5A093813 /* TextInsertion.swift in Sources */,
+				C6408C0FBE97AC8E61B7A373 /* TouchTrace.swift in Sources */,
+				DAB0807EB39C3EA6AFEB03F4 /* TouchWitness.swift in Sources */,
 				24D6E87B9EE199DCFDFC66D6 /* TranscriptHistoryModel.swift in Sources */,
 				D1CD3C13398FA4514EF57CA7 /* TranscriptHistoryView.swift in Sources */,
 				ED04BFBB1AB30BB6226D77B3 /* TranscriptRepair.swift in Sources */,
@@ -1431,6 +1459,7 @@
 				8DD5E5E2B734765883552523 /* DictationBarView.swift in Sources */,
 				1BB4BED912ADFA11ED122052 /* DictationPresentation.swift in Sources */,
 				DEB245BAC4DEE643F2EB38B0 /* DictationPresentationTests.swift in Sources */,
+				CDFE48F60144A96B1C41080A /* DictationSurfaceView.swift in Sources */,
 				F1EC3EE86C05A57F3A42EFF1 /* DownloadReadiness.swift in Sources */,
 				AAD8F3868CD1C6C2338CDA74 /* DownloadReadinessTests.swift in Sources */,
 				1F45494DE6D2E1E471D446B5 /* EmojiCatalog.swift in Sources */,
@@ -1438,6 +1467,7 @@
 				75EC59510885420249491B03 /* EmojiSuggestions.swift in Sources */,
 				CD600A39A4DFB39AD6F0E5E1 /* EmojiSuggestionsTests.swift in Sources */,
 				835DAA1BE436ED79B7C602FC /* EmojiTable.swift in Sources */,
+				F43318EAC4CF26D8C46ECD19 /* FrameMonitor.swift in Sources */,
 				A2112E100F4277466EA8DD4F /* GatewayEndpoint.swift in Sources */,
 				12F5617A0ECD4D904FC8FEA6 /* HomePresentation.swift in Sources */,
 				162E1C513A0E6585E3445812 /* HomePresentationTests.swift in Sources */,
@@ -1527,6 +1557,8 @@
 				9AE625A9A97E5A57DC6520E9 /* TelemetryStats.swift in Sources */,
 				361B273516585197E5B3D8F1 /* TelemetryTests.swift in Sources */,
 				D7CC096732C721CE14B5F682 /* TextInsertion.swift in Sources */,
+				C571D55DDA9D6C70259F0236 /* TouchTrace.swift in Sources */,
+				32ACD083D95E809FF6453331 /* TouchWitness.swift in Sources */,
 				8A69E16ABEF642C3D68FADD5 /* TranscriptHistoryModel.swift in Sources */,
 				834AEADC7B9757282E300418 /* TranscriptHistoryModelTests.swift in Sources */,
 				AF3CF11CC0E9E65B026EBEF8 /* TranscriptRepair.swift in Sources */,

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@
 		6BF87A2C089381E060D13D22 /* KeyAlternativesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0326EF6FB3E96C942C6065 /* KeyAlternativesTests.swift */; };
 		6C48D9ED8AF4FE61AB76AE49 /* StopQuickDictationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332854D2644CFCE5843E3F31 /* StopQuickDictationIntent.swift */; };
 		6CEF2A686643F72F4BCDD51D /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
+		6E40FED503FAF66243463C4F /* KeyboardSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DC28A915553380C82653C9 /* KeyboardSurfaceTests.swift */; };
 		6EAFD2EC2E02A1270A140E47 /* TypingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B9027C03A87FBC74CE1130 /* TypingEngine.swift */; };
 		70232F18D7B4AA7F6BB15C64 /* TelemetrySink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E413C2A7ADDFE5C3B5F27C7 /* TelemetrySink.swift */; };
 		7118F0F04A2C3D94C65EC00D /* TelemetrySink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E413C2A7ADDFE5C3B5F27C7 /* TelemetrySink.swift */; };
@@ -251,6 +252,7 @@
 		A0420E3166FF08AE5059A805 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9BB34E20645F3D8C78A0363 /* Telemetry.swift */; };
 		A0B8569F3B1A3F72EAC9C1DB /* TranscriptionQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E2BF42CAC209DA12464566 /* TranscriptionQuality.swift */; };
 		A0C4342BED6EC86029B3C492 /* SwipeTrailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */; };
+		A152E65E03F4486BB3DDD881 /* KeyboardLab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75DF25C6DFB6E5314D467D96 /* KeyboardLab.swift */; };
 		A201DF59DBFB56276A6D5A00 /* KeyHitMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91ACC58FF89C43C9BD2D9F6 /* KeyHitMap.swift */; };
 		A2112E100F4277466EA8DD4F /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */; };
 		A2BD20604DA50ECB8AE82BC0 /* SherpaDecodeOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EFEBD6293F9649D551A9014 /* SherpaDecodeOutcome.swift */; };
@@ -449,6 +451,7 @@
 		06FC8DDB89A55103E29C10D3 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		07178E9C6A3CF354CD83A2C1 /* SmartPunctuation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartPunctuation.swift; sourceTree = "<group>"; };
 		07C4BD2142E9377F123A8848 /* SwipeRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeRecognizer.swift; sourceTree = "<group>"; };
+		09DC28A915553380C82653C9 /* KeyboardSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSurfaceTests.swift; sourceTree = "<group>"; };
 		0AB84927D76F9C32C4BE1547 /* QuickDictationAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDictationAvailability.swift; sourceTree = "<group>"; };
 		0AC0739F69438AEC347C44A4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0B31528AA0DAB644EFBBE967 /* TypingCandidatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingCandidatesTests.swift; sourceTree = "<group>"; };
@@ -524,6 +527,7 @@
 		70CAE08F934281250A314597 /* PreviewMatrix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewMatrix.swift; sourceTree = "<group>"; };
 		71DC06463C8AA4C516363157 /* TranscriptRepairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptRepairTests.swift; sourceTree = "<group>"; };
 		755A4279065D41A705E1F19D /* DesignSystemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemTests.swift; sourceTree = "<group>"; };
+		75DF25C6DFB6E5314D467D96 /* KeyboardLab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardLab.swift; sourceTree = "<group>"; };
 		75FD84E65614D9F94D8EF0AC /* DictationBarComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarComponents.swift; sourceTree = "<group>"; };
 		783E7FC5F9553FD419487180 /* QuickDictationDuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDictationDuration.swift; sourceTree = "<group>"; };
 		786DEF44BDB4C70935762971 /* VocaPhoneLiveActivity.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VocaPhoneLiveActivity.entitlements; sourceTree = "<group>"; };
@@ -905,6 +909,7 @@
 				B75D17831C48C07141D7066C /* KeyboardHandoffPresentationTests.swift */,
 				97639A09609D9E6E76153CDB /* KeyboardHapticsTests.swift */,
 				22D68C853A7603A9B3224B3C /* KeyboardStatusPublicationTests.swift */,
+				09DC28A915553380C82653C9 /* KeyboardSurfaceTests.swift */,
 				3EC2C1575D306E7683092FBA /* KeyGridLayoutTests.swift */,
 				6AC704CBD16EF6C7FCCBC6D6 /* KeyHitMapTests.swift */,
 				46CC84644E8CF9B1E83696D3 /* KeyPreviewRenderTests.swift */,
@@ -974,6 +979,7 @@
 				02C96151B8C8ECE035FF0D8F /* HomePresentation.swift */,
 				46E8BCA13C319737A50B7CE9 /* KeyboardHandoffPresentation.swift */,
 				A5E5F9C1D93EF4EFB2AF5EA7 /* KeyboardHandoffView.swift */,
+				75DF25C6DFB6E5314D467D96 /* KeyboardLab.swift */,
 				D97C6225AC98D4FE053BDB13 /* KeyboardPreview.swift */,
 				406B0C287866B36EF3109238 /* LocalModelPicker.swift */,
 				2D34E7E54437AFA69FDC2848 /* OnboardingPresentation.swift */,
@@ -1301,6 +1307,7 @@
 				1A5451979B0206365EE36D5E /* KeyboardHandoffPresentation.swift in Sources */,
 				7AE5598954918484EE8BB6B9 /* KeyboardHandoffView.swift in Sources */,
 				98AE213452E133E22550785B /* KeyboardHaptics.swift in Sources */,
+				A152E65E03F4486BB3DDD881 /* KeyboardLab.swift in Sources */,
 				A568F548D639C064CDA86F0D /* KeyboardPreferences.swift in Sources */,
 				F7432B1674EF3B6924FB89B1 /* KeyboardPreview.swift in Sources */,
 				61D705F2D38349B0A9667F2E /* KeyboardStatus.swift in Sources */,
@@ -1491,6 +1498,7 @@
 				5673DF7E07F7F800FB847C2A /* KeyboardStatus.swift in Sources */,
 				75A2C56534698189538C7B87 /* KeyboardStatusPublication.swift in Sources */,
 				A8E7D7F8F6BE5CED2509C07F /* KeyboardStatusPublicationTests.swift in Sources */,
+				6E40FED503FAF66243463C4F /* KeyboardSurfaceTests.swift in Sources */,
 				52151816E957DE430B67B9F8 /* KeyboardViewPreview.swift in Sources */,
 				3C4DE9EF77062407F71ACDCB /* LanguageMenuTests.swift in Sources */,
 				D0E6AF99E65342BE66CF809A /* LearnedWords.swift in Sources */,

--- a/ios/VocaPhoneApp/App/KeyboardLab.swift
+++ b/ios/VocaPhoneApp/App/KeyboardLab.swift
@@ -210,7 +210,7 @@ struct KeyboardLabView: View {
         )
         surface.primarySymbol = model.primary.symbol
         surface.primaryIsEnabled = model.primary.isEnabled
-        surface.centerMessage = DictationBarModel.surfaceLine(for: state)
+        surface.centerMessage = model.surfaceMessage(for: state)
         // The lab stands in for the session the extension would be driving.
         // Without these the buttons are a picture of buttons: they call a
         // closure nobody set, and nothing happens when you press them.

--- a/ios/VocaPhoneApp/App/KeyboardLab.swift
+++ b/ios/VocaPhoneApp/App/KeyboardLab.swift
@@ -1,0 +1,383 @@
+#if DEBUG
+import SwiftUI
+import UIKit
+
+/// The keyboard's own views, in any session state, without the extension.
+///
+/// Looking at a dictation state normally costs a device build, adding the
+/// keyboard in iOS Settings, opening a host app, and actually speaking — for
+/// every one-point change to a bar nobody can see from the app. These are the
+/// same `DictationBarView` and `KeyGridView` the extension builds, driven by a
+/// state picker and a synthetic meter, so a state can be looked at in the
+/// simulator in a second.
+///
+/// Debug only, and unreachable from a release build: `just ios lint-previews`
+/// fails if anything here becomes reachable from one.
+struct KeyboardLabView: View {
+    @State private var state: SessionState = .recording
+    @State private var isDark = false
+    @State private var isSpeaking = true
+    @State private var showsCandidates = false
+    @State private var usesSurface = true
+    @State private var hapticStyle = KeyboardPreferences.typingHapticStyle
+    @State private var hapticIntensity = KeyboardPreferences.typingHapticIntensity
+    @State private var keyReleaseFade = KeyboardPreferences.keyReleaseFade
+    @State private var keyPreviewAnimates = KeyboardPreferences.keyPreviewAnimates
+    @StateObject private var surface = DictationSurfaceState()
+    /// Synthetic levels at the rate the microphone produces them: five per
+    /// quarter-second tick, the same split `AudioCapturePipeline` makes.
+    private let meterTick = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
+
+    /// Every state worth looking at, in the order a session moves through them,
+    /// failures last. The point of the lab is the states nobody can reach on
+    /// purpose — an unreachable gateway, a transcript that came back empty, a
+    /// field that went away while the app was open.
+    private static let states: [SessionState] = [
+        .idle,
+        .launchingApp,
+        .recording,
+        .transcribing,
+        .readyToInsert,
+        .targetContextChanged,
+        .serverUnavailable,
+        .uploadFailedRecoverable,
+        .transcriptionFailedRecoverable,
+        .transcriptionFailedPermanent,
+        .permissionDenied,
+    ]
+
+    /// What the keyboard is on a phone: strip, gap, grid, insets. The preview
+    /// holds this height in every state, because the keyboard does — a preview
+    /// that collapses is showing a bug it invented itself.
+    private static let keyboardHeight: CGFloat = 274
+
+    private static let sampleCandidates: [TypingCandidate] = [
+        TypingCandidate(text: "whats", kind: .literal),
+        TypingCandidate(text: "what's", kind: .correction, isEmphasised: true),
+        TypingCandidate(text: "whatsapp", kind: .completion),
+    ]
+
+    var body: some View {
+        List {
+            Section {
+                if usesSurface {
+                    DictationSurfaceView(state: surface)
+                        .padding(.horizontal, 12)
+                        .frame(height: Self.keyboardHeight, alignment: .top)
+                        .background(
+                            (isDark ? Color(white: 0.09) : Color(white: 0.886))
+                                .clipShape(
+                                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                                )
+                        )
+                        .environment(\.colorScheme, isDark ? .dark : .light)
+                } else {
+                    KeyboardLabRepresentable(
+                        state: state,
+                        isDark: isDark,
+                        isSpeaking: isSpeaking
+                    )
+                    .frame(height: 340)
+                }
+            }
+            .listRowInsets(EdgeInsets())
+            .listRowBackground(Color.clear)
+            Section {
+                Toggle("New surface", isOn: $usesSurface)
+                Picker("State", selection: $state) {
+                    ForEach(Self.states, id: \.self) { state in
+                        Text(state.displayName).tag(state)
+                    }
+                }
+                Toggle("Dark keyboard", isOn: $isDark)
+                Toggle("Speaking", isOn: $isSpeaking)
+                Toggle("Suggestions", isOn: $showsCandidates)
+            } footer: {
+                Text("Tap the microphone in the preview to play the transition.")
+            }
+            transitionSection
+            hapticsSection
+        }
+        .navigationTitle("Keyboard lab")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            surface.animationResponse = KeyboardPreferences.surfaceAnimationResponse
+            surface.animationDamping = KeyboardPreferences.surfaceAnimationDamping
+            syncSurface()
+        }
+        .onChange(of: state) { syncSurface() }
+        .onChange(of: isDark) { syncSurface() }
+        .onChange(of: showsCandidates) { syncSurface() }
+        .onReceive(meterTick) { _ in
+            guard usesSurface, state == .recording, isSpeaking else { return }
+            surface.appendMeterLevels(Self.nextLevels())
+        }
+    }
+
+    /// Two sliders, because a spring is judged by thumb and not by argument.
+    private var transitionSection: some View {
+        Section {
+            VStack(alignment: .leading) {
+                Text("Response \(surface.animationResponse, specifier: "%.2f") s")
+                    .font(.footnote.monospacedDigit())
+                Slider(value: $surface.animationResponse, in: 0.05...0.60)
+            }
+            VStack(alignment: .leading) {
+                Text("Damping \(surface.animationDamping, specifier: "%.2f")")
+                    .font(.footnote.monospacedDigit())
+                Slider(value: $surface.animationDamping, in: 0.5...1.0)
+            }
+            Button("Reset to shipped values") {
+                surface.animationResponse = 0.15
+                surface.animationDamping = 1.0
+            }
+        } header: {
+            Text("Transition")
+        } footer: {
+            Text(
+                "Response is how long the change takes; damping is how much it "
+                    + "overshoots — 1.00 does not overshoot at all. Tell me the "
+                    + "pair you settle on and it goes into the keyboard."
+            )
+        }
+    }
+
+    /// The key tap, tuned by hand. Fires on every change so the thumb hears
+    /// the answer while the slider is still under it.
+    private var hapticsSection: some View {
+        Section {
+            Picker("Feel", selection: $hapticStyle) {
+                ForEach(TypingHapticStyle.allCases) { style in
+                    Text(style.displayName).tag(style)
+                }
+            }
+            Text(hapticStyle.detail)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading) {
+                Text("Strength \(hapticIntensity, specifier: "%.2f")")
+                    .font(.footnote.monospacedDigit())
+                Slider(value: $hapticIntensity, in: 0.2...1.0)
+            }
+            Button("Play it") { playHaptic() }
+            Toggle("Release fade on letters", isOn: $keyReleaseFade)
+            Toggle("Animate the key preview", isOn: $keyPreviewAnimates)
+        } header: {
+            Text("Key press")
+        } footer: {
+            Text(
+                "This is the tap a letter gives back. It needs Full Access on "
+                    + "the keyboard itself; here in the app it always plays."
+            )
+        }
+        .onChange(of: hapticStyle) {
+            KeyboardPreferences.typingHapticStyle = hapticStyle
+            playHaptic()
+        }
+        .onChange(of: hapticIntensity) {
+            KeyboardPreferences.typingHapticIntensity = hapticIntensity
+        }
+        .onChange(of: keyReleaseFade) {
+            KeyboardPreferences.keyReleaseFade = keyReleaseFade
+        }
+        .onChange(of: keyPreviewAnimates) {
+            KeyboardPreferences.keyPreviewAnimates = keyPreviewAnimates
+        }
+    }
+
+    private func playHaptic() {
+        let generator = UIImpactFeedbackGenerator(style: hapticStyle.feedbackStyle)
+        generator.prepare()
+        generator.impactOccurred(intensity: hapticIntensity)
+    }
+
+    private func syncSurface() {
+        surface.state = state
+        surface.isDark = isDark
+        surface.showsGlobeKey = true
+        surface.candidates = showsCandidates && state == .idle ? Self.sampleCandidates : []
+        if state != .recording { surface.clearMeterLevels() }
+
+        // The same model the extension draws from, so the copy in the lab is
+        // the copy on the phone rather than something written for the preview.
+        let model = DictationBarModel.make(
+            DictationContext(
+                state: state,
+                transcript: state == .readyToInsert ? "This is what came back." : nil,
+                errorMessage: nil,
+                canRetry: true
+            )
+        )
+        surface.primarySymbol = model.primary.symbol
+        surface.primaryIsEnabled = model.primary.isEnabled
+        surface.centerMessage = DictationBarModel.surfaceLine(for: state)
+        // The lab stands in for the session the extension would be driving.
+        // Without these the buttons are a picture of buttons: they call a
+        // closure nobody set, and nothing happens when you press them.
+        surface.onStart = { state = .recording }
+        surface.onFinish = { state = .transcribing }
+        surface.onCancel = { state = .idle }
+    }
+
+    /// Syllables over a slower breath. A sine wave reads as a machine humming.
+    private static var meterPhase: CGFloat = 0
+
+    private static func nextLevels() -> [Float] {
+        (0..<5).map { _ in
+            meterPhase += 0.28
+            let syllable = abs(sin(meterPhase * 2.3))
+            let breath = 0.45 + 0.45 * abs(sin(meterPhase * 0.21))
+            return Float(min(max(syllable * breath, 0.05), 1))
+        }
+    }
+}
+
+private struct KeyboardLabRepresentable: UIViewRepresentable {
+    let state: SessionState
+    let isDark: Bool
+    let isSpeaking: Bool
+
+    func makeUIView(context: Context) -> KeyboardLabContainer {
+        KeyboardLabContainer()
+    }
+
+    func updateUIView(_ view: KeyboardLabContainer, context: Context) {
+        view.configure(state: state, isDark: isDark, isSpeaking: isSpeaking)
+    }
+}
+
+/// Lays the two keyboard views out the way `KeyboardViewController` does:
+/// hung from the bottom, one chrome inset around them.
+final class KeyboardLabContainer: UIView {
+    private var grid: KeyGridView?
+    private var bar: DictationBarView?
+    private var barLayout: DictationBarLayout = .strip
+    private var isExpanded = false
+    private var meterTimer: Timer?
+    private var meterPhase: CGFloat = 0
+
+    private static let chromeInset: CGFloat = 6
+    private static let chromeSpacing: CGFloat = 12
+    /// Matches `AudioCapturePipeline.meterSlices` over one quarter-second tick,
+    /// so the meter is fed at the rate the microphone actually feeds it.
+    private static let meterTick: TimeInterval = 0.25
+    private static let levelsPerTick = 5
+
+    init() {
+        super.init(frame: .zero)
+        clipsToBounds = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(state: SessionState, isDark: Bool, isSpeaking: Bool) {
+        let traits = UITraitCollection { $0.verticalSizeClass = .regular }
+        let palette = KeyboardPalette(isDark: isDark)
+        let gridMetrics = KeyboardMetrics.resolved(for: traits, preference: .standard)
+        let barMetrics = DictationBarMetrics.resolved(for: traits, preference: .standard)
+        // The extension leaves this to the system's input view. Here there is
+        // no input view, so the fallback colour stands in for it.
+        backgroundColor = palette.background
+
+        let grid = self.grid ?? {
+            let created = KeyGridView(metrics: gridMetrics, palette: palette)
+            addSubview(created)
+            self.grid = created
+            return created
+        }()
+        grid.metrics = gridMetrics
+        grid.palette = palette
+        grid.showsGlobeKey = true
+
+        let bar = self.bar ?? {
+            let created = DictationBarView(metrics: barMetrics, palette: palette)
+            addSubview(created)
+            self.bar = created
+            return created
+        }()
+        bar.metrics = barMetrics
+        bar.palette = palette
+
+        let model = DictationBarModel.make(
+            DictationContext(
+                state: state,
+                transcript: state == .readyToInsert ? "This is what came back." : nil,
+                errorMessage: state == .serverUnavailable ? "Gateway unavailable" : nil
+            )
+        )
+        barLayout = model.layout
+        isExpanded = model.isExpanded
+        bar.apply(model, animated: false)
+
+        if state == .recording, isSpeaking {
+            startMeter(on: bar)
+        } else {
+            stopMeter()
+        }
+        setNeedsLayout()
+    }
+
+    private func startMeter(on bar: DictationBarView) {
+        guard meterTimer == nil else { return }
+        meterTimer = Timer.scheduledTimer(
+            withTimeInterval: Self.meterTick,
+            repeats: true
+        ) { [weak self, weak bar] _ in
+            MainActor.assumeIsolated {
+                guard let self, let bar else { return }
+                bar.push(meterLevels: self.nextLevels())
+            }
+        }
+    }
+
+    private func stopMeter() {
+        meterTimer?.invalidate()
+        meterTimer = nil
+    }
+
+    /// Something with the shape of speech: syllables on top of a slower breath,
+    /// rather than a sine wave, which reads as a machine humming.
+    private func nextLevels() -> [Float] {
+        (0..<Self.levelsPerTick).map { _ in
+            meterPhase += 0.28
+            let syllable = abs(sin(meterPhase * 2.3))
+            let breath = 0.45 + 0.45 * abs(sin(meterPhase * 0.21))
+            return Float(min(max(syllable * breath, 0.05), 1))
+        }
+    }
+
+    /// The timer retains this view through its own block, so the meter has to
+    /// stop when the view leaves the screen; a `deinit` would never run.
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window == nil { stopMeter() }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard let grid, let bar else { return }
+        let traits = UITraitCollection { $0.verticalSizeClass = .regular }
+        let gridMetrics = KeyboardMetrics.resolved(for: traits, preference: .standard)
+        let barMetrics = DictationBarMetrics.resolved(for: traits, preference: .standard)
+        let inset = Self.chromeInset
+        let width = bounds.width - 2 * inset
+        let barHeight = barMetrics.height(for: barLayout, expanded: isExpanded)
+        let gridTop = bounds.height - gridMetrics.gridHeight
+        grid.frame = CGRect(
+            x: inset,
+            y: gridTop,
+            width: width,
+            height: gridMetrics.gridHeight
+        )
+        bar.frame = CGRect(
+            x: inset,
+            y: max(inset, gridTop - Self.chromeSpacing - barHeight),
+            width: width,
+            height: barHeight
+        )
+    }
+}
+#endif

--- a/ios/VocaPhoneApp/App/KeyboardPreview.swift
+++ b/ios/VocaPhoneApp/App/KeyboardPreview.swift
@@ -40,7 +40,7 @@ private struct KeyboardPreviewRepresentable: UIViewRepresentable {
     /// The same arithmetic the extension does, so the preview is the height the
     /// keyboard will actually be.
     static let chromeInset: CGFloat = 6
-    static let chromeSpacing: CGFloat = 7
+    static let chromeSpacing: CGFloat = 12
 
     static func height(for preference: KeyboardHeightPreference) -> CGFloat {
         let traits = UITraitCollection { $0.verticalSizeClass = .regular }

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -192,6 +192,12 @@ struct KeyboardSettingsView: View {
             learningSection
             typingDetailSection
             appearanceSection
+            // Last: it is a tool for whoever is building the keyboard, and it
+            // has no business sitting between two settings somebody came here
+            // to change.
+            #if DEBUG
+            keyboardLabSection
+            #endif
         }
         .navigationTitle("Keyboard")
         .navigationBarTitleDisplayMode(.inline)
@@ -213,6 +219,18 @@ struct KeyboardSettingsView: View {
             )
         }
     }
+
+    #if DEBUG
+    /// Every dictation state, on demand, without a device build. See
+    /// ``KeyboardLabView``.
+    private var keyboardLabSection: some View {
+        Section {
+            NavigationLink("Keyboard lab") { KeyboardLabView() }
+        } footer: {
+            Text("Debug builds only. The keyboard's own views in every session state.")
+        }
+    }
+    #endif
 
     /// The real keyboard, at the chosen height, redrawing as the switches move.
     private var previewSection: some View {

--- a/ios/VocaPhoneApp/Audio/AudioCapturePipeline.swift
+++ b/ios/VocaPhoneApp/Audio/AudioCapturePipeline.swift
@@ -104,6 +104,8 @@ final class AudioCapturePipeline: @unchecked Sendable {
     private var file: AVAudioFile?
     private var carry: [Float] = []
     private let meter = OSAllocatedUnfairLock(initialState: Float(0))
+    /// Sub-levels waiting to be collected, oldest first. See ``meterSlices``.
+    private let meterHistory = OSAllocatedUnfairLock(initialState: [Float]())
     private let peak = OSAllocatedUnfairLock(initialState: Float(0))
     private let dropped = OSAllocatedUnfairLock(initialState: 0)
     private var emit: ((Data) -> Bool)?
@@ -112,6 +114,25 @@ final class AudioCapturePipeline: @unchecked Sendable {
     /// untrustworthy, so the caller falls back to uploading the intact file.
     var droppedChunkCount: Int { dropped.withLock { $0 } }
     var meterLevel: Float { meter.withLock { $0 } }
+
+    /// How many levels one drain tick is split into.
+    ///
+    /// A tick is a quarter second of audio, and folding all of it into a single
+    /// number threw away everything but the average: four levels a second, from
+    /// which the meter then invented the fourteen bars a second it drew. The
+    /// samples for the finer levels were already in the buffer — nobody had
+    /// asked for them. Five slices is 50 ms each, or twenty real levels a
+    /// second, which is roughly the rate at which speech changes loudness.
+    static let meterSlices = 5
+
+    /// Takes the levels produced since the last call and clears them, so a
+    /// reader appends each slice of audio exactly once.
+    func drainMeterLevels() -> [Float] {
+        meterHistory.withLock { history in
+            defer { history.removeAll(keepingCapacity: true) }
+            return history
+        }
+    }
     /// The loudest sample of the whole recording, which is what separates a
     /// microphone another app silenced from one that simply heard a quiet room.
     var peakLevel: Float { peak.withLock { $0 } }
@@ -231,7 +252,7 @@ final class AudioCapturePipeline: @unchecked Sendable {
         channel.update(from: scratch, count: sampleCount)
         inputBuffer.frameLength = AVAudioFrameCount(sampleCount)
 
-        meter.withLock { $0 = Self.normalizedLevel(scratch, count: sampleCount) }
+        recordMeterLevels(sampleCount: sampleCount)
         var loudest: Float = 0
         vDSP_maxmgv(scratch, 1, &loudest, vDSP_Length(sampleCount))
         peak.withLock { [loudest] in $0 = max($0, loudest) }
@@ -272,6 +293,38 @@ final class AudioCapturePipeline: @unchecked Sendable {
             carry.removeFirst(size)
             if !emit(data) {
                 dropped.withLock { $0 += 1 }
+            }
+        }
+    }
+
+    /// Splits this tick into ``meterSlices`` levels rather than one.
+    private func recordMeterLevels(sampleCount: Int) {
+        let sliceLength = sampleCount / Self.meterSlices
+        guard sliceLength > 0 else {
+            let level = Self.normalizedLevel(scratch, count: sampleCount)
+            meter.withLock { $0 = level }
+            appendMeterLevels([level])
+            return
+        }
+        var levels: [Float] = []
+        levels.reserveCapacity(Self.meterSlices)
+        for slice in 0..<Self.meterSlices {
+            // The last slice takes the remainder, so no sample is dropped.
+            let start = slice * sliceLength
+            let length = slice == Self.meterSlices - 1 ? sampleCount - start : sliceLength
+            levels.append(Self.normalizedLevel(scratch + start, count: length))
+        }
+        if let last = levels.last { meter.withLock { $0 = last } }
+        appendMeterLevels(levels)
+    }
+
+    /// The reader collects several times a second; the cap is only there so a
+    /// reader that stopped collecting cannot grow this without bound.
+    private func appendMeterLevels(_ levels: [Float]) {
+        meterHistory.withLock { history in
+            history.append(contentsOf: levels)
+            if history.count > 60 {
+                history.removeFirst(history.count - 60)
             }
         }
     }

--- a/ios/VocaPhoneApp/Audio/AudioRecorder.swift
+++ b/ios/VocaPhoneApp/Audio/AudioRecorder.swift
@@ -22,7 +22,7 @@ final class AudioRecorder: NSObject {
     private var meterTimer: Timer?
     private var limitTimer: Timer?
     nonisolated(unsafe) private var lifecycleObservers: [any NSObjectProtocol] = []
-    var onMeter: ((Float) -> Void)?
+    var onMeter: (([Float]) -> Void)?
     var onMaximumDuration: (() -> Void)?
     var onInputRouteChanged: ((String?) -> Void)?
     var onAudioSessionLifecycleEvent: ((AudioSessionLifecycleEvent) -> Void)?
@@ -398,7 +398,11 @@ final class AudioRecorder: NSObject {
 
     private func sampleMeter() {
         guard let pipeline else { return }
-        onMeter?(pipeline.meterLevel)
+        // Every level since the last tick, so the meter's motion comes from the
+        // microphone rather than from interpolation between samples.
+        let levels = pipeline.drainMeterLevels()
+        guard !levels.isEmpty else { return }
+        onMeter?(levels)
     }
 
     private func stopTimers() {

--- a/ios/VocaPhoneApp/Models/LocalModelManager.swift
+++ b/ios/VocaPhoneApp/Models/LocalModelManager.swift
@@ -85,6 +85,7 @@ final class LocalModelManager {
     private var whisperKit: WhisperKit?
     private var sherpaRecognizer: SherpaRecognizer?
     private var loadedModelID: String?
+
     private var loadedLanguage: String?
     /// Canary bakes source and target into the recognizer exactly as it bakes
     /// the language, so a change of translation target has to rebuild it too.

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -1040,6 +1040,18 @@ final class RecordingCoordinator {
             message = "Uploading to your gateway…"
             liveActivity.update(status: "Sending to your gateway", canFinish: false)
 
+            // A reachable server can still have no usable model. Check before
+            // sending audio or entering the long-running transcription request.
+            guard try await client.health().engineReady else {
+                await fail(
+                    &record,
+                    state: .serverUnavailable,
+                    code: "engine_not_ready",
+                    message: "Your gateway's speech-to-text model is not ready. "
+                        + "Select and load a model in the gateway, then retry. Your recording is kept."
+                )
+                return
+            }
             let created = try await client.createSession(
                 id: record.sessionID,
                 language: record.language,
@@ -1112,7 +1124,9 @@ final class RecordingCoordinator {
                 &record,
                 state: state,
                 code: code,
-                message: "The recording is preserved. Return to the keyboard to retry."
+                message: error is URLError
+                    ? "Check that your gateway is running and connected, then retry. Your recording is kept."
+                    : "Check your gateway and its selected model, then retry. Your recording is kept."
             )
         }
     }

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -16,6 +16,9 @@ final class RecordingCoordinator {
     /// Kept separate from `activeRecord` so a level update several times a
     /// second invalidates only the views that draw the meter.
     private(set) var meterLevel: Float = 0
+    /// Levels produced in the current recording, counted so the keyboard can
+    /// tell new audio from a re-read of the same file.
+    private var meterSequence = 0
     /// Guided setup reads system state that emits no change notifications —
     /// keyboard installation, a permission flipped in iOS Settings — so it is
     /// snapshotted here and refreshed deliberately rather than polled.
@@ -298,7 +301,8 @@ final class RecordingCoordinator {
         // marker behind. The new app process is not warm until it arms audio.
         try? store.clearQuickDictationAvailability()
         recorder.microphonePreference = KeyboardPreferences.microphonePreference
-        recorder.onMeter = { [weak self] level in self?.persistMeter(level) }
+        meterSequence = 0
+        recorder.onMeter = { [weak self] levels in self?.persistMeter(levels) }
         recorder.onMaximumDuration = { [weak self] in self?.requestFinish() }
         recorder.onInputRouteChanged = { [weak self] inputName in
             guard let self else { return }
@@ -1281,16 +1285,23 @@ final class RecordingCoordinator {
             : "Transcript ready. Return to the keyboard to insert it."
     }
 
-    private func persistMeter(_ level: Float) {
+    private func persistMeter(_ levels: [Float]) {
         guard let record = activeRecord, record.state == .recording else { return }
-        let clamped = min(max(level, 0), 1)
+        guard let last = levels.last else { return }
         // Only the level changes here. Leaving `activeRecord` untouched keeps
         // this from invalidating every view observing the session.
-        meterLevel = clamped
+        meterLevel = min(max(last, 0), 1)
+        // The whole run goes across, not just the newest level: the keyboard
+        // draws one bar per level, and the levels it never saw are the motion
+        // it used to invent.
+        meterSequence += levels.count
         // Meter updates are intentionally stored separately from the session
         // record. Otherwise a stale meter write from the app can overwrite a
         // finalizing/canceled state written by the keyboard extension.
-        try? store.saveMeter(clamped, for: record.sessionID)
+        try? store.saveMeter(
+            MeterSample(sequence: meterSequence, levels: levels),
+            for: record.sessionID
+        )
     }
 
     private func shouldKeepQuickDictationReady(after record: SessionRecord) -> Bool {
@@ -1319,6 +1330,20 @@ final class RecordingCoordinator {
             quickDictationExpiresAt = availability.expiresAt
             beginQuickDictationWatcher(availability, duration: duration)
             liveActivity.startStandby(expiresAt: availability.expiresAt)
+            // No speech model is warmed here, and that is a measured choice.
+            //
+            // The first dictation of a session spends 1.8-2.7 s building the
+            // engine while the microphone is already recording; every one after
+            // it spends 9 ms. Warming it at this point fixes that and breaks
+            // something worse: arming happens after every session, so the model
+            // then stays resident for the whole standby window, and the app went
+            // from never being memory-killed to hitting its three-gigabyte
+            // per-process limit within the hour. Killing the containing app
+            // takes the standby, the Live Activity and any unsaved session with
+            // it — a worse failure than a slow first dictation.
+            //
+            // Whatever fixes the latency has to bound how long the model stays
+            // in memory, not just when it is loaded.
             DiagnosticLog.record(.quickDictationArmed)
             debugQuickDictation("armed until \(availability.expiresAt)")
         } catch {

--- a/ios/VocaPhoneKeyboard/DictationBarComponents.swift
+++ b/ios/VocaPhoneKeyboard/DictationBarComponents.swift
@@ -22,14 +22,17 @@ final class WaveformView: UIView {
         didSet { setNeedsDisplay() }
     }
 
-    private static let barWidth: CGFloat = 3
-    private static let barGap: CGFloat = 2.5
-    /// New bars per second. Slow enough to read as speech, fast enough that a
-    /// short utterance still fills the view.
-    private static let barsPerSecond: CGFloat = 14
+    private static let barWidth: CGFloat = 4
+    private static let barGap: CGFloat = 3
+    /// Bars per second, which is also the rate at which real levels arrive:
+    /// five per quarter-second tick from ``AudioCapturePipeline``. The two
+    /// numbers have to agree — the meter used to draw fourteen a second from
+    /// four, and every bar the microphone had not supplied was made up.
+    private static let barsPerSecond: CGFloat = 20
 
     private var levels: [CGFloat] = []
-    private var smoothedLevel: CGFloat = 0
+    /// Levels the microphone has produced and the meter has not drawn yet.
+    private var pending: [CGFloat] = []
     private var targetLevel: CGFloat = 0
     private var advanceProgress: CGFloat = 0
     private var phase: CGFloat = -0.25
@@ -53,17 +56,26 @@ final class WaveformView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    /// The newest microphone level, published by the app roughly four times a
-    /// second. Rendering interpolates between these so the meter does not step.
-    func push(level: Float) {
-        targetLevel = min(max(CGFloat(level), 0), 1)
+    /// Microphone levels the meter has not shown yet, oldest first.
+    ///
+    /// Each one becomes exactly one bar. What the view is showing is then the
+    /// audio itself, at the rate it was measured, which is the whole difference
+    /// between a level meter and an animation of a level meter.
+    func push(levels newLevels: [Float]) {
+        guard !newLevels.isEmpty else { return }
+        pending.append(contentsOf: newLevels.map { min(max(CGFloat($0), 0), 1) })
+        // A backlog this long means the meter is not being drawn — an offscreen
+        // keyboard, a stalled run loop. Showing seconds-old audio afterwards is
+        // worse than dropping it.
+        if pending.count > 40 { pending.removeFirst(pending.count - 40) }
+        targetLevel = pending.last ?? targetLevel
         updateAccessibilityValue()
         // Reduce Motion, an offscreen keyboard, anything that stops the display
-        // link: with nothing else advancing the meter, each published level has
-        // to become a bar itself rather than leaving a frozen line.
+        // link: with nothing else advancing the meter, the levels have to become
+        // bars here rather than leaving a frozen line.
         guard displayLink == nil, mode == .live else { return }
-        smoothedLevel = targetLevel
-        appendBar(smoothedLevel)
+        for level in pending { appendBar(level) }
+        pending.removeAll(keepingCapacity: true)
         setNeedsDisplay()
     }
 
@@ -99,12 +111,13 @@ final class WaveformView: UIView {
 
     // MARK: - Rendering values
 
-    /// Older bars fade out, which gives the meter a direction of travel without
-    /// adding another visual layer.
+    /// One weight for every bar.
+    ///
+    /// Older bars used to fade along a gradient, which reads as decoration
+    /// because it is: it says nothing about the audio, and it made the meter
+    /// look like it was doing more than measuring.
     private func alpha(at index: Int) -> CGFloat {
-        guard mode != .indeterminate else { return 0.85 }
-        let position = CGFloat(index) / CGFloat(max(levels.count - 1, 1))
-        return 0.24 + 0.76 * position
+        mode == .indeterminate ? 0.85 : 1
     }
 
     /// A soft bump travelling from the leading edge to the trailing one. Shaped
@@ -149,7 +162,7 @@ final class WaveformView: UIView {
             displayLink = nil
             if mode == nil {
                 levels = levels.map { _ in 0 }
-                smoothedLevel = 0
+                pending.removeAll(keepingCapacity: true)
                 advanceProgress = 0
             }
             return
@@ -167,12 +180,14 @@ final class WaveformView: UIView {
         let elapsed = max(link.targetTimestamp - link.timestamp, 1.0 / 120)
         switch mode {
         case .live:
-            smoothedLevel += (targetLevel - smoothedLevel) * 0.3
             advanceProgress += Self.barsPerSecond * CGFloat(elapsed)
-            while advanceProgress >= 1 {
+            while advanceProgress >= 1, !pending.isEmpty {
                 advanceProgress -= 1
-                appendBar(smoothedLevel)
+                appendBar(pending.removeFirst())
             }
+            // Nothing left to draw: hold, rather than scrolling emptiness past
+            // the reader as though the microphone were still saying something.
+            if pending.isEmpty { advanceProgress = min(advanceProgress, 1) }
         case .indeterminate:
             phase += CGFloat(elapsed) * 0.75
             if phase > 1.25 { phase = -0.25 }
@@ -305,10 +320,13 @@ final class FlatButton: UIButton {
         didSet {
             guard isHighlighted != oldValue else { return }
             let collapse = isHighlighted
+            // Damping was 0.7 over 0.22s, which overshoots visibly: the button
+            // came back past its own size and settled — a bounce on every tap
+            // of the one control people press most.
             UIView.animate(
-                withDuration: collapse ? 0.09 : 0.22,
+                withDuration: collapse ? 0.09 : 0.16,
                 delay: 0,
-                usingSpringWithDamping: 0.7,
+                usingSpringWithDamping: 0.9,
                 initialSpringVelocity: 0,
                 options: [.allowUserInteraction, .beginFromCurrentState]
             ) {

--- a/ios/VocaPhoneKeyboard/DictationBarView.swift
+++ b/ios/VocaPhoneKeyboard/DictationBarView.swift
@@ -198,10 +198,10 @@ final class DictationBarView: UIView, TypingStripViewDelegate {
         return true
     }
 
-    /// The most recent microphone level. Kept separate from `apply` because it
-    /// changes on every tick while the model does not.
-    func push(meterLevel: Float) {
-        waveform.push(level: meterLevel)
+    /// The levels measured since the last tick. Kept separate from `apply`
+    /// because they change on every tick while the model does not.
+    func push(meterLevels: [Float]) {
+        waveform.push(levels: meterLevels)
     }
 
     func setElapsed(_ interval: TimeInterval?) {

--- a/ios/VocaPhoneKeyboard/DictationBarView.swift
+++ b/ios/VocaPhoneKeyboard/DictationBarView.swift
@@ -73,6 +73,8 @@ final class DictationBarView: UIView, TypingStripViewDelegate {
     private var primaryHeightConstraint: NSLayoutConstraint?
     private var waveformHeightConstraint: NSLayoutConstraint?
     private var controlHeights: [NSLayoutConstraint] = []
+    /// Active only in the look that has no card: an icon-only chip is a circle.
+    private var chipCircleWidths: [NSLayoutConstraint] = []
     private var secondarySizes: [NSLayoutConstraint] = []
 
     private static let flashDuration: TimeInterval = 2.6
@@ -198,8 +200,8 @@ final class DictationBarView: UIView, TypingStripViewDelegate {
         return true
     }
 
-    /// The levels measured since the last tick. Kept separate from `apply`
-    /// because they change on every tick while the model does not.
+    /// The most recent microphone level. Kept separate from `apply` because it
+    /// changes on every tick while the model does not.
     func push(meterLevels: [Float]) {
         waveform.push(levels: meterLevels)
     }
@@ -528,8 +530,45 @@ final class DictationBarView: UIView, TypingStripViewDelegate {
         styleButton.accessibilityValue = style.displayName
     }
 
+    /// A round glass control, the shape the system uses for chrome that floats
+    /// on a surface rather than sitting in a panel.
+    ///
+    /// Glass here and nowhere near the keys: two buttons of real material is
+    /// chrome, thirty sampling keys is a keyboard extension being killed at
+    /// 45–60 MB. The selected language and style are no longer written on the
+    /// control — the glyph and the menu carry them, and VoiceOver still reads
+    /// the value from `accessibilityValue`, which the callers set.
+    private func applyGlassChipConfiguration(to button: UIButton, symbol: String) {
+        var configuration = UIButton.Configuration.plain()
+        configuration.image = UIImage(
+            systemName: symbol,
+            withConfiguration: UIImage.SymbolConfiguration(
+                pointSize: metrics.bodyFontSize + 4,
+                weight: .semibold
+            )
+        )
+        configuration.contentInsets = .zero
+        configuration.cornerStyle = .capsule
+        configuration.baseForegroundColor = palette.tint(for: .brand)
+        if #available(iOS 26.0, *) {
+            let glass = UIGlassEffect()
+            // The material reacts to the press by itself, which is the whole
+            // reason to use the system's glass rather than a tinted circle.
+            glass.isInteractive = true
+            configuration.background.visualEffect = glass
+            configuration.background.backgroundColor = .clear
+        } else {
+            configuration.background.backgroundColor = palette.chipBackground
+        }
+        button.configuration = configuration
+    }
+
     private func applyChipConfiguration(to button: UIButton, title: String, symbol: String) {
         var configuration = UIButton.Configuration.plain()
+        if palette.usesSystemKeyboardBackdrop {
+            applyGlassChipConfiguration(to: button, symbol: symbol)
+            return
+        }
         configuration.title = title
         configuration.image = UIImage(
             systemName: symbol,
@@ -572,7 +611,10 @@ final class DictationBarView: UIView, TypingStripViewDelegate {
         // backing layer does not, so its border is animated by hand.
         primaryButton.fillColor = tint
         indicator.color = tint
-        waveform.color = tint
+        // The meter keeps the product's own colour through every state. Red is
+        // the recording signal and it stays on the dot and the timer, where it
+        // means one thing; a red meter made the whole bar read as an alarm.
+        waveform.color = palette.color(for: .brand)
         crossfade(timerLabel, animated: animated) { self.timerLabel.textColor = tint }
 
         // A live session tints the outline; at rest the bar keeps the neutral
@@ -593,7 +635,15 @@ final class DictationBarView: UIView, TypingStripViewDelegate {
     }
 
     private func applyPalette() {
-        backgroundColor = palette.barBackground
+        // No card. The bar's own fill, hairline and shadow drew a white panel
+        // sitting on the keyboard, which is one surface too many now that the
+        // keyboard itself is the system's: the controls belong directly on it,
+        // the way the system's own keyboard chrome sits on it.
+        let onSystemSurface = palette.usesSystemKeyboardBackdrop
+        backgroundColor = onSystemSurface ? .clear : palette.barBackground
+        layer.borderWidth = onSystemSurface ? 0 : 0.5
+        layer.shadowOpacity = onSystemSurface ? 0 : 0.07
+        chipCircleWidths.forEach { $0.isActive = onSystemSurface }
         layer.borderColor = palette.cardBorder.cgColor
         titleLabel.textColor = palette.label
         messageLabel.textColor = palette.secondaryLabel
@@ -627,7 +677,16 @@ final class DictationBarView: UIView, TypingStripViewDelegate {
             : metrics.primaryHeight
         bodyTopToBarConstraint?.constant = metrics.verticalInset
         waveformHeightConstraint?.constant = metrics.waveformHeight
-        controlHeights.forEach { $0.constant = metrics.controlHeight }
+        // A round control on the keyboard surface is sized like the microphone
+        // button beside it, not like a label with a fill behind it: same
+        // diameter, same row, one family. `controlHeight` is 30pt — the height
+        // of a pill with a word in it — and a 30pt circle next to a 38pt one
+        // reads as a mistake, which is what it was.
+        controlHeights.forEach {
+            $0.constant = palette.usesSystemKeyboardBackdrop
+                ? metrics.chipHeight
+                : metrics.controlHeight
+        }
         secondarySizes.forEach { $0.constant = metrics.secondaryDiameter }
 
         layer.cornerRadius = metrics.cornerRadius
@@ -805,6 +864,9 @@ final class DictationBarView: UIView, TypingStripViewDelegate {
             let constraint = $0.heightAnchor.constraint(equalToConstant: metrics.controlHeight)
             constraint.priority = .defaultHigh
             return constraint
+        }
+        chipCircleWidths = [languageButton, styleButton].map {
+            $0.widthAnchor.constraint(equalTo: $0.heightAnchor)
         }
         secondarySizes = secondaryButtons.flatMap { button in
             [

--- a/ios/VocaPhoneKeyboard/DictationPresentation.swift
+++ b/ios/VocaPhoneKeyboard/DictationPresentation.swift
@@ -154,6 +154,37 @@ struct DictationContext: Equatable {
 }
 
 extension DictationBarModel {
+    /// The single line the dictation surface shows in the middle, or `nil` when
+    /// the state has nothing to explain.
+    ///
+    /// Deliberately shorter than the card's copy above, and deliberately not a
+    /// concatenation of it. The card is two lines inside an app; this is one
+    /// line over somebody else's text field, and the fix is already on the
+    /// button beside it — "retry after checking the selected model" is an
+    /// instruction for a screen the reader is not on.
+    ///
+    /// What survives the cut is the fact that changes what the person does
+    /// next: the recording is still there, so they can retry instead of saying
+    /// it all again.
+    static func surfaceLine(for state: SessionState) -> String? {
+        switch state {
+        case .serverUnavailable:
+            "Can't reach your gateway. Recording kept."
+        case .uploadFailedRecoverable:
+            "Upload failed. Recording kept."
+        case .transcriptionFailedRecoverable:
+            "Couldn't transcribe. Recording kept."
+        case .transcriptionFailedPermanent:
+            "Couldn't transcribe this recording."
+        case .permissionDenied:
+            "vocaphone needs microphone access."
+        case .targetContextChanged:
+            "Tap the field you were typing in."
+        default:
+            nil
+        }
+    }
+
     static func make(_ context: DictationContext) -> DictationBarModel {
         guard context.hasFullAccess else { return locked }
         switch context.state {
@@ -272,7 +303,7 @@ extension DictationBarModel {
         pulse: .listening,
         primary: DictationButton(
             title: "Finish",
-            symbol: "stop.fill",
+            symbol: "checkmark",
             action: .finish,
             hint: "Stops recording and starts transcription."
         ),

--- a/ios/VocaPhoneKeyboard/DictationPresentation.swift
+++ b/ios/VocaPhoneKeyboard/DictationPresentation.swift
@@ -154,6 +154,15 @@ struct DictationContext: Equatable {
 }
 
 extension DictationBarModel {
+    /// Preserve the transcript and field guidance from the shared presentation.
+    func surfaceMessage(for state: SessionState) -> String? {
+        if state == .readyToInsert || state == .targetContextChanged,
+           case let .message(message) = body {
+            return message
+        }
+        return Self.surfaceLine(for: state)
+    }
+
     /// The single line the dictation surface shows in the middle, or `nil` when
     /// the state has nothing to explain.
     ///

--- a/ios/VocaPhoneKeyboard/DictationPresentation.swift
+++ b/ios/VocaPhoneKeyboard/DictationPresentation.swift
@@ -154,11 +154,21 @@ struct DictationContext: Equatable {
 }
 
 extension DictationBarModel {
-    /// Preserve the transcript and field guidance from the shared presentation.
+    /// Use the same failure detail and recovery action as the original card.
     func surfaceMessage(for state: SessionState) -> String? {
-        if state == .readyToInsert || state == .targetContextChanged,
-           case let .message(message) = body {
-            return message
+        switch state {
+        case .serverUnavailable, .uploadFailedRecoverable,
+             .transcriptionFailedRecoverable, .transcriptionFailedPermanent,
+             .permissionDenied:
+            if case let .message(message) = body {
+                return "\(title). \(message) \(primary.title)."
+            }
+        case .readyToInsert, .targetContextChanged:
+            if case let .message(message) = body { return message }
+        case .finalizing, .uploading, .transcribing:
+            return title
+        default:
+            break
         }
         return Self.surfaceLine(for: state)
     }

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -650,7 +650,7 @@ struct DictationSurfaceView: View {
                     .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
                     .shadow(color: Self.brandGreen.opacity(0.35), radius: 4, x: 0, y: 2)
 
-                if isWorking {
+                if isWorking && !state.primaryIsEnabled {
                     // The same circle, still there, no longer an action: the
                     // work it started is what it is now reporting.
                     ProgressView()
@@ -666,10 +666,9 @@ struct DictationSurfaceView: View {
             }
         }
         .buttonStyle(.plain)
-        // Tapping through a transcription would start a second recording over
-        // the top of the first. Cancel stays live; this does not.
-        .disabled(isWorking || !state.primaryIsEnabled)
-        .accessibilityLabel(isWorking ? "Transcribing" : state.primaryLabel)
+        // The model disables processing but keeps handoff recovery available.
+        .disabled(!state.primaryIsEnabled)
+        .accessibilityLabel(state.primaryLabel)
         .matchedGeometryEffect(id: "trailingActionCircle", in: animationNamespace)
     }
 }

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -1,0 +1,828 @@
+import SwiftUI
+import UIKit
+
+// MARK: - State Observable
+
+final class DictationSurfaceState: ObservableObject {
+    private var storedState: SessionState = .idle
+    var state: SessionState {
+        get { storedState }
+        set { change(&storedState, to: newValue) }
+    }
+    @Published var meterLevels: [Float] = []
+    private var storedLanguage: TranscriptionLanguage = KeyboardPreferences.effectiveTranscriptionLanguage
+    var language: TranscriptionLanguage {
+        get { storedLanguage }
+        set { change(&storedLanguage, to: newValue) }
+    }
+    private var storedStyle: WritingStyle = KeyboardPreferences.writingStyle
+    var style: WritingStyle {
+        get { storedStyle }
+        set { change(&storedStyle, to: newValue) }
+    }
+    private var storedShowsGlobeKey: Bool = false
+    var showsGlobeKey: Bool {
+        get { storedShowsGlobeKey }
+        set { change(&storedShowsGlobeKey, to: newValue) }
+    }
+    /// What the typing engine is offering right now, kept in its own object.
+    ///
+    /// Every keystroke replaces this list. Published on *this* object, that
+    /// invalidated the whole surface — glass buttons, waveform, menus — on each
+    /// letter, on the main thread, inside an extension with about fifty
+    /// megabytes to its name. Typing fast felt like typing through treacle for
+    /// exactly that reason. In its own object, a keystroke redraws the row of
+    /// words and nothing else.
+    let typing = TypingRowState()
+
+    /// Whether there is anything to suggest. Separate from the list because the
+    /// surface's own layout only cares about empty or not, and that answer
+    /// changes once a word rather than once a letter.
+    @Published private(set) var hasCandidates = false
+
+    var candidates: [TypingCandidate] {
+        get { typing.candidates }
+        set {
+            typing.candidates = newValue
+            let has = !newValue.isEmpty
+            if has != hasCandidates { hasCandidates = has }
+        }
+    }
+    /// What the centre says instead of the language and style line: the state's
+    /// own words, from the same place the old bar took them. "Gateway
+    /// unavailable", "Nothing was recognised" and the rest are the product's
+    /// copy, and the surface has no business inventing a second wording.
+    private var storedCenterMessage: String? = nil
+    var centerMessage: String? {
+        get { storedCenterMessage }
+        set { change(&storedCenterMessage, to: newValue) }
+    }
+    /// The trailing button in this state: Finish, Insert, Retry, Start.
+    private var storedPrimarySymbol: String = "mic.fill"
+    var primarySymbol: String {
+        get { storedPrimarySymbol }
+        set { change(&storedPrimarySymbol, to: newValue) }
+    }
+    private var storedPrimaryIsEnabled: Bool = true
+    var primaryIsEnabled: Bool {
+        get { storedPrimaryIsEnabled }
+        set { change(&storedPrimaryIsEnabled, to: newValue) }
+    }
+    /// The spring every phase change of this surface uses.
+    ///
+    /// Published so the keyboard lab can drive it from two sliders: how a
+    /// transition feels is not a number anybody picks correctly by reasoning
+    /// about it, and the loop of guess → build → install → press is a minute
+    /// long.
+    ///
+    /// They persist to the App Group, so a pair settled on in the lab is the
+    /// pair the keyboard extension uses the next time it appears — the point is
+    /// to feel it on the real keyboard, not only in a preview. Nothing in a
+    /// shipping build writes them: the lab is the only writer, and it is
+    /// debug-only.
+    @Published var animationResponse: Double = KeyboardPreferences.surfaceAnimationResponse {
+        didSet { KeyboardPreferences.surfaceAnimationResponse = animationResponse }
+    }
+    @Published var animationDamping: Double = KeyboardPreferences.surfaceAnimationDamping {
+        didSet { KeyboardPreferences.surfaceAnimationDamping = animationDamping }
+    }
+    private var storedIsDark: Bool = false
+    var isDark: Bool {
+        get { storedIsDark }
+        set { change(&storedIsDark, to: newValue) }
+    }
+
+    /// One place for the buzz, and only for typing.
+    ///
+    /// The three round controls do not buzz: a tap that starts or ends a
+    /// recording already answers with the whole surface changing, and a second
+    /// confirmation in the hand is noise. Choosing a suggestion has no such
+    /// answer — the word simply appears in somebody else's text field — so that
+    /// one keeps its tap.
+    ///
+    /// It answers to the keyboard's own haptics setting, the one already in
+    /// Settings, rather than a second switch of its own. Two switches for one
+    /// sensation is how somebody turns haptics off and still feels the
+    /// keyboard buzz.
+    func tap(_ style: UIImpactFeedbackGenerator.FeedbackStyle) {
+        guard KeyboardPreferences.typingHapticsEnabled else { return }
+        UIImpactFeedbackGenerator(style: style).impactOccurred()
+    }
+
+    /// Announces a change only when there is one.
+    ///
+    /// `@Published` announces on every assignment, changed or not — and the
+    /// render below assigns nine of these in a row, on a path it takes twice a
+    /// word: once when the suggestions go on a space, and once when they come
+    /// back on the next letter. Each announcement rebuilds this whole surface,
+    /// glass and menus and waveform included. Measured on device: 39 rebuilds
+    /// of everything per 95 keystrokes, at 7.5 ms apiece against a 16.6 ms
+    /// frame, in a process with fifty megabytes to its name.
+    private func change<T: Equatable>(_ storage: inout T, to value: T) {
+        guard storage != value else { return }
+        objectWillChange.send()
+        storage = value
+    }
+
+    var onStart: (() -> Void)?
+    var onFinish: (() -> Void)?
+    var onCancel: (() -> Void)?
+    var onLanguageChanged: ((TranscriptionLanguage) -> Void)?
+    var onStyleChanged: ((WritingStyle) -> Void)?
+    var onGlobe: (() -> Void)?
+    var onCandidate: ((TypingCandidate) -> Void)? {
+        get { typing.onCandidate }
+        set { typing.onCandidate = newValue }
+    }
+    /// Whatever the trailing button means right now.
+    var onPrimary: (() -> Void)?
+
+    init() {}
+
+    /// Re-reads both preferences.
+    ///
+    /// They live in the App Group, and the app's own Settings screen writes the
+    /// same two keys — so a language changed in the app while the keyboard was
+    /// on screen has to land here, or the line under the waveform starts naming
+    /// a setting that is no longer in force.
+
+    func refreshPreferences() {
+        language = KeyboardPreferences.effectiveTranscriptionLanguage
+        style = KeyboardPreferences.writingStyle
+    }
+
+    /// Persists the choice, exactly as the dictation bar's own menu does.
+    ///
+    /// `effectiveTranscriptionLanguage` rather than the raw choice: a language
+    /// the loaded model cannot be asked for resolves back to Automatic, and the
+    /// line under the waveform must say what will actually happen.
+    func select(language newLanguage: TranscriptionLanguage) {
+        KeyboardPreferences.transcriptionLanguage = newLanguage
+        KeyboardPreferences.noteTranscriptionLanguageUse(newLanguage)
+        language = KeyboardPreferences.effectiveTranscriptionLanguage
+        onLanguageChanged?(newLanguage)
+    }
+
+    func select(style newStyle: WritingStyle) {
+        KeyboardPreferences.writingStyle = newStyle
+        style = newStyle
+        onStyleChanged?(newStyle)
+    }
+
+    /// Automatic, then the languages this person actually uses, then the rest.
+    ///
+    /// The shortcuts are filtered by what the loaded model can be asked for: a
+    /// greyed-out row is worse than no row when only about five of them fit.
+    var languageShortcuts: [TranscriptionLanguage] {
+        let modelLanguages = KeyboardPreferences.activeModelLanguages
+        let recents = KeyboardPreferences.recentTranscriptionLanguages.filter {
+            $0 != .automatic
+                && ModelLanguageSupport.isSelectable($0, modelLanguages: modelLanguages)
+        }
+        var shortcuts: [TranscriptionLanguage] = [.automatic] + recents
+        // The current selection always deserves a row, even if it was never
+        // recorded as recent: it is the one entry being looked for.
+        if language != .automatic, !shortcuts.contains(language) {
+            shortcuts.append(language)
+        }
+        return shortcuts
+    }
+
+    var remainingLanguages: [TranscriptionLanguage] {
+        let shortcuts = Set(languageShortcuts)
+        return TranscriptionLanguage.allCases.filter { !shortcuts.contains($0) }
+    }
+
+    func isSelectable(_ candidate: TranscriptionLanguage) -> Bool {
+        ModelLanguageSupport.isSelectable(
+            candidate,
+            modelLanguages: KeyboardPreferences.activeModelLanguages
+        )
+    }
+}
+
+/// The suggestion row's own state, so a keystroke does not redraw a keyboard.
+final class TypingRowState: ObservableObject {
+    @Published var candidates: [TypingCandidate] = []
+    @Published var isDark = false
+    var onCandidate: ((TypingCandidate) -> Void)?
+    var hapticsEnabled = true
+
+    func tap() {
+        guard KeyboardPreferences.typingHapticsEnabled else { return }
+        UIImpactFeedbackGenerator(style: KeyboardPreferences.typingHapticStyle.feedbackStyle)
+            .impactOccurred(intensity: KeyboardPreferences.typingHapticIntensity)
+    }
+}
+
+// MARK: - DictationSurfaceView
+
+struct DictationSurfaceView: View {
+    @ObservedObject var state: DictationSurfaceState
+    @Namespace private var animationNamespace
+
+    private static let brandGreen = Color(red: 13 / 255, green: 104 / 255, blue: 77 / 255)
+    /// The diameter the rest of the product already uses for a round control:
+    /// `VocaMetrics.minimumTarget`, which is also the HIG minimum. Named again
+    /// rather than imported because the design system is compiled into the app
+    /// and this view has to build inside the keyboard extension too.
+    ///
+    /// 60 was picked by eye from a mockup and came out a third larger than the
+    /// toolbar buttons on the app's own home screen.
+    private static let buttonDiameter: CGFloat = 44
+    /// The air around the control row.
+    ///
+    /// Ten above and nothing below sat the buttons on the keys; six and four
+    /// puts the row in the middle of its strip. The sides matter for the same
+    /// reason — the keyboard's own inset is six points, and a round control
+    /// against that edge reads as falling off it.
+    private static let topInset: CGFloat = 6
+    private static let bottomInset: CGFloat = 4
+    private static let sideInset: CGFloat = 6
+    /// Glyphs at the toolbar's own weight and size, for the same reason.
+    private static let glyphSize: CGFloat = 17
+
+    init(state: DictationSurfaceState) {
+        self.state = state
+    }
+
+    private var isRecording: Bool {
+        state.state == .recording
+    }
+
+    /// Recording is over and the transcript is not back yet.
+    ///
+    /// This is a phase of the same surface, not a different screen. Handing the
+    /// session back to another layout the instant the check is tapped throws
+    /// away the one thing the person is watching — and they tapped it half a
+    /// second ago.
+    private var isWorking: Bool {
+        switch state.state {
+        case .launchingApp, .awaitingReturn: true
+        case .finalizing, .uploading, .transcribing: true
+        default: false
+        }
+    }
+
+    /// The one line under the middle of the surface.
+    private var centerText: String {
+        if let message = state.centerMessage, !isRecording { return message }
+        if isWorking { return workingTitle }
+        return "\(state.language.displayName) • \(state.style.displayName)"
+    }
+
+    /// What the wait is called. Starting and finishing are both waits, and both
+    /// are this surface holding still — but they are not the same wait, and a
+    /// surface that said "Transcribing" before a word was spoken would be
+    /// lying about which one it is.
+    private var workingTitle: String {
+        switch state.state {
+        case .launchingApp, .awaitingReturn: "Starting"
+        default: "Transcribing"
+        }
+    }
+
+    /// A state the surface has to explain rather than just offer: a failure, a
+    /// transcript waiting to go in, a field that went away.
+    private var hasMessage: Bool { state.centerMessage != nil }
+
+    /// Whether the surface stands open: the tall layout with a centre.
+    private var isOpen: Bool { isRecording || isWorking || hasMessage }
+
+    /// Typing, with something to offer. The two menu buttons collapse into one
+    /// so the row they were using becomes the suggestions — which is what the
+    /// hand needs while typing, and the menus are one tap away in it.
+    private var isSuggesting: Bool { !isOpen && state.hasCandidates }
+
+    private var surfaceSpring: Animation {
+        .spring(response: state.animationResponse, dampingFraction: state.animationDamping)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Top Controls Bar (Top row of both Idle and Recording)
+            HStack(spacing: 8) {
+                if #available(iOS 26, *) {
+                    GlassEffectContainer(spacing: 8) {
+                        HStack(spacing: 8) {
+                            leadingGlassGroup
+                        }
+                    }
+                } else {
+                    HStack(spacing: 8) {
+                        leadingGlassGroup
+                    }
+                }
+
+                if isSuggesting {
+                    CandidateRow(state: state.typing)
+                } else {
+                    Spacer()
+                }
+
+                trailingActionButton
+            }
+            // No fixed height. `GlassEffectContainer` lays out taller than its
+            // content — it reserves room for the glass to spill and merge — and
+            // pinning the row to 44 pt made that surplus appear as space above
+            // and below the buttons, which is what pushed them off the top.
+            // The row is the first thing in the stack; that is what puts it at
+            // the top, not a height.
+
+            if isOpen {
+                Spacer(minLength: 0)
+
+                // Center Waveform and Subtitle
+                VStack(spacing: 16) {
+                    if hasMessage, !isRecording {
+                        // Nothing to meter: the bars would be decoration on top
+                        // of a sentence the reader needs to actually read.
+                        EmptyView()
+                    } else {
+                        // One waveform across both phases, not two swapped for
+                        // one another. Two of them are two identities to
+                        // SwiftUI: it removes one and inserts the other, and
+                        // the row relaxes and re-expands around the gap. What
+                        // changes on finishing is the *input* — the bars are
+                        // held, because there is no audio any more and bars
+                        // that kept moving would say the microphone is open.
+                        LiveWaveformBars(
+                            levels: isWorking ? [] : state.meterLevels,
+                            tint: isWorking
+                                ? Self.brandGreen.opacity(0.35)
+                                : Self.brandGreen
+                        )
+                        .frame(height: 48)
+                    }
+
+                    Text(centerText)
+                        .font(.system(size: 15, weight: .regular))
+                        .multilineTextAlignment(.center)
+                        .lineLimit(3)
+                        .padding(.horizontal, 24)
+                        .foregroundStyle(state.isDark ? Color(white: 0.65) : Color(white: 0.45))
+                        // A reserved line, so swapping one sentence for another
+                        // does not resize the block the waveform is sitting on.
+                        // "Automatic • Clean" and "Transcribing" are not the
+                        // same width, and without this the row re-centres
+                        // around the difference.
+                        .frame(minHeight: 20)
+                        .animation(nil, value: centerText)
+                }
+                .transition(.asymmetric(
+                    insertion: .scale(scale: 0.88).combined(with: .opacity),
+                    removal: .opacity
+                ))
+
+                Spacer()
+
+                // Bottom row for system globe key if needed
+                if state.showsGlobeKey {
+                    HStack {
+                        Button {
+                            state.onGlobe?()
+                        } label: {
+                            Image(systemName: "globe")
+                                .font(.system(size: 20))
+                                .foregroundStyle(state.isDark ? Color.white : Color.primary)
+                                .frame(width: 44, height: 44)
+                        }
+                        .buttonStyle(.plain)
+                        Spacer()
+                    }
+                    .transition(.opacity)
+                }
+            } else {
+                Spacer(minLength: 0)
+            }
+        }
+        // Deliberate air above the controls, rather than whatever the glass
+        // container happened to reserve. One number, in one place, so it stays
+        // the same in every phase.
+        .padding(.top, Self.topInset)
+        .padding(.bottom, Self.bottomInset)
+        .padding(.horizontal, Self.sideInset)
+        .onAppear {
+            state.refreshPreferences()
+        }
+        // Hung from the top. The controls are in the same place in every phase,
+        // which is the point of keeping one surface: the finger that just
+        // tapped the check knows where Cancel is without looking for it.
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        // Fast, and barely springy. A keyboard control answers the finger; a
+        // settle of a third of a second reads as the keyboard thinking about
+        // it. Tunable from the lab — see ``DictationSurfaceState/animationResponse``.
+        .animation(surfaceSpring, value: isOpen)
+        .animation(surfaceSpring, value: isWorking)
+        .animation(surfaceSpring, value: isSuggesting)
+    }
+
+    // MARK: - Leading Glass Buttons
+
+    @ViewBuilder
+    private var leadingGlassGroup: some View {
+        if isOpen {
+            cancelGlassButton
+        } else {
+            languageMenuButton
+            styleMenuButton
+        }
+    }
+
+    @ViewBuilder
+    private var cancelGlassButton: some View {
+        Button {
+            state.onCancel?()
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: Self.glyphSize, weight: .semibold))
+                .foregroundStyle(state.isDark ? Color.white : Color.black)
+                .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .modifier(GlassButtonModifier(id: "leadGlass", namespace: animationNamespace))
+    }
+
+    /// The two menus, collapsed into one while the row is carrying suggestions.
+    /// Same glass, same place, same `glassEffectID` — so it is the two buttons
+    /// merging rather than three buttons swapping.
+    @ViewBuilder
+    private var menusGlassButton: some View {
+        Menu {
+            Menu("Language") {
+                ForEach(state.languageShortcuts, id: \.self) { lang in
+                    languageButton(lang)
+                }
+                Menu("More languages") {
+                    ForEach(state.remainingLanguages, id: \.self) { lang in
+                        languageButton(lang)
+                    }
+                }
+            }
+            Menu("Style") {
+                ForEach(WritingStyle.allCases, id: \.self) { item in
+                    Button {
+                        state.select(style: item)
+                    } label: {
+                        HStack {
+                            Text(item.displayName)
+                            if item == state.style {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: Self.glyphSize, weight: .semibold))
+                .foregroundStyle(state.isDark ? Color.white : Color.black)
+                .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                .contentShape(Circle())
+        }
+        .modifier(GlassButtonModifier(id: "leadGlass", namespace: animationNamespace))
+    }
+
+    @ViewBuilder
+    private var languageMenuButton: some View {
+        Menu {
+            ForEach(state.languageShortcuts, id: \.self) { lang in
+                languageButton(lang)
+            }
+            Menu("More languages") {
+                ForEach(state.remainingLanguages, id: \.self) { lang in
+                    languageButton(lang)
+                }
+            }
+        } label: {
+            Image(systemName: "globe")
+                .font(.system(size: Self.glyphSize, weight: .semibold))
+                .foregroundStyle(state.isDark ? Color.white : Color.black)
+                .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                .contentShape(Circle())
+        }
+        .modifier(GlassButtonModifier(id: "leadGlass", namespace: animationNamespace))
+    }
+
+    @ViewBuilder
+    private var styleMenuButton: some View {
+        Menu {
+            // A `Picker` rather than a row of buttons: iOS draws the tick on
+            // the chosen row itself, which frees the row's own image for the
+            // style's icon. Hand-rolled buttons had to spend that image on the
+            // tick, so the menu listed six styles with no icons at all — the
+            // same six icons the button beside it is drawn from.
+            // Toggles rather than a `Picker`, and this is the whole reason the
+            // button's icon lagged a beat behind the choice: a picker inside a
+            // menu commits its selection when the menu *dismisses*, not when
+            // the row is tapped. The old style stayed on screen for the length
+            // of that animation because it was still the truth.
+            //
+            // A toggle fires on the tap, and keeps what the picker was chosen
+            // for: iOS draws the tick itself, so the row's image stays free for
+            // the style's own icon.
+            ForEach(WritingStyle.allCases, id: \.self) { item in
+                Toggle(isOn: styleBinding(for: item)) {
+                    Label(item.displayName, systemImage: item.symbolName)
+                }
+            }
+        } label: {
+            // The button shows the style that is in force. Three things used
+            // to make it show it late, and all three are gone: the picker that
+            // committed on dismissal rather than on the tap, the second writer
+            // in the controller, and the poll that reassigned the value several
+            // times a second and could put a stale one back.
+            Image(systemName: state.style.symbolName)
+                .font(.system(size: Self.glyphSize, weight: .semibold))
+                .foregroundStyle(state.isDark ? Color.white : Color.black)
+                .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                .contentShape(Circle())
+        }
+        .modifier(GlassButtonModifier(id: "styleGlass", namespace: animationNamespace))
+        .accessibilityLabel("Writing style")
+        .accessibilityValue(state.style.displayName)
+    }
+
+    /// Writes through ``DictationSurfaceState/select(style:)`` so the choice is
+    /// persisted, rather than only changing what the menu shows.
+    /// Turning a style off is not a thing — one of the six is always in force —
+    /// so only the on direction does anything.
+    private func styleBinding(for style: WritingStyle) -> Binding<Bool> {
+        Binding(
+            get: { state.style == style },
+            set: { isOn in if isOn { state.select(style: style) } }
+        )
+    }
+
+    /// One row of the language menu. Disabled where the loaded model cannot be
+    /// asked for it, which is the same rule the dictation bar's menu applies.
+    @ViewBuilder
+    private func languageButton(_ lang: TranscriptionLanguage) -> some View {
+        Button {
+            state.select(language: lang)
+        } label: {
+            HStack {
+                Text(lang.displayName)
+                if lang == state.language {
+                    Image(systemName: "checkmark")
+                }
+            }
+        }
+        .disabled(!state.isSelectable(lang))
+    }
+
+    // MARK: - Trailing Primary Action Button (Green Circle)
+
+    private var trailingActionButton: some View {
+        Button {
+            // Finish, Insert, Retry, Start: the state decides, the surface
+            // draws it. `onPrimary` is set for every state the controller
+            // drives; the two below are what the lab and the previews use.
+            if let onPrimary = state.onPrimary {
+                onPrimary()
+            } else if isRecording {
+                state.onFinish?()
+            } else {
+                state.onStart?()
+            }
+        } label: {
+            ZStack {
+                Circle()
+                    .fill(Self.brandGreen)
+                    .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                    .shadow(color: Self.brandGreen.opacity(0.35), radius: 4, x: 0, y: 2)
+
+                if isWorking {
+                    // The same circle, still there, no longer an action: the
+                    // work it started is what it is now reporting.
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .tint(.white)
+                        .transition(.scale.combined(with: .opacity))
+                } else {
+                    Image(systemName: isRecording ? "checkmark" : state.primarySymbol)
+                        .font(.system(size: Self.glyphSize, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .transition(.scale.combined(with: .opacity))
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        // Tapping through a transcription would start a second recording over
+        // the top of the first. Cancel stays live; this does not.
+        .disabled(isWorking || !state.primaryIsEnabled)
+        .accessibilityLabel(isWorking ? "Transcribing" : (isRecording ? "Finish" : "Start dictation"))
+        .matchedGeometryEffect(id: "trailingActionCircle", in: animationNamespace)
+    }
+}
+
+/// The suggestion row.
+///
+/// Its own view on purpose: it observes ``TypingRowState`` and nothing else, so
+/// the letter-by-letter churn of candidates redraws these words and leaves the
+/// glass, the waveform and the menus alone.
+private struct CandidateRow: View {
+    @ObservedObject var state: TypingRowState
+
+    private static let rowHeight: CGFloat = 44
+
+    var body: some View {
+        // Scrolls rather than squeezes. Dividing the row equally meant every
+        // suggestion got the same width whatever it was, so a long word came
+        // out as "correspond…" while a two-letter one sat in a puddle of space.
+        // A word the reader cannot finish reading is not a suggestion.
+        ScrollView(.horizontal) {
+            row
+        }
+        .scrollIndicators(.hidden)
+        .scrollClipDisabled()
+        // The fade says "there is more this way" without a scrollbar, which on
+        // a strip this short would be most of the strip.
+        .mask {
+            LinearGradient(
+                stops: [
+                    .init(color: .clear, location: 0),
+                    .init(color: .black, location: 0.04),
+                    .init(color: .black, location: 0.96),
+                    .init(color: .clear, location: 1),
+                ],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var row: some View {
+        HStack(spacing: 0) {
+            ForEach(Array(state.candidates.enumerated()), id: \.offset) { index, candidate in
+                if index > 0 {
+                    Divider()
+                        .frame(height: 20)
+                        .padding(.horizontal, 2)
+                }
+                Button {
+                    state.tap()
+                    state.onCandidate?(candidate)
+                } label: {
+                    Text(Self.title(for: candidate))
+                        .font(.system(
+                            size: 17,
+                            weight: candidate.isEmphasised ? .semibold : .regular
+                        ))
+                        .foregroundStyle(state.isDark ? Color.white : Color.black)
+                        .lineLimit(1)
+                        // No truncation and no equal shares: each word takes
+                        // the width it needs and the row scrolls.
+                        .fixedSize(horizontal: true, vertical: false)
+                        .padding(.horizontal, 14)
+                        .frame(minHeight: Self.rowHeight)
+                        .background {
+                            // The one the keyboard will apply when you press
+                            // space still has to be tellable from the rest —
+                            // without it the row is five identical words and no
+                            // sign which one has already been chosen for you.
+                            Capsule()
+                                .fill(state.isDark ? Color.white.opacity(0.14) : Color.white)
+                                .opacity(candidate.isEmphasised ? 1 : 0)
+                        }
+                        .contentShape(Capsule())
+                }
+                .buttonStyle(CandidateButtonStyle(isDark: state.isDark))
+            }
+        }
+    }
+
+    /// The literal and the revert are quoted, exactly as the system keyboard
+    /// quotes a word it is about to take away or has just taken. The revert
+    /// carries the undo arrow too: by the time it appears the replacement is
+    /// already in the document, so the chip has to say "put it back".
+    private static func title(for candidate: TypingCandidate) -> String {
+        switch candidate.kind {
+        case .literal: "\u{201C}\(candidate.text)\u{201D}"
+        case .revert: "\u{21A9} \u{201C}\(candidate.text)\u{201D}"
+        default: candidate.text
+        }
+    }
+}
+
+/// A suggestion chip. Flat until it is touched, then a solid capsule — the
+/// press has to read on a surface that has no fill of its own.
+private struct CandidateButtonStyle: ButtonStyle {
+    let isDark: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .background {
+                // Full height, matching the round controls in the same row: a
+                // chip inset from its own tap target looks like a smaller
+                // thing than the one the finger actually hits.
+                Capsule()
+                    .fill(isDark ? Color.white.opacity(0.16) : Color.white)
+                    .opacity(configuration.isPressed ? 1 : 0)
+            }
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+}
+
+// MARK: - Glass Button Modifier
+
+private struct GlassButtonModifier: ViewModifier {
+    let id: String
+    let namespace: Namespace.ID
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content
+                .glassEffect(.regular.interactive(), in: .circle)
+                .glassEffectID(id, in: namespace)
+        } else {
+            content
+                .background(.ultraThinMaterial, in: Circle())
+                .overlay {
+                    Circle()
+                        .stroke(Color.white.opacity(0.35), lineWidth: 0.75)
+                }
+                .shadow(color: Color.black.opacity(0.12), radius: 3, x: 0, y: 1.5)
+        }
+    }
+}
+
+// MARK: - Live Waveform (9 Bars)
+
+/// Nine bars that breathe with the microphone.
+///
+/// **This is decoration, and deliberately so.** ``derivedHeights`` multiplies
+/// every level by a fixed envelope — 0.45 at the ends, 1.0 in the middle — so
+/// the row is always a spindle whatever is said into it. Speak at one steady
+/// volume and the outer bars still cannot rise past 45%: that shape is drawn,
+/// not measured.
+///
+/// It is left in on purpose. A shaped ribbon that is obviously an ornament is
+/// honest in a way a fake meter is not — Voicenotes ships the same thing, and
+/// nobody is misled, because nobody reads it as an instrument. The line it must
+/// not cross is *pretending*: the previous waveform invented three bars out of
+/// every four and presented them as the voice, and that is what read as slop.
+///
+/// The measurement it decorates is real and lives elsewhere: `AudioCapture-
+/// Pipeline` splits each quarter-second buffer into five, so twenty true levels
+/// a second reach this view, and the bars only move when audio does. Remove the
+/// envelope and this becomes a meter; keep it and it stays an ornament driven
+/// by real sound. Both are defensible. Silently drifting between them is not.
+struct LiveWaveformBars: View {
+    let levels: [Float]
+    let tint: Color
+
+    private static let barCount = 15
+    private static let barWidth: CGFloat = 5
+    private static let barSpacing: CGFloat = 5
+    private static let cornerRadius: CGFloat = 2.5
+    private static let minHeight: CGFloat = 8
+    private static let maxHeight: CGFloat = 46
+
+    init(levels: [Float], tint: Color) {
+        self.levels = levels
+        self.tint = tint
+    }
+
+    var body: some View {
+        HStack(spacing: Self.barSpacing) {
+            ForEach(0..<Self.barCount, id: \.self) { index in
+                RoundedRectangle(cornerRadius: Self.cornerRadius)
+                    .fill(tint)
+                    .frame(width: Self.barWidth, height: height(for: index))
+            }
+        }
+        .animation(.spring(response: 0.18, dampingFraction: 0.75), value: derivedHeights)
+    }
+
+    private var derivedHeights: [CGFloat] {
+        // The envelope, stretched across however many bars there are rather
+        // than written out by hand: adding bars used to mean editing a literal
+        // and getting the shape subtly wrong.
+        let weights: [CGFloat] = (0..<Self.barCount).map { index in
+            let position = CGFloat(index) / CGFloat(max(Self.barCount - 1, 1))
+            return 0.45 + 0.55 * sin(position * .pi)
+        }
+        let recent = levels.suffix(Self.barCount)
+        let baseLevel: CGFloat = recent.isEmpty ? 0 : CGFloat(recent.reduce(0, +) / Float(recent.count))
+
+        return (0..<Self.barCount).map { i in
+            let sample = i < recent.count ? CGFloat(Array(recent)[i]) : baseLevel
+            // Speech at a normal distance sits low in the 0-1 range, so a
+            // straight mapping leaves the row nearly flat until somebody
+            // shouts. The curve lifts the quiet end and leaves the loud end
+            // where it is.
+            let effective = pow(max(sample, baseLevel * 0.7), 0.55)
+            let rawHeight = Self.minHeight + (Self.maxHeight - Self.minHeight) * effective * weights[i]
+            return min(max(rawHeight, Self.minHeight), Self.maxHeight)
+        }
+    }
+
+    private func height(for index: Int) -> CGFloat {
+        let heights = derivedHeights
+        guard index < heights.count else { return Self.minHeight }
+        return heights[index]
+    }
+}

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -9,7 +9,11 @@ final class DictationSurfaceState: ObservableObject {
         get { storedState }
         set { change(&storedState, to: newValue) }
     }
-    @Published var meterLevels: [Float] = []
+    /// The meter's own state. Levels arrive several times a second, and
+    /// published here they invalidated the whole surface each time — glass,
+    /// menus, centre text and all — in a process with fifty megabytes to its
+    /// name. The row of bars is the only thing that has to redraw.
+    let meter = MeterState()
     private var storedLanguage: TranscriptionLanguage = KeyboardPreferences.effectiveTranscriptionLanguage
     var language: TranscriptionLanguage {
         get { storedLanguage }
@@ -38,7 +42,11 @@ final class DictationSurfaceState: ObservableObject {
     /// Whether there is anything to suggest. Separate from the list because the
     /// surface's own layout only cares about empty or not, and that answer
     /// changes once a word rather than once a letter.
-    @Published private(set) var hasCandidates = false
+    private var storedHasCandidates = false
+    private(set) var hasCandidates: Bool {
+        get { storedHasCandidates }
+        set { change(&storedHasCandidates, to: newValue) }
+    }
 
     var candidates: [TypingCandidate] {
         get { typing.candidates }
@@ -67,6 +75,15 @@ final class DictationSurfaceState: ObservableObject {
     var primaryIsEnabled: Bool {
         get { storedPrimaryIsEnabled }
         set { change(&storedPrimaryIsEnabled, to: newValue) }
+    }
+    /// What the trailing button does right now, in words: Finish, Insert,
+    /// Retry, Dictate. VoiceOver reads this, and "Start dictation" spoken over
+    /// a button that inserts a finished transcript is worse than silence — it
+    /// tells somebody their words are gone.
+    private var storedPrimaryLabel: String = "Start dictation"
+    var primaryLabel: String {
+        get { storedPrimaryLabel }
+        set { change(&storedPrimaryLabel, to: newValue) }
     }
     /// The spring every phase change of this surface uses.
     ///
@@ -104,20 +121,29 @@ final class DictationSurfaceState: ObservableObject {
     /// Settings, rather than a second switch of its own. Two switches for one
     /// sensation is how somebody turns haptics off and still feels the
     /// keyboard buzz.
-    func tap(_ style: UIImpactFeedbackGenerator.FeedbackStyle) {
-        guard KeyboardPreferences.typingHapticsEnabled else { return }
-        UIImpactFeedbackGenerator(style: style).impactOccurred()
+    ///
+    /// Through `KeyboardHaptics` rather than a generator built here. One made
+    /// fresh for each tap is a generator the Taptic Engine has not been warned
+    /// about, so the first buzz after it arrives late or not at all — and it
+    /// bypasses the Full Access check, without which there is no engine to reach
+    /// at all.
+    @MainActor
+    func tap() {
+        KeyboardHaptics.shared.textCommitted()
     }
 
     /// Announces a change only when there is one.
     ///
-    /// `@Published` announces on every assignment, changed or not — and the
-    /// render below assigns nine of these in a row, on a path it takes twice a
-    /// word: once when the suggestions go on a space, and once when they come
-    /// back on the next letter. Each announcement rebuilds this whole surface,
-    /// glass and menus and waveform included. Measured on device: 39 rebuilds
-    /// of everything per 95 keystrokes, at 7.5 ms apiece against a 16.6 ms
-    /// frame, in a process with fifty megabytes to its name.
+    /// `@Published` announces on every assignment, changed or not — and `render`
+    /// assigns nine of these in a row, on a path it takes twice a word: once
+    /// when the suggestions go on a space, and once when they come back on the
+    /// next letter. Each announcement rebuilds this whole surface, glass and
+    /// menus and waveform included. Measured on device: 39 rebuilds of
+    /// everything per 95 keystrokes, at 7.5 ms apiece against a 16.6 ms frame.
+    ///
+    /// Two of the nine — `language` and `style` — were already guarded at their
+    /// call site. Guarding them here instead means the other seven cannot be
+    /// forgotten, and nor can the next one somebody adds.
     private func change<T: Equatable>(_ storage: inout T, to value: T) {
         guard storage != value else { return }
         objectWillChange.send()
@@ -138,6 +164,13 @@ final class DictationSurfaceState: ObservableObject {
     var onPrimary: (() -> Void)?
 
     init() {}
+
+    func appendMeterLevels(_ levels: [Float]) { meter.append(levels) }
+
+    /// Ends the reading without ending the picture. See ``MeterState/hold()``.
+    func holdMeterLevels() { meter.hold() }
+
+    func clearMeterLevels() { meter.clear() }
 
     /// Re-reads both preferences.
     ///
@@ -201,17 +234,68 @@ final class DictationSurfaceState: ObservableObject {
     }
 }
 
+/// The bars' own state, so a microphone level does not redraw a keyboard.
+final class MeterState: ObservableObject {
+    /// The last few seconds of measured levels, oldest first.
+    @Published private(set) var levels: [Float] = []
+
+    /// Enough for the bars on screen and a little history: a keyboard that has
+    /// been recording for a minute must not be carrying a minute of numbers.
+    private static let capacity = 60
+
+    func append(_ newLevels: [Float]) {
+        guard !newLevels.isEmpty else { return }
+        var next = levels + newLevels
+        if next.count > Self.capacity { next.removeFirst(next.count - Self.capacity) }
+        levels = next
+    }
+
+    /// Stops reading, and keeps what was read.
+    ///
+    /// Called the moment a recording ends, which is also the moment the bars are
+    /// meant to hold the shape the voice left them in. Emptying the array made
+    /// them collapse to a flat line instead — the opposite of holding a shape,
+    /// and the thing anybody watching would notice first.
+    func hold() {}
+
+    /// Starts again from nothing. Only a new session does this.
+    func clear() {
+        guard !levels.isEmpty else { return }
+        levels = []
+    }
+}
+
 /// The suggestion row's own state, so a keystroke does not redraw a keyboard.
 final class TypingRowState: ObservableObject {
-    @Published var candidates: [TypingCandidate] = []
-    @Published var isDark = false
+    private var storedCandidates: [TypingCandidate] = []
+    var candidates: [TypingCandidate] {
+        get { storedCandidates }
+        set { change(&storedCandidates, to: newValue) }
+    }
+    /// The theme, assigned on every render whether or not it moved.
+    private var storedIsDark = false
+    var isDark: Bool {
+        get { storedIsDark }
+        set { change(&storedIsDark, to: newValue) }
+    }
+
+    /// Announces a change only when there is one. See the same method on
+    /// ``DictationSurfaceState`` for what this costs when it is missing.
+    private func change<T: Equatable>(_ storage: inout T, to value: T) {
+        guard storage != value else { return }
+        objectWillChange.send()
+        storage = value
+    }
     var onCandidate: ((TypingCandidate) -> Void)?
     var hapticsEnabled = true
 
+    /// Choosing a suggestion is the one thing on this surface that buzzes: the
+    /// word simply appears in somebody else's text field, with nothing else to
+    /// confirm it. Through ``KeyboardHaptics`` so the engine is prepared and
+    /// Full Access is honoured — see the note on the surface's own `tap()`.
+    @MainActor
     func tap() {
-        guard KeyboardPreferences.typingHapticsEnabled else { return }
-        UIImpactFeedbackGenerator(style: KeyboardPreferences.typingHapticStyle.feedbackStyle)
-            .impactOccurred(intensity: KeyboardPreferences.typingHapticIntensity)
+        KeyboardHaptics.shared.textCommitted()
     }
 }
 
@@ -299,6 +383,10 @@ struct DictationSurfaceView: View {
     }
 
     var body: some View {
+        // Counts what SwiftUI actually rebuilt. A keystroke changes three
+        // chips; if the whole surface re-evaluates with them, the cost is the
+        // surface, not the row, and no amount of trimming the row will move it.
+        let _ = TouchTrace.note("      body surface")
         VStack(spacing: 0) {
             // Top Controls Bar (Top row of both Idle and Recording)
             HStack(spacing: 8) {
@@ -347,7 +435,8 @@ struct DictationSurfaceView: View {
                         // held, because there is no audio any more and bars
                         // that kept moving would say the microphone is open.
                         LiveWaveformBars(
-                            levels: isWorking ? [] : state.meterLevels,
+                            state: state.meter,
+                            isHeld: isWorking,
                             tint: isWorking
                                 ? Self.brandGreen.opacity(0.35)
                                 : Self.brandGreen
@@ -388,6 +477,7 @@ struct DictationSurfaceView: View {
                                 .frame(width: 44, height: 44)
                         }
                         .buttonStyle(.plain)
+                        .accessibilityLabel("Next keyboard")
                         Spacer()
                     }
                     .transition(.opacity)
@@ -442,46 +532,7 @@ struct DictationSurfaceView: View {
         }
         .buttonStyle(.plain)
         .modifier(GlassButtonModifier(id: "leadGlass", namespace: animationNamespace))
-    }
-
-    /// The two menus, collapsed into one while the row is carrying suggestions.
-    /// Same glass, same place, same `glassEffectID` — so it is the two buttons
-    /// merging rather than three buttons swapping.
-    @ViewBuilder
-    private var menusGlassButton: some View {
-        Menu {
-            Menu("Language") {
-                ForEach(state.languageShortcuts, id: \.self) { lang in
-                    languageButton(lang)
-                }
-                Menu("More languages") {
-                    ForEach(state.remainingLanguages, id: \.self) { lang in
-                        languageButton(lang)
-                    }
-                }
-            }
-            Menu("Style") {
-                ForEach(WritingStyle.allCases, id: \.self) { item in
-                    Button {
-                        state.select(style: item)
-                    } label: {
-                        HStack {
-                            Text(item.displayName)
-                            if item == state.style {
-                                Image(systemName: "checkmark")
-                            }
-                        }
-                    }
-                }
-            }
-        } label: {
-            Image(systemName: "ellipsis")
-                .font(.system(size: Self.glyphSize, weight: .semibold))
-                .foregroundStyle(state.isDark ? Color.white : Color.black)
-                .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
-                .contentShape(Circle())
-        }
-        .modifier(GlassButtonModifier(id: "leadGlass", namespace: animationNamespace))
+        .accessibilityLabel("Cancel dictation")
     }
 
     @ViewBuilder
@@ -503,6 +554,7 @@ struct DictationSurfaceView: View {
                 .contentShape(Circle())
         }
         .modifier(GlassButtonModifier(id: "leadGlass", namespace: animationNamespace))
+        .accessibilityLabel("Cancel dictation")
     }
 
     @ViewBuilder
@@ -612,7 +664,7 @@ struct DictationSurfaceView: View {
         // Tapping through a transcription would start a second recording over
         // the top of the first. Cancel stays live; this does not.
         .disabled(isWorking || !state.primaryIsEnabled)
-        .accessibilityLabel(isWorking ? "Transcribing" : (isRecording ? "Finish" : "Start dictation"))
+        .accessibilityLabel(isWorking ? "Transcribing" : state.primaryLabel)
         .matchedGeometryEffect(id: "trailingActionCircle", in: animationNamespace)
     }
 }
@@ -629,9 +681,17 @@ private struct CandidateRow: View {
 
     var body: some View {
         // Scrolls rather than squeezes. Dividing the row equally meant every
-        // suggestion got the same width whatever it was, so a long word came
-        // out as "correspond…" while a two-letter one sat in a puddle of space.
-        // A word the reader cannot finish reading is not a suggestion.
+        // suggestion got the same width whatever it was, so a long word came out
+        // as "correspond…" while a two-letter one sat in a puddle of space — and
+        // a word the reader cannot finish reading is not a suggestion.
+        //
+        // This was taken out on the suspicion that its layout was what made the
+        // keyboard feel slow. Three runs on device with suggestions off, on, and
+        // switched off entirely said otherwise: the lag was unchanged, and it
+        // turned out to be the holds on the key's own highlight and balloon. So
+        // the scroll comes back. What does not come back is `ViewThatFits`,
+        // which was measured making it worse — it builds and measures every
+        // branch it might choose, mask and all.
         ScrollView(.horizontal) {
             row
         }
@@ -656,7 +716,11 @@ private struct CandidateRow: View {
 
     private var row: some View {
         HStack(spacing: 0) {
-            ForEach(Array(state.candidates.enumerated()), id: \.offset) { index, candidate in
+            // Identified by the word, not by the slot. On `\.offset` SwiftUI
+            // treats the candidate for a new prefix as the same chip with new
+            // text, and carries a press or a highlight over from the word
+            // before it.
+            ForEach(Array(state.candidates.enumerated()), id: \.element.identity) { index, candidate in
                 if index > 0 {
                     Divider()
                         .frame(height: 20)
@@ -674,7 +738,8 @@ private struct CandidateRow: View {
                         .foregroundStyle(state.isDark ? Color.white : Color.black)
                         .lineLimit(1)
                         // No truncation and no equal shares: each word takes
-                        // the width it needs and the row scrolls.
+                        // the width it needs, and the row scrolls. An ellipsis
+                        // in a suggestion is a word the reader has to guess at.
                         .fixedSize(horizontal: true, vertical: false)
                         .padding(.horizontal, 14)
                         .frame(minHeight: Self.rowHeight)
@@ -690,6 +755,7 @@ private struct CandidateRow: View {
                         .contentShape(Capsule())
                 }
                 .buttonStyle(CandidateButtonStyle(isDark: state.isDark))
+                .accessibilityLabel(Self.accessibilityLabel(for: candidate))
             }
         }
     }
@@ -698,6 +764,16 @@ private struct CandidateRow: View {
     /// quotes a word it is about to take away or has just taken. The revert
     /// carries the undo arrow too: by the time it appears the replacement is
     /// already in the document, so the chip has to say "put it back".
+    /// The arrow and the quotation marks are there for the eye. "Left arrow
+    /// hook, quote, whats, quote" tells a VoiceOver user nothing at all.
+    private static func accessibilityLabel(for candidate: TypingCandidate) -> String {
+        switch candidate.kind {
+        case .literal: "Keep \(candidate.text)"
+        case .revert: "Put \(candidate.text) back"
+        default: candidate.text
+        }
+    }
+
     private static func title(for candidate: TypingCandidate) -> String {
         switch candidate.kind {
         case .literal: "\u{201C}\(candidate.text)\u{201D}"
@@ -771,7 +847,12 @@ private struct GlassButtonModifier: ViewModifier {
 /// envelope and this becomes a meter; keep it and it stays an ornament driven
 /// by real sound. Both are defensible. Silently drifting between them is not.
 struct LiveWaveformBars: View {
-    let levels: [Float]
+    @ObservedObject var state: MeterState
+    /// Recording is over: the bars keep their shape and stop reading levels.
+    /// Whether the recording is over. The bars stop moving with it, which they
+    /// do by themselves once no more levels arrive — this is what stops the
+    /// spring from animating the last arrival after the fact.
+    let isHeld: Bool
     let tint: Color
 
     private static let barCount = 15
@@ -781,20 +862,26 @@ struct LiveWaveformBars: View {
     private static let minHeight: CGFloat = 8
     private static let maxHeight: CGFloat = 46
 
-    init(levels: [Float], tint: Color) {
-        self.levels = levels
+    init(state: MeterState, isHeld: Bool, tint: Color) {
+        self.state = state
+        self.isHeld = isHeld
         self.tint = tint
     }
 
     var body: some View {
-        HStack(spacing: Self.barSpacing) {
-            ForEach(0..<Self.barCount, id: \.self) { index in
+        // Once, not once per bar. `derivedHeights` allocates, sines and powers
+        // its way along the whole row; asking each of the fifteen bars for its
+        // own height ran all of that fifteen times a frame, and once more for
+        // the animation to compare against.
+        let heights = derivedHeights
+        return HStack(spacing: Self.barSpacing) {
+            ForEach(Array(heights.enumerated()), id: \.offset) { _, height in
                 RoundedRectangle(cornerRadius: Self.cornerRadius)
                     .fill(tint)
-                    .frame(width: Self.barWidth, height: height(for: index))
+                    .frame(width: Self.barWidth, height: height)
             }
         }
-        .animation(.spring(response: 0.18, dampingFraction: 0.75), value: derivedHeights)
+        .animation(isHeld ? nil : .spring(response: 0.18, dampingFraction: 0.75), value: heights)
     }
 
     private var derivedHeights: [CGFloat] {
@@ -805,7 +892,11 @@ struct LiveWaveformBars: View {
             let position = CGFloat(index) / CGFloat(max(Self.barCount - 1, 1))
             return 0.45 + 0.55 * sin(position * .pi)
         }
-        let recent = levels.suffix(Self.barCount)
+        // Held means the recording is over and the bars stop *reading* new
+        // levels — not that there are none. Handing this an empty array flattened
+        // the whole waveform to its minimum the instant somebody stopped
+        // speaking, which is the opposite of keeping the shape it ended on.
+        let recent = Array(state.levels.suffix(Self.barCount))
         let baseLevel: CGFloat = recent.isEmpty ? 0 : CGFloat(recent.reduce(0, +) / Float(recent.count))
 
         return (0..<Self.barCount).map { i in
@@ -820,9 +911,4 @@ struct LiveWaveformBars: View {
         }
     }
 
-    private func height(for index: Int) -> CGFloat {
-        let heights = derivedHeights
-        guard index < heights.count else { return Self.minHeight }
-        return heights[index]
-    }
 }

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -7,7 +7,10 @@ final class DictationSurfaceState: ObservableObject {
     private var storedState: SessionState = .idle
     var state: SessionState {
         get { storedState }
-        set { change(&storedState, to: newValue) }
+        set {
+            if storedState != newValue { recoveryMessage = nil }
+            change(&storedState, to: newValue)
+        }
     }
     /// The meter's own state. Levels arrive several times a second, and
     /// published here they invalidated the whole surface each time — glass,
@@ -62,9 +65,22 @@ final class DictationSurfaceState: ObservableObject {
     /// copy, and the surface has no business inventing a second wording.
     private var storedCenterMessage: String? = nil
     var centerMessage: String? {
-        get { storedCenterMessage }
+        get { recoveryMessage ?? storedCenterMessage }
         set { change(&storedCenterMessage, to: newValue) }
     }
+    /// Recovery guidance survives polling until the session makes progress.
+    /// Keep it separate from the model message that render refreshes each time.
+    @Published private(set) var recoveryMessage: String?
+    var sessionID: UUID? {
+        didSet {
+            if sessionID != oldValue { recoveryMessage = nil }
+        }
+    }
+
+    func showRecoveryMessage(_ message: String) {
+        recoveryMessage = message
+    }
+
     /// The trailing button in this state: Finish, Insert, Retry, Start.
     private var storedPrimarySymbol: String = "mic.fill"
     var primarySymbol: String {

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -552,9 +552,13 @@ struct DictationSurfaceView: View {
                 .foregroundStyle(state.isDark ? Color.white : Color.black)
                 .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
                 .contentShape(Circle())
+                .background(.ultraThinMaterial, in: Circle())
         }
-        .modifier(GlassButtonModifier(id: "leadGlass", namespace: animationNamespace))
-        .accessibilityLabel("Cancel dictation")
+        // Keep decoration inside the label. Interactive glass around a Menu
+        // participates in its presentation snapshot and can leave the source
+        // button hidden or enlarged after dismissal in the keyboard extension.
+        .buttonStyle(.plain)
+        .accessibilityLabel("Transcription language")
     }
 
     @ViewBuilder
@@ -590,8 +594,9 @@ struct DictationSurfaceView: View {
                 .foregroundStyle(state.isDark ? Color.white : Color.black)
                 .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
                 .contentShape(Circle())
+                .background(.ultraThinMaterial, in: Circle())
         }
-        .modifier(GlassButtonModifier(id: "styleGlass", namespace: animationNamespace))
+        .buttonStyle(.plain)
         .accessibilityLabel("Writing style")
         .accessibilityValue(state.style.displayName)
     }

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -438,7 +438,7 @@ struct DictationSurfaceView: View {
 
                 // Center Waveform and Subtitle
                 VStack(spacing: 16) {
-                    if hasMessage, !isRecording {
+                    if hasMessage, !isRecording, !isWorking {
                         // Nothing to meter: the bars would be decoration on top
                         // of a sentence the reader needs to actually read.
                         EmptyView()
@@ -460,19 +460,23 @@ struct DictationSurfaceView: View {
                         .frame(height: 48)
                     }
 
-                    Text(centerText)
-                        .font(.system(size: 15, weight: .regular))
-                        .multilineTextAlignment(.center)
-                        .lineLimit(3)
-                        .padding(.horizontal, 24)
-                        .foregroundStyle(state.isDark ? Color(white: 0.65) : Color(white: 0.45))
-                        // A reserved line, so swapping one sentence for another
-                        // does not resize the block the waveform is sitting on.
-                        // "Automatic • Clean" and "Transcribing" are not the
-                        // same width, and without this the row re-centres
-                        // around the difference.
-                        .frame(minHeight: 20)
-                        .animation(nil, value: centerText)
+                    ScrollView {
+                        Text(centerText)
+                            .frame(maxWidth: .infinity)
+                            .font(.system(size: 15, weight: .regular))
+                            .multilineTextAlignment(.center)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.horizontal, 24)
+                            .foregroundStyle(state.isDark ? Color(white: 0.65) : Color(white: 0.45))
+                            // A reserved line, so swapping one sentence for another
+                            // does not resize the block the waveform is sitting on.
+                            // "Automatic • Clean" and "Transcribing" are not the
+                            // same width, and without this the row re-centres
+                            // around the difference.
+                            .frame(minHeight: 20)
+                            .animation(nil, value: centerText)
+                    }
+                    .frame(maxHeight: hasMessage && !isWorking ? 140 : 40)
                 }
                 .transition(.asymmetric(
                     insertion: .scale(scale: 0.88).combined(with: .opacity),

--- a/ios/VocaPhoneKeyboard/EmojiPanelView.swift
+++ b/ios/VocaPhoneKeyboard/EmojiPanelView.swift
@@ -245,7 +245,10 @@ final class EmojiPanelView: UIView {
     }
 
     private func applyPalette() {
-        backgroundColor = palette.background
+        // The panel sits inside the keyboard, so it inherits the same surface:
+        // painting the fallback grey here would show as a patch against the
+        // system backdrop the keys stand on.
+        backgroundColor = palette.usesSystemKeyboardBackdrop ? .clear : palette.background
         searchField.backgroundColor = palette.functionKey
         searchField.textColor = palette.keyForeground
         for button in bottomRow.arrangedSubviews.compactMap({ $0 as? UIButton }) {

--- a/ios/VocaPhoneKeyboard/FrameMonitor.swift
+++ b/ios/VocaPhoneKeyboard/FrameMonitor.swift
@@ -1,0 +1,136 @@
+import Foundation
+import os
+import QuartzCore
+
+/// How long the keyboard's frames actually take.
+///
+/// Everything else measured here is main-thread CPU: how long the code for a
+/// keystroke runs. That is not what a person means by a keyboard feeling laggy.
+/// A key press is a picture, and the picture arrives when a frame is composited
+/// — which can be several frames after the code that asked for it, if the work
+/// between them is on the render server rather than in this process. A backdrop
+/// blur is exactly that kind of work, and a keyboard extension shares its render
+/// server with the app it is typing into.
+///
+/// So this measures the other half: the interval between frames, and how many of
+/// them missed. A press that costs one millisecond of code and three frames of
+/// compositing looks, to the finger, like a press that took 50 ms.
+@MainActor
+enum FrameMonitor {
+    private static var link: CADisplayLink?
+    private static var observer: CFRunLoopObserver?
+    /// What the current runloop turn was asked to redraw, and when.
+    private static var pending: (label: String, at: CFTimeInterval)?
+
+    /// Records that something set state the view layer will have to act on.
+    ///
+    /// The cost of a SwiftUI update is not where the code that causes it runs.
+    /// Setting a published property is free; evaluating the bodies it
+    /// invalidated, laying them out and committing the transaction happens at
+    /// the end of the runloop turn, after every measurement this keyboard could
+    /// take from the inside. Timed from the outside instead: from the state
+    /// change to the moment the runloop goes back to sleep.
+    static func noteStateChange(_ label: String) {
+        guard isEnabled else { return }
+        guard pending == nil else { return }
+        pending = (label, CACurrentMediaTime())
+    }
+
+    private static var isEnabled: Bool { link != nil }
+
+    private static func installObserver() {
+        guard observer == nil else { return }
+        let observer = CFRunLoopObserverCreateWithHandler(
+            nil,
+            CFRunLoopActivity.beforeWaiting.rawValue,
+            true,
+            0
+        ) { _, _ in
+            MainActor.assumeIsolated {
+                guard let work = pending else { return }
+                pending = nil
+                let elapsed = (CACurrentMediaTime() - work.at) * 1000
+                guard elapsed > 4 else { return }
+                TouchTrace.note(String(format: "    commit %@ %.1fms", work.label, elapsed))
+            }
+        }
+        CFRunLoopAddObserver(CFRunLoopGetMain(), observer, .commonModes)
+        self.observer = observer
+    }
+    private static var lastTimestamp: CFTimeInterval = 0
+    private static var expected: CFTimeInterval = 1.0 / 60
+    /// Frame intervals since the last report, in milliseconds.
+    private static var intervals: [Double] = []
+    private static var reportedAt: CFTimeInterval = 0
+
+    static func start() {
+        guard link == nil, TouchTrace.isEnabled else { return }
+        let link = CADisplayLink(target: Proxy.shared, selector: #selector(Proxy.tick(_:)))
+        link.add(to: .main, forMode: .common)
+        self.link = link
+        installObserver()
+    }
+
+    static func stop() {
+        link?.invalidate()
+        link = nil
+        if let observer { CFRunLoopRemoveObserver(CFRunLoopGetMain(), observer, .commonModes) }
+        observer = nil
+        pending = nil
+        report()
+    }
+
+    fileprivate static func tick(_ link: CADisplayLink) {
+        expected = link.targetTimestamp - link.timestamp
+        defer { lastTimestamp = link.timestamp }
+        guard lastTimestamp > 0 else {
+            reportedAt = link.timestamp
+            return
+        }
+        let interval = (link.timestamp - lastTimestamp) * 1000
+        intervals.append(interval)
+        // A frame that took more than twice its budget is one a finger can see.
+        if interval > expected * 2000 {
+            TouchTrace.note(String(format: "    FRAME %.1fms (budget %.1f)", interval, expected * 1000))
+        }
+        if link.timestamp - reportedAt >= 2 {
+            reportedAt = link.timestamp
+            report()
+        }
+    }
+
+    private static func report() {
+        guard !intervals.isEmpty else { return }
+        let sorted = intervals.sorted()
+        let budget = expected * 1000
+        let missed = intervals.filter { $0 > budget * 1.5 }.count
+        // Alongside the frames, because an extension that is running out of
+        // room does not fail — it is throttled, and the only symptom is that
+        // everything gets slower the longer it is used.
+        let availableMB = Double(os_proc_available_memory()) / 1_048_576
+        TouchTrace.note(
+            String(
+                format: "frames n=%d budget=%.1fms p50=%.1f p90=%.1f max=%.1f missed=%d "
+                    + "free=%.1fMB",
+                intervals.count,
+                budget,
+                sorted[sorted.count / 2],
+                sorted[Int(Double(sorted.count) * 0.9)],
+                sorted[sorted.count - 1],
+                missed,
+                availableMB
+            )
+        )
+        intervals.removeAll(keepingCapacity: true)
+    }
+
+    /// `CADisplayLink` keeps its target alive and wants an object; the state
+    /// above is the enum's.
+    @MainActor
+    private final class Proxy: NSObject {
+        static let shared = Proxy()
+        @objc func tick(_ link: CADisplayLink) {
+            FrameMonitor.tick(link)
+        }
+    }
+}

--- a/ios/VocaPhoneKeyboard/KeyAlternatives.swift
+++ b/ios/VocaPhoneKeyboard/KeyAlternatives.swift
@@ -132,7 +132,7 @@ final class KeyAlternativesView: UIView {
         // The row is announced by the key's custom actions, not by the popover:
         // VoiceOver never drives this gesture. See `KeyView.accessibility…`.
         isAccessibilityElement = false
-        backgroundColor = palette.standardKey
+        backgroundColor = palette.raisedKey
         layer.cornerRadius = metrics.cornerRadius + 5
         layer.cornerCurve = .continuous
         layer.shadowColor = UIColor.black.cgColor
@@ -163,7 +163,7 @@ final class KeyAlternativesView: UIView {
         self.metrics = metrics
         self.options = options
         highlightedIndex = 0
-        backgroundColor = palette.standardKey
+        backgroundColor = palette.raisedKey
         layer.cornerRadius = metrics.cornerRadius + 5
 
         while labels.count < options.count {

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -153,6 +153,20 @@ final class KeyGridView: UIView {
     private var alternativesView: KeyAlternativesView?
     /// Rebuilt by layout from the same frames that are rendered. Touches never
     /// scan UIKit subviews directly, so a gutter boundary has one stable owner.
+    /// Whether the touch trace may write down which key was pressed.
+    ///
+    /// It may not, in a field that has switched typing intelligence off — a
+    /// password, a passcode, a one-time code. The composition is already kept
+    /// out of those by ``TypingFieldPolicy``, but the trace records individual
+    /// keys, and a character key's name in the trace is the character. A debug
+    /// build would have written somebody's password into the App Group one
+    /// glyph at a time, and `just ios trace` copies that file to a Mac.
+    var traceNamesKeys = true
+
+    private func traceName(for key: KeyView) -> String {
+        traceNamesKeys ? key.spec.cap.traceName : "redacted"
+    }
+
     private(set) var hitMap = KeyHitMap(targets: [])
     private var tracked: [TrackedTouch] = []
     /// The plane key's hold-for-emoji gesture. Owned by the grid rather than by
@@ -280,6 +294,7 @@ final class KeyGridView: UIView {
         let unit = (available - 9 * metrics.columnGap) / 10
         guard unit > 0 else {
             hitMap = KeyHitMap(targets: [])
+            TouchTrace.note("layout ABANDONED, no width")
             return
         }
         // Android's 8dp is measured against its ~40dp key; expressing it as a
@@ -352,6 +367,7 @@ final class KeyGridView: UIView {
             hysteresis: hysteresis,
             likelihood: nextCharacterLikelihood
         )
+        TouchTrace.note("layout targets=\(targets.count)")
     }
 
     /// The native letters plane leaves a larger visual moat around Shift and
@@ -416,6 +432,65 @@ final class KeyGridView: UIView {
         return widths
     }
 
+    /// How far above its own bounds the top row claims, so a finger reaching
+    /// high for `q` through `p` still types. The touch arrives with its real
+    /// location, which is outside the grid, and the hit map is what has to
+    /// forgive it.
+    static let claimedTopMargin: CGFloat = 28
+
+    /// Does nothing, and must exist.
+    ///
+    /// UIKit declines to recognise a touch that lands on a fully transparent
+    /// pixel — not merely declines to route it, but never reports it at all: no
+    /// hit test, no event, no gesture. This grid is transparent by design, since
+    /// it draws over the system's own keyboard backdrop, and the keys are
+    /// painted while the gutters between them are not. A finger landing in a
+    /// gutter therefore vanished, which is what "typing fast, the key doesn't
+    /// press and there's no balloon" was: not a touch this keyboard lost, but a
+    /// touch iOS never admitted to having.
+    ///
+    /// Implementing `draw(_:)` — even emptily — opts the view out of that
+    /// optimisation. The trick is not mine: it is in `ForwardingView.swift` of
+    /// Archagon's open reimplementation of the system keyboard, with the same
+    /// explanation attached, and it has been there for a decade.
+    override func draw(_ rect: CGRect) {}
+
+    /// Every touch inside the grid belongs to the grid.
+    ///
+    /// The keys are drawing, not targets. Hit-testing to them handed each touch
+    /// to a `KeyView` — 516 of 520 in one measured session — and UIKit gives a
+    /// view without `isMultipleTouchEnabled` only the first touch of a
+    /// multi-touch sequence, withholding the rest entirely. The same open
+    /// keyboard above answers this the same way: one view claims every touch,
+    /// and the keys underneath it never see one.
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard !isHidden, alpha > 0, isUserInteractionEnabled else { return nil }
+        return self.point(inside: point, with: event) ? self : nil
+    }
+
+    /// How far above itself the grid will answer for a touch: the gap the stack
+    /// leaves between the dictation bar and the keys, and not one point more.
+    ///
+    /// The gap belongs to nobody, so the keys may have it. What is above the gap
+    /// is the bar, and the bar has buttons in it. This used to claim the full
+    /// `claimedTopMargin`, which reaches 28 points up — past the gap and into
+    /// the bar's own row — and because the grid is the later of the two in the
+    /// stack, it was hit-tested first and won. Pressing the globe typed `q`.
+    ///
+    /// `hitRect` still forgives 28 points, and that is a different question: it
+    /// decides which key a touch the grid has *already been given* belongs to,
+    /// not whether the grid should have been given it.
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        let expanded = bounds.inset(by: UIEdgeInsets(
+            top: -KeyboardChrome.gapAboveKeys,
+            left: -KeyboardChrome.sideMargin,
+            bottom: 0,
+            right: -KeyboardChrome.sideMargin
+        ))
+        return expanded.contains(point)
+    }
+
     /// Keys claim the surrounding gutter, and edge keys claim everything out to
     /// the boundary. A near miss should still type the intended character.
     private func hitRect(
@@ -425,30 +500,23 @@ final class KeyGridView: UIView {
         isTopRow: Bool,
         isBottomRow: Bool
     ) -> CGRect {
-        var rect = frame.insetBy(dx: -metrics.columnGap / 2, dy: -metrics.rowGap / 2)
-        if isLeading {
-            rect = CGRect(x: 0, y: rect.minY, width: rect.maxX, height: rect.height)
-        }
-        if isTrailing {
-            rect = CGRect(
-                x: rect.minX,
-                y: rect.minY,
-                width: bounds.width - rect.minX,
-                height: rect.height
-            )
-        }
-        if isTopRow {
-            rect = CGRect(x: rect.minX, y: 0, width: rect.width, height: rect.maxY)
-        }
-        if isBottomRow {
-            rect = CGRect(
-                x: rect.minX,
-                y: rect.minY,
-                width: rect.width,
-                height: bounds.height - rect.minY
-            )
-        }
-        return rect
+        let slot = frame.insetBy(dx: -metrics.columnGap / 2, dy: -metrics.rowGap / 2)
+        // Built from edges rather than by adding to a width: an edge key's own
+        // boundary has to stay bit-for-bit where the neighbour's begins, or the
+        // gutter between them acquires a hairline nothing owns.
+        var minX = slot.minX
+        var maxX = slot.maxX
+        var minY = slot.minY
+        var maxY = slot.maxY
+        // Only out to the grid's own edge. The stack claims the chrome beyond
+        // it and forwards those touches with the x clamped inside, so widening
+        // these rects buys nothing and costs the exact adjacency that keeps the
+        // gutter between an edge key and its neighbour owned by one of them.
+        if isLeading { minX = 0 }
+        if isTrailing { maxX = bounds.width }
+        if isTopRow { minY = -Self.claimedTopMargin }
+        if isBottomRow { maxY = bounds.height }
+        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
     }
 
     // MARK: - Building
@@ -456,6 +524,10 @@ final class KeyGridView: UIView {
     /// Discards every cached plane. Only geometry or colour changes need this;
     /// a plane switch goes through `activatePlane`.
     private func rebuild() {
+        measured("rebuild") { rebuildBody() }
+    }
+
+    private func rebuildBody() {
         hitMap = KeyHitMap(targets: [])
         endDeleteRepeat()
         cancelPlaneHold()
@@ -481,6 +553,10 @@ final class KeyGridView: UIView {
     }
 
     private func activatePlane() {
+        measured("activatePlane") { activatePlaneBody() }
+    }
+
+    private func activatePlaneBody() {
         // Cleared here and rebuilt before this method returns: never let a
         // touch resolve old target indices against the new plane's views.
         hitMap = KeyHitMap(targets: [])
@@ -521,6 +597,7 @@ final class KeyGridView: UIView {
         // still come out on top, because both bring themselves to the front.
         swipeTrail.color = palette.swipeTrail
         addSubview(swipeTrail)
+        fillPreviewPool()
         updateKeys()
         invalidateIntrinsicContentSize()
         setNeedsLayout()
@@ -551,6 +628,7 @@ final class KeyGridView: UIView {
     /// pinned touch can still commit that letter when it lifts even though the
     /// view behind it now belongs to a plane that is no longer on screen.
     private func pinTouchesToTheirKeys() {
+        if !tracked.isEmpty { TouchTrace.note("pin \(tracked.count) in flight") }
         spaceTrackpadTimer?.invalidate()
         spaceTrackpadTimer = nil
         swipeTrail.cancel()
@@ -574,6 +652,7 @@ final class KeyGridView: UIView {
     }
 
     private func releaseTouches() {
+        if !tracked.isEmpty { TouchTrace.note("RELEASE \(tracked.count) in flight, uncommitted") }
         spaceTrackpadTimer?.invalidate()
         spaceTrackpadTimer = nil
         swipeTrail.cancel()
@@ -600,25 +679,13 @@ final class KeyGridView: UIView {
         }
     }
 
-    /// Does nothing, and must exist.
-    ///
-    /// UIKit declines to recognise a touch that lands on a fully transparent
-    /// pixel — not merely declines to route it, but never reports it at all: no
-    /// hit test, no event, no gesture. Letting the system draw the backdrop, as
-    /// this commit does, is what makes that reachable here: the keys are
-    /// painted and the gutters between them are not, so a finger landing in a
-    /// gutter simply vanished. Typed fast, roughly one keystroke in twenty went
-    /// missing with no trace of a touch anywhere in the process.
-    ///
-    /// Implementing `draw(_:)` — even emptily — opts the view out of that
-    /// optimisation. The trick is not mine: it is in `ForwardingView.swift` of
-    /// Archagon's open reimplementation of the system keyboard, carrying the
-    /// same explanation, and it has been there for a decade.
-    override func draw(_ rect: CGRect) {}
-
     // MARK: - Touch tracking
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        measured("touchesBegan") { beginTouches(touches, with: event) }
+    }
+
+    private func beginTouches(_ touches: Set<UITouch>, with event: UIEvent?) {
         // Sorted, because `Set` has no order and two thumbs landing inside one
         // event would otherwise type in whichever order the set happened to
         // hash — the letters of a fast word arriving transposed.
@@ -626,9 +693,19 @@ final class KeyGridView: UIView {
             let point = touch.location(in: self)
             guard let index = keyIndex(at: point, characterOnly: false)
             else {
+                TouchTrace.note(
+                    "began \(TouchTrace.name(touch)) "
+                        + "(\(Int(point.x)),\(Int(point.y))) NO KEY "
+                        + "targets=\(hitMap.targets.count) tracked=\(tracked.count)"
+                )
                 continue
             }
             let key = keyViews[index]
+            TouchTrace.note(
+                "began \(TouchTrace.name(touch)) "
+                    + "(\(Int(point.x)),\(Int(point.y))) "
+                    + "\(traceName(for: key)) tracked=\(tracked.count)"
+            )
             // A dimmed Return takes no touch at all — not the highlight and not
             // the click, both of which would promise something it will not do.
             if key.spec.cap == .newline, !returnKeyIsEnabled { continue }
@@ -638,10 +715,10 @@ final class KeyGridView: UIView {
             // The click belongs to the press, not to the commit: the system
             // keyboard sounds a key as the finger lands, and every key here
             // does the same so the rhythm never depends on which key it was.
-            feedback.keyPressed()
-            showPreview(for: item)
+            measured("feedback") { feedback.keyPressed() }
+            measured("showPreview") { showPreview(for: item) }
             if key.spec.cap == .space { scheduleSpaceTrackpad(for: item) }
-            scheduleAlternatives(for: item)
+            measured("scheduleAlternatives") { scheduleAlternatives(for: item) }
             if case .plane = key.spec.cap {
                 beginPlaneHold(at: point)
                 planeHoldTouch = touch
@@ -711,7 +788,7 @@ final class KeyGridView: UIView {
                 // Function keys stay bound to their own touch but disengage when
                 // the finger wanders off, so a drag away cancels instead of
                 // firing something the user no longer intends.
-                let isInside = item.key.hitRect.contains(point)
+                let isInside = stillHolds(item.key, at: point)
                 guard item.isEngaged != isInside else { continue }
                 item.isEngaged = isInside
                 setHighlight(isInside, on: item.key)
@@ -821,8 +898,28 @@ final class KeyGridView: UIView {
         var planeToRestore: KeyPlane?
         for touch in touches.sorted(by: { $0.timestamp < $1.timestamp }) {
             if planeHoldTouch === touch { cancelPlaneHold() }
-            guard let index = tracked.firstIndex(where: { $0.touch === touch }) else { continue }
+            guard let index = tracked.firstIndex(where: { $0.touch === touch }) else {
+                TouchTrace.note(
+                    "\(commit ? "end" : "cancel") \(TouchTrace.name(touch)) UNTRACKED"
+                )
+                continue
+            }
             let item = tracked.remove(at: index)
+            // How far the finger went between landing and lifting. A letter
+            // that never appeared and left no touch at all has one remaining
+            // explanation this keyboard could act on: the finger never left the
+            // glass, so the second key was a continuation of the first press
+            // rather than a press of its own. A long travel here is what that
+            // looks like from inside.
+            let lift = touch.location(in: self)
+            let travel = hypot(lift.x - item.initialPoint.x, lift.y - item.initialPoint.y)
+            TouchTrace.note(
+                "\(commit ? "end" : "cancel") \(TouchTrace.name(touch)) "
+                    + "\(traceName(for: item.key)) engaged=\(item.isEngaged) "
+                    + "pinned=\(item.isPinned) swipe=\(item.isSwiping) "
+                    + "cursor=\(item.isCursorTracking) "
+                    + "travel=\(Int(travel)) at (\(Int(lift.x)),\(Int(lift.y)))"
+            )
             if item.key.spec.cap == .space {
                 spaceTrackpadTimer?.invalidate()
                 spaceTrackpadTimer = nil
@@ -834,7 +931,7 @@ final class KeyGridView: UIView {
             // only, so sliding back onto the modifier leaves `item.key` on the
             // letter it passed over. Lifting there must type nothing.
             if item.isModifierSlide,
-               !item.key.hitRect.contains(touch.location(in: self))
+               !stillHolds(item.key, at: touch.location(in: self))
             {
                 shouldCommit = false
             }
@@ -956,7 +1053,7 @@ final class KeyGridView: UIView {
                 spaceTrackpadTimer?.invalidate()
                 spaceTrackpadTimer = nil
             }
-            item.isEngaged = item.key.hitRect.contains(point)
+            item.isEngaged = stillHolds(item.key, at: point)
             setHighlight(item.isEngaged, on: item.key)
             return
         }
@@ -1190,9 +1287,56 @@ final class KeyGridView: UIView {
         return keyViews[index]
     }
 
+    /// Times one phase of a touch into the trace.
+    ///
+    /// Everything measured so far happened on the *lift* — the letter, the
+    /// suggestions, the strip. What a person means by a keyboard feeling heavy
+    /// is the other end: the gap between the finger landing and the key looking
+    /// pressed. That is this method's half.
+    private func measured<T>(_ name: String, _ body: () -> T) -> T {
+        guard TouchTrace.isEnabled else { return body() }
+        let startedAt = CACurrentMediaTime()
+        defer {
+            TouchTrace.note(
+                String(format: "    %@ %.1fms", name, (CACurrentMediaTime() - startedAt) * 1000)
+            )
+        }
+        return body()
+    }
+
+    /// Whether a finger that pressed `key` is still holding it.
+    ///
+    /// The same slack the hit map already allows before it hands a *sliding*
+    /// finger to a neighbour, applied to the question of whether a *held* key
+    /// is still held. Without it that boundary is a knife edge, and every press
+    /// moves: a thumb landing just inside the space bar's top edge and rolling
+    /// upward as it presses leaves the rect it is standing on, disengages, and
+    /// lifts having typed nothing.
+    ///
+    /// Measured on device: two spaces in 442 keystrokes were pressed, tracked
+    /// and silently dropped, both within 2 pt of the bottom row's top edge —
+    /// which is what "this is" arriving as "thisis" was. Worse than the missing
+    /// space, the composition then ran two words together and autocorrect
+    /// started offering to fix the result.
+    private func stillHolds(_ key: KeyView, at point: CGPoint) -> Bool {
+        let slack = hitMap.hysteresis
+        return key.hitRect.insetBy(dx: -slack, dy: -slack).contains(point)
+    }
+
     private func keyIndex(at point: CGPoint, characterOnly: Bool) -> Int? {
-        guard let index = hitMap.targetIndex(at: point, characterOnly: characterOnly),
-              keyViews.indices.contains(index)
+        let clamped = CGPoint(
+            x: min(max(point.x, 0.5), max(bounds.width - 0.5, 0.5)),
+            y: min(max(point.y, 0.5), max(bounds.height - 0.5, 0.5))
+        )
+        // The clamped point is the second question, not a different answer: a
+        // touch that landed in the chrome beside the grid is asked about at the
+        // nearest point inside it. What is deliberately absent is a fall back to
+        // the *nearest* key — the hit map tiles the whole grid including its
+        // gutters, so a point it does not claim is a point outside the keys, and
+        // typing the closest letter to it would be inventing a keystroke.
+        guard let index = hitMap.targetIndex(at: point, characterOnly: characterOnly)
+            ?? hitMap.targetIndex(at: clamped, characterOnly: characterOnly),
+            keyViews.indices.contains(index)
         else { return nil }
         return index
     }
@@ -1379,11 +1523,35 @@ final class KeyGridView: UIView {
 
     /// Reused rather than allocated per touch; a fast typist would otherwise
     /// create and discard a view for every keystroke.
+    /// How many balloons the grid keeps standing by.
+    ///
+    /// Six, and all of them exist before the first keystroke. A pool that runs
+    /// out is a pool that builds a `KeyPreviewView` and calls `addSubview` from
+    /// inside `touchesBegan` — mutating the view hierarchy in the middle of
+    /// UIKit delivering touches through it, and tearing it down again a moment
+    /// later. At typing speed that happened on every letter, which is exactly
+    /// when the fingers are arriving fastest and a lost press is least
+    /// forgivable. Six covers two thumbs with four balloons still fading.
+    private static let previewPoolSize = 6
+
+    private func fillPreviewPool() {
+        guard metrics.showsPreview else { return }
+        while previewPool.count < Self.previewPoolSize {
+            let preview = KeyPreviewView(palette: palette, metrics: metrics)
+            preview.isHidden = true
+            addSubview(preview)
+            previewPool.append(preview)
+        }
+    }
+
     private func dequeuePreview() -> KeyPreviewView {
         if let reused = previewPool.popLast() {
             reused.isHidden = false
             return reused
         }
+        // Only reachable if six balloons are in flight at once, which two hands
+        // cannot manage. It still must not fail, so it builds one — and the
+        // pool below keeps it rather than tearing it down again.
         let preview = KeyPreviewView(palette: palette, metrics: metrics)
         addSubview(preview)
         return preview
@@ -1402,8 +1570,10 @@ final class KeyGridView: UIView {
             animated: metrics.showsPreview && KeyboardPreferences.keyPreviewAnimates
         ) { [weak self, weak preview] in
             guard let self, let preview else { return }
-            // Two covers two-thumb typing; holding more would just retain views.
-            guard previewPool.count < 2, preview.superview === self else {
+            // Kept, not torn down. Removing a view from the hierarchy while
+            // touches are being delivered through it is the same disruption as
+            // adding one, and a balloon costs nothing to leave hidden.
+            guard previewPool.count < Self.previewPoolSize, preview.superview === self else {
                 preview.removeFromSuperview()
                 return
             }

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -600,6 +600,22 @@ final class KeyGridView: UIView {
         }
     }
 
+    /// Does nothing, and must exist.
+    ///
+    /// UIKit declines to recognise a touch that lands on a fully transparent
+    /// pixel — not merely declines to route it, but never reports it at all: no
+    /// hit test, no event, no gesture. Letting the system draw the backdrop, as
+    /// this commit does, is what makes that reachable here: the keys are
+    /// painted and the gutters between them are not, so a finger landing in a
+    /// gutter simply vanished. Typed fast, roughly one keystroke in twenty went
+    /// missing with no trace of a touch anywhere in the process.
+    ///
+    /// Implementing `draw(_:)` — even emptily — opts the view out of that
+    /// optimisation. The trick is not mine: it is in `ForwardingView.swift` of
+    /// Archagon's open reimplementation of the system keyboard, carrying the
+    /// same explanation, and it has been there for a decade.
+    override func draw(_ rect: CGRect) {}
+
     // MARK: - Touch tracking
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -609,7 +625,9 @@ final class KeyGridView: UIView {
         for touch in touches.sorted(by: { $0.timestamp < $1.timestamp }) {
             let point = touch.location(in: self)
             guard let index = keyIndex(at: point, characterOnly: false)
-            else { continue }
+            else {
+                continue
+            }
             let key = keyViews[index]
             // A dimmed Return takes no touch at all — not the highlight and not
             // the click, both of which would promise something it will not do.
@@ -1205,6 +1223,23 @@ final class KeyGridView: UIView {
         key.isHighlighted = false
     }
 
+#if DEBUG
+    /// Shows a key's preview with no touch behind it, so the balloon can be
+    /// rendered and looked at without installing the keyboard on a device.
+    ///
+    /// The throwaway `TrackedTouch` is deliberately not added to `tracked`: it
+    /// carries no real `UITouch`, and live touch tracking must never see one.
+    /// `showPreview` only reads the item, and the balloon it dequeues is a
+    /// subview of the grid, so it survives for the render either way. Its
+    /// `keyIndex` is deliberately out of range for the same reason: nothing
+    /// will ever ask the hit map to re-target it.
+    func previewKeyForRendering(_ key: KeyView) {
+        showPreview(
+            for: TrackedTouch(touch: UITouch(), key: key, keyIndex: -1, initialPoint: .zero)
+        )
+    }
+#endif
+
     // MARK: - Timers
 
     /// One-shot timer on the *common* run loop modes.
@@ -1339,25 +1374,8 @@ final class KeyGridView: UIView {
         // Only the first appearance grows. Sliding from one key to the next
         // moves the same balloon, and re-animating it there would be the glyph
         // pulsing under a finger that is simply correcting its aim.
-        if isNew { preview.appear(animated: true) }
+        if isNew { preview.appear(animated: KeyboardPreferences.keyPreviewAnimates) }
     }
-
-#if DEBUG
-    /// Shows a key's preview with no touch behind it, so the balloon can be
-    /// rendered and looked at without installing the keyboard on a device.
-    ///
-    /// The throwaway `TrackedTouch` is deliberately not added to `tracked`: it
-    /// carries no real `UITouch`, and live touch tracking must never see one.
-    /// `showPreview` only reads the item, and the balloon it dequeues is a
-    /// subview of the grid, so it survives for the render either way. Its
-    /// `keyIndex` is deliberately out of range for the same reason: nothing
-    /// will ever ask the hit map to re-target it.
-    func previewKeyForRendering(_ key: KeyView) {
-        showPreview(
-            for: TrackedTouch(touch: UITouch(), key: key, keyIndex: -1, initialPoint: .zero)
-        )
-    }
-#endif
 
     /// Reused rather than allocated per touch; a fast typist would otherwise
     /// create and discard a view for every keystroke.
@@ -1380,7 +1398,9 @@ final class KeyGridView: UIView {
     /// the line.
     private func recycle(_ preview: KeyPreviewView?) {
         guard let preview else { return }
-        preview.disappear(animated: metrics.showsPreview) { [weak self, weak preview] in
+        preview.disappear(
+            animated: metrics.showsPreview && KeyboardPreferences.keyPreviewAnimates
+        ) { [weak self, weak preview] in
             guard let self, let preview else { return }
             // Two covers two-thumb typing; holding more would just retain views.
             guard previewPool.count < 2, preview.superview === self else {

--- a/ios/VocaPhoneKeyboard/KeyLayout.swift
+++ b/ios/VocaPhoneKeyboard/KeyLayout.swift
@@ -25,6 +25,24 @@ enum KeyPlane: Equatable {
     }
 }
 
+/// The space around the keys that belongs to the keyboard rather than to any
+/// key, in points.
+///
+/// Three views have to agree about these two numbers, and they used to hold
+/// five copies between two files, tied together by a comment. The stack lays
+/// the gap out, the grid claims it — a stack's spacing belongs to no subview,
+/// so a touch landing there is delivered to nobody — and the stack's own hit
+/// test forwards from both. Changing one copy and not the others is silent:
+/// the stack simply starts claiming a strip the grid does not answer for.
+enum KeyboardChrome {
+    /// Between the dictation bar and the top row.
+    static let gapAboveKeys: CGFloat = 12
+    /// Beyond the grid's left and right edges, out into the keyboard's own
+    /// margin — wider than that margin, so a thumb landing on the bezel side
+    /// of `a` or `l` is not thrown away.
+    static let sideMargin: CGFloat = 8
+}
+
 enum KeyCap: Equatable {
     /// Stores the unshifted form. Letters resolve through the current shift
     /// state; digits and punctuation ignore it.
@@ -50,6 +68,14 @@ enum KeyCap: Equatable {
     /// Whether this key can be pressed at all. A blank is laid out and drawn as
     /// nothing, and must never take a touch from the keys either side of it.
     var isInteractive: Bool { self != .blank }
+
+    /// A name for this key in a touch trace. Not user-facing.
+    var traceName: String {
+        switch self {
+        case let .character(base): base
+        default: String(describing: self).prefix(12).description
+        }
+    }
 
     func resolvedText(shift: ShiftState) -> String? {
         guard case let .character(value) = self else { return nil }

--- a/ios/VocaPhoneKeyboard/KeyLayout.swift
+++ b/ios/VocaPhoneKeyboard/KeyLayout.swift
@@ -172,7 +172,7 @@ enum KeyLayout {
                 KeyRow(keys: [
                     KeySpec(cap: .plane(.symbols), width: .fill, style: .function)
                 ]
-                    + map(".,?!'")
+                    + fillMap(".,?!'")
                     + [KeySpec(cap: .delete, width: .fill, style: .function)]),
                 bottomRow(
                     planeSwitch: .letters,
@@ -188,7 +188,7 @@ enum KeyLayout {
                 KeyRow(keys: [
                     KeySpec(cap: .plane(.numbers), width: .fill, style: .function)
                 ]
-                    + map(".,?!'")
+                    + fillMap(".,?!'")
                     + [KeySpec(cap: .delete, width: .fill, style: .function)]),
                 bottomRow(
                     planeSwitch: .letters,
@@ -379,6 +379,19 @@ enum KeyLayout {
         characters.map { KeySpec.letter(String($0)) }
     }
 
+    /// Character keys that share the row's slack instead of standing at one
+    /// letter column each.
+    ///
+    /// The punctuation row of the numbers and symbols planes has seven keys
+    /// against the ten columns above it. Leaving the five characters at a
+    /// column apiece handed all three spare columns to `#+=` and Delete, which
+    /// came out at two and a half columns each — two slabs on either side of
+    /// five narrow punctuation keys. The system divides that row evenly, and
+    /// the keys people actually reach for there are the punctuation.
+    private static func fillMap(_ characters: String) -> [KeySpec] {
+        characters.map { KeySpec(cap: .character(String($0)), width: .fill) }
+    }
+
     /// Title shown on the plane-switch key, mirroring the system keyboard.
     static func planeTitle(_ plane: KeyPlane) -> String {
         switch plane {
@@ -412,6 +425,14 @@ struct KeyboardMetrics: Equatable {
     /// Regular-width iPads and landscape phones are resolved from their traits
     /// instead: a regular/regular canvas has room the preference was never
     /// scaled for, and a compact-height phone has none to give.
+    /// The glyph sizes and radii are read off the system keyboard rather than
+    /// derived: a letter is roughly 0.58 of the key's height and the corner is
+    /// roughly 0.23 of it. The keyboard this replaced sat at 0.51 and 0.14,
+    /// which is what "small letters on square keys" measures out to.
+    ///
+    /// Note that the system does *not* scale its key glyphs with Dynamic Type.
+    /// ``KeyFont/scaled(_:maximum:weight:)`` still does, within a bound, which
+    /// is a deliberate difference and the reason the maximum exists.
     static func resolved(
         for traits: UITraitCollection,
         preference: KeyboardHeightPreference = KeyboardPreferences.keyboardHeight
@@ -422,9 +443,9 @@ struct KeyboardMetrics: Equatable {
                 rowGap: 12,
                 columnGap: 11,
                 sideInset: 8,
-                letterFontSize: 24,
-                functionFontSize: 17,
-                cornerRadius: 7
+                letterFontSize: 25,
+                functionFontSize: 18,
+                cornerRadius: 10
             )
         }
         if traits.verticalSizeClass == .compact {
@@ -435,9 +456,9 @@ struct KeyboardMetrics: Equatable {
                 rowGap: 6,
                 columnGap: 5,
                 sideInset: 3,
-                letterFontSize: 17,
-                functionFontSize: 13,
-                cornerRadius: 5
+                letterFontSize: 18,
+                functionFontSize: 14,
+                cornerRadius: 7
             )
         }
         switch preference {
@@ -447,9 +468,9 @@ struct KeyboardMetrics: Equatable {
                 rowGap: 9,
                 columnGap: 6,
                 sideInset: 2 / 3,
-                letterFontSize: 21,
-                functionFontSize: 15,
-                cornerRadius: 6
+                letterFontSize: 23,
+                functionFontSize: 16,
+                cornerRadius: 9
             )
         case .standard:
             return KeyboardMetrics(
@@ -457,9 +478,9 @@ struct KeyboardMetrics: Equatable {
                 rowGap: 11,
                 columnGap: 6,
                 sideInset: 2 / 3,
-                letterFontSize: 22,
-                functionFontSize: 16,
-                cornerRadius: 6
+                letterFontSize: 24,
+                functionFontSize: 17,
+                cornerRadius: 10
             )
         case .tall:
             return KeyboardMetrics(
@@ -467,9 +488,13 @@ struct KeyboardMetrics: Equatable {
                 rowGap: 12,
                 columnGap: 6,
                 sideInset: 2 / 3,
-                letterFontSize: 23,
-                functionFontSize: 16,
-                cornerRadius: 7
+                // 0.55 of the key, like the other two heights. It was 0.51
+                // here — the tall keyboard kept the old proportion when the
+                // others were corrected, which is the sort of thing nobody
+                // notices until the ratio is written down as a test.
+                letterFontSize: 27,
+                functionFontSize: 17,
+                cornerRadius: 11
             )
         }
     }
@@ -492,6 +517,19 @@ struct KeyboardPalette: Equatable {
         return false
     }
 
+    /// Whether the extension may leave the surface behind the keys unpainted
+    /// and let `UIInputView`'s keyboard style draw it.
+    ///
+    /// ``background`` below is this project's guess at the colour iOS puts
+    /// behind a keyboard, and a guess is exactly what makes a keyboard read as
+    /// somebody else's product: it is one grey nothing else on the phone uses.
+    /// The input view the extension is handed already draws the real thing, in
+    /// every host, both appearances, and the next iOS as well.
+    ///
+    /// ``background`` stays for the surfaces that have no input view to borrow
+    /// it from — the settings preview and the SwiftUI canvases.
+    var usesSystemKeyboardBackdrop: Bool { usesUnifiedSystemKeyFill }
+
     /// Neutral charcoal in dark, neutral grey in light. Both were previously
     /// tinted toward blue, which is the drift the design standard names.
     var background: UIColor {
@@ -511,12 +549,38 @@ struct KeyboardPalette: Equatable {
 
     /// The brightest key in either appearance, because a character key is what
     /// the eye should land on first.
+    ///
+    /// In dark this is *translucent*, and that is the whole point. The 61/255
+    /// this replaces was read off a screenshot of the system keyboard sitting
+    /// on its own near-black backdrop — a true pixel, but a composite one. The
+    /// system draws a light film over whatever is behind the keyboard, so on
+    /// Spotlight or over a bright wallpaper its keys lift and stay legible,
+    /// while an opaque 61/255 stays flat black wherever it is put. That is the
+    /// difference between this keyboard and the system one on a home screen.
+    ///
+    /// The alpha is chosen to reproduce the measured pixel exactly against the
+    /// backdrop it was measured on: 23 + (255 − 23) × 0.164 ≈ 61.
     var standardKey: UIColor {
         if usesUnifiedSystemKeyFill {
-            return isDark ? UIColor(white: 61 / 255, alpha: 1) : .white
+            // Declared in RGB rather than `UIColor(white:alpha:)`: the
+            // contrast maths reads colours through `getRed`, which reports
+            // nothing for a translucent monochrome colour and silently scores
+            // it as black. Everything else in this palette is RGB for the same
+            // reason.
+            return isDark ? UIColor(red: 1, green: 1, blue: 1, alpha: 0.164) : .white
         }
         return isDark ? UIColor(white: 0.29, alpha: 1) : .white
     }
+
+    /// The fill for a surface that floats *above* the keys — the magnified
+    /// preview balloon and the accent popover.
+    ///
+    /// Flattened, not filmed. ``standardKey`` is translucent in dark so a key
+    /// can pick up whatever the keyboard is standing on, but a balloon lifted
+    /// over the row is standing on the keys themselves: left translucent, it
+    /// shows the letters it exists to cover, which is what a magnified preview
+    /// is for.
+    var raisedKey: UIColor { standardKey.compositedOver(background) }
 
     /// Visibly a step down from ``standardKey``, and neutral — a muddy or blue
     /// function key is what made the old palette read as someone else's product.
@@ -606,7 +670,12 @@ private extension UIColor {
             red: red + (otherRed - red) * mix,
             green: green + (otherGreen - green) * mix,
             blue: blue + (otherBlue - blue) * mix,
-            alpha: 1
+            // Alpha mixes with everything else. Pinning it to 1 was safe while
+            // every fill here was opaque; against the translucent dark key it
+            // turned a press into solid white — with white labels on it. The
+            // accent this was written for still comes out solid, because its
+            // own alpha is 1 and mixing 1 with 1 is 1.
+            alpha: alpha + (otherAlpha - alpha) * mix
         )
     }
 }

--- a/ios/VocaPhoneKeyboard/KeyLayout.swift
+++ b/ios/VocaPhoneKeyboard/KeyLayout.swift
@@ -654,17 +654,19 @@ private extension UIColor {
     /// would have let the key background show through a key that is meant to
     /// stay solid.
     func blended(with other: UIColor, amount: CGFloat) -> UIColor {
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
-        var otherRed: CGFloat = 0
-        var otherGreen: CGFloat = 0
-        var otherBlue: CGFloat = 0
-        var otherAlpha: CGFloat = 0
-        guard getRed(&red, green: &green, blue: &blue, alpha: &alpha),
-              other.getRed(&otherRed, green: &otherGreen, blue: &otherBlue, alpha: &otherAlpha)
+        // Through `ContrastMath.rgba`, which falls back to `getWhite`.
+        //
+        // `getRed` answers nothing for a monochrome colour, and the two this is
+        // always mixed with — `.white` and `.black` — are exactly that. The
+        // guard then returned the colour unchanged, so on any build where that
+        // happens a pressed key kept its resting fill: the press had no visible
+        // effect at all. This is the same trap the luminance maths was just
+        // taken out of, one file away.
+        guard let base = ContrastMath.rgba(self),
+              let mixer = ContrastMath.rgba(other)
         else { return self }
+        let (red, green, blue, alpha) = base
+        let (otherRed, otherGreen, otherBlue, otherAlpha) = mixer
         let mix = min(max(amount, 0), 1)
         return UIColor(
             red: red + (otherRed - red) * mix,

--- a/ios/VocaPhoneKeyboard/KeyView.swift
+++ b/ios/VocaPhoneKeyboard/KeyView.swift
@@ -36,12 +36,19 @@ final class KeyView: UIView {
     /// key never looked pressed, which is what "some keys don't respond" turns
     /// out to be: the input is fine and the feedback is missing.
     ///
-    /// Four frames is enough to be seen and short enough to be gone before the
-    /// next letter needs the same key.
-    static let minimumHighlightSeconds: TimeInterval = 0.07
+    /// One composited frame, and not a millisecond more than it takes to
+    /// guarantee one. This was four frames, on the reasoning that four is
+    /// easier to see than one — but the hold runs *after the finger has left*,
+    /// and a fast typist is on the next key 125 ms later. At 70 ms the key they
+    /// just left was still lit under the key they were pressing, and the
+    /// keyboard read as trailing a letter or two behind the hand. What the
+    /// press needs is to be drawn at all; 20 ms clears a 60 Hz frame and is
+    /// gone before the hand arrives anywhere else.
 
     /// How long the release has to wait so the press was visible. Pure, so the
     /// rule can be tested without a screen.
+    static let minimumHighlightSeconds: TimeInterval = 0.02
+
     static func releaseDelay(shownFor seconds: TimeInterval) -> TimeInterval {
         max(0, minimumHighlightSeconds - seconds)
     }
@@ -113,6 +120,13 @@ final class KeyView: UIView {
 
         layer.cornerCurve = .continuous
         applyShadow()
+        // A key is the view a touch is hit-tested to — 516 of 520 touches in a
+        // measured session landed on one of these rather than on the grid behind
+        // them. UIKit gives a view with this flag off *only the first touch of a
+        // multi-touch sequence* and withholds the rest, delivering them nowhere
+        // at all. The grid has always had it on; the keys the touches actually
+        // arrive at did not.
+        isMultipleTouchEnabled = true
 
         titleLabel.textAlignment = .center
         titleLabel.adjustsFontSizeToFitWidth = true
@@ -364,8 +378,12 @@ final class KeyView: UIView {
             apply()
             return
         }
+        // Half of what it was. The key settles back rather than snapping — the
+        // system's does the same — but 110 ms of settling ran on past the next
+        // keystroke, and a row of keys still fading behind the hand is exactly
+        // what a keyboard lagging looks like.
         UIView.animate(
-            withDuration: 0.11,
+            withDuration: 0.06,
             delay: 0,
             options: [.beginFromCurrentState, .allowUserInteraction],
             animations: apply
@@ -388,6 +406,17 @@ final class KeyPreviewView: UIView {
     private let balloonCornerRadius: CGFloat
     private var balloonHeight: CGFloat = 0
     private var neck: CGRect = .zero
+    private var appearedAt: CFTimeInterval = 0
+
+    /// A balloon says where the finger is. It has no business outliving it.
+    ///
+    /// This was held for 70 ms past the lift, so that a tap shorter than a frame
+    /// still showed one. What it actually produced was a balloon still standing
+    /// over the row while the next key was being pressed — two and three of them
+    /// at typing speed — which is what "the keyboard lags when I move between
+    /// keys" turned out to be. The key's own highlight is what guarantees a
+    /// press is seen, and it is bounded for that. This one follows the finger.
+    static let minimumPreviewSeconds: TimeInterval = 0
 
     init(palette: KeyboardPalette, metrics: KeyboardMetrics) {
         keyCornerRadius = metrics.cornerRadius
@@ -456,6 +485,7 @@ final class KeyPreviewView: UIView {
     /// The anchor is the bottom of the view, which is the bottom of the *key*,
     /// so the growth runs upward out of what the finger is covering.
     func appear(animated: Bool) {
+        appearedAt = CACurrentMediaTime()
         layer.removeAllAnimations()
         isHidden = false
         guard animated, !UIAccessibility.isReduceMotionEnabled else {
@@ -463,14 +493,19 @@ final class KeyPreviewView: UIView {
             transform = .identity
             return
         }
-        alpha = 0
+        // Opaque from the first frame. The balloon confirms a key that is
+        // already under the finger, so anything it fades in over is time the
+        // press spends looking unanswered — at 90 ms that was most of a fast
+        // keystroke, and it is what "not as quick as other keyboards" measured
+        // out to. The growth stays: the system's balloon grows out of its key
+        // too, and a scale is free where an opacity ramp is a delay.
+        alpha = 1
         transform = Self.growth(from: 0.82, 0.62, in: bounds)
         UIView.animate(
-            withDuration: 0.09,
+            withDuration: 0.05,
             delay: 0,
             options: [.beginFromCurrentState, .allowUserInteraction]
         ) {
-            self.alpha = 1
             self.transform = .identity
         }
     }
@@ -480,6 +515,14 @@ final class KeyPreviewView: UIView {
     /// `completion` runs whether or not the fade finished, so a pooled preview
     /// is never left half-transparent for the next keystroke to dequeue.
     func disappear(animated: Bool, completion: @escaping () -> Void) {
+        let elapsed = CACurrentMediaTime() - appearedAt
+        let remaining = max(0, Self.minimumPreviewSeconds - elapsed)
+        if remaining > 0 {
+            DispatchQueue.main.asyncAfter(deadline: .now() + remaining) { [weak self] in
+                self?.disappear(animated: animated, completion: completion)
+            }
+            return
+        }
         layer.removeAllAnimations()
         let finish = {
             self.isHidden = true

--- a/ios/VocaPhoneKeyboard/KeyView.swift
+++ b/ios/VocaPhoneKeyboard/KeyView.swift
@@ -28,10 +28,60 @@ final class KeyView: UIView {
     /// layout because only the grid knows which keys sit against an edge.
     var hitRect: CGRect = .zero
 
+    /// How long a press stays visible even when the finger has already gone.
+    ///
+    /// A tap can be shorter than a frame. On a 60 Hz panel that is 16.6 ms, and
+    /// a keystroke that goes down and up inside one frame is composited exactly
+    /// once — with the key already back at rest. The letter is typed and the
+    /// key never looked pressed, which is what "some keys don't respond" turns
+    /// out to be: the input is fine and the feedback is missing.
+    ///
+    /// Four frames is enough to be seen and short enough to be gone before the
+    /// next letter needs the same key.
+    static let minimumHighlightSeconds: TimeInterval = 0.07
+
+    /// How long the release has to wait so the press was visible. Pure, so the
+    /// rule can be tested without a screen.
+    static func releaseDelay(shownFor seconds: TimeInterval) -> TimeInterval {
+        max(0, minimumHighlightSeconds - seconds)
+    }
+
+    private var highlightedAt: CFTimeInterval = 0
+    private var pendingRelease: DispatchWorkItem?
+
     var isHighlighted = false {
         didSet {
             guard isHighlighted != oldValue else { return }
-            applyColors(animated: !isHighlighted)
+            // A press that arrives during the hold cancels it: the key is being
+            // used again, and it must look pressed now rather than finish
+            // showing the last one.
+            pendingRelease?.cancel()
+            pendingRelease = nil
+            if isHighlighted {
+                highlightedAt = CACurrentMediaTime()
+                applyColors()
+                return
+            }
+            let delay = Self.releaseDelay(shownFor: CACurrentMediaTime() - highlightedAt)
+            if delay > 0 {
+                let work = DispatchWorkItem { [weak self] in
+                    guard let self, !isHighlighted else { return }
+                    applyColors(animated: KeyboardPreferences.keyReleaseFade)
+                }
+                pendingRelease = work
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+                return
+            }
+            // Only a character key settles back. Delete, Shift and the plane
+            // keys drop their highlight the instant the finger leaves, which is
+            // what the system does: a held Delete lifts to a key that is
+            // already grey again, where a fade of even a tenth of a second
+            // reads as the key sticking to the thumb.
+            applyColors(
+                animated: !isHighlighted
+                    && spec.cap.isCharacter
+                    && KeyboardPreferences.keyReleaseFade
+            )
         }
     }
 
@@ -62,10 +112,7 @@ final class KeyView: UIView {
         super.init(frame: .zero)
 
         layer.cornerCurve = .continuous
-        layer.shadowColor = UIColor.black.cgColor
-        layer.shadowOpacity = 0.16
-        layer.shadowRadius = 0.75
-        layer.shadowOffset = CGSize(width: 0, height: 1.25)
+        applyShadow()
 
         titleLabel.textAlignment = .center
         titleLabel.adjustsFontSizeToFitWidth = true
@@ -82,9 +129,6 @@ final class KeyView: UIView {
         // must not be somewhere VoiceOver can land either.
         isAccessibilityElement = spec.cap.isInteractive
         accessibilityTraits = .keyboardKey
-        if !spec.cap.isInteractive {
-            layer.shadowOpacity = 0
-        }
         refresh()
     }
 
@@ -100,6 +144,8 @@ final class KeyView: UIView {
         layer.cornerRadius = metrics.cornerRadius
         // Without an explicit path every key forces an offscreen pass to derive
         // its shadow, which is expensive when thirty of them redraw at once.
+        // Nothing to derive when nothing is drawn.
+        guard layer.shadowOpacity > 0 else { return }
         layer.shadowPath = UIBezierPath(
             roundedRect: bounds,
             cornerRadius: metrics.cornerRadius
@@ -278,6 +324,24 @@ final class KeyView: UIView {
         return .standard
     }
 
+    /// The drop shadow under a key.
+    ///
+    /// 16% black at a 0.75pt radius, one point down, is a hard dark line under
+    /// every key — the contact shadow of a keyboard nobody has drawn this way
+    /// in years, thirty of them at once. Where the keys carry the system's own
+    /// fill against the system's own backdrop, that separation is already
+    /// there, and this draws nothing.
+    private func applyShadow() {
+        guard !palette.usesSystemKeyboardBackdrop, spec.cap.isInteractive else {
+            layer.shadowOpacity = 0
+            return
+        }
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.16
+        layer.shadowRadius = 0.75
+        layer.shadowOffset = CGSize(width: 0, height: 1.25)
+    }
+
     private func applyColors(animated: Bool = false) {
         let style = renderedStyle
         let background = isHighlighted
@@ -334,7 +398,7 @@ final class KeyPreviewView: UIView {
         // The shape carries the fill and the shadow; the view itself must not
         // paint a rectangle behind it.
         backgroundColor = .clear
-        shape.fillColor = palette.standardKey.cgColor
+        shape.fillColor = palette.raisedKey.cgColor
         shape.shadowColor = UIColor.black.cgColor
         shape.shadowOpacity = 0.22
         shape.shadowRadius = 5

--- a/ios/VocaPhoneKeyboard/KeyboardHaptics.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardHaptics.swift
@@ -15,6 +15,20 @@ protocol KeyboardFeedbackProviding: AnyObject {
 /// The semantic feedback a keyboard interaction may produce. Keeping this as
 /// data lets tests prove that a cancelled touch cannot buzz or click, without
 /// pretending the simulator has a Taptic Engine.
+extension TypingHapticStyle {
+    /// Kept here rather than beside the enum: `VocaPhoneShared` is compiled
+    /// into the Live Activity too, and that target has no UIKit.
+    var feedbackStyle: UIImpactFeedbackGenerator.FeedbackStyle {
+        switch self {
+        case .light: .light
+        case .soft: .soft
+        case .medium: .medium
+        case .heavy: .heavy
+        case .rigid: .rigid
+        }
+    }
+}
+
 enum KeyboardFeedbackEvent: Equatable {
     case inputClick
     case typingHaptic
@@ -59,10 +73,12 @@ enum KeyboardFeedbackPolicy {
             // already clicked.
             return allowsHaptics ? [.typingHaptic] : []
         case .deleteRepeated:
-            // A held Delete is a stream of separate deletions, and the system
-            // keyboard sounds each one. Silence here makes a hold feel like it
-            // has stopped working.
-            return [.inputClick] + (allowsHaptics ? [.typingHaptic] : [])
+            // The click stays — the system keyboard sounds every deletion, and
+            // silence makes a hold feel like it has stopped working — but the
+            // haptic does not. A hold runs at about ten deletions a second, and
+            // ten taps a second is not ten taps: it is a buzz, which is what a
+            // phone does to say something is wrong.
+            return [.inputClick]
         case .selectionChanged:
             return allowsHaptics ? [.selectionHaptic] : []
         case .dictationAction:
@@ -105,6 +121,7 @@ final class KeyboardHaptics: KeyboardFeedbackProviding {
     /// right display, which an extension cannot be assumed to infer on its own.
     private weak var host: UIView?
     private var keyTapGenerator: UIImpactFeedbackGenerator?
+    private var keyTapStyle: UIImpactFeedbackGenerator.FeedbackStyle = .rigid
     private var actionGenerator: UIImpactFeedbackGenerator?
     private var selectionGenerator: UISelectionFeedbackGenerator?
 
@@ -230,7 +247,7 @@ final class KeyboardHaptics: KeyboardFeedbackProviding {
                 // is exactly what made this feel weaker than every other
                 // keyboard on the phone.
                 let generator = keyTapImpact()
-                generator.impactOccurred(intensity: 1)
+                generator.impactOccurred(intensity: KeyboardPreferences.typingHapticIntensity)
                 generator.prepare()
             case .selectionHaptic:
                 let generator = selection()
@@ -264,7 +281,14 @@ final class KeyboardHaptics: KeyboardFeedbackProviding {
     /// generator would have been silently ignored, leaving the keyboard playing
     /// whichever texture happened to be requested first.
     private func keyTapImpact() -> UIImpactFeedbackGenerator {
-        cached(&keyTapGenerator, style: .rigid)
+        // The style is stored, so it has to be able to change under a running
+        // keyboard: a generator is built for one style and cannot be retuned.
+        let wanted = KeyboardPreferences.typingHapticStyle.feedbackStyle
+        if keyTapStyle != wanted {
+            keyTapStyle = wanted
+            keyTapGenerator = nil
+        }
+        return cached(&keyTapGenerator, style: wanted)
     }
 
     /// The generator for rare, weightier events: softer and more diffuse.

--- a/ios/VocaPhoneKeyboard/KeyboardHaptics.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardHaptics.swift
@@ -120,7 +120,7 @@ final class KeyboardHaptics: KeyboardFeedbackProviding {
     /// right display, which an extension cannot be assumed to infer on its own.
     private weak var host: UIView?
     private var keyTapGenerator: UIImpactFeedbackGenerator?
-    private var keyTapStyle: UIImpactFeedbackGenerator.FeedbackStyle = .soft
+    private var keyTapStyle: UIImpactFeedbackGenerator.FeedbackStyle = .rigid
     private var actionGenerator: UIImpactFeedbackGenerator?
     private var selectionGenerator: UISelectionFeedbackGenerator?
 
@@ -239,17 +239,8 @@ final class KeyboardHaptics: KeyboardFeedbackProviding {
             case .inputClick:
                 UIDevice.current.playInputClick()
             case .typingHaptic:
-                // `.soft` at 0.72, settled by feel on a device rather than by
-                // argument. The reasoning that used to sit here — that a key is
-                // a hard click, so only `.rigid` at full power could avoid
-                // reading as weaker than every other keyboard on the phone —
-                // turned out to be wrong in the hand: at full power the tap
-                // buzzes rather than clicks, and stops being a keystroke.
-                //
-                // Style and strength are both preferences, so this is a default
-                // and not a verdict. The keyboard lab drives them from two
-                // sliders precisely because how a tap feels is not a number
-                // anybody picks correctly by reasoning about it.
+                // Match main's rigid, full-strength tap by default while
+                // respecting explicit adjustments made in the keyboard lab.
                 let generator = keyTapImpact()
                 generator.impactOccurred(intensity: KeyboardPreferences.typingHapticIntensity)
                 generator.prepare()

--- a/ios/VocaPhoneKeyboard/KeyboardHaptics.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardHaptics.swift
@@ -12,9 +12,7 @@ protocol KeyboardFeedbackProviding: AnyObject {
     func swipeCommitted()
 }
 
-/// The semantic feedback a keyboard interaction may produce. Keeping this as
-/// data lets tests prove that a cancelled touch cannot buzz or click, without
-/// pretending the simulator has a Taptic Engine.
+/// The `UIKit` tap each named style plays.
 extension TypingHapticStyle {
     /// Kept here rather than beside the enum: `VocaPhoneShared` is compiled
     /// into the Live Activity too, and that target has no UIKit.
@@ -29,6 +27,9 @@ extension TypingHapticStyle {
     }
 }
 
+/// The semantic feedback a keyboard interaction may produce. Keeping this as
+/// data lets tests prove that a cancelled touch cannot buzz or click, without
+/// pretending the simulator has a Taptic Engine.
 enum KeyboardFeedbackEvent: Equatable {
     case inputClick
     case typingHaptic
@@ -97,10 +98,8 @@ enum KeyboardFeedbackPolicy {
 /// is not a haptic, must not be disabled by VocaPhone's optional tactile
 /// preference, and is played on touch-down because that is when the system
 /// keyboard plays it. Custom haptics are deliberately opt-in and wait for the
-/// interaction to commit. Typing is played at full strength on the crispest
-/// style, because a key is a hard, short click and anything softer reads as
-/// weaker than every other keyboard on the phone. The rarer events vary against
-/// that reference rather than sitting below it.
+/// interaction to commit. The rarer events vary against typing's tap rather
+/// than sitting below it.
 @MainActor
 final class KeyboardHaptics: KeyboardFeedbackProviding {
     static let shared = KeyboardHaptics()
@@ -121,7 +120,7 @@ final class KeyboardHaptics: KeyboardFeedbackProviding {
     /// right display, which an extension cannot be assumed to infer on its own.
     private weak var host: UIView?
     private var keyTapGenerator: UIImpactFeedbackGenerator?
-    private var keyTapStyle: UIImpactFeedbackGenerator.FeedbackStyle = .rigid
+    private var keyTapStyle: UIImpactFeedbackGenerator.FeedbackStyle = .soft
     private var actionGenerator: UIImpactFeedbackGenerator?
     private var selectionGenerator: UISelectionFeedbackGenerator?
 
@@ -240,12 +239,17 @@ final class KeyboardHaptics: KeyboardFeedbackProviding {
             case .inputClick:
                 UIDevice.current.playInputClick()
             case .typingHaptic:
-                // `.rigid` rather than `.light`: a key is a hard, short click,
-                // and `.light` is the softest and most diffuse of the styles —
-                // it reads as a nudge where the system keyboard reads as a
-                // press. Full intensity because a third of the engine's power
-                // is exactly what made this feel weaker than every other
-                // keyboard on the phone.
+                // `.soft` at 0.72, settled by feel on a device rather than by
+                // argument. The reasoning that used to sit here — that a key is
+                // a hard click, so only `.rigid` at full power could avoid
+                // reading as weaker than every other keyboard on the phone —
+                // turned out to be wrong in the hand: at full power the tap
+                // buzzes rather than clicks, and stops being a keystroke.
+                //
+                // Style and strength are both preferences, so this is a default
+                // and not a verdict. The keyboard lab drives them from two
+                // sliders precisely because how a tap feels is not a number
+                // anybody picks correctly by reasoning about it.
                 let generator = keyTapImpact()
                 generator.impactOccurred(intensity: KeyboardPreferences.typingHapticIntensity)
                 generator.prepare()

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -1312,7 +1312,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // The state's own copy and its own action, taken from the model the old
         // bar was already built from. Two wordings for one failure is how a
         // product ends up telling a person two different things about it.
-        dictationSurfaceState.centerMessage = DictationBarModel.surfaceLine(for: state)
+        dictationSurfaceState.centerMessage = model.surfaceMessage(for: state)
         dictationSurfaceState.primarySymbol = model.primary.symbol
         dictationSurfaceState.primaryLabel = model.primary.title
         dictationSurfaceState.primaryIsEnabled = model.primary.isEnabled

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -699,7 +699,14 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         if !typed.isEmpty,
            !isPerformingInsertion,
            typing.composer.isAutocorrectable,
-           let correction = typing.strip.autocorrection
+           let correction = typing.strip.autocorrection,
+           // The offer has to be about the word in hand. The strip is not
+           // cleared while the checker is being consulted, so a space arriving
+           // before its answer finds the correction worked out for the word as
+           // it stood a keystroke ago — and applying that rewrites "howit" with
+           // a correction meant for "howi". No answer yet is not an emergency:
+           // the word stands, which is what it would have done anyway.
+           typing.strip.autocorrectionTarget?.lowercased() == typed.lowercased()
         {
             let replacement = TypingCandidates.matchingCase(
                 of: typed,

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -17,6 +17,8 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// the app, which is not what the user is watching tick up.
     private var recordingStartedAt: Date?
     /// How much of the recording's measured audio the meter has already drawn.
+    /// The session the meter on screen belongs to.
+    private var meteredSessionID: UUID?
     private var drawnMeterSequence = 0
     private var lastRenderedState: SessionState?
     private var hasRendered = false
@@ -1176,7 +1178,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             pushMeter(for: sessionID)
         } else {
             drawnMeterSequence = 0
-            dictationSurfaceState.meterLevels = []
+            dictationSurfaceState.holdMeterLevels()
         }
 
         dictationSurfaceState.state = state
@@ -1248,11 +1250,26 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// exactly the new audio, counted once.
     private func pushMeter(for sessionID: UUID) {
         guard let sample = store.meterSample(for: sessionID) else { return }
+        // A recording that has just begun starts from an empty meter. The bars
+        // hold their shape when one *ends*, and without this the next session
+        // opened on the last one's waveform — somebody else's voice drawn for
+        // the first three quarters of a second.
+        if sessionID != meteredSessionID {
+            meteredSessionID = sessionID
+            drawnMeterSequence = 0
+            dictationSurfaceState.clearMeterLevels()
+            dictationBar.push(meterLevels: [])
+        }
         let unseen = sample.sequence - drawnMeterSequence
         guard unseen > 0 else { return }
         drawnMeterSequence = sample.sequence
-        dictationBar.push(meterLevels: Array(sample.levels.suffix(unseen)))
-        dictationSurfaceState.meterLevels = sample.levels
+        // Appended, not assigned. One write carries the three to five levels of
+        // a single tick and the meter draws fifteen bars, so replacing the list
+        // left two thirds of them with nothing to show — a moving waveform
+        // turned back into five twitching bars.
+        let fresh = Array(sample.levels.suffix(unseen))
+        dictationBar.push(meterLevels: fresh)
+        dictationSurfaceState.appendMeterLevels(fresh)
     }
 
     private func updateElapsedTime(for state: SessionState) {

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -192,6 +192,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // The preference behind this lives in the shared defaults and is
         // changed in the app, which the user reaches by leaving the keyboard.
         // Coming back is the moment it can have changed under us.
+        cachedSmartPunctuation = nil
 #if DEBUG
         // Armed for the whole of a debug build: the fault it is here to catch
         // only happens at full typing speed, which is not a thing anyone can
@@ -659,13 +660,24 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         return snapshot
     }
 
-    /// Re-read per keystroke rather than cached: the field can change its own
-    /// traits, and the cost is two property reads.
+    /// The field's smart-punctuation traits, held for as long as the field is.
+    ///
+    /// This used to be re-read per keystroke, on the grounds that the cost was
+    /// two property reads. It is three, each one a hop into the host process,
+    /// and on device they were part of the 9.4 ms a single letter spent on the
+    /// main thread against a frame budget of 8.3. Traits belong to the field,
+    /// and ``applyDocumentTraits`` — which the keyboard already trusts to know
+    /// when the field has changed — is what drops this.
+    private var cachedSmartPunctuation: SmartPunctuation.Traits?
+
     private var smartPunctuation: SmartPunctuation.Traits {
-        SmartPunctuation.Traits.resolve(
+        if let cachedSmartPunctuation { return cachedSmartPunctuation }
+        let resolved = SmartPunctuation.Traits.resolve(
             for: textDocumentProxy,
             enabled: KeyboardPreferences.smartPunctuationEnabled
         )
+        cachedSmartPunctuation = resolved
+        return resolved
     }
 
     /// The characters that end a word and are therefore the moment an
@@ -1721,6 +1733,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// keyboard capitalizes usernames, labels every action "return", and renders
     /// a light theme inside a dark-appearance field.
     private func applyDocumentTraits() {
+        cachedSmartPunctuation = nil
         let proxy = textDocumentProxy
         // Passwords, one-time codes and PINs switch the whole subsystem off —
         // not just the strip. A hidden strip over a live spell checker would

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -418,11 +418,16 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         guard let url = URL(
             string: "\(AppConfiguration.urlScheme)://retry?session=\(record.sessionID.uuidString)"
         ) else { return }
+        let sessionID = record.sessionID
         openURLFromKeyboard(url) { [weak self] opened in
             DispatchQueue.main.async {
-                if !opened {
-                    self?.dictationBar.flash("Open vocaphone to retry the preserved recording.")
-                }
+                guard let self, !opened,
+                      self.activeSessionID == sessionID,
+                      self.lastRecord?.state == .uploading
+                else { return }
+                self.dictationSurfaceState.showRecoveryMessage(
+                    "Open vocaphone to retry the preserved recording."
+                )
             }
         }
     }
@@ -1028,13 +1033,16 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         openURLFromKeyboard(url) { [weak self] opened in
             DispatchQueue.main.async {
                 guard let self else { return }
-                if opened { return }
+                guard !opened, self.activeSessionID == sessionID,
+                      let current = try? self.store.load(sessionID),
+                      current.state == .launchingApp || current.state == .awaitingReturn
+                else { return }
                 if var waiting = try? self.store.load(sessionID),
                    waiting.state == .launchingApp
                 {
                     self.transition(&waiting, to: .awaitingReturn)
                 }
-                self.dictationBar.flash(
+                self.dictationSurfaceState.showRecoveryMessage(
                     "Open vocaphone manually; the recording request is waiting."
                 )
             }
@@ -1289,6 +1297,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             dictationSurfaceState.holdMeterLevels()
         }
 
+        dictationSurfaceState.sessionID = record?.sessionID
         dictationSurfaceState.state = state
         dictationSurfaceState.isDark = prefersDarkAppearance
         dictationSurfaceState.typing.isDark = prefersDarkAppearance

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -16,6 +16,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// record's timestamps cover the whole session, including the hand-off to
     /// the app, which is not what the user is watching tick up.
     private var recordingStartedAt: Date?
+    /// Whether the surface held the whole keyboard at the last layout pass.
+    private var surfaceOwnedKeyboard = false
+
     /// How much of the recording's measured audio the meter has already drawn.
     /// The session the meter on screen belongs to.
     private var meteredSessionID: UUID?
@@ -167,7 +170,35 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         )
     }
 
+#if DEBUG
+    /// The window-level witness, installed once there is a window to put it on.
+    ///
+    /// See `TouchWitness`: this is the half that tells a touch routed away from
+    /// the keys apart from a touch that never arrived at all.
+    private var windowWitness: TouchWitness?
+
+    private func installTouchWitnessOnWindow() {
+        guard windowWitness == nil, let window = view.window else { return }
+        let witness = TouchWitness(label: "window")
+        window.addGestureRecognizer(witness)
+        windowWitness = witness
+        TouchTrace.note(
+            "window \(type(of: window)) bounds=\(window.bounds) keyboard=\(view.frame)"
+        )
+    }
+#endif
+
     override func viewWillAppear(_ animated: Bool) {
+        // The preference behind this lives in the shared defaults and is
+        // changed in the app, which the user reaches by leaving the keyboard.
+        // Coming back is the moment it can have changed under us.
+#if DEBUG
+        // Armed for the whole of a debug build: the fault it is here to catch
+        // only happens at full typing speed, which is not a thing anyone can
+        // reach for a switch in the middle of.
+        TouchTrace.isEnabled = true
+        TouchTrace.beginSession("keyboard appeared")
+#endif
         super.viewWillAppear(animated)
         // Extension controllers can be reused across host fields and apps.
         hasDictationKey = true
@@ -223,6 +254,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // setup expects the extension to prove its state.
         publishKeyboardStatus()
         KeyboardHaptics.shared.attach(to: view, hasFullAccess: hasFullAccess)
+#if DEBUG
+        installTouchWitnessOnWindow()
+        FrameMonitor.start()
+#endif
         // A session found before the keyboard is on screen is work already in
         // flight being restored, not something that just happened to the user,
         // and it must not arrive as a buzz in their hand.
@@ -248,6 +283,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // A held key or an open accent popover must not survive the keyboard
         // being dismissed; iOS does not reliably cancel those touches for us.
         keyGrid.endActiveInteractions()
+#if DEBUG
+        FrameMonitor.stop()
+#endif
+        TouchTrace.flush()
         // A prepared generator keeps the Taptic Engine powered for a second or
         // two, which a dismissed keyboard has no business spending.
         KeyboardHaptics.shared.release()
@@ -290,6 +329,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// hottest place in the extension for a redundant hop into the host process.
     /// One snapshot, shared by everything below.
     private func handleTextChange() {
+        measured("handleTextChange") { handleTextChangeBody() }
+    }
+
+    private func handleTextChangeBody() {
         let snapshot = document
         // Moving to a different field brings different traits with it, and the
         // plane should reset so a number pad never leaves the user on letters.
@@ -405,6 +448,21 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     }
 
     private func handle(_ output: KeyboardOutput) {
+        // The cost of a keystroke, measured where it is paid. Everything below
+        // runs on the main thread between one finger landing and the next, and
+        // a hop into the host process for the document is the expensive part.
+        let startedAt = CACurrentMediaTime()
+        documentReads = 0
+        defer {
+            TouchTrace.note(
+                String(
+                    format: "handled %@ in %.1fms, %d document reads",
+                    String(describing: output).prefix(24).description,
+                    (CACurrentMediaTime() - startedAt) * 1000,
+                    documentReads
+                )
+            )
+        }
         switch output {
         case let .text(text):
             if let substitution = SmartPunctuation.substitution(
@@ -418,8 +476,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             } else if Self.isBoundary(text) {
                 commitComposition(followedBy: text)
             } else {
-                textDocumentProxy.insertText(text)
-                typing.insert(text, document: refreshDocument())
+                measured("insertText") { textDocumentProxy.insertText(text) }
+                let document = refreshDocument()
+                measured("typing.insert") { typing.insert(text, document: document) }
             }
             lastSpaceInsertedAt = nil
             releaseUndoIfDetached()
@@ -514,6 +573,22 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         return panel
     }
 
+    /// Times one phase of a keystroke into the trace.
+    ///
+    /// The first guess at where a letter's nine milliseconds went was the round
+    /// trips into the host process. Removing them moved the median by 0.2 ms,
+    /// which is what a guess is worth here: the phases get measured instead.
+    private func measured<T>(_ name: String, _ body: () -> T) -> T {
+        guard TouchTrace.isEnabled else { return body() }
+        let startedAt = CACurrentMediaTime()
+        defer {
+            TouchTrace.note(
+                String(format: "    %@ %.1fms", name, (CACurrentMediaTime() - startedAt) * 1000)
+            )
+        }
+        return body()
+    }
+
     /// The text either side of the cursor, read once and reused for the rest of
     /// the event.
     ///
@@ -524,11 +599,18 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// autocapitalization. On a slow host that is most of a frame spent asking
     /// the same question.
     private func readDocument() -> DocumentSnapshot {
-        DocumentSnapshot(
+        documentReads += 1
+        return DocumentSnapshot(
             before: textDocumentProxy.documentContextBeforeInput,
             after: textDocumentProxy.documentContextAfterInput
         )
     }
+
+    /// How many times the host process has been asked for the document since
+    /// the current keystroke began. Two proxy properties each, and the trace
+    /// prints it beside the milliseconds so the cost stays attributed.
+    private var documentReads = 0
+
 
     /// The snapshot taken at the start of the event currently being handled.
     ///
@@ -1128,6 +1210,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// empty by construction — those go through the full render, where they
     /// belong.
     private func renderStrip(_ strip: TypingStrip) {
+        measured("renderStrip") { renderStripBody(strip) }
+    }
+
+    private func renderStripBody(_ strip: TypingStrip) {
         // An empty strip means the bar goes back to its controls, which is a
         // change of body rather than a change of chips — that belongs to the
         // full render, which owns the crossfade between the two.
@@ -1138,12 +1224,15 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             render(lastRecord)
             return
         }
-        // The surface draws the strip now, so it needs the fast path as much as
-        // the bar does. Without this line it only ever saw the candidates a
-        // full render happened to carry — and a full render does not run on a
-        // keystroke, which is every keystroke — so the row on screen belonged
-        // to some earlier word.
-        dictationSurfaceState.candidates = strip.candidates
+        // Whichever of the two is on screen gets the chips; the other is not
+        // laid out for a row nobody is looking at.
+        if dictationSurfaceHosting?.view.isHidden == false {
+            dictationSurfaceState.candidates = strip.candidates
+#if DEBUG
+            FrameMonitor.noteStateChange("surface.candidates")
+#endif
+            return
+        }
         // The bar may still be showing its controls, in which case arriving at
         // the strip is a change of body and the full render owns the crossfade.
         if !dictationBar.updateCandidates(strip.candidates) { render(lastRecord) }
@@ -1206,6 +1295,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // product ends up telling a person two different things about it.
         dictationSurfaceState.centerMessage = DictationBarModel.surfaceLine(for: state)
         dictationSurfaceState.primarySymbol = model.primary.symbol
+        dictationSurfaceState.primaryLabel = model.primary.title
         dictationSurfaceState.primaryIsEnabled = model.primary.isEnabled
         let primaryAction = model.primary.action
         dictationSurfaceState.onPrimary = { [weak self] in self?.perform(primaryAction) }
@@ -1214,14 +1304,26 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // session to another layout: it stays where it was tapped, the line
         // under the bars becomes "Transcribing", and the check itself turns
         // into the spinner. Cancel keeps working throughout.
-        let isRecording = Self.surfaceOwnsKeyboard(state)
+        let isRecording = Self.surfaceOwnsKeyboard(state, hasFullAccess: hasFullAccess)
         if isRecording {
             keyGrid.endActiveInteractions()
             keyGrid.isHidden = true
+            // The panel is a second full-height view in the same stack. Left
+            // showing, it stands beside a bar that now fills the keyboard.
+            emojiPanel?.isHidden = true
             dictationBar.isHidden = true
             dictationSurfaceHosting?.view.isHidden = false
         } else {
             keyGrid.isHidden = (emojiPanel?.isHidden == false)
+            // One surface owns the keyboard, typing included, so there is no
+            // seam between a strip and a session.
+            //
+            // Typing was moved back to the old UIKit bar for one build, to find
+            // out whether hosting SwiftUI on the keystroke path was what made
+            // the keyboard feel slow. It was not: with the surface off that path
+            // entirely — zero commits recorded — frames still dropped 48 to
+            // 195 ms. That answered the question, and the answer let the surface
+            // come back.
             if model.layout == .strip {
                 dictationSurfaceHosting?.view.isHidden = false
                 dictationBar.isHidden = true
@@ -1231,9 +1333,18 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             }
         }
 
-        if model.isExpanded != isBarExpanded || model.layout != barLayout {
+        // Ownership is part of the geometry: the bar is the whole keyboard
+        // while the surface holds it and a strip afterwards. Two states can
+        // share a bar model and differ in ownership — `.inserting` and
+        // `.completed` do — and without this the constraints keep the sizes of
+        // the state before, which is a stack taller than the keyboard.
+        if model.isExpanded != isBarExpanded
+            || model.layout != barLayout
+            || isRecording != surfaceOwnedKeyboard
+        {
             isBarExpanded = model.isExpanded
             barLayout = model.layout
+            surfaceOwnedKeyboard = isRecording
             applyLayoutMetrics(animated: hasRendered)
         }
         dictationBar.apply(model, animated: hasRendered)
@@ -1251,24 +1362,30 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     private func pushMeter(for sessionID: UUID) {
         guard let sample = store.meterSample(for: sessionID) else { return }
         // A recording that has just begun starts from an empty meter. The bars
-        // hold their shape when one *ends*, and without this the next session
-        // opened on the last one's waveform — somebody else's voice drawn for
-        // the first three quarters of a second.
+        // hold their shape when one *ends* — which is the point of `hold()` —
+        // and without this the next session opened on the last one's waveform,
+        // drawing somebody else's voice for the first three quarters of a
+        // second.
         if sessionID != meteredSessionID {
             meteredSessionID = sessionID
             drawnMeterSequence = 0
             dictationSurfaceState.clearMeterLevels()
             dictationBar.push(meterLevels: [])
         }
+        // A file written by an older build, or read while it was being
+        // replaced, comes back with a sequence of zero. Treated as "nothing
+        // new" that stops the meter for the rest of the session, so a count
+        // that went backwards restarts the reckoning instead.
+        if sample.sequence < drawnMeterSequence { drawnMeterSequence = 0 }
         let unseen = sample.sequence - drawnMeterSequence
         guard unseen > 0 else { return }
         drawnMeterSequence = sample.sequence
-        // Appended, not assigned. One write carries the three to five levels of
-        // a single tick and the meter draws fifteen bars, so replacing the list
-        // left two thirds of them with nothing to show — a moving waveform
-        // turned back into five twitching bars.
         let fresh = Array(sample.levels.suffix(unseen))
         dictationBar.push(meterLevels: fresh)
+        // Appended, not assigned. One write carries the three to five levels of
+        // a single tick, and the meter draws fifteen bars: replacing the list
+        // left two thirds of them with nothing to show and turned a moving
+        // waveform back into five twitching bars.
         dictationSurfaceState.appendMeterLevels(fresh)
     }
 
@@ -1370,7 +1487,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         keyGrid.delegate = self
 
         topBarContainer.translatesAutoresizingMaskIntoConstraints = false
-        topBarContainer.clipsToBounds = false
+        topBarContainer.clipsToBounds = true
         topBarContainer.addSubview(dictationBar)
         dictationBar.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -1381,10 +1498,21 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         ])
 
         let stack = KeyboardStack(arrangedSubviews: [topBarContainer, keyGrid])
+        stack.backgroundColor = KeyboardStack.touchableClear
         stack.keyGrid = keyGrid
+        stack.topBarContainer = topBarContainer
+        stack.isMultipleTouchEnabled = true
+        view.isMultipleTouchEnabled = true
+#if DEBUG
+        // Sees the touches before the hit test does, and answers the one
+        // question the rest of the trace cannot: whether a letter that never
+        // appeared was a touch this keyboard lost or a touch it was never
+        // given. See `TouchWitness`.
+        view.addGestureRecognizer(TouchWitness(label: "view"))
+#endif
         keyboardStack = stack
         stack.axis = .vertical
-        stack.spacing = Self.chromeSpacing
+        stack.spacing = KeyboardChrome.gapAboveKeys
         stack.translatesAutoresizingMaskIntoConstraints = false
         // Key previews for the top row draw above the grid's own bounds.
         stack.clipsToBounds = false
@@ -1448,12 +1576,18 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// is the 54 pt the strip is — so this gap is the only space between the
     /// buttons and the keys, and seven points of it read as the two rows
     /// touching.
-    private static let chromeSpacing: CGFloat = 12
 
     /// The states the dictation surface owns outright: it fills the keyboard,
     /// the keys are put away, and the old bar stays out of it.
-    private static func surfaceOwnsKeyboard(_ state: SessionState) -> Bool {
-        switch state {
+    private static func surfaceOwnsKeyboard(
+        _ state: SessionState,
+        hasFullAccess: Bool
+    ) -> Bool {
+        // Without Full Access the keyboard is locked, and the only thing worth
+        // saying is the path to unlock it. That is the old bar's card, and it
+        // has to be allowed to appear whatever state the stored session is in.
+        guard hasFullAccess else { return false }
+        return switch state {
         // The hand-off belongs here as much as the recording does. Measured on
         // device: a tap on the microphone goes to `launchingApp` first, and
         // that state's bar model is the expanded status card — 84 pt against
@@ -1466,7 +1600,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // seam: the surface handed the session back to the old bar at the exact
         // moment it had something to report, and the whole keyboard changed
         // shape to say "Gateway unavailable".
-        case .readyToInsert, .inserting, .targetContextChanged: true
+        // `.inserted` belongs with `.inserting`: one model serves both, so a
+        // session that reached it while the surface was up would otherwise
+        // hand the keyboard back mid-insertion.
+        case .readyToInsert, .inserting, .inserted, .targetContextChanged: true
         case .serverUnavailable, .uploadFailedRecoverable: true
         case .transcriptionFailedRecoverable, .transcriptionFailedPermanent: true
         case .permissionDenied: true
@@ -1474,7 +1611,20 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         }
     }
 
-    private static let chromeInset: CGFloat = 6
+    /// The margin between the keys and the edge of the screen.
+    ///
+    /// Three points, which is the system keyboard's, and it has to be the
+    /// system keyboard's because every key's position is measured from it. At
+    /// six, this keyboard's ten columns were laid out across 381 points where
+    /// iOS lays them across 387 — every key about 1.5% narrower, and every
+    /// boundary between two keys a little further left than the one a thumb has
+    /// spent years learning.
+    ///
+    /// Measured on device: touches meaning the spacebar landed between x=269
+    /// and x=291, and the ones past 287 typed a line break instead, because 287
+    /// is where the spacebar's target ended. On the system's geometry it ends at
+    /// 293. Three of them in one sentence, and none of them a slip of the thumb.
+    private static let chromeInset: CGFloat = 3
 
     /// Nothing under the last row of keys.
     ///
@@ -1498,7 +1648,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         keyGrid.metrics = metrics
         dictationBar.metrics = barMetrics
 
-        let isRecording = Self.surfaceOwnsKeyboard(dictationSurfaceState.state)
+        let isRecording = Self.surfaceOwnsKeyboard(
+            dictationSurfaceState.state,
+            hasFullAccess: hasFullAccess
+        )
         // Recording's own bar model is the *expanded status* layout — the tall
         // card the old bar used to draw — and asking it for a height is what
         // still made the keyboard grow, by about forty points, after the two
@@ -1522,7 +1675,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         let keyboardHeight = Self.chromeInset
             + Self.chromeBottomInset
             + barHeight
-            + Self.chromeSpacing
+            + KeyboardChrome.gapAboveKeys
             + metrics.gridHeight
 
         let wantedBarHeight = isRecording
@@ -1572,7 +1725,11 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // Passwords, one-time codes and PINs switch the whole subsystem off —
         // not just the strip. A hidden strip over a live spell checker would
         // still be running the user's password through a dictionary.
-        typing.documentChanged(policy: TypingFieldPolicy.resolve(for: proxy))
+        let policy = TypingFieldPolicy.resolve(for: proxy)
+        typing.documentChanged(policy: policy)
+        // The trace writes which key was pressed, and a character key's name is
+        // the character. Not in a field that has asked for no intelligence.
+        keyGrid.traceNamesKeys = policy.allowsTypingIntelligence
         keyGrid.showsGlobeKey = needsInputModeSwitchKey
         let returnKeyType = proxy.returnKeyType ?? .default
         keyGrid.returnKeyTitle = Self.returnKeyTitle(for: returnKeyType)
@@ -1834,36 +1991,88 @@ extension KeyboardViewController: DictationBarViewDelegate {
 
 /// The stack that holds the dictation surface above the keys.
 ///
-/// Its only job beyond stacking is to make sure the gap between the two is not
-/// a hole. A stack view's spacing belongs to no subview: a touch landing there
-/// hits the stack, which handles nothing, and is never delivered to anybody.
-/// The measurement that led here is unambiguous — every letter touch the grid
-/// receives becomes a character, and letters still went missing, so they were
-/// the ones that never arrived.
+/// Its only job beyond stacking is to make sure the three thin dead strips
+/// around the grid are not holes. Two sources create them:
 ///
-/// Twelve points is nothing to look at and quite a lot to type into: a fast
-/// typist reaching for the top row lands high, and the gap sits exactly there.
-/// It is given to the keys, which already know how to claim the space around
-/// them.
+/// 1. The vertical gap (`KeyboardChrome.gapAboveKeys`) between the bar and
+///    the key grid. A stack view's spacing belongs to no subview, so touches
+///    landing there hit the stack, which handles nothing.
+///
+/// 2. The lateral margins (chromeInset = 6 pt on each side) between the stack
+///    and the UIInputView edge. Touches outside the stack frame are routed by
+///    UIKit to the input view itself, which also handles nothing. The leading
+///    and trailing keys already extend their hit rects to the grid's own bounds,
+///    but those rects live in grid-local space — they can only be consulted
+///    after UIKit delivers the touch to the grid, which it never does for the
+///    side strips.
+///
+/// All three strips are claimed here by forwarding to the grid with coordinates
+/// clamped to the grid's bounding box, so the grid's own hit-map decides which
+/// key wins rather than the touch being silently discarded.
 final class KeyboardStack: UIStackView {
+    /// A colour that is not `clear`, and cannot be seen.
+    ///
+    /// The same UIKit behaviour `KeyGridView.draw(_:)` documents: a touch on a
+    /// fully transparent pixel is not recognised at all. The stack's own spacing
+    /// is transparent, and a `UIStackView` does not draw, so it cannot opt out
+    /// the way the grid does — a background a thousandth of a percent from clear
+    /// does the same job and is invisible.
+    static let touchableClear = UIColor(white: 0, alpha: 0.001)
+
     weak var keyGrid: UIView?
+    weak var topBarContainer: UIView?
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        if let hit = super.hitTest(point, with: event) { return hit }
-        guard let keyGrid, !keyGrid.isHidden, keyGrid.alpha > 0 else { return nil }
-        // Only the strip directly above the keys, and only downwards: this must
-        // not steal a touch aimed at the surface's own controls.
-        let gap = CGRect(
-            x: keyGrid.frame.minX,
-            y: keyGrid.frame.minY - Self.claimedGap,
-            width: keyGrid.frame.width,
-            height: Self.claimedGap
+        guard let keyGrid, !keyGrid.isHidden, keyGrid.alpha > 0 else {
+            return super.hitTest(point, with: event)
+        }
+
+        let gridFrame = keyGrid.frame
+        let lateralSpan =
+            (gridFrame.minX - KeyboardChrome.sideMargin)...(gridFrame.maxX + KeyboardChrome.sideMargin)
+
+        /// Hands the touch to the grid at the nearest point inside it, so a
+        /// near miss resolves against the hit map instead of being discarded.
+        func forwardToGrid(_ zone: String) -> UIView {
+            var local = keyGrid.convert(point, from: self)
+            local.x = min(max(local.x, 0.5), keyGrid.bounds.width - 0.5)
+            local.y = min(max(local.y, 0.5), keyGrid.bounds.height - 0.5)
+            let hit = keyGrid.hitTest(local, with: event) ?? keyGrid
+            TouchTrace.note(
+                "hit \(zone) (\(Int(point.x)),\(Int(point.y))) -> \(type(of: hit))"
+            )
+            return hit
+        }
+
+        // 1. The keys themselves, and the lateral margins beside them.
+        if point.y >= gridFrame.minY, lateralSpan.contains(point.x) {
+            return forwardToGrid("keys")
+        }
+
+        // 2. The vertical gap the stack's spacing leaves between bar and keys.
+        let topBarMaxY = topBarContainer?.frame.maxY ?? (gridFrame.minY - KeyboardChrome.gapAboveKeys)
+        if point.y >= topBarMaxY, point.y < gridFrame.minY, lateralSpan.contains(point.x) {
+            return forwardToGrid("gap")
+        }
+
+        let hit = super.hitTest(point, with: event)
+        TouchTrace.note(
+            "hit none (\(Int(point.x)),\(Int(point.y))) -> "
+                + "\(hit.map { String(describing: type(of: $0)) } ?? "nil")"
         )
-        guard gap.contains(point) else { return nil }
-        return keyGrid.hitTest(keyGrid.convert(point, from: self), with: event) ?? keyGrid
+        return hit
     }
 
-    /// The keyboard's own spacing. Named here rather than shared, because what
-    /// this claims is the space the layout leaves empty, whatever it is.
-    private static let claimedGap: CGFloat = 12
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        if super.point(inside: point, with: event) { return true }
+        guard let keyGrid, !keyGrid.isHidden, keyGrid.alpha > 0 else { return false }
+        let claimRect = keyGrid.frame.inset(by: UIEdgeInsets(
+            top: -KeyboardChrome.gapAboveKeys,
+            left: -KeyboardChrome.sideMargin,
+            bottom: 0,
+            right: -KeyboardChrome.sideMargin
+        ))
+        return claimRect.contains(point)
+    }
+
 }

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -1,4 +1,5 @@
 import os
+import SwiftUI
 import UIKit
 
 final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedback {
@@ -15,6 +16,8 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// record's timestamps cover the whole session, including the hand-off to
     /// the app, which is not what the user is watching tick up.
     private var recordingStartedAt: Date?
+    /// How much of the recording's measured audio the meter has already drawn.
+    private var drawnMeterSequence = 0
     private var lastRenderedState: SessionState?
     private var hasRendered = false
     private var announcesStateChanges = false
@@ -75,6 +78,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         metrics: KeyboardMetrics.resolved(for: traitCollection, preference: heightPreference),
         palette: palette
     )
+    private let dictationSurfaceState = DictationSurfaceState()
+    private var dictationSurfaceHosting: UIHostingController<DictationSurfaceView>?
+    private let topBarContainer = UIView()
     private var keyboardHeightConstraint: NSLayoutConstraint?
     private var barHeightConstraint: NSLayoutConstraint?
     private var gridHeightConstraint: NSLayoutConstraint?
@@ -147,6 +153,8 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
     private var sampledMoments: Set<String> = []
 
+    /// How much room the extension has left, sampled at the two moments that
+    /// decide whether it survives.
     private func noteAvailableMemory(_ moment: MemorySample) {
         let key = "\(moment)"
         guard sampledMoments.insert(key).inserted else { return }
@@ -164,6 +172,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // A recreated extension instance can inherit a session the previous one
         // started, so scan once on appear and let `render` decide about polling.
         applyDocumentTraits()
+        // The app's settings screen writes the same two keys, and it may have
+        // done so while another keyboard was on screen.
+        dictationSurfaceState.refreshPreferences()
         // A new appearance is a new field as far as this keyboard can tell.
         //
         // The insertion target was previously kept for the life of the
@@ -1125,6 +1136,12 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             render(lastRecord)
             return
         }
+        // The surface draws the strip now, so it needs the fast path as much as
+        // the bar does. Without this line it only ever saw the candidates a
+        // full render happened to carry — and a full render does not run on a
+        // keystroke, which is every keystroke — so the row on screen belonged
+        // to some earlier word.
+        dictationSurfaceState.candidates = strip.candidates
         // The bar may still be showing its controls, in which case arriving at
         // the strip is a change of body and the full render owns the crossfade.
         if !dictationBar.updateCandidates(strip.candidates) { render(lastRecord) }
@@ -1154,21 +1171,88 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // An idle keyboard needs no meter and no subtitle, and the height they
         // would occupy is better spent on the keys — the idle bar is a one-row
         // typing strip, shorter than the collapsed status bar it replaces.
+        updateElapsedTime(for: state)
+        if state == .recording, let sessionID = record?.sessionID {
+            pushMeter(for: sessionID)
+        } else {
+            drawnMeterSequence = 0
+            dictationSurfaceState.meterLevels = []
+        }
+
+        dictationSurfaceState.state = state
+        dictationSurfaceState.isDark = prefersDarkAppearance
+        dictationSurfaceState.typing.isDark = prefersDarkAppearance
+        dictationSurfaceState.showsGlobeKey = needsInputModeSwitchKey
+        // Assigned only when they actually differ. This runs on every poll —
+        // several times a second — and each assignment publishes a change to
+        // the whole surface whether or not anything moved. It is also the one
+        // place that can put a stale value back over a fresh choice.
+        let language = KeyboardPreferences.effectiveTranscriptionLanguage
+        if dictationSurfaceState.language != language {
+            dictationSurfaceState.language = language
+        }
+        let style = KeyboardPreferences.writingStyle
+        if dictationSurfaceState.style != style {
+            dictationSurfaceState.style = style
+        }
+        // The same candidates the strip was drawing. Typing intelligence is not
+        // a feature of the old bar; it is a feature of the keyboard, and the
+        // surface replaced the bar, not the engine behind it.
+        dictationSurfaceState.candidates = typing.strip.candidates
+        // The state's own copy and its own action, taken from the model the old
+        // bar was already built from. Two wordings for one failure is how a
+        // product ends up telling a person two different things about it.
+        dictationSurfaceState.centerMessage = DictationBarModel.surfaceLine(for: state)
+        dictationSurfaceState.primarySymbol = model.primary.symbol
+        dictationSurfaceState.primaryIsEnabled = model.primary.isEnabled
+        let primaryAction = model.primary.action
+        dictationSurfaceState.onPrimary = { [weak self] in self?.perform(primaryAction) }
+
+        // Recording *and* the wait that follows it. The check does not hand the
+        // session to another layout: it stays where it was tapped, the line
+        // under the bars becomes "Transcribing", and the check itself turns
+        // into the spinner. Cancel keeps working throughout.
+        let isRecording = Self.surfaceOwnsKeyboard(state)
+        if isRecording {
+            keyGrid.endActiveInteractions()
+            keyGrid.isHidden = true
+            dictationBar.isHidden = true
+            dictationSurfaceHosting?.view.isHidden = false
+        } else {
+            keyGrid.isHidden = (emojiPanel?.isHidden == false)
+            if model.layout == .strip {
+                dictationSurfaceHosting?.view.isHidden = false
+                dictationBar.isHidden = true
+            } else {
+                dictationSurfaceHosting?.view.isHidden = true
+                dictationBar.isHidden = false
+            }
+        }
+
         if model.isExpanded != isBarExpanded || model.layout != barLayout {
             isBarExpanded = model.isExpanded
             barLayout = model.layout
             applyLayoutMetrics(animated: hasRendered)
         }
-        updateElapsedTime(for: state)
-        if state == .recording {
-            // One level per poll, which is what the record carries. The run
-            // the pipeline now measures reaches the bar with the surface that
-            // draws it.
-            dictationBar.push(meterLevels: [record?.meterLevel ?? 0])
-        }
         dictationBar.apply(model, animated: hasRendered)
         announceStateChange(to: state, saying: model.announcement)
         hasRendered = true
+    }
+
+    /// Hands the bar the levels it has not drawn yet.
+    ///
+    /// This runs on the session refresh, which is a poll with a notification in
+    /// front of it — it can fire twice on the same file or miss a write. The
+    /// sequence number is what makes that harmless: it says how much audio the
+    /// app has measured in total, so the tail past what was already drawn is
+    /// exactly the new audio, counted once.
+    private func pushMeter(for sessionID: UUID) {
+        guard let sample = store.meterSample(for: sessionID) else { return }
+        let unseen = sample.sequence - drawnMeterSequence
+        guard unseen > 0 else { return }
+        drawnMeterSequence = sample.sequence
+        dictationBar.push(meterLevels: Array(sample.levels.suffix(unseen)))
+        dictationSurfaceState.meterLevels = sample.levels
     }
 
     private func updateElapsedTime(for state: SessionState) {
@@ -1209,10 +1293,78 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         }
     }
 
+    private func configureDictationSurface() {
+        dictationSurfaceState.onStart = { [weak self] in self?.perform(.start) }
+        dictationSurfaceState.onFinish = { [weak self] in self?.perform(.finish) }
+        dictationSurfaceState.onCancel = { [weak self] in self?.perform(.cancel) }
+        dictationSurfaceState.onGlobe = { [weak self] in self?.advanceToNextInputMode() }
+        dictationSurfaceState.onCandidate = { [weak self] candidate in
+            guard let self, !isPerformingInsertion else { return }
+            documentEvent { self.apply(candidate) }
+        }
+        dictationSurfaceState.onLanguageChanged = { [weak self] lang in
+            KeyboardPreferences.transcriptionLanguage = lang
+            KeyboardPreferences.noteTranscriptionLanguageUse(lang)
+            self?.refresh()
+        }
+        dictationSurfaceState.onStyleChanged = { [weak self] _ in
+            // The surface has already stored it. Writing the same value again
+            // here only created a second writer for one setting, and a second
+            // writer is a second chance to write the wrong thing.
+            self?.refresh()
+        }
+
+        // Seeded before the first frame. A fresh extension instance — which is
+        // what a keyboard switch produces — otherwise draws one frame from the
+        // defaults: the style icon reverts to Raw and the icons are black on a
+        // dark keyboard, and only the first refresh puts them right.
+        dictationSurfaceState.refreshPreferences()
+        dictationSurfaceState.isDark = prefersDarkAppearance
+        dictationSurfaceState.typing.isDark = prefersDarkAppearance
+        let host = UIHostingController(rootView: DictationSurfaceView(state: dictationSurfaceState))
+        dictationSurfaceHosting = host
+        addChild(host)
+        let hostView = host.view!
+        hostView.backgroundColor = .clear
+        hostView.translatesAutoresizingMaskIntoConstraints = false
+        topBarContainer.addSubview(hostView)
+        NSLayoutConstraint.activate([
+            hostView.leadingAnchor.constraint(equalTo: topBarContainer.leadingAnchor),
+            hostView.trailingAnchor.constraint(equalTo: topBarContainer.trailingAnchor),
+            hostView.topAnchor.constraint(equalTo: topBarContainer.topAnchor),
+            hostView.bottomAnchor.constraint(equalTo: topBarContainer.bottomAnchor),
+        ])
+        host.didMove(toParent: self)
+        // Laid out now, not at the first appearance.
+        //
+        // The surface draws the right style in its very first frame — measured
+        // — but that frame arrives about a tenth of a second after the keyboard
+        // is asked for, and until it does the screen shows the system's own
+        // picture of this keyboard from last time. Forcing the layout pass here
+        // moves SwiftUI's first render off the appearance path, which is the
+        // only part of that delay this code owns.
+        hostView.setNeedsLayout()
+        hostView.layoutIfNeeded()
+    }
+
     private func configureUI() {
+        configureDictationSurface()
         dictationBar.delegate = self
         keyGrid.delegate = self
-        let stack = UIStackView(arrangedSubviews: [dictationBar, keyGrid])
+
+        topBarContainer.translatesAutoresizingMaskIntoConstraints = false
+        topBarContainer.clipsToBounds = false
+        topBarContainer.addSubview(dictationBar)
+        dictationBar.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            dictationBar.leadingAnchor.constraint(equalTo: topBarContainer.leadingAnchor),
+            dictationBar.trailingAnchor.constraint(equalTo: topBarContainer.trailingAnchor),
+            dictationBar.topAnchor.constraint(equalTo: topBarContainer.topAnchor),
+            dictationBar.bottomAnchor.constraint(equalTo: topBarContainer.bottomAnchor),
+        ])
+
+        let stack = KeyboardStack(arrangedSubviews: [topBarContainer, keyGrid])
+        stack.keyGrid = keyGrid
         keyboardStack = stack
         stack.axis = .vertical
         stack.spacing = Self.chromeSpacing
@@ -1226,7 +1378,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             for: traitCollection,
             preference: heightPreference
         )
-        let barHeight = dictationBar.heightAnchor.constraint(
+        let barHeight = topBarContainer.heightAnchor.constraint(
             equalToConstant: barMetrics.height(for: .strip, expanded: false)
         )
         let gridHeight = keyGrid.heightAnchor.constraint(equalToConstant: 202)
@@ -1242,23 +1394,77 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
                 equalTo: view.trailingAnchor,
                 constant: -Self.chromeInset
             ),
-            stack.topAnchor.constraint(equalTo: view.topAnchor, constant: Self.chromeInset),
+            stack.topAnchor.constraint(
+                greaterThanOrEqualTo: view.topAnchor,
+                constant: Self.chromeInset
+            ),
             stack.bottomAnchor.constraint(
-                lessThanOrEqualTo: view.bottomAnchor,
-                constant: -Self.chromeInset
+                equalTo: view.bottomAnchor,
+                constant: -Self.chromeBottomInset
             ),
             barHeight,
             gridHeight,
             keyboardHeight,
         ])
+        // The height above is a request — `allowsSelfSizing` lets iOS hand the
+        // extension a taller input view — and with the stack hung from the
+        // bottom every spare point opened as an empty band above the controls.
+        // Pinning the top as well makes the stack fill whatever it is given;
+        // the grid keeps its exact height, so the surplus goes to the bar,
+        // which is the one part built to be any height.
+        let stackTop = stack.topAnchor.constraint(
+            equalTo: view.topAnchor,
+            constant: Self.chromeInset
+        )
+        stackTop.priority = UILayoutPriority(999)
+        stackTop.isActive = true
+        barHeight.priority = .defaultHigh
         applyTheme()
         applyLayoutMetrics()
         applyDocumentTraits()
         updateAutomaticShift()
     }
 
-    private static let chromeSpacing: CGFloat = 7
+    /// The gap between the dictation surface and the top row of keys.
+    ///
+    /// The surface fills its strip exactly — 10 pt of air above a 44 pt control
+    /// is the 54 pt the strip is — so this gap is the only space between the
+    /// buttons and the keys, and seven points of it read as the two rows
+    /// touching.
+    private static let chromeSpacing: CGFloat = 12
+
+    /// The states the dictation surface owns outright: it fills the keyboard,
+    /// the keys are put away, and the old bar stays out of it.
+    private static func surfaceOwnsKeyboard(_ state: SessionState) -> Bool {
+        switch state {
+        // The hand-off belongs here as much as the recording does. Measured on
+        // device: a tap on the microphone goes to `launchingApp` first, and
+        // that state's bar model is the expanded status card — 84 pt against
+        // the strip's 54. The keyboard grew by thirty points before recording
+        // had even begun, which is the jump, and the flash of a card nobody
+        // asked for is the same event seen from the other side.
+        case .launchingApp, .awaitingReturn: true
+        case .recording, .finalizing, .uploading, .transcribing: true
+        // The transcript arriving, and every way it can fail. These were the
+        // seam: the surface handed the session back to the old bar at the exact
+        // moment it had something to report, and the whole keyboard changed
+        // shape to say "Gateway unavailable".
+        case .readyToInsert, .inserting, .targetContextChanged: true
+        case .serverUnavailable, .uploadFailedRecoverable: true
+        case .transcriptionFailedRecoverable, .transcriptionFailedPermanent: true
+        case .permissionDenied: true
+        default: false
+        }
+    }
+
     private static let chromeInset: CGFloat = 6
+
+    /// Nothing under the last row of keys.
+    ///
+    /// The system draws its own globe and dictation bar below this view and
+    /// gives that bar its own padding; six more points of ours sat on top of it
+    /// and read as a gap the system keyboard does not have.
+    private static let chromeBottomInset: CGFloat = 0
 
     /// Sizes everything from the current traits instead of a single portrait
     /// iPhone constant, and gives the dictation bar only as much room as the
@@ -1275,14 +1481,54 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         keyGrid.metrics = metrics
         dictationBar.metrics = barMetrics
 
-        let barHeight = barMetrics.height(for: barLayout, expanded: isBarExpanded)
-        barHeightConstraint?.constant = barHeight
+        let isRecording = Self.surfaceOwnsKeyboard(dictationSurfaceState.state)
+        // Recording's own bar model is the *expanded status* layout — the tall
+        // card the old bar used to draw — and asking it for a height is what
+        // still made the keyboard grow, by about forty points, after the two
+        // sums were merged into one. The surface does not use that layout at
+        // all: it stands in the strip and then takes the keys' room from the
+        // inside, so the height is the strip's, in every state.
+        let barHeight = barMetrics.height(
+            for: isRecording ? .strip : barLayout,
+            expanded: isRecording ? false : isBarExpanded
+        )
+
+        // One height, and recording does not get a say in it: whatever the
+        // typing layout needs is what the keyboard is, in every state. The
+        // surface takes the keys' room from the inside — the grid is hidden and
+        // the stack, pinned top and bottom, hands the bar what the grid had.
+        //
+        // Deriving a second height for recording is what made the controls
+        // jump: two sums over the same three numbers, and any drift between
+        // them moves the keyboard, which the host app sits on the bottom of the
+        // screen. There is one sum now.
+        let keyboardHeight = Self.chromeInset
+            + Self.chromeBottomInset
+            + barHeight
+            + Self.chromeSpacing
+            + metrics.gridHeight
+
+        let wantedBarHeight = isRecording
+            ? keyboardHeight - Self.chromeInset - Self.chromeBottomInset
+            : barHeight
+        // Nothing moved, so nothing is animated.
+        //
+        // This is called on every change of bar layout, and the surface changes
+        // layout at moments where the keyboard's own geometry does not — going
+        // from recording to transcribing is the same three numbers. Running a
+        // third-of-a-second spring over a layout that resolves to exactly where
+        // it already was is not a no-op on screen: the hosting view is asked to
+        // re-lay its SwiftUI content mid-flight, against the surface's own
+        // animation, and the pair of them is the twitch.
+        let unchanged = barHeightConstraint?.constant == wantedBarHeight
+            && gridHeightConstraint?.constant == metrics.gridHeight
+            && keyboardHeightConstraint?.constant == keyboardHeight
+        guard !unchanged else { return }
+
+        barHeightConstraint?.constant = wantedBarHeight
         gridHeightConstraint?.constant = metrics.gridHeight
         emojiPanelHeightConstraint?.constant = metrics.gridHeight
-        keyboardHeightConstraint?.constant = 2 * Self.chromeInset
-            + barHeight
-            + metrics.gridHeight
-            + Self.chromeSpacing
+        keyboardHeightConstraint?.constant = keyboardHeight
 
         guard animated, !UIAccessibility.isReduceMotionEnabled else {
             view.setNeedsLayout()
@@ -1408,10 +1654,23 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
     private func applyTheme() {
         palette = KeyboardPalette(isDark: prefersDarkAppearance)
-        view.backgroundColor = palette.background
-        inputView?.backgroundColor = palette.background
+        // Clear lets the input view iOS handed this extension draw the system
+        // keyboard surface itself. See ``KeyboardPalette/usesSystemKeyboardBackdrop``.
+        let backdrop: UIColor = palette.usesSystemKeyboardBackdrop ? .clear : palette.background
+        view.backgroundColor = backdrop
+        inputView?.backgroundColor = backdrop
         dictationBar.palette = palette
         keyGrid.palette = palette
+        dictationSurfaceState.isDark = prefersDarkAppearance
+        dictationSurfaceState.typing.isDark = prefersDarkAppearance
+        // The glass and every system material inside the surface resolve
+        // against the *trait* appearance, not against the flag above. Left
+        // alone they follow the phone, while the keys follow the field — which
+        // is a different answer whenever a dark field sits in a light app, and
+        // is why the globe kept coming back a slightly different colour after a
+        // keyboard switch.
+        dictationSurfaceHosting?.overrideUserInterfaceStyle =
+            prefersDarkAppearance ? .dark : .light
     }
 
     /// Autocapitalization follows the field's own request. A username or URL
@@ -1554,4 +1813,40 @@ extension KeyboardViewController: DictationBarViewDelegate {
         releaseUndoIfDetached()
         updateAutomaticShift()
     }
+}
+
+/// The stack that holds the dictation surface above the keys.
+///
+/// Its only job beyond stacking is to make sure the gap between the two is not
+/// a hole. A stack view's spacing belongs to no subview: a touch landing there
+/// hits the stack, which handles nothing, and is never delivered to anybody.
+/// The measurement that led here is unambiguous — every letter touch the grid
+/// receives becomes a character, and letters still went missing, so they were
+/// the ones that never arrived.
+///
+/// Twelve points is nothing to look at and quite a lot to type into: a fast
+/// typist reaching for the top row lands high, and the gap sits exactly there.
+/// It is given to the keys, which already know how to claim the space around
+/// them.
+final class KeyboardStack: UIStackView {
+    weak var keyGrid: UIView?
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        if let hit = super.hitTest(point, with: event) { return hit }
+        guard let keyGrid, !keyGrid.isHidden, keyGrid.alpha > 0 else { return nil }
+        // Only the strip directly above the keys, and only downwards: this must
+        // not steal a touch aimed at the surface's own controls.
+        let gap = CGRect(
+            x: keyGrid.frame.minX,
+            y: keyGrid.frame.minY - Self.claimedGap,
+            width: keyGrid.frame.width,
+            height: Self.claimedGap
+        )
+        guard gap.contains(point) else { return nil }
+        return keyGrid.hitTest(keyGrid.convert(point, from: self), with: event) ?? keyGrid
+    }
+
+    /// The keyboard's own spacing. Named here rather than shared, because what
+    /// this claims is the space the layout leaves empty, whatever it is.
+    private static let claimedGap: CGFloat = 12
 }

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -1161,7 +1161,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         }
         updateElapsedTime(for: state)
         if state == .recording {
-            dictationBar.push(meterLevel: record?.meterLevel ?? 0)
+            // One level per poll, which is what the record carries. The run
+            // the pipeline now measures reaches the bar with the surface that
+            // draws it.
+            dictationBar.push(meterLevels: [record?.meterLevel ?? 0])
         }
         dictationBar.apply(model, animated: hasRendered)
         announceStateChange(to: state, saying: model.announcement)

--- a/ios/VocaPhoneKeyboard/SpellChecking.swift
+++ b/ios/VocaPhoneKeyboard/SpellChecking.swift
@@ -29,6 +29,15 @@ protocol SpellChecking: AnyObject {
 ///
 /// One instance. A second one also means a second copy of the loaded language
 /// data, which matters when the whole extension is fighting for 45–60 MB.
+/// Main-actor isolated, because `UITextChecker` is. The SDK marks the class
+/// `NS_SWIFT_UI_ACTOR` — a per-class annotation Apple wrote deliberately, not
+/// UIKit's blanket one — so there is no version of this that runs on a queue of
+/// its own, however much the measurements would like one.
+///
+/// What those measurements found is real: 50 to 135 ms per new prefix, with the
+/// display link stopped for the whole of it, starting the instant a letter was
+/// committed. The answer is not to move the work but to ask for it less often —
+/// see ``TypingEngine``, which now waits for the hand to pause.
 @MainActor
 final class SystemSpellChecker: SpellChecking {
     /// Built on first use, never at launch.

--- a/ios/VocaPhoneKeyboard/TouchTrace.swift
+++ b/ios/VocaPhoneKeyboard/TouchTrace.swift
@@ -1,0 +1,143 @@
+import UIKit
+
+/// What happened to every finger that touched the keyboard, written where a
+/// Mac can read it.
+///
+/// Letters go missing at speed and only at speed, which is the one condition a
+/// person cannot hold still long enough to look at. Three different things
+/// would look identical from the outside — the touch never reaching the grid,
+/// the grid resolving no key under it, and the key resolving but never
+/// committing — and each has a different fix. This tells them apart.
+///
+/// Debug only, and off unless something turns it on: the flush is a file write
+/// on the main thread, which is not a thing a keyboard should be doing while
+/// somebody types on it.
+@MainActor
+enum TouchTrace {
+    /// Armed for the whole of a debug build, and impossible to arm in a release
+    /// one: the fault this exists for only appears at full typing speed, which
+    /// is not a state anybody can reach while also reaching for a switch.
+    ///
+    /// What it records is deliberately not everything. A character key's name is
+    /// the character, so ``KeyGridView/traceNamesKeys`` withholds it in a field
+    /// that has switched typing intelligence off.
+    static var isEnabled = false
+
+    private static var lines: [String] = []
+    private static var origin: CFTimeInterval = 0
+    private static var flushTimer: Timer?
+
+    /// A short, readable name for a `UITouch`.
+    ///
+    /// Deliberately the object's own address: UIKit pools `UITouch` instances
+    /// and hands the same object to the next finger, and a tracked entry that
+    /// outlived its sequence would then be matched by `===` against a touch it
+    /// has nothing to do with. If that is what is happening, the same name
+    /// appearing twice without an end between is what shows it.
+    static func name(_ touch: UITouch) -> String {
+        let address = UInt(bitPattern: ObjectIdentifier(touch).hashValue)
+        return String(format: "t%03X", address & 0xFFF)
+    }
+
+    static func note(_ text: @autoclosure () -> String) {
+#if DEBUG
+        guard isEnabled else { return }
+        if origin == 0 { origin = CACurrentMediaTime() }
+        lines.append(
+            String(format: "%9.1f  %@", (CACurrentMediaTime() - origin) * 1000, text())
+        )
+        if lines.count >= 400 { flush() }
+#endif
+    }
+
+    /// Marks a new run in the file, so a trace pulled after several attempts
+    /// still says which keystrokes belong together.
+    static func beginSession(_ label: String) {
+#if DEBUG
+        guard isEnabled else { return }
+        origin = CACurrentMediaTime()
+        scheduleFlush()
+        lines.append("\n===== \(label) — \(Date()) =====")
+        scheduleFlush()
+#endif
+    }
+
+    /// One repeating timer, not one per line.
+    ///
+    /// This used to invalidate and re-schedule on every note. A keystroke emits
+    /// about fifteen of them, so typing churned fifteen runloop timers per
+    /// letter — an instrument that got heavier the longer it was left running,
+    /// which is precisely the shape of the fault it was armed to find.
+    private static func scheduleFlush() {
+        guard flushTimer == nil else { return }
+        flushTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            MainActor.assumeIsolated { flushIfIdle() }
+        }
+    }
+
+    private static func flushIfIdle() {
+        guard !lines.isEmpty else { return }
+        flush(keepingTimer: true)
+    }
+
+    static func flush() { flush(keepingTimer: false) }
+
+    /// The writes happen here, off the main thread.
+    ///
+    /// This is the mistake an instrument must not make. Appending the buffer to
+    /// the App Group container took a `FileHandle` open, a seek to the end of a
+    /// file that grows to a megabyte, a write and a close — and it did all of it
+    /// on the main thread, once a second, for as long as somebody was typing.
+    /// Measured on device, that was frames of 48 to 195 ms arriving about once a
+    /// second while the keyboard's own code was doing nothing at all: the
+    /// instrument was producing the fault it was armed to find.
+    private static let writer = DispatchQueue(label: "vocaphone.touch-trace")
+
+    private static func flush(keepingTimer: Bool) {
+        if !keepingTimer {
+            flushTimer?.invalidate()
+            flushTimer = nil
+        }
+        guard !lines.isEmpty, let url = fileURL else { return }
+        let payload = lines.joined(separator: "\n") + "\n"
+        lines.removeAll(keepingCapacity: true)
+        guard let data = payload.data(using: .utf8) else { return }
+        writer.async { append(data, to: url) }
+    }
+
+    nonisolated private static func append(_ data: Data, to url: URL) {
+        // Every appearance of the keyboard appends, and it appears dozens of
+        // times a day. A trace that has outgrown the fault it was armed for is
+        // worth less than the one about to be recorded.
+        if let size = try? FileManager.default
+            .attributesOfItem(atPath: url.path)[.size] as? Int,
+            size > 1_000_000
+        {
+            try? FileManager.default.removeItem(at: url)
+        }
+        if let handle = try? FileHandle(forWritingTo: url) {
+            defer { try? handle.close() }
+            _ = try? handle.seekToEnd()
+            try? handle.write(contentsOf: data)
+        } else {
+            try? data.write(to: url, options: .atomic)
+        }
+    }
+
+    static let fileName = "touch-trace.txt"
+
+    private static var fileURL: URL? {
+        FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: AppConfiguration.appGroupIdentifier
+        )?.appendingPathComponent(fileName)
+    }
+
+    /// Starts the next run from an empty file, so what comes back is only the
+    /// typing that was done to reproduce the fault.
+    static func reset() {
+        lines.removeAll(keepingCapacity: true)
+        origin = 0
+        guard let fileURL else { return }
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+}

--- a/ios/VocaPhoneKeyboard/TouchWitness.swift
+++ b/ios/VocaPhoneKeyboard/TouchWitness.swift
@@ -1,0 +1,70 @@
+import UIKit
+
+/// Records every touch the keyboard is handed, whatever the hit test then does
+/// with it.
+///
+/// A gesture recognizer is attached to a view, not to a hit-test result: UIKit
+/// offers it every touch inside that view's hierarchy before deciding which
+/// view owns it, and it keeps seeing them even when the owner discards them.
+/// That makes it the one instrument that can separate the two explanations for
+/// a letter that never appeared:
+///
+/// - The keyboard was given the touch and lost it. Something in this keyboard's
+///   own routing is at fault, and reverting that routing would fix it.
+/// - The keyboard was never given a touch at all. iOS discarded the contact
+///   before any view saw it, and no arrangement of views can recover it — only
+///   correcting the word afterwards can.
+///
+/// Those have opposite fixes, which is why guessing between them is not good
+/// enough.
+///
+/// One of these on the keyboard's own view answers the first question. A second
+/// on the *window* answers the one behind it: a recognizer attached to a window
+/// is offered every touch in that window, whichever view ends up owning it. If
+/// the window sees a touch the view never does, the touch is arriving and being
+/// routed away from the keys; if neither sees it, it is not arriving at all.
+///
+/// Deliberately inert: it fails the moment it sees anything, does not delay
+/// touches, and does not cancel them, so the keyboard behaves exactly as it
+/// would without it.
+final class TouchWitness: UIGestureRecognizer {
+    /// Which view this one is watching, so two of them can be told apart in the
+    /// trace.
+    private let label: String
+
+    init(label: String) {
+        self.label = label
+        super.init(target: nil, action: nil)
+        cancelsTouchesInView = false
+        delaysTouchesBegan = false
+        delaysTouchesEnded = false
+        requiresExclusiveTouchType = false
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+        // What the *event* carries, not only what was handed to us.
+        //
+        // Every instrument so far can see a touch only once the system has
+        // decided it belongs to this keyboard. `allTouches` is the one place a
+        // contact shows up that was delivered somewhere else, or that exists in
+        // a phase nobody routed — which is the last remaining explanation for a
+        // press that leaves no trace anywhere in this process.
+        if let all = event.allTouches, all.count != touches.count {
+            let phases = all
+                .map { "\(TouchTrace.name($0)):\($0.phase.rawValue)" }
+                .sorted()
+                .joined(separator: " ")
+            TouchTrace.note("event carries \(all.count) touches — \(phases)")
+        }
+        for touch in touches {
+            let point = touch.location(in: view)
+            TouchTrace.note(
+                "witness/\(label) \(TouchTrace.name(touch)) "
+                    + "(\(Int(point.x)),\(Int(point.y))) "
+                    + "major=\(String(format: "%.1f", touch.majorRadius)) "
+                    + "type=\(touch.type.rawValue)"
+            )
+        }
+        state = .failed
+    }
+}

--- a/ios/VocaPhoneKeyboard/TypingCandidates.swift
+++ b/ios/VocaPhoneKeyboard/TypingCandidates.swift
@@ -38,6 +38,13 @@ struct TypingCandidate: Equatable {
     /// emphasised chip that space does not apply is a lie the user only catches
     /// after losing a word.
     var isEmphasised = false
+
+    /// What makes this chip *this* chip on screen.
+    ///
+    /// The row is rebuilt on every keystroke, and identifying a chip by its
+    /// position means the suggestion for a new prefix inherits the identity —
+    /// and the running animation — of the word that stood there before it.
+    var identity: String { "\(kind)-\(text)" }
 }
 
 /// Everything the strip needs to draw itself for one keystroke.

--- a/ios/VocaPhoneKeyboard/TypingCandidates.swift
+++ b/ios/VocaPhoneKeyboard/TypingCandidates.swift
@@ -43,7 +43,7 @@ struct TypingCandidate: Equatable {
     ///
     /// The row is rebuilt on every keystroke, and identifying a chip by its
     /// position means the suggestion for a new prefix inherits the identity —
-    /// and the running animation — of the word that stood there before it.
+    /// and the running animation — of the word that was there before it.
     var identity: String { "\(kind)-\(text)" }
 }
 
@@ -53,6 +53,14 @@ struct TypingStrip: Equatable {
     /// The replacement a boundary key will apply, or `nil` when the typed word
     /// stands. Always mirrored by an emphasised chip.
     var autocorrection: String?
+    /// The word that replacement was worked out for.
+    ///
+    /// The strip is not cleared while the checker is being consulted, so between
+    /// one letter and the checker's answer it still carries the correction for
+    /// the word as it stood a keystroke ago. A space arriving in that window
+    /// used to apply it — rewriting "howit" with a correction meant for "howi".
+    /// The boundary now checks that the offer is about the word in hand.
+    var autocorrectionTarget: String?
 
     var isEmpty: Bool { candidates.isEmpty }
 
@@ -104,6 +112,13 @@ enum TypingCandidates {
         var isMidWord = false
 
         /// Whether the system checker recognises the composition.
+        /// Whether the checker has answered for this word yet.
+        ///
+        /// It is asked only once the hand pauses, so for the length of a brisk
+        /// keystroke there is no answer and `isKnownToChecker` is `false` — which
+        /// is not the same as "not a word". Rules that read that flag as
+        /// evidence must wait; rules that merely rank may proceed.
+        var hasCheckerAnswer = false
         var isKnownToChecker = false
         /// Whether the word list contains it.
         var isInWordList = false
@@ -114,7 +129,10 @@ enum TypingCandidates {
         var emojiSuggestion: String?
 
         var suggestionsEnabled = true
-        var autocorrectEnabled = true
+        /// Where each system guess sits in the shipped frequency list, if the list
+    /// knows it at all. Keyed lowercase.
+    var listRanks: [String: Int] = [:]
+    var autocorrectEnabled = true
         var predictionEnabled = true
         var emojiEnabled = true
         var allowsTypingIntelligence = true
@@ -164,7 +182,8 @@ enum TypingCandidates {
         }
         return TypingStrip(
             candidates: appendingEmoji(to: candidates, context: context),
-            autocorrection: correction
+            autocorrection: correction,
+            autocorrectionTarget: correction == nil ? nil : context.composition
         )
     }
 
@@ -233,23 +252,31 @@ enum TypingCandidates {
     /// worse than no autocorrect at all: it takes a word the user typed
     /// deliberately and replaces it after they have stopped looking. The rules
     /// are individually tested, and each test fails if its rule is removed.
-    static func autocorrection(_ context: Context) -> String? {
+    /// Whether the next boundary should replace the word, and when it should
+    /// not, what stopped it.
+    ///
+    /// The reason is not decoration. This rule is a ladder of fifteen refusals,
+    /// each one written against a case where correcting would have been worse
+    /// than leaving the word alone — and from the outside every one of them
+    /// looks identical: the word stands. Working out which rung a given word
+    /// fell off by reading the ladder is guesswork; making it say so is not.
+    static func autocorrectDecision(_ context: Context) -> AutocorrectDecision {
         guard context.suggestionsEnabled,
               context.autocorrectEnabled,
               context.allowsTypingIntelligence
-        else { return nil }
+        else { return .refused("off") }
 
         // Only keystrokes. A dictated word, an accepted swipe and a tapped
         // suggestion were all chosen by something the user saw.
-        guard context.origin == .typed else { return nil }
+        guard context.origin == .typed else { return .refused("not typed") }
 
         // The cursor is inside a longer word. The keyboard is holding a prefix
         // of something it cannot see the end of, and rewriting that prefix
         // corrupts a word the user never finished typing in the first place.
-        guard !context.isMidWord else { return nil }
+        guard !context.isMidWord else { return .refused("mid-word") }
 
         let typed = context.composition
-        guard !typed.isEmpty else { return nil }
+        guard !typed.isEmpty else { return .refused("nothing composed") }
 
         // The user's own assertion outranks every source below, including the
         // curated table: someone who put their spelling back once has answered
@@ -257,7 +284,7 @@ enum TypingCandidates {
         guard !contains(context.customWords, typed),
               !contains(context.learnedWords, typed),
               !context.assertedWords.contains(typed.lowercased())
-        else { return nil }
+        else { return .refused("the user asserted this spelling") }
 
         // A text replacement the user configured in Settings. Not a guess — an
         // instruction — which is why it outranks everything below it.
@@ -278,7 +305,7 @@ enum TypingCandidates {
         if let expansion = context.lexiconExpansion,
            expansion.lowercased() != typed.lowercased()
         {
-            return expansion
+            return .apply(expansion)
         }
 
         // The curated short-word table, ahead of every guard below it. Each of
@@ -295,7 +322,7 @@ enum TypingCandidates {
         // contraction before the acronym rule ever ran. Deliberately *below*
         // the lexicon, because a text replacement is an instruction the user
         // configured, and "OMW" should expand whatever case it is typed in.
-        guard !isAllCaps(typed) else { return nil }
+        guard !isAllCaps(typed) else { return .refused("shouted") }
 
         // Exact comparison here, and here it *is* the whole point: "i" → "I" is
         // a case-only change, which is precisely what the general path below
@@ -308,18 +335,18 @@ enum TypingCandidates {
         if let replacement = ShortWordCorrections.replacement(for: typed),
            replacement != typed
         {
-            return replacement
+            return .apply(replacement)
         }
 
         // Two-letter words are mostly deliberate, and the shorter the word the
         // more words sit within one edit of it. Anything genuinely worth fixing
         // at that length is in the table above.
-        guard typed.count >= 3 else { return nil }
+        guard typed.count >= 3 else { return .refused("shorter than three letters") }
 
         // Anything the user or the language already recognises stands.
         guard !context.isKnownToChecker,
               !context.isInWordList
-        else { return nil }
+        else { return .refused("already a word") }
 
         // A word this keyboard has a curated emoji for is a word people type on
         // purpose. Most of them — "omg", "lmao", "haha", "yay", "ugh", "meh",
@@ -331,19 +358,61 @@ enum TypingCandidates {
         //
         // Independent of whether the emoji chip is switched on: the setting
         // controls whether a chip is drawn, not whether the word was meant.
-        guard context.emojiSuggestion == nil else { return nil }
+        guard context.emojiSuggestion == nil else { return .refused("a word with an emoji of its own") }
 
         // Letters and apostrophes only. A token with a digit, an `@`, a slash or
         // an underscore is an identifier, a handle, a path or a password hint —
         // never something to "fix".
         guard typed.allSatisfy({ $0.isLetter || $0 == "'" || $0 == "\u{2019}" }) else {
-            return nil
+            return .refused("not a word token")
         }
 
-        let guesses = context.systemGuesses.filter {
-            $0.caseInsensitiveCompare(typed) != .orderedSame
+        let typedIsLowercase = typed == typed.lowercased()
+        let typedIsSplit = typed.contains("-") || typed.contains(" ")
+        // A word that is two words with the space missed.
+        //
+        // This is the correction the typing in front of me actually needed:
+        // "howit", "sothis", "thisi", "worksn" — every one of them a space that
+        // did not register, and every one of them offered back by the checker
+        // as a hyphenation ("how-it", "so-this") because a spell checker's job
+        // is to spell one word rather than to notice there are two.
+        //
+        // Deliberately strict, because splitting a word the user meant is worse
+        // than leaving one they did not: both halves have to be words the
+        // shipped list knows, both at least two letters, and the split has to be
+        // the only one that works. "into" is not "in to" — the whole word is
+        // known, and this is only reached for words that are not.
+        // And only once the checker has answered. Until it does,
+        // `isKnownToChecker` is false for every word, so the guard above lets
+        // real compounds through — and the shipped ten thousand does not contain
+        // "sometime", "backend", "frontend", "logout", "weekday" or "standup".
+        // Splitting those is not a correction, it is damage.
+        if context.hasCheckerAnswer,
+           let split = wordSplit(typed, context: context)
+        {
+            return .apply(split)
         }
-        guard !guesses.isEmpty else { return nil }
+
+        let guesses = context.systemGuesses
+            .filter { $0.caseInsensitiveCompare(typed) != .orderedSame }
+            // One word typed becomes one word corrected.
+            //
+            // `UITextChecker` answers "howit" with "how-it" and "sothis" with
+            // "so-this": it splits the word at a hyphen, which is not what
+            // anybody meant and is exactly what a keyboard correcting "howit"
+            // to "how-it" looks like from the outside. Measured across a
+            // session's typing, these split guesses were also the ones
+            // defeating the margin rule below — "so-this and sot-his both fit"
+            // is two pieces of nonsense agreeing that a real typo stands.
+            .filter { typedIsSplit || !$0.contains(where: { $0 == "-" || $0 == " " }) }
+            // And a word typed in lowercase does not become a proper noun. The
+            // checker's dictionary carries place names and abbreviations —
+            // "Sotho" for "sothi", "IoW" for "sow" — and a sentence being typed
+            // in lowercase did not ask for either. Capitalisation that is
+            // *wanted* comes from the curated table and the lexicon above,
+            // both of which have already had their say.
+            .filter { !typedIsLowercase || $0.first?.isUppercase != true }
+        guard !guesses.isEmpty else { return .refused("the checker offered nothing") }
 
         // Re-ranked rather than taken in the order the checker offered them.
         //
@@ -354,13 +423,13 @@ enum TypingCandidates {
         let scored = guesses
             .map { (word: $0, cost: correctionCost(typed: typed, candidate: $0, context: context)) }
             .sorted { $0.cost < $1.cost }
-        guard let best = scored.first else { return nil }
+        guard let best = scored.first else { return .refused("nothing scored") }
 
         // Close enough to be a typo rather than a different word. Measured
         // unweighted, because "is this a typo at all" is a question about how
         // many characters moved, not about which keys they were near.
         let bestEdits = editDistance(typed.lowercased(), best.word.lowercased(), maximum: 2)
-        guard bestEdits <= 2 else { return nil }
+        guard bestEdits <= 2 else { return .refused("too far: \(bestEdits) edits to \(best.word)") }
 
         // A comfortable margin over the runner-up. Two equally good guesses
         // means nothing here knows which either, and picking one is a coin toss
@@ -399,20 +468,88 @@ enum TypingCandidates {
                 maximum: 3
             )
             let hasSpellingMargin = secondEdits > bestEdits
-            let hasProximityMargin = scored[1].cost - best.cost >= 0.7
+            // Not proximity alone, whatever this used to be called. The cost
+            // compared here now carries three things — how far the fingers
+            // travelled, whether the sentence predicts the word, and how well
+            // the shipped list knows it — and the last can clear the threshold
+            // by itself: a common word against one the list has never heard of
+            // differs by 0.85 before a finger is considered. That is deliberate,
+            // and it is what stopped "both" losing to "coth".
+            let hasCostMargin = scored[1].cost - best.cost >= 0.7
             let isContextual = contains(context.contextualFollowers, best.word)
             guard hasSpellingMargin
-                || hasProximityMargin
+                || hasCostMargin
                 || isContextual
                 || isTransposition(typed.lowercased(), best.word.lowercased())
-            else { return nil }
+            else { return .refused("ambiguous: \(best.word) and \(scored[1].word) both fit") }
         }
 
         // Capitalization is `updateAutomaticShift`'s job. An autocorrect that
         // only changes case is the keyboard fighting the shift key.
-        guard best.word.lowercased() != typed.lowercased() else { return nil }
+        guard best.word.lowercased() != typed.lowercased() else { return .refused("a change of case only") }
 
-        return best.word
+        return .apply(best.word)
+    }
+
+    /// What the boundary should do with the word, and why.
+    enum AutocorrectDecision: Equatable {
+        case apply(String)
+        case refused(String)
+
+        var replacement: String? {
+            switch self {
+            case let .apply(word): word
+            case .refused: nil
+            }
+        }
+
+        /// What happened, in the words the decision was made in.
+        var outcomeDescription: String {
+            switch self {
+            case let .apply(word): "would apply \(word)"
+            case let .refused(reason): "stands — \(reason)"
+            }
+        }
+
+        var refusal: String? {
+            switch self {
+            case .apply: nil
+            case let .refused(reason): reason
+            }
+        }
+    }
+
+    static func autocorrection(_ context: Context) -> String? {
+        autocorrectDecision(context).replacement
+    }
+
+    /// The one way `typed` reads as two words, or `nil` if there is not exactly
+    /// one.
+    ///
+    /// Both halves must be in the shipped frequency list — which is ten thousand
+    /// words in order of how often they are written — and common enough that the
+    /// pair is a sentence rather than a coincidence. Ambiguity is refused the
+    /// same way it is everywhere else here: two possible splits mean the
+    /// keyboard does not know which, and guessing costs the user their word.
+    static func wordSplit(_ typed: String, context: Context) -> String? {
+        let lowered = typed.lowercased()
+        guard lowered.count >= 4, lowered.allSatisfy({ $0.isLetter }) else { return nil }
+        let characters = Array(lowered)
+        var found: String?
+        for cut in 2...(characters.count - 2) {
+            let left = String(characters[..<cut])
+            let right = String(characters[cut...])
+            guard let leftRank = context.listRanks[left],
+                  let rightRank = context.listRanks[right]
+            else { continue }
+            // Common on both sides. A rare word paired with a rare word is how
+            // "themes" becomes "the mes".
+            guard leftRank < 3000, rightRank < 3000 else { continue }
+            // A second way to cut it means the keyboard has no idea which.
+            guard found == nil else { return nil }
+            found = matchingCase(of: typed, applyingTo: left + " " + right)
+        }
+        return found
     }
 
     /// How reluctant the keyboard should be to replace `typed` with `candidate`.
@@ -434,6 +571,23 @@ enum TypingCandidates {
         // The shipped list is frequency-ordered and the checker is not, so a
         // guess the list knows is the more likely reading of the two.
         if contains(context.listCompletions, candidate) { cost -= 0.1 }
+        // And how well it knows it.
+        //
+        // `UITextChecker` ranks nothing: "coth" comes back beside "both" as an
+        // equal reading of "coth"'s neighbour, and the margin rule below then
+        // refuses to choose between them — which is how "both" went uncorrected
+        // eight times in one session. The shipped list is ten thousand words in
+        // frequency order, so it can say what the checker cannot: that one of
+        // the two is a word people write and the other is not.
+        //
+        // Bounded like every other adjustment here. A word the list has never
+        // heard of is not disqualified — plenty of real words are outside ten
+        // thousand — it simply stops counting as an equal.
+        if let rank = context.listRanks[candidate.lowercased()] {
+            cost -= rank < 2000 ? 0.35 : 0.15
+        } else {
+            cost += 0.5
+        }
         return cost
     }
 

--- a/ios/VocaPhoneKeyboard/TypingEngine.swift
+++ b/ios/VocaPhoneKeyboard/TypingEngine.swift
@@ -304,6 +304,9 @@ final class TypingEngine {
     /// is therefore never autocorrected: the recogniser already picked from the
     /// dictionary, and correcting its answer would be two guesses stacked.
     func noteSwipeWord(_ word: String, alternates: [String]) {
+        pendingCheck?.cancel()
+        pendingCheck = nil
+        generation += 1
         composer.adopt(word, origin: .swipe)
         // Kept beside the composer rather than inside it. The document reads
         // "word " and the composer describes the word the cursor is inside, so
@@ -407,6 +410,10 @@ final class TypingEngine {
     // MARK: - Computation
 
     private func refresh(document: DocumentSnapshot) {
+        // Retire the previous composition even when this refresh exits early.
+        pendingCheck?.cancel()
+        pendingCheck = nil
+        generation += 1
         measured("nextCharacters") { publishNextCharacters() }
         guard KeyboardPreferences.typingSuggestionsEnabled, policy.allowsTypingIntelligence
         else {
@@ -433,7 +440,6 @@ final class TypingEngine {
             return
         }
 
-        generation += 1
         let generation = generation
         let composition = composer.text
         if !composition.isEmpty { measured("ensureLoaded") { ensureLoaded() } }

--- a/ios/VocaPhoneKeyboard/TypingEngine.swift
+++ b/ios/VocaPhoneKeyboard/TypingEngine.swift
@@ -190,7 +190,16 @@ final class TypingEngine {
     /// Adopts the current field. Resets everything document-scoped: a new field
     /// is a new document, and carrying an assertion or a half-typed word across
     /// is how a keyboard corrects a password field's contents into a message.
+    ///
+    /// Also retires any deferred checker task. The quiet-period wait is 90 ms,
+    /// and without a cancel plus a generation bump a task born in the previous
+    /// field wakes, sees a matching generation, and publishes that field's
+    /// completions into this one.
     func documentChanged(policy newPolicy: TypingFieldPolicy) {
+        pendingCheck?.cancel()
+        pendingCheck = nil
+        generation += 1
+        pendingSwipe = nil
         policy = newPolicy
         composer.reset()
         assertedWords.removeAll()

--- a/ios/VocaPhoneKeyboard/TypingEngine.swift
+++ b/ios/VocaPhoneKeyboard/TypingEngine.swift
@@ -74,6 +74,21 @@ final class TypingEngine {
     }
 
     private let checker: any SpellChecking
+    /// How long the hand has to be still before the checker is asked anything.
+    ///
+    /// `UITextChecker` is the most expensive thing this keyboard does — 50 to
+    /// 135 ms for a prefix it has not seen — and it is main-actor isolated, so
+    /// there is nowhere else to do it. What there is instead is *when*: a
+    /// keystroke is 120 ms from the next one at a brisk pace, and asking after
+    /// every one of them put that block in every gap between two letters, which
+    /// is exactly where the next finger lands.
+    ///
+    /// Waiting 90 ms means a burst of typing asks nothing at all — the strip is
+    /// carried by the shipped word list, which answers in a quarter of a
+    /// millisecond — and one question is asked when the hand stops, which is
+    /// also when somebody starts reading the strip.
+    private static let checkerQuietPeriod: Duration = .milliseconds(90)
+    private var pendingCheck: Task<Void, Never>?
     private let learned: LearnedWordStore
     private var cache = SuggestionCache()
     private var generation = 0
@@ -85,6 +100,21 @@ final class TypingEngine {
     struct LexiconEntry: Sendable, Equatable {
         let userInput: String
         let documentText: String
+        /// `userInput` folded once, when the entry arrives.
+        ///
+        /// This list is not the handful of replacements someone typed into
+        /// Settings — `UILexicon` also carries every name in their address
+        /// book. Lowercasing each of them to compare against the word being
+        /// typed allocated a string per entry per keystroke, twice over, and
+        /// measured on device that was most of the 4.2 ms a keystroke spent
+        /// assembling its context.
+        let lowered: String
+
+        init(userInput: String, documentText: String) {
+            self.userInput = userInput
+            self.documentText = documentText
+            lowered = userInput.lowercased()
+        }
     }
 
     /// Carries a main-actor-isolated object from a background callback back to
@@ -100,6 +130,8 @@ final class TypingEngine {
     }
     private var language = TypingLanguage.fallback
     private var customWords: [String] = []
+    /// `customWords` folded once. See ``LexiconEntry/lowered``.
+    private var loweredCustomWords: [String] = []
 
     init(
         checker: any SpellChecking = SystemSpellChecker(),
@@ -116,6 +148,7 @@ final class TypingEngine {
             hasLoaded = true
         }
         customWords = CustomVocabulary.terms(LocalTranscriptionPreferences.customVocabulary)
+        loweredCustomWords = customWords.map { $0.lowercased() }
     }
 
     private var hasLoaded = false
@@ -192,7 +225,7 @@ final class TypingEngine {
         pendingRevert = nil
         pendingSwipe = nil
         isMidWord = document.isMidWord
-        composer.insert(text, origin: origin)
+        measured("composer.insert") { composer.insert(text, origin: origin) }
         refresh(document: document)
     }
 
@@ -365,7 +398,7 @@ final class TypingEngine {
     // MARK: - Computation
 
     private func refresh(document: DocumentSnapshot) {
-        publishNextCharacters()
+        measured("nextCharacters") { publishNextCharacters() }
         guard KeyboardPreferences.typingSuggestionsEnabled, policy.allowsTypingIntelligence
         else {
             publish(.none)
@@ -394,60 +427,69 @@ final class TypingEngine {
         generation += 1
         let generation = generation
         let composition = composer.text
-        if !composition.isEmpty { ensureLoaded() }
+        if !composition.isEmpty { measured("ensureLoaded") { ensureLoaded() } }
         let origin = composer.origin
-        let preceding = PrecedingWord.lastWord(in: document.before)
+        let preceding = measured("precedingWord") {
+            PrecedingWord.lastWord(in: document.before)
+        }
 
         // Nothing being composed: prediction needs no checker, so it renders on
         // this turn rather than costing a hop.
         guard !composition.isEmpty else {
-            publish(
-                TypingCandidates.strip(
-                    context(composition: "", origin: origin, preceding: preceding, checked: nil)
-                )
+            publishStrip(
+                for: context(composition: "", origin: origin, preceding: preceding, checked: nil)
             )
             return
         }
 
         let key = SuggestionCache.Key(prefix: composition.lowercased(), language: language)
         if let cached = cache.value(for: key) {
-            publish(
-                TypingCandidates.strip(
-                    context(
-                        composition: composition,
-                        origin: origin,
-                        preceding: preceding,
-                        checked: cached
-                    )
+            publishStrip(
+                for: context(
+                    composition: composition,
+                    origin: origin,
+                    preceding: preceding,
+                    checked: cached
                 )
             )
             return
         }
 
-        // Enqueued rather than called: this returns immediately, the keystroke
-        // that triggered it finishes, and the checker runs on a later turn.
-        Task { @MainActor [weak self] in
-            guard let self, generation == self.generation else { return }
+        // Nothing is asked while the hand is moving.
+        //
+        // The strip still updates on this keystroke, from the shipped word list
+        // — that is the `publishStrip` below, and it costs a quarter of a
+        // millisecond. What waits is the checker, and every further keystroke
+        // cancels the wait and starts it again, so a burst of typing asks it
+        // nothing at all and a pause asks it once.
+        publishStrip(
+            for: context(
+                composition: composition,
+                origin: origin,
+                preceding: preceding,
+                checked: nil
+            )
+        )
+        pendingCheck?.cancel()
+        pendingCheck = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: Self.checkerQuietPeriod)
+            guard !Task.isCancelled, let self, generation == self.generation else { return }
             let value = SuggestionCache.Value(
                 completions: self.checker.completions(for: composition, language: self.language),
                 guesses: self.checker.guesses(for: composition, language: self.language),
                 isKnown: self.checker.isKnown(composition, language: self.language),
-                // Computed here, on the later turn, rather than inside
-                // `context` — which the cache-hit path also runs.
+                // Computed here rather than inside `context`, which the
+                // cache-hit path also runs.
                 similar: self.wordList.similarWords(to: composition, limit: 2)
             )
-            // Checked again: the user may have typed on while this task waited
-            // its turn, and a strip two keystrokes behind is worse than none.
             guard generation == self.generation else { return }
             self.cache.insert(value, for: key)
-            self.publish(
-                TypingCandidates.strip(
-                    self.context(
-                        composition: composition,
-                        origin: origin,
-                        preceding: preceding,
-                        checked: value
-                    )
+            self.publishStrip(
+                for: self.context(
+                    composition: composition,
+                    origin: origin,
+                    preceding: preceding,
+                    checked: value
                 )
             )
         }
@@ -459,26 +501,56 @@ final class TypingEngine {
         preceding: String?,
         checked: SuggestionCache.Value?
     ) -> TypingCandidates.Context {
+        measured("build context") {
+            buildContext(
+                composition: composition,
+                origin: origin,
+                preceding: preceding,
+                checked: checked
+            )
+        }
+    }
+
+    private func buildContext(
+        composition: String,
+        origin: WordComposer.Origin,
+        preceding: String?,
+        checked: SuggestionCache.Value?
+    ) -> TypingCandidates.Context {
         let snapshot = learned.snapshot()
         var context = TypingCandidates.Context()
         context.composition = composition
         context.origin = origin
         context.precedingWord = preceding
         let lowered = composition.lowercased()
-        context.lexiconEntries = lexiconEntries
-            .filter { !composition.isEmpty && $0.userInput.lowercased().hasPrefix(lowered) }
-            .map(\.documentText)
+        // One pass for both, over the folded copies: the prefix matches that
+        // reach the strip, and the exact match that outranks it.
+        var lexiconCompletions: [String] = []
+        var lexiconExpansion: String?
+        if !composition.isEmpty {
+            for entry in lexiconEntries where entry.lowered.hasPrefix(lowered) {
+                lexiconCompletions.append(entry.documentText)
+                if lexiconExpansion == nil,
+                   entry.lowered == lowered,
+                   !entry.documentText.isEmpty
+                {
+                    lexiconExpansion = entry.documentText
+                }
+            }
+        }
+        context.lexiconEntries = lexiconCompletions
         // An *exact* match is an instruction rather than a suggestion: the user
         // told Settings that "omw" means something, and iOS hands keyboards the
         // lexicon precisely so it can be honoured. It used to reach the strip as
         // a chip and stop there, so the expansion only ever happened if the user
         // noticed it and tapped.
-        context.lexiconExpansion = lexiconEntries
-            .first { $0.userInput.lowercased() == lowered && !$0.documentText.isEmpty }?
-            .documentText
-        context.customWords = customWords.filter {
-            !composition.isEmpty && $0.lowercased().hasPrefix(composition.lowercased())
-        }
+        context.lexiconExpansion = lexiconExpansion
+        // Folded once with the vocabulary, for the same reason.
+        context.customWords = composition.isEmpty
+            ? []
+            : zip(customWords, loweredCustomWords)
+                .filter { $0.1.hasPrefix(lowered) }
+                .map(\.0)
         context.learnedWords = snapshot.completions(for: composition, limit: 3)
         context.systemCompletions = Array((checked?.completions ?? []).prefix(8))
         // The checker's guesses first, the list's own near-matches behind them:
@@ -543,6 +615,31 @@ final class TypingEngine {
     /// space would happily autocorrect — rewriting the first half of a word the
     /// keyboard could only see half of.
     private var isMidWord = false
+
+    /// Times one phase of a keystroke into the trace. See the twin of this in
+    /// the controller: the phases are measured because guessing at them cost a
+    /// round of work that moved the median by 0.2 ms.
+    private func measured<T>(_ name: String, _ body: () -> T) -> T {
+        guard TouchTrace.isEnabled else { return body() }
+        let startedAt = CACurrentMediaTime()
+        defer {
+            TouchTrace.note(
+                String(format: "    %@ %.1fms", name, (CACurrentMediaTime() - startedAt) * 1000)
+            )
+        }
+        return body()
+    }
+
+    /// Publishes the strip for `context`, and — while a touch trace is armed —
+    /// records what the next boundary would do with the word, and why.
+    ///
+    /// The refusal is the part worth recording. A word that stands looks the
+    /// same whether the rule found it already correct, found two equally good
+    /// readings, or was switched off, and those are three different bugs.
+    private func publishStrip(for context: TypingCandidates.Context) {
+        let strip = measured("candidates.strip") { TypingCandidates.strip(context) }
+        measured("publish") { publish(strip) }
+    }
 
     private func publish(_ newStrip: TypingStrip) {
         guard newStrip != strip else { return }

--- a/ios/VocaPhoneKeyboard/TypingEngine.swift
+++ b/ios/VocaPhoneKeyboard/TypingEngine.swift
@@ -560,6 +560,25 @@ final class TypingEngine {
             checked?.similar ?? []
         )
         context.listCompletions = wordList.completions(for: composition, limit: 3)
+        // One dictionary lookup per guess, half a dozen of them. What it buys is
+        // the difference between "both" and "coth" — see `correctionCost`.
+        var listRanks: [String: Int] = [:]
+        for guess in context.systemGuesses {
+            let guessed = guess.lowercased()
+            if let rank = wordList.rank(of: guessed) { listRanks[guessed] = rank }
+        }
+        // And every way the word could be cut in two, for the split that puts a
+        // missed space back. Dictionary lookups, one per cut, on a word.
+        if lowered.count >= 4, lowered.allSatisfy({ $0.isLetter }) {
+            let characters = Array(lowered)
+            for cut in 2...(characters.count - 2) {
+                for half in [String(characters[..<cut]), String(characters[cut...])]
+                where listRanks[half] == nil {
+                    if let rank = wordList.rank(of: half) { listRanks[half] = rank }
+                }
+            }
+        }
+        context.listRanks = listRanks
         context.predictions = preceding.map { wordList.nextWords(after: $0, limit: 3) } ?? []
         // The same bigrams, but as evidence about the word being typed rather
         // than a guess about the next one. A wider window than the strip shows,
@@ -568,6 +587,7 @@ final class TypingEngine {
             wordList.nextWords(after: $0, limit: 12)
         } ?? []
         context.isMidWord = isMidWord
+        context.hasCheckerAnswer = checked != nil
         context.isKnownToChecker = checked?.isKnown ?? false
         context.isInWordList = wordList.contains(composition)
         context.assertedWords = assertedWords
@@ -637,6 +657,10 @@ final class TypingEngine {
     /// same whether the rule found it already correct, found two equally good
     /// readings, or was switched off, and those are three different bugs.
     private func publishStrip(for context: TypingCandidates.Context) {
+        TouchTrace.note(
+            "compose \"\(context.composition)\" "
+                + TypingCandidates.autocorrectDecision(context).outcomeDescription
+        )
         let strip = measured("candidates.strip") { TypingCandidates.strip(context) }
         measured("publish") { publish(strip) }
     }

--- a/ios/VocaPhoneKeyboard/TypingWordList.swift
+++ b/ios/VocaPhoneKeyboard/TypingWordList.swift
@@ -21,6 +21,22 @@ struct TypingWordList: Sendable {
     private let ranks: [String: Int]
     private let words: [String]
     private let bigrams: [String: [String]]
+    /// Where in `words` to start looking for a prefix, keyed by its first one
+    /// and two characters, each bucket in frequency order.
+    ///
+    /// Every prefix query used to walk the whole list — ten thousand words, and
+    /// a grapheme-counting `word.count` on each — because a frequency-ordered
+    /// list cannot be searched. `scanLimit` bounded the number of *matches*, not
+    /// the scan, so a rare prefix paid for all ten thousand. Measured on device
+    /// that was 5.5 ms of a 9.5 ms keystroke, on a frame budget of 8.3.
+    ///
+    /// Positions rather than words: the weight below is a function of a word's
+    /// rank in the whole list, so a bucket has to remember where its words came
+    /// from.
+    private let prefixIndex: [String: [Int32]]
+    /// Each word's length, so a query that only wants to know whether a word is
+    /// the right size never walks its graphemes to find out.
+    private let lengths: [Int]
     /// Each word with consecutive repeats removed, in `words` order.
     ///
     /// Built once with the list rather than per swipe. The recogniser needs the
@@ -42,6 +58,26 @@ struct TypingWordList: Sendable {
         }
         self.ranks = ranks
         collapsedWords = words.map(SwipeRecognizer.collapsed)
+        lengths = words.map(\.count)
+        var index: [String: [Int32]] = [:]
+        index.reserveCapacity(words.count / 8)
+        for (position, word) in words.enumerated() {
+            let one = String(word.prefix(1))
+            index[one, default: []].append(Int32(position))
+            guard word.count > 1 else { continue }
+            index[String(word.prefix(2)), default: []].append(Int32(position))
+        }
+        prefixIndex = index
+    }
+
+    /// The positions worth looking at for `lowered`, in frequency order, or
+    /// `nil` when the list has nothing that starts that way.
+    ///
+    /// Keyed on at most the first two characters, which is all it takes: after
+    /// two the buckets are already small enough that the difference is not
+    /// worth the memory of a third.
+    private func positions(startingWith lowered: String) -> [Int32]? {
+        prefixIndex[String(lowered.prefix(2))]
     }
 
     var isEmpty: Bool { words.isEmpty }
@@ -63,11 +99,14 @@ struct TypingWordList: Sendable {
     func completions(for prefix: String, limit: Int) -> [String] {
         guard !prefix.isEmpty, limit > 0 else { return [] }
         let lowered = prefix.lowercased()
+        guard let positions = positions(startingWith: lowered) else { return [] }
         var found: [String] = []
         found.reserveCapacity(limit)
-        // `words` is already frequency-ordered, so the first matches found are
-        // the best ones and the scan can stop early.
-        for word in words where word.count > lowered.count && word.hasPrefix(lowered) {
+        // The bucket is in frequency order, so the first matches found are the
+        // best ones and the scan can stop early.
+        for position in positions {
+            let word = words[Int(position)]
+            guard word != lowered, word.hasPrefix(lowered) else { continue }
             found.append(word)
             if found.count == limit { break }
         }
@@ -88,8 +127,9 @@ struct TypingWordList: Sendable {
         let longest = lowered.count + 2
         var withinOne: [String] = []
         var withinTwo: [String] = []
-        for word in words {
-            guard word.count >= shortest, word.count <= longest else { continue }
+        for (position, word) in words.enumerated() {
+            let length = lengths[position]
+            guard length >= shortest, length <= longest else { continue }
             switch TypingCandidates.editDistance(lowered, word, maximum: 2) {
             case 1: withinOne.append(word)
             case 2: if withinTwo.count < limit { withinTwo.append(word) }
@@ -118,15 +158,18 @@ struct TypingWordList: Sendable {
     func nextCharacterWeights(after prefix: String, scanLimit: Int = 400) -> [Character: Double] {
         guard !prefix.isEmpty else { return [:] }
         let lowered = prefix.lowercased()
+        guard let positions = positions(startingWith: lowered) else { return [:] }
         var weights: [Character: Double] = [:]
         var matches = 0
-        // `words` is frequency-ordered, so a match found early is a more likely
-        // continuation than one found late — which is exactly the weighting
-        // wanted, and it comes for free from the scan order.
-        for (rank, word) in words.enumerated() {
-            guard word.count > lowered.count, word.hasPrefix(lowered) else { continue }
+        // The bucket carries each word's rank in the whole list, so a match
+        // found early is still a more likely continuation than one found late —
+        // which is exactly the weighting wanted, and it still comes for free
+        // from the order.
+        for position in positions {
+            let word = words[Int(position)]
+            guard word != lowered, word.hasPrefix(lowered) else { continue }
             let next = word[word.index(word.startIndex, offsetBy: lowered.count)]
-            weights[next, default: 0] += 1 / (1 + Double(rank) / 500)
+            weights[next, default: 0] += 1 / (1 + Double(position) / 500)
             matches += 1
             if matches >= scanLimit { break }
         }

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -668,7 +668,7 @@ enum KeyboardPreferences {
         get {
             guard let raw = defaults?.string(forKey: typingHapticStyleKey),
                   let style = TypingHapticStyle(rawValue: raw)
-            else { return .soft }
+            else { return .rigid }
             return style
         }
         set { defaults?.set(newValue.rawValue, forKey: typingHapticStyleKey) }
@@ -677,8 +677,10 @@ enum KeyboardPreferences {
     /// 0 to 1, where 1 is the whole engine.
     static var typingHapticIntensity: Double {
         get {
-            let stored = defaults?.double(forKey: typingHapticIntensityKey) ?? 0
-            return stored > 0 ? min(stored, 1) : 0.72
+            guard let stored = defaults?.object(forKey: typingHapticIntensityKey) as? Double,
+                  stored.isFinite
+            else { return 1 }
+            return min(max(stored, 0), 1)
         }
         set { defaults?.set(min(max(newValue, 0), 1), forKey: typingHapticIntensityKey) }
     }

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -540,6 +540,33 @@ enum KeyboardPreferences {
         set { defaults?.set(newValue, forKey: repairSpeechKey) }
     }
 
+    /// Whether the magnified key above a press grows into place, or is simply
+    /// there.
+    ///
+    /// The balloon scales up over about a tenth of a second and back down on
+    /// release. That is the animation a fast typist has several of in flight at
+    /// once, and it is the one thing on the press path that is not instant:
+    /// the touch handler itself measures under a millisecond.
+    static var keyPreviewAnimates: Bool {
+        get { defaults?.object(forKey: keyPreviewAnimatesKey) as? Bool ?? false }
+        set { defaults?.set(newValue, forKey: keyPreviewAnimatesKey) }
+    }
+
+    /// Whether a character key fades back to its resting colour when the finger
+    /// leaves, or snaps.
+    ///
+    /// A switch rather than a constant because it is a suspect: every release
+    /// starts a tenth-of-a-second animation, and a fast typist has several of
+    /// them in flight at once. Whether that is what makes speed feel heavy is a
+    /// question for a thumb, not for an argument.
+    static var keyReleaseFade: Bool {
+        get { defaults?.object(forKey: keyReleaseFadeKey) as? Bool ?? false }
+        set { defaults?.set(newValue, forKey: keyReleaseFadeKey) }
+    }
+
+    static let keyPreviewAnimatesKey = "keyPreviewAnimates"
+    static let keyReleaseFadeKey = "keyReleaseFade"
+
     static var writingStyle: WritingStyle {
         get {
             guard let rawValue = defaults?.string(forKey: writingStyleKey),

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -3,6 +3,40 @@ import Foundation
 /// Presentation only. No style adds, removes or substitutes a word, and
 /// numbers, times, addresses and contractions are always left as the model
 /// transcribed them.
+/// The five taps `UIImpactFeedbackGenerator` can play, named for the hand
+/// rather than for the API: they differ in how hard and how sharp they are.
+enum TypingHapticStyle: String, CaseIterable, Identifiable, Sendable {
+    case light
+    case soft
+    case medium
+    case heavy
+    case rigid
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .light: "Light"
+        case .soft: "Soft"
+        case .medium: "Medium"
+        case .heavy: "Heavy"
+        case .rigid: "Rigid"
+        }
+    }
+
+    /// What each one feels like, so the picker is not five words in a row.
+    var detail: String {
+        switch self {
+        case .light: "A nudge. The softest and most diffuse."
+        case .soft: "Rounded and slow — a cushion rather than a click."
+        case .medium: "The middle of the range."
+        case .heavy: "The hardest hit the engine has."
+        case .rigid: "Short and sharp. What the system keyboard uses."
+        }
+    }
+
+}
+
 enum WritingStyle: String, Codable, CaseIterable, Identifiable, Sendable {
     case raw
     case clean
@@ -566,6 +600,33 @@ enum KeyboardPreferences {
 
     static let keyPreviewAnimatesKey = "keyPreviewAnimates"
     static let keyReleaseFadeKey = "keyReleaseFade"
+
+    /// How hard a key hits back.
+    ///
+    /// Stored because "strong enough" is a matter of hands and cases, not of
+    /// argument: the same generator that reads as a crisp press through a bare
+    /// phone is a rumour through a thick case.
+    static var typingHapticStyle: TypingHapticStyle {
+        get {
+            guard let raw = defaults?.string(forKey: typingHapticStyleKey),
+                  let style = TypingHapticStyle(rawValue: raw)
+            else { return .soft }
+            return style
+        }
+        set { defaults?.set(newValue.rawValue, forKey: typingHapticStyleKey) }
+    }
+
+    /// 0 to 1, where 1 is the whole engine.
+    static var typingHapticIntensity: Double {
+        get {
+            let stored = defaults?.double(forKey: typingHapticIntensityKey) ?? 0
+            return stored > 0 ? min(stored, 1) : 0.68
+        }
+        set { defaults?.set(min(max(newValue, 0), 1), forKey: typingHapticIntensityKey) }
+    }
+
+    static let typingHapticStyleKey = "typingHapticStyle"
+    static let typingHapticIntensityKey = "typingHapticIntensity"
 
     static var writingStyle: WritingStyle {
         get {

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-/// Presentation only. No style adds, removes or substitutes a word, and
-/// numbers, times, addresses and contractions are always left as the model
-/// transcribed them.
 /// The five taps `UIImpactFeedbackGenerator` can play, named for the hand
 /// rather than for the API: they differ in how hard and how sharp they are.
 enum TypingHapticStyle: String, CaseIterable, Identifiable, Sendable {
@@ -37,6 +34,9 @@ enum TypingHapticStyle: String, CaseIterable, Identifiable, Sendable {
 
 }
 
+/// Presentation only. No style adds, removes or substitutes a word, and
+/// numbers, times, addresses and contractions are always left as the model
+/// transcribed them.
 enum WritingStyle: String, Codable, CaseIterable, Identifiable, Sendable {
     case raw
     case clean
@@ -678,7 +678,7 @@ enum KeyboardPreferences {
     static var typingHapticIntensity: Double {
         get {
             let stored = defaults?.double(forKey: typingHapticIntensityKey) ?? 0
-            return stored > 0 ? min(stored, 1) : 0.68
+            return stored > 0 ? min(stored, 1) : 0.72
         }
         set { defaults?.set(min(max(newValue, 0), 1), forKey: typingHapticIntensityKey) }
     }

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -84,14 +84,27 @@ enum WritingStyle: String, Codable, CaseIterable, Identifiable, Sendable {
         TranscriptStyler.apply(Self.exampleSource, style: self)
     }
 
+    /// Everyday objects rather than typographic notation.
+    ///
+    /// The set this replaces described the *genre* of the text — a document, a
+    /// wand, two speech bubbles — while what actually separates these styles is
+    /// punctuation and capitalisation. Nobody tells `textformat` from
+    /// `textformat.abc` at 17 pt, and nobody should have to: an eraser, a
+    /// briefcase and sunglasses are read without being decoded.
     var symbolName: String {
         switch self {
-        case .raw: "doc.plaintext"
-        case .clean: "wand.and.stars"
-        case .formal: "textformat"
-        case .casual: "text.bubble"
-        case .veryCasual: "textformat.abc"
-        case .excited: "sparkles"
+        // What was said, unedited.
+        case .raw: "waveform"
+        // Tidied: spacing, a closing full stop, stray capitals rubbed out.
+        case .clean: "eraser"
+        // Sentence case and a full stop — the way work writing looks.
+        case .formal: "briefcase"
+        // A line in a conversation, which does not end in a full stop.
+        case .casual: "bubble.left"
+        // Lowercase throughout, clauses run together.
+        case .veryCasual: "sunglasses"
+        // Everything ends in an exclamation mark.
+        case .excited: "party.popper"
         }
     }
 }
@@ -574,6 +587,49 @@ enum KeyboardPreferences {
         set { defaults?.set(newValue, forKey: repairSpeechKey) }
     }
 
+    static let surfaceAnimationResponseKey = "surfaceAnimationResponse2"
+    static let surfaceAnimationDampingKey = "surfaceAnimationDamping2"
+
+    /// The spring the dictation surface changes phase with.
+    ///
+    /// Stored rather than hardcoded so the keyboard lab can tune it against a
+    /// thumb: the lab writes here, the extension reads here, and the value
+    /// survives leaving the screen. Nothing in a shipping build writes these —
+    /// the lab is the only writer and it is debug-only — so the defaults below
+    /// are what every user gets.
+    static var surfaceAnimationResponse: Double {
+        get {
+            let stored = defaults?.double(forKey: surfaceAnimationResponseKey) ?? 0
+            return stored > 0 ? stored : 0.15
+        }
+        set { defaults?.set(newValue, forKey: surfaceAnimationResponseKey) }
+    }
+
+    static var surfaceAnimationDamping: Double {
+        get {
+            let stored = defaults?.double(forKey: surfaceAnimationDampingKey) ?? 0
+            return stored > 0 ? stored : 1.0
+        }
+        set { defaults?.set(newValue, forKey: surfaceAnimationDampingKey) }
+    }
+
+    static let lastShownWritingStyleKey = "lastShownWritingStyle"
+
+    /// The style the dictation surface was showing when it last appeared.
+    ///
+    /// The one signal that iOS's cached picture of the keyboard is out of date:
+    /// the style changed while the keyboard was up, so the snapshot taken
+    /// before that change still carries the previous icon.
+    static var lastShownWritingStyle: WritingStyle? {
+        get {
+            guard let raw = defaults?.string(forKey: lastShownWritingStyleKey) else { return nil }
+            return WritingStyle(rawValue: raw)
+        }
+        set { defaults?.set(newValue?.rawValue, forKey: lastShownWritingStyleKey) }
+    }
+
+    static let keyPreviewAnimatesKey = "keyPreviewAnimates"
+
     /// Whether the magnified key above a press grows into place, or is simply
     /// there.
     ///
@@ -585,6 +641,8 @@ enum KeyboardPreferences {
         get { defaults?.object(forKey: keyPreviewAnimatesKey) as? Bool ?? false }
         set { defaults?.set(newValue, forKey: keyPreviewAnimatesKey) }
     }
+
+    static let keyReleaseFadeKey = "keyReleaseFade"
 
     /// Whether a character key fades back to its resting colour when the finger
     /// leaves, or snaps.
@@ -598,8 +656,8 @@ enum KeyboardPreferences {
         set { defaults?.set(newValue, forKey: keyReleaseFadeKey) }
     }
 
-    static let keyPreviewAnimatesKey = "keyPreviewAnimates"
-    static let keyReleaseFadeKey = "keyReleaseFade"
+    static let typingHapticStyleKey = "typingHapticStyle"
+    static let typingHapticIntensityKey = "typingHapticIntensity"
 
     /// How hard a key hits back.
     ///
@@ -624,9 +682,6 @@ enum KeyboardPreferences {
         }
         set { defaults?.set(min(max(newValue, 0), 1), forKey: typingHapticIntensityKey) }
     }
-
-    static let typingHapticStyleKey = "typingHapticStyle"
-    static let typingHapticIntensityKey = "typingHapticIntensity"
 
     static var writingStyle: WritingStyle {
         get {

--- a/ios/VocaPhoneShared/SemanticPalette.swift
+++ b/ios/VocaPhoneShared/SemanticPalette.swift
@@ -175,15 +175,35 @@ enum ContrastMath {
 
     /// WCAG relative luminance, which is defined on *linear* channels.
     static func relativeLuminance(_ color: UIColor) -> CGFloat {
+        guard let channels = rgba(color) else { return 0 }
+        func linear(_ channel: CGFloat) -> CGFloat {
+            channel <= 0.03928 ? channel / 12.92 : pow((channel + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * linear(channels.red)
+            + 0.7152 * linear(channels.green)
+            + 0.0722 * linear(channels.blue)
+    }
+
+    /// Channels for any colour these palettes can produce.
+    ///
+    /// `getRed` answers nothing for a *monochrome* `UIColor` — everything built
+    /// with `UIColor(white:alpha:)`, which is most of the neutral greys here —
+    /// and both callers used to read that failure as pure black. A grey scored
+    /// as black is a contrast test that passes when it should fail, and a
+    /// translucent fill that flattens to nothing.
+    static func rgba(
+        _ color: UIColor
+    ) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)? {
         var red: CGFloat = 0
         var green: CGFloat = 0
         var blue: CGFloat = 0
         var alpha: CGFloat = 0
-        guard color.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return 0 }
-        func linear(_ channel: CGFloat) -> CGFloat {
-            channel <= 0.03928 ? channel / 12.92 : pow((channel + 0.055) / 1.055, 2.4)
+        if color.getRed(&red, green: &green, blue: &blue, alpha: &alpha) {
+            return (red, green, blue, alpha)
         }
-        return 0.2126 * linear(red) + 0.7152 * linear(green) + 0.0722 * linear(blue)
+        var white: CGFloat = 0
+        guard color.getWhite(&white, alpha: &alpha) else { return nil }
+        return (white, white, white, alpha)
     }
 }
 
@@ -191,21 +211,13 @@ extension UIColor {
     /// Flattens a translucent colour onto an opaque one, so a disabled fill can
     /// be judged as the user sees it rather than as it was declared.
     func compositedOver(_ background: UIColor) -> UIColor {
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
-        var backRed: CGFloat = 0
-        var backGreen: CGFloat = 0
-        var backBlue: CGFloat = 0
-        var backAlpha: CGFloat = 0
-        guard getRed(&red, green: &green, blue: &blue, alpha: &alpha),
-              background.getRed(&backRed, green: &backGreen, blue: &backBlue, alpha: &backAlpha)
+        guard let front = ContrastMath.rgba(self),
+              let back = ContrastMath.rgba(background)
         else { return self }
         return UIColor(
-            red: alpha * red + (1 - alpha) * backRed,
-            green: alpha * green + (1 - alpha) * backGreen,
-            blue: alpha * blue + (1 - alpha) * backBlue,
+            red: front.alpha * front.red + (1 - front.alpha) * back.red,
+            green: front.alpha * front.green + (1 - front.alpha) * back.green,
+            blue: front.alpha * front.blue + (1 - front.alpha) * back.blue,
             alpha: 1
         )
     }

--- a/ios/VocaPhoneShared/SharedStore.swift
+++ b/ios/VocaPhoneShared/SharedStore.swift
@@ -5,6 +5,21 @@ enum SharedStoreError: Error {
     case unsupportedSchema(Int)
 }
 
+/// A run of microphone levels, written by the app and read by the keyboard.
+///
+/// `sequence` counts every level produced in this session, so a reader that
+/// polls can tell how many of them it has not drawn yet. Without it a reader
+/// that ticks faster than the writer draws the same audio twice, and one that
+/// ticks slower silently skips it.
+struct MeterSample: Codable, Equatable, Sendable {
+    var sequence: Int
+    var levels: [Float]
+
+    func clamped() -> MeterSample {
+        MeterSample(sequence: sequence, levels: levels.map { min(max($0, 0), 1) })
+    }
+}
+
 final class SharedStore: @unchecked Sendable {
     static let shared = SharedStore()
 
@@ -44,10 +59,9 @@ final class SharedStore: @unchecked Sendable {
     /// temporary file plus a rename on every tick, and re-creating the directory
     /// each time adds another syscall — both wasteful for four bytes whose next
     /// value arrives 150 ms later. A torn read simply shows a stale level.
-    func saveMeter(_ level: Float, for id: UUID) throws {
+    func saveMeter(_ sample: MeterSample, for id: UUID) throws {
         let directory = try sessionsDirectory()
-        let clamped = min(max(level, 0), 1)
-        let data = try encoder.encode(clamped)
+        let data = try encoder.encode(sample.clamped())
         let fileURL = meterURL(for: id, directory: directory)
         do {
             try data.write(to: fileURL)
@@ -316,10 +330,26 @@ final class SharedStore: @unchecked Sendable {
             return
         }
         let fileURL = meterURL(for: record.sessionID, directory: directory)
-        guard let data = try? Data(contentsOf: fileURL),
-              let level = try? decoder.decode(Float.self, from: data)
-        else { return }
+        guard let sample = meterSample(at: fileURL), let level = sample.levels.last else { return }
         record.meterLevel = min(max(level, 0), 1)
+    }
+
+    /// The levels the recorder has produced for this session, for a reader that
+    /// draws them rather than just showing the current loudness.
+    func meterSample(for id: UUID) -> MeterSample? {
+        guard let directory = try? sessionsDirectory() else { return nil }
+        return meterSample(at: meterURL(for: id, directory: directory))
+    }
+
+    private func meterSample(at fileURL: URL) -> MeterSample? {
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        if let sample = try? decoder.decode(MeterSample.self, from: data) {
+            return sample
+        }
+        // A file written by a build that stored one number. Worth reading rather
+        // than dropping: it is the level of an in-flight recording.
+        guard let level = try? decoder.decode(Float.self, from: data) else { return nil }
+        return MeterSample(sequence: 0, levels: [level])
     }
 
     private func notify(_ notification: VocaPhoneDarwinNotification) {

--- a/ios/VocaPhoneTests/DictationBarLayoutTests.swift
+++ b/ios/VocaPhoneTests/DictationBarLayoutTests.swift
@@ -87,7 +87,7 @@ struct DictationBarLayoutTests {
         let before = Self.descendants(of: bar).count
         for _ in 0..<20 {
             bar.apply(Self.model(.recording), animated: false)
-            bar.push(meterLevel: 0.6)
+            bar.push(meterLevels: [0.4, 0.6, 0.5, 0.7, 0.6])
         }
         bar.layoutIfNeeded()
         // A poll tick that changes nothing must not accumulate views.

--- a/ios/VocaPhoneTests/DictationPresentationTests.swift
+++ b/ios/VocaPhoneTests/DictationPresentationTests.swift
@@ -3,6 +3,37 @@ import UIKit
 
 @MainActor
 struct DictationPresentationTests {
+    @Test func readySurfaceRetainsTranscriptAndCancel() {
+        let ready = Self.model(.readyToInsert, transcript: "A preview to check.")
+        let message = ready.surfaceMessage(for: .readyToInsert)
+        #expect(message?.contains("A preview to check.") == true)
+        #expect(ready.secondaries.contains(.cancel))
+        #expect(ready.primary.action == .insert)
+        #expect(ready.primary.isEnabled)
+        let empty = Self.model(.readyToInsert)
+        #expect(empty.surfaceMessage(for: .readyToInsert) != nil)
+    }
+
+    @Test func changedFieldSurfaceRetainsTranscriptAndGuidance() {
+        let ready = Self.model(.targetContextChanged, transcript: "Waiting text.")
+        let message = ready.surfaceMessage(for: .targetContextChanged)
+        #expect(message?.contains("Waiting text.") == true)
+        #expect(message?.contains("different text field") == true)
+        #expect(ready.primary.action == .insertHere)
+    }
+
+    @Test func handoffRecoveryRemainsEnabledWhileProcessingIsDisabled() {
+        for state in [SessionState.launchingApp, .awaitingReturn] {
+            let presentation = Self.model(state)
+            #expect(presentation.primary.isEnabled)
+            #expect(presentation.primary.action == .openApp)
+            #expect(presentation.primary.title == "Open app")
+        }
+        for state in [SessionState.finalizing, .uploading, .transcribing] {
+            #expect(!Self.model(state).primary.isEnabled)
+        }
+    }
+
     private static func model(
         _ state: SessionState,
         transcript: String? = nil,

--- a/ios/VocaPhoneTests/DictationPresentationTests.swift
+++ b/ios/VocaPhoneTests/DictationPresentationTests.swift
@@ -3,6 +3,33 @@ import UIKit
 
 @MainActor
 struct DictationPresentationTests {
+    @Test func failuresKeepTheirDetailsAndRecoveryInstructions() {
+        for state in [SessionState.serverUnavailable, .uploadFailedRecoverable,
+                      .transcriptionFailedRecoverable, .transcriptionFailedPermanent] {
+            let model = Self.model(
+                state,
+                errorMessage: "Select and load a speech-to-text model in the gateway.",
+                canRetry: true
+            )
+            let message = model.surfaceMessage(for: state)
+            #expect(message?.contains("Select and load a speech-to-text model") == true)
+            #expect(message?.contains(model.title) == true)
+            #expect(message?.contains(model.primary.title) == true)
+            #expect(model.primary.isEnabled)
+        }
+        let permission = Self.model(.permissionDenied)
+        #expect(permission.surfaceMessage(for: .permissionDenied)?.contains("allow the microphone") == true)
+    }
+
+    @Test func preparationDoesNotClaimTranscriptionHasStarted() {
+        for location in [SessionProcessingLocation.gateway, .onDevice] {
+            let uploading = Self.model(.uploading, location: location)
+            #expect(uploading.surfaceMessage(for: .uploading) == uploading.title)
+            #expect(uploading.surfaceMessage(for: .uploading)?.contains("Transcribing") == false)
+        }
+        #expect(Self.model(.finalizing).surfaceMessage(for: .finalizing) == "Finishing recording")
+    }
+
     @Test func readySurfaceRetainsTranscriptAndCancel() {
         let ready = Self.model(.readyToInsert, transcript: "A preview to check.")
         let message = ready.surfaceMessage(for: .readyToInsert)

--- a/ios/VocaPhoneTests/KeyGridLayoutTests.swift
+++ b/ios/VocaPhoneTests/KeyGridLayoutTests.swift
@@ -7,7 +7,8 @@ struct KeyGridLayoutTests {
 
     private static func makeGrid(
         traits: UITraitCollection = UITraitCollection { $0.verticalSizeClass = .regular },
-        plane: KeyPlane = .letters
+        plane: KeyPlane = .letters,
+        width: CGFloat = referenceWidth
     ) -> KeyGridView {
         let metrics = KeyboardMetrics.resolved(for: traits)
         let grid = KeyGridView(metrics: metrics, palette: KeyboardPalette(isDark: false))
@@ -15,7 +16,7 @@ struct KeyGridLayoutTests {
         grid.frame = CGRect(
             x: 0,
             y: 0,
-            width: referenceWidth,
+            width: width,
             height: metrics.gridHeight
         )
         grid.layoutIfNeeded()
@@ -189,6 +190,53 @@ struct KeyGridLayoutTests {
             .sorted { $0.key < $1.key }
             .map { $0.value.sorted { $0.frame.minX < $1.frame.minX } }
     }
+
+    /// The spacebar reaches as far as the system's does.
+    ///
+    /// Measured on device: every touch that typed a space landed between x=269
+    /// and x=286, and the first one that typed a *newline* landed at x=288 —
+    /// with the finger nowhere near the Return key, which starts a hundred
+    /// points further right. Somebody aiming at the right-hand end of the
+    /// spacebar was getting a line break instead, three times in one sentence.
+    ///
+    /// The proportions come from Apple's own bottom row, quoted in
+    /// `BottomRowColumns.resolved`: `1.25 | 1.25 | 5 | 2.5`. What this checks is
+    /// that the space the user can *hit* matches the space they can see, all the
+    /// way to where Return's own target begins.
+    @Test func theSpacebarsTargetReachesTheReturnKey() {
+        // Laid out the width the keyboard actually gives it: the screen less the
+        // chrome margin on each side. That margin is the whole point of this
+        // test — it decides where every boundary in the row falls, and at six
+        // points a side the spacebar ended six points short of the system's.
+        let chromeInset: CGFloat = 3
+        let grid = Self.makeGrid(width: Self.referenceWidth - 2 * chromeInset)
+        let row = Self.rowsByPosition(in: grid)[3]
+        guard let space = row.first(where: { $0.spec.cap == .space }),
+              let newline = row.first(where: { $0.spec.cap == .newline })
+        else {
+            Issue.record("bottom row has no space or no return: \(row.map(\.spec.cap))")
+            return
+        }
+        // No gap between them that belongs to neither.
+        #expect(
+            space.hitRect.maxX >= newline.hitRect.minX,
+            "space ends at \(space.hitRect.maxX), return starts at \(newline.hitRect.minX)"
+        )
+        // And the boundary is where the drawing says it is, not short of it.
+        #expect(
+            space.hitRect.maxX > space.frame.maxX,
+            "space is drawn to \(space.frame.maxX) but only claims \(space.hitRect.maxX)"
+        )
+        // And the boundary lands where the system's does, because that is where
+        // a thumb has learned it is. The grid is inset from the screen by the
+        // keyboard's chrome, so this is checked in screen terms: at 393 points
+        // wide, iOS ends its spacebar at about 293.
+        let boundaryOnScreen = space.hitRect.maxX + chromeInset
+        #expect(
+            abs(boundaryOnScreen - 293) < 4,
+            "spacebar ends at \(boundaryOnScreen) on screen, the system's at ~293"
+        )
+    }
 }
 
 /// The numeric keypads, which a `.numberPad` or `.phonePad` field used to be
@@ -274,4 +322,5 @@ struct KeypadLayoutTests {
         #expect(!KeyCap.blank.isCharacter)
         #expect(KeyCap.character("0").isInteractive)
     }
+
 }

--- a/ios/VocaPhoneTests/KeyHitMapTests.swift
+++ b/ios/VocaPhoneTests/KeyHitMapTests.swift
@@ -377,7 +377,11 @@ struct KeyHitMapTests {
 
     /// A locked Shift is a deliberate state, so a slide off it does not undo it.
     @Test func slidingOffALockedShiftKeepsCapsLock() throws {
-        let grid = Self.makeGrid(feedback: KeyboardFeedbackSpy(), delegate: KeyGridDelegateSpy())
+        // Held by name. The grid's `delegate` is weak, so a spy created inside the
+        // call is deallocated on the same line and every assertion about what it
+        // received is an assertion about nil.
+        let delegate = KeyGridDelegateSpy()
+        let grid = Self.makeGrid(feedback: KeyboardFeedbackSpy(), delegate: delegate)
         grid.shiftState = .locked
 
         let landed = try #require(grid.keyViews.first { $0.spec.cap == KeyCap.character("q") })

--- a/ios/VocaPhoneTests/KeyboardHapticsTests.swift
+++ b/ios/VocaPhoneTests/KeyboardHapticsTests.swift
@@ -64,21 +64,21 @@ struct KeyboardHapticsTests {
 
     /// A held Delete is a stream of separate deletions, and each one sounds —
     /// otherwise a hold reads as a keyboard that has stopped responding.
-    @Test func eachDeleteRepeatSoundsLikeItsOwnKeystroke() {
-        #expect(
-            KeyboardFeedbackPolicy.events(
-                for: .deleteRepeated,
-                typingHapticsEnabled: false,
-                hasFullAccess: true
-            ) == [.inputClick]
-        )
-        #expect(
-            KeyboardFeedbackPolicy.events(
-                for: .deleteRepeated,
-                typingHapticsEnabled: true,
-                hasFullAccess: true
-            ) == [.inputClick, .typingHaptic]
-        )
+    ///
+    /// It does not buzz, though, and that is the point of the second case here:
+    /// a hold runs at about ten deletions a second, and ten taps a second stops
+    /// being ten taps. It becomes one continuous vibration — which on a phone
+    /// is the signal for something being wrong, not for something working.
+    @Test func aHeldDeleteClicksEveryTimeAndBuzzesNever() {
+        for hapticsEnabled in [true, false] {
+            #expect(
+                KeyboardFeedbackPolicy.events(
+                    for: .deleteRepeated,
+                    typingHapticsEnabled: hapticsEnabled,
+                    hasFullAccess: true
+                ) == [.inputClick]
+            )
+        }
     }
 
     @Test func optionalHapticsAreSilentWithoutBothPermissions() {

--- a/ios/VocaPhoneTests/KeyboardHapticsTests.swift
+++ b/ios/VocaPhoneTests/KeyboardHapticsTests.swift
@@ -6,6 +6,25 @@ import UIKit
 /// explicit VocaPhone preference and Full Access.
 @MainActor
 struct KeyboardHapticsTests {
+    @Test func defaultFeedbackMatchesMainAndZeroIntensityIsPreserved() {
+        let defaults = KeyboardPreferences.defaults
+        let styleKey = KeyboardPreferences.typingHapticStyleKey
+        let intensityKey = KeyboardPreferences.typingHapticIntensityKey
+        let savedStyle = defaults?.object(forKey: styleKey)
+        let savedIntensity = defaults?.object(forKey: intensityKey)
+        defer {
+            defaults?.set(savedStyle, forKey: styleKey)
+            defaults?.set(savedIntensity, forKey: intensityKey)
+        }
+        defaults?.removeObject(forKey: styleKey)
+        defaults?.removeObject(forKey: intensityKey)
+        #expect(KeyboardPreferences.typingHapticStyle == .rigid)
+        #expect(KeyboardPreferences.typingHapticIntensity == 1)
+        KeyboardPreferences.typingHapticIntensity = 0
+        #expect(KeyboardPreferences.typingHapticIntensity == 0)
+        KeyboardPreferences.typingHapticIntensity = 0.4
+        #expect(KeyboardPreferences.typingHapticIntensity == 0.4)
+    }
     @Test func hapticsNeedBothThePreferenceAndFullAccess() {
         #expect(KeyboardHaptics.allowsHaptics(preferenceEnabled: true, hasFullAccess: true))
         #expect(!KeyboardHaptics.allowsHaptics(preferenceEnabled: false, hasFullAccess: true))

--- a/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
+++ b/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
@@ -1,0 +1,252 @@
+import Testing
+import UIKit
+
+/// The numbers and rules changed while making the keyboard read as part of iOS.
+///
+/// Each of these was arrived at by measurement — against a screenshot of the
+/// system keyboard, against a device, or against a log pulled off one — and
+/// none of them survives being a number somebody remembers. That is what these
+/// tests are for: not to prove the arithmetic, but to keep the reasoning
+/// attached to the value.
+@MainActor
+struct KeyboardSurfaceTests {
+    private static var portrait: UITraitCollection {
+        UITraitCollection { traits in
+            traits.horizontalSizeClass = .compact
+            traits.verticalSizeClass = .regular
+        }
+    }
+
+    // MARK: - Proportions
+
+    /// Letters sit at roughly 0.57 of the key's height, corners at roughly
+    /// 0.23 — both read off Apple's own keyboard on the same phone.
+    ///
+    /// The keyboard this replaced was at 0.51 and 0.14, which is what "small
+    /// letters on square keys" measures out to. The bands are wide enough for
+    /// judgement and narrow enough that a drift back is a failure.
+    @Test func keyGlyphsAndCornersKeepTheSystemsProportions() {
+        for preference in KeyboardHeightPreference.allCases {
+            let metrics = KeyboardMetrics.resolved(for: Self.portrait, preference: preference)
+            let glyphRatio = metrics.letterFontSize / metrics.keyHeight
+            let cornerRatio = metrics.cornerRadius / metrics.keyHeight
+            #expect(
+                glyphRatio > 0.54 && glyphRatio < 0.62,
+                "\(preference.displayName) letter is \(glyphRatio) of the key"
+            )
+            #expect(
+                cornerRatio > 0.18 && cornerRatio < 0.26,
+                "\(preference.displayName) corner is \(cornerRatio) of the key"
+            )
+        }
+    }
+
+    /// The punctuation row divides between all seven keys.
+    ///
+    /// `#+=` and Delete used to be the only filling keys in that row, so the
+    /// three spare columns went to them — two slabs beside five narrow
+    /// punctuation keys, when the punctuation is what the finger is aiming for.
+    @Test func thePunctuationRowIsSharedByEveryKeyInIt() {
+        for plane in [KeyPlane.numbers, .symbols] {
+            let rows = KeyLayout.rows(
+                for: plane,
+                includesGlobe: true,
+                returnIsProminent: false
+            )
+            let punctuationRow = rows[2]
+            #expect(punctuationRow.keys.count == 7)
+            for key in punctuationRow.keys {
+                #expect(key.width == .fill, "\(plane) row 3 has a fixed-width key")
+            }
+        }
+    }
+
+    // MARK: - The press nobody could see
+
+    /// A press is held long enough to be composited once, and no longer.
+    ///
+    /// A tap can be shorter than a frame. On a 60 Hz panel that is 16.6 ms, and
+    /// a keystroke that goes down and up inside one frame is drawn once — with
+    /// the key already back at rest. The letter arrives and the key never looks
+    /// pressed, which is what "some keys don't respond" turned out to be.
+    ///
+    /// The other half of this is the half that was got wrong. The hold runs
+    /// *after the finger has left*, so every millisecond of it is a millisecond
+    /// the key stays lit under a hand that has moved on. At 70 ms a typist
+    /// moving between keys every 125 ms left a trail of lit keys behind them,
+    /// and reported the keyboard as lagging. The bound is one frame, not four.
+    @Test func aPressIsHeldLongEnoughToBeSeenAndNoLonger() {
+        // Shorter than a frame at 60 Hz: the release waits.
+        #expect(KeyView.releaseDelay(shownFor: 0.005) > 0.01)
+        // But never long enough to still be lit when the next key is pressed.
+        // 125 ms is a brisk but ordinary typing interval.
+        #expect(KeyView.minimumHighlightSeconds < 0.125 / 2)
+        // Long enough to clear a frame on the slowest panel this runs on.
+        #expect(KeyView.minimumHighlightSeconds > 1.0 / 60)
+        // Long enough to have been drawn: nothing to wait for.
+        #expect(KeyView.releaseDelay(shownFor: 0.2) == 0)
+        // The wait never exceeds the minimum itself.
+        #expect(KeyView.releaseDelay(shownFor: 0) == KeyView.minimumHighlightSeconds)
+    }
+
+    // MARK: - The meter
+
+    /// Levels cross to the keyboard as a run with a count, not as one number.
+    ///
+    /// The count is what lets a reader take only what it has not drawn: the
+    /// keyboard polls on its own clock, so without it the same audio is drawn
+    /// twice or skipped, and the meter goes back to being an animation of a
+    /// meter rather than one.
+    @Test func aMeterSampleCarriesItsRunAndItsCount() {
+        let sample = MeterSample(sequence: 25, levels: [0.2, 1.4, -0.3, 0.9])
+        let clamped = sample.clamped()
+        #expect(clamped.sequence == 25)
+        #expect(clamped.levels == [0.2, 1, 0, 0.9])
+
+        // A reader that has drawn 21 of the 25 takes the last four.
+        let alreadyDrawn = 21
+        let unseen = clamped.sequence - alreadyDrawn
+        #expect(Array(clamped.levels.suffix(unseen)) == [0.2, 1, 0, 0.9])
+
+        // One that is up to date takes none, however often it asks.
+        #expect(clamped.sequence - 25 == 0)
+    }
+
+    // MARK: - What the surface says
+
+    /// Every failure has one line, and no state that is merely in progress has
+    /// one at all.
+    ///
+    /// The line is deliberately shorter than the bar's card: this is one line
+    /// over somebody else's text field, and the fix is on the button beside it.
+    /// What survives the cut is the fact that changes what the person does next
+    /// — the recording is still there.
+    @Test func everyFailureHasOneLineAndProgressHasNone() {
+        let failures: [SessionState] = [
+            .serverUnavailable,
+            .uploadFailedRecoverable,
+            .transcriptionFailedRecoverable,
+            .transcriptionFailedPermanent,
+            .permissionDenied,
+            .targetContextChanged,
+        ]
+        for state in failures {
+            let line = DictationBarModel.surfaceLine(for: state)
+            #expect(line != nil, "\(state.rawValue) says nothing")
+            #expect(line?.count ?? 0 < 60, "\(state.rawValue) is too long for the strip")
+        }
+        for state in [SessionState.idle, .recording, .transcribing, .launchingApp] {
+            #expect(DictationBarModel.surfaceLine(for: state) == nil)
+        }
+        // The two recoverable ones promise the recording is kept, which is the
+        // only fact that changes whether the person speaks it all again.
+        #expect(
+            DictationBarModel.surfaceLine(for: .serverUnavailable)?
+                .contains("Recording kept") == true
+        )
+        #expect(
+            DictationBarModel.surfaceLine(for: .transcriptionFailedRecoverable)?
+                .contains("Recording kept") == true
+        )
+    }
+
+    // MARK: - Contrast maths
+
+    /// A grey is not black, even when it was declared as a monochrome colour.
+    ///
+    /// `getRed` reports nothing for those, and both the luminance and the
+    /// compositor used to read that failure as pure black — so a contrast test
+    /// on half the palette was passing without measuring anything.
+    @Test func monochromeColoursAreMeasuredRatherThanReadAsBlack() {
+        let grey = UIColor(white: 0.5, alpha: 1)
+        let luminance = ContrastMath.relativeLuminance(grey)
+        #expect(luminance > 0.15 && luminance < 0.3, "monochrome grey scored \(luminance)")
+
+        // And a translucent monochrome film composites onto what is behind it
+        // rather than collapsing to its own declared colour.
+        let film = UIColor(white: 1, alpha: 0.5)
+        let backdrop = UIColor(white: 0, alpha: 1)
+        let composited = film.compositedOver(backdrop)
+        var white: CGFloat = 0
+        var alpha: CGFloat = 0
+        _ = composited.getWhite(&white, alpha: &alpha)
+        #expect(abs(white - 0.5) < 0.01)
+        #expect(alpha == 1)
+    }
+
+    // MARK: - The press that let go of itself
+
+    /// A key keeps its finger through the drift of pressing it.
+    ///
+    /// Measured on device: two spaces in 442 keystrokes were pressed, tracked,
+    /// and silently dropped — both within 2 pt of the bottom row's top edge.
+    /// A press is not still; the thumb rolls a few points as it lands, and the
+    /// bottom row has only half the row gap above it, so leaving the rect is a
+    /// matter of two or three points. What made it invisible is that the
+    /// keyboard then ran the words together and offered to autocorrect the
+    /// result, so the symptom looked like a bad correction rather than a lost
+    /// key.
+    ///
+    /// The slack is the hit map's own: the distance a *sliding* finger must
+    /// clear before the map hands it to a neighbour is the same distance a
+    /// *held* finger may wander without letting go.
+    @Test func aHeldKeyIsNotLostToTheDriftOfPressingIt() {
+        let key = KeyHitMap.Target(
+            index: 0,
+            frame: CGRect(x: 100, y: 162, width: 180, height: 43),
+            hitRect: CGRect(x: 100, y: 156.5, width: 180, height: 48.5),
+            isCharacter: false
+        )
+        let map = KeyHitMap(targets: [key], hysteresis: 6.7)
+        let slack = map.hysteresis
+        let held = key.hitRect.insetBy(dx: -slack, dy: -slack)
+
+        // The press that was dropped: 161 pt, four points inside the rect, and
+        // a roll upward of five takes it out.
+        #expect(key.hitRect.contains(CGPoint(x: 190, y: 156)) == false)
+        #expect(held.contains(CGPoint(x: 190, y: 156)))
+        // Far enough above to be a different key is still a different key.
+        #expect(held.contains(CGPoint(x: 190, y: 148)) == false)
+    }
+
+    // MARK: - Where a keystroke's time went
+
+    /// Looking a prefix up does not read the whole list.
+    ///
+    /// A frequency-ordered list cannot be searched, so every prefix query walked
+    /// all ten thousand words and called a grapheme-counting `count` on each.
+    /// The bound that was there — `scanLimit` — limited the number of *matches*,
+    /// which is no bound at all for a prefix the language barely uses. Measured
+    /// on device: 5.5 ms of a 9.5 ms keystroke, against a frame budget of 8.3.
+    ///
+    /// The index has to give the same answers, in the same order, or it has
+    /// traded the keyboard's suggestions for its frame rate.
+    @Test func aPrefixIndexAnswersExactlyAsTheFullScanDid() {
+        let words = [
+            "the", "there", "then", "they", "to", "that",
+            "this", "think", "thymus", "top", "quixotic",
+        ]
+        let list = TypingWordList(words: words, bigrams: [:])
+
+        // Frequency order survives: "the" is first in the list and first out.
+        #expect(list.completions(for: "th", limit: 3) == ["the", "there", "then"])
+        // The prefix itself is a match of the prefix, and never a completion of
+        // it — "the" completes to "there", not to itself.
+        #expect(list.completions(for: "the", limit: 3) == ["there", "then", "they"])
+        // A prefix the list has nothing for answers nothing, without a scan.
+        #expect(list.completions(for: "zz", limit: 3).isEmpty)
+        #expect(list.nextCharacterWeights(after: "zz").isEmpty)
+
+        // The weights are still ranked by position in the whole list, not by
+        // position within the bucket: "e" leads because "the" is the most
+        // common word here, not because it was first among the "th" words.
+        let weights = list.nextCharacterWeights(after: "th")
+        #expect(weights["e"] == 1)
+        #expect((weights["i"] ?? 0) < 1)
+        #expect((weights["y"] ?? 0) < (weights["i"] ?? 0))
+        #expect(weights["o"] == nil)
+
+        // A one-character prefix is answered from its own bucket.
+        #expect(list.completions(for: "q", limit: 2) == ["quixotic"])
+    }
+}

--- a/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
+++ b/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
@@ -10,6 +10,31 @@ import UIKit
 /// attached to the value.
 @MainActor
 struct KeyboardSurfaceTests {
+    @Test func recoveryGuidanceSurvivesPollingUntilTheStateChanges() {
+        let surface = DictationSurfaceState()
+        surface.state = .awaitingReturn
+        surface.showRecoveryMessage("Open vocaphone manually")
+        surface.state = .awaitingReturn
+        surface.centerMessage = nil
+        #expect(surface.centerMessage == "Open vocaphone manually")
+
+        surface.state = .recording
+        #expect(surface.centerMessage == nil)
+    }
+
+    @Test func retryGuidanceDoesNotLeakIntoAnotherSession() {
+        let surface = DictationSurfaceState()
+        surface.sessionID = UUID()
+        surface.state = .uploading
+        surface.showRecoveryMessage("Open vocaphone to retry")
+        surface.centerMessage = "Uploading"
+        #expect(surface.centerMessage == "Open vocaphone to retry")
+
+        surface.sessionID = UUID()
+        #expect(surface.centerMessage == "Uploading")
+        #expect(surface.recoveryMessage == nil)
+    }
+
     private static var portrait: UITraitCollection {
         UITraitCollection { traits in
             traits.horizontalSizeClass = .compact

--- a/ios/VocaPhoneTests/SemanticPaletteTests.swift
+++ b/ios/VocaPhoneTests/SemanticPaletteTests.swift
@@ -173,7 +173,13 @@ struct SemanticPaletteTests {
         #expect(Self.rgb(KeyboardPalette(isDark: false).background) == (226, 228, 232))
         #expect(Self.rgb(KeyboardPalette(isDark: false).standardKey) == (255, 255, 255))
         #expect(Self.rgb(KeyboardPalette(isDark: true).background) == (23, 23, 23))
-        #expect(Self.rgb(KeyboardPalette(isDark: true).standardKey) == (61, 61, 61))
+        // The dark key is a film, not a fill: what was measured off the system
+        // keyboard is the film *over that backdrop*, and that is what this
+        // pins. Asserting the colour itself would have frozen the composite
+        // and taken the translucency — the reason the keys stay legible on a
+        // bright home screen — back out again.
+        let dark = KeyboardPalette(isDark: true)
+        #expect(Self.rgb(dark.standardKey.compositedOver(dark.background)) == (61, 61, 61))
     }
 
     /// An engaged Shift lifts to the *standard* key surface, which is what the
@@ -232,7 +238,20 @@ struct SemanticPaletteTests {
                 for fill in [
                     palette.background(for: style), palette.pressedBackground(for: style),
                 ] {
-                    let measured = contrast(fill, palette.foreground(for: style))
+                    // Composited first: the dark key fill is a translucent film
+                    // and has no colour of its own to measure. What the eye
+                    // reads is the film over the keyboard surface, and that is
+                    // what has to clear 4.5:1.
+                    //
+                    // This measures against the keyboard's own surface. Over a
+                    // bright wallpaper the system backdrop lightens and so does
+                    // the key, which is the trade the system keyboard itself
+                    // makes with the same white labels; its dark-mode backdrop
+                    // keeps a scrim rather than going clear.
+                    let measured = contrast(
+                        fill.compositedOver(palette.background),
+                        palette.foreground(for: style)
+                    )
                     #expect(
                         measured >= 4.5,
                         "\(isDark ? "dark" : "light") \(style) key label is \(measured):1"

--- a/ios/VocaPhoneTests/SessionRecordTests.swift
+++ b/ios/VocaPhoneTests/SessionRecordTests.swift
@@ -50,7 +50,7 @@ struct SessionRecordTests {
         try record.transition(to: .launchingApp)
         try record.transition(to: .recording)
         try store.save(record)
-        try store.saveMeter(0.8, for: record.sessionID)
+        try store.saveMeter(MeterSample(sequence: 5, levels: [0.2, 0.8]), for: record.sessionID)
 
         let recording = try #require(try store.load(record.sessionID))
         #expect(recording.state == .recording)
@@ -59,7 +59,7 @@ struct SessionRecordTests {
         try record.transition(to: .finalizing)
         try store.save(record)
         // Simulate one late microphone callback racing with the keyboard tap.
-        try store.saveMeter(0.4, for: record.sessionID)
+        try store.saveMeter(MeterSample(sequence: 7, levels: [0.4]), for: record.sessionID)
 
         let finalizing = try #require(try store.load(record.sessionID))
         #expect(finalizing.state == .finalizing)

--- a/ios/VocaPhoneTests/TypingCandidatesTests.swift
+++ b/ios/VocaPhoneTests/TypingCandidatesTests.swift
@@ -832,3 +832,64 @@ struct AppliedCorrectionArmingTests {
     }
 
 }
+
+/// A field switch must drop work that still belongs to the previous document.
+@MainActor
+struct TypingEngineDocumentChangeTests {
+    /// Distinctive so a leaked publication cannot be mistaken for a word-list hit.
+    private static let staleCompletion = "hellofromoldfield"
+
+    @MainActor
+    private final class RecordingSpellChecker: SpellChecking {
+        var completionsByPrefix: [String: [String]] = [:]
+        private(set) var prefixesAsked: [String] = []
+
+        func completions(for prefix: String, language: String) -> [String] {
+            prefixesAsked.append(prefix)
+            return completionsByPrefix[prefix] ?? []
+        }
+
+        func guesses(for word: String, language: String) -> [String] { [] }
+        func isKnown(_ word: String, language: String) -> Bool { false }
+    }
+
+    /// The checker is asked only after the hand pauses. Switching fields in that
+    /// window used to let the previous composition's completions arrive in the
+    /// next field, because `documentChanged` reset the strip but left the
+    /// deferred task and its generation standing.
+    @Test func aFieldSwitchDropsAPendingCheck() async throws {
+        let suggestions = KeyboardPreferences.typingSuggestionsEnabled
+        defer { KeyboardPreferences.typingSuggestionsEnabled = suggestions }
+        KeyboardPreferences.typingSuggestionsEnabled = true
+
+        let checker = RecordingSpellChecker()
+        checker.completionsByPrefix = ["hel": [Self.staleCompletion]]
+        let engine = TypingEngine(
+            checker: checker,
+            learned: LearnedWordStore(containerURL: nil),
+            wordList: .empty
+        )
+        var published: [TypingStrip] = []
+        engine.onStrip = { published.append($0) }
+
+        engine.insert("hel", document: DocumentSnapshot(before: "hel"))
+        #expect(engine.composer.text == "hel")
+
+        engine.documentChanged(policy: .allowed)
+        #expect(engine.composer.isEmpty)
+        #expect(engine.strip.isEmpty)
+        #expect(engine.pendingSwipeWord == nil)
+        let publishedThroughChange = published.count
+
+        // Longer than `checkerQuietPeriod` (~90 ms), so a task that was not
+        // cancelled would have asked the checker and published by now.
+        try await Task.sleep(for: .milliseconds(200))
+
+        #expect(checker.prefixesAsked.isEmpty)
+        #expect(engine.strip.isEmpty)
+        #expect(published.dropFirst(publishedThroughChange).isEmpty)
+        #expect(!published.contains { strip in
+            strip.candidates.contains { $0.text == Self.staleCompletion }
+        })
+    }
+}

--- a/ios/VocaPhoneTests/TypingCandidatesTests.swift
+++ b/ios/VocaPhoneTests/TypingCandidatesTests.swift
@@ -835,7 +835,42 @@ struct AppliedCorrectionArmingTests {
 
 /// A field switch must drop work that still belongs to the previous document.
 @MainActor
+@Suite(.serialized)
 struct TypingEngineDocumentChangeTests {
+    @Test func swipingRetiresThePreviousTypedWordsCheck() async throws {
+        let suggestions = KeyboardPreferences.typingSuggestionsEnabled
+        defer { KeyboardPreferences.typingSuggestionsEnabled = suggestions }
+        KeyboardPreferences.typingSuggestionsEnabled = true
+        let checker = RecordingSpellChecker()
+        let engine = TypingEngine(
+            checker: checker,
+            learned: LearnedWordStore(containerURL: nil),
+            wordList: .empty
+        )
+        engine.insert("hel", document: DocumentSnapshot(before: "hel"))
+        engine.noteSwipeWord("world", alternates: ["world", "word"])
+        let alternates = engine.strip
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(checker.prefixesAsked.isEmpty)
+        #expect(engine.strip == alternates)
+    }
+    @Test func disablingSuggestionsRetiresThePendingChecker() async throws {
+        let suggestions = KeyboardPreferences.typingSuggestionsEnabled
+        defer { KeyboardPreferences.typingSuggestionsEnabled = suggestions }
+        KeyboardPreferences.typingSuggestionsEnabled = true
+        let checker = RecordingSpellChecker()
+        let engine = TypingEngine(
+            checker: checker,
+            learned: LearnedWordStore(containerURL: nil),
+            wordList: .empty
+        )
+        engine.insert("hel", document: DocumentSnapshot(before: "hel"))
+        KeyboardPreferences.typingSuggestionsEnabled = false
+        engine.reconcile(document: DocumentSnapshot(before: "hel"))
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(checker.prefixesAsked.isEmpty)
+        #expect(engine.strip.isEmpty)
+    }
     /// Distinctive so a leaked publication cannot be mistaken for a word-list hit.
     private static let staleCompletion = "hellofromoldfield"
 

--- a/ios/VocaPhoneTests/TypingCandidatesTests.swift
+++ b/ios/VocaPhoneTests/TypingCandidatesTests.swift
@@ -27,7 +27,9 @@ struct TypingCandidatesTests {
         allowed: Bool = true,
         followers: [String] = [],
         expansion: String? = nil,
-        isMidWord: Bool = false
+        isMidWord: Bool = false,
+        ranks: [String: Int] = [:],
+        hasCheckerAnswer: Bool = true
     ) -> TypingCandidates.Context {
         var context = TypingCandidates.Context()
         context.composition = composition
@@ -40,6 +42,8 @@ struct TypingCandidatesTests {
         context.learnedWords = learned
         context.predictions = predictions
         context.precedingWord = preceding
+        context.listRanks = ranks
+        context.hasCheckerAnswer = hasCheckerAnswer
         context.isKnownToChecker = isKnownToChecker
         context.isInWordList = isInWordList
         context.assertedWords = asserted
@@ -566,6 +570,132 @@ struct TypingCandidatesTests {
         #expect(TypingCandidates.matchingCase(of: "TEH", applyingTo: "the") == "THE")
         #expect(TypingCandidates.matchingCase(of: "teh", applyingTo: "the") == "the")
     }
+
+    // MARK: - A word that is two words
+
+    /// The space that never registered is put back.
+    ///
+    /// This is the correction the typing in front of me actually needed —
+    /// "howit", "sothis", "worksn" — and the one a spell checker cannot make,
+    /// because its job is to spell one word rather than to notice there are
+    /// two. It answers them with a hyphen instead.
+    @Test func aMissedSpaceIsPutBack() {
+        let context = Self.context(
+            composition: "howit",
+            ranks: ["how": 40, "it": 20]
+        )
+        #expect(TypingCandidates.autocorrection(context) == "how it")
+    }
+
+    /// Both halves have to be words, and common ones.
+    ///
+    /// A rare word beside a rare word is how "themes" becomes "the mes": the
+    /// cut exists, the dictionary allows it, and nobody meant it.
+    @Test func aSplitNeedsTwoCommonWords() {
+        // The list has never heard of the second half.
+        #expect(
+            TypingCandidates.autocorrection(
+                Self.context(composition: "howzt", ranks: ["how": 40])
+            ) == nil
+        )
+        // It has, but only barely — far outside the words people write.
+        #expect(
+            TypingCandidates.autocorrection(
+                Self.context(composition: "howit", ranks: ["how": 40, "it": 9000])
+            ) == nil
+        )
+    }
+
+    /// Two ways to cut it means the keyboard does not know which.
+    ///
+    /// The same rule the margin below lives by: an ambiguity is refused rather
+    /// than settled by a coin toss in somebody's sentence.
+    @Test func anAmbiguousSplitIsRefused() {
+        let context = Self.context(
+            composition: "tobeat",
+            ranks: ["to": 5, "beat": 300, "tobe": 900, "at": 30]
+        )
+        #expect(TypingCandidates.autocorrection(context) == nil)
+    }
+
+    /// And only once the checker has answered.
+    ///
+    /// It is asked when the hand pauses, so for the length of a brisk keystroke
+    /// there is no answer and every word looks unknown. The shipped ten
+    /// thousand contains neither "sometime" nor "backend" nor "logout", so a
+    /// split fired in that window is not a correction, it is damage.
+    @Test func noSplitBeforeTheCheckerHasSpoken() {
+        let waiting = Self.context(
+            composition: "sometime",
+            ranks: ["some": 60, "time": 90],
+            hasCheckerAnswer: false
+        )
+        #expect(TypingCandidates.autocorrection(waiting) == nil)
+        // The same word, once the checker has been heard from and does not
+        // know it either, is a genuine candidate.
+        let answered = Self.context(
+            composition: "sometime",
+            ranks: ["some": 60, "time": 90]
+        )
+        #expect(TypingCandidates.autocorrection(answered) == "some time")
+    }
+
+    // MARK: - Which guesses count
+
+    /// The list says what the checker cannot: which of two is a word people
+    /// write.
+    ///
+    /// `UITextChecker` ranks nothing, so it offers "coth" beside "both" as
+    /// equal readings and the margin rule — rightly unwilling to toss a coin —
+    /// declined both. Measured on a session of real typing, that refusal fired
+    /// seventy-five times.
+    @Test func aGuessTheListHasNeverHeardOfStopsCountingAsAnEqual() {
+        let context = Self.context(
+            composition: "coth",
+            guesses: ["both", "coth-", "cloth"],
+            ranks: ["both": 120]
+        )
+        #expect(TypingCandidates.autocorrection(context) == "both")
+    }
+
+    /// One word typed becomes one word corrected.
+    ///
+    /// The checker answers "howit" with "how-it" and "sothis" with "so-this" —
+    /// it splits at a hyphen because that is a spelling, and a keyboard that
+    /// turns "howit" into "how-it" is not helping.
+    @Test func aHyphenatedGuessIsNotACorrectionOfOneWord() {
+        let context = Self.context(
+            composition: "hwit",
+            guesses: ["how-it"],
+            ranks: ["how-it": 50]
+        )
+        #expect(TypingCandidates.autocorrection(context) == nil)
+    }
+
+    /// A word typed in lowercase does not become a proper noun.
+    ///
+    /// The checker's dictionary carries place names and abbreviations — "Sotho"
+    /// for "sothi", "IoW" for "sow" — and a sentence being typed in lowercase
+    /// did not ask for one. Capitalisation that *is* wanted comes from the
+    /// curated table and the lexicon, which have already had their say.
+    @Test func aLowercaseWordDoesNotBecomeAProperNoun() {
+        let context = Self.context(
+            composition: "sothi",
+            guesses: ["Sotho"],
+            ranks: ["sotho": 4000]
+        )
+        #expect(TypingCandidates.autocorrection(context) == nil)
+    }
+
+    /// A capital typed deliberately still gets the checker's proper nouns.
+    @Test func aCapitalisedWordMayStillBecomeAProperNoun() {
+        let context = Self.context(
+            composition: "Sothi",
+            guesses: ["Sotho"],
+            ranks: ["sotho": 400]
+        )
+        #expect(TypingCandidates.autocorrection(context) == "Sotho")
+    }
 }
 // MARK: - Emoji
 
@@ -700,4 +830,5 @@ struct AppliedCorrectionArmingTests {
         #expect(punctuated.isArmed(documentBefore: "the."))
         #expect(!punctuated.isArmed(documentBefore: "the "))
     }
+
 }

--- a/ios/justfile
+++ b/ios/justfile
@@ -185,6 +185,34 @@ device: gen
 devices:
     xcrun devicectl list devices
 
+# Pull the keyboard's touch trace off the phone and print it.
+#
+# The keyboard writes one line per finger — where it was hit-tested, which key
+# it resolved to, and whether it committed — into the App Group. A dropped
+# keystroke looks different in each of those three places, which is the only
+# way to tell them apart without a simulator.
+[group('device')]
+trace:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    udid="${VOCAPHONE_DEVICE:-$({{ just_executable() }} _device_udid)}"
+    # Read from the source rather than written twice: local signing swaps the
+    # App Group for one this developer's team actually owns.
+    group=$(
+        sed -n 's/.*appGroupIdentifier = "\(.*\)"/\1/p' \
+            VocaPhoneShared/AppConfiguration.swift
+    )
+    out="{{ justfile_directory() }}/build/touch-trace.txt"
+    mkdir -p "$(dirname "${out}")"
+    rm -f "${out}"
+    xcrun devicectl device copy from --device "${udid}" \
+        --domain-type appGroupDataContainer \
+        --domain-identifier "${group}" \
+        --source touch-trace.txt \
+        --destination "${out}" >/dev/null
+    echo "${out}"
+    cat "${out}"
+
 # Delete build output and derived data.
 [group('build')]
 clean:

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -33,6 +33,11 @@ targets:
       - path: VocaPhoneKeyboard/KeyHitMap.swift
       - path: VocaPhoneKeyboard/KeyView.swift
       - path: VocaPhoneKeyboard/KeyGridView.swift
+      # The grid traces what it does with every touch, so any target that
+      # compiles the grid needs the trace in scope with it.
+      - path: VocaPhoneKeyboard/TouchTrace.swift
+      - path: VocaPhoneKeyboard/TouchWitness.swift
+      - path: VocaPhoneKeyboard/FrameMonitor.swift
       - path: VocaPhoneKeyboard/KeyAlternatives.swift
       - path: VocaPhoneKeyboard/KeyProximity.swift
       - path: VocaPhoneKeyboard/ShortWordCorrections.swift
@@ -43,6 +48,9 @@ targets:
       - path: VocaPhoneKeyboard/DictationPresentation.swift
       - path: VocaPhoneKeyboard/DictationBarStyle.swift
       - path: VocaPhoneKeyboard/DictationBarView.swift
+      # The dictation surface itself, so the settings preview and the keyboard
+      # lab show the thing the extension actually draws.
+      - path: VocaPhoneKeyboard/DictationSurfaceView.swift
       - path: VocaPhoneKeyboard/DictationBarComponents.swift
       - path: VocaPhoneKeyboard/TypingStripView.swift
       - path: VocaPhoneKeyboard/TypingCandidates.swift
@@ -140,6 +148,11 @@ targets:
       - path: VocaPhoneKeyboard/KeyHitMap.swift
       - path: VocaPhoneKeyboard/KeyView.swift
       - path: VocaPhoneKeyboard/KeyGridView.swift
+      # The grid traces what it does with every touch, so any target that
+      # compiles the grid needs the trace in scope with it.
+      - path: VocaPhoneKeyboard/TouchTrace.swift
+      - path: VocaPhoneKeyboard/TouchWitness.swift
+      - path: VocaPhoneKeyboard/FrameMonitor.swift
       # The trail's ageing and taper is pure arithmetic over sampled points, and
       # the view around it is what the grid links against.
       - path: VocaPhoneKeyboard/SwipeTrailView.swift
@@ -179,6 +192,9 @@ targets:
       - path: VocaPhoneKeyboard/DictationPresentation.swift
       - path: VocaPhoneKeyboard/DictationBarStyle.swift
       - path: VocaPhoneKeyboard/DictationBarView.swift
+      # The dictation surface itself, so the settings preview and the keyboard
+      # lab show the thing the extension actually draws.
+      - path: VocaPhoneKeyboard/DictationSurfaceView.swift
       - path: VocaPhoneKeyboard/DictationBarComponents.swift
       - path: VocaPhoneKeyboard/TypingStripView.swift
       # The realtime capture path is the highest-risk code in the app.


### PR DESCRIPTION
The iOS keyboard and its dictation session, brought closer to the system's.
Three separate pieces of work, and it is worth knowing which is which before
reading:

| | lines | |
|---|---|---|
| **a dictation session that is one surface** | 1309 | the largest part of this PR |
| **keystrokes that land where they were aimed** | 854 | the part with a bug story |
| **the keyboard looks like the system's** | ~450 | backdrop, metrics, punctuation row |
| perf, autocorrect, the meter, the typing tap | ~600 | |
| *touch trace* | 425 | scaffolding — not product |
| *keyboard lab* | 410 | debug-only — not product |

**Roughly a fifth of the diff is not product.** The trace and the lab are
marked below and can be skipped or dropped; nothing in the keyboard depends on
the lab, and the trace is where every measurement here came from.

Verified on an iPhone throughout. The simulator was not used: touch delivery,
haptics and the memory ceiling all behave differently there.

## One surface for a dictation session

Recording, transcribing, inserting and every failure in between were drawn by
two different views that swapped places mid-session, so the keyboard changed
shape under a finger that had not moved, and a session that failed handed the
keyboard back at the exact moment it had something to report. One surface now
owns the session from the tap that starts it to the text that lands, with the
keys put away beneath it rather than beside it.

Its waveform is drawn from measured audio rather than animated, holds the
shape the voice left it in when a recording ends, and starts empty for the
next one. Levels and suggestions each live in their own observable object: on
the surface's own, every level and every keystroke invalidated the whole
thing — glass, menus, waveform, centre text — in a process with fifty
megabytes to its name.

## The keyboard looks like the system's

It stopped painting its own background over the one iOS already draws, so the
keys sit on the system's backdrop instead of a second grey nobody else has.
The rest follows from measuring Apple's keyboard on the same phone:

| | before | after |
|---|---|---|
| letter size (standard) | 22 pt | 24 pt — 0.57 of the key, as the system's is |
| corner radius | 6 pt | 10 pt — 0.23 of the key |
| key shadow | always | none on iOS 26, where the system draws none |
| punctuation row | two slabs beside five narrow keys | all seven share the row |
| dark theme | a guessed grey | a translucent film over the system's backdrop |
| writing-style icons | `wand.and.stars`, `textformat`, `sparkles` | `eraser`, `briefcase`, `sunglasses`, `party.popper` |

## Keystrokes that land

Typing dropped keystrokes at speed — no balloon, no letter, and the key "had
to be pressed properly". Two causes, and they are not the same age.

**Long-standing, and still on `main`.** Hit-testing delivered touches to the
individual `KeyView`s — 516 of 520 in one recorded session — and UIKit gives a
view without `isMultipleTouchEnabled` only the *first* touch of a multi-touch
sequence, withholding the rest with no event at all. So does the 6-point
chrome margin, which laid ten columns across 381 points where iOS lays them
across 387: every boundary a little left of the one a thumb has spent years
learning, which is why touches meaning the spacebar landed past its target and
typed a line break instead — three of them in one sentence.

**Introduced here, and fixed in the commit that introduced it.** Letting the
system draw the backdrop made the keyboard transparent, and UIKit does not
recognise a touch on a fully transparent pixel — no hit test, no event,
nothing. The gutters between keys swallowed fingers. An empty `draw(_:)` opts
out, which is what `ForwardingView.swift` in
[archagon/tasty-imitation-keyboard](https://github.com/archagon/tasty-imitation-keyboard)
has done for a decade with the same explanation attached.

The press also stopped outstaying the finger: the highlight was held 70 ms
*after* the lift and the balloon 150 ms, so at 125 ms between keys the one
just left was still lit under the one being pressed.

## What was measured

Before and after are both this branch, on the same phone, same phrase. `main`
was never instrumented, so it is not the baseline — but two of these costs it
carries as well, and those savings are real rather than a repair of this
branch's own work: the whole-list prefix scan and the checker asked after
every keystroke.

| | before | after |
|---|---|---|
| a keystroke, main thread, median | 9.5 ms | **0.7 ms** |
| dropped frames while typing | 14 per session | **0** |
| word-list prefix query | 5.70 ms | 0.26 ms |
| touches delivered vs typed | 442 / 440 in one session | ~1500 / ~1500 across later ones |

The frame budget in that process is 16.6 ms. `UITextChecker` is main-actor
isolated — the SDK marks the class `NS_SWIFT_UI_ACTOR` — so it cannot be moved
off the thread the keyboard draws on; it is asked when the hand pauses
instead of after every letter.

## How to review

The commits are meant to be read in order and each stands on its own.

| | commit | lines | |
|---|---|---|---|
| 1 | system backdrop | 284 | with the transparent-pixel fix it makes necessary |
| 2 | recording meter | 181 | |
| 3 | the tap's vocabulary, and a silent held Delete | 106 | |
| 4 | one dictation surface | 1309 | the biggest one |
| 5 | **touch trace** | 425 | *scaffolding* |
| 6 | monochrome colour | 12 | a pressed key had no visible effect on some palettes |
| 7 | meter and row state | 190 | a keystroke stops redrawing the whole surface |
| 8 | **the keyboard answers the finger** | 854 | |
| 9 | keystroke cost | 217 | |
| 10 | autocorrect | 203 | |
| 11 | typing tap | 22 | a default settled by feel, and prose that argued against it |
| 12 | **keyboard lab** | 410 | *optional — drop with one reset* |

Commit 12 is debug-only, last, and nothing depends on it. Commit 5 is the
instrument every measurement above came from; it is early because the commits
after it are instrumented through it, so it cannot simply be dropped from the
end. It is debug-only and redacts the key in any field that has switched
typing intelligence off — a character key's name is the character, and a trace
that recorded a password would be indefensible. **Whether it stays is this
repository's call**, and I am happy to strip it and the measurements with it.

## Testing

753 tests, all passing. No personal identifier appears anywhere in the diff.

## Known gaps

None outstanding.
