### PR TITLE
feat(android): expose VocaPhone as a voice-input shortcut (#199)

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -11,6 +11,8 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.ExtractedTextRequest
 import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputContentInfo
+import android.view.inputmethod.InputMethodManager
+import android.view.inputmethod.InputMethodSubtype
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -84,6 +86,11 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
     private var lastState = DictationState()
     private var currentInputType: Int = 0
     private var startedImeDictation = false
+    private var voiceShortcutActive by mutableStateOf(false)
+    private var voiceShortcutOwnedSession = false
+    private var voiceShortcutStartRequested = false
+    private var voiceShortcutLeftIdle = false
+    private var voiceShortcutReturned = false
     private var ignoredClipboardText: String? = null
     private var lastRecordedClip: String? = null
     private var lastImageSource: String? = null
@@ -109,6 +116,10 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
                 lastState = state
                 visibleDictationState.value = state
                 if (!state.phase.isBusy) startedImeDictation = false
+                if (voiceShortcutOwnedSession && state.phase != DictationPhase.IDLE) {
+                    voiceShortcutLeftIdle = true
+                }
+                maybeReturnToPreviousIme()
             }
         }
         scope.launch {
@@ -134,39 +145,51 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         val dictationState by visibleDictationState.collectAsState()
         val settings by visibleSettings.collectAsState()
         val isPreferenceWritePending by preferenceWrites.pending.collectAsState()
-        val clipboard by visibleClipboard.collectAsState()
-        val editorText by visibleEditorText.collectAsState()
-        val dictionary by suggestionDictionary.collectAsState()
-        val emojis by emojiCatalog.collectAsState()
-        VocaPhoneKeyboard(
-            dictationState = dictationState,
-            editor = editorConfig,
-            settings = settings,
-            isPreferenceWritePending = isPreferenceWritePending,
-            clipboard = clipboard,
-            editorText = editorText,
-            suggestions = dictionary,
-            emojiCatalog = emojis,
-            onCommand = ::handleCommand,
-            onMicTap = ::toggleDictation,
-            onMicLongPress = ::cancelDictationFromMic,
-            onOpenSettings = ::openCompanion,
-            onLanguageSelected = ::setLanguage,
-            onStyleSelected = ::setStyle,
-            onSuggestionPicked = ::commitSuggestion,
-            onSaveToDictionary = ::addPersonalWord,
-            onEmojiSuggestion = ::commitEmojiSuggestion,
-            onPasteClipboard = { pasteClipboard(it) },
-            onDismissClipboard = ::dismissClipboard,
-            onRemoveClipboardHistory = ::removeClipboardHistory,
-            onClearClipboardHistory = ::clearClipboardHistory,
-            onEmojiUsed = ::recordEmojiRecent,
-        )
+        if (voiceShortcutActive) {
+            VoiceShortcutListeningChrome(
+                dictationState = dictationState,
+                editor = editorConfig,
+                settings = settings,
+                isPreferenceWritePending = isPreferenceWritePending,
+                onMicTap = ::toggleDictation,
+                onMicLongPress = ::cancelDictationFromMic,
+            )
+        } else {
+            val clipboard by visibleClipboard.collectAsState()
+            val editorText by visibleEditorText.collectAsState()
+            val dictionary by suggestionDictionary.collectAsState()
+            val emojis by emojiCatalog.collectAsState()
+            VocaPhoneKeyboard(
+                dictationState = dictationState,
+                editor = editorConfig,
+                settings = settings,
+                isPreferenceWritePending = isPreferenceWritePending,
+                clipboard = clipboard,
+                editorText = editorText,
+                suggestions = dictionary,
+                emojiCatalog = emojis,
+                onCommand = ::handleCommand,
+                onMicTap = ::toggleDictation,
+                onMicLongPress = ::cancelDictationFromMic,
+                onOpenSettings = ::openCompanion,
+                onLanguageSelected = ::setLanguage,
+                onStyleSelected = ::setStyle,
+                onSuggestionPicked = ::commitSuggestion,
+                onSaveToDictionary = ::addPersonalWord,
+                onEmojiSuggestion = ::commitEmojiSuggestion,
+                onPasteClipboard = { pasteClipboard(it) },
+                onDismissClipboard = ::dismissClipboard,
+                onRemoveClipboardHistory = ::removeClipboardHistory,
+                onClearClipboardHistory = ::clearClipboardHistory,
+                onEmojiUsed = ::recordEmojiRecent,
+            )
+        }
     }
 
     override fun onStartInput(attribute: EditorInfo?, restarting: Boolean) {
         super.onStartInput(attribute, restarting)
         currentInputType = attribute?.inputType ?: 0
+        applyVoiceShortcutSubtype(currentSubtype())
         val identity = EditorIdentity.of(attribute)
         val sameEditor = EditorRestart.keepsSession(editorIdentity, identity)
         editorIdentity = identity
@@ -176,9 +199,13 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         lastSelStart = attribute?.initialSelStart ?: -1
         lastSelEnd = attribute?.initialSelEnd ?: -1
         composingRegionActive = false
-        val cursorCapsMode = runCatching {
-            currentInputConnection?.getCursorCapsMode(currentInputType) ?: 0
-        }.getOrDefault(0)
+        val cursorCapsMode = if (voiceShortcutActive) {
+            0
+        } else {
+            runCatching {
+                currentInputConnection?.getCursorCapsMode(currentInputType) ?: 0
+            }.getOrDefault(0)
+        }
         val started = KeyboardEditorConfig.from(attribute, editorSession).let { config ->
             if (config.initialLayer == KeyboardLayer.LETTERS) {
                 config.copy(initialShift = KeyboardEditorConfig.shiftFromCapsMode(cursorCapsMode))
@@ -199,19 +226,44 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         } else {
             started
         }
-        refreshEditorText()
+        if (!voiceShortcutActive) refreshEditorText()
     }
 
     override fun onStartInputView(info: EditorInfo?, restarting: Boolean) {
         super.onStartInputView(info, restarting)
-        startClipboardWatch()
-        refreshEditorText()
+        applyVoiceShortcutSubtype(currentSubtype())
+        if (!voiceShortcutActive) {
+            startClipboardWatch()
+            refreshEditorText()
+        }
+        maybeStartVoiceShortcutDictation()
+        maybeHandBackVoiceShortcut()
     }
 
     override fun onFinishInputView(finishingInput: Boolean) {
+        if (voiceShortcutActive) {
+            cancelOwnedDictation("voice_shortcut_hidden")
+            if (VoiceShortcutIme.shouldReturnWhenViewFinishes(
+                    voiceShortcutActive,
+                    voiceShortcutReturned,
+                )
+            ) {
+                returnToPreviousIme()
+            }
+        }
         stopClipboardWatch()
         visibleClipboard.value = null
         super.onFinishInputView(finishingInput)
+    }
+
+    override fun onCurrentInputMethodSubtypeChanged(newSubtype: InputMethodSubtype?) {
+        super.onCurrentInputMethodSubtypeChanged(newSubtype)
+        val wasActive = voiceShortcutActive
+        applyVoiceShortcutSubtype(newSubtype)
+        if (voiceShortcutActive && !wasActive) {
+            maybeStartVoiceShortcutDictation()
+            maybeHandBackVoiceShortcut()
+        }
     }
 
     override fun onUpdateSelection(
@@ -230,6 +282,13 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
             candidatesStart,
             candidatesEnd,
         )
+        if (voiceShortcutActive) {
+            lastCandidatesStart = candidatesStart
+            lastCandidatesEnd = candidatesEnd
+            lastSelStart = newSelStart
+            lastSelEnd = newSelEnd
+            return
+        }
         val userMove = EditorCursorSync.isUserMove(
             oldSelStart,
             oldSelEnd,
@@ -274,6 +333,16 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
 
     override fun onFinishInput() {
         cancelOwnedDictation("editor_finished")
+        if (VoiceShortcutIme.shouldReturnWhenViewFinishes(
+                voiceShortcutActive,
+                voiceShortcutReturned,
+            )
+        ) {
+            returnToPreviousIme()
+        }
+        voiceShortcutOwnedSession = false
+        voiceShortcutStartRequested = false
+        voiceShortcutLeftIdle = false
         currentInputType = 0
         editorIdentity = null
         editorSession += 1
@@ -816,16 +885,7 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
                     DictationService.send(this, DictationService.ACTION_CANCEL)
                 }
                 MicDictationAction.OPEN_APP -> openCompanion()
-                MicDictationAction.START -> {
-                    if (lastState.phase == DictationPhase.FAILED ||
-                        lastState.phase == DictationPhase.READY_TO_INSERT ||
-                        lastState.phase == DictationPhase.INSERTED
-                    ) {
-                        container.dictation.clearTransient()
-                    }
-                    startedImeDictation = true
-                    DictationService.start(this, DictationSource.IME)
-                }
+                MicDictationAction.START -> startImeDictation()
             }
         }
     }
