### PR TITLE
Bump Android to 0.2.0

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.vocahq.vocaphone"
         minSdk = 33
         targetSdk = 36
-        versionCode = 27
-        versionName = "0.1.6"
+        versionCode = 28
+        versionName = "0.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/docs/play-store.md
+++ b/docs/play-store.md
@@ -28,8 +28,8 @@ Upload the full AAB only. Never upload the fdroid APK or an fdroid bundle to
 Play. The fdroid flavour drops prebuilt sherpa-onnx / ONNX Runtime so F-Droid
 can rebuild from source; Play testers should get the full catalog.
 
-Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 27,
-`versionName` `0.1.6`. Keep that until the next Play-bound tag needs a bump;
+Package: `com.vocahq.vocaphone`. Current tree on main: `versionCode` 28,
+`versionName` `0.2.0`. Keep that until the next Play-bound tag needs a bump;
 the release workflow refuses to publish when the tag is not `android/v$versionName`.
 
 `dependenciesInfo.includeInApk` / `includeInBundle` stay `false` so AGP does

--- a/fastlane/metadata/android/en-US/changelogs/28.txt
+++ b/fastlane/metadata/android/en-US/changelogs/28.txt
@@ -1,0 +1,1 @@
+Long-press period for a comma. One Stop button: tap to finish, hold to discard. Swipe alternatives stay on the suggestion strip. Language rows are 48dp. Optional Material You, teal still default. Other keyboards can hand their mic to VocaPhone.

--- a/fdroid/com.vocahq.vocaphone.yml
+++ b/fdroid/com.vocahq.vocaphone.yml
@@ -37,9 +37,9 @@ Binaries:
   https://github.com/VocaHQ/vocaphone/releases/download/android/v%v/vocaphone-fdroid.apk
 
 Builds:
-  - versionName: 0.1.6
-    versionCode: 27
-    commit: android/v0.1.6
+  - versionName: 0.2.0
+    versionCode: 28
+    commit: android/v0.2.0
     subdir: android/app
     submodules: true
     gradle:
@@ -59,5 +59,5 @@ AllowedAPKSigningKeys: e6131446f8afeff13516f78036db9ea26aaa16e01b39f37182bf262cc
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags ^android/v[0-9.]+$
-CurrentVersion: 0.1.6
-CurrentVersionCode: 27
+CurrentVersion: 0.2.0
+CurrentVersionCode: 28

--- a/web/README.md
+++ b/web/README.md
@@ -13,7 +13,7 @@ Then open `http://127.0.0.1:4173/`. The iPhone setup guide is available at
 `http://127.0.0.1:4173/privacy/`.
 
 The site uses only local brand assets and system fonts. The Android install and
-download CTAs point at a pinned release tag (`android/v0.1.6`), where the release
+download CTAs point at a pinned release tag (`android/v0.2.0`), where the release
 includes the APK and its verification files. New Android tags are `android/v*`;
 **move the pin when you cut the next Android release people should install**
 (see [releasing.md](../docs/releasing.md)). `npm run check` asserts the tag the

--- a/web/index.html
+++ b/web/index.html
@@ -117,7 +117,7 @@
           <div class="hero-actions">
             <a
               class="button button-primary"
-              href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.6"
+              href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.2.0"
             >
               <svg class="mark-solid" aria-hidden="true"><use href="#mark-android" /></svg>
               get the android beta
@@ -626,7 +626,7 @@
             </div>
             <p><strong>Real Android app screenshot.</strong> Run speech-to-text on your phone and insert text directly from the VocaPhone keyboard.</p>
             <div class="platform-card-actions">
-              <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.6">
+              <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.2.0">
                 <svg class="mark-solid" aria-hidden="true"><use href="#mark-android" /></svg>
                 get the beta <span aria-hidden="true">↗</span>
               </a>
@@ -770,16 +770,16 @@
             <ul class="install-facts">
               <li><b>Requires</b><span>Android 13 or newer</span></li>
               <li><b>Install</b><span>Download and sideload the signed APK</span></li>
