### PR TITLE
feat(android): keyboard train for the next feature release

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationService.kt
@@ -9,7 +9,9 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.vocahq.vocaphone.VocaPhoneApplication
@@ -33,7 +35,12 @@ import kotlinx.coroutines.withTimeoutOrNull
 class DictationService : Service() {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val mainHandler = Handler(Looper.getMainLooper())
     private var observer: Job? = null
+    private var pendingSource: DictationSource? = null
+    private var promoteFailures = 0
+    private var microphoneForeground = false
+    private val promoteRetry = Runnable { promoteMicrophoneForeground() }
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -46,26 +53,26 @@ class DictationService : Service() {
         val controller = VocaPhoneApplication.container(this).dictation
         when (intent?.action) {
             ACTION_START -> {
-                // Called before any capture begins: Android requires the microphone
-                // foreground service to be visible for the whole recording.
-                startForeground(
-                    NOTIFICATION_ID,
-                    notification("Listening"),
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
-                )
+                if (microphoneForeground) return START_NOT_STICKY
                 val source = intent.getStringExtra(EXTRA_SOURCE)
                     ?.let { runCatching { DictationSource.valueOf(it) }.getOrNull() }
                     ?: DictationSource.COMPANION_APP
-                controller.start(source)
-                observeUntilIdle()
+                pendingSource = source
+                promoteFailures = 0
+                mainHandler.removeCallbacks(promoteRetry)
+                promoteMicrophoneForeground()
             }
 
             ACTION_FINISH -> {
+                mainHandler.removeCallbacks(promoteRetry)
+                pendingSource = null
                 controller.finish()
                 stopUnlessHoldingMicrophone()
             }
 
             ACTION_CANCEL -> {
+                mainHandler.removeCallbacks(promoteRetry)
+                pendingSource = null
                 controller.cancel()
                 stopUnlessHoldingMicrophone()
             }
@@ -73,6 +80,54 @@ class DictationService : Service() {
             else -> stopSelf()
         }
         return START_NOT_STICKY
+    }
+
+    /**
+     * startForeground(MICROPHONE) is refused until the app is in an eligible
+     * state. HeliBoard can start this service a frame before our IME window
+     * counts; retry rather than crash the process.
+     */
+    private fun promoteMicrophoneForeground() {
+        val source = pendingSource
+        if (source == null) {
+            if (!microphoneForeground && enterMicrophoneForeground()) {
+                stopForegroundAndSelf()
+            }
+            return
+        }
+        if (enterMicrophoneForeground()) {
+            pendingSource = null
+            promoteFailures = 0
+            VocaPhoneApplication.container(this).dictation.start(source)
+            observeUntilIdle()
+            return
+        }
+        promoteFailures++
+        if (source != DictationSource.IME &&
+            MicrophoneForegroundPromote.shouldLaunchVisibleActivity(promoteFailures)
+        ) {
+            launchVisibleStarter(this, source)
+        }
+        if (MicrophoneForegroundPromote.shouldRetry(promoteFailures)) {
+            mainHandler.postDelayed(promoteRetry, MicrophoneForegroundPromote.RETRY_DELAY_MS)
+        }
+    }
+
+    private fun enterMicrophoneForeground(): Boolean {
+        if (microphoneForeground) return true
+        return try {
+            startForeground(
+                NOTIFICATION_ID,
+                notification("Listening"),
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
+            )
+            microphoneForeground = true
+            true
+        } catch (_: SecurityException) {
+            false
+        } catch (_: ForegroundServiceStartNotAllowedException) {
+            false
+        }
     }
 
     /**
@@ -113,11 +168,18 @@ class DictationService : Service() {
     private fun stopForegroundAndSelf() {
         observer?.cancel()
         observer = null
+        pendingSource = null
+        promoteFailures = 0
+        microphoneForeground = false
+        mainHandler.removeCallbacks(promoteRetry)
         stopForeground(STOP_FOREGROUND_REMOVE)
         stopSelf()
     }
 
     override fun onDestroy() {
+        mainHandler.removeCallbacks(promoteRetry)
+        pendingSource = null
+        microphoneForeground = false
         scope.cancel()
         super.onDestroy()
     }
@@ -207,18 +269,40 @@ class DictationService : Service() {
             try {
                 ContextCompat.startForegroundService(context, intent)
             } catch (_: ForegroundServiceStartNotAllowedException) {
-                context.startActivity(
-                    Intent(context, DictationLauncherActivity::class.java)
-                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_NO_ANIMATION)
-                        .putExtra(EXTRA_SOURCE, source.name)
-                )
+                launchVisibleStarter(context, source)
+            } catch (_: SecurityException) {
+                launchVisibleStarter(context, source)
             }
         }
 
         fun send(context: Context, action: String) {
             context.startService(Intent(context, DictationService::class.java).setAction(action))
         }
+
+        private fun launchVisibleStarter(context: Context, source: DictationSource) {
+            context.startActivity(
+                Intent(context, DictationLauncherActivity::class.java)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_NO_ANIMATION)
+                    .putExtra(EXTRA_SOURCE, source.name),
+            )
+        }
     }
+}
+
+/**
+ * How long [DictationService] keeps retrying startForeground(MICROPHONE)
+ * after a handoff that beat the IME window. Stays under the system timeout
+ * for startForegroundService (~5–10 s).
+ */
+internal object MicrophoneForegroundPromote {
+    const val RETRY_DELAY_MS = 50L
+    const val MAX_ATTEMPTS = 20
+    const val LAUNCH_ACTIVITY_AFTER = 4
+
+    fun shouldRetry(failedTries: Int): Boolean = failedTries < MAX_ATTEMPTS
+
+    fun shouldLaunchVisibleActivity(failedTries: Int): Boolean =
+        failedTries == LAUNCH_ACTIVITY_AFTER
 }
 
 /**

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyAccents.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyAccents.kt
@@ -45,7 +45,8 @@ internal object KeyAccents {
         "'" to listOf("'", "‘", "’", "‚"),
         "\"" to listOf("\"", "“", "”", "„"),
         "-" to listOf("-", "–", "—", "•"),
-        "." to listOf(".", "…"),
+        // Tap types `.`; hold-and-release types comma. Base omitted like letter accents.
+        "." to listOf(",", "?", "!", ":", ";", "'", "\"", "…", "@", "&"),
         "?" to listOf("?", "¿"),
         "!" to listOf("!", "¡"),
         "$" to listOf("$", "€", "£", "¥", "₹", "₩"),

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/KeyboardModel.kt
@@ -188,8 +188,12 @@ internal object KeyboardChrome {
      *
      * [startedTyping] is what makes that true. Without it the chip outlived the
      * empty field and sat where the word suggestions should be for the whole
-     * sentence, because the render order in `DictationBar` reaches the clipboard
-     * branch first and never falls through to the suggestions one.
+     * sentence.
+     *
+     * A swipe on an empty field is the other producer. `applySwipe` fills
+     * alternatives and clears composing before the coalesced editor read, so
+     * [startedTyping] can still be false while those choices are already on
+     * the strip. [swipeChoicesActive] hides the chip for that window.
      *
      * Deliberately hidden for the rest of the sentence rather than reappearing
      * whenever suggestions happen to run dry: a paste target that pops back
@@ -200,8 +204,22 @@ internal object KeyboardChrome {
     fun clipboardForStrip(
         clipboard: ClipboardChip?,
         startedTyping: Boolean,
+        swipeChoicesActive: Boolean = false,
         alreadyPasted: Boolean = false,
-    ): ClipboardChip? = clipboard.takeIf { !alreadyPasted && !startedTyping }
+    ): ClipboardChip? =
+        clipboard.takeIf { !alreadyPasted && !startedTyping && !swipeChoicesActive }
+
+    /**
+     * Swipe alternatives are filled in `applySwipe` before the coalesced
+     * editor read. [swipeWordArmed] still needs that read, so an empty field
+     * can have choices that are neither armed nor "typing" yet.
+     */
+    fun swipeChoicesActive(
+        hasChoices: Boolean,
+        swipeArmed: Boolean,
+        startedTyping: Boolean,
+        composing: String,
+    ): Boolean = hasChoices && (swipeArmed || (!startedTyping && composing.isEmpty()))
 
     /**
      * Dismissing the chip hides that clip until a different one is copied.

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/MicDictationControl.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/MicDictationControl.kt
@@ -21,6 +21,13 @@ internal object MicDictationControl {
     fun longPress(phase: DictationPhase): MicDictationAction? =
         if (phase.isBusy) MicDictationAction.CANCEL else null
 
+    /**
+     * Visible X next to the mic. Hidden while listening so a walking tap cannot
+     * discard; the red Stop long-press is the discard path then.
+     */
+    fun showsSeparateCancel(phase: DictationPhase): Boolean =
+        phase.isBusy && phase != DictationPhase.LISTENING
+
     /** Menu, clipboard, and models stay reachable unless dictation is actually running. */
     fun allowsMenu(phase: DictationPhase): Boolean = !phase.isBusy
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -11,6 +11,8 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.ExtractedTextRequest
 import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputContentInfo
+import android.view.inputmethod.InputMethodManager
+import android.view.inputmethod.InputMethodSubtype
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -84,6 +86,11 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
     private var lastState = DictationState()
     private var currentInputType: Int = 0
     private var startedImeDictation = false
+    private var voiceShortcutActive by mutableStateOf(false)
+    private var voiceShortcutOwnedSession = false
+    private var voiceShortcutStartRequested = false
+    private var voiceShortcutLeftIdle = false
+    private var voiceShortcutReturned = false
     private var ignoredClipboardText: String? = null
     private var lastRecordedClip: String? = null
     private var lastImageSource: String? = null
@@ -109,6 +116,10 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
                 lastState = state
                 visibleDictationState.value = state
                 if (!state.phase.isBusy) startedImeDictation = false
+                if (voiceShortcutOwnedSession && state.phase != DictationPhase.IDLE) {
+                    voiceShortcutLeftIdle = true
+                }
+                maybeReturnToPreviousIme()
             }
         }
         scope.launch {
@@ -134,39 +145,51 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         val dictationState by visibleDictationState.collectAsState()
         val settings by visibleSettings.collectAsState()
         val isPreferenceWritePending by preferenceWrites.pending.collectAsState()
-        val clipboard by visibleClipboard.collectAsState()
-        val editorText by visibleEditorText.collectAsState()
-        val dictionary by suggestionDictionary.collectAsState()
-        val emojis by emojiCatalog.collectAsState()
-        VocaPhoneKeyboard(
-            dictationState = dictationState,
-            editor = editorConfig,
-            settings = settings,
-            isPreferenceWritePending = isPreferenceWritePending,
-            clipboard = clipboard,
-            editorText = editorText,
-            suggestions = dictionary,
-            emojiCatalog = emojis,
-            onCommand = ::handleCommand,
-            onMicTap = ::toggleDictation,
-            onMicLongPress = ::cancelDictationFromMic,
-            onOpenSettings = ::openCompanion,
-            onLanguageSelected = ::setLanguage,
-            onStyleSelected = ::setStyle,
-            onSuggestionPicked = ::commitSuggestion,
-            onSaveToDictionary = ::addPersonalWord,
-            onEmojiSuggestion = ::commitEmojiSuggestion,
-            onPasteClipboard = { pasteClipboard(it) },
-            onDismissClipboard = ::dismissClipboard,
-            onRemoveClipboardHistory = ::removeClipboardHistory,
-            onClearClipboardHistory = ::clearClipboardHistory,
-            onEmojiUsed = ::recordEmojiRecent,
-        )
+        if (voiceShortcutActive) {
+            VoiceShortcutListeningChrome(
+                dictationState = dictationState,
+                editor = editorConfig,
+                settings = settings,
+                isPreferenceWritePending = isPreferenceWritePending,
+                onMicTap = ::toggleDictation,
+                onMicLongPress = ::cancelDictationFromMic,
+            )
+        } else {
+            val clipboard by visibleClipboard.collectAsState()
+            val editorText by visibleEditorText.collectAsState()
+            val dictionary by suggestionDictionary.collectAsState()
+            val emojis by emojiCatalog.collectAsState()
+            VocaPhoneKeyboard(
+                dictationState = dictationState,
+                editor = editorConfig,
+                settings = settings,
+                isPreferenceWritePending = isPreferenceWritePending,
+                clipboard = clipboard,
+                editorText = editorText,
+                suggestions = dictionary,
+                emojiCatalog = emojis,
+                onCommand = ::handleCommand,
+                onMicTap = ::toggleDictation,
+                onMicLongPress = ::cancelDictationFromMic,
+                onOpenSettings = ::openCompanion,
+                onLanguageSelected = ::setLanguage,
+                onStyleSelected = ::setStyle,
+                onSuggestionPicked = ::commitSuggestion,
+                onSaveToDictionary = ::addPersonalWord,
+                onEmojiSuggestion = ::commitEmojiSuggestion,
+                onPasteClipboard = { pasteClipboard(it) },
+                onDismissClipboard = ::dismissClipboard,
+                onRemoveClipboardHistory = ::removeClipboardHistory,
+                onClearClipboardHistory = ::clearClipboardHistory,
+                onEmojiUsed = ::recordEmojiRecent,
+            )
+        }
     }
 
     override fun onStartInput(attribute: EditorInfo?, restarting: Boolean) {
         super.onStartInput(attribute, restarting)
         currentInputType = attribute?.inputType ?: 0
+        applyVoiceShortcutSubtype(currentSubtype())
         val identity = EditorIdentity.of(attribute)
         val sameEditor = EditorRestart.keepsSession(editorIdentity, identity)
         editorIdentity = identity
@@ -176,9 +199,13 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         lastSelStart = attribute?.initialSelStart ?: -1
         lastSelEnd = attribute?.initialSelEnd ?: -1
         composingRegionActive = false
-        val cursorCapsMode = runCatching {
-            currentInputConnection?.getCursorCapsMode(currentInputType) ?: 0
-        }.getOrDefault(0)
+        val cursorCapsMode = if (voiceShortcutActive) {
+            0
+        } else {
+            runCatching {
+                currentInputConnection?.getCursorCapsMode(currentInputType) ?: 0
+            }.getOrDefault(0)
+        }
         val started = KeyboardEditorConfig.from(attribute, editorSession).let { config ->
             if (config.initialLayer == KeyboardLayer.LETTERS) {
                 config.copy(initialShift = KeyboardEditorConfig.shiftFromCapsMode(cursorCapsMode))
@@ -199,19 +226,44 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         } else {
             started
         }
-        refreshEditorText()
+        if (!voiceShortcutActive) refreshEditorText()
     }
 
     override fun onStartInputView(info: EditorInfo?, restarting: Boolean) {
         super.onStartInputView(info, restarting)
-        startClipboardWatch()
-        refreshEditorText()
+        applyVoiceShortcutSubtype(currentSubtype())
+        if (!voiceShortcutActive) {
+            startClipboardWatch()
+            refreshEditorText()
+        }
+        maybeStartVoiceShortcutDictation()
+        maybeHandBackVoiceShortcut()
     }
 
     override fun onFinishInputView(finishingInput: Boolean) {
+        if (voiceShortcutActive) {
+            cancelOwnedDictation("voice_shortcut_hidden")
+            if (VoiceShortcutIme.shouldReturnWhenViewFinishes(
+                    voiceShortcutActive,
+                    voiceShortcutReturned,
+                )
+            ) {
+                returnToPreviousIme()
+            }
+        }
         stopClipboardWatch()
         visibleClipboard.value = null
         super.onFinishInputView(finishingInput)
+    }
+
+    override fun onCurrentInputMethodSubtypeChanged(newSubtype: InputMethodSubtype?) {
+        super.onCurrentInputMethodSubtypeChanged(newSubtype)
+        val wasActive = voiceShortcutActive
+        applyVoiceShortcutSubtype(newSubtype)
+        if (voiceShortcutActive && !wasActive) {
+            maybeStartVoiceShortcutDictation()
+            maybeHandBackVoiceShortcut()
+        }
     }
 
     override fun onUpdateSelection(
@@ -230,6 +282,13 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
             candidatesStart,
             candidatesEnd,
         )
+        if (voiceShortcutActive) {
+            lastCandidatesStart = candidatesStart
+            lastCandidatesEnd = candidatesEnd
+            lastSelStart = newSelStart
+            lastSelEnd = newSelEnd
+            return
+        }
         val userMove = EditorCursorSync.isUserMove(
             oldSelStart,
             oldSelEnd,
@@ -274,6 +333,16 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
 
     override fun onFinishInput() {
         cancelOwnedDictation("editor_finished")
+        if (VoiceShortcutIme.shouldReturnWhenViewFinishes(
+                voiceShortcutActive,
+                voiceShortcutReturned,
+            )
+        ) {
+            returnToPreviousIme()
+        }
+        voiceShortcutOwnedSession = false
+        voiceShortcutStartRequested = false
+        voiceShortcutLeftIdle = false
         currentInputType = 0
         editorIdentity = null
         editorSession += 1
@@ -816,16 +885,7 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
                     DictationService.send(this, DictationService.ACTION_CANCEL)
                 }
                 MicDictationAction.OPEN_APP -> openCompanion()
-                MicDictationAction.START -> {
-                    if (lastState.phase == DictationPhase.FAILED ||
-                        lastState.phase == DictationPhase.READY_TO_INSERT ||
-                        lastState.phase == DictationPhase.INSERTED
-                    ) {
-                        container.dictation.clearTransient()
-                    }
-                    startedImeDictation = true
-                    DictationService.start(this, DictationSource.IME)
-                }
+                MicDictationAction.START -> startImeDictation()
             }
         }
     }