@@ -860,6 +920,85 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         // An editor connection is unsafe after this callback, so do not let a
         // late gateway response insert into whichever field receives focus next.
         container.dictation.cancel()
+    }
+
+    private fun startImeDictation() {
+        if (lastState.phase == DictationPhase.FAILED ||
+            lastState.phase == DictationPhase.READY_TO_INSERT ||
+            lastState.phase == DictationPhase.INSERTED
+        ) {
+            container.dictation.clearTransient()
+        }
+        startedImeDictation = true
+        if (voiceShortcutActive) {
+            voiceShortcutOwnedSession = true
+            voiceShortcutStartRequested = true
+        }
+        DictationService.start(this, DictationSource.IME)
+    }
+
+    private fun currentSubtype(): InputMethodSubtype? =
+        getSystemService(InputMethodManager::class.java)?.currentInputMethodSubtype
+
+    private fun applyVoiceShortcutSubtype(subtype: InputMethodSubtype?) {
+        val active = VoiceShortcutIme.isVoiceShortcutSubtype(
+            mode = subtype?.mode,
+            auxiliary = subtype?.isAuxiliary == true,
+        )
+        if (active == voiceShortcutActive) return
+        voiceShortcutActive = active
+        voiceShortcutOwnedSession = false
+        voiceShortcutStartRequested = false
+        voiceShortcutLeftIdle = false
+        voiceShortcutReturned = false
+    }
+
+    private fun maybeStartVoiceShortcutDictation() {
+        if (!VoiceShortcutIme.shouldAutoStart(
+                isVoiceShortcut = voiceShortcutActive,
+                dictationAllowed = editorConfig.dictationAllowed,
+                isBusy = lastState.phase.isBusy,
+                alreadyRequested = voiceShortcutStartRequested,
+            )
+        ) {
+            return
+        }
+        startImeDictation()
+    }
+
+    private fun maybeHandBackVoiceShortcut() {
+        if (VoiceShortcutIme.shouldReturnWhenDictationRejected(
+                isVoiceShortcut = voiceShortcutActive,
+                dictationAllowed = editorConfig.dictationAllowed,
+            )
+        ) {
+            returnToPreviousIme()
+        } else {
+            maybeReturnToPreviousIme()
+        }
+    }
+
+    private fun maybeReturnToPreviousIme() {
+        if (voiceShortcutReturned) return
+        if (!VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = voiceShortcutActive,
+                ownedSession = voiceShortcutOwnedSession,
+                sessionLeftIdle = voiceShortcutLeftIdle,
+                phase = lastState.phase,
+            )
+        ) {
+            return
+        }
+        returnToPreviousIme()
+    }
+
+    private fun returnToPreviousIme() {
+        if (voiceShortcutReturned) return
+        voiceShortcutReturned = true
+        voiceShortcutOwnedSession = false
+        if (!switchToPreviousInputMethod()) {
+            voiceShortcutReturned = false
+        }
     }
 
     private fun openCompanion(page: String? = null) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -1108,6 +1108,127 @@ private fun DictationBar(
 }
 
 @Composable