-              <li><b>Latest</b><span>v0.1.6</span></li>
+              <li><b>Latest</b><span>v0.2.0</span></li>
               <li><b>Privacy</b><span>On-device model or optional gateway</span></li>
             </ul>
             <p class="install-note">
               Uninstall <code>io.github.mrsunglasses.localflow</code> before
               sideloading if that older Local Flow build is still installed.
             </p>
-            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.6">
+            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.2.0">
               <svg class="mark-solid" aria-hidden="true"><use href="#mark-android" /></svg>
-              open v0.1.6 <span aria-hidden="true">↗</span>
+              open v0.2.0 <span aria-hidden="true">↗</span>
             </a>
             <p class="install-note">
               Download <code>vocaphone.apk</code> from that tag and verify it with
@@ -828,7 +828,7 @@
           <h2 id="download-title">say less.<br />type more.</h2>
           <p>Download a model to your phone and turn speech into text without sending your voice anywhere.</p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.6"><svg class="mark-solid" aria-hidden="true"><use href="#mark-android" /></svg>get Android beta v0.1.6 <span aria-hidden="true">↗</span></a>
+            <a class="button button-primary" href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.2.0"><svg class="mark-solid" aria-hidden="true"><use href="#mark-android" /></svg>get Android beta v0.2.0 <span aria-hidden="true">↗</span></a>
             <a class="button button-primary" href="https://testflight.apple.com/join/wd85wQ3W"><svg class="mark-solid" aria-hidden="true"><use href="#mark-apple" /></svg>join the iPhone TestFlight <span aria-hidden="true">↗</span></a>
           </div>
           <span class="download-fineprint">no gateway required · free &amp; open source · AGPL-3.0</span>
@@ -850,7 +850,7 @@
           <p>product</p>
           <a href="#why">why VocaPhone</a>
           <a href="#how">how it works</a>
-          <a href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.6">releases</a>
+          <a href="https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.2.0">releases</a>
         </div>
         <div>
           <p>resources</p>

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -209,9 +209,9 @@ test("availability and install paths are honest", () => {
   assert.match(html, /There is\s+no App Store release yet/);
   assert.match(
     html,
-    /href="https:\/\/github\.com\/VocaHQ\/vocaphone\/releases\/tag\/android\/v0\.1\.6"/,
+    /href="https:\/\/github\.com\/VocaHQ\/vocaphone\/releases\/tag\/android\/v0\.2\.0"/,
   );
-  assert.match(html, /v0\.1\.6/);
+  assert.match(html, /v0\.2\.0/);
   assert.match(html, /io\.github\.mrsunglasses\.localflow/);
   assert.match(html, /href="\/iphone\/"/);
   assert.match(html, /SHA256SUMS\.txt/);
@@ -237,14 +237,14 @@ test("availability and install paths are honest", () => {
   assert.match(hero, /<use href="#mark-android"/);
   assert.match(hero, /<use href="#mark-apple"/);
   assert.ok(
-    hero.includes("https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.6"),
+    hero.includes("https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.2.0"),
     "hero is missing the Android release link",
   );
 
   const androidCard = androidInstallBlock(html);
   const uninstallAt = androidCard.indexOf("io.github.mrsunglasses.localflow");
   const tagHrefAt = androidCard.indexOf(
-    "https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.1.6",
+    "https://github.com/VocaHQ/vocaphone/releases/tag/android/v0.2.0",
   );
   const checksumAt = androidCard.indexOf("SHA256SUMS.txt");
   assert.ok(uninstallAt !== -1, "uninstall note missing from Android install block");


### PR DESCRIPTION
## Summary

Cuts Android 0.2.0 (versionCode 28). Play Internal already has 0.1.6 as 27, so this is the next AAB it will take. Keyboard train from #255 is on main. Website pin, Play notes, F-Droid metadata, and changelog 28.txt move with the bump. iOS is unchanged. After merge, tag `android/v0.2.0`.

## Verification

- [x] `just ios ci` — N/A, version pin and Android metadata only
- [x] `just android ci` — N/A for this bump; `web` `npm run check` passed (27/27)
- [x] Gateway changes: none
- [x] Physical-device test — N/A for the bump itself; keyboard train was walked on a Nothing Phone (1) on #255

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] Documentation updated for data-flow, permission, retention, or network changes — n/a (version pin only)