@@ -860,6 +920,85 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         // An editor connection is unsafe after this callback, so do not let a
         // late gateway response insert into whichever field receives focus next.
         container.dictation.cancel()
+    }
+
+    private fun startImeDictation() {
+        if (lastState.phase == DictationPhase.FAILED ||
+            lastState.phase == DictationPhase.READY_TO_INSERT ||
+            lastState.phase == DictationPhase.INSERTED
+        ) {
+            container.dictation.clearTransient()
+        }
+        startedImeDictation = true
+        if (voiceShortcutActive) {
+            voiceShortcutOwnedSession = true
+            voiceShortcutStartRequested = true
+        }
+        DictationService.start(this, DictationSource.IME)
+    }
+
+    private fun currentSubtype(): InputMethodSubtype? =
+        getSystemService(InputMethodManager::class.java)?.currentInputMethodSubtype
+
+    private fun applyVoiceShortcutSubtype(subtype: InputMethodSubtype?) {
+        val active = VoiceShortcutIme.isVoiceShortcutSubtype(
+            mode = subtype?.mode,
+            auxiliary = subtype?.isAuxiliary == true,
+        )
+        if (active == voiceShortcutActive) return
+        voiceShortcutActive = active
+        voiceShortcutOwnedSession = false
+        voiceShortcutStartRequested = false
+        voiceShortcutLeftIdle = false
+        voiceShortcutReturned = false
+    }
+
+    private fun maybeStartVoiceShortcutDictation() {
+        if (!VoiceShortcutIme.shouldAutoStart(
+                isVoiceShortcut = voiceShortcutActive,
+                dictationAllowed = editorConfig.dictationAllowed,
+                isBusy = lastState.phase.isBusy,
+                alreadyRequested = voiceShortcutStartRequested,
+            )
+        ) {
+            return
+        }
+        startImeDictation()
+    }
+
+    private fun maybeHandBackVoiceShortcut() {
+        if (VoiceShortcutIme.shouldReturnWhenDictationRejected(
+                isVoiceShortcut = voiceShortcutActive,
+                dictationAllowed = editorConfig.dictationAllowed,
+            )
+        ) {
+            returnToPreviousIme()
+        } else {
+            maybeReturnToPreviousIme()
+        }
+    }
+
+    private fun maybeReturnToPreviousIme() {
+        if (voiceShortcutReturned) return
+        if (!VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = voiceShortcutActive,
+                ownedSession = voiceShortcutOwnedSession,
+                sessionLeftIdle = voiceShortcutLeftIdle,
+                phase = lastState.phase,
+            )
+        ) {
+            return
+        }
+        returnToPreviousIme()
+    }
+
+    private fun returnToPreviousIme() {
+        if (voiceShortcutReturned) return
+        voiceShortcutReturned = true
+        voiceShortcutOwnedSession = false
+        if (!switchToPreviousInputMethod()) {
+            voiceShortcutReturned = false
+        }
     }
 
     private fun openCompanion(page: String? = null) {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -91,6 +91,8 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
     private var voiceShortcutStartRequested = false
     private var voiceShortcutLeftIdle = false
     private var voiceShortcutReturned = false
+    private var voiceShortcutWindowWaits = 0
+    private val startVoiceShortcutDictation = Runnable { maybeStartVoiceShortcutDictation() }
     private var ignoredClipboardText: String? = null
     private var lastRecordedClip: String? = null
     private var lastImageSource: String? = null
@@ -110,6 +112,7 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
 
     override fun onCreate() {
         super.onCreate()
+        publishVoiceShortcutSubtypes()
         container.dictation.imeInserter = this
         scope.launch {
             container.dictation.state.collect { state ->
@@ -153,6 +156,7 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
                 isPreferenceWritePending = isPreferenceWritePending,
                 onMicTap = ::toggleDictation,
                 onMicLongPress = ::cancelDictationFromMic,
+                onReadyToListen = ::scheduleVoiceShortcutDictation,
             )
         } else {
             val clipboard by visibleClipboard.collectAsState()
@@ -236,11 +240,23 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
             startClipboardWatch()
             refreshEditorText()
         }
-        maybeStartVoiceShortcutDictation()
+        // Auto-start waits for VoiceShortcutListeningChrome's first frame.
+        // A microphone FGS is not eligible on this handoff (targetSdk 36).
         maybeHandBackVoiceShortcut()
     }
 
     override fun onFinishInputView(finishingInput: Boolean) {
+        if (VoiceShortcutIme.shouldKeepShortcutSession(
+                voiceShortcutActive,
+                voiceShortcutStartRequested,
+                voiceShortcutLeftIdle,
+            )
+        ) {
+            super.onFinishInputView(finishingInput)
+            return
+        }
+        mainHandler.removeCallbacks(startVoiceShortcutDictation)
+        voiceShortcutWindowWaits = 0
         if (voiceShortcutActive) {
             cancelOwnedDictation("voice_shortcut_hidden")
             if (VoiceShortcutIme.shouldReturnWhenViewFinishes(
@@ -261,7 +277,6 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         val wasActive = voiceShortcutActive
         applyVoiceShortcutSubtype(newSubtype)
         if (voiceShortcutActive && !wasActive) {
-            maybeStartVoiceShortcutDictation()
             maybeHandBackVoiceShortcut()
         }
     }
@@ -332,6 +347,8 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
     }
 
     override fun onFinishInput() {
+        mainHandler.removeCallbacks(startVoiceShortcutDictation)
+        voiceShortcutWindowWaits = 0
         cancelOwnedDictation("editor_finished")
         if (VoiceShortcutIme.shouldReturnWhenViewFinishes(
                 voiceShortcutActive,
@@ -364,6 +381,8 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
     }
 
     override fun onDestroy() {
+        mainHandler.removeCallbacks(startVoiceShortcutDictation)
+        voiceShortcutWindowWaits = 0
         stopClipboardWatch()
         cancelOwnedDictation("keyboard_destroyed")
         if (container.dictation.imeInserter === this) {
@@ -878,11 +897,11 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
             else -> when (MicDictationControl.tap(lastState.phase)) {
                 MicDictationAction.FINISH -> {
                     container.diagnostics.recordAction("finish", DictationSource.IME.name)
-                    DictationService.send(this, DictationService.ACTION_FINISH)
+                    finishImeDictation()
                 }
                 MicDictationAction.CANCEL -> {
                     container.diagnostics.recordAction("cancel", DictationSource.IME.name)
-                    DictationService.send(this, DictationService.ACTION_CANCEL)
+                    cancelImeDictation()
                 }
                 MicDictationAction.OPEN_APP -> openCompanion()
                 MicDictationAction.START -> startImeDictation()
@@ -893,7 +912,7 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
     private fun cancelDictationFromMic() {
         if (MicDictationControl.longPress(lastState.phase) != MicDictationAction.CANCEL) return
         container.diagnostics.recordAction("cancel", DictationSource.IME.name)
-        DictationService.send(this, DictationService.ACTION_CANCEL)
+        cancelImeDictation()
     }
 
     private fun setLanguage(language: TranscriptionLanguage) {
@@ -914,7 +933,7 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
     }
 
     private fun cancelOwnedDictation(reason: String) {
-        if (!startedImeDictation || !lastState.phase.isBusy) return
+        if (!startedImeDictation) return
         container.diagnostics.recordAction(reason, DictationSource.IME.name)
         startedImeDictation = false
         // An editor connection is unsafe after this callback, so do not let a
@@ -934,11 +953,40 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
             voiceShortcutOwnedSession = true
             voiceShortcutStartRequested = true
         }
-        DictationService.start(this, DictationSource.IME)
+        if (VoiceShortcutIme.usesMicrophoneForegroundService(voiceShortcutActive)) {
+            DictationService.start(this, DictationSource.IME)
+        } else {
+            container.dictation.start(DictationSource.IME)
+        }
+    }
+
+    private fun finishImeDictation() {
+        if (VoiceShortcutIme.usesMicrophoneForegroundService(voiceShortcutActive)) {
+            DictationService.send(this, DictationService.ACTION_FINISH)
+        } else {
+            container.dictation.finish()
+        }
+    }
+
+    private fun cancelImeDictation() {
+        if (VoiceShortcutIme.usesMicrophoneForegroundService(voiceShortcutActive)) {
+            DictationService.send(this, DictationService.ACTION_CANCEL)
+        } else {
+            container.dictation.cancel()
+        }
     }
 
     private fun currentSubtype(): InputMethodSubtype? =
         getSystemService(InputMethodManager::class.java)?.currentInputMethodSubtype
+
+    private fun publishVoiceShortcutSubtypes() {
+        val imm = getSystemService(InputMethodManager::class.java) ?: return
+        val imi = imm.inputMethodList.firstOrNull {
+            it.packageName == packageName &&
+                it.serviceName.endsWith("VocaPhoneInputMethodService")
+        } ?: return
+        VoiceShortcutIme.publishEnabledSubtypes(imm, imi.id, imi)
+    }
 
     private fun applyVoiceShortcutSubtype(subtype: InputMethodSubtype?) {
         val active = VoiceShortcutIme.isVoiceShortcutSubtype(
@@ -951,19 +999,38 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
         voiceShortcutStartRequested = false
         voiceShortcutLeftIdle = false
         voiceShortcutReturned = false
+        voiceShortcutWindowWaits = 0
+    }
+
+    private fun scheduleVoiceShortcutDictation() {
+        if (!voiceShortcutActive) return
+        mainHandler.removeCallbacks(startVoiceShortcutDictation)
+        voiceShortcutWindowWaits = 0
+        mainHandler.post(startVoiceShortcutDictation)
     }
 
     private fun maybeStartVoiceShortcutDictation() {
-        if (!VoiceShortcutIme.shouldAutoStart(
+        if (VoiceShortcutIme.shouldAutoStart(
                 isVoiceShortcut = voiceShortcutActive,
                 dictationAllowed = editorConfig.dictationAllowed,
                 isBusy = lastState.phase.isBusy,
                 alreadyRequested = voiceShortcutStartRequested,
+                inputViewShown = isInputViewShown,
             )
         ) {
+            startImeDictation()
             return
         }
-        startImeDictation()
+        if (VoiceShortcutIme.shouldWaitForInputView(
+                isVoiceShortcut = voiceShortcutActive,
+                alreadyRequested = voiceShortcutStartRequested,
+                inputViewShown = isInputViewShown,
+                waitAttempts = voiceShortcutWindowWaits,
+            )
+        ) {
+            voiceShortcutWindowWaits++
+            mainHandler.postDelayed(startVoiceShortcutDictation, VoiceShortcutIme.WINDOW_WAIT_DELAY_MS)
+        }
     }
 
     private fun maybeHandBackVoiceShortcut() {

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -530,7 +530,7 @@ internal fun VocaPhoneKeyboard(
         }
     }
 
-    VocaPhoneTheme {
+    VocaPhoneTheme(dynamicColor = settings.dynamicColorEnabled) {
         Surface(
             color = MaterialTheme.colorScheme.surfaceContainerLowest,
             contentColor = MaterialTheme.colorScheme.onSurface,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -1416,7 +1417,7 @@ private fun LanguageOptionRow(
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .height(40.dp)
+            .heightIn(min = 48.dp)
             .semantics { this.selected = selected },
         shape = RoundedCornerShape(8.dp),
         color = if (selected) {
@@ -1447,7 +1448,7 @@ private fun LanguageOptionRow(
                 !enabled -> Text(
                     text = "Unavailable",
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 10.sp,
+                    style = MaterialTheme.typography.labelMedium,
                 )
             }
         }
@@ -1502,6 +1503,7 @@ private fun RowScope.StyleOptionCard(
         modifier = Modifier
             .weight(1f)
             .fillMaxHeight()
+            .heightIn(min = 48.dp)
             .semantics { this.selected = selected },
         shape = RoundedCornerShape(8.dp),
         color = if (selected) {
@@ -1524,7 +1526,7 @@ private fun RowScope.StyleOptionCard(
             Column(Modifier.weight(1f)) {
                 Text(
                     text = style.displayName,
-                    fontSize = 11.sp,
+                    style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.SemiBold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
@@ -1532,9 +1534,8 @@ private fun RowScope.StyleOptionCard(
                 Text(
                     text = style.keyboardDetail,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 9.sp,
-                    lineHeight = 10.sp,
-                    maxLines = 2,
+                    style = MaterialTheme.typography.labelMedium,
+                    maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
             }
@@ -1595,12 +1596,12 @@ private fun ToolbarCloseButton(onClick: () -> Unit) {
 
 private val WritingStyle.keyboardDetail: String
     get() = when (this) {
-        WritingStyle.RAW -> "Unchanged model output"
-        WritingStyle.CLEAN -> "Tidy spacing + final period"
-        WritingStyle.FORMAL -> "Capitalization + final period"
-        WritingStyle.CASUAL -> "Natural, no final period"
+        WritingStyle.RAW -> "Unchanged output"
+        WritingStyle.CLEAN -> "Tidy spacing + period"
+        WritingStyle.FORMAL -> "Caps + final period"
+        WritingStyle.CASUAL -> "No final period"
         WritingStyle.VERY_CASUAL -> "Lowercase + commas"
-        WritingStyle.EXCITED -> "Statements end with !"
+        WritingStyle.EXCITED -> "Ends with !"
     }
 
 @Composable

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -1108,6 +1108,127 @@ private fun DictationBar(
 }
 
 @Composable
+internal fun VoiceShortcutListeningChrome(
+    dictationState: DictationState,
+    editor: KeyboardEditorConfig,
+    settings: VocaPhoneSettings,
+    isPreferenceWritePending: Boolean,
+    onMicTap: () -> Unit,
+    onMicLongPress: () -> Unit,
+) {
+    VocaPhoneTheme(dynamicColor = settings.dynamicColorEnabled) {
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainerLowest,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        ) {
+            VoiceShortcutListeningBar(
+                state = dictationState,
+                editor = editor,
+                barHeight = settings.keyboardHeight.dictationBarDp.dp,
+                isPreferenceWritePending = isPreferenceWritePending,
+                onMicTap = onMicTap,
+                onMicLongPress = onMicLongPress,
+            )
+        }
+    }
+}
+
+@Composable
+private fun VoiceShortcutListeningBar(
+    state: DictationState,
+    editor: KeyboardEditorConfig,
+    barHeight: Dp,
+    isPreferenceWritePending: Boolean,
+    onMicTap: () -> Unit,
+    onMicLongPress: () -> Unit,
+) {
+    val idle = state.phase == DictationPhase.IDLE
+    val status = when {
+        editor.sensitive -> "Private field"
+        !editor.dictationAllowed -> "Typing only"
+        idle -> "VocaPhone"
+        state.phase == DictationPhase.LISTENING -> "Listening · ${formatDuration(state.recordedMillis)}"
+        else -> state.statusText
+    }
+    val detail = when {
+        editor.sensitive -> "Dictation is off here"
+        !editor.dictationAllowed -> "Dictation is available in text fields"
+        idle -> "Voice input"
+        state.phase == DictationPhase.LISTENING && state.partialTranscript.isNotBlank() ->
+            state.partialTranscript.replace('\n', ' ').take(64)
+        state.phase == DictationPhase.LISTENING ->
+            state.inputRouteLabel ?: "Tap the red button to finish"
+        state.phase == DictationPhase.PERMISSION_REPAIR -> "Open VocaPhone to finish setup"
+        state.phase == DictationPhase.FAILED -> "Tap the mic to try again"
+        state.phase.isBusy -> ""
+        else -> "Ready"
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp, bottom = 6.dp)
+            .height(barHeight)
+            .padding(horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight()
+                .semantics { liveRegion = LiveRegionMode.Polite },
+            contentAlignment = Alignment.Center,
+        ) {
+            if (state.isRecording) {
+                Waveform(
+                    level = state.level,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(34.dp),
+                    alpha = 0.34f,
+                    bars = 13,
+                )
+            }
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = status,
+                    modifier = Modifier.fillMaxWidth(),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center,
+                )
+                if (detail.isNotEmpty()) {
+                    Text(
+                        text = detail,
+                        modifier = Modifier.fillMaxWidth(),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.labelSmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+        if (MicDictationControl.showsSeparateCancel(state.phase)) {
+            DictationCancelButton(onClick = onMicLongPress)
+        }
+        MicButton(
+            state = state,
+            enabled = editor.dictationAllowed && !isPreferenceWritePending,
+            onClick = onMicTap,
+            onLongPress = onMicLongPress,
+        )
+    }
+}
+
+@Composable
 private fun ToolbarIconButton(
     contentDescription: String,
     onClick: () -> Unit,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -1115,7 +1115,9 @@ internal fun VoiceShortcutListeningChrome(
     isPreferenceWritePending: Boolean,
     onMicTap: () -> Unit,
     onMicLongPress: () -> Unit,
+    onReadyToListen: () -> Unit = {},
 ) {
+    LaunchedEffect(Unit) { onReadyToListen() }
     VocaPhoneTheme(dynamicColor = settings.dynamicColorEnabled) {
         Surface(
             color = MaterialTheme.colorScheme.surfaceContainerLowest,

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -317,14 +317,27 @@ internal fun VocaPhoneKeyboard(
     }
     val clipboardChip = clipboard.takeIf { settings.clipboardChipEnabled && !editor.sensitive }
     val startedTyping = KeyboardChrome.startedTyping(keyboardState.composing, editorText.before)
-    val stripClipboard = KeyboardChrome.clipboardForStrip(clipboardChip, startedTyping)
     val swipeArmed = KeyboardChrome.swipeWordArmed(swipeWord, editorText.before, editorText.after)
-    val stripSuggestions = if (swipeArmed && swipeChoices.isNotEmpty()) {
-        swipeChoices.map { SuggestionItem(it) }
+    val swipeChoicesActive = KeyboardChrome.swipeChoicesActive(
+        hasChoices = swipeChoices.isNotEmpty(),
+        swipeArmed = swipeArmed,
+        startedTyping = startedTyping,
+        composing = keyboardState.composing,
+    )
+    val stripClipboard = KeyboardChrome.clipboardForStrip(
+        clipboardChip,
+        startedTyping,
+        swipeChoicesActive = swipeChoicesActive,
+    )
+    val stripSuggestions = if (swipeChoicesActive) {
+        buildList(swipeChoices.size + 1) {
+            swipeWord?.let { add(SuggestionItem(it)) }
+            addAll(swipeChoices.map { SuggestionItem(it) })
+        }
     } else {
         KeyboardChrome.suggestionsForStrip(suggestionStrip.items, startedTyping)
     }
-    val swipeReplacesWord = swipeArmed && swipeChoices.isNotEmpty()
+    val swipeReplacesWord = swipeChoicesActive
 
     fun clearSwipe() {
         swipeChoices = emptyList()
@@ -1033,6 +1046,10 @@ private fun DictationBar(
                     onSelect = onEmojiCategory,
                     modifier = Modifier.weight(1f),
                 )
+                suggestions.isNotEmpty() -> SuggestionStripRow(
+                    suggestions = suggestions,
+                    onSuggestion = onSuggestion,
+                )
                 clipboard != null -> {
                     Box(
                         modifier = Modifier
@@ -1048,10 +1065,6 @@ private fun DictationBar(
                         )
                     }
                 }
-                suggestions.isNotEmpty() -> SuggestionStripRow(
-                    suggestions = suggestions,
-                    onSuggestion = onSuggestion,
-                )
                 else -> Spacer(Modifier.weight(1f))
             }
         }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -1081,13 +1081,14 @@ private fun DictationBar(
         if (panelTitle != null) {
             ToolbarCloseButton(onClick = onClosePanel)
         }
-        if (state.phase.isBusy) {
+        if (MicDictationControl.showsSeparateCancel(state.phase)) {
             DictationCancelButton(onClick = onMicLongPress)
         }
         MicButton(
             state = state,
             enabled = editor.dictationAllowed && !isPreferenceWritePending,
             onClick = onMicTap,
+            onLongPress = onMicLongPress,
         )
     }
 }
@@ -1635,6 +1636,7 @@ private fun MicButton(
     state: DictationState,
     enabled: Boolean,
     onClick: () -> Unit,
+    onLongPress: () -> Unit,
 ) {
     val view = LocalView.current
     val processing = state.phase in setOf(
@@ -1646,7 +1648,7 @@ private fun MicButton(
     val recording = state.phase == DictationPhase.LISTENING
     val description = when {
         !enabled -> "Dictation unavailable"
-        recording -> "Finish dictation"
+        recording -> "Finish dictation. Long-press to discard without inserting"
         processing -> "Dictation in progress"
         state.phase == DictationPhase.PERMISSION_REPAIR -> "Open VocaPhone"
         else -> "Start dictation"
@@ -1678,6 +1680,10 @@ private fun MicButton(
                     onTap = {
                         view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
                         onClick()
+                    },
+                    onLongPress = { _ ->
+                        view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                        onLongPress()
                     },
                 )
             },

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VoiceShortcutIme.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VoiceShortcutIme.kt
@@ -1,0 +1,58 @@
+package com.vocahq.vocaphone.ime
+
+import com.vocahq.vocaphone.core.DictationPhase
+
+/**
+ * Decisions for the auxiliary voice subtype other keyboards hand off to.
+ *
+ * HeliBoard / Gboard-style mic keys call
+ * [android.view.inputmethod.InputMethodManager.getShortcutInputMethodsAndSubtypes],
+ * which only lists IMEs that declare a voice-mode auxiliary subtype.
+ */
+internal object VoiceShortcutIme {
+    const val MODE_VOICE = "voice"
+
+    fun isVoiceShortcutSubtype(mode: String?, auxiliary: Boolean): Boolean =
+        auxiliary && !mode.isNullOrEmpty() && mode.equals(MODE_VOICE, ignoreCase = true)
+
+    fun shouldAutoStart(
+        isVoiceShortcut: Boolean,
+        dictationAllowed: Boolean,
+        isBusy: Boolean,
+        alreadyRequested: Boolean,
+    ): Boolean = isVoiceShortcut && dictationAllowed && !isBusy && !alreadyRequested
+
+    /**
+     * Whether this activation should hand back to the typing keyboard.
+     *
+     * [ownedSession] is the voice-shortcut flag, not "VocaPhone is the normal
+     * keyboard". IDLE is a return only after the session left idle — otherwise
+     * auto-start would bounce back before listening began.
+     */
+    fun shouldReturnToPreviousIme(
+        isVoiceShortcut: Boolean,
+        ownedSession: Boolean,
+        sessionLeftIdle: Boolean,
+        phase: DictationPhase,
+    ): Boolean {
+        if (!isVoiceShortcut || !ownedSession) return false
+        return when (phase) {
+            DictationPhase.INSERTED,
+            DictationPhase.FAILED,
+            DictationPhase.READY_TO_INSERT,
+            -> true
+            DictationPhase.IDLE -> sessionLeftIdle
+            else -> false
+        }
+    }
+
+    fun shouldReturnWhenDictationRejected(
+        isVoiceShortcut: Boolean,
+        dictationAllowed: Boolean,
+    ): Boolean = isVoiceShortcut && !dictationAllowed
+
+    fun shouldReturnWhenViewFinishes(
+        isVoiceShortcut: Boolean,
+        alreadyReturned: Boolean,
+    ): Boolean = isVoiceShortcut && !alreadyReturned
+}

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VoiceShortcutIme.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VoiceShortcutIme.kt
@@ -1,5 +1,8 @@
 package com.vocahq.vocaphone.ime
 
+import android.os.Build
+import android.view.inputmethod.InputMethodInfo
+import android.view.inputmethod.InputMethodManager
 import com.vocahq.vocaphone.core.DictationPhase
 
 /**
@@ -11,16 +14,41 @@ import com.vocahq.vocaphone.core.DictationPhase
  */
 internal object VoiceShortcutIme {
     const val MODE_VOICE = "voice"
+    const val MAX_WINDOW_WAITS = 10
+    const val WINDOW_WAIT_DELAY_MS = 50L
 
     fun isVoiceShortcutSubtype(mode: String?, auxiliary: Boolean): Boolean =
         auxiliary && !mode.isNullOrEmpty() && mode.equals(MODE_VOICE, ignoreCase = true)
+
+    /** Hash codes of every subtype, so the voice shortcut is explicitly enabled. */
+    fun subtypeHashes(imi: InputMethodInfo): IntArray =
+        IntArray(imi.subtypeCount) { imi.getSubtypeAt(it).hashCode() }
+
+    fun publishEnabledSubtypes(imm: InputMethodManager?, imiId: String, imi: InputMethodInfo?) {
+        if (imm == null || imi == null) return
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return
+        imm.setExplicitlyEnabledInputMethodSubtypes(imiId, subtypeHashes(imi))
+    }
 
     fun shouldAutoStart(
         isVoiceShortcut: Boolean,
         dictationAllowed: Boolean,
         isBusy: Boolean,
         alreadyRequested: Boolean,
-    ): Boolean = isVoiceShortcut && dictationAllowed && !isBusy && !alreadyRequested
+        inputViewShown: Boolean = true,
+    ): Boolean = isVoiceShortcut && dictationAllowed && !isBusy && !alreadyRequested && inputViewShown
+
+    /**
+     * HeliBoard hands off before our IME window counts as visible, and
+     * startForeground(MICROPHONE) on targetSdk 36 throws until it does.
+     */
+    fun shouldWaitForInputView(
+        isVoiceShortcut: Boolean,
+        alreadyRequested: Boolean,
+        inputViewShown: Boolean,
+        waitAttempts: Int,
+    ): Boolean = isVoiceShortcut && !alreadyRequested && !inputViewShown &&
+        waitAttempts < MAX_WINDOW_WAITS
 
     /**
      * Whether this activation should hand back to the typing keyboard.
@@ -55,4 +83,22 @@ internal object VoiceShortcutIme {
         isVoiceShortcut: Boolean,
         alreadyReturned: Boolean,
     ): Boolean = isVoiceShortcut && !alreadyReturned
+
+    /**
+     * A HeliBoard handoff can hide our input view for a frame while the
+     * microphone service is still coming up. Returning then would make
+     * HeliBoard the current IME again and leave insert with no connection.
+     */
+    fun shouldKeepShortcutSession(
+        isVoiceShortcut: Boolean,
+        startRequested: Boolean,
+        sessionLeftIdle: Boolean,
+    ): Boolean = isVoiceShortcut && startRequested && !sessionLeftIdle
+
+    /**
+     * HeliBoard handoff does not get while-in-use for a microphone FGS
+     * (targetSdk 36). The IME window is visible, so capture can run without
+     * it; we cancel when the view finishes.
+     */
+    fun usesMicrophoneForegroundService(isVoiceShortcut: Boolean): Boolean = !isVoiceShortcut
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VoiceShortcutIme.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VoiceShortcutIme.kt
@@ -56,6 +56,9 @@ internal object VoiceShortcutIme {
      * [ownedSession] is the voice-shortcut flag, not "VocaPhone is the normal
      * keyboard". IDLE is a return only after the session left idle — otherwise
      * auto-start would bounce back before listening began.
+     *
+     * READY_TO_INSERT is an IME insert that already failed. Stay on the
+     * shortcut chrome so retry and the transcript are still on screen.
      */
     fun shouldReturnToPreviousIme(
         isVoiceShortcut: Boolean,
@@ -67,7 +70,6 @@ internal object VoiceShortcutIme {
         return when (phase) {
             DictationPhase.INSERTED,
             DictationPhase.FAILED,
-            DictationPhase.READY_TO_INSERT,
             -> true
             DictationPhase.IDLE -> sessionLeftIdle
             else -> false

--- a/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/settings/SettingsRepository.kt
@@ -246,6 +246,8 @@ data class VocaPhoneSettings(
     val numberRowEnabled: Boolean = true,
     val keyboardHeight: KeyboardHeight = KeyboardHeight.DEFAULT,
     val splitKeyboard: SplitKeyboard = SplitKeyboard.DEFAULT,
+    /** Material You wallpaper colors. Off keeps the brand teal. */
+    val dynamicColorEnabled: Boolean = false,
     val suggestionsEnabled: Boolean = true,
     val correctionsEnabled: Boolean = true,
     val numberKeyHintsEnabled: Boolean = true,
@@ -432,6 +434,8 @@ class SettingsRepository(private val context: Context) {
     suspend fun setKeyboardHeight(height: KeyboardHeight) = put(Keys.KEYBOARD_HEIGHT, height.storedValue)
 
     suspend fun setSplitKeyboard(mode: SplitKeyboard) = put(Keys.SPLIT_KEYBOARD, mode.storedValue)
+
+    suspend fun setDynamicColorEnabled(enabled: Boolean) = put(Keys.DYNAMIC_COLOR, enabled)
 
     suspend fun setSuggestionsEnabled(enabled: Boolean) = put(Keys.SUGGESTIONS, enabled)
 
@@ -633,6 +637,7 @@ class SettingsRepository(private val context: Context) {
         numberRowEnabled = this[Keys.NUMBER_ROW] ?: true,
         keyboardHeight = KeyboardHeight.fromStored(this[Keys.KEYBOARD_HEIGHT]),
         splitKeyboard = SplitKeyboard.fromStored(this[Keys.SPLIT_KEYBOARD]),
+        dynamicColorEnabled = this[Keys.DYNAMIC_COLOR] ?: false,
         suggestionsEnabled = this[Keys.SUGGESTIONS] ?: true,
         correctionsEnabled = this[Keys.CORRECTIONS] ?: true,
         numberKeyHintsEnabled = this[Keys.NUMBER_KEY_HINTS] ?: true,
@@ -680,6 +685,7 @@ class SettingsRepository(private val context: Context) {
         val NUMBER_ROW = booleanPreferencesKey("keyboard_number_row")
         val KEYBOARD_HEIGHT = stringPreferencesKey("keyboard_height")
         val SPLIT_KEYBOARD = stringPreferencesKey("keyboard_split")
+        val DYNAMIC_COLOR = booleanPreferencesKey("keyboard_dynamic_color")
         val SUGGESTIONS = booleanPreferencesKey("keyboard_suggestions")
         val CORRECTIONS = booleanPreferencesKey("keyboard_corrections")
         val NUMBER_KEY_HINTS = booleanPreferencesKey("keyboard_number_key_hints")

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/MainActivity.kt
@@ -61,8 +61,10 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             val launchIntent by launchIntents.collectAsStateWithLifecycle()
-            VocaPhoneTheme {
-                VocaPhoneApp(launchIntent = launchIntent)
+            val appViewModel: VocaPhoneViewModel = viewModel()
+            val settings by appViewModel.settings.collectAsStateWithLifecycle()
+            VocaPhoneTheme(dynamicColor = settings.dynamicColorEnabled) {
+                VocaPhoneApp(viewModel = appViewModel, launchIntent = launchIntent)
             }
         }
     }
@@ -418,6 +420,7 @@ fun VocaPhoneApp(
                 onNumberRow = { viewModel.setNumberRowEnabled(it) },
                 onKeyboardHeight = { viewModel.setKeyboardHeight(it) },
                 onSplitKeyboard = { viewModel.setSplitKeyboard(it) },
+                onDynamicColor = { viewModel.setDynamicColorEnabled(it) },
                 onSuggestions = { viewModel.setSuggestionsEnabled(it) },
                 onCorrections = { viewModel.setCorrectionsEnabled(it) },
                 onNumberKeyHints = { viewModel.setNumberKeyHintsEnabled(it) },

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SettingsScreen.kt
@@ -106,6 +106,7 @@ fun SettingsScreen(
     onNumberRow: (Boolean) -> Unit,
     onKeyboardHeight: (KeyboardHeight) -> Unit,
     onSplitKeyboard: (SplitKeyboard) -> Unit,
+    onDynamicColor: (Boolean) -> Unit,
     onSuggestions: (Boolean) -> Unit,
     onCorrections: (Boolean) -> Unit,
     onNumberKeyHints: (Boolean) -> Unit,
@@ -289,6 +290,14 @@ fun SettingsScreen(
 
             SettingsPage.KEYBOARD -> {
                 ImeSetupCard(setup.ime)
+                Section("Appearance") {
+                    SettingToggle(
+                        title = "Dynamic color",
+                        detail = "Follow the system wallpaper colors. Off keeps the Voca teal.",
+                        checked = settings.dynamicColorEnabled,
+                        onCheckedChange = onDynamicColor,
+                    )
+                }
                 Section("Layout") {
                     SettingToggle(
                         title = "Number row",

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/VocaPhoneViewModel.kt
@@ -396,6 +396,9 @@ class VocaPhoneViewModel(application: Application) : AndroidViewModel(applicatio
     fun setSplitKeyboard(mode: SplitKeyboard) =
         viewModelScope.launch { container.settings.setSplitKeyboard(mode) }
 
+    fun setDynamicColorEnabled(enabled: Boolean) =
+        viewModelScope.launch { container.settings.setDynamicColorEnabled(enabled) }
+
     fun setSuggestionsEnabled(enabled: Boolean) =
         viewModelScope.launch { container.settings.setSuggestionsEnabled(enabled) }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/theme/Theme.kt
@@ -1,11 +1,15 @@
 package com.vocahq.vocaphone.ui.theme
 
+import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 
 /**
  * The light containers are deliberately a full step darker than a Material
@@ -99,16 +103,24 @@ internal val VocaPhoneDarkColors = darkColorScheme(
     onTertiaryContainer = Color(0xFFFFE2B0),
 )
 
-/** A stable, quiet palette that does not inherit a device wallpaper's colours. */
+/**
+ * Brand teal by default. [dynamicColor] opts into Material You wallpaper colors
+ * on API 31+; otherwise the fixed palette is kept so the IME and companion
+ * stay on Voca teal.
+ */
 @Composable
 fun VocaPhoneTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = false,
     content: @Composable () -> Unit,
 ) {
-    val colors = if (darkTheme) {
-        VocaPhoneDarkColors
-    } else {
-        VocaPhoneLightColors
+    val colors = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+        darkTheme -> VocaPhoneDarkColors
+        else -> VocaPhoneLightColors
     }
     MaterialTheme(colorScheme = colors, content = content)
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="app_name">VocaPhone</string>
 
     <string name="ime_name">VocaPhone keyboard</string>
+    <string name="voice_input_label">VocaPhone voice input</string>
 </resources>

--- a/android/app/src/main/res/xml/method.xml
+++ b/android/app/src/main/res/xml/method.xml
@@ -1,3 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <input-method xmlns:android="http://schemas.android.com/apk/res/android"
-    android:supportsSwitchingToNextInputMethod="true" />
+    android:supportsSwitchingToNextInputMethod="true">
+    <!-- Non-auxiliary keyboard subtype keeps VocaPhone selectable as a normal IME.
+         An auxiliary-only method.xml would mark the whole IME as aux and hide it
+         from the default keyboard picker. -->
+    <subtype
+        android:label="@string/ime_name"
+        android:imeSubtypeMode="keyboard"
+        android:isAsciiCapable="true"
+        android:overridesImplicitlyEnabledSubtype="true" />
+    <subtype
+        android:label="@string/voice_input_label"
+        android:imeSubtypeMode="voice"
+        android:isAuxiliary="true" />
+</input-method>

--- a/android/app/src/main/res/xml/method.xml
+++ b/android/app/src/main/res/xml/method.xml
@@ -9,8 +9,14 @@
         android:imeSubtypeMode="keyboard"
         android:isAsciiCapable="true"
         android:overridesImplicitlyEnabledSubtype="true" />
+    <!-- Auxiliary so it is a one-shot voice shortcut, not a picker language.
+         overridesImplicitlyEnabledSubtype so the system includes it in
+         getShortcutInputMethodsAndSubtypes() without a subtype-enabler tap.
+         Google Voice Typing uses the same two flags; without the override,
+         HeliBoard sees an empty shortcut list and greys out its mic. -->
     <subtype
         android:label="@string/voice_input_label"
         android:imeSubtypeMode="voice"
-        android:isAuxiliary="true" />
+        android:isAuxiliary="true"
+        android:overridesImplicitlyEnabledSubtype="true" />
 </input-method>

--- a/android/app/src/test/java/com/vocahq/vocaphone/dictation/MicrophoneForegroundPromoteTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/dictation/MicrophoneForegroundPromoteTest.kt
@@ -1,0 +1,37 @@
+package com.vocahq.vocaphone.dictation
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MicrophoneForegroundPromoteTest {
+
+    @Test
+    fun `retries stay under the startForegroundService timeout`() {
+        val budgetMs = MicrophoneForegroundPromote.MAX_ATTEMPTS *
+            MicrophoneForegroundPromote.RETRY_DELAY_MS
+        assertTrue(budgetMs < 5_000L)
+        assertTrue(MicrophoneForegroundPromote.shouldRetry(1))
+        assertTrue(
+            MicrophoneForegroundPromote.shouldRetry(MicrophoneForegroundPromote.MAX_ATTEMPTS - 1),
+        )
+        assertFalse(
+            MicrophoneForegroundPromote.shouldRetry(MicrophoneForegroundPromote.MAX_ATTEMPTS),
+        )
+    }
+
+    @Test
+    fun `the visible activity is a later fallback not the first retry`() {
+        assertFalse(MicrophoneForegroundPromote.shouldLaunchVisibleActivity(1))
+        assertTrue(
+            MicrophoneForegroundPromote.shouldLaunchVisibleActivity(
+                MicrophoneForegroundPromote.LAUNCH_ACTIVITY_AFTER,
+            ),
+        )
+        assertFalse(
+            MicrophoneForegroundPromote.shouldLaunchVisibleActivity(
+                MicrophoneForegroundPromote.LAUNCH_ACTIVITY_AFTER + 1,
+            ),
+        )
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyAccentsTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyAccentsTest.kt
@@ -34,6 +34,18 @@ class KeyAccentsTest {
     }
 
     @Test
+    fun periodLongPressOffersGboardPunctuation() {
+        val key = KeyboardKey(id = "character-.", label = ".", output = ".")
+        val variants = KeyAccents.forKey(key, ShiftState.OFF)
+        assertEquals(
+            listOf(",", "?", "!", ":", ";", "'", "\"", "…", "@", "&"),
+            variants,
+        )
+        assertEquals(",", variants.first())
+        assertTrue("." !in variants)
+    }
+
+    @Test
     fun numberKeysShowTheLongPressHint() {
         assertEquals("!", KeyAccents.hint(KeyboardKey(id = "1", label = "1", output = "1")))
         assertEquals(")", KeyAccents.hint(KeyboardKey(id = "0", label = "0", output = "0")))

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardChromeTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardChromeTest.kt
@@ -72,24 +72,26 @@ class KeyboardChromeTest {
     fun `the clip chip and the suggestions never both claim the row`() {
         val words = listOf(SuggestionItem("you"), SuggestionItem("the"))
         listOf(false, true).forEach { typing ->
-            val chip = KeyboardChrome.clipboardForStrip(clip, startedTyping = typing)
-            val strip = KeyboardChrome.suggestionsForStrip(words, startedTyping = typing)
-            assertFalse(
-                "the clip chip and ${strip.size} suggestions both claimed the row " +
-                    "with startedTyping=$typing",
-                chip != null && strip.isNotEmpty(),
-            )
+            listOf(false, true).forEach { swipe ->
+                val chip = KeyboardChrome.clipboardForStrip(
+                    clip,
+                    startedTyping = typing,
+                    swipeChoicesActive = swipe,
+                )
+                val strip = if (swipe) {
+                    words
+                } else {
+                    KeyboardChrome.suggestionsForStrip(words, startedTyping = typing)
+                }
+                assertFalse(
+                    "the clip chip and ${strip.size} suggestions both claimed the row " +
+                        "with startedTyping=$typing swipeChoicesActive=$swipe",
+                    chip != null && strip.isNotEmpty(),
+                )
+            }
         }
     }
 
-    /**
-     * Swipe alternatives reach the strip without passing through
-     * [KeyboardChrome.suggestionsForStrip], so the exclusion above cannot see
-     * that path. It holds anyway, but for a different reason: arming a swiped
-     * word requires a replaceable word behind the cursor, which is text, which
-     * is already typing. Asserted rather than argued, because the two helpers
-     * are free to drift apart.
-     */
     @Test
     fun `json clips are named instead of dumping the first keys`() {
         assertEquals(
@@ -112,6 +114,78 @@ class KeyboardChromeTest {
             KeyboardChrome.clipboardForStrip(
                 clip,
                 startedTyping = KeyboardChrome.startedTyping("", before),
+            ),
+        )
+    }
+
+    /**
+     * Right after a swipe on an empty field, composing is cleared and
+     * `editorText` is still the pre-commit snapshot for up to 50ms. The
+     * alternatives are already filled; `startedTyping` and `swipeWordArmed`
+     * are not. The chip has to yield on the choices themselves.
+     */
+    @Test
+    fun `clipboard yields when swipe choices are active even if startedTyping is false`() {
+        val startedTyping = KeyboardChrome.startedTyping(composing = "", textBeforeCursor = "")
+        assertFalse(startedTyping)
+        assertFalse(KeyboardChrome.swipeWordArmed("hello", "", ""))
+        assertTrue(
+            KeyboardChrome.swipeChoicesActive(
+                hasChoices = true,
+                swipeArmed = false,
+                startedTyping = false,
+                composing = "",
+            ),
+        )
+        assertNull(
+            KeyboardChrome.clipboardForStrip(
+                clip,
+                startedTyping = false,
+                swipeChoicesActive = true,
+            ),
+        )
+        assertEquals(
+            clip,
+            KeyboardChrome.clipboardForStrip(
+                clip,
+                startedTyping = false,
+                swipeChoicesActive = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `swipe choices stay inactive on an idle empty field`() {
+        assertFalse(
+            KeyboardChrome.swipeChoicesActive(
+                hasChoices = false,
+                swipeArmed = false,
+                startedTyping = false,
+                composing = "",
+            ),
+        )
+        assertFalse(
+            KeyboardChrome.swipeChoicesActive(
+                hasChoices = true,
+                swipeArmed = false,
+                startedTyping = true,
+                composing = "",
+            ),
+        )
+        assertTrue(
+            KeyboardChrome.swipeChoicesActive(
+                hasChoices = true,
+                swipeArmed = true,
+                startedTyping = true,
+                composing = "",
+            ),
+        )
+        assertFalse(
+            KeyboardChrome.swipeChoicesActive(
+                hasChoices = true,
+                swipeArmed = false,
+                startedTyping = false,
+                composing = "h",
             ),
         )
     }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardLayoutsTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/KeyboardLayoutsTest.kt
@@ -45,4 +45,15 @@ class KeyboardLayoutsTest {
         val right = bottom.keys.drop(spaceIndex + 1).sumOf { it.weight.toDouble() }
         assertEquals(left, right, 0.01)
     }
+
+    @Test
+    fun `letter utility row keeps comma period and emoji as separate keys`() {
+        val bottom = KeyboardLayouts.rows(KeyboardLayer.LETTERS, KeyboardEditorConfig.empty()).last()
+        val outputs = bottom.keys.map { it.output }
+        assertTrue("," in outputs)
+        assertTrue("." in outputs)
+        assertTrue(
+            bottom.keys.any { it.type == KeyboardKeyType.LAYER_SWITCH && it.targetLayer == KeyboardLayer.EMOJI },
+        )
+    }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/MicDictationControlTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/MicDictationControlTest.kt
@@ -36,6 +36,15 @@ class MicDictationControlTest {
     }
 
     @Test
+    fun `separate cancel is hidden while listening so a walking tap cannot discard`() {
+        assertFalse(MicDictationControl.showsSeparateCancel(DictationPhase.IDLE))
+        assertFalse(MicDictationControl.showsSeparateCancel(DictationPhase.LISTENING))
+        assertTrue(MicDictationControl.showsSeparateCancel(DictationPhase.TRANSCRIBING))
+        assertTrue(MicDictationControl.showsSeparateCancel(DictationPhase.FINALIZING))
+        assertFalse(MicDictationControl.showsSeparateCancel(DictationPhase.FAILED))
+    }
+
+    @Test
     fun `a failed empty transcript does not lock the keyboard menu`() {
         assertTrue(MicDictationControl.allowsMenu(DictationPhase.IDLE))
         assertTrue(MicDictationControl.allowsMenu(DictationPhase.FAILED))

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/VoiceShortcutImeTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/VoiceShortcutImeTest.kt
@@ -61,6 +61,59 @@ class VoiceShortcutImeTest {
                 alreadyRequested = true,
             ),
         )
+        assertFalse(
+            VoiceShortcutIme.shouldAutoStart(
+                isVoiceShortcut = true,
+                dictationAllowed = true,
+                isBusy = false,
+                alreadyRequested = false,
+                inputViewShown = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `auto-start waits while the IME window is not yet visible`() {
+        assertTrue(
+            VoiceShortcutIme.shouldWaitForInputView(
+                isVoiceShortcut = true,
+                alreadyRequested = false,
+                inputViewShown = false,
+                waitAttempts = 0,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldWaitForInputView(
+                isVoiceShortcut = true,
+                alreadyRequested = false,
+                inputViewShown = true,
+                waitAttempts = 0,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldWaitForInputView(
+                isVoiceShortcut = true,
+                alreadyRequested = true,
+                inputViewShown = false,
+                waitAttempts = 0,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldWaitForInputView(
+                isVoiceShortcut = false,
+                alreadyRequested = false,
+                inputViewShown = false,
+                waitAttempts = 0,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldWaitForInputView(
+                isVoiceShortcut = true,
+                alreadyRequested = false,
+                inputViewShown = false,
+                waitAttempts = VoiceShortcutIme.MAX_WINDOW_WAITS,
+            ),
+        )
     }
 
     @Test
@@ -230,7 +283,50 @@ class VoiceShortcutImeTest {
     }
 
     @Test
+    fun `a hide during auto-start does not bounce back to the typing keyboard`() {
+        assertTrue(
+            VoiceShortcutIme.shouldKeepShortcutSession(
+                isVoiceShortcut = true,
+                startRequested = true,
+                sessionLeftIdle = false,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldKeepShortcutSession(
+                isVoiceShortcut = true,
+                startRequested = true,
+                sessionLeftIdle = true,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldKeepShortcutSession(
+                isVoiceShortcut = true,
+                startRequested = false,
+                sessionLeftIdle = false,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldKeepShortcutSession(
+                isVoiceShortcut = false,
+                startRequested = true,
+                sessionLeftIdle = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `the voice shortcut does not take a microphone foreground service`() {
+        assertFalse(VoiceShortcutIme.usesMicrophoneForegroundService(isVoiceShortcut = true))
+        assertTrue(VoiceShortcutIme.usesMicrophoneForegroundService(isVoiceShortcut = false))
+    }
+
+    @Test
     fun `voice mode string matches method xml`() {
         assertEquals("voice", VoiceShortcutIme.MODE_VOICE)
+    }
+
+    @Test
+    fun `publishing subtypes is a no-op without a manager or info`() {
+        VoiceShortcutIme.publishEnabledSubtypes(null, "com.vocahq.vocaphone/.ime.VocaPhoneInputMethodService", null)
     }
 }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/VoiceShortcutImeTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/VoiceShortcutImeTest.kt
@@ -1,0 +1,236 @@
+package com.vocahq.vocaphone.ime
+
+import com.vocahq.vocaphone.core.DictationPhase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VoiceShortcutImeTest {
+
+    @Test
+    fun `only an auxiliary voice subtype is the system shortcut`() {
+        assertTrue(VoiceShortcutIme.isVoiceShortcutSubtype("voice", auxiliary = true))
+        assertTrue(VoiceShortcutIme.isVoiceShortcutSubtype("VOICE", auxiliary = true))
+        assertFalse(VoiceShortcutIme.isVoiceShortcutSubtype("voice", auxiliary = false))
+        assertFalse(VoiceShortcutIme.isVoiceShortcutSubtype("keyboard", auxiliary = true))
+        assertFalse(VoiceShortcutIme.isVoiceShortcutSubtype("keyboard", auxiliary = false))
+        assertFalse(VoiceShortcutIme.isVoiceShortcutSubtype(null, auxiliary = true))
+        assertFalse(VoiceShortcutIme.isVoiceShortcutSubtype("", auxiliary = true))
+    }
+
+    @Test
+    fun `auto-start requires the shortcut, a dictation field, and a free pipeline`() {
+        assertTrue(
+            VoiceShortcutIme.shouldAutoStart(
+                isVoiceShortcut = true,
+                dictationAllowed = true,
+                isBusy = false,
+                alreadyRequested = false,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldAutoStart(
+                isVoiceShortcut = false,
+                dictationAllowed = true,
+                isBusy = false,
+                alreadyRequested = false,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldAutoStart(
+                isVoiceShortcut = true,
+                dictationAllowed = false,
+                isBusy = false,
+                alreadyRequested = false,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldAutoStart(
+                isVoiceShortcut = true,
+                dictationAllowed = true,
+                isBusy = true,
+                alreadyRequested = false,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldAutoStart(
+                isVoiceShortcut = true,
+                dictationAllowed = true,
+                isBusy = false,
+                alreadyRequested = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `the normal keyboard never hands back to a previous IME`() {
+        val phases = listOf(
+            DictationPhase.IDLE,
+            DictationPhase.LISTENING,
+            DictationPhase.INSERTED,
+            DictationPhase.FAILED,
+            DictationPhase.READY_TO_INSERT,
+        )
+        for (phase in phases) {
+            assertFalse(
+                "non-shortcut $phase should stay on VocaPhone",
+                VoiceShortcutIme.shouldReturnToPreviousIme(
+                    isVoiceShortcut = false,
+                    ownedSession = true,
+                    sessionLeftIdle = true,
+                    phase = phase,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `shortcut returns after insert, cancel idle, or failed empty`() {
+        assertTrue(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = true,
+                phase = DictationPhase.INSERTED,
+            ),
+        )
+        assertTrue(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = true,
+                phase = DictationPhase.FAILED,
+            ),
+        )
+        assertTrue(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = true,
+                phase = DictationPhase.IDLE,
+            ),
+        )
+        assertTrue(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = false,
+                phase = DictationPhase.INSERTED,
+            ),
+        )
+    }
+
+    @Test
+    fun `shortcut does not bounce back before listening starts`() {
+        assertFalse(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = false,
+                phase = DictationPhase.IDLE,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = false,
+                phase = DictationPhase.LISTENING,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = true,
+                phase = DictationPhase.LISTENING,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = true,
+                phase = DictationPhase.TRANSCRIBING,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = true,
+                phase = DictationPhase.PERMISSION_REPAIR,
+            ),
+        )
+    }
+
+    @Test
+    fun `a session this shortcut did not start does not steal the keyboard`() {
+        assertFalse(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = false,
+                sessionLeftIdle = true,
+                phase = DictationPhase.INSERTED,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = false,
+                sessionLeftIdle = true,
+                phase = DictationPhase.IDLE,
+            ),
+        )
+    }
+
+    @Test
+    fun `password and other rejected fields hand back immediately`() {
+        assertTrue(
+            VoiceShortcutIme.shouldReturnWhenDictationRejected(
+                isVoiceShortcut = true,
+                dictationAllowed = false,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnWhenDictationRejected(
+                isVoiceShortcut = true,
+                dictationAllowed = true,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnWhenDictationRejected(
+                isVoiceShortcut = false,
+                dictationAllowed = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `hiding the shortcut view returns even if dictation never started`() {
+        assertTrue(
+            VoiceShortcutIme.shouldReturnWhenViewFinishes(
+                isVoiceShortcut = true,
+                alreadyReturned = false,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnWhenViewFinishes(
+                isVoiceShortcut = true,
+                alreadyReturned = true,
+            ),
+        )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnWhenViewFinishes(
+                isVoiceShortcut = false,
+                alreadyReturned = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `voice mode string matches method xml`() {
+        assertEquals("voice", VoiceShortcutIme.MODE_VOICE)
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/VoiceShortcutImeTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/VoiceShortcutImeTest.kt
@@ -172,6 +172,14 @@ class VoiceShortcutImeTest {
                 phase = DictationPhase.INSERTED,
             ),
         )
+        assertFalse(
+            VoiceShortcutIme.shouldReturnToPreviousIme(
+                isVoiceShortcut = true,
+                ownedSession = true,
+                sessionLeftIdle = true,
+                phase = DictationPhase.READY_TO_INSERT,
+            ),
+        )
     }
 
     @Test

--- a/android/app/src/test/java/com/vocahq/vocaphone/settings/VocaPhoneSettingsTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/settings/VocaPhoneSettingsTest.kt
@@ -1,0 +1,12 @@
+package com.vocahq.vocaphone.settings
+
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class VocaPhoneSettingsTest {
+
+    @Test
+    fun dynamicColorDefaultsOffSoBrandTealStays() {
+        assertFalse(VocaPhoneSettings().dynamicColorEnabled)
+    }
+}

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/SettingsChoiceTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/SettingsChoiceTest.kt
@@ -56,6 +56,7 @@ class SettingsChoiceTest {
         assertEquals(KeyboardHeight.DEFAULT, KeyboardHeight.fromStored(null))
         assertEquals(KeyboardHeight.DEFAULT, VocaPhoneSettings().keyboardHeight)
         assertFalse(VocaPhoneSettings().numbersAsDigits)
+        assertFalse(VocaPhoneSettings().dynamicColorEnabled)
         assertEquals(48, KeyboardHeight.DEFAULT.keyHeightDp)
     }
 

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/theme/ThemePaletteTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/theme/ThemePaletteTest.kt
@@ -1,0 +1,13 @@
+package com.vocahq.vocaphone.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ThemePaletteTest {
+
+    @Test
+    fun brandDarkPrimaryStaysVocaTeal() {
+        assertEquals(Color(0xFF77D0B2), VocaPhoneDarkColors.primary)
+    }
+}


### PR DESCRIPTION
## Summary

Android-only train on `release/android-0.2.0`. Six issue PRs landed there, then this PR brings the train to `main`. iOS is untouched.

- **#74** IME language/style rows meet a 48dp hit target; preference type is at least 12sp.
- **#79** Optional Material You. Brand teal stays the default.
- **#146** Long-press on `.` types comma (Gboard-style punctuation set). The dedicated comma key stays.
- **#195** While listening, the red Stop finishes on tap and discards on long-press. The extra X is hidden so a walking tap cannot cancel.
- **#198** After a swipe, alternatives take the suggestion strip even if a clipboard chip would have occupied that row.
- **#199** Auxiliary `voice` IME subtype so other keyboards can hand off to VocaPhone. A non-aux keyboard subtype keeps us in the picker. Follow-up on this branch: the voice subtype overrides the implicitly-enabled set so HeliBoard's mic is not greyed out; after the switch we record from the visible IME instead of `startForeground(MICROPHONE)`, which throws on targetSdk 36.

Stacked PRs already merged into this branch: #251, #252, #249, #250, #253, #254.

Closes #74. Closes #79. Closes #146. Closes #195. Closes #198. Closes #199.

## Verification

- [x] `just ios ci` — N/A, Android IME/settings only
- [x] `just android ci` — targeted `testFullDebugUnitTest` for `ime.*`, `settings.*`, `SettingsChoiceTest`, `ui.theme.*` on the train tip (BUILD SUCCESSFUL). Full `just android ci` not re-run on this merge PR; each stacked PR ran its own unit tests. HeliBoard follow-up: `VoiceShortcutImeTest` and `MicrophoneForegroundPromoteTest` on `assembleFullDebug`.
- [x] Gateway changes: none
- [x] Physical-device test

Device: Nothing Phone (1) (`A063` / Spacewar), Android 16, USB debugging via Windows `adb.exe` from WSL.

Sequence:

1. Uninstalled the Play-signed build (signature mismatch), installed `vocaphone-fullDebug.apk` from this branch, enabled the IME, granted mic/notifications.
2. Keyboard comes up in Chrome. Long-press on `.` inserted a comma (`ñ` became `ñ,`).
3. Keyboard menu → Language panel: rows are taller (48dp). Automatic is selected.
4. Downloaded Whisper Tiny Q5 (32 MB) to finish setup. Keyboard settings shows **Dynamic color**, off by default.
5. Mic tap starts listening: red Stop, waveform, "Listening · 0:01", "Phone microphone (A063)". No separate X.
6. Long-press Stop discarded the take. Mic returned to idle teal. No "Transcribing..." hang. FGS "Listening" notification went away.
7. `dumpsys input_method` shows two VocaPhone subtypes: `keyboard` (non-aux) and `voice` (auxiliary, `overridesImplicitlyEnabledSubtype=true`). Still in the picker (`mShowInInputMethodPicker=true`).
8. Installed HeliBoard 4.1 from F-Droid, set it as the default typing IME, pinned the toolbar mic. Disabled Google Voice Typing. Tapping HeliBoard's mic in notepad.js.org switched to VocaPhone listening chrome (`Listening · 0:00`, system mic indicator). Stop transcribed on-device, inserted into the field, and returned to HeliBoard. No crash.

Not fully exercised on device: Material You toggle (tap missed the switch; default-off is visible), a clean swipe that fills alternatives (the test swipe landed on `tryhe` and showed the +dictionary chip).

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for data-flow, permission, retention, or network changes — n/a