+internal fun VoiceShortcutListeningChrome(
+    dictationState: DictationState,
+    editor: KeyboardEditorConfig,
+    settings: VocaPhoneSettings,
+    isPreferenceWritePending: Boolean,
+    onMicTap: () -> Unit,
+    onMicLongPress: () -> Unit,
+) {
+    VocaPhoneTheme(dynamicColor = settings.dynamicColorEnabled) {
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainerLowest,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        ) {
+            VoiceShortcutListeningBar(
+                state = dictationState,
+                editor = editor,
+                barHeight = settings.keyboardHeight.dictationBarDp.dp,
+                isPreferenceWritePending = isPreferenceWritePending,
+                onMicTap = onMicTap,
+                onMicLongPress = onMicLongPress,
+            )
+        }
+    }
+}
+
+@Composable
+private fun VoiceShortcutListeningBar(
+    state: DictationState,
+    editor: KeyboardEditorConfig,
+    barHeight: Dp,
+    isPreferenceWritePending: Boolean,
+    onMicTap: () -> Unit,
+    onMicLongPress: () -> Unit,
+) {
+    val idle = state.phase == DictationPhase.IDLE
+    val status = when {
+        editor.sensitive -> "Private field"
+        !editor.dictationAllowed -> "Typing only"
+        idle -> "VocaPhone"
+        state.phase == DictationPhase.LISTENING -> "Listening · ${formatDuration(state.recordedMillis)}"
+        else -> state.statusText
+    }
+    val detail = when {
+        editor.sensitive -> "Dictation is off here"
+        !editor.dictationAllowed -> "Dictation is available in text fields"
+        idle -> "Voice input"
+        state.phase == DictationPhase.LISTENING && state.partialTranscript.isNotBlank() ->
+            state.partialTranscript.replace('\n', ' ').take(64)
+        state.phase == DictationPhase.LISTENING ->
+            state.inputRouteLabel ?: "Tap the red button to finish"
+        state.phase == DictationPhase.PERMISSION_REPAIR -> "Open VocaPhone to finish setup"
+        state.phase == DictationPhase.FAILED -> "Tap the mic to try again"
+        state.phase.isBusy -> ""
+        else -> "Ready"
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp, bottom = 6.dp)
+            .height(barHeight)
+            .padding(horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight()
+                .semantics { liveRegion = LiveRegionMode.Polite },
+            contentAlignment = Alignment.Center,
+        ) {
+            if (state.isRecording) {
+                Waveform(
+                    level = state.level,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(34.dp),
+                    alpha = 0.34f,
+                    bars = 13,
+                )
+            }
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = status,
+                    modifier = Modifier.fillMaxWidth(),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center,
+                )
+                if (detail.isNotEmpty()) {
+                    Text(
+                        text = detail,
+                        modifier = Modifier.fillMaxWidth(),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.labelSmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+        if (MicDictationControl.showsSeparateCancel(state.phase)) {
+            DictationCancelButton(onClick = onMicLongPress)
+        }
+        MicButton(
+            state = state,
+            enabled = editor.dictationAllowed && !isPreferenceWritePending,
+            onClick = onMicTap,
+            onLongPress = onMicLongPress,
+        )
+    }
+}
+
+@Composable
 private fun ToolbarIconButton(
     contentDescription: String,
     onClick: () -> Unit,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VoiceShortcutIme.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VoiceShortcutIme.kt
@@ -1,0 +1,58 @@
+package com.vocahq.vocaphone.ime
+
+import com.vocahq.vocaphone.core.DictationPhase
+
+/**
+ * Decisions for the auxiliary voice subtype other keyboards hand off to.
+ *
+ * HeliBoard / Gboard-style mic keys call
+ * [android.view.inputmethod.InputMethodManager.getShortcutInputMethodsAndSubtypes],
+ * which only lists IMEs that declare a voice-mode auxiliary subtype.
+ */
+internal object VoiceShortcutIme {
+    const val MODE_VOICE = "voice"
+
+    fun isVoiceShortcutSubtype(mode: String?, auxiliary: Boolean): Boolean =
+        auxiliary && !mode.isNullOrEmpty() && mode.equals(MODE_VOICE, ignoreCase = true)
+
+    fun shouldAutoStart(
+        isVoiceShortcut: Boolean,
+        dictationAllowed: Boolean,
+        isBusy: Boolean,
+        alreadyRequested: Boolean,
+    ): Boolean = isVoiceShortcut && dictationAllowed && !isBusy && !alreadyRequested
+
+    /**
+     * Whether this activation should hand back to the typing keyboard.
+     *
+     * [ownedSession] is the voice-shortcut flag, not "VocaPhone is the normal
+     * keyboard". IDLE is a return only after the session left idle — otherwise
+     * auto-start would bounce back before listening began.
+     */
+    fun shouldReturnToPreviousIme(
+        isVoiceShortcut: Boolean,
+        ownedSession: Boolean,
+        sessionLeftIdle: Boolean,
+        phase: DictationPhase,
+    ): Boolean {
+        if (!isVoiceShortcut || !ownedSession) return false
+        return when (phase) {
+            DictationPhase.INSERTED,
+            DictationPhase.FAILED,
+            DictationPhase.READY_TO_INSERT,
+            -> true
+            DictationPhase.IDLE -> sessionLeftIdle
+            else -> false
+        }
+    }
+
+    fun shouldReturnWhenDictationRejected(
+        isVoiceShortcut: Boolean,
+        dictationAllowed: Boolean,
+    ): Boolean = isVoiceShortcut && !dictationAllowed
+
+    fun shouldReturnWhenViewFinishes(
+        isVoiceShortcut: Boolean,
+        alreadyReturned: Boolean,
+    ): Boolean = isVoiceShortcut && !alreadyReturned
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="app_name">VocaPhone</string>
 
     <string name="ime_name">VocaPhone keyboard</string>
+    <string name="voice_input_label">VocaPhone voice input</string>
 </resources>

--- a/android/app/src/main/res/xml/method.xml
+++ b/android/app/src/main/res/xml/method.xml
@@ -1,3 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <input-method xmlns:android="http://schemas.android.com/apk/res/android"
-    android:supportsSwitchingToNextInputMethod="true" />
+    android:supportsSwitchingToNextInputMethod="true">
+    <!-- Non-auxiliary keyboard subtype keeps VocaPhone selectable as a normal IME.
+         An auxiliary-only method.xml would mark the whole IME as aux and hide it
+         from the default keyboard picker. -->
+    <subtype
+        android:label="@string/ime_name"
+        android:imeSubtypeMode="keyboard"
+        android:isAsciiCapable="true"
+        android:overridesImplicitlyEnabledSubtype="true" />
+    <subtype
+        android:label="@string/voice_input_label"
+        android:imeSubtypeMode="voice"
+        android:isAuxiliary="true" />
+</input-method>

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/VoiceShortcutImeTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/VoiceShortcutImeTest.kt
@@ -1,0 +1,236 @@
+package com.vocahq.vocaphone.ime
+
+import com.vocahq.vocaphone.core.DictationPhase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VoiceShortcutImeTest {
+
+    @Test
+    fun `only an auxiliary voice subtype is the system shortcut`() {
+        assertTrue(VoiceShortcutIme.isVoiceShortcutSubtype("voice", auxiliary = true))
+        assertTrue(VoiceShortcutIme.isVoiceShortcutSubtype("VOICE", auxiliary = true))
+        assertFalse(VoiceShortcutIme.isVoiceShortcutSubtype("voice", auxiliary = false))
+        assertFalse(VoiceShortcutIme.isVoiceShortcutSubtype("keyboard", auxiliary = true))
+        assertFalse(VoiceShortcutIme.isVoiceShortcutSubtype("keyboard", auxiliary = false))
+        assertFalse(VoiceShortcutIme.isVoiceShortcutSubtype(null, auxiliary = true))
+        assertFalse(VoiceShortcutIme.isVoiceShortcutSubtype("", auxiliary = true))
+    }
+
+    @Test
+    fun `auto-start requires the shortcut, a dictation field, and a free pipeline`() {
+        assertTrue(
+            VoiceShortcutIme.shouldAutoStart(
+                isVoiceShortcut = true,
+                dictationAllowed = true,
+                isBusy = false,
+                alreadyRequested = false,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldAutoStart(
+                isVoiceShortcut = false,
+                dictationAllowed = true,
+                isBusy = false,
+                alreadyRequested = false,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldAutoStart(
+                isVoiceShortcut = true,
+                dictationAllowed = false,
+                isBusy = false,
+                alreadyRequested = false,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldAutoStart(
+                isVoiceShortcut = true,
+                dictationAllowed = true,
+                isBusy = true,
+                alreadyRequested = false,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldAutoStart(
+                isVoiceShortcut = true,
+                dictationAllowed = true,
+                isBusy = false,
+                alreadyRequested = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `the normal keyboard never hands back to a previous IME`() {
+        val phases = listOf(
+            DictationPhase.IDLE,
+            DictationPhase.LISTENING,
+            DictationPhase.INSERTED,
+            DictationPhase.FAILED,
+            DictationPhase.READY_TO_INSERT,
+        )
+        for (phase in phases) {
+            assertFalse(
+                "non-shortcut $phase should stay on VocaPhone",
+                VoiceShortcutIme.shouldReturnToPreviousIme(
+                    isVoiceShortcut = false,
+                    ownedSession = true,
+                    sessionLeftIdle = true,
+                    phase = phase,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `shortcut returns after insert, cancel idle, or failed empty`() {
+        assertTrue(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = true,
+                phase = DictationPhase.INSERTED,
+            ),
+        )
+        assertTrue(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = true,
+                phase = DictationPhase.FAILED,
+            ),
+        )
+        assertTrue(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = true,
+                phase = DictationPhase.IDLE,
+            ),
+        )
+        assertTrue(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = false,
+                phase = DictationPhase.INSERTED,
+            ),
+        )
+    }
+
+    @Test
+    fun `shortcut does not bounce back before listening starts`() {
+        assertFalse(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = false,
+                phase = DictationPhase.IDLE,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = false,
+                phase = DictationPhase.LISTENING,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = true,
+                phase = DictationPhase.LISTENING,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = true,
+                phase = DictationPhase.TRANSCRIBING,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = true,
+                phase = DictationPhase.PERMISSION_REPAIR,
+            ),
+        )
+    }
+
+    @Test
+    fun `a session this shortcut did not start does not steal the keyboard`() {
+        assertFalse(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = false,
+                sessionLeftIdle = true,
+                phase = DictationPhase.INSERTED,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = false,
+                sessionLeftIdle = true,
+                phase = DictationPhase.IDLE,
+            ),
+        )
+    }
+
+    @Test
+    fun `password and other rejected fields hand back immediately`() {
+        assertTrue(
+            VoiceShortcutIme.shouldReturnWhenDictationRejected(
+                isVoiceShortcut = true,
+                dictationAllowed = false,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnWhenDictationRejected(
+                isVoiceShortcut = true,
+                dictationAllowed = true,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnWhenDictationRejected(
+                isVoiceShortcut = false,
+                dictationAllowed = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `hiding the shortcut view returns even if dictation never started`() {
+        assertTrue(
+            VoiceShortcutIme.shouldReturnWhenViewFinishes(
+                isVoiceShortcut = true,
+                alreadyReturned = false,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnWhenViewFinishes(
+                isVoiceShortcut = true,
+                alreadyReturned = true,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnWhenViewFinishes(
+                isVoiceShortcut = false,
+                alreadyReturned = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `voice mode string matches method xml`() {
+        assertEquals("voice", VoiceShortcutIme.MODE_VOICE)
+    }
+}


### PR DESCRIPTION
## Summary

- Declares an auxiliary `voice` IME subtype so other keyboards (HeliBoard, Gboard-style mic keys) can hand off to VocaPhone.
- In that subtype, the IME shows a compact listening chrome and starts dictation instead of the full QWERTY.
- After a successful insert (or cancel/idle), it calls `switchToPreviousInputMethod()` so the user lands back on their typing keyboard.

Closes #199 once this train lands on main.

## Verification

- [x] `just ios ci` — N/A, Android IME subtype only
- [x] `just android ci` — targeted unit tests
- [x] Gateway changes: none
- [ ] Physical-device test, if keyboard, microphone, background audio, or insertion changed — needed on a phone with HeliBoard; not run in this PR

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for data-flow, permission, retention, or network changes — n/a