### PR TITLE
fix(android): swipe word and alternatives beat the clipboard chip (#198)

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -188,8 +188,12 @@ internal object KeyboardChrome {
      *
      * [startedTyping] is what makes that true. Without it the chip outlived the
      * empty field and sat where the word suggestions should be for the whole
-     * sentence, because the render order in `DictationBar` reaches the clipboard
-     * branch first and never falls through to the suggestions one.
+     * sentence.
+     *
+     * A swipe on an empty field is the other producer. `applySwipe` fills
+     * alternatives and clears composing before the coalesced editor read, so
+     * [startedTyping] can still be false while those choices are already on
+     * the strip. [swipeChoicesActive] hides the chip for that window.
      *
      * Deliberately hidden for the rest of the sentence rather than reappearing
      * whenever suggestions happen to run dry: a paste target that pops back
@@ -200,8 +204,22 @@ internal object KeyboardChrome {
     fun clipboardForStrip(
         clipboard: ClipboardChip?,
         startedTyping: Boolean,
+        swipeChoicesActive: Boolean = false,
         alreadyPasted: Boolean = false,
-    ): ClipboardChip? = clipboard.takeIf { !alreadyPasted && !startedTyping }
+    ): ClipboardChip? =
+        clipboard.takeIf { !alreadyPasted && !startedTyping && !swipeChoicesActive }
+
+    /**
+     * Swipe alternatives are filled in `applySwipe` before the coalesced
+     * editor read. [swipeWordArmed] still needs that read, so an empty field
+     * can have choices that are neither armed nor "typing" yet.
+     */
+    fun swipeChoicesActive(
+        hasChoices: Boolean,
+        swipeArmed: Boolean,
+        startedTyping: Boolean,
+        composing: String,
+    ): Boolean = hasChoices && (swipeArmed || (!startedTyping && composing.isEmpty()))
 
     /**
      * Dismissing the chip hides that clip until a different one is copied.

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -316,14 +316,27 @@ internal fun VocaPhoneKeyboard(
     }
     val clipboardChip = clipboard.takeIf { settings.clipboardChipEnabled && !editor.sensitive }
     val startedTyping = KeyboardChrome.startedTyping(keyboardState.composing, editorText.before)
-    val stripClipboard = KeyboardChrome.clipboardForStrip(clipboardChip, startedTyping)
     val swipeArmed = KeyboardChrome.swipeWordArmed(swipeWord, editorText.before, editorText.after)
-    val stripSuggestions = if (swipeArmed && swipeChoices.isNotEmpty()) {
-        swipeChoices.map { SuggestionItem(it) }
+    val swipeChoicesActive = KeyboardChrome.swipeChoicesActive(
+        hasChoices = swipeChoices.isNotEmpty(),
+        swipeArmed = swipeArmed,
+        startedTyping = startedTyping,
+        composing = keyboardState.composing,
+    )
+    val stripClipboard = KeyboardChrome.clipboardForStrip(
+        clipboardChip,
+        startedTyping,
+        swipeChoicesActive = swipeChoicesActive,
+    )
+    val stripSuggestions = if (swipeChoicesActive) {
+        buildList(swipeChoices.size + 1) {
+            swipeWord?.let { add(SuggestionItem(it)) }
+            addAll(swipeChoices.map { SuggestionItem(it) })
+        }
     } else {
         KeyboardChrome.suggestionsForStrip(suggestionStrip.items, startedTyping)
     }
-    val swipeReplacesWord = swipeArmed && swipeChoices.isNotEmpty()
+    val swipeReplacesWord = swipeChoicesActive
 
     fun clearSwipe() {
         swipeChoices = emptyList()
@@ -1032,6 +1045,10 @@ private fun DictationBar(
                     onSelect = onEmojiCategory,
                     modifier = Modifier.weight(1f),
                 )
+                suggestions.isNotEmpty() -> SuggestionStripRow(
+                    suggestions = suggestions,
+                    onSuggestion = onSuggestion,
+                )
                 clipboard != null -> {
                     Box(
                         modifier = Modifier
@@ -1047,10 +1064,6 @@ private fun DictationBar(
                         )
                     }
                 }
-                suggestions.isNotEmpty() -> SuggestionStripRow(
-                    suggestions = suggestions,
-                    onSuggestion = onSuggestion,
-                )
                 else -> Spacer(Modifier.weight(1f))
             }
         }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardChromeTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardChromeTest.kt
@@ -72,24 +72,26 @@ class KeyboardChromeTest {
     fun `the clip chip and the suggestions never both claim the row`() {
         val words = listOf(SuggestionItem("you"), SuggestionItem("the"))
         listOf(false, true).forEach { typing ->
-            val chip = KeyboardChrome.clipboardForStrip(clip, startedTyping = typing)
-            val strip = KeyboardChrome.suggestionsForStrip(words, startedTyping = typing)
-            assertFalse(
-                "the clip chip and ${strip.size} suggestions both claimed the row " +
-                    "with startedTyping=$typing",
-                chip != null && strip.isNotEmpty(),
-            )
+            listOf(false, true).forEach { swipe ->
+                val chip = KeyboardChrome.clipboardForStrip(
+                    clip,
+                    startedTyping = typing,
+                    swipeChoicesActive = swipe,
+                )
+                val strip = if (swipe) {
+                    words
+                } else {
+                    KeyboardChrome.suggestionsForStrip(words, startedTyping = typing)
+                }
+                assertFalse(
+                    "the clip chip and ${strip.size} suggestions both claimed the row " +
+                        "with startedTyping=$typing swipeChoicesActive=$swipe",
+                    chip != null && strip.isNotEmpty(),
+                )
+            }
         }
     }
 
-    /**
-     * Swipe alternatives reach the strip without passing through
-     * [KeyboardChrome.suggestionsForStrip], so the exclusion above cannot see
-     * that path. It holds anyway, but for a different reason: arming a swiped
-     * word requires a replaceable word behind the cursor, which is text, which
-     * is already typing. Asserted rather than argued, because the two helpers
-     * are free to drift apart.
-     */
     @Test
     fun `json clips are named instead of dumping the first keys`() {
         assertEquals(
@@ -112,6 +114,78 @@ class KeyboardChromeTest {
             KeyboardChrome.clipboardForStrip(
                 clip,
                 startedTyping = KeyboardChrome.startedTyping("", before),
+            ),
+        )
+    }
+
+    /**
+     * Right after a swipe on an empty field, composing is cleared and
+     * `editorText` is still the pre-commit snapshot for up to 50ms. The
+     * alternatives are already filled; `startedTyping` and `swipeWordArmed`
+     * are not. The chip has to yield on the choices themselves.
+     */
+    @Test
+    fun `clipboard yields when swipe choices are active even if startedTyping is false`() {
+        val startedTyping = KeyboardChrome.startedTyping(composing = "", textBeforeCursor = "")
+        assertFalse(startedTyping)
+        assertFalse(KeyboardChrome.swipeWordArmed("hello", "", ""))
+        assertTrue(
+            KeyboardChrome.swipeChoicesActive(
+                hasChoices = true,
+                swipeArmed = false,
+                startedTyping = false,
+                composing = "",
+            ),
+        )
+        assertNull(
+            KeyboardChrome.clipboardForStrip(
+                clip,
+                startedTyping = false,
+                swipeChoicesActive = true,
+            ),
+        )
+        assertEquals(
+            clip,
+            KeyboardChrome.clipboardForStrip(
+                clip,
+                startedTyping = false,
+                swipeChoicesActive = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `swipe choices stay inactive on an idle empty field`() {
+        assertFalse(
+            KeyboardChrome.swipeChoicesActive(
+                hasChoices = false,
+                swipeArmed = false,
+                startedTyping = false,
+                composing = "",
+            ),
+        )
+        assertFalse(
+            KeyboardChrome.swipeChoicesActive(
+                hasChoices = true,
+                swipeArmed = false,
+                startedTyping = true,
+                composing = "",
+            ),
+        )
+        assertTrue(
+            KeyboardChrome.swipeChoicesActive(
+                hasChoices = true,
+                swipeArmed = true,
+                startedTyping = true,
+                composing = "",
+            ),
+        )
+        assertFalse(
+            KeyboardChrome.swipeChoicesActive(
+                hasChoices = true,
+                swipeArmed = false,
+                startedTyping = false,
+                composing = "h",
             ),
         )
     }


### PR DESCRIPTION
## Summary

- After a swipe, the suggestion strip shows the committed word and its alternatives even when a clipboard chip would have occupied that row.
- The clipboard chip still shows on an idle empty field; it yields as soon as swipe choices are armed.
- No finger-following popup (hot path). Alternatives stay in the existing strip.

Closes #198 once this train lands on main.

## Verification

- [x] `just ios ci` — N/A, Android IME strip only
- [x] `just android ci` — targeted unit tests
- [x] Gateway changes: none
- [ ] Physical-device test, if keyboard, microphone, background audio, or insertion changed

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for data-flow, permission, retention, or network changes — n/a