### PR TITLE
Auto-finish onboarding once all steps are complete

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/SetupScreen.kt
@@ -47,7 +47,6 @@ internal object SetupCopy {
     val LOGO = R.drawable.ic_vocaphone_logo
     const val TITLE = "Set up VocaPhone"
     const val INTRO = "Turn on the keyboard, allow the microphone, then download a model."
-    const val START = "Start dictating"
     const val DOWNLOAD = "Download"
     const val DOWNLOAD_AND_CONTINUE = "Download and continue"
     const val HELP_ME_CHOOSE = "Help me choose"
@@ -126,6 +125,16 @@ fun SetupScreen(
     var askingUsageReporting by remember { mutableStateOf(false) }
     val recentlyReady = rememberRecentlyReadySteps(status)
 
+    // Once the last step is satisfied, leave onboarding on its own — no button
+    // press required. A brief delay lets the user see the final row flip to
+    // "ready" before the screen collapses out from under them.
+    LaunchedEffect(status.isReadyToDictate) {
+        if (status.isReadyToDictate) {
+            delay(600)
+            if (askUsageReporting) askingUsageReporting = true else onFinish()
+        }
+    }
+
     Column(
         modifier = modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -199,24 +208,6 @@ fun SetupScreen(
                     )
                 }
             }
-        }
-
-        Column(
-            modifier = Modifier
-                .widthIn(max = AppContentMaxWidth)
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-                .padding(bottom = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            PrimaryButton(
-                text = SetupCopy.START,
-                onClick = {
-                    if (askUsageReporting) askingUsageReporting = true else onFinish()
-                },
-                enabled = status.isReadyToDictate,
-                modifier = Modifier.fillMaxWidth(),
-            )
         }
     }
 

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupCopyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/SetupCopyTest.kt
@@ -27,7 +27,6 @@ class SetupCopyTest {
         val copy = listOf(
             SetupCopy.TITLE,
             SetupCopy.INTRO,
-            SetupCopy.START,
             SetupCopy.DOWNLOAD,
             SetupCopy.DOWNLOAD_AND_CONTINUE,
             SetupCopy.HELP_ME_CHOOSE,


### PR DESCRIPTION
Fixes #258.

Previously onboarding required tapping a 'Start dictating' button after all 4/4 steps were satisfied, which made onboarding feel endless and hid Settings behind it until the button was pressed. Now a LaunchedEffect watches SetupStatus.isReadyToDictate and calls onFinish() (or opens the telemetry ask if pending) automatically, with a short delay so the user sees the last step flip to ready before the screen collapses. The manual finish button is removed as it's no longer needed.

Tested manually: built the app, walked through onboarding end to end, confirmed it now collapses into Settings automatically after 4/4 steps. Also verified local model downloading (Settings → Models) is unaffected — that flow was already independent of onboarding state.

The only thing - for those who already got accustomed, the new UX logic can feel slightly less smooth. But it's only on phones which have animations disabled, like mine. I tested with animations on - and everything feels right, smooth, logical and expected. 