### PR TITLE
feat(android): punctuation long-press on the period key (#146)

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyAccents.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyAccents.kt
@@ -45,7 +45,8 @@ internal object KeyAccents {
         "'" to listOf("'", "‘", "’", "‚"),
         "\"" to listOf("\"", "“", "”", "„"),
         "-" to listOf("-", "–", "—", "•"),
-        "." to listOf(".", "…"),
+        // Tap types `.`; hold-and-release types comma. Base omitted like letter accents.
+        "." to listOf(",", "?", "!", ":", ";", "'", "\"", "…", "@", "&"),
         "?" to listOf("?", "¿"),
         "!" to listOf("!", "¡"),
         "$" to listOf("$", "€", "£", "¥", "₹", "₩"),

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyAccentsTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyAccentsTest.kt
@@ -34,6 +34,18 @@ class KeyAccentsTest {
     }
 
     @Test
+    fun periodLongPressOffersGboardPunctuation() {
+        val key = KeyboardKey(id = "character-.", label = ".", output = ".")
+        val variants = KeyAccents.forKey(key, ShiftState.OFF)
+        assertEquals(
+            listOf(",", "?", "!", ":", ";", "'", "\"", "…", "@", "&"),
+            variants,
+        )
+        assertEquals(",", variants.first())
+        assertTrue("." !in variants)
+    }
+
+    @Test
     fun numberKeysShowTheLongPressHint() {
         assertEquals("!", KeyAccents.hint(KeyboardKey(id = "1", label = "1", output = "1")))
         assertEquals(")", KeyAccents.hint(KeyboardKey(id = "0", label = "0", output = "0")))

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardLayoutsTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardLayoutsTest.kt
@@ -45,4 +45,15 @@ class KeyboardLayoutsTest {
         val right = bottom.keys.drop(spaceIndex + 1).sumOf { it.weight.toDouble() }
         assertEquals(left, right, 0.01)
     }
+
+    @Test
+    fun `letter utility row keeps comma period and emoji as separate keys`() {
+        val bottom = KeyboardLayouts.rows(KeyboardLayer.LETTERS, KeyboardEditorConfig.empty()).last()
+        val outputs = bottom.keys.map { it.output }
+        assertTrue("," in outputs)
+        assertTrue("." in outputs)
+        assertTrue(
+            bottom.keys.any { it.type == KeyboardKeyType.LAYER_SWITCH && it.targetLayer == KeyboardLayer.EMOJI },
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- Long-press on `.` offers the usual Android punctuation set (comma, ?, !, :, ;, quotes, ellipsis, etc.).
- The dedicated comma key stays; this does not steal a high-frequency key.
- Emoji stays on its own key. Globe/emoji swap is #142 and is out of scope.

Closes #146 once this train lands on main.

## Verification

- [x] `just ios ci` — N/A, Android IME accents only
- [x] `just android ci` — targeted unit tests
- [x] Gateway changes: none
- [ ] Physical-device test, if keyboard, microphone, background audio, or insertion changed

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for data-flow, permission, retention, or network changes — n/a