### PR TITLE
feat(android): optional Material You dynamic color (#79)

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -530,7 +530,7 @@ internal fun VocaPhoneKeyboard(
         }
     }
 
-    VocaPhoneTheme {
+    VocaPhoneTheme(dynamicColor = settings.dynamicColorEnabled) {
         Surface(
             color = MaterialTheme.colorScheme.surfaceContainerLowest,
             contentColor = MaterialTheme.colorScheme.onSurface,

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -246,6 +246,8 @@ data class VocaPhoneSettings(
     val numberRowEnabled: Boolean = true,
     val keyboardHeight: KeyboardHeight = KeyboardHeight.DEFAULT,
     val splitKeyboard: SplitKeyboard = SplitKeyboard.DEFAULT,
+    /** Material You wallpaper colors. Off keeps the brand teal. */
+    val dynamicColorEnabled: Boolean = false,
     val suggestionsEnabled: Boolean = true,
     val correctionsEnabled: Boolean = true,
     val numberKeyHintsEnabled: Boolean = true,
@@ -432,6 +434,8 @@ class SettingsRepository(private val context: Context) {
     suspend fun setKeyboardHeight(height: KeyboardHeight) = put(Keys.KEYBOARD_HEIGHT, height.storedValue)
 
     suspend fun setSplitKeyboard(mode: SplitKeyboard) = put(Keys.SPLIT_KEYBOARD, mode.storedValue)
+
+    suspend fun setDynamicColorEnabled(enabled: Boolean) = put(Keys.DYNAMIC_COLOR, enabled)
 
     suspend fun setSuggestionsEnabled(enabled: Boolean) = put(Keys.SUGGESTIONS, enabled)
 
@@ -633,6 +637,7 @@ class SettingsRepository(private val context: Context) {
         numberRowEnabled = this[Keys.NUMBER_ROW] ?: true,
         keyboardHeight = KeyboardHeight.fromStored(this[Keys.KEYBOARD_HEIGHT]),
         splitKeyboard = SplitKeyboard.fromStored(this[Keys.SPLIT_KEYBOARD]),
+        dynamicColorEnabled = this[Keys.DYNAMIC_COLOR] ?: false,
         suggestionsEnabled = this[Keys.SUGGESTIONS] ?: true,
         correctionsEnabled = this[Keys.CORRECTIONS] ?: true,
         numberKeyHintsEnabled = this[Keys.NUMBER_KEY_HINTS] ?: true,
@@ -680,6 +685,7 @@ class SettingsRepository(private val context: Context) {
         val NUMBER_ROW = booleanPreferencesKey("keyboard_number_row")
         val KEYBOARD_HEIGHT = stringPreferencesKey("keyboard_height")
         val SPLIT_KEYBOARD = stringPreferencesKey("keyboard_split")
+        val DYNAMIC_COLOR = booleanPreferencesKey("keyboard_dynamic_color")
         val SUGGESTIONS = booleanPreferencesKey("keyboard_suggestions")
         val CORRECTIONS = booleanPreferencesKey("keyboard_corrections")
         val NUMBER_KEY_HINTS = booleanPreferencesKey("keyboard_number_key_hints")

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
@@ -61,8 +61,10 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             val launchIntent by launchIntents.collectAsStateWithLifecycle()
-            VocaPhoneTheme {
-                VocaPhoneApp(launchIntent = launchIntent)
+            val appViewModel: VocaPhoneViewModel = viewModel()
+            val settings by appViewModel.settings.collectAsStateWithLifecycle()
+            VocaPhoneTheme(dynamicColor = settings.dynamicColorEnabled) {
+                VocaPhoneApp(viewModel = appViewModel, launchIntent = launchIntent)
             }
         }
     }
@@ -418,6 +420,7 @@ fun VocaPhoneApp(
                 onNumberRow = { viewModel.setNumberRowEnabled(it) },
                 onKeyboardHeight = { viewModel.setKeyboardHeight(it) },
                 onSplitKeyboard = { viewModel.setSplitKeyboard(it) },
+                onDynamicColor = { viewModel.setDynamicColorEnabled(it) },
                 onSuggestions = { viewModel.setSuggestionsEnabled(it) },
                 onCorrections = { viewModel.setCorrectionsEnabled(it) },
                 onNumberKeyHints = { viewModel.setNumberKeyHintsEnabled(it) },

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -106,6 +106,7 @@ fun SettingsScreen(
     onNumberRow: (Boolean) -> Unit,
     onKeyboardHeight: (KeyboardHeight) -> Unit,
     onSplitKeyboard: (SplitKeyboard) -> Unit,
+    onDynamicColor: (Boolean) -> Unit,
     onSuggestions: (Boolean) -> Unit,
     onCorrections: (Boolean) -> Unit,
     onNumberKeyHints: (Boolean) -> Unit,
@@ -289,6 +290,14 @@ fun SettingsScreen(
 
             SettingsPage.KEYBOARD -> {
                 ImeSetupCard(setup.ime)
+                Section("Appearance") {
+                    SettingToggle(
+                        title = "Dynamic color",
+                        detail = "Follow the system wallpaper colors. Off keeps the Voca teal.",
+                        checked = settings.dynamicColorEnabled,
+                        onCheckedChange = onDynamicColor,
+                    )
+                }
                 Section("Layout") {
                     SettingToggle(
                         title = "Number row",

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
@@ -396,6 +396,9 @@ class VocaPhoneViewModel(application: Application) : AndroidViewModel(applicatio
     fun setSplitKeyboard(mode: SplitKeyboard) =
         viewModelScope.launch { container.settings.setSplitKeyboard(mode) }
 
+    fun setDynamicColorEnabled(enabled: Boolean) =
+        viewModelScope.launch { container.settings.setDynamicColorEnabled(enabled) }
+
     fun setSuggestionsEnabled(enabled: Boolean) =
         viewModelScope.launch { container.settings.setSuggestionsEnabled(enabled) }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/theme/Theme.kt
@@ -1,11 +1,15 @@
 package com.vocahq.vocaphone.ui.theme
 
+import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 
 /**
  * The light containers are deliberately a full step darker than a Material
@@ -99,16 +103,24 @@ internal val VocaPhoneDarkColors = darkColorScheme(
     onTertiaryContainer = Color(0xFFFFE2B0),
 )
 
-/** A stable, quiet palette that does not inherit a device wallpaper's colours. */
+/**
+ * Brand teal by default. [dynamicColor] opts into Material You wallpaper colors
+ * on API 31+; otherwise the fixed palette is kept so the IME and companion
+ * stay on Voca teal.
+ */
 @Composable
 fun VocaPhoneTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = false,
     content: @Composable () -> Unit,
 ) {
-    val colors = if (darkTheme) {
-        VocaPhoneDarkColors
-    } else {
-        VocaPhoneLightColors
+    val colors = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+        darkTheme -> VocaPhoneDarkColors
+        else -> VocaPhoneLightColors
     }
     MaterialTheme(colorScheme = colors, content = content)
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/settings/VocaPhoneSettingsTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/settings/VocaPhoneSettingsTest.kt
@@ -1,0 +1,12 @@
+package com.vocahq.vocaphone.settings
+
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class VocaPhoneSettingsTest {
+
+    @Test
+    fun dynamicColorDefaultsOffSoBrandTealStays() {
+        assertFalse(VocaPhoneSettings().dynamicColorEnabled)
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/SettingsChoiceTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/SettingsChoiceTest.kt
@@ -56,6 +56,7 @@ class SettingsChoiceTest {
         assertEquals(KeyboardHeight.DEFAULT, KeyboardHeight.fromStored(null))
         assertEquals(KeyboardHeight.DEFAULT, VocaPhoneSettings().keyboardHeight)
         assertFalse(VocaPhoneSettings().numbersAsDigits)
+        assertFalse(VocaPhoneSettings().dynamicColorEnabled)
         assertEquals(48, KeyboardHeight.DEFAULT.keyHeightDp)
     }
 

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/theme/ThemePaletteTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/theme/ThemePaletteTest.kt
@@ -1,0 +1,13 @@
+package com.vocahq.vocaphone.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ThemePaletteTest {
+
+    @Test
+    fun brandDarkPrimaryStaysVocaTeal() {
+        assertEquals(Color(0xFF77D0B2), VocaPhoneDarkColors.primary)
+    }
+}


### PR DESCRIPTION
## Summary

- Brand teal stays the default.
- Optional Keyboard/Appearance toggle uses Material You dynamic color on the IME and companion.
- Falls back to the brand palette when dynamic color is off or unavailable.

Closes #79 once this train lands on main.

## Verification

- [x] `just ios ci` — N/A, Android theme only
- [x] `just android ci` — targeted unit tests
- [x] Gateway changes: none
- [ ] Physical-device test, if keyboard, microphone, background audio, or insertion changed

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for data-flow, permission, retention, or network changes — n/a