### PR TITLE
feat(android): one Stop button, long-press to discard (#195)

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/MicDictationControl.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/MicDictationControl.kt
@@ -21,6 +21,13 @@ internal object MicDictationControl {
     fun longPress(phase: DictationPhase): MicDictationAction? =
         if (phase.isBusy) MicDictationAction.CANCEL else null
 
+    /**
+     * Visible X next to the mic. Hidden while listening so a walking tap cannot
+     * discard; the red Stop long-press is the discard path then.
+     */
+    fun showsSeparateCancel(phase: DictationPhase): Boolean =
+        phase.isBusy && phase != DictationPhase.LISTENING
+
     /** Menu, clipboard, and models stay reachable unless dictation is actually running. */
     fun allowsMenu(phase: DictationPhase): Boolean = !phase.isBusy
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -1081,13 +1081,14 @@ private fun DictationBar(
         if (panelTitle != null) {
             ToolbarCloseButton(onClick = onClosePanel)
         }
-        if (state.phase.isBusy) {
+        if (MicDictationControl.showsSeparateCancel(state.phase)) {
             DictationCancelButton(onClick = onMicLongPress)
         }
         MicButton(
             state = state,
             enabled = editor.dictationAllowed && !isPreferenceWritePending,
             onClick = onMicTap,
+            onLongPress = onMicLongPress,
         )
     }
 }
@@ -1635,6 +1636,7 @@ private fun MicButton(
     state: DictationState,
     enabled: Boolean,
     onClick: () -> Unit,
+    onLongPress: () -> Unit,
 ) {
     val view = LocalView.current
     val processing = state.phase in setOf(
@@ -1646,7 +1648,7 @@ private fun MicButton(
     val recording = state.phase == DictationPhase.LISTENING
     val description = when {
         !enabled -> "Dictation unavailable"
-        recording -> "Finish dictation"
+        recording -> "Finish dictation. Long-press to discard without inserting"
         processing -> "Dictation in progress"
         state.phase == DictationPhase.PERMISSION_REPAIR -> "Open VocaPhone"
         else -> "Start dictation"
@@ -1678,6 +1680,10 @@ private fun MicButton(
                     onTap = {
                         view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
                         onClick()
+                    },
+                    onLongPress = { _ ->
+                        view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                        onLongPress()
                     },
                 )
             },

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/MicDictationControlTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/MicDictationControlTest.kt
@@ -36,6 +36,15 @@ class MicDictationControlTest {
     }
 
     @Test
+    fun `separate cancel is hidden while listening so a walking tap cannot discard`() {
+        assertFalse(MicDictationControl.showsSeparateCancel(DictationPhase.IDLE))
+        assertFalse(MicDictationControl.showsSeparateCancel(DictationPhase.LISTENING))
+        assertTrue(MicDictationControl.showsSeparateCancel(DictationPhase.TRANSCRIBING))
+        assertTrue(MicDictationControl.showsSeparateCancel(DictationPhase.FINALIZING))
+        assertFalse(MicDictationControl.showsSeparateCancel(DictationPhase.FAILED))
+    }
+
+    @Test
     fun `a failed empty transcript does not lock the keyboard menu`() {
         assertTrue(MicDictationControl.allowsMenu(DictationPhase.IDLE))
         assertTrue(MicDictationControl.allowsMenu(DictationPhase.FAILED))


### PR DESCRIPTION
## Summary

- While listening, the red Stop control both finishes (tap) and discards (long-press).
- The separate cancel X is hidden during listening so a walking tap cannot hit discard by accident.
- `MicDictationControl` already mapped long-press to CANCEL; the IME now actually sends that from the Stop button.

Closes #195 once this train lands on main.

## Verification

- [x] `just ios ci` — N/A, Android IME chrome only
- [x] `just android ci` — targeted unit tests
- [x] Gateway changes: none
- [ ] Physical-device test, if keyboard, microphone, background audio, or insertion changed

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for data-flow, permission, retention, or network changes — n/a