### PR TITLE
feat(ios): languages, a spacebar cursor, and the swipe back

### DIFF
--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -288,6 +288,7 @@
 		B1A1053055864F55448F5FED /* ProMotionOptInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4529D7325A4F1D2340C306FD /* ProMotionOptInTests.swift */; };
 		B1D4DE96B74C3327DA6A0FAD /* SwipeTrailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBFC48C457EF15183DB453 /* SwipeTrailView.swift */; };
 		B2406DA05AE90DDB7EED6246 /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
+		B3395FBBC095FA4A38CCE232 /* SwipeBackScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4167FFF96F4349C76E9BA116 /* SwipeBackScreen.swift */; };
 		B4213158A69A8307967F0845 /* KeyboardHandoffPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75D17831C48C07141D7066C /* KeyboardHandoffPresentationTests.swift */; };
 		B4542386951D03680B5F6638 /* SpeechAudioConditioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */; };
 		B463A007E4ABBFF427073748 /* SessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */; };
@@ -508,6 +509,7 @@
 		3E3E4382E021BE30F6D687A7 /* SherpaTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaTranscriptTests.swift; sourceTree = "<group>"; };
 		3EC2C1575D306E7683092FBA /* KeyGridLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyGridLayoutTests.swift; sourceTree = "<group>"; };
 		406B0C287866B36EF3109238 /* LocalModelPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelPicker.swift; sourceTree = "<group>"; };
+		4167FFF96F4349C76E9BA116 /* SwipeBackScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeBackScreen.swift; sourceTree = "<group>"; };
 		41C0A3D1DBF6BCF25C37CF24 /* EmojiSuggestionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiSuggestionsTests.swift; sourceTree = "<group>"; };
 		4453D027A8B7CC1D29FF8285 /* LearnedWords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnedWords.swift; sourceTree = "<group>"; };
 		4529D7325A4F1D2340C306FD /* ProMotionOptInTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProMotionOptInTests.swift; sourceTree = "<group>"; };
@@ -1027,6 +1029,7 @@
 				2978D103DB7CEA2D29A546C1 /* StatsShare.swift */,
 				5E522B238D0F1A138634161D /* StatsView.swift */,
 				0BAEF22ED143D3569B005C88 /* SwipeBackCoach.swift */,
+				4167FFF96F4349C76E9BA116 /* SwipeBackScreen.swift */,
 				5A89F2BEC08F07614372D84D /* TranscriptHistoryModel.swift */,
 				28ECEDA044D2B1021710F205 /* TranscriptHistoryView.swift */,
 				5995603DDA33014FFA52B079 /* TranscriptionSourceStatus.swift */,
@@ -1393,6 +1396,7 @@
 				878ED4FE5F11E43F16D27E44 /* StatsView.swift in Sources */,
 				108C096B9C0FB4861FC26437 /* StopQuickDictationIntent.swift in Sources */,
 				A7216F1D388DBC1B95658666 /* SwipeBackCoach.swift in Sources */,
+				B3395FBBC095FA4A38CCE232 /* SwipeBackScreen.swift in Sources */,
 				AD2CCDE7DC189E63810890BB /* SwipeRecognizer.swift in Sources */,
 				81131D34DE3F3CBDBA61BE4E /* SwipeTrailView.swift in Sources */,
 				A0420E3166FF08AE5059A805 /* Telemetry.swift in Sources */,

--- a/ios/VocaPhoneApp/App/ContentView.swift
+++ b/ios/VocaPhoneApp/App/ContentView.swift
@@ -100,10 +100,8 @@ struct ContentView: View {
                let presentation = KeyboardHandoffPresentation.make(record)
             {
                 KeyboardHandoffView(record: record, presentation: presentation)
-                .transition(.opacity)
             }
         }
-        .animation(.easeInOut(duration: 0.2), value: keyboardHandoffRecord?.state)
     }
 
     // MARK: - Attention

--- a/ios/VocaPhoneApp/App/ContentView.swift
+++ b/ios/VocaPhoneApp/App/ContentView.swift
@@ -11,6 +11,7 @@ import UIKit
 struct ContentView: View {
     @Environment(RecordingCoordinator.self) private var coordinator
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @AppStorage(
         KeyboardPreferences.setupCompletedKey,
         store: KeyboardPreferences.defaults
@@ -38,9 +39,14 @@ struct ContentView: View {
     @State private var isShowingSourceDetail = false
     @FocusState private var diagFocused: Bool
     @Binding private var isShowingSettings: Bool
+    @Binding private var isShowingQuickDictationReturnGuide: Bool
 
-    init(isShowingSettings: Binding<Bool> = .constant(false)) {
+    init(
+        isShowingSettings: Binding<Bool> = .constant(false),
+        isShowingQuickDictationReturnGuide: Binding<Bool> = .constant(false)
+    ) {
         _isShowingSettings = isShowingSettings
+        _isShowingQuickDictationReturnGuide = isShowingQuickDictationReturnGuide
     }
 
     var body: some View {
@@ -90,6 +96,12 @@ struct ContentView: View {
                 await coordinator.refreshGatewayHealth()
             }
             .onChange(of: scenePhase) { previousPhase, currentPhase in
+                if currentPhase == .background {
+                    // The guide has done its job once the user swipes back. Do
+                    // not leave it covering Home on a later ordinary launch.
+                    isShowingQuickDictationReturnGuide = false
+                    return
+                }
                 guard previousPhase != .active, currentPhase == .active else { return }
                 coordinator.refreshSetupStatus()
                 Task { await coordinator.refreshGatewayHealth() }
@@ -112,6 +124,8 @@ struct ContentView: View {
                let presentation = KeyboardHandoffPresentation.make(record)
             {
                 KeyboardHandoffView(record: record, presentation: presentation)
+            } else if isShowingQuickDictationReturnGuide {
+                QuickDictationReturnGuide(reduceMotion: reduceMotion)
             }
         }
     }
@@ -464,6 +478,40 @@ struct ContentView: View {
               KeyboardHandoffPresentation.shouldPresent(record)
         else { return nil }
         return record
+    }
+}
+
+/// The keyboard may open the app from a cold start. Do not tell the user to
+/// return until the recorder has actually taken standby and published the
+/// availability lease the keyboard consumes.
+private struct QuickDictationReturnGuide: View {
+    @Environment(RecordingCoordinator.self) private var coordinator
+    let reduceMotion: Bool
+
+    var body: some View {
+        if coordinator.isQuickDictationReady {
+            SwipeBackScreen(
+                title: "Swipe back to your keyboard",
+                detail: "Quick Dictation is ready. Tap the microphone there.",
+                reduceMotion: reduceMotion
+            )
+        } else {
+            ZStack {
+                Color.vocaCanvas.ignoresSafeArea()
+                VStack(spacing: VocaMetrics.grouping) {
+                    ProgressView()
+                        .controlSize(.large)
+                        .tint(Color.brand)
+                    Text("Getting Quick Dictation ready")
+                        .font(.title2.weight(.bold))
+                    Text("Keep VocaPhone open for a moment.")
+                        .font(.body)
+                        .foregroundStyle(Color.vocaSecondaryText)
+                }
+                .multilineTextAlignment(.center)
+                .padding(VocaMetrics.grouping)
+            }
+        }
     }
 }
 

--- a/ios/VocaPhoneApp/App/ContentView.swift
+++ b/ios/VocaPhoneApp/App/ContentView.swift
@@ -37,6 +37,11 @@ struct ContentView: View {
     @State private var testText = ""
     @State private var isShowingSourceDetail = false
     @FocusState private var diagFocused: Bool
+    @Binding private var isShowingSettings: Bool
+
+    init(isShowingSettings: Binding<Bool> = .constant(false)) {
+        _isShowingSettings = isShowingSettings
+    }
 
     var body: some View {
         NavigationStack {
@@ -93,6 +98,13 @@ struct ContentView: View {
                 NavigationStack {
                     SetupView(mode: .onboarding)
                 }
+            }
+            .sheet(isPresented: $isShowingSettings) {
+                NavigationStack {
+                    SettingsView()
+                }
+                .environment(coordinator)
+                .tint(.brand)
             }
         }
         .overlay {

--- a/ios/VocaPhoneApp/App/ContentView.swift
+++ b/ios/VocaPhoneApp/App/ContentView.swift
@@ -125,7 +125,9 @@ struct ContentView: View {
             {
                 KeyboardHandoffView(record: record, presentation: presentation)
             } else if isShowingQuickDictationReturnGuide {
-                QuickDictationReturnGuide(reduceMotion: reduceMotion)
+                QuickDictationReturnGuide(reduceMotion: reduceMotion) {
+                    isShowingQuickDictationReturnGuide = false
+                }
             }
         }
     }
@@ -487,6 +489,12 @@ struct ContentView: View {
 private struct QuickDictationReturnGuide: View {
     @Environment(RecordingCoordinator.self) private var coordinator
     let reduceMotion: Bool
+    let onDismiss: () -> Void
+    /// Arming takes well under a second when it works. A wait past this is
+    /// not going to end on its own — audio held by a call, another app's
+    /// session — so the screen stops asking for patience and offers a way out
+    /// instead of covering Home until the user leaves the app.
+    @State private var isTakingLong = false
 
     var body: some View {
         if coordinator.isQuickDictationReady {
@@ -495,22 +503,62 @@ private struct QuickDictationReturnGuide: View {
                 detail: "Quick Dictation is ready. Tap the microphone there.",
                 reduceMotion: reduceMotion
             )
+        } else if coordinator.setupStatus.microphone == .denied {
+            status(
+                title: "Microphone access is off",
+                detail: "Quick Dictation needs the microphone. Turn it on in Settings, then try again."
+            ) {
+                VocaPrimaryButton(title: "Open Settings", symbol: "gear") {
+                    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                    UIApplication.shared.open(url)
+                }
+            }
         } else {
-            ZStack {
-                Color.vocaCanvas.ignoresSafeArea()
-                VStack(spacing: VocaMetrics.grouping) {
+            status(
+                title: "Getting Quick Dictation ready",
+                detail: isTakingLong
+                    ? (coordinator.message ?? "VocaPhone could not get the microphone yet.")
+                    : "Keep VocaPhone open for a moment.",
+                showsProgress: true
+            ) {
+                EmptyView()
+            }
+            .task {
+                try? await Task.sleep(for: .seconds(4))
+                isTakingLong = true
+            }
+        }
+    }
+
+    private func status<Actions: View>(
+        title: String,
+        detail: String,
+        showsProgress: Bool = false,
+        @ViewBuilder actions: () -> Actions
+    ) -> some View {
+        ZStack {
+            Color.vocaCanvas.ignoresSafeArea()
+            VStack(spacing: VocaMetrics.grouping) {
+                if showsProgress {
                     ProgressView()
                         .controlSize(.large)
                         .tint(Color.brand)
-                    Text("Getting Quick Dictation ready")
-                        .font(.title2.weight(.bold))
-                    Text("Keep VocaPhone open for a moment.")
-                        .font(.body)
-                        .foregroundStyle(Color.vocaSecondaryText)
                 }
-                .multilineTextAlignment(.center)
-                .padding(VocaMetrics.grouping)
+                Text(title)
+                    .font(.title2.weight(.bold))
+                Text(detail)
+                    .font(.body)
+                    .foregroundStyle(Color.vocaSecondaryText)
+                actions()
+                if !showsProgress || isTakingLong {
+                    Button("Close", action: onDismiss)
+                        .font(.body.weight(.semibold))
+                        .frame(minHeight: VocaMetrics.minimumTarget)
+                }
             }
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: 480)
+            .padding(VocaMetrics.grouping)
         }
     }
 }

--- a/ios/VocaPhoneApp/App/KeyboardHandoffPresentation.swift
+++ b/ios/VocaPhoneApp/App/KeyboardHandoffPresentation.swift
@@ -32,6 +32,16 @@ struct KeyboardHandoffPresentation: Equatable {
               record.startedInContainingApp != true
         else { return false }
 
+        // The wait for the app to come up belongs to the hand-off, not to the
+        // home screen. Presenting from `launchingApp` is what makes the app
+        // open *on* the swipe-back screen instead of painting its home screen
+        // for a frame and then covering it. A hand-off nobody claimed is
+        // retired by `SessionExpiryPolicy`, but a record that is already past
+        // its window must not put this screen up on an ordinary launch.
+        if record.state == .launchingApp || record.state == .awaitingReturn {
+            return !SessionExpiryPolicy.isStale(record)
+        }
+
         return switch record.state {
         case .recording, .finalizing, .uploading, .transcribing, .readyToInsert,
              .targetContextChanged, .serverUnavailable, .uploadFailedRecoverable,
@@ -46,14 +56,18 @@ struct KeyboardHandoffPresentation: Equatable {
         guard shouldPresent(record) else { return nil }
 
         switch record.state {
-        case .recording:
+        // One screen from the moment the app is asked for until the transcript
+        // exists: the request is the same request whether the recorder has
+        // caught up yet or not, and swapping layouts underneath the user while
+        // they are reading is what made this feel like three separate steps.
+        case .launchingApp, .awaitingReturn, .recording:
             return KeyboardHandoffPresentation(
                 kind: .recording,
-                title: "Recording",
-                detail: "Swipe back to the app where you were typing. Recording keeps going as you switch.",
-                primaryAction: .finish,
-                primaryTitle: "Finish & transcribe here",
-                showsCancel: true
+                title: "Swipe back to your app",
+                detail: "Recording follows you there.",
+                primaryAction: .none,
+                primaryTitle: nil,
+                showsCancel: false
             )
         case .finalizing:
             return processing(title: "Finishing recording")

--- a/ios/VocaPhoneApp/App/KeyboardHandoffView.swift
+++ b/ios/VocaPhoneApp/App/KeyboardHandoffView.swift
@@ -25,82 +25,20 @@ struct KeyboardHandoffView: View {
         .accessibilityElement(children: .contain)
     }
 
+    /// vocaphone has nothing useful to say here and one thing to ask, so the
+    /// screen says that one thing and holds nothing else. Finishing and
+    /// cancelling stay where they already were: the Live Activity, and the
+    /// keyboard the user is going back to.
     private var recordingHandoff: some View {
-        ScrollView {
-            VStack(spacing: VocaMetrics.section) {
-                header
-
-                VStack(spacing: VocaMetrics.related) {
-                    Text("Keep speaking")
-                        .font(.largeTitle.weight(.bold))
-                    Text("Swipe right across the bottom edge to return")
-                        .font(.title2.weight(.semibold))
-                        .multilineTextAlignment(.center)
-                        .fixedSize(horizontal: false, vertical: true)
-                    Text("Recording continues while you switch apps.")
-                        .font(.body)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity)
-
-                SwipeBackCoach(reduceMotion: reduceMotion, prominent: true)
-
-                VStack(spacing: VocaMetrics.related) {
-                    Button {
-                        perform(.finish)
-                    } label: {
-                        Label("Can't swipe back? Finish here instead", systemImage: "stop.fill")
-                            .font(.subheadline.weight(.semibold))
-                            .frame(minHeight: VocaMetrics.minimumTarget)
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
-                    .accessibilityHint(primaryHint)
-
-                    Button("Cancel dictation", role: .destructive) {
-                        coordinator.cancel()
-                    }
-                    .font(.subheadline.weight(.semibold))
-                    .frame(minHeight: VocaMetrics.minimumTarget)
-                }
-            }
-            .frame(maxWidth: 560)
-            .padding(.horizontal, VocaMetrics.grouping)
-            .padding(.vertical, VocaMetrics.section)
-            .frame(maxWidth: .infinity, minHeight: 720)
-        }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            realBottomEdgeCue
-        }
-    }
-
-    private var realBottomEdgeCue: some View {
-        VStack(spacing: 8) {
-            Label("Swipe at the real iPhone bottom edge", systemImage: "arrow.down")
-                .font(.headline)
-
-            HStack(spacing: VocaMetrics.related) {
-                Text("Then swipe right")
-                Rectangle()
-                    .fill(Color.brand)
-                    .frame(height: 3)
-                Image(systemName: "arrow.right")
-                    .font(.headline.weight(.bold))
-            }
-            .font(.subheadline.weight(.bold))
-        }
-        .foregroundStyle(Color.brand)
-        .padding(.horizontal, VocaMetrics.grouping)
-        .padding(.vertical, VocaMetrics.padding)
-        .background(Color.vocaSurface)
-        .overlay(alignment: .top) {
-            Rectangle()
-                .fill(Color.vocaBorder)
-                .frame(height: 1)
-        }
-        .allowsHitTesting(false)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("At the real bottom edge of this iPhone, swipe right.")
+        SwipeBackScreen(
+            title: presentation.title,
+            detail: presentation.detail,
+            reduceMotion: reduceMotion
+        )
+        // Same picture from launching through recording. Without this the
+        // state change remounts the animation, which is the hitch after the
+        // app has already opened on this screen.
+        .id("recording-handoff")
     }
 
     private var statusHandoff: some View {

--- a/ios/VocaPhoneApp/App/KeyboardLab.swift
+++ b/ios/VocaPhoneApp/App/KeyboardLab.swift
@@ -14,11 +14,30 @@ import UIKit
 /// Debug only, and unreachable from a release build: `just ios lint-previews`
 /// fails if anything here becomes reachable from one.
 struct KeyboardLabView: View {
-    @State private var state: SessionState = .recording
-    @State private var isDark = false
-    @State private var isSpeaking = true
-    @State private var showsCandidates = false
-    @State private var usesSurface = true
+    // Idle rather than recording: it is the state the row is actually about —
+    // the one where nothing has been typed and nothing is running — and
+    // opening on a recording meant the left button was the cancel in every
+    // variant, which made the arrangements look identical.
+    @AppStorage("lab.state", store: KeyboardPreferences.defaults)
+    private var stateRawValue = SessionState.idle.rawValue
+    private var state: SessionState {
+        get { SessionState(rawValue: stateRawValue) ?? .idle }
+        nonmutating set { stateRawValue = newValue.rawValue }
+    }
+    // Stored, not `@State`. These were state, which meant every switch in the
+    // lab reset itself the moment the screen went away — turn one on, go back
+    // to compare against the keyboard, come back, and it is off again. A
+    // variant you cannot leave switched on is a variant you cannot look at.
+    @AppStorage("lab.isDark", store: KeyboardPreferences.defaults)
+    private var isDark = false
+    @AppStorage("lab.isSpeaking", store: KeyboardPreferences.defaults)
+    private var isSpeaking = true
+    @AppStorage("lab.showsCandidates", store: KeyboardPreferences.defaults)
+    private var showsCandidates = false
+    @AppStorage("lab.usesSurface", store: KeyboardPreferences.defaults)
+    private var usesSurface = true
+    @AppStorage(KeyboardPreferences.compactControlsKey, store: KeyboardPreferences.defaults)
+    private var usesCompactControls = false
     @State private var touchTrace = KeyboardPreferences.touchTraceEnabled
     @State private var hapticStyle = KeyboardPreferences.typingHapticStyle
     @State private var hapticIntensity = KeyboardPreferences.typingHapticIntensity
@@ -85,9 +104,11 @@ struct KeyboardLabView: View {
             .listRowBackground(Color.clear)
             Section {
                 Toggle("New surface", isOn: $usesSurface)
-                Picker("State", selection: $state) {
+                Toggle("Compact controls", isOn: $usesCompactControls)
+                    .disabled(!usesSurface)
+                Picker("State", selection: $stateRawValue) {
                     ForEach(Self.states, id: \.self) { state in
-                        Text(state.displayName).tag(state)
+                        Text(state.displayName).tag(state.rawValue)
                     }
                 }
                 Toggle("Dark keyboard", isOn: $isDark)
@@ -111,9 +132,10 @@ struct KeyboardLabView: View {
             surface.animationDamping = KeyboardPreferences.surfaceAnimationDamping
             syncSurface()
         }
-        .onChange(of: state) { syncSurface() }
+        .onChange(of: stateRawValue) { syncSurface() }
         .onChange(of: isDark) { syncSurface() }
         .onChange(of: showsCandidates) { syncSurface() }
+        .onChange(of: usesCompactControls) { syncSurface() }
         .onChange(of: touchTrace) { KeyboardPreferences.touchTraceEnabled = touchTrace }
         .onReceive(meterTick) { _ in
             guard usesSurface, state == .recording, isSpeaking else { return }
@@ -202,6 +224,7 @@ struct KeyboardLabView: View {
         surface.state = state
         surface.isDark = isDark
         surface.showsGlobeKey = true
+        surface.usesCompactControls = usesCompactControls
         surface.candidates = showsCandidates && state == .idle ? Self.sampleCandidates : []
         if state != .recording { surface.clearMeterLevels() }
 

--- a/ios/VocaPhoneApp/App/KeyboardLab.swift
+++ b/ios/VocaPhoneApp/App/KeyboardLab.swift
@@ -124,6 +124,7 @@ struct KeyboardLabView: View {
             }
             transitionSection
             hapticsSection
+            handoffSection
         }
         .navigationTitle("Keyboard lab")
         .navigationBarTitleDisplayMode(.inline)
@@ -140,6 +141,22 @@ struct KeyboardLabView: View {
         .onReceive(meterTick) { _ in
             guard usesSurface, state == .recording, isSpeaking else { return }
             surface.appendMeterLevels(Self.nextLevels())
+        }
+    }
+
+    /// The screen the app shows when the keyboard had to open it. It is the
+    /// one surface nobody can reach on purpose from the app: it needs a real
+    /// dictation, started from the keyboard, in some other app.
+    private var handoffSection: some View {
+        Section {
+            NavigationLink("Swipe back screen") { SwipeBackLabScreen() }
+        } header: {
+            Text("Handoff")
+        } footer: {
+            Text(
+                "The loop runs on its own. The toggle inside parks it on the "
+                    + "last frame, which is what Reduce Motion shows."
+            )
         }
     }
 
@@ -259,6 +276,26 @@ struct KeyboardLabView: View {
             let breath = 0.45 + 0.45 * abs(sin(meterPhase * 0.21))
             return Float(min(max(syllable * breath, 0.05), 1))
         }
+    }
+}
+
+/// The handoff screen at full size, with the motion switch the lab exists for:
+/// the system setting needs a trip to Settings and a relaunch to compare.
+private struct SwipeBackLabScreen: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var parksTheAnimation = false
+
+    var body: some View {
+        SwipeBackScreen(reduceMotion: reduceMotion || parksTheAnimation)
+            .navigationTitle("Swipe back")
+            .navigationBarTitleDisplayMode(.inline)
+            .safeAreaInset(edge: .bottom) {
+                Toggle("Park the animation", isOn: $parksTheAnimation)
+                    .font(.subheadline)
+                    .padding(.horizontal, VocaMetrics.grouping)
+                    .padding(.vertical, VocaMetrics.related)
+                    .background(.bar)
+            }
     }
 }
 

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -185,6 +185,10 @@ struct KeyboardSettingsView: View {
         KeyboardPreferences.swipeTypingKey,
         store: KeyboardPreferences.defaults
     ) private var swipeTypingEnabled = false
+    @AppStorage(
+        KeyboardPreferences.spacebarCursorKey,
+        store: KeyboardPreferences.defaults
+    ) private var spacebarCursorEnabled = true
 
     /// Held rather than read straight from ``KeyboardPreferences`` on every
     /// redraw: the list has to keep its order, and the order is the order the
@@ -399,6 +403,7 @@ struct KeyboardSettingsView: View {
             Toggle("Emoji suggestions", isOn: $emojiSuggestionsEnabled)
             Toggle("Typing haptics", isOn: $typingHapticsEnabled)
             Toggle("Swipe to type", isOn: $swipeTypingEnabled)
+            Toggle("Space bar cursor", isOn: $spacebarCursorEnabled)
         } footer: {
             VStack(alignment: .leading, spacing: VocaMetrics.related) {
                 Text(
@@ -432,6 +437,13 @@ struct KeyboardSettingsView: View {
                     "Swipe to type is new and off by default. Slide from letter to "
                         + "letter without lifting; alternatives appear in the "
                         + "suggestion row."
+                )
+                // The hold is the whole rule, and it is what makes the two
+                // gestures on this one key tell themselves apart: a swipe never
+                // waits, a cursor drag always does.
+                Text(
+                    "Hold the space bar, then slide to move the cursor. Swipe "
+                        + "across it to switch language."
                 )
             }
         }

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -307,6 +307,19 @@ struct KeyboardSettingsView: View {
         }
     }
 
+    /// Only the space bar gestures that are actually on: the cursor has its own
+    /// switch, and the swipe needs a second language to go to.
+    private var spaceBarHelp: String? {
+        let cursor = spacebarCursorEnabled
+            ? "Hold the space bar, then slide to move the cursor." : nil
+        let swipe = enabledLayoutIDs.count > 1
+            ? "Swipe across it to switch language." : nil
+        let parts = [cursor, swipe].compactMap { $0 }
+        guard !parts.isEmpty else { return nil }
+        if cursor == nil { return "Swipe across the space bar to switch language." }
+        return parts.joined(separator: " ")
+    }
+
     /// What the row shows on its right: the language, or the first of them and
     /// how many more. Naming them all turns the row into a paragraph at three,
     /// and the sheet is one tap away for the rest.
@@ -441,10 +454,9 @@ struct KeyboardSettingsView: View {
                 // The hold is the whole rule, and it is what makes the two
                 // gestures on this one key tell themselves apart: a swipe never
                 // waits, a cursor drag always does.
-                Text(
-                    "Hold the space bar, then slide to move the cursor. Swipe "
-                        + "across it to switch language."
-                )
+                if let spaceBarHelp {
+                    Text(spaceBarHelp)
+                }
             }
         }
     }
@@ -1772,8 +1784,13 @@ struct KeyboardLanguagesSheet: View {
         // Matched on the id as well as the written name, because somebody
         // looking for Russian may well type "ru" — and somebody whose keyboard
         // is currently Cyrillic cannot type "Русский" to find it.
+        // And on the name in the phone's own language, since somebody after
+        // German types "German", not "Deutsch".
         return TypingLayout.catalogue.filter {
-            $0.displayName.lowercased().contains(query) || $0.id.contains(query)
+            $0.displayName.lowercased().contains(query)
+                || $0.id.contains(query)
+                || (Locale.current.localizedString(forLanguageCode: $0.id)?
+                    .lowercased().contains(query) ?? false)
         }
     }
 

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -186,6 +186,15 @@ struct KeyboardSettingsView: View {
         store: KeyboardPreferences.defaults
     ) private var swipeTypingEnabled = false
 
+    /// Held rather than read straight from ``KeyboardPreferences`` on every
+    /// redraw: the list has to keep its order, and the order is the order the
+    /// language key walks through, so it is a value the view owns and writes
+    /// back rather than a set it recomputes.
+    @State private var enabledLayoutIDs: [String] = KeyboardPreferences
+        .enabledTypingLayouts
+        .map(\.id)
+    @State private var isChoosingLanguages = false
+
     @State private var learnedStore = LearnedWordStore()
     @State private var learnedCount = 0
     @State private var isConfirmingLearnedReset = false
@@ -197,6 +206,7 @@ struct KeyboardSettingsView: View {
     var body: some View {
         List {
             previewSection
+            languagesSection
             heightSection
             suggestionsSection
             learningSection
@@ -211,6 +221,14 @@ struct KeyboardSettingsView: View {
         }
         .navigationTitle("Keyboard")
         .navigationBarTitleDisplayMode(.inline)
+        // On the List, not on the section that owns the row. Attached to the
+        // section, the first tap opened the sheet and shut it again: tapping
+        // changes nothing, but presenting re-renders the list, the section is
+        // rebuilt, and the sheet goes down with the modifier it was attached
+        // to. The second tap worked because by then the list had settled.
+        .sheet(isPresented: $isChoosingLanguages) {
+            KeyboardLanguagesSheet(enabledLayoutIDs: $enabledLayoutIDs)
+        }
         .task { learnedCount = learnedStore.snapshot().count }
         .confirmationDialog(
             "Forget \(learnedCount) learned word\(learnedCount == 1 ? "" : "s")?",
@@ -249,6 +267,51 @@ struct KeyboardSettingsView: View {
                 .listRowInsets(EdgeInsets())
                 .listRowBackground(Color.clear)
         }
+    }
+
+    private var languagesSection: some View {
+        Section {
+            Button {
+                isChoosingLanguages = true
+            } label: {
+                HStack {
+                    // "Keyboard" rather than "Languages": the header above has
+                    // just said that word, and saying it twice was the first
+                    // thing wrong with this screen.
+                    Text("Keyboard")
+                        .foregroundStyle(.primary)
+                    Spacer(minLength: VocaMetrics.related)
+                    Text(enabledSummary)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    Image(systemName: "chevron.right")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                }
+                .contentShape(.rect)
+            }
+            .buttonStyle(.plain)
+        } header: {
+            Text("Languages")
+        } footer: {
+            Text(
+                enabledLayoutIDs.count > 1
+                    ? "Switch with the key beside 123, or swipe across the space bar."
+                    : "Add another to switch from the keyboard itself — a key beside "
+                        + "123, or a swipe across the space bar."
+            )
+        }
+    }
+
+    /// What the row shows on its right: the language, or the first of them and
+    /// how many more. Naming them all turns the row into a paragraph at three,
+    /// and the sheet is one tap away for the rest.
+    private var enabledSummary: String {
+        let names = TypingLayout.catalogue
+            .filter { enabledLayoutIDs.contains($0.id) }
+            .map(\.displayName)
+        guard let first = names.first else { return "" }
+        return names.count > 1 ? "\(first) +\(names.count - 1)" : first
     }
 
     private var heightSection: some View {
@@ -1679,3 +1742,93 @@ private struct SnippetEditorView: View {
     }
 }
 #endif
+
+/// The language picker, as a sheet rather than a pushed screen.
+///
+/// A list of seven with a search field is something somebody opens, changes and
+/// dismisses, and a sheet says exactly that: it comes up over the settings it
+/// belongs to and goes away again, with them still visible behind it. A push
+/// would file it in the navigation stack as though it were somewhere you go.
+struct KeyboardLanguagesSheet: View {
+    @Binding var enabledLayoutIDs: [String]
+    @Environment(\.dismiss) private var dismiss
+    @State private var search = ""
+
+    private var matches: [TypingLayout] {
+        let query = search.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !query.isEmpty else { return TypingLayout.catalogue }
+        // Matched on the id as well as the written name, because somebody
+        // looking for Russian may well type "ru" — and somebody whose keyboard
+        // is currently Cyrillic cannot type "Русский" to find it.
+        return TypingLayout.catalogue.filter {
+            $0.displayName.lowercased().contains(query) || $0.id.contains(query)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(matches) { layout in
+                    Button {
+                        toggle(layout)
+                    } label: {
+                        row(for: layout)
+                    }
+                    .buttonStyle(.plain)
+                    // The last one on cannot be turned off: a keyboard with no
+                    // letters is not a narrower keyboard, it is a broken one.
+                    .disabled(enabledLayoutIDs == [layout.id])
+                }
+            }
+            // Inset grouped is the settings-sheet default. `.plain` draws a
+            // full-width hairline above the first row, under the search field
+            // — a separator with nothing above it, which reads as a fault.
+            .listStyle(.insetGrouped)
+            .searchable(text: $search, prompt: "Search")
+            .navigationTitle("Languages")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button { dismiss() } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .accessibilityLabel("Close")
+                }
+            }
+        }
+        .presentationDetents([.large, .medium])
+        .presentationDragIndicator(.visible)
+    }
+
+    private func row(for layout: TypingLayout) -> some View {
+        let isOn = enabledLayoutIDs.contains(layout.id)
+        return HStack(spacing: VocaMetrics.related) {
+            Text(layout.flag)
+                .font(.title2)
+            Text(layout.displayName)
+                .foregroundStyle(.primary)
+            Spacer(minLength: VocaMetrics.related)
+            Image(systemName: isOn ? "checkmark.circle.fill" : "circle")
+                .font(.title2)
+                .foregroundStyle(isOn ? AnyShapeStyle(.tint) : AnyShapeStyle(.tertiary))
+        }
+        .frame(minHeight: VocaMetrics.minimumTarget)
+        .contentShape(.rect)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
+    }
+
+    /// Writes straight through to the shared defaults the extension reads.
+    ///
+    /// The order is rebuilt from the catalogue rather than appended to, so
+    /// switching a language off and back on returns it to its place instead of
+    /// to the end of the cycle the language key walks.
+    private func toggle(_ layout: TypingLayout) {
+        var wanted = Set(enabledLayoutIDs)
+        if wanted.contains(layout.id) { wanted.remove(layout.id) } else { wanted.insert(layout.id) }
+        let resolved = TypingLayout.catalogue.filter { wanted.contains($0.id) }
+        guard !resolved.isEmpty else { return }
+        KeyboardPreferences.enabledTypingLayouts = resolved
+        enabledLayoutIDs = resolved.map(\.id)
+    }
+}

--- a/ios/VocaPhoneApp/App/SwipeBackCoach.swift
+++ b/ios/VocaPhoneApp/App/SwipeBackCoach.swift
@@ -6,7 +6,6 @@ import SwiftUI
 struct SwipeBackCoach: View {
     let reduceMotion: Bool
     var compact = false
-    var prominent = false
 
     @State private var progress: CGFloat = 0
     @State private var replayID = 0
@@ -42,10 +41,10 @@ struct SwipeBackCoach: View {
                     ZStack {
                         Circle()
                             .fill(Color.brand)
-                            .frame(width: prominent ? 48 : 32, height: prominent ? 48 : 32)
+                            .frame(width: 32, height: 32)
                             .shadow(color: .black.opacity(0.18), radius: 5, y: 2)
                         Image(systemName: "hand.point.up.left.fill")
-                            .font((prominent ? Font.body : Font.caption).weight(.bold))
+                            .font(.caption.weight(.bold))
                             .foregroundStyle(Color.onBrand)
                     }
                     .offset(x: -width * 0.31 + progress * width * 0.52, y: -26)
@@ -83,44 +82,30 @@ struct SwipeBackCoach: View {
                         }
                 )
             }
-            .frame(height: prominent ? 258 : compact ? 150 : 174)
-            .allowsHitTesting(!prominent)
+            .frame(height: compact ? 150 : 174)
 
-            if prominent {
-                Label(
-                    "Preview only — do not swipe here",
-                    systemImage: "play.rectangle"
-                )
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .center)
-            } else {
-                HStack(spacing: 8) {
-                    instruction(number: 1, title: "Touch the home bar")
-                    Image(systemName: "arrow.right")
-                        .font(.caption.weight(.bold))
-                        .foregroundStyle(.secondary)
-                        .accessibilityHidden(true)
-                    instruction(number: 2, title: "Swipe right")
-                }
+            HStack(spacing: 8) {
+                instruction(number: 1, title: "Touch the home bar")
+                Image(systemName: "arrow.right")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+                instruction(number: 2, title: "Swipe right")
             }
 
-            if !prominent {
-                HStack {
-                    Label(
-                        progress < 0.5 ? "Try the swipe in this demo" : "The previous app appears",
-                        systemImage: progress < 0.5 ? "hand.point.up.left" : "text.cursor"
-                    )
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(Color.brand)
-                    .contentTransition(.symbolEffect(.replace))
+            HStack {
+                Label(
+                    progress < 0.5 ? "Try the swipe in this demo" : "The previous app appears",
+                    systemImage: progress < 0.5 ? "hand.point.up.left" : "text.cursor"
+                )
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Color.brand)
+                .contentTransition(.symbolEffect(.replace))
 
-                    Spacer()
+                Spacer()
 
-                    Button("Replay swipe", action: replay)
-                        .font(.caption.weight(.semibold))
-                }
+                Button("Replay swipe", action: replay)
+                    .font(.caption.weight(.semibold))
             }
         }
         .task(id: replayID) {
@@ -128,9 +113,7 @@ struct SwipeBackCoach: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(
-            prominent
-                ? "Animation preview. Use the real iPhone home indicator at the bottom of the screen to return to the app where you were typing."
-                : "Interactive demonstration. Swipe right along the home indicator to return to the app where you were typing."
+            "Interactive demonstration. Swipe right along the home indicator to return to the app where you were typing."
         )
         .accessibilityAction(named: "Replay swipe", replay)
     }
@@ -153,7 +136,7 @@ struct SwipeBackCoach: View {
                 }
                 .padding(12)
             }
-            .frame(height: prominent ? 232 : compact ? 132 : 156)
+            .frame(height: compact ? 132 : 156)
     }
 
     private var vocaphoneCard: some View {
@@ -166,7 +149,7 @@ struct SwipeBackCoach: View {
             .overlay(alignment: .topLeading) {
                 VStack(alignment: .leading, spacing: 10) {
                     Label("vocaphone is recording", systemImage: "mic.fill")
-                        .font((prominent ? Font.subheadline : Font.caption).weight(.semibold))
+                        .font(.caption.weight(.semibold))
                         .foregroundStyle(Color.vocaRecording)
                     HStack(spacing: 4) {
                         ForEach(0..<8, id: \.self) { index in
@@ -178,7 +161,7 @@ struct SwipeBackCoach: View {
                 }
                 .padding(12)
             }
-            .frame(height: prominent ? 194 : compact ? 112 : 136)
+            .frame(height: compact ? 112 : 136)
     }
 
     private func instruction(number: Int, title: String) -> some View {

--- a/ios/VocaPhoneApp/App/SwipeBackScreen.swift
+++ b/ios/VocaPhoneApp/App/SwipeBackScreen.swift
@@ -1,0 +1,290 @@
+import SwiftUI
+
+/// The one step vocaphone cannot take for the user.
+///
+/// A keyboard extension has no way to put the app it came from back on screen;
+/// only the person holding the phone can do that, with the system's own
+/// previous-app gesture. So the screen is a demonstration and nothing else: no
+/// controls to mistake for navigation, no status to read, one sentence and a
+/// picture of the gesture running on a loop.
+///
+/// The phone in the picture is drawn, not photographed, so it follows the
+/// palette into dark mode and scales with the space it is given.
+struct SwipeBackScreen: View {
+    var title = "Swipe back to your app"
+    var detail = "Recording follows you there."
+    let reduceMotion: Bool
+
+    var body: some View {
+        ZStack {
+            Color.vocaCanvas
+                .ignoresSafeArea()
+
+            ScrollView {
+                VStack(spacing: VocaMetrics.section) {
+                    Spacer(minLength: 0)
+
+                    SwipeBackPhone(reduceMotion: reduceMotion)
+                        .frame(maxWidth: 340)
+                        .frame(height: 330)
+
+                    VStack(spacing: VocaMetrics.related + 2) {
+                        Text(title)
+                            .font(.largeTitle.weight(.bold))
+                        Text(detail)
+                            .font(.title3)
+                            .foregroundStyle(Color.vocaSecondaryText)
+                    }
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityElement(children: .combine)
+
+                    Spacer(minLength: 0)
+                }
+                .frame(maxWidth: 520)
+                .padding(.horizontal, VocaMetrics.grouping)
+                .padding(.vertical, VocaMetrics.section)
+                .frame(maxWidth: .infinity, minHeight: 640)
+            }
+        }
+    }
+}
+
+/// The bottom of a phone, with the gesture playing inside it.
+///
+/// Only the bottom: the top of a phone has nothing to do with a gesture made at
+/// the home indicator, and leaving it out is what keeps the keys underneath big
+/// enough to recognise. It ends in a fade rather than a cut — a hard edge across
+/// the middle of a phone reads as a drawing mistake.
+private struct SwipeBackPhone: View {
+    let reduceMotion: Bool
+
+    /// 0 — vocaphone is on screen. 1 — the app the user came from is back, with
+    /// the keyboard and the cursor still waiting in it.
+    @State private var progress: CGFloat = 0
+    @State private var touchOpacity: Double = 0
+
+    /// How far above the drawn area the shell continues before it fades out.
+    private static let overhang: CGFloat = 190
+    private static let shellWidth: CGFloat = 9
+    /// Room under the phone for the finger, which overlaps the bottom edge the
+    /// way a real thumb does.
+    private static let bottomRoom: CGFloat = 46
+    /// The strip the home indicator lives in, which the keys stay clear of.
+    static let indicatorRoom: CGFloat = 30
+    /// The fade at the top, as fractions of the drawn height. Four stops
+    /// rather than two: a straight ramp starts somewhere, and the eye finds
+    /// exactly where.
+    private static let fade: [Gradient.Stop] = [
+        .init(color: .clear, location: 0),
+        .init(color: .black.opacity(0.18), location: 0.08),
+        .init(color: .black.opacity(0.62), location: 0.16),
+        .init(color: .black, location: 0.26),
+    ]
+
+    var body: some View {
+        GeometryReader { proxy in
+            let width = proxy.size.width
+            let phoneHeight = proxy.size.height - Self.bottomRoom
+            let shellHeight = phoneHeight + Self.overhang
+            let radius = width * 0.155
+
+            ZStack(alignment: .bottom) {
+                // The phone, fading out towards the top of the frame.
+                ZStack(alignment: .bottom) {
+                    screen(
+                        width: width,
+                        height: shellHeight,
+                        visible: phoneHeight,
+                        radius: radius
+                    )
+                    .offset(y: -Self.shellWidth)
+
+                    RoundedRectangle(cornerRadius: radius, style: .continuous)
+                        .strokeBorder(Color.vocaPrimaryText, lineWidth: Self.shellWidth)
+                        .frame(width: width, height: shellHeight)
+
+                    Capsule()
+                        .fill(Color.vocaPrimaryText.opacity(0.8))
+                        .frame(width: width * 0.38, height: 5)
+                        .padding(.bottom, 22)
+                }
+                .frame(width: width, height: phoneHeight, alignment: .bottom)
+                .mask(alignment: .bottom) {
+                    LinearGradient(
+                        stops: Self.fade,
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                }
+                .padding(.bottom, Self.bottomRoom)
+
+                // Outside the mask, so it stays solid and can hang past the
+                // bottom edge the way a thumb does.
+                touch(width: width)
+            }
+            .frame(width: width, height: proxy.size.height, alignment: .bottom)
+        }
+        .task(id: reduceMotion) { await play() }
+        .accessibilityElement()
+        .accessibilityLabel(
+            "Animation. A finger swipes right along the bottom edge of a phone, "
+                + "and the app the user was typing in comes back with its keyboard."
+        )
+    }
+
+    private func screen(
+        width: CGFloat,
+        height: CGFloat,
+        visible: CGFloat,
+        radius: CGFloat
+    ) -> some View {
+        ZStack {
+            hostApp(width: width)
+
+            vocaphone(visible: visible)
+                .offset(x: progress * width)
+                .shadow(color: .black.opacity(0.16 * (1 - progress)), radius: 12, x: -6)
+        }
+        .frame(width: width - 2 * Self.shellWidth, height: height - 2 * Self.shellWidth)
+        .clipShape(
+            RoundedRectangle(cornerRadius: radius - Self.shellWidth, style: .continuous)
+        )
+    }
+
+    /// Where the user was typing: the keyboard is still up and the cursor is
+    /// still in the field, which is the whole reason the gesture is worth making.
+    private func hostApp(width: CGFloat) -> some View {
+        VStack(spacing: 0) {
+            Color.vocaSurface
+            SwipeBackKeyboardMark()
+                .frame(height: width * 0.6 + Self.indicatorRoom)
+        }
+    }
+
+    /// The wordmark sits in the part of the screen that is actually drawn.
+    /// Centred in the whole screen it would land under the fade, which is how
+    /// it came out cropped.
+    private func vocaphone(visible: CGFloat) -> some View {
+        Color.vocaSurface
+            .overlay(alignment: .bottom) {
+                VStack(spacing: VocaMetrics.related) {
+                    BrandMark(size: 44)
+                    Text("vocaphone")
+                        .font(.system(size: 29, weight: .bold, design: .rounded))
+                        .foregroundStyle(Color.brand)
+                }
+                .opacity(0.3)
+                .padding(.bottom, visible * 0.34)
+            }
+    }
+
+    /// The finger. Grey and translucent on purpose — a hand illustration reads
+    /// as a control to press, and this one is being watched, not used.
+    private func touch(width: CGFloat) -> some View {
+        Circle()
+            .fill(Color.vocaPrimaryText.opacity(0.26))
+            .frame(width: 92, height: 92)
+            .offset(
+                x: (-0.2 + progress * 0.46) * width,
+                y: -(Self.bottomRoom + 8)
+            )
+            .opacity(touchOpacity)
+    }
+
+    private func play() async {
+        guard !reduceMotion else {
+            progress = 1
+            touchOpacity = 0
+            return
+        }
+
+        // The first pass starts with the screen. A lead-in is fine on the
+        // repeats, when the user is watching a loop; on arrival it is dead time
+        // in front of somebody who is standing in another app waiting to be
+        // told what to do.
+        var isFirstPass = true
+        while !Task.isCancelled {
+            progress = 0
+            touchOpacity = 0
+            if !isFirstPass {
+                try? await Task.sleep(for: .milliseconds(320))
+                guard !Task.isCancelled else { return }
+            }
+            isFirstPass = false
+
+            // The finger arrives already moving. Showing it, then waiting, then
+            // starting is three beats for one instruction.
+            touchOpacity = 1
+            withAnimation(.easeInOut(duration: 0.9)) { progress = 1 }
+            try? await Task.sleep(for: .milliseconds(1_050))
+            guard !Task.isCancelled else { return }
+
+            withAnimation(.easeIn(duration: 0.28)) { touchOpacity = 0 }
+            try? await Task.sleep(for: .milliseconds(700))
+        }
+    }
+}
+
+/// A keyboard at a glance: four rows, the shape of the thing rather than its
+/// letters. The real `KeyGridView` is a different job — it is the keyboard
+/// being configured, at the size it will be. This one is scenery, and drawing
+/// letters at this scale would only make them unreadable.
+private struct SwipeBackKeyboardMark: View {
+    private static let rows: [[CGFloat]] = [
+        Array(repeating: 1, count: 10),
+        Array(repeating: 1, count: 9),
+        [1.5] + Array(repeating: 1, count: 7) + [1.5],
+        [2.2, 5.4, 2.2],
+    ]
+
+    var body: some View {
+        GeometryReader { proxy in
+            let width = proxy.size.width
+            let inset = width * 0.022
+            let gap = width * 0.013
+            // Ten columns, the way a QWERTY row divides a phone. Every other
+            // row is measured in the same unit, so a wide key stays as wide as
+            // the letters it spans plus the gaps it swallows.
+            let unit = (width - 2 * inset - 9 * gap) / 10
+
+            VStack(spacing: gap * 1.5) {
+                ForEach(Array(Self.rows.enumerated()), id: \.offset) { index, row in
+                    HStack(spacing: gap) {
+                        ForEach(Array(row.enumerated()), id: \.offset) { key, span in
+                            RoundedRectangle(cornerRadius: 5, style: .continuous)
+                                .fill(fill(row: index, key: key, count: row.count))
+                                .frame(width: unit * span + gap * (span - 1))
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, inset)
+            .padding(.top, gap * 2.5)
+            // The bed reaches the bottom edge, the keys stop above the home
+            // indicator — which is what iOS does, and what stops the bottom row
+            // from sitting on top of the line the finger is following.
+            .padding(.bottom, SwipeBackPhone.indicatorRoom)
+        }
+        .background(Color.vocaRecessedSurface)
+    }
+
+    /// Modifier keys sit a shade back, the way they do on the system keyboard.
+    private func fill(row: Int, key: Int, count: Int) -> Color {
+        let isEdge = key == 0 || key == count - 1
+        let isModifier = (row == 2 && isEdge) || (row == 3 && isEdge)
+        return isModifier ? Color.vocaBorder.opacity(0.75) : Color.vocaSurface
+    }
+}
+
+#if DEBUG
+
+#Preview("Swipe back screen") {
+    SwipeBackScreen(reduceMotion: false)
+}
+
+#Preview("Swipe back screen — reduced motion") {
+    SwipeBackScreen(reduceMotion: true)
+}
+#endif

--- a/ios/VocaPhoneApp/App/VocaPhoneApp.swift
+++ b/ios/VocaPhoneApp/App/VocaPhoneApp.swift
@@ -98,6 +98,9 @@ struct VocaPhoneApp: App {
                     }
                 }
                 .onAppear {
+#if DEBUG
+                    DiagnosticLog.mirrorForDeviceTransfer()
+#endif
                     KeyboardPreferences.containingAppIsForeground = true
                     KeyboardPreferences.migrateTypingHapticsIfNeeded()
                     KeyboardPreferences.markQuickDictationRecoveryOfferIfNeeded()
@@ -114,6 +117,9 @@ struct VocaPhoneApp: App {
                     Task.detached(priority: .utility) { EmojiTable.warmUp() }
                 }
                 .onChange(of: scenePhase) { _, phase in
+#if DEBUG
+                    DiagnosticLog.mirrorForDeviceTransfer()
+#endif
                     KeyboardPreferences.containingAppIsForeground = phase == .active
                     guard phase == .active else {
                         // The queue is in memory and does not survive the

--- a/ios/VocaPhoneApp/App/VocaPhoneApp.swift
+++ b/ios/VocaPhoneApp/App/VocaPhoneApp.swift
@@ -59,13 +59,33 @@ struct VocaPhoneApp: App {
     @UIApplicationDelegateAdaptor(VocaPhoneAppDelegate.self) private var appDelegate
     @Environment(\.scenePhase) private var scenePhase
     @State private var coordinator = RecordingCoordinator()
+    @State private var isShowingSettings = false
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(isShowingSettings: $isShowingSettings)
                 .environment(coordinator)
                 .tint(.brand)
-                .onOpenURL { coordinator.handleDeepLink($0) }
+                .onOpenURL { url in
+                    guard url.scheme == AppConfiguration.urlScheme else {
+                        coordinator.handleDeepLink(url)
+                        return
+                    }
+                    switch url.host {
+                    case "settings":
+                        isShowingSettings = true
+                    case "ready":
+                        isShowingSettings = false
+                        // Foregrounding the app is the only supported way for
+                        // its process to own the microphone. If permission has
+                        // not been granted yet, this presents the real system
+                        // request here rather than pretending the keyboard can
+                        // record by itself.
+                        coordinator.setQuickDictationEnabled(true)
+                    default:
+                        coordinator.handleDeepLink(url)
+                    }
+                }
                 .onAppear {
                     KeyboardPreferences.containingAppIsForeground = true
                     KeyboardPreferences.migrateTypingHapticsIfNeeded()

--- a/ios/VocaPhoneApp/App/VocaPhoneApp.swift
+++ b/ios/VocaPhoneApp/App/VocaPhoneApp.swift
@@ -87,10 +87,12 @@ struct VocaPhoneApp: App {
                         // not been granted yet, this presents the real system
                         // request here rather than pretending the keyboard can
                         // record by itself.
-                        // The compact dashboard controls only this live standby
-                        // window. Keep the saved duration and durable Settings
-                        // choice untouched, just as the Live Activity pause does.
-                        coordinator.startQuickDictationWindow()
+                        // The keyboard's VocaPhone switch turned on: a launch,
+                        // arming the usual window with the saved duration. It
+                        // also has to leave Quick Dictation enabled — a window
+                        // armed around a disabled setting works once, then every
+                        // later launch from Start comes up with no window at all.
+                        coordinator.setQuickDictationEnabled(true)
                     default:
                         coordinator.handleDeepLink(url)
                     }

--- a/ios/VocaPhoneApp/App/VocaPhoneApp.swift
+++ b/ios/VocaPhoneApp/App/VocaPhoneApp.swift
@@ -60,10 +60,14 @@ struct VocaPhoneApp: App {
     @Environment(\.scenePhase) private var scenePhase
     @State private var coordinator = RecordingCoordinator()
     @State private var isShowingSettings = false
+    @State private var isShowingQuickDictationReturnGuide = false
 
     var body: some Scene {
         WindowGroup {
-            ContentView(isShowingSettings: $isShowingSettings)
+            ContentView(
+                isShowingSettings: $isShowingSettings,
+                isShowingQuickDictationReturnGuide: $isShowingQuickDictationReturnGuide
+            )
                 .environment(coordinator)
                 .tint(.brand)
                 .onOpenURL { url in
@@ -73,9 +77,11 @@ struct VocaPhoneApp: App {
                     }
                     switch url.host {
                     case "settings":
+                        isShowingQuickDictationReturnGuide = false
                         isShowingSettings = true
                     case "ready":
                         isShowingSettings = false
+                        isShowingQuickDictationReturnGuide = true
                         // Foregrounding the app is the only supported way for
                         // its process to own the microphone. If permission has
                         // not been granted yet, this presents the real system

--- a/ios/VocaPhoneApp/App/VocaPhoneApp.swift
+++ b/ios/VocaPhoneApp/App/VocaPhoneApp.swift
@@ -100,6 +100,7 @@ struct VocaPhoneApp: App {
                 .onAppear {
 #if DEBUG
                     DiagnosticLog.mirrorForDeviceTransfer()
+                    DiagnosticLog.mirrorKeyboardTraceForDeviceTransfer()
 #endif
                     KeyboardPreferences.containingAppIsForeground = true
                     KeyboardPreferences.migrateTypingHapticsIfNeeded()
@@ -119,6 +120,7 @@ struct VocaPhoneApp: App {
                 .onChange(of: scenePhase) { _, phase in
 #if DEBUG
                     DiagnosticLog.mirrorForDeviceTransfer()
+                    DiagnosticLog.mirrorKeyboardTraceForDeviceTransfer()
 #endif
                     KeyboardPreferences.containingAppIsForeground = phase == .active
                     guard phase == .active else {

--- a/ios/VocaPhoneApp/App/VocaPhoneApp.swift
+++ b/ios/VocaPhoneApp/App/VocaPhoneApp.swift
@@ -87,7 +87,10 @@ struct VocaPhoneApp: App {
                         // not been granted yet, this presents the real system
                         // request here rather than pretending the keyboard can
                         // record by itself.
-                        coordinator.setQuickDictationEnabled(true)
+                        // The compact dashboard controls only this live standby
+                        // window. Keep the saved duration and durable Settings
+                        // choice untouched, just as the Live Activity pause does.
+                        coordinator.startQuickDictationWindow()
                     default:
                         coordinator.handleDeepLink(url)
                     }

--- a/ios/VocaPhoneApp/Audio/RecordingSoundFeedback.swift
+++ b/ios/VocaPhoneApp/Audio/RecordingSoundFeedback.swift
@@ -20,6 +20,10 @@ enum RecordingSoundCue: Sendable {
 final class RecordingSoundFeedback {
     private var player: AVAudioPlayer?
 
+    /// The tone is 75 ms; this is it plus the margin a player needs to get it
+    /// out of the speaker before the tap opens.
+    static let cueTail: Duration = .milliseconds(95)
+
     func play(_ cue: RecordingSoundCue) async {
         guard KeyboardPreferences.recordingSoundsEnabled else { return }
         do {
@@ -28,7 +32,11 @@ final class RecordingSoundFeedback {
             player.volume = 0.28
             player.prepareToPlay()
             guard player.play() else { return }
-            try? await Task.sleep(for: .milliseconds(140))
+            // The tone itself, and a hair over it. Capture starts when this
+            // returns — that is what keeps the beep out of the recording — so
+            // every millisecond past the sound is the microphone opening late
+            // for no reason. It was 140 for a 75 ms tone.
+            try? await Task.sleep(for: Self.cueTail)
             if Task.isCancelled { player.stop() }
             if self.player === player { self.player = nil }
         } catch {

--- a/ios/VocaPhoneApp/Models/LocalModelManager.swift
+++ b/ios/VocaPhoneApp/Models/LocalModelManager.swift
@@ -1312,6 +1312,28 @@ final class LocalModelManager {
             }
     }
 
+    /// Drops the loaded engine and its weights.
+    ///
+    /// The model is kept after a dictation so the next one starts instantly,
+    /// which is right for the next dictation and wrong for the ten minutes of
+    /// standby that usually follow it: several hundred megabytes resident for
+    /// nothing. iOS answers memory pressure by shrinking what it allows an app
+    /// *extension*, so the process that pays is the keyboard — launched with
+    /// four megabytes of headroom, killed at once, and the user is handed
+    /// somebody else's keyboard mid-sentence.
+    ///
+    /// The caller decides when: see `RecordingCoordinator`, which waits for the
+    /// window to go quiet and answers memory warnings with this.
+    func releaseLoadedEngines() {
+        guard whisperKit != nil || sherpaRecognizer != nil else { return }
+        whisperKit = nil
+        sherpaRecognizer = nil
+        loadedModelID = nil
+        loadedLanguage = nil
+        loadedTranslateTo = ""
+        loadedQuality = nil
+    }
+
     func delete(_ descriptor: LocalModelDescriptor) throws {
         guard let folder = modelDirectory(for: descriptor.id) else {
             throw LocalModelManagerError.noModelContainer

--- a/ios/VocaPhoneApp/Models/LocalModelManager.swift
+++ b/ios/VocaPhoneApp/Models/LocalModelManager.swift
@@ -1324,14 +1324,16 @@ final class LocalModelManager {
     ///
     /// The caller decides when: see `RecordingCoordinator`, which waits for the
     /// window to go quiet and answers memory warnings with this.
-    func releaseLoadedEngines() {
-        guard whisperKit != nil || sherpaRecognizer != nil else { return }
+    @discardableResult
+    func releaseLoadedEngines() -> Bool {
+        guard whisperKit != nil || sherpaRecognizer != nil else { return false }
         whisperKit = nil
         sherpaRecognizer = nil
         loadedModelID = nil
         loadedLanguage = nil
         loadedTranslateTo = ""
         loadedQuality = nil
+        return true
     }
 
     func delete(_ descriptor: LocalModelDescriptor) throws {

--- a/ios/VocaPhoneApp/Sessions/LiveActivityManager.swift
+++ b/ios/VocaPhoneApp/Sessions/LiveActivityManager.swift
@@ -7,6 +7,17 @@ import UIKit
 final class LiveActivityManager: @unchecked Sendable {
     static let shared = LiveActivityManager()
 
+    /// The activity this process asked for, held rather than looked up.
+    ///
+    /// `Activity.activities` is the reason the Dynamic Island flickered between
+    /// two faces: the array does not contain an activity the instant
+    /// `Activity.request` returns, so two presentations close together — arming
+    /// standby twice, or standby followed by a recording — each saw an empty
+    /// list and each requested one. Two activities is not one activity shown
+    /// twice: iOS splits the island between them and cycles, which is the
+    /// microphone in one glance and the app icon in the next.
+    private var currentActivityID: String?
+
     private var activeSessionID: String?
     private var recordingStartedAt: Date?
     private var standbyExpiresAt: Date?
@@ -287,17 +298,16 @@ final class LiveActivityManager: @unchecked Sendable {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
 
         let content = ActivityContent(state: state, staleDate: staleDate)
-        enqueueActivityMutation {
-            if !Activity<VocaPhoneActivityAttributes>.activities.isEmpty {
-                var isPrimary = true
-                for activity in Activity<VocaPhoneActivityAttributes>.activities {
-                    if isPrimary {
-                        isPrimary = false
-                        await activity.update(content)
-                    } else {
-                        await activity.end(content, dismissalPolicy: .immediate)
-                    }
-                }
+        enqueueActivityMutation { [weak self] in
+            guard let self else { return }
+            // The one this process is driving, waiting out the moment after a
+            // request in which the system has not listed it yet.
+            if let liveID = await self.presentableActivityID() {
+                self.currentActivityID = liveID
+                // Through a nonisolated helper, which is what keeps an
+                // `Activity` — not a `Sendable` type — from being handed from
+                // this actor to ActivityKit's own.
+                await Self.update(id: liveID, to: content)
                 return
             }
 
@@ -308,15 +318,82 @@ final class LiveActivityManager: @unchecked Sendable {
                 startedAt: state.startedAt ?? Date()
             )
             do {
-                _ = try Activity.request(
+                self.currentActivityID = try Activity.request(
                     attributes: attributes,
                     content: content,
                     pushType: nil
-                )
+                ).id
             } catch {
                 // Dictation must continue when the system declines to present
                 // a Live Activity.
+                self.currentActivityID = nil
             }
+        }
+    }
+
+    /// The activity to update: the one this process requested, or one left
+    /// listed by a previous process of this app.
+    ///
+    /// The wait is the whole point. `Activity.request` returns before the
+    /// activity is necessarily in `Activity.activities`, so a second
+    /// presentation arriving in that gap used to find an empty list and request
+    /// a second activity — which is the island showing two faces in turn. A
+    /// presentation is already asynchronous and off the user's path, so waiting
+    /// out that gap costs nothing a person can see.
+    ///
+    /// An activity the user has swiped away, or that the system has retired, is
+    /// not one to update: updating it shows nothing and stops a new one from
+    /// being requested.
+    private func presentableActivityID() async -> String? {
+        if let listed = Self.listedActivity(currentActivityID) { return listed.id }
+        guard currentActivityID != nil else {
+            return Activity<VocaPhoneActivityAttributes>.activities
+                .first(where: Self.isPresentable)?.id
+        }
+        for _ in 0..<Self.registrationPolls {
+            try? await Task.sleep(for: Self.registrationPollInterval)
+            if let listed = Self.listedActivity(currentActivityID) { return listed.id }
+        }
+        // It never arrived, or it has already gone. Either way this process is
+        // not driving it any more.
+        currentActivityID = nil
+        return Activity<VocaPhoneActivityAttributes>.activities
+            .first(where: Self.isPresentable)?.id
+    }
+
+    private static let registrationPolls = 10
+    private static let registrationPollInterval: Duration = .milliseconds(80)
+
+    private static func listedActivity(
+        _ id: String?
+    ) -> Activity<VocaPhoneActivityAttributes>? {
+        guard let id else { return nil }
+        return Activity<VocaPhoneActivityAttributes>.activities
+            .first { $0.id == id && isPresentable($0) }
+    }
+
+    /// Updates the one activity this app is driving and ends every other.
+    ///
+    /// Anything else carrying these attributes is from a process that died
+    /// mid-recording, or is a duplicate: two activities are not one activity
+    /// shown twice, they are two faces the island cycles between.
+    private nonisolated static func update(
+        id: String,
+        to content: ActivityContent<VocaPhoneActivityAttributes.ContentState>
+    ) async {
+        for activity in Activity<VocaPhoneActivityAttributes>.activities {
+            if activity.id == id {
+                await activity.update(content)
+            } else {
+                await activity.end(content, dismissalPolicy: .immediate)
+            }
+        }
+    }
+
+    private static func isPresentable(_ activity: Activity<VocaPhoneActivityAttributes>) -> Bool {
+        switch activity.activityState {
+        case .active, .stale: true
+        default: false
         }
     }
 
@@ -325,10 +402,20 @@ final class LiveActivityManager: @unchecked Sendable {
         dismissalPolicy: ActivityUIDismissalPolicy
     ) {
         let content = ActivityContent(state: state, staleDate: nil)
-        enqueueActivityMutation {
-            for activity in Activity<VocaPhoneActivityAttributes>.activities {
-                await activity.end(content, dismissalPolicy: dismissalPolicy)
-            }
+        enqueueActivityMutation { [weak self] in
+            // Cleared first: a presentation that arrives while these ends are
+            // in flight must make a new activity rather than update a dying one.
+            self?.currentActivityID = nil
+            await Self.endEverything(with: content, dismissalPolicy: dismissalPolicy)
+        }
+    }
+
+    private nonisolated static func endEverything(
+        with content: ActivityContent<VocaPhoneActivityAttributes.ContentState>,
+        dismissalPolicy: ActivityUIDismissalPolicy
+    ) async {
+        for activity in Activity<VocaPhoneActivityAttributes>.activities {
+            await activity.end(content, dismissalPolicy: dismissalPolicy)
         }
     }
 

--- a/ios/VocaPhoneApp/Sessions/LiveActivityManager.swift
+++ b/ios/VocaPhoneApp/Sessions/LiveActivityManager.swift
@@ -24,6 +24,7 @@ final class LiveActivityManager: @unchecked Sendable {
     private var standbyRequested = false
     private var transitionGeneration = 0
     private var pendingStandbyTask: Task<Void, Never>?
+    private var pendingEndTask: Task<Void, Never>?
     private var activityMutationTask: Task<Void, Never>?
     private var lifecycleObservers: [NSObjectProtocol] = []
     private var isAppExiting = false
@@ -131,7 +132,7 @@ final class LiveActivityManager: @unchecked Sendable {
         guard activeSessionID == nil else { return }
 
         beginTransition()
-        endAll(
+        scheduleEndAll(
             state: VocaPhoneActivityAttributes.ContentState(
                 status: "Quick Dictation off",
                 canFinish: false,
@@ -206,7 +207,7 @@ final class LiveActivityManager: @unchecked Sendable {
         )
 
         guard standbyRequested, let standbyExpiresAt, standbyExpiresAt > Date() else {
-            endAll(
+            scheduleEndAll(
                 state: finishedState,
                 dismissalPolicy: seconds > 0
                     ? .after(Date().addingTimeInterval(seconds))
@@ -286,6 +287,10 @@ final class LiveActivityManager: @unchecked Sendable {
     }
 
     private func beginTransition() {
+        // Whatever is starting now takes over the activity a deferred end was
+        // about to destroy. See ``scheduleEndAll``.
+        pendingEndTask?.cancel()
+        pendingEndTask = nil
         pendingStandbyTask?.cancel()
         pendingStandbyTask = nil
         transitionGeneration &+= 1
@@ -407,6 +412,36 @@ final class LiveActivityManager: @unchecked Sendable {
             // in flight must make a new activity rather than update a dying one.
             self?.currentActivityID = nil
             await Self.endEverything(with: content, dismissalPolicy: dismissalPolicy)
+        }
+    }
+
+    /// The gap between "standby is over" and "recording has begun".
+    ///
+    /// Those two arrive within the same second of each other, in that order,
+    /// for every dictation: the window is cleared as the microphone is taken,
+    /// and the session's own presentation follows. Ending the activity in
+    /// between destroyed the one the next presentation would have updated, so
+    /// the island blinked out and a new one grew back — twice a dictation, once
+    /// each way. Waiting this long before ending means the next presentation
+    /// finds it and updates it, and the island simply changes what it says.
+    ///
+    /// Long enough to cover that handover, short enough that an activity nobody
+    /// takes over still goes promptly.
+    private static let endGrace: Duration = .seconds(1)
+
+    /// Ends every activity unless something claims the island first.
+    private func scheduleEndAll(
+        state: VocaPhoneActivityAttributes.ContentState,
+        dismissalPolicy: ActivityUIDismissalPolicy
+    ) {
+        pendingEndTask?.cancel()
+        pendingEndTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: Self.endGrace)
+            guard !Task.isCancelled, let self else { return }
+            self.pendingEndTask = nil
+            // A standby that re-armed, or a session that started, has taken it.
+            guard !self.standbyRequested, self.activeSessionID == nil else { return }
+            self.endAll(state: state, dismissalPolicy: dismissalPolicy)
         }
     }
 

--- a/ios/VocaPhoneApp/Sessions/LiveActivityManager.swift
+++ b/ios/VocaPhoneApp/Sessions/LiveActivityManager.swift
@@ -25,6 +25,8 @@ final class LiveActivityManager: @unchecked Sendable {
     private var transitionGeneration = 0
     private var pendingStandbyTask: Task<Void, Never>?
     private var pendingEndTask: Task<Void, Never>?
+    /// When ``currentActivityID`` was requested, so a stale id is not waited on.
+    private var requestedAt: Date?
     private var activityMutationTask: Task<Void, Never>?
     private var lifecycleObservers: [NSObjectProtocol] = []
     private var isAppExiting = false
@@ -328,10 +330,12 @@ final class LiveActivityManager: @unchecked Sendable {
                     content: content,
                     pushType: nil
                 ).id
+                self.requestedAt = Date()
             } catch {
                 // Dictation must continue when the system declines to present
                 // a Live Activity.
                 self.currentActivityID = nil
+                self.requestedAt = nil
             }
         }
     }
@@ -351,23 +355,31 @@ final class LiveActivityManager: @unchecked Sendable {
     /// being requested.
     private func presentableActivityID() async -> String? {
         if let listed = Self.listedActivity(currentActivityID) { return listed.id }
-        guard currentActivityID != nil else {
-            return Activity<VocaPhoneActivityAttributes>.activities
-                .first(where: Self.isPresentable)?.id
-        }
-        for _ in 0..<Self.registrationPolls {
-            try? await Task.sleep(for: Self.registrationPollInterval)
-            if let listed = Self.listedActivity(currentActivityID) { return listed.id }
+        // Only an activity this process asked for *just now* is worth waiting
+        // for. An id left over from one the system has since retired is not
+        // coming back, and waiting on it was a delay the user could feel: every
+        // dictation that followed a finished one paid it before ActivityKit was
+        // so much as asked.
+        if currentActivityID != nil, let requestedAt, requestedAt.timeIntervalSinceNow > -Self.registrationWindow {
+            for _ in 0..<Self.registrationPolls {
+                try? await Task.sleep(for: Self.registrationPollInterval)
+                if let listed = Self.listedActivity(currentActivityID) { return listed.id }
+            }
         }
         // It never arrived, or it has already gone. Either way this process is
         // not driving it any more.
         currentActivityID = nil
+        requestedAt = nil
         return Activity<VocaPhoneActivityAttributes>.activities
             .first(where: Self.isPresentable)?.id
     }
 
-    private static let registrationPolls = 10
-    private static let registrationPollInterval: Duration = .milliseconds(80)
+    /// Six polls of fifty milliseconds: three hundred in the worst case, and
+    /// only in the moments right after a request.
+    private static let registrationPolls = 6
+    private static let registrationPollInterval: Duration = .milliseconds(50)
+    /// How long after a request the system list is still worth waiting on.
+    private static let registrationWindow: TimeInterval = 2
 
     private static func listedActivity(
         _ id: String?
@@ -411,6 +423,7 @@ final class LiveActivityManager: @unchecked Sendable {
             // Cleared first: a presentation that arrives while these ends are
             // in flight must make a new activity rather than update a dying one.
             self?.currentActivityID = nil
+            self?.requestedAt = nil
             await Self.endEverything(with: content, dismissalPolicy: dismissalPolicy)
         }
     }

--- a/ios/VocaPhoneApp/Sessions/LiveActivityManager.swift
+++ b/ios/VocaPhoneApp/Sessions/LiveActivityManager.swift
@@ -25,6 +25,11 @@ final class LiveActivityManager: @unchecked Sendable {
     private var transitionGeneration = 0
     private var pendingStandbyTask: Task<Void, Never>?
     private var pendingEndTask: Task<Void, Never>?
+    /// What a deferred end would say, so that backgrounding can say it now.
+    private var pendingEnd: (
+        state: VocaPhoneActivityAttributes.ContentState,
+        dismissalPolicy: ActivityUIDismissalPolicy
+    )?
     /// When ``currentActivityID`` was requested, so a stale id is not waited on.
     private var requestedAt: Date?
     private var activityMutationTask: Task<Void, Never>?
@@ -46,6 +51,20 @@ final class LiveActivityManager: @unchecked Sendable {
                 MainActor.assumeIsolated {
                     self?.endBeforeProcessExit(reason: "scene disconnected")
                 }
+            }
+        )
+        // A deferred end waits a second for something to take the activity
+        // over. The app is usually in the background while all of this happens
+        // — the keyboard's switch turning VocaPhone off is exactly that — and a
+        // process suspended inside that second would leave the island showing a
+        // window that has ended, until the next launch noticed the orphan.
+        lifecycleObservers.append(
+            center.addObserver(
+                forName: UIApplication.didEnterBackgroundNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.flushPendingEnd() }
             }
         )
         lifecycleObservers.append(
@@ -293,6 +312,7 @@ final class LiveActivityManager: @unchecked Sendable {
         // about to destroy. See ``scheduleEndAll``.
         pendingEndTask?.cancel()
         pendingEndTask = nil
+        pendingEnd = nil
         pendingStandbyTask?.cancel()
         pendingStandbyTask = nil
         transitionGeneration &+= 1
@@ -448,14 +468,26 @@ final class LiveActivityManager: @unchecked Sendable {
         dismissalPolicy: ActivityUIDismissalPolicy
     ) {
         pendingEndTask?.cancel()
+        pendingEnd = (state, dismissalPolicy)
         pendingEndTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: Self.endGrace)
             guard !Task.isCancelled, let self else { return }
             self.pendingEndTask = nil
+            self.pendingEnd = nil
             // A standby that re-armed, or a session that started, has taken it.
             guard !self.standbyRequested, self.activeSessionID == nil else { return }
             self.endAll(state: state, dismissalPolicy: dismissalPolicy)
         }
+    }
+
+    /// Ends now what was going to be ended in a moment.
+    private func flushPendingEnd() {
+        guard let pending = pendingEnd else { return }
+        pendingEndTask?.cancel()
+        pendingEndTask = nil
+        pendingEnd = nil
+        guard !standbyRequested, activeSessionID == nil else { return }
+        endAll(state: pending.state, dismissalPolicy: pending.dismissalPolicy)
     }
 
     private nonisolated static func endEverything(

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -1435,6 +1435,26 @@ final class RecordingCoordinator {
               !recorder.isRecording
         else { return }
 
+        // Already armed on the same terms. Several paths arm on return from the
+        // background — the scene going active, the pause being cleared, the
+        // keyboard's own switch — and they arrive within a second of each
+        // other. Each one used to tear the window down and build another: a
+        // Live Activity ended and a new one requested, which is the Dynamic
+        // Island blinking out and back for nothing. Renewing the lease says the
+        // same thing without the flicker.
+        if recorder.isStandbyActive,
+           quickDictationDuration == KeyboardPreferences.quickDictationDuration,
+           let expiresAt = quickDictationExpiresAt,
+           expiresAt > Date(),
+           let availability = try? store.loadQuickDictationAvailability(),
+           availability.isReady()
+        {
+            try? store.saveQuickDictationAvailability(
+                availability.renewingLease(KeyboardPreferences.quickDictationDuration)
+            )
+            return
+        }
+
         clearQuickDictationMarker()
         let duration = KeyboardPreferences.quickDictationDuration
         do {

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import SwiftUI
 import UIKit
 
@@ -58,6 +59,10 @@ final class RecordingCoordinator {
     private let store = SharedStore.shared
     private var pollingTask: Task<Void, Never>?
     private var pipelineTask: Task<Void, Never>?
+    /// Releases the loaded speech model once a window has gone quiet. See
+    /// ``LocalModelManager/releaseLoadedEngines()``.
+    private var localEngineReleaseTask: Task<Void, Never>?
+    private var memoryWarningObservation: (any NSObjectProtocol)?
     private var pipelineSessionID: UUID?
     private var cancellationMonitorTask: Task<Void, Never>?
     private var quickDictationWatcherTask: Task<Void, Never>?
@@ -780,6 +785,9 @@ final class RecordingCoordinator {
     private func startSession(id: UUID) async {
         guard startingSessionID == nil || startingSessionID == id else { return }
         guard startingSessionID != id else { return }
+        // A dictation is starting; the model it may need must not be dropped
+        // out from under it by a release scheduled after the last one.
+        localEngineReleaseTask?.cancel()
         startingSessionID = id
         defer { startingSessionID = nil }
 
@@ -935,13 +943,48 @@ final class RecordingCoordinator {
     private func startPipeline(_ record: SessionRecord) {
         guard pipelineSessionID != record.sessionID else { return }
         pipelineTask?.cancel()
+        localEngineReleaseTask?.cancel()
         pipelineSessionID = record.sessionID
         pipelineTask = Task { [weak self] in
             await self?.finalizeAndTranscribe(record)
             guard let self, self.pipelineSessionID == record.sessionID else { return }
             self.pipelineSessionID = nil
             self.pipelineTask = nil
+            self.scheduleLocalEngineRelease()
         }
+    }
+
+    /// How long a loaded model outlives the dictation that built it.
+    ///
+    /// Long enough that a second thought — the reply after the reply — still
+    /// starts instantly, and far short of the ten-minute window it used to sit
+    /// through. What that residency costs is not paid by this app: iOS answers
+    /// memory pressure by shrinking what an extension may have, and the
+    /// keyboard is then killed as it comes back, which iOS answers by switching
+    /// the user to another keyboard.
+    private static let localEngineIdleRelease: Duration = .seconds(30)
+
+    private func scheduleLocalEngineRelease() {
+        localEngineReleaseTask?.cancel()
+        localEngineReleaseTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.localEngineIdleRelease)
+            guard !Task.isCancelled else { return }
+            self?.releaseLocalEnginesIfIdle()
+        }
+    }
+
+    /// Never mid-dictation: a recording in flight is about to need the model,
+    /// and a transcription in flight is holding it.
+    private func releaseLocalEnginesIfIdle() {
+        guard !isInert, pipelineTask == nil, !recorder.isRecording, startingSessionID == nil
+        else { return }
+        localModels.releaseLoadedEngines()
+        // The number this exists to move, recorded where the keyboard's own
+        // headroom is recorded, so the two can be read against each other.
+        DiagnosticLog.record(
+            .localEngineReleased,
+            metadata: .megabytesAvailable(Int(os_proc_available_memory() / (1024 * 1024)))
+        )
     }
 
     private func beginPolling() {
@@ -1547,6 +1590,16 @@ final class RecordingCoordinator {
                 }
             }
         )
+        // The one warning iOS gives before it starts killing things. The
+        // keyboard cannot hear it — it is a different process, and the one
+        // whose allowance shrinks first — so the app answers on its behalf.
+        memoryWarningObservation = NotificationCenter.default.addObserver(
+            forName: UIApplication.didReceiveMemoryWarningNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.releaseLocalEnginesIfIdle() }
+        }
         darwinObservations.append(
             VocaPhoneDarwinCenter.observe(.closeVocaPhoneRequested) { [weak self] in
                 Task { @MainActor [weak self] in

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -812,8 +812,17 @@ final class RecordingCoordinator {
             try? store.save(record)
             clearQuickDictationMarker()
             activeRecord = record
-            let granted = await withCheckedContinuation { continuation in
-                recorder.requestPermission { continuation.resume(returning: $0) }
+            // Asked only when the answer is not already known. Every dictation
+            // paid a cross-process round trip to be told what
+            // `AVAudioApplication` had already cached, in the moment between
+            // the tap and the microphone opening.
+            let granted: Bool
+            if recorder.recordPermission == .granted {
+                granted = true
+            } else {
+                granted = await withCheckedContinuation { continuation in
+                    recorder.requestPermission { continuation.resume(returning: $0) }
+                }
             }
             guard granted else {
                 try record.transition(to: .permissionDenied)

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -479,6 +479,29 @@ final class RecordingCoordinator {
         debugQuickDictation("pause cleared on foreground")
     }
 
+    /// Starts one live standby window from the keyboard dashboard without
+    /// rewriting the durable Settings switch or its selected duration. This is
+    /// intentionally different from `setQuickDictationEnabled`: the dashboard
+    /// is a now control, while Settings decides what future launches re-arm.
+    func startQuickDictationWindow() {
+        guard !isInert else { return }
+        KeyboardPreferences.quickDictationPausedUntilRelaunch = false
+        if recorder.recordPermission == .granted {
+            armQuickDictation(allowWhenDisabled: true)
+            return
+        }
+        recorder.requestPermission { [weak self] granted in
+            guard let self else { return }
+            if granted {
+                self.message = "Microphone permission granted."
+                self.armQuickDictation(allowWhenDisabled: true)
+            } else {
+                self.message = "Microphone permission denied."
+            }
+            self.refreshSetupStatus()
+        }
+    }
+
     func setQuickDictationEnabled(_ enabled: Bool) {
         guard !isInert else { return }
         KeyboardPreferences.quickDictationEnabled = enabled
@@ -1366,8 +1389,8 @@ final class RecordingCoordinator {
             && record.sourceDocumentID != "in-app-test"
     }
 
-    private func armQuickDictation() {
-        guard KeyboardPreferences.quickDictationArmable,
+    private func armQuickDictation(allowWhenDisabled: Bool = false) {
+        guard (KeyboardPreferences.quickDictationArmable || allowWhenDisabled),
               audioSessionAvailable,
               !recorder.isRecording
         else { return }

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -63,6 +63,7 @@ final class RecordingCoordinator {
     /// ``LocalModelManager/releaseLoadedEngines()``.
     private var localEngineReleaseTask: Task<Void, Never>?
     private var memoryWarningObservation: (any NSObjectProtocol)?
+    private var memoryPressureSource: (any DispatchSourceMemoryPressure)?
     private var pipelineSessionID: UUID?
     private var cancellationMonitorTask: Task<Void, Never>?
     private var quickDictationWatcherTask: Task<Void, Never>?
@@ -954,15 +955,16 @@ final class RecordingCoordinator {
         }
     }
 
-    /// How long a loaded model outlives the dictation that built it.
+    /// The backstop, not the mechanism.
     ///
-    /// Long enough that a second thought — the reply after the reply — still
-    /// starts instantly, and far short of the ten-minute window it used to sit
-    /// through. What that residency costs is not paid by this app: iOS answers
-    /// memory pressure by shrinking what an extension may have, and the
-    /// keyboard is then killed as it comes back, which iOS answers by switching
-    /// the user to another keyboard.
-    private static let localEngineIdleRelease: Duration = .seconds(30)
+    /// A clock is the wrong instrument here: thirty seconds of quiet costs the
+    /// next dictation the two or three seconds of rebuilding a model nothing
+    /// was short of, while ten minutes of it can starve the keyboard in the
+    /// first thirty seconds. So the model is dropped when memory is actually
+    /// wanted — the system says so, or the keyboard says so, or the standby
+    /// window it belonged to has ended — and this is only the long stop for a
+    /// window that stays armed all day with nothing happening in it.
+    private static let localEngineIdleRelease: Duration = .seconds(10 * 60)
 
     private func scheduleLocalEngineRelease() {
         localEngineReleaseTask?.cancel()
@@ -973,10 +975,14 @@ final class RecordingCoordinator {
         }
     }
 
-    /// Never mid-dictation: a recording in flight is about to need the model,
-    /// and a transcription in flight is holding it.
+    /// Never mid-dictation: a recording in flight is about to need the model, a
+    /// transcription in flight is holding it, and a session that has stopped
+    /// recording but not yet reached its end is between the two — which is
+    /// exactly where the finish path clears standby, so the record's own state
+    /// is checked rather than the pipeline alone.
     private func releaseLocalEnginesIfIdle() {
-        guard !isInert, pipelineTask == nil, !recorder.isRecording, startingSessionID == nil
+        guard !isInert, pipelineTask == nil, !recorder.isRecording, startingSessionID == nil,
+              activeRecord.map(\.state.isTerminal) ?? true
         else { return }
         localModels.releaseLoadedEngines()
         // The number this exists to move, recorded where the keyboard's own
@@ -1533,6 +1539,11 @@ final class RecordingCoordinator {
         clearQuickDictationMarker()
         recorder.stopStandby(deactivateAudioSession: deactivateAudioSession)
         liveActivity.stopStandby()
+        // The window the model was kept warm for has ended — by expiry, by the
+        // switch in the keyboard, or by the Live Activity. Nothing is coming
+        // that needs it, and the next dictation starts by opening this app
+        // anyway, which is seconds this load can hide behind.
+        releaseLocalEnginesIfIdle()
     }
 
     private func clearQuickDictationMarker() {
@@ -1590,9 +1601,8 @@ final class RecordingCoordinator {
                 }
             }
         )
-        // The one warning iOS gives before it starts killing things. The
-        // keyboard cannot hear it — it is a different process, and the one
-        // whose allowance shrinks first — so the app answers on its behalf.
+        // The one warning iOS gives this process before it starts killing
+        // things.
         memoryWarningObservation = NotificationCenter.default.addObserver(
             forName: UIApplication.didReceiveMemoryWarningNotification,
             object: nil,
@@ -1600,6 +1610,31 @@ final class RecordingCoordinator {
         ) { [weak self] _ in
             MainActor.assumeIsolated { self?.releaseLocalEnginesIfIdle() }
         }
+        // And the one the *system* gives, which arrives earlier and for the
+        // whole device. This is the signal that matters: the app is rarely
+        // short of memory itself — it has gigabytes — while the keyboard's
+        // allowance is being cut to single megabytes on the same phone at the
+        // same moment.
+        let pressure = DispatchSource.makeMemoryPressureSource(
+            eventMask: [.warning, .critical],
+            queue: .main
+        )
+        pressure.setEventHandler { [weak self] in
+            MainActor.assumeIsolated { self?.releaseLocalEnginesIfIdle() }
+        }
+        pressure.resume()
+        memoryPressureSource = pressure
+        // The keyboard, starving in a process that cannot free what is holding
+        // the memory. It is the most direct evidence there is that this model
+        // has to go: somebody is typing, and their keyboard is about to be
+        // taken away from them.
+        darwinObservations.append(
+            VocaPhoneDarwinCenter.observe(.keyboardLowOnMemory) { [weak self] in
+                Task { @MainActor [weak self] in
+                    self?.releaseLocalEnginesIfIdle()
+                }
+            }
+        )
         darwinObservations.append(
             VocaPhoneDarwinCenter.observe(.closeVocaPhoneRequested) { [weak self] in
                 Task { @MainActor [weak self] in

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -70,7 +70,10 @@ final class RecordingCoordinator {
     private let liveActivity = LiveActivityManager.shared
     private let streamingBridge = StreamingAudioBridge()
     private let soundFeedback = RecordingSoundFeedback()
-    private var localSherpaSession: SherpaIncrementalSession?
+    /// Held as the work rather than the result: the ONNX graph takes 1.8-2.7 s
+    /// to build the first time in a process, and nothing before the transcript
+    /// needs it. Awaited once, at finish.
+    private var localSherpaSession: Task<SherpaIncrementalSession?, Never>?
     let localModels: LocalModelManager
 
     var isRecording: Bool {
@@ -329,7 +332,20 @@ final class RecordingCoordinator {
         installDarwinObservers()
         loadGatewaySettings()
         refreshSetupStatus()
+        adoptPendingHandoff()
         DiagnosticLog.record(.appStarted)
+    }
+
+    /// A hand-off is the only reason this app is opened by something other than
+    /// the user, and the record that says so is already on disk. Read here
+    /// rather than in the first `task`, which runs after the first frame: the
+    /// home screen would paint, and then be covered — and a flash of somewhere
+    /// else, after a microphone was tapped, reads as the request being lost.
+    private func adoptPendingHandoff() {
+        guard let record = try? store.mostRecent(),
+              KeyboardHandoffPresentation.shouldPresent(record)
+        else { return }
+        activeRecord = record
     }
 
 #if DEBUG
@@ -652,8 +668,7 @@ final class RecordingCoordinator {
         pipelineSessionID = nil
         cancellationMonitorTask?.cancel()
         Task { await streamingBridge.cancel() }
-        localSherpaSession?.cancel()
-        localSherpaSession = nil
+        discardIncrementalSession()
         guard var record = activeRecord else { return }
         let shouldRemainReady = shouldKeepQuickDictationReady(after: record)
         recorder.cancelSession(keepAudioSessionActive: shouldRemainReady)
@@ -818,19 +833,20 @@ final class RecordingCoordinator {
                 includeLocalModelChunks: shouldUseSherpaIncremental
             )
             if shouldUseSherpaIncremental, let chunks = recorder.localPcmChunks {
-                do {
-                    // Awaited rather than built inline: the ONNX graph now loads
-                    // off the main actor, so the capture that has already
-                    // started is not competing with a synchronous disk read.
-                    localSherpaSession = try await localModels.startSherpaIncrementalSession(
+                // Started, not awaited. Capture is already running and the
+                // chunks queue while the graph builds, so waiting here bought
+                // nothing and cost everything downstream of it: the recording
+                // state, the Live Activity, and the Finish button the user
+                // reaches for the moment they have swiped back.
+                //
+                // A failure keeps the intact WAV fallback — the finish path
+                // retries the same model in batch mode.
+                let language = record.language
+                localSherpaSession = Task { [localModels] in
+                    try? await localModels.startSherpaIncrementalSession(
                         chunks: chunks,
-                        language: record.language
+                        language: language
                     )
-                } catch {
-                    // Keep the intact WAV fallback. The normal finish path will
-                    // retry the same selected model in batch mode if preparing
-                    // the incremental engine fails.
-                    localSherpaSession = nil
                 }
             }
             if let client = gatewayClient, let chunks = recorder.pcmChunks {
@@ -1160,7 +1176,9 @@ final class RecordingCoordinator {
             try store.save(record)
             activeRecord = record
 
-            let incremental = localSherpaSession
+            // The only place the graph is waited for. By now the user has
+            // spoken, which is usually longer than it took to build.
+            let incremental = await localSherpaSession?.value
             localSherpaSession = nil
             // A chunk the queue refused never reached the decoder, so the
             // session cannot know it is short. Only the recorder can say.
@@ -1313,6 +1331,14 @@ final class RecordingCoordinator {
         message = record.sourceDocumentID == "in-app-test"
             ? "Transcript ready. Your gateway is working end to end."
             : "Transcript ready. Return to the keyboard to insert it."
+    }
+
+    /// Drops the incremental engine whether it finished building or not.
+    private func discardIncrementalSession() {
+        guard let building = localSherpaSession else { return }
+        localSherpaSession = nil
+        building.cancel()
+        Task { await building.value?.cancel() }
     }
 
     private func persistMeter(_ levels: [Float]) {
@@ -1540,8 +1566,7 @@ final class RecordingCoordinator {
             pipelineTask = nil
             pipelineSessionID = nil
             await streamingBridge.cancel()
-            localSherpaSession?.cancel()
-            localSherpaSession = nil
+            discardIncrementalSession()
             let shouldRemainReady = shouldKeepQuickDictationReady(after: shared)
             recorder.cancelSession(keepAudioSessionActive: shouldRemainReady)
             let headline = shared.state == .expired

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -479,29 +479,6 @@ final class RecordingCoordinator {
         debugQuickDictation("pause cleared on foreground")
     }
 
-    /// Starts one live standby window from the keyboard dashboard without
-    /// rewriting the durable Settings switch or its selected duration. This is
-    /// intentionally different from `setQuickDictationEnabled`: the dashboard
-    /// is a now control, while Settings decides what future launches re-arm.
-    func startQuickDictationWindow() {
-        guard !isInert else { return }
-        KeyboardPreferences.quickDictationPausedUntilRelaunch = false
-        if recorder.recordPermission == .granted {
-            armQuickDictation(allowWhenDisabled: true)
-            return
-        }
-        recorder.requestPermission { [weak self] granted in
-            guard let self else { return }
-            if granted {
-                self.message = "Microphone permission granted."
-                self.armQuickDictation(allowWhenDisabled: true)
-            } else {
-                self.message = "Microphone permission denied."
-            }
-            self.refreshSetupStatus()
-        }
-    }
-
     func setQuickDictationEnabled(_ enabled: Bool) {
         guard !isInert else { return }
         KeyboardPreferences.quickDictationEnabled = enabled
@@ -551,6 +528,20 @@ final class RecordingCoordinator {
         DiagnosticLog.record(
             .quickDictationStopped,
             metadata: .reason(.userRequested)
+        )
+    }
+
+    /// The keyboard's VocaPhone switch turned off — the same end as swiping
+    /// VocaPhone away in the app switcher. The live window, its microphone and
+    /// its Live Activity go; Quick Dictation, its duration and the pause flag
+    /// stay exactly as they were, so the next launch (the switch turned back
+    /// on, or the keyboard's Start) arms the usual window again.
+    func closeFromKeyboard() {
+        guard !isInert else { return }
+        clearQuickDictationReadiness(deactivateAudioSession: true)
+        DiagnosticLog.record(
+            .quickDictationStopped,
+            metadata: .reason(.closedFromKeyboard)
         )
     }
 
@@ -1389,8 +1380,8 @@ final class RecordingCoordinator {
             && record.sourceDocumentID != "in-app-test"
     }
 
-    private func armQuickDictation(allowWhenDisabled: Bool = false) {
-        guard (KeyboardPreferences.quickDictationArmable || allowWhenDisabled),
+    private func armQuickDictation() {
+        guard KeyboardPreferences.quickDictationArmable,
               audioSessionAvailable,
               !recorder.isRecording
         else { return }
@@ -1451,9 +1442,13 @@ final class RecordingCoordinator {
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(2))
                 guard let self else { return }
+                // The keyboard's VocaPhone switch removes the marker itself
+                // before it asks this process to close, so a dropped Darwin
+                // ping still ends the window here rather than being rewritten.
                 guard refreshedAvailability.expiresAt > Date(),
                       self.recorder.isStandbyActive,
-                      self.audioSessionAvailable
+                      self.audioSessionAvailable,
+                      (try? self.store.loadQuickDictationAvailability()) != nil
                 else {
                     self.clearQuickDictationReadiness(deactivateAudioSession: true)
                     return
@@ -1549,6 +1544,13 @@ final class RecordingCoordinator {
                 Task { @MainActor [weak self] in
                     DiagnosticLog.record(.stopQuickDictationRequested)
                     self?.pauseQuickDictation()
+                }
+            }
+        )
+        darwinObservations.append(
+            VocaPhoneDarwinCenter.observe(.closeVocaPhoneRequested) { [weak self] in
+                Task { @MainActor [weak self] in
+                    self?.closeFromKeyboard()
                 }
             }
         )

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -993,7 +993,9 @@ final class RecordingCoordinator {
         guard !isInert, pipelineTask == nil, !recorder.isRecording, startingSessionID == nil,
               activeRecord.map(\.state.isTerminal) ?? true
         else { return }
-        localModels.releaseLoadedEngines()
+        // Only when something was actually let go: a line saying a release
+        // recovered nothing is a line that makes the log harder to read.
+        guard localModels.releaseLoadedEngines() else { return }
         // The number this exists to move, recorded where the keyboard's own
         // headroom is recorded, so the two can be read against each other.
         DiagnosticLog.record(

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -207,7 +207,7 @@ final class DictationSurfaceState: ObservableObject {
     var onGlobe: (() -> Void)?
     var onOpenSettings: (() -> Void)?
     var onDashboardVisibilityChanged: ((Bool) -> Void)?
-    var onQuickDictationReadinessChanged: ((Bool) -> Void)?
+    var onVocaPhoneRunningChanged: ((Bool) -> Void)?
     var onCandidate: ((TypingCandidate) -> Void)? {
         get { typing.onCandidate }
         set { typing.onCandidate = newValue }
@@ -254,21 +254,21 @@ final class DictationSurfaceState: ObservableObject {
         onDashboardVisibilityChanged?(presented)
     }
 
-    /// Controls the live standby window shown by this dashboard. The durable
-    /// Settings preference and its ten-minute duration are deliberately not
-    /// changed here; this is the same temporary pause/resume contract as the
-    /// Live Activity control.
-    func setQuickDictationReady(_ ready: Bool) {
-        guard quickDictationReady != ready else { return }
-        quickDictationReady = ready
-        if !ready {
+    /// The dashboard's VocaPhone switch: on opens VocaPhone, off closes it the
+    /// way the app switcher does. It says whether VocaPhone is running, not
+    /// whether Quick Dictation is enabled: off leaves that setting and its
+    /// duration alone, so the next launch from Start arms the same window.
+    func setVocaPhoneRunning(_ running: Bool) {
+        guard quickDictationReady != running else { return }
+        quickDictationReady = running
+        if !running {
             // Match the keyboard-first behavior of the reference flow: once
             // standby is off, the dashboard has no follow-up action to offer.
             // Close it in the same tap so the typing keys and Start control are
             // immediately visible again.
             setCompactDashboardPresented(false)
         }
-        onQuickDictationReadinessChanged?(ready)
+        onVocaPhoneRunningChanged?(running)
     }
 
     /// Persists the choice, exactly as the dictation bar's own menu does.
@@ -721,16 +721,16 @@ struct DictationSurfaceView: View {
             .accessibilityLabel("Open VocaPhone settings")
 
             Toggle(
-                "Quick Dictation",
+                "VocaPhone",
                 isOn: Binding(
                     get: { state.quickDictationReady },
-                    set: { state.setQuickDictationReady($0) }
+                    set: { state.setVocaPhoneRunning($0) }
                 )
             )
             .labelsHidden()
             .toggleStyle(.switch)
             .tint(dashboardAccent)
-            .accessibilityHint("Keeps VocaPhone ready for dictation from the keyboard")
+            .accessibilityHint("Opens or closes VocaPhone. Quick Dictation settings stay as they are.")
         }
     }
 

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -27,6 +27,30 @@ final class DictationSurfaceState: ObservableObject {
         get { storedStyle }
         set { change(&storedStyle, to: newValue) }
     }
+    /// Whether anything has been typed since this keyboard instance came up.
+    ///
+    /// Only the compact row cares: it puts the action button in the middle
+    /// until there is something to type beside it, and that has to be a latch
+    /// rather than a question about the current candidates. It is not reset on
+    /// every appearance — coming back from vocaphone is the same session, and
+    /// resetting here flew the microphone to the middle and back.
+    private var storedHasTypedThisSession: Bool = false
+    var hasTypedThisSession: Bool {
+        get { storedHasTypedThisSession }
+        set { change(&storedHasTypedThisSession, to: newValue) }
+    }
+    /// The compact arrangement, for looking at in the keyboard lab.
+    ///
+    /// Two glass circles on the left and a solid green one on the right is the
+    /// shipping row. This collapses the left pair behind one ellipsis menu and
+    /// turns the right circle into a fixed-width glass capsule — the same row
+    /// with less on it, which is the sort of thing that has to be seen beside
+    /// the original rather than argued about. Debug builds only.
+    private var storedUsesCompactControls: Bool = false
+    var usesCompactControls: Bool {
+        get { storedUsesCompactControls }
+        set { change(&storedUsesCompactControls, to: newValue) }
+    }
     private var storedShowsGlobeKey: Bool = false
     var showsGlobeKey: Bool {
         get { storedShowsGlobeKey }
@@ -198,6 +222,7 @@ final class DictationSurfaceState: ObservableObject {
     func refreshPreferences() {
         language = KeyboardPreferences.effectiveTranscriptionLanguage
         style = KeyboardPreferences.writingStyle
+        usesCompactControls = KeyboardPreferences.compactControlsEnabled
     }
 
     /// Persists the choice, exactly as the dictation bar's own menu does.
@@ -320,6 +345,10 @@ final class TypingRowState: ObservableObject {
 struct DictationSurfaceView: View {
     @ObservedObject var state: DictationSurfaceState
     @Namespace private var animationNamespace
+    /// Layout springs stay off until the first real frame has landed. The
+    /// keyboard restores a session in `viewDidLoad`; animating idle into
+    /// recording is the blink after swiping back from vocaphone.
+    @State private var layoutAnimationEnabled = false
 
     private static let brandGreen = Color(red: 13 / 255, green: 104 / 255, blue: 77 / 255)
     /// The diameter the rest of the product already uses for a round control:
@@ -341,6 +370,10 @@ struct DictationSurfaceView: View {
     private static let sideInset: CGFloat = 6
     /// Glyphs at the toolbar's own weight and size, for the same reason.
     private static let glyphSize: CGFloat = 17
+    /// The compact action button's width. Wider than the 44pt circle it
+    /// replaces so it reads as the row's one action, and fixed so it does not
+    /// move under the thumb when the state swaps its glyph.
+    private static let compactActionWidth: CGFloat = 116
 
     init(state: DictationSurfaceState) {
         self.state = state
@@ -405,27 +438,7 @@ struct DictationSurfaceView: View {
         let _ = TouchTrace.note("      body surface")
         VStack(spacing: 0) {
             // Top Controls Bar (Top row of both Idle and Recording)
-            HStack(spacing: 8) {
-                if #available(iOS 26, *) {
-                    GlassEffectContainer(spacing: 8) {
-                        HStack(spacing: 8) {
-                            leadingGlassGroup
-                        }
-                    }
-                } else {
-                    HStack(spacing: 8) {
-                        leadingGlassGroup
-                    }
-                }
-
-                if isSuggesting {
-                    CandidateRow(state: state.typing)
-                } else {
-                    Spacer()
-                }
-
-                trailingActionButton
-            }
+            controlsRow
             // No fixed height. `GlassEffectContainer` lays out taller than its
             // content — it reserves room for the glass to spill and merge — and
             // pinning the row to 44 pt made that surplus appear as space above
@@ -514,6 +527,7 @@ struct DictationSurfaceView: View {
         .padding(.horizontal, Self.sideInset)
         .onAppear {
             state.refreshPreferences()
+            DispatchQueue.main.async { layoutAnimationEnabled = true }
         }
         // Hung from the top. The controls are in the same place in every phase,
         // which is the point of keeping one surface: the finger that just
@@ -522,9 +536,77 @@ struct DictationSurfaceView: View {
         // Fast, and barely springy. A keyboard control answers the finger; a
         // settle of a third of a second reads as the keyboard thinking about
         // it. Tunable from the lab — see ``DictationSurfaceState/animationResponse``.
-        .animation(surfaceSpring, value: isOpen)
-        .animation(surfaceSpring, value: isWorking)
-        .animation(surfaceSpring, value: isSuggesting)
+        .animation(layoutAnimationEnabled ? surfaceSpring : nil, value: isOpen)
+        .animation(layoutAnimationEnabled ? surfaceSpring : nil, value: isWorking)
+        .animation(layoutAnimationEnabled ? surfaceSpring : nil, value: isSuggesting)
+    }
+
+    // MARK: - Controls Row
+
+    /// Whether the action button stands in the middle of the row.
+    ///
+    /// Only with nothing typed and no session running. Once there are
+    /// suggestions they take the middle, and once a session is open the row
+    /// has a cancel on one end and a finish on the other — a finish floating
+    /// in the centre above a waveform is not a row, it is a button that has
+    /// come loose.
+    private var centresAction: Bool {
+        state.usesCompactControls && !isOpen && !state.hasTypedThisSession
+    }
+
+    @ViewBuilder
+    private var controlsRow: some View {
+        // A `ZStack` rather than balanced spacers: with the ellipsis pinned
+        // left, spacers centre the button in what is *left over*, which lands
+        // it visibly right of centre. Here it is centred against the whole row
+        // and the ellipsis floats over it.
+        //
+        // Both arrangements draw the same button carrying the same
+        // `matchedGeometryEffect`, so the first keystroke slides it from the
+        // middle to the end instead of teleporting it there.
+        ZStack {
+            if centresAction {
+                trailingActionButton
+            }
+            HStack(spacing: 8) {
+                leadingGlassContainer
+
+                if isSuggesting {
+                    CandidateRow(state: state.typing)
+                } else {
+                    Spacer()
+                }
+
+                if !centresAction {
+                    trailingActionButton
+                }
+            }
+        }
+        .animation(layoutAnimationEnabled ? .snappy(duration: 0.24) : nil, value: centresAction)
+        // Latched here rather than derived, because `isSuggesting` is false
+        // between words: the candidates empty on a space and fill again on the
+        // next letter, and a position derived from them threw the microphone
+        // back to the middle and out again on every word. Once typing has
+        // started it has started, and the button stays where typing put it
+        // until the keyboard goes away.
+        .onChange(of: isSuggesting) { _, suggesting in
+            if suggesting { state.hasTypedThisSession = true }
+        }
+    }
+
+    @ViewBuilder
+    private var leadingGlassContainer: some View {
+        if #available(iOS 26, *) {
+            GlassEffectContainer(spacing: 8) {
+                HStack(spacing: 8) {
+                    leadingGlassGroup
+                }
+            }
+        } else {
+            HStack(spacing: 8) {
+                leadingGlassGroup
+            }
+        }
     }
 
     // MARK: - Leading Glass Buttons
@@ -533,10 +615,48 @@ struct DictationSurfaceView: View {
     private var leadingGlassGroup: some View {
         if isOpen {
             cancelGlassButton
+        } else if state.usesCompactControls {
+            compactMenuButton
         } else {
             languageMenuButton
             styleMenuButton
         }
+    }
+
+    /// Both left menus behind one key.
+    ///
+    /// The ellipsis is what iOS uses for "the rest of it", and nesting the two
+    /// menus inside it keeps every destination the pair had — one more tap to
+    /// reach either, one less thing on the row.
+    @ViewBuilder
+    private var compactMenuButton: some View {
+        Menu {
+            Menu("Language") {
+                ForEach(state.languageShortcuts, id: \.self) { lang in
+                    languageButton(lang)
+                }
+                Menu("More languages") {
+                    ForEach(state.remainingLanguages, id: \.self) { lang in
+                        languageButton(lang)
+                    }
+                }
+            }
+            Menu("Style") {
+                ForEach(WritingStyle.allCases, id: \.self) { item in
+                    Toggle(isOn: styleBinding(for: item)) {
+                        Label(item.displayName, systemImage: item.symbolName)
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: Self.glyphSize, weight: .semibold))
+                .foregroundStyle(state.isDark ? Color.white : Color.black)
+                .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                .contentShape(Circle())
+        }
+        .modifier(GlassButtonModifier(id: "leadGlass", namespace: animationNamespace))
+        .accessibilityLabel("Language and style")
     }
 
     @ViewBuilder
@@ -572,12 +692,9 @@ struct DictationSurfaceView: View {
                 .foregroundStyle(state.isDark ? Color.white : Color.black)
                 .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
                 .contentShape(Circle())
-                .background(.ultraThinMaterial, in: Circle())
         }
-        // Keep decoration inside the label. Interactive glass around a Menu
-        // participates in its presentation snapshot and can leave the source
-        // button hidden or enlarged after dismissal in the keyboard extension.
         .buttonStyle(.plain)
+        .modifier(GlassButtonModifier(id: "languageGlass", namespace: animationNamespace))
         .accessibilityLabel("Transcription language")
     }
 
@@ -614,9 +731,9 @@ struct DictationSurfaceView: View {
                 .foregroundStyle(state.isDark ? Color.white : Color.black)
                 .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
                 .contentShape(Circle())
-                .background(.ultraThinMaterial, in: Circle())
         }
         .buttonStyle(.plain)
+        .modifier(GlassButtonModifier(id: "styleGlass", namespace: animationNamespace))
         .accessibilityLabel("Writing style")
         .accessibilityValue(state.style.displayName)
     }
@@ -665,22 +782,51 @@ struct DictationSurfaceView: View {
             }
         } label: {
             ZStack {
-                Circle()
-                    .fill(Self.brandGreen)
-                    .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
-                    .shadow(color: Self.brandGreen.opacity(0.35), radius: 4, x: 0, y: 2)
+                // Glass rather than the brand circle, and a capsule rather than
+                // a circle: the extra width is what makes it read as the row's
+                // one action instead of a third icon. Fixed, because a button
+                // that grows with its glyph moves under the thumb every time
+                // the state changes the glyph.
+                if state.usesCompactControls {
+                    // Wide while it is the only thing on the row, round once
+                    // the suggestions have taken the middle: the same button
+                    // with the room it happens to have.
+                    Capsule()
+                        .fill(.clear)
+                        .frame(
+                            width: centresAction
+                                ? Self.compactActionWidth
+                                : Self.buttonDiameter,
+                            height: Self.buttonDiameter
+                        )
+                        .modifier(GlassCapsuleModifier())
+                } else {
+                    Circle()
+                        .fill(Self.brandGreen)
+                        .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                        .shadow(color: Self.brandGreen.opacity(0.35), radius: 4, x: 0, y: 2)
+                }
 
                 if isWorking && !state.primaryIsEnabled {
                     // The same circle, still there, no longer an action: the
                     // work it started is what it is now reporting.
                     ProgressView()
                         .progressViewStyle(.circular)
-                        .tint(.white)
+                        // The same colour as the glyph it replaces. White was
+                        // right on a green circle and invisible on glass, so
+                        // transcribing looked like a button that had gone
+                        // blank rather than one that was working.
+                        .tint(state.usesCompactControls ? Self.brandGreen : Color.white)
                         .transition(.scale.combined(with: .opacity))
                 } else {
                     Image(systemName: isRecording ? "checkmark" : state.primarySymbol)
                         .font(.system(size: Self.glyphSize, weight: .semibold))
-                        .foregroundStyle(.white)
+                        // Green on glass. The brand colour has moved off the
+                        // fill and onto the glyph, which is the only place left
+                        // for it once the button stops being a green circle.
+                        .foregroundStyle(
+                            state.usesCompactControls ? Self.brandGreen : Color.white
+                        )
                         .transition(.scale.combined(with: .opacity))
                 }
             }
@@ -827,6 +973,17 @@ private struct CandidateButtonStyle: ButtonStyle {
 }
 
 // MARK: - Glass Button Modifier
+
+/// The same glass as the leading buttons, in a capsule.
+private struct GlassCapsuleModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content.glassEffect(.regular.interactive(), in: .capsule)
+        } else {
+            content.background(.ultraThinMaterial, in: Capsule())
+        }
+    }
+}
 
 private struct GlassButtonModifier: ViewModifier {
     let id: String

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -759,8 +759,21 @@ struct DictationSurfaceView: View {
                     .accessibilityElement(children: .combine)
                 }
             }
-            .tabViewStyle(.page(indexDisplayMode: .always))
-            .indexViewStyle(.page(backgroundDisplayMode: .never))
+            // Drawn here rather than by the page style: its dots are white
+            // whatever the keyboard's appearance, and on a light keyboard they
+            // vanish into the background.
+            .tabViewStyle(.page(indexDisplayMode: .never))
+
+            HStack(spacing: 8) {
+                ForEach(CompactDashboardPage.allCases) { page in
+                    Circle()
+                        .fill(controlForeground.opacity(page == selectedDashboardPage ? 0.9 : 0.25))
+                        .frame(width: 7, height: 7)
+                }
+            }
+            .padding(.bottom, 6)
+            .animation(.easeOut(duration: 0.15), value: selectedDashboardPage)
+            .accessibilityHidden(true)
 
             if state.showsGlobeKey {
                 HStack {
@@ -854,9 +867,10 @@ struct DictationSurfaceView: View {
             .padding(.horizontal, 16)
             .frame(minWidth: 116, minHeight: Self.buttonDiameter)
             .contentShape(Capsule())
+            .background(.ultraThinMaterial, in: Capsule())
         }
+        // Inside the label for the same reason as the shipping menus.
         .buttonStyle(.plain)
-        .modifier(GlassCapsuleModifier())
         .accessibilityLabel("Writing style")
         .accessibilityValue(state.style.displayName)
     }
@@ -881,9 +895,10 @@ struct DictationSurfaceView: View {
             .padding(.horizontal, 12)
             .frame(minHeight: Self.buttonDiameter)
             .contentShape(Capsule())
+            .background(.ultraThinMaterial, in: Capsule())
         }
+        // Inside the label for the same reason as the shipping menus.
         .buttonStyle(.plain)
-        .modifier(GlassCapsuleModifier())
         .accessibilityLabel("Transcription language")
         .accessibilityValue(state.language.displayName)
     }
@@ -921,9 +936,12 @@ struct DictationSurfaceView: View {
                 .foregroundStyle(state.isDark ? Color.white : Color.black)
                 .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
                 .contentShape(Circle())
+                .background(.ultraThinMaterial, in: Circle())
         }
+        // Keep decoration inside the label. Interactive glass around a Menu
+        // participates in its presentation snapshot and can leave the source
+        // button hidden or enlarged after dismissal in the keyboard extension.
         .buttonStyle(.plain)
-        .modifier(GlassButtonModifier(id: "languageGlass", namespace: animationNamespace))
         .accessibilityLabel("Transcription language")
     }
 
@@ -960,9 +978,12 @@ struct DictationSurfaceView: View {
                 .foregroundStyle(state.isDark ? Color.white : Color.black)
                 .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
                 .contentShape(Circle())
+                .background(.ultraThinMaterial, in: Circle())
         }
+        // Keep decoration inside the label. Interactive glass around a Menu
+        // participates in its presentation snapshot and can leave the source
+        // button hidden or enlarged after dismissal in the keyboard extension.
         .buttonStyle(.plain)
-        .modifier(GlassButtonModifier(id: "styleGlass", namespace: animationNamespace))
         .accessibilityLabel("Writing style")
         .accessibilityValue(state.style.displayName)
     }

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -263,7 +263,14 @@ final class DictationSurfaceState: ObservableObject {
     func setQuickDictationEnabled(_ enabled: Bool) {
         guard quickDictationEnabled != enabled else { return }
         quickDictationEnabled = enabled
-        if !enabled { quickDictationReady = false }
+        if !enabled {
+            quickDictationReady = false
+            // Match the keyboard-first behavior of the reference flow: once
+            // standby is off, the dashboard has no follow-up action to offer.
+            // Close it in the same tap so the typing keys and Start control are
+            // immediately visible again.
+            setCompactDashboardPresented(false)
+        }
         onQuickDictationChanged?(enabled)
     }
 
@@ -668,16 +675,18 @@ struct DictationSurfaceView: View {
         }
     }
 
-    /// Logo/readiness, the writing style in force, and the microphone: the
-    /// three things the sketch asks the idle compact row to answer at a glance.
+    /// While VocaPhone is unavailable there is only one useful action: Start.
+    /// Style becomes relevant after standby is ready, beside the live mic.
     private var compactControlsRow: some View {
         HStack(spacing: 8) {
             compactStatusControl
             if isSuggesting {
                 CandidateRow(state: state.typing)
-            } else {
+            } else if state.quickDictationReady {
                 compactStyleButton
                     .frame(maxWidth: .infinity)
+            } else {
+                Spacer()
             }
             trailingActionButton
         }

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -55,11 +55,17 @@ final class DictationSurfaceState: ObservableObject {
         get { storedUsageStats }
         set { change(&storedUsageStats, to: newValue) }
     }
-    private var storedCompactDashboardPresented = false
-    private(set) var compactDashboardPresented: Bool {
-        get { storedCompactDashboardPresented }
-        set { change(&storedCompactDashboardPresented, to: newValue) }
+    /// The full-height panel open over the keys, if any. The stats dashboard
+    /// and the two pickers take the keyboard's room the same way a recording
+    /// does, and never alongside one.
+    private var storedPresentedPanel: SurfacePanel?
+    private(set) var presentedPanel: SurfacePanel? {
+        get { storedPresentedPanel }
+        set { change(&storedPresentedPanel, to: newValue) }
     }
+    /// Where closing a picker goes back to: the dashboard, when that is where
+    /// it was opened from.
+    private var panelToReturnTo: SurfacePanel?
     private var storedShowsGlobeKey: Bool = false
     var showsGlobeKey: Bool {
         get { storedShowsGlobeKey }
@@ -206,7 +212,7 @@ final class DictationSurfaceState: ObservableObject {
     var onStyleChanged: ((WritingStyle) -> Void)?
     var onGlobe: (() -> Void)?
     var onOpenSettings: (() -> Void)?
-    var onDashboardVisibilityChanged: ((Bool) -> Void)?
+    var onPanelVisibilityChanged: ((Bool) -> Void)?
     var onVocaPhoneRunningChanged: ((Bool) -> Void)?
     var onCandidate: ((TypingCandidate) -> Void)? {
         get { typing.onCandidate }
@@ -248,11 +254,27 @@ final class DictationSurfaceState: ObservableObject {
         usageStats = UsageStatsStore.shared.current()
     }
 
-    func setCompactDashboardPresented(_ presented: Bool) {
-        guard compactDashboardPresented != presented else { return }
-        compactDashboardPresented = presented
-        onDashboardVisibilityChanged?(presented)
+    /// Opens a panel over the keys, or closes whichever is open with `nil`.
+    ///
+    /// The controller only hears when the keys are covered or uncovered, not
+    /// when one panel replaces another: going from the dashboard to the
+    /// language picker must not flash the keys in between.
+    func present(_ panel: SurfacePanel?, returningTo previous: SurfacePanel? = nil) {
+        panelToReturnTo = panel == nil ? nil : previous
+        guard presentedPanel != panel else { return }
+        let wasCovering = presentedPanel != nil
+        presentedPanel = panel
+        if wasCovering != (panel != nil) {
+            onPanelVisibilityChanged?(panel != nil)
+        }
     }
+
+    /// Leaves a picker: back to the panel it came from, or to the keys.
+    func dismissPanel() {
+        present(panelToReturnTo)
+    }
+
+    var panelReturnsToPrevious: Bool { panelToReturnTo != nil }
 
     /// The dashboard's VocaPhone switch: on opens VocaPhone, off closes it the
     /// way the app switcher does. It says whether VocaPhone is running, not
@@ -266,7 +288,7 @@ final class DictationSurfaceState: ObservableObject {
             // standby is off, the dashboard has no follow-up action to offer.
             // Close it in the same tap so the typing keys and Start control are
             // immediately visible again.
-            setCompactDashboardPresented(false)
+            present(nil)
         }
         onVocaPhoneRunningChanged?(running)
     }
@@ -319,6 +341,18 @@ final class DictationSurfaceState: ObservableObject {
             modelLanguages: KeyboardPreferences.activeModelLanguages
         )
     }
+}
+
+/// What can stand over the keys in place of a recording.
+enum SurfacePanel: Equatable, Sendable {
+    /// Local usage stats, from the compact row's disclosure button.
+    case dashboard
+    /// Writing styles. In the keyboard rather than in a system menu: a menu
+    /// inside a keyboard extension is squeezed into the keyboard's frame and
+    /// animates on the host app's render server, and it felt like it.
+    case style
+    /// Dictation languages, for the same reason.
+    case language
 }
 
 /// The honest, local-only numbers the compact keyboard dashboard can show.
@@ -513,9 +547,10 @@ struct DictationSurfaceView: View {
     /// Whether a dictation session owns the full keyboard surface.
     private var sessionIsOpen: Bool { isRecording || isWorking || hasMessage }
 
-    /// The dashboard is another deliberate expansion of the same surface, but
-    /// never competes with a live session or a recovery message.
-    private var isOpen: Bool { sessionIsOpen || state.compactDashboardPresented }
+    /// A panel — the dashboard or a picker — is another deliberate expansion of
+    /// the same surface, but never competes with a live session or a recovery
+    /// message.
+    private var isOpen: Bool { sessionIsOpen || state.presentedPanel != nil }
 
     /// Typing, with something to offer. The two menu buttons collapse into one
     /// so the row they were using becomes the suggestions — which is what the
@@ -541,8 +576,8 @@ struct DictationSurfaceView: View {
             // The row is the first thing in the stack; that is what puts it at
             // the top, not a height.
 
-            if state.compactDashboardPresented, !sessionIsOpen {
-                compactDashboard
+            if let panel = state.presentedPanel, !sessionIsOpen {
+                panelContent(panel)
             } else if sessionIsOpen {
                 Spacer(minLength: 0)
 
@@ -638,10 +673,10 @@ struct DictationSurfaceView: View {
         .animation(layoutAnimationEnabled ? surfaceSpring : nil, value: isSuggesting)
         .animation(
             layoutAnimationEnabled ? surfaceSpring : nil,
-            value: state.compactDashboardPresented
+            value: state.presentedPanel
         )
         .onChange(of: sessionIsOpen) { _, open in
-            if open { state.setCompactDashboardPresented(false) }
+            if open { state.present(nil) }
         }
     }
 
@@ -650,8 +685,12 @@ struct DictationSurfaceView: View {
     @ViewBuilder
     private var controlsRow: some View {
         Group {
-            if state.compactDashboardPresented, !sessionIsOpen {
-                dashboardControlsRow
+            if let panel = state.presentedPanel, !sessionIsOpen {
+                switch panel {
+                case .dashboard: dashboardControlsRow
+                case .style: pickerControlsRow(title: "Writing style")
+                case .language: pickerControlsRow(title: "Dictation language")
+                }
             } else if state.usesCompactControls, !sessionIsOpen {
                 compactControlsRow
             } else {
@@ -692,7 +731,7 @@ struct DictationSurfaceView: View {
     private var dashboardControlsRow: some View {
         HStack(spacing: 8) {
             Button {
-                state.setCompactDashboardPresented(false)
+                state.present(nil)
             } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: Self.glyphSize, weight: .semibold))
@@ -775,24 +814,10 @@ struct DictationSurfaceView: View {
             .animation(.easeOut(duration: 0.15), value: selectedDashboardPage)
             .accessibilityHidden(true)
 
-            if state.showsGlobeKey {
-                HStack {
-                    Button {
-                        state.onGlobe?()
-                    } label: {
-                        Image(systemName: "globe")
-                            .font(.system(size: 20))
-                            .foregroundStyle(controlForeground)
-                            .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Next keyboard")
-                    Spacer()
-                }
-            }
+            panelGlobeRow
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .transition(.opacity.combined(with: .scale(scale: 0.97)))
+        .transition(Self.panelTransition)
     }
 
     private var controlForeground: Color {
@@ -836,7 +861,7 @@ struct DictationSurfaceView: View {
         Button {
             state.refreshDashboard()
             selectedDashboardPage = .words
-            state.setCompactDashboardPresented(true)
+            state.present(.dashboard)
         } label: {
             Image(systemName: "ellipsis")
                 .font(.system(size: Self.glyphSize, weight: .bold))
@@ -850,12 +875,8 @@ struct DictationSurfaceView: View {
     }
 
     private var compactStyleButton: some View {
-        Menu {
-            ForEach(WritingStyle.allCases, id: \.self) { item in
-                Toggle(isOn: styleBinding(for: item)) {
-                    Label(item.displayName, systemImage: item.symbolName)
-                }
-            }
+        Button {
+            state.present(.style)
         } label: {
             HStack(spacing: 7) {
                 Image(systemName: state.style.symbolName)
@@ -867,24 +888,16 @@ struct DictationSurfaceView: View {
             .padding(.horizontal, 16)
             .frame(minWidth: 116, minHeight: Self.buttonDiameter)
             .contentShape(Capsule())
-            .background(.ultraThinMaterial, in: Capsule())
         }
-        // Inside the label for the same reason as the shipping menus.
         .buttonStyle(.plain)
+        .modifier(GlassCapsuleModifier())
         .accessibilityLabel("Writing style")
         .accessibilityValue(state.style.displayName)
     }
 
     private var compactLanguageButton: some View {
-        Menu {
-            ForEach(state.languageShortcuts, id: \.self) { lang in
-                languageButton(lang)
-            }
-            Menu("More languages") {
-                ForEach(state.remainingLanguages, id: \.self) { lang in
-                    languageButton(lang)
-                }
-            }
+        Button {
+            state.present(.language, returningTo: .dashboard)
         } label: {
             HStack(spacing: 5) {
                 Image(systemName: "globe")
@@ -895,10 +908,9 @@ struct DictationSurfaceView: View {
             .padding(.horizontal, 12)
             .frame(minHeight: Self.buttonDiameter)
             .contentShape(Capsule())
-            .background(.ultraThinMaterial, in: Capsule())
         }
-        // Inside the label for the same reason as the shipping menus.
         .buttonStyle(.plain)
+        .modifier(GlassCapsuleModifier())
         .accessibilityLabel("Transcription language")
         .accessibilityValue(state.language.displayName)
     }
@@ -919,101 +931,279 @@ struct DictationSurfaceView: View {
         .accessibilityLabel("Cancel dictation")
     }
 
-    @ViewBuilder
     private var languageMenuButton: some View {
-        Menu {
-            ForEach(state.languageShortcuts, id: \.self) { lang in
-                languageButton(lang)
-            }
-            Menu("More languages") {
-                ForEach(state.remainingLanguages, id: \.self) { lang in
-                    languageButton(lang)
-                }
-            }
+        Button {
+            state.present(.language)
         } label: {
             Image(systemName: "globe")
                 .font(.system(size: Self.glyphSize, weight: .semibold))
                 .foregroundStyle(state.isDark ? Color.white : Color.black)
                 .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
                 .contentShape(Circle())
-                .background(.ultraThinMaterial, in: Circle())
         }
-        // Keep decoration inside the label. Interactive glass around a Menu
-        // participates in its presentation snapshot and can leave the source
-        // button hidden or enlarged after dismissal in the keyboard extension.
         .buttonStyle(.plain)
+        .modifier(GlassButtonModifier(id: "languageGlass", namespace: animationNamespace))
         .accessibilityLabel("Transcription language")
+        .accessibilityValue(state.language.displayName)
     }
 
-    @ViewBuilder
     private var styleMenuButton: some View {
-        Menu {
-            // A `Picker` rather than a row of buttons: iOS draws the tick on
-            // the chosen row itself, which frees the row's own image for the
-            // style's icon. Hand-rolled buttons had to spend that image on the
-            // tick, so the menu listed six styles with no icons at all — the
-            // same six icons the button beside it is drawn from.
-            // Toggles rather than a `Picker`, and this is the whole reason the
-            // button's icon lagged a beat behind the choice: a picker inside a
-            // menu commits its selection when the menu *dismisses*, not when
-            // the row is tapped. The old style stayed on screen for the length
-            // of that animation because it was still the truth.
-            //
-            // A toggle fires on the tap, and keeps what the picker was chosen
-            // for: iOS draws the tick itself, so the row's image stays free for
-            // the style's own icon.
-            ForEach(WritingStyle.allCases, id: \.self) { item in
-                Toggle(isOn: styleBinding(for: item)) {
-                    Label(item.displayName, systemImage: item.symbolName)
-                }
-            }
+        Button {
+            state.present(.style)
         } label: {
-            // The button shows the style that is in force. Three things used
-            // to make it show it late, and all three are gone: the picker that
-            // committed on dismissal rather than on the tap, the second writer
-            // in the controller, and the poll that reassigned the value several
-            // times a second and could put a stale one back.
+            // The button shows the style that is in force, straight from the
+            // state the picker writes — one writer, no poll to put a stale
+            // value back.
             Image(systemName: state.style.symbolName)
                 .font(.system(size: Self.glyphSize, weight: .semibold))
                 .foregroundStyle(state.isDark ? Color.white : Color.black)
                 .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
                 .contentShape(Circle())
-                .background(.ultraThinMaterial, in: Circle())
         }
-        // Keep decoration inside the label. Interactive glass around a Menu
-        // participates in its presentation snapshot and can leave the source
-        // button hidden or enlarged after dismissal in the keyboard extension.
         .buttonStyle(.plain)
+        .modifier(GlassButtonModifier(id: "styleGlass", namespace: animationNamespace))
         .accessibilityLabel("Writing style")
         .accessibilityValue(state.style.displayName)
     }
 
-    /// Writes through ``DictationSurfaceState/select(style:)`` so the choice is
-    /// persisted, rather than only changing what the menu shows.
-    /// Turning a style off is not a thing — one of the six is always in force —
-    /// so only the on direction does anything.
-    private func styleBinding(for style: WritingStyle) -> Binding<Bool> {
-        Binding(
-            get: { state.style == style },
-            set: { isOn in if isOn { state.select(style: style) } }
-        )
+    // MARK: - Pickers
+
+    /// The panels come and go the way the dashboard does.
+    private static let panelTransition = AnyTransition.opacity
+        .combined(with: .scale(scale: 0.97))
+
+    @ViewBuilder
+    private func panelContent(_ panel: SurfacePanel) -> some View {
+        switch panel {
+        case .dashboard: compactDashboard
+        case .style: stylePicker
+        case .language: languagePicker
+        }
     }
 
-    /// One row of the language menu. Disabled where the loaded model cannot be
-    /// asked for it, which is the same rule the dictation bar's menu applies.
-    @ViewBuilder
-    private func languageButton(_ lang: TranscriptionLanguage) -> some View {
-        Button {
-            state.select(language: lang)
-        } label: {
-            HStack {
-                Text(lang.displayName)
-                if lang == state.language {
-                    Image(systemName: "checkmark")
+    /// Above a picker: the way back, and what is being picked. A chevron when
+    /// back is the dashboard it was opened from, a cross when back is the keys.
+    private func pickerControlsRow(title: String) -> some View {
+        HStack(spacing: 8) {
+            Button {
+                state.dismissPanel()
+            } label: {
+                Image(systemName: state.panelReturnsToPrevious ? "chevron.left" : "xmark")
+                    .font(.system(size: Self.glyphSize, weight: .semibold))
+                    .foregroundStyle(controlForeground)
+                    .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                    .contentShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .modifier(GlassButtonModifier(id: "pickerClose", namespace: animationNamespace))
+            .accessibilityLabel(state.panelReturnsToPrevious ? "Back" : "Close")
+
+            Spacer(minLength: 0)
+            Text(title)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(controlForeground)
+                .accessibilityAddTraits(.isHeader)
+            Spacer(minLength: 0)
+            // The close button's width again, so the title sits in the middle.
+            Color.clear
+                .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                .accessibilityHidden(true)
+        }
+    }
+
+    /// Six styles, all visible at once, in the room the keys just left.
+    ///
+    /// Choosing one closes the picker in the same tap: the row it came from
+    /// shows the new style, which is the confirmation.
+    private var stylePicker: some View {
+        let rows = stride(from: 0, to: WritingStyle.allCases.count, by: 3).map {
+            Array(WritingStyle.allCases[$0..<min($0 + 3, WritingStyle.allCases.count)])
+        }
+        return VStack(spacing: 8) {
+            ForEach(rows, id: \.self) { row in
+                HStack(spacing: 8) {
+                    ForEach(row) { item in
+                        pickerTile(
+                            title: item.displayName,
+                            symbol: item.symbolName,
+                            isSelected: item == state.style
+                        ) {
+                            state.select(style: item)
+                            state.dismissPanel()
+                        }
+                    }
+                }
+                .frame(maxHeight: 84)
+            }
+            Text(state.style.detail)
+                .font(.system(size: 13))
+                .foregroundStyle(controlForeground.opacity(0.6))
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 12)
+                .padding(.top, 4)
+            Spacer(minLength: 0)
+            panelGlobeRow
+        }
+        .padding(.top, 10)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .transition(Self.panelTransition)
+    }
+
+    /// Automatic and the languages this person uses first, then every language
+    /// the loaded model can be asked for, by name.
+    ///
+    /// The ones it cannot are counted rather than shown. On an English-only
+    /// model that is every language but one, and a screen of fifty dimmed
+    /// buttons reads as a broken keyboard rather than as a model's limits.
+    private var languagePicker: some View {
+        let remaining = state.remainingLanguages
+        let available = remaining
+            .filter(state.isSelectable)
+            .sorted { $0.displayName.localizedCompare($1.displayName) == .orderedAscending }
+        let unavailable = remaining.count - available.count
+        return VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    languageSection("Suggested", state.languageShortcuts)
+                    if !available.isEmpty {
+                        languageSection("All languages", available)
+                    }
+                    if unavailable > 0 {
+                        Text(
+                            "\(unavailable) more \(unavailable == 1 ? "language needs" : "languages need") "
+                                + "a multilingual model. Choose one in VocaPhone Settings."
+                        )
+                        .font(.system(size: 13))
+                        .foregroundStyle(controlForeground.opacity(0.55))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 4)
+                    }
+                }
+                .padding(.vertical, 10)
+            }
+            panelGlobeRow
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .transition(Self.panelTransition)
+    }
+
+    private func languageSection(
+        _ title: String,
+        _ languages: [TranscriptionLanguage]
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 12, weight: .bold))
+                .tracking(1)
+                .textCase(.uppercase)
+                .foregroundStyle(controlForeground.opacity(0.55))
+                .padding(.leading, 4)
+                .accessibilityAddTraits(.isHeader)
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 3),
+                spacing: 8
+            ) {
+                ForEach(languages, id: \.self) { lang in
+                    languageChip(lang)
                 }
             }
         }
-        .disabled(!state.isSelectable(lang))
+    }
+
+    private func languageChip(_ lang: TranscriptionLanguage) -> some View {
+        let isSelected = lang == state.language
+        let isSelectable = state.isSelectable(lang)
+        return Button {
+            state.select(language: lang)
+            state.dismissPanel()
+        } label: {
+            HStack(spacing: 4) {
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 12, weight: .bold))
+                }
+                Text(lang.displayName)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+            }
+            .font(.system(size: 14, weight: isSelected ? .semibold : .medium))
+            .foregroundStyle(isSelected ? dashboardAccent : controlForeground)
+            .padding(.horizontal, 8)
+            .frame(maxWidth: .infinity, minHeight: 38)
+            .background(pickerFill(isSelected: isSelected), in: Capsule())
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .disabled(!isSelectable)
+        .opacity(isSelectable ? 1 : 0.35)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private func pickerTile(
+        title: String,
+        symbol: String,
+        isSelected: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            VStack(spacing: 6) {
+                // One height for every glyph, so the names line up across a
+                // row whatever shape the symbol above them is.
+                Image(systemName: symbol)
+                    .font(.system(size: 20, weight: .medium))
+                    .frame(height: 24)
+                Text(title)
+                    .font(.system(size: 14, weight: .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .foregroundStyle(isSelected ? dashboardAccent : controlForeground)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(minHeight: 60)
+            .background(
+                pickerFill(isSelected: isSelected),
+                in: RoundedRectangle(cornerRadius: 14, style: .continuous)
+            )
+            .overlay {
+                if isSelected {
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .strokeBorder(dashboardAccent, lineWidth: 1.5)
+                }
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .buttonStyle(PickerTileButtonStyle())
+        .accessibilityLabel(title)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    /// The key colour's cousin: quiet on both backgrounds, and the accent's
+    /// tint for the choice in force.
+    private func pickerFill(isSelected: Bool) -> Color {
+        isSelected
+            ? dashboardAccent.opacity(state.isDark ? 0.22 : 0.14)
+            : controlForeground.opacity(state.isDark ? 0.12 : 0.07)
+    }
+
+    @ViewBuilder
+    private var panelGlobeRow: some View {
+        if state.showsGlobeKey {
+            HStack {
+                Button {
+                    state.onGlobe?()
+                } label: {
+                    Image(systemName: "globe")
+                        .font(.system(size: 20))
+                        .foregroundStyle(controlForeground)
+                        .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Next keyboard")
+                Spacer()
+            }
+        }
     }
 
     // MARK: - Trailing Primary Action Button (Green Circle)
@@ -1242,6 +1432,16 @@ private struct CandidateButtonStyle: ButtonStyle {
 }
 
 // MARK: - Glass Button Modifier
+
+/// A picker tile answers the finger the way a key does: it dims while held.
+private struct PickerTileButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .opacity(configuration.isPressed ? 0.6 : 1)
+            .scaleEffect(configuration.isPressed ? 0.97 : 1)
+            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+    }
+}
 
 /// The same glass as the leading buttons, in a capsule.
 private struct GlassCapsuleModifier: ViewModifier {

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -47,6 +47,11 @@ final class DictationSurfaceState: ObservableObject {
         get { storedQuickDictationReady }
         set { change(&storedQuickDictationReady, to: newValue) }
     }
+    private var storedQuickDictationEnabled = KeyboardPreferences.quickDictationEnabled
+    var quickDictationEnabled: Bool {
+        get { storedQuickDictationEnabled }
+        set { change(&storedQuickDictationEnabled, to: newValue) }
+    }
     /// Private, on-device totals shared by the app and keyboard through their
     /// existing App Group. Loaded only when the dashboard is opened so ordinary
     /// typing never pays for a directory scan.
@@ -54,6 +59,11 @@ final class DictationSurfaceState: ObservableObject {
     var usageStats: UsageStats {
         get { storedUsageStats }
         set { change(&storedUsageStats, to: newValue) }
+    }
+    private var storedCompactDashboardPresented = false
+    private(set) var compactDashboardPresented: Bool {
+        get { storedCompactDashboardPresented }
+        set { change(&storedCompactDashboardPresented, to: newValue) }
     }
     private var storedShowsGlobeKey: Bool = false
     var showsGlobeKey: Bool {
@@ -200,8 +210,9 @@ final class DictationSurfaceState: ObservableObject {
     var onLanguageChanged: ((TranscriptionLanguage) -> Void)?
     var onStyleChanged: ((WritingStyle) -> Void)?
     var onGlobe: (() -> Void)?
-    var onStartQuickDictation: (() -> Void)?
     var onOpenSettings: (() -> Void)?
+    var onDashboardVisibilityChanged: ((Bool) -> Void)?
+    var onQuickDictationChanged: ((Bool) -> Void)?
     var onCandidate: ((TypingCandidate) -> Void)? {
         get { typing.onCandidate }
         set { typing.onCandidate = newValue }
@@ -229,6 +240,7 @@ final class DictationSurfaceState: ObservableObject {
         language = KeyboardPreferences.effectiveTranscriptionLanguage
         style = KeyboardPreferences.writingStyle
         usesCompactControls = KeyboardPreferences.compactControlsEnabled
+        quickDictationEnabled = KeyboardPreferences.quickDictationEnabled
         refreshQuickDictationReadiness()
     }
 
@@ -240,6 +252,19 @@ final class DictationSurfaceState: ObservableObject {
     func refreshDashboard(at now: Date = Date()) {
         refreshQuickDictationReadiness(at: now)
         usageStats = UsageStatsStore.shared.current()
+    }
+
+    func setCompactDashboardPresented(_ presented: Bool) {
+        guard compactDashboardPresented != presented else { return }
+        compactDashboardPresented = presented
+        onDashboardVisibilityChanged?(presented)
+    }
+
+    func setQuickDictationEnabled(_ enabled: Bool) {
+        guard quickDictationEnabled != enabled else { return }
+        quickDictationEnabled = enabled
+        if !enabled { quickDictationReady = false }
+        onQuickDictationChanged?(enabled)
     }
 
     /// Persists the choice, exactly as the dictation bar's own menu does.
@@ -307,24 +332,36 @@ enum CompactDashboardPage: Int, CaseIterable, Identifiable, Sendable {
     func value(for stats: UsageStats, now: Date = Date()) -> String {
         switch self {
         case .words:
-            return "\(stats.totalWords.formatted(.number.grouping(.automatic))) words"
+            return stats.totalWords.formatted(.number.grouping(.automatic))
         case .sessions:
-            return "\(stats.totalDictations.formatted(.number.grouping(.automatic))) sessions"
+            return stats.totalDictations.formatted(.number.grouping(.automatic))
+        case .streak:
+            return stats.currentStreak(at: now).formatted()
+        case .speed:
+            return Int(stats.averageWordsPerMinute.rounded()).formatted()
+        }
+    }
+
+    func label(for stats: UsageStats, now: Date = Date()) -> String {
+        switch self {
+        case .words: return "Words dictated"
+        case .sessions: return "Dictations"
         case .streak:
             let days = stats.currentStreak(at: now)
-            return "\(days) \(days == 1 ? "day" : "days")"
-        case .speed:
-            return "\(Int(stats.averageWordsPerMinute.rounded())) WPM"
+            return "\(days == 1 ? "Day" : "Days") in your current streak"
+        case .speed: return "Average WPM"
         }
     }
 
     func detail(for stats: UsageStats) -> String {
         switch self {
-        case .words: "Dictated with VocaPhone so far"
-        case .sessions: "Completed dictations"
+        case .words:
+            let count = stats.totalDictations
+            return "Across \(count.formatted()) completed \(count == 1 ? "dictation" : "dictations")"
+        case .sessions: return "Completed with VocaPhone"
         case .streak:
-            "Best streak: \(stats.bestStreak) \(stats.bestStreak == 1 ? "day" : "days")"
-        case .speed: "Average speaking speed"
+            return "Best streak: \(stats.bestStreak) \(stats.bestStreak == 1 ? "day" : "days")"
+        case .speed: return "Based on recorded speaking time"
         }
     }
 }
@@ -403,7 +440,6 @@ struct DictationSurfaceView: View {
     /// keyboard restores a session in `viewDidLoad`; animating idle into
     /// recording is the blink after swiping back from vocaphone.
     @State private var layoutAnimationEnabled = false
-    @State private var showsDashboard = false
     @State private var selectedDashboardPage = CompactDashboardPage.words
 
     private static let brandGreen = Color(red: 13 / 255, green: 104 / 255, blue: 77 / 255)
@@ -475,7 +511,7 @@ struct DictationSurfaceView: View {
 
     /// The dashboard is another deliberate expansion of the same surface, but
     /// never competes with a live session or a recovery message.
-    private var isOpen: Bool { sessionIsOpen || showsDashboard }
+    private var isOpen: Bool { sessionIsOpen || state.compactDashboardPresented }
 
     /// Typing, with something to offer. The two menu buttons collapse into one
     /// so the row they were using becomes the suggestions — which is what the
@@ -501,7 +537,7 @@ struct DictationSurfaceView: View {
             // The row is the first thing in the stack; that is what puts it at
             // the top, not a height.
 
-            if showsDashboard, !sessionIsOpen {
+            if state.compactDashboardPresented, !sessionIsOpen {
                 compactDashboard
             } else if sessionIsOpen {
                 Spacer(minLength: 0)
@@ -596,9 +632,12 @@ struct DictationSurfaceView: View {
         .animation(layoutAnimationEnabled ? surfaceSpring : nil, value: isOpen)
         .animation(layoutAnimationEnabled ? surfaceSpring : nil, value: isWorking)
         .animation(layoutAnimationEnabled ? surfaceSpring : nil, value: isSuggesting)
-        .animation(layoutAnimationEnabled ? surfaceSpring : nil, value: showsDashboard)
+        .animation(
+            layoutAnimationEnabled ? surfaceSpring : nil,
+            value: state.compactDashboardPresented
+        )
         .onChange(of: sessionIsOpen) { _, open in
-            if open { showsDashboard = false }
+            if open { state.setCompactDashboardPresented(false) }
         }
     }
 
@@ -607,7 +646,7 @@ struct DictationSurfaceView: View {
     @ViewBuilder
     private var controlsRow: some View {
         Group {
-            if showsDashboard, !sessionIsOpen {
+            if state.compactDashboardPresented, !sessionIsOpen {
                 dashboardControlsRow
             } else if state.usesCompactControls, !sessionIsOpen {
                 compactControlsRow
@@ -647,7 +686,7 @@ struct DictationSurfaceView: View {
     private var dashboardControlsRow: some View {
         HStack(spacing: 8) {
             Button {
-                showsDashboard = false
+                state.setCompactDashboardPresented(false)
             } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: Self.glyphSize, weight: .semibold))
@@ -675,7 +714,17 @@ struct DictationSurfaceView: View {
             .modifier(GlassButtonModifier(id: "dashboardSettings", namespace: animationNamespace))
             .accessibilityLabel("Open VocaPhone settings")
 
-            compactReadinessButton
+            Toggle(
+                "Quick Dictation",
+                isOn: Binding(
+                    get: { state.quickDictationEnabled },
+                    set: { state.setQuickDictationEnabled($0) }
+                )
+            )
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .tint(dashboardAccent)
+            .accessibilityHint("Keeps VocaPhone ready for dictation from the keyboard")
         }
     }
 
@@ -683,16 +732,21 @@ struct DictationSurfaceView: View {
         VStack(spacing: 0) {
             TabView(selection: $selectedDashboardPage) {
                 ForEach(CompactDashboardPage.allCases) { page in
-                    VStack(spacing: 12) {
+                    VStack(spacing: 10) {
+                        Text(page.label(for: state.usageStats))
+                            .font(.system(size: 13, weight: .bold))
+                            .tracking(1.4)
+                            .textCase(.uppercase)
+                            .foregroundStyle(controlForeground.opacity(0.62))
                         Text(page.value(for: state.usageStats))
-                            .font(.system(size: 44, weight: .medium, design: .rounded))
+                            .font(.system(size: 62, weight: .semibold, design: .rounded))
                             .minimumScaleFactor(0.65)
                             .lineLimit(1)
                             .foregroundStyle(dashboardAccent)
                         Text(page.detail(for: state.usageStats))
-                            .font(.system(size: 16, weight: .medium))
+                            .font(.system(size: 15, weight: .medium))
                             .multilineTextAlignment(.center)
-                            .foregroundStyle(controlForeground.opacity(0.82))
+                            .foregroundStyle(controlForeground.opacity(0.72))
                     }
                     .padding(.horizontal, 24)
                     .tag(page)
@@ -757,64 +811,23 @@ struct DictationSurfaceView: View {
         }
     }
 
-    /// The logo is the disclosure control. When the app's short-lived readiness
-    /// heartbeat is absent, Start is a separate target in the same capsule so
-    /// opening the dashboard never accidentally foregrounds the app.
+    /// The ellipsis is the disclosure control from the sketch. Readiness lives
+    /// with the microphone action on the opposite side of the row.
     private var compactStatusControl: some View {
-        HStack(spacing: 0) {
-            Button {
-                state.refreshDashboard()
-                selectedDashboardPage = .words
-                showsDashboard = true
-            } label: {
-                compactLogo
-                    .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Open VocaPhone controls")
-            .accessibilityValue(
-                state.quickDictationReady ? "Quick Dictation ready" : "Quick Dictation not ready"
-            )
-
-            if !state.quickDictationReady {
-                Divider()
-                    .frame(height: 22)
-                Button("Start") {
-                    state.onStartQuickDictation?()
-                }
-                .font(.system(size: 14, weight: .semibold))
+        Button {
+            state.refreshDashboard()
+            selectedDashboardPage = .words
+            state.setCompactDashboardPresented(true)
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: Self.glyphSize, weight: .bold))
                 .foregroundStyle(controlForeground)
-                .padding(.horizontal, 10)
-                .frame(height: Self.buttonDiameter)
-                .buttonStyle(.plain)
-                .accessibilityLabel("Start Quick Dictation")
-            }
+                .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                .contentShape(Circle())
         }
-        .fixedSize(horizontal: true, vertical: false)
-        .modifier(GlassCapsuleModifier())
-    }
-
-    /// The same readiness control in the expanded header. A ready app needs
-    /// only its mark; an unavailable one keeps the explicit Start action.
-    private var compactReadinessButton: some View {
-        Group {
-            if state.quickDictationReady {
-                compactLogo
-                    .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
-                    .accessibilityLabel("Quick Dictation ready")
-            } else {
-                Button("Start") {
-                    state.onStartQuickDictation?()
-                }
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(controlForeground)
-                .padding(.horizontal, 12)
-                .frame(height: Self.buttonDiameter)
-                .accessibilityLabel("Start Quick Dictation")
-            }
-        }
-        .modifier(GlassCapsuleModifier())
+        .buttonStyle(.plain)
+        .modifier(GlassButtonModifier(id: "compactDisclosure", namespace: animationNamespace))
+        .accessibilityLabel("Open VocaPhone controls")
     }
 
     private var compactStyleButton: some View {
@@ -867,19 +880,6 @@ struct DictationSurfaceView: View {
         .modifier(GlassCapsuleModifier())
         .accessibilityLabel("Transcription language")
         .accessibilityValue(state.language.displayName)
-    }
-
-    /// The product mark reduced to the same two shapes as the app icon: brand
-    /// field and microphone. Drawing it here keeps the keyboard target from
-    /// carrying a second copy of the generated artwork.
-    private var compactLogo: some View {
-        ZStack {
-            Circle().fill(dashboardAccent)
-            Image(systemName: "mic.fill")
-                .font(.system(size: 12, weight: .bold))
-                .foregroundStyle(state.isDark ? Color(BrandPalette.ink) : .white)
-        }
-        .frame(width: 25, height: 25)
     }
 
     @ViewBuilder
@@ -991,11 +991,20 @@ struct DictationSurfaceView: View {
 
     // MARK: - Trailing Primary Action Button (Green Circle)
 
+    private var compactShowsStart: Bool {
+        state.usesCompactControls && !sessionIsOpen && !state.quickDictationReady
+    }
+
     private var trailingActionButton: some View {
         Button {
             // Finish, Insert, Retry, Start: the state decides, the surface
             // draws it. `onPrimary` is set for every state the controller
             // drives; the two below are what the lab and the previews use.
+            //
+            // "Start" is only a readiness label, not a separate setup action.
+            // The first tap must create the real shared session and open the
+            // containing app on its recording handoff. Requiring a second mic
+            // tap after returning made cold starts fundamentally racy.
             if let onPrimary = state.onPrimary {
                 onPrimary()
             } else if isRecording {
@@ -1004,53 +1013,70 @@ struct DictationSurfaceView: View {
                 state.onStart?()
             }
         } label: {
-            ZStack {
-                // The compact row keeps the microphone at the trailing edge,
-                // matching the sketch and keeping its target fixed while the
-                // centre swaps between a style and suggestions.
-                if state.usesCompactControls {
-                    Circle()
-                        .fill(.clear)
-                        .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
-                        .modifier(GlassButtonModifier(
-                            id: "compactPrimary",
-                            namespace: animationNamespace
-                        ))
-                } else {
-                    Circle()
-                        .fill(Self.brandGreen)
-                        .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
-                        .shadow(color: Self.brandGreen.opacity(0.35), radius: 4, x: 0, y: 2)
+            if compactShowsStart {
+                HStack(spacing: 9) {
+                    Image(systemName: "mic.fill")
+                    Text("Start")
                 }
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(Self.brandGreen)
+                .padding(.horizontal, 14)
+                .frame(height: Self.buttonDiameter)
+                .modifier(GlassCapsuleModifier())
+            } else {
+                ZStack {
+                    // The compact row keeps the microphone at the trailing edge,
+                    // matching the sketch and keeping its target fixed while the
+                    // centre swaps between a style and suggestions.
+                    if state.usesCompactControls {
+                        Circle()
+                            .fill(.clear)
+                            .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                            .modifier(GlassButtonModifier(
+                                id: "compactPrimary",
+                                namespace: animationNamespace
+                            ))
+                    } else {
+                        Circle()
+                            .fill(Self.brandGreen)
+                            .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                            .shadow(
+                                color: Self.brandGreen.opacity(0.35),
+                                radius: 4,
+                                x: 0,
+                                y: 2
+                            )
+                    }
 
-                if isWorking && !state.primaryIsEnabled {
-                    // The same circle, still there, no longer an action: the
-                    // work it started is what it is now reporting.
-                    ProgressView()
-                        .progressViewStyle(.circular)
-                        // The same colour as the glyph it replaces. White was
-                        // right on a green circle and invisible on glass, so
-                        // transcribing looked like a button that had gone
-                        // blank rather than one that was working.
-                        .tint(state.usesCompactControls ? Self.brandGreen : Color.white)
-                        .transition(.scale.combined(with: .opacity))
-                } else {
-                    Image(systemName: isRecording ? "checkmark" : state.primarySymbol)
-                        .font(.system(size: Self.glyphSize, weight: .semibold))
-                        // Green on glass. The brand colour has moved off the
-                        // fill and onto the glyph, which is the only place left
-                        // for it once the button stops being a green circle.
-                        .foregroundStyle(
-                            state.usesCompactControls ? Self.brandGreen : Color.white
-                        )
-                        .transition(.scale.combined(with: .opacity))
+                    if isWorking && !state.primaryIsEnabled {
+                        // The same circle, still there, no longer an action: the
+                        // work it started is what it is now reporting.
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            // The same colour as the glyph it replaces. White was
+                            // right on a green circle and invisible on glass, so
+                            // transcribing looked like a button that had gone
+                            // blank rather than one that was working.
+                            .tint(state.usesCompactControls ? Self.brandGreen : Color.white)
+                            .transition(.scale.combined(with: .opacity))
+                    } else {
+                        Image(systemName: isRecording ? "checkmark" : state.primarySymbol)
+                            .font(.system(size: Self.glyphSize, weight: .semibold))
+                            // Green on glass. The brand colour has moved off the
+                            // fill and onto the glyph, which is the only place left
+                            // for it once the button stops being a green circle.
+                            .foregroundStyle(
+                                state.usesCompactControls ? Self.brandGreen : Color.white
+                            )
+                            .transition(.scale.combined(with: .opacity))
+                    }
                 }
             }
         }
         .buttonStyle(.plain)
         // The model disables processing but keeps handoff recovery available.
         .disabled(!state.primaryIsEnabled)
-        .accessibilityLabel(state.primaryLabel)
+        .accessibilityLabel(compactShowsStart ? "Start dictation" : state.primaryLabel)
         .matchedGeometryEffect(id: "trailingActionCircle", in: animationNamespace)
     }
 }

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -738,7 +738,7 @@ struct DictationSurfaceView: View {
                     .font(.system(size: Self.glyphSize, weight: .semibold))
                     .foregroundStyle(controlForeground)
                     .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
-                    .contentShape(Circle())
+                    .contentShape(.rect)
             }
             .buttonStyle(.plain)
             .modifier(GlassButtonModifier(id: "dashboardClose", namespace: animationNamespace))
@@ -754,7 +754,7 @@ struct DictationSurfaceView: View {
                     .font(.system(size: Self.glyphSize, weight: .semibold))
                     .foregroundStyle(controlForeground)
                     .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
-                    .contentShape(Circle())
+                    .contentShape(.rect)
             }
             .buttonStyle(.plain)
             .modifier(GlassButtonModifier(id: "dashboardSettings", namespace: animationNamespace))
@@ -869,6 +869,11 @@ struct DictationSurfaceView: View {
 
     /// The ellipsis is the disclosure control from the sketch. Readiness lives
     /// with the microphone action on the opposite side of the row.
+    ///
+    /// Square hit shapes on these round controls, here and below: a circle
+    /// inscribed in the 44-point frame throws away its corners — a fifth of the
+    /// target — and the corner is exactly where a thumb reaching across the
+    /// keyboard lands. The glass stays round; only the touch area is square.
     private var compactStatusControl: some View {
         Button {
             state.refreshDashboard()
@@ -879,7 +884,7 @@ struct DictationSurfaceView: View {
                 .font(.system(size: Self.glyphSize, weight: .bold))
                 .foregroundStyle(controlForeground)
                 .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
-                .contentShape(Circle())
+                .contentShape(.rect)
         }
         .buttonStyle(.plain)
         .modifier(GlassButtonModifier(id: "compactDisclosure", namespace: animationNamespace))
@@ -936,7 +941,7 @@ struct DictationSurfaceView: View {
                 .font(.system(size: Self.glyphSize, weight: .semibold))
                 .foregroundStyle(state.isDark ? Color.white : Color.black)
                 .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
-                .contentShape(Circle())
+                .contentShape(.rect)
         }
         .buttonStyle(.plain)
         .modifier(GlassButtonModifier(id: "leadGlass", namespace: animationNamespace))
@@ -951,7 +956,7 @@ struct DictationSurfaceView: View {
                 .font(.system(size: Self.glyphSize, weight: .semibold))
                 .foregroundStyle(state.isDark ? Color.white : Color.black)
                 .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
-                .contentShape(Circle())
+                .contentShape(.rect)
         }
         .buttonStyle(.plain)
         .modifier(GlassButtonModifier(id: "languageGlass", namespace: animationNamespace))
@@ -970,7 +975,7 @@ struct DictationSurfaceView: View {
                 .font(.system(size: Self.glyphSize, weight: .semibold))
                 .foregroundStyle(state.isDark ? Color.white : Color.black)
                 .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
-                .contentShape(Circle())
+                .contentShape(.rect)
         }
         .buttonStyle(.plain)
         .modifier(GlassButtonModifier(id: "styleGlass", namespace: animationNamespace))
@@ -1011,7 +1016,7 @@ struct DictationSurfaceView: View {
                     .font(.system(size: Self.glyphSize, weight: .semibold))
                     .foregroundStyle(controlForeground)
                     .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
-                    .contentShape(Circle())
+                    .contentShape(.rect)
             }
             .buttonStyle(.plain)
             .modifier(GlassButtonModifier(id: "pickerClose", namespace: animationNamespace))

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -47,11 +47,6 @@ final class DictationSurfaceState: ObservableObject {
         get { storedQuickDictationReady }
         set { change(&storedQuickDictationReady, to: newValue) }
     }
-    private var storedQuickDictationEnabled = KeyboardPreferences.quickDictationEnabled
-    var quickDictationEnabled: Bool {
-        get { storedQuickDictationEnabled }
-        set { change(&storedQuickDictationEnabled, to: newValue) }
-    }
     /// Private, on-device totals shared by the app and keyboard through their
     /// existing App Group. Loaded only when the dashboard is opened so ordinary
     /// typing never pays for a directory scan.
@@ -212,7 +207,7 @@ final class DictationSurfaceState: ObservableObject {
     var onGlobe: (() -> Void)?
     var onOpenSettings: (() -> Void)?
     var onDashboardVisibilityChanged: ((Bool) -> Void)?
-    var onQuickDictationChanged: ((Bool) -> Void)?
+    var onQuickDictationReadinessChanged: ((Bool) -> Void)?
     var onCandidate: ((TypingCandidate) -> Void)? {
         get { typing.onCandidate }
         set { typing.onCandidate = newValue }
@@ -240,7 +235,6 @@ final class DictationSurfaceState: ObservableObject {
         language = KeyboardPreferences.effectiveTranscriptionLanguage
         style = KeyboardPreferences.writingStyle
         usesCompactControls = KeyboardPreferences.compactControlsEnabled
-        quickDictationEnabled = KeyboardPreferences.quickDictationEnabled
         refreshQuickDictationReadiness()
     }
 
@@ -260,18 +254,21 @@ final class DictationSurfaceState: ObservableObject {
         onDashboardVisibilityChanged?(presented)
     }
 
-    func setQuickDictationEnabled(_ enabled: Bool) {
-        guard quickDictationEnabled != enabled else { return }
-        quickDictationEnabled = enabled
-        if !enabled {
-            quickDictationReady = false
+    /// Controls the live standby window shown by this dashboard. The durable
+    /// Settings preference and its ten-minute duration are deliberately not
+    /// changed here; this is the same temporary pause/resume contract as the
+    /// Live Activity control.
+    func setQuickDictationReady(_ ready: Bool) {
+        guard quickDictationReady != ready else { return }
+        quickDictationReady = ready
+        if !ready {
             // Match the keyboard-first behavior of the reference flow: once
             // standby is off, the dashboard has no follow-up action to offer.
             // Close it in the same tap so the typing keys and Start control are
             // immediately visible again.
             setCompactDashboardPresented(false)
         }
-        onQuickDictationChanged?(enabled)
+        onQuickDictationReadinessChanged?(ready)
     }
 
     /// Persists the choice, exactly as the dictation bar's own menu does.
@@ -726,8 +723,8 @@ struct DictationSurfaceView: View {
             Toggle(
                 "Quick Dictation",
                 isOn: Binding(
-                    get: { state.quickDictationEnabled },
-                    set: { state.setQuickDictationEnabled($0) }
+                    get: { state.quickDictationReady },
+                    set: { state.setQuickDictationReady($0) }
                 )
             )
             .labelsHidden()

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -27,29 +27,33 @@ final class DictationSurfaceState: ObservableObject {
         get { storedStyle }
         set { change(&storedStyle, to: newValue) }
     }
-    /// Whether anything has been typed since this keyboard instance came up.
-    ///
-    /// Only the compact row cares: it puts the action button in the middle
-    /// until there is something to type beside it, and that has to be a latch
-    /// rather than a question about the current candidates. It is not reset on
-    /// every appearance — coming back from vocaphone is the same session, and
-    /// resetting here flew the microphone to the middle and back.
-    private var storedHasTypedThisSession: Bool = false
-    var hasTypedThisSession: Bool {
-        get { storedHasTypedThisSession }
-        set { change(&storedHasTypedThisSession, to: newValue) }
-    }
     /// The compact arrangement, for looking at in the keyboard lab.
     ///
-    /// Two glass circles on the left and a solid green one on the right is the
-    /// shipping row. This collapses the left pair behind one ellipsis menu and
-    /// turns the right circle into a fixed-width glass capsule — the same row
-    /// with less on it, which is the sort of thing that has to be seen beside
-    /// the original rather than argued about. Debug builds only.
+    /// The shipping row keeps language and style in separate leading buttons.
+    /// Compact mode instead shows VocaPhone readiness, style and microphone,
+    /// with the first control expanding into language, settings and local
+    /// usage stats. Debug builds opt into it from the keyboard lab.
     private var storedUsesCompactControls: Bool = false
     var usesCompactControls: Bool {
         get { storedUsesCompactControls }
         set { change(&storedUsesCompactControls, to: newValue) }
+    }
+    /// A fresh Quick Dictation heartbeat means the containing app is alive and
+    /// can claim a microphone request without taking the user out of the app
+    /// they are typing in. This is the real readiness signal, not a guess based
+    /// on whether Quick Dictation is enabled in Settings.
+    private var storedQuickDictationReady = false
+    var quickDictationReady: Bool {
+        get { storedQuickDictationReady }
+        set { change(&storedQuickDictationReady, to: newValue) }
+    }
+    /// Private, on-device totals shared by the app and keyboard through their
+    /// existing App Group. Loaded only when the dashboard is opened so ordinary
+    /// typing never pays for a directory scan.
+    private var storedUsageStats = UsageStats()
+    var usageStats: UsageStats {
+        get { storedUsageStats }
+        set { change(&storedUsageStats, to: newValue) }
     }
     private var storedShowsGlobeKey: Bool = false
     var showsGlobeKey: Bool {
@@ -196,6 +200,8 @@ final class DictationSurfaceState: ObservableObject {
     var onLanguageChanged: ((TranscriptionLanguage) -> Void)?
     var onStyleChanged: ((WritingStyle) -> Void)?
     var onGlobe: (() -> Void)?
+    var onStartQuickDictation: (() -> Void)?
+    var onOpenSettings: (() -> Void)?
     var onCandidate: ((TypingCandidate) -> Void)? {
         get { typing.onCandidate }
         set { typing.onCandidate = newValue }
@@ -223,6 +229,17 @@ final class DictationSurfaceState: ObservableObject {
         language = KeyboardPreferences.effectiveTranscriptionLanguage
         style = KeyboardPreferences.writingStyle
         usesCompactControls = KeyboardPreferences.compactControlsEnabled
+        refreshQuickDictationReadiness()
+    }
+
+    func refreshQuickDictationReadiness(at now: Date = Date()) {
+        let availability = try? SharedStore.shared.loadQuickDictationAvailability()
+        quickDictationReady = availability?.isReady(at: now) == true
+    }
+
+    func refreshDashboard(at now: Date = Date()) {
+        refreshQuickDictationReadiness(at: now)
+        usageStats = UsageStatsStore.shared.current()
     }
 
     /// Persists the choice, exactly as the dictation bar's own menu does.
@@ -272,6 +289,43 @@ final class DictationSurfaceState: ObservableObject {
             candidate,
             modelLanguages: KeyboardPreferences.activeModelLanguages
         )
+    }
+}
+
+/// The honest, local-only numbers the compact keyboard dashboard can show.
+/// There is deliberately no percentile or made-up equivalent such as "cover
+/// letters": the store knows words, sessions, speaking time and streaks, and
+/// the keyboard says only what it knows.
+enum CompactDashboardPage: Int, CaseIterable, Identifiable, Sendable {
+    case words
+    case sessions
+    case streak
+    case speed
+
+    var id: Int { rawValue }
+
+    func value(for stats: UsageStats, now: Date = Date()) -> String {
+        switch self {
+        case .words:
+            return "\(stats.totalWords.formatted(.number.grouping(.automatic))) words"
+        case .sessions:
+            return "\(stats.totalDictations.formatted(.number.grouping(.automatic))) sessions"
+        case .streak:
+            let days = stats.currentStreak(at: now)
+            return "\(days) \(days == 1 ? "day" : "days")"
+        case .speed:
+            return "\(Int(stats.averageWordsPerMinute.rounded())) WPM"
+        }
+    }
+
+    func detail(for stats: UsageStats) -> String {
+        switch self {
+        case .words: "Dictated with VocaPhone so far"
+        case .sessions: "Completed dictations"
+        case .streak:
+            "Best streak: \(stats.bestStreak) \(stats.bestStreak == 1 ? "day" : "days")"
+        case .speed: "Average speaking speed"
+        }
     }
 }
 
@@ -349,6 +403,8 @@ struct DictationSurfaceView: View {
     /// keyboard restores a session in `viewDidLoad`; animating idle into
     /// recording is the blink after swiping back from vocaphone.
     @State private var layoutAnimationEnabled = false
+    @State private var showsDashboard = false
+    @State private var selectedDashboardPage = CompactDashboardPage.words
 
     private static let brandGreen = Color(red: 13 / 255, green: 104 / 255, blue: 77 / 255)
     /// The diameter the rest of the product already uses for a round control:
@@ -370,11 +426,6 @@ struct DictationSurfaceView: View {
     private static let sideInset: CGFloat = 6
     /// Glyphs at the toolbar's own weight and size, for the same reason.
     private static let glyphSize: CGFloat = 17
-    /// The compact action button's width. Wider than the 44pt circle it
-    /// replaces so it reads as the row's one action, and fixed so it does not
-    /// move under the thumb when the state swaps its glyph.
-    private static let compactActionWidth: CGFloat = 116
-
     init(state: DictationSurfaceState) {
         self.state = state
     }
@@ -419,8 +470,12 @@ struct DictationSurfaceView: View {
     /// transcript waiting to go in, a field that went away.
     private var hasMessage: Bool { state.centerMessage != nil }
 
-    /// Whether the surface stands open: the tall layout with a centre.
-    private var isOpen: Bool { isRecording || isWorking || hasMessage }
+    /// Whether a dictation session owns the full keyboard surface.
+    private var sessionIsOpen: Bool { isRecording || isWorking || hasMessage }
+
+    /// The dashboard is another deliberate expansion of the same surface, but
+    /// never competes with a live session or a recovery message.
+    private var isOpen: Bool { sessionIsOpen || showsDashboard }
 
     /// Typing, with something to offer. The two menu buttons collapse into one
     /// so the row they were using becomes the suggestions — which is what the
@@ -446,7 +501,9 @@ struct DictationSurfaceView: View {
             // The row is the first thing in the stack; that is what puts it at
             // the top, not a height.
 
-            if isOpen {
+            if showsDashboard, !sessionIsOpen {
+                compactDashboard
+            } else if sessionIsOpen {
                 Spacer(minLength: 0)
 
                 // Center Waveform and Subtitle
@@ -539,59 +596,138 @@ struct DictationSurfaceView: View {
         .animation(layoutAnimationEnabled ? surfaceSpring : nil, value: isOpen)
         .animation(layoutAnimationEnabled ? surfaceSpring : nil, value: isWorking)
         .animation(layoutAnimationEnabled ? surfaceSpring : nil, value: isSuggesting)
+        .animation(layoutAnimationEnabled ? surfaceSpring : nil, value: showsDashboard)
+        .onChange(of: sessionIsOpen) { _, open in
+            if open { showsDashboard = false }
+        }
     }
 
     // MARK: - Controls Row
 
-    /// Whether the action button stands in the middle of the row.
-    ///
-    /// Only with nothing typed and no session running. Once there are
-    /// suggestions they take the middle, and once a session is open the row
-    /// has a cancel on one end and a finish on the other — a finish floating
-    /// in the centre above a waveform is not a row, it is a button that has
-    /// come loose.
-    private var centresAction: Bool {
-        state.usesCompactControls && !isOpen && !state.hasTypedThisSession
-    }
-
     @ViewBuilder
     private var controlsRow: some View {
-        // A `ZStack` rather than balanced spacers: with the ellipsis pinned
-        // left, spacers centre the button in what is *left over*, which lands
-        // it visibly right of centre. Here it is centred against the whole row
-        // and the ellipsis floats over it.
-        //
-        // Both arrangements draw the same button carrying the same
-        // `matchedGeometryEffect`, so the first keystroke slides it from the
-        // middle to the end instead of teleporting it there.
-        ZStack {
-            if centresAction {
-                trailingActionButton
+        Group {
+            if showsDashboard, !sessionIsOpen {
+                dashboardControlsRow
+            } else if state.usesCompactControls, !sessionIsOpen {
+                compactControlsRow
+            } else {
+                standardControlsRow
             }
-            HStack(spacing: 8) {
-                leadingGlassContainer
+        }
+    }
 
-                if isSuggesting {
-                    CandidateRow(state: state.typing)
-                } else {
+    private var standardControlsRow: some View {
+        HStack(spacing: 8) {
+            leadingGlassContainer
+            if isSuggesting {
+                CandidateRow(state: state.typing)
+            } else {
+                Spacer()
+            }
+            trailingActionButton
+        }
+    }
+
+    /// Logo/readiness, the writing style in force, and the microphone: the
+    /// three things the sketch asks the idle compact row to answer at a glance.
+    private var compactControlsRow: some View {
+        HStack(spacing: 8) {
+            compactStatusControl
+            if isSuggesting {
+                CandidateRow(state: state.typing)
+            } else {
+                compactStyleButton
+                    .frame(maxWidth: .infinity)
+            }
+            trailingActionButton
+        }
+    }
+
+    private var dashboardControlsRow: some View {
+        HStack(spacing: 8) {
+            Button {
+                showsDashboard = false
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: Self.glyphSize, weight: .semibold))
+                    .foregroundStyle(controlForeground)
+                    .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                    .contentShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .modifier(GlassButtonModifier(id: "dashboardClose", namespace: animationNamespace))
+            .accessibilityLabel("Close controls")
+
+            Spacer(minLength: 0)
+            compactLanguageButton
+
+            Button {
+                state.onOpenSettings?()
+            } label: {
+                Image(systemName: "gearshape")
+                    .font(.system(size: Self.glyphSize, weight: .semibold))
+                    .foregroundStyle(controlForeground)
+                    .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                    .contentShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .modifier(GlassButtonModifier(id: "dashboardSettings", namespace: animationNamespace))
+            .accessibilityLabel("Open VocaPhone settings")
+
+            compactReadinessButton
+        }
+    }
+
+    private var compactDashboard: some View {
+        VStack(spacing: 0) {
+            TabView(selection: $selectedDashboardPage) {
+                ForEach(CompactDashboardPage.allCases) { page in
+                    VStack(spacing: 12) {
+                        Text(page.value(for: state.usageStats))
+                            .font(.system(size: 44, weight: .medium, design: .rounded))
+                            .minimumScaleFactor(0.65)
+                            .lineLimit(1)
+                            .foregroundStyle(dashboardAccent)
+                        Text(page.detail(for: state.usageStats))
+                            .font(.system(size: 16, weight: .medium))
+                            .multilineTextAlignment(.center)
+                            .foregroundStyle(controlForeground.opacity(0.82))
+                    }
+                    .padding(.horizontal, 24)
+                    .tag(page)
+                    .accessibilityElement(children: .combine)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .always))
+            .indexViewStyle(.page(backgroundDisplayMode: .never))
+
+            if state.showsGlobeKey {
+                HStack {
+                    Button {
+                        state.onGlobe?()
+                    } label: {
+                        Image(systemName: "globe")
+                            .font(.system(size: 20))
+                            .foregroundStyle(controlForeground)
+                            .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Next keyboard")
                     Spacer()
                 }
-
-                if !centresAction {
-                    trailingActionButton
-                }
             }
         }
-        .animation(layoutAnimationEnabled ? .snappy(duration: 0.24) : nil, value: centresAction)
-        // Latched here rather than derived, because `isSuggesting` is false
-        // between words: the candidates empty on a space and fill again on the
-        // next letter, and a position derived from them threw the microphone
-        // back to the middle and out again on every word. Once typing has
-        // started it has started, and the button stays where typing put it
-        // until the keyboard goes away.
-        .onChange(of: isSuggesting) { _, suggesting in
-            if suggesting { state.hasTypedThisSession = true }
-        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .transition(.opacity.combined(with: .scale(scale: 0.97)))
+    }
+
+    private var controlForeground: Color {
+        state.isDark ? .white : .black
+    }
+
+    private var dashboardAccent: Color {
+        Color(BrandPalette.accent(isDark: state.isDark))
     }
 
     @ViewBuilder
@@ -615,48 +751,135 @@ struct DictationSurfaceView: View {
     private var leadingGlassGroup: some View {
         if isOpen {
             cancelGlassButton
-        } else if state.usesCompactControls {
-            compactMenuButton
         } else {
             languageMenuButton
             styleMenuButton
         }
     }
 
-    /// Both left menus behind one key.
-    ///
-    /// The ellipsis is what iOS uses for "the rest of it", and nesting the two
-    /// menus inside it keeps every destination the pair had — one more tap to
-    /// reach either, one less thing on the row.
-    @ViewBuilder
-    private var compactMenuButton: some View {
-        Menu {
-            Menu("Language") {
-                ForEach(state.languageShortcuts, id: \.self) { lang in
-                    languageButton(lang)
-                }
-                Menu("More languages") {
-                    ForEach(state.remainingLanguages, id: \.self) { lang in
-                        languageButton(lang)
-                    }
-                }
+    /// The logo is the disclosure control. When the app's short-lived readiness
+    /// heartbeat is absent, Start is a separate target in the same capsule so
+    /// opening the dashboard never accidentally foregrounds the app.
+    private var compactStatusControl: some View {
+        HStack(spacing: 0) {
+            Button {
+                state.refreshDashboard()
+                selectedDashboardPage = .words
+                showsDashboard = true
+            } label: {
+                compactLogo
+                    .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                    .contentShape(Rectangle())
             }
-            Menu("Style") {
-                ForEach(WritingStyle.allCases, id: \.self) { item in
-                    Toggle(isOn: styleBinding(for: item)) {
-                        Label(item.displayName, systemImage: item.symbolName)
-                    }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Open VocaPhone controls")
+            .accessibilityValue(
+                state.quickDictationReady ? "Quick Dictation ready" : "Quick Dictation not ready"
+            )
+
+            if !state.quickDictationReady {
+                Divider()
+                    .frame(height: 22)
+                Button("Start") {
+                    state.onStartQuickDictation?()
+                }
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(controlForeground)
+                .padding(.horizontal, 10)
+                .frame(height: Self.buttonDiameter)
+                .buttonStyle(.plain)
+                .accessibilityLabel("Start Quick Dictation")
+            }
+        }
+        .fixedSize(horizontal: true, vertical: false)
+        .modifier(GlassCapsuleModifier())
+    }
+
+    /// The same readiness control in the expanded header. A ready app needs
+    /// only its mark; an unavailable one keeps the explicit Start action.
+    private var compactReadinessButton: some View {
+        Group {
+            if state.quickDictationReady {
+                compactLogo
+                    .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                    .accessibilityLabel("Quick Dictation ready")
+            } else {
+                Button("Start") {
+                    state.onStartQuickDictation?()
+                }
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(controlForeground)
+                .padding(.horizontal, 12)
+                .frame(height: Self.buttonDiameter)
+                .accessibilityLabel("Start Quick Dictation")
+            }
+        }
+        .modifier(GlassCapsuleModifier())
+    }
+
+    private var compactStyleButton: some View {
+        Menu {
+            ForEach(WritingStyle.allCases, id: \.self) { item in
+                Toggle(isOn: styleBinding(for: item)) {
+                    Label(item.displayName, systemImage: item.symbolName)
                 }
             }
         } label: {
-            Image(systemName: "ellipsis")
-                .font(.system(size: Self.glyphSize, weight: .semibold))
-                .foregroundStyle(state.isDark ? Color.white : Color.black)
-                .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
-                .contentShape(Circle())
+            HStack(spacing: 7) {
+                Image(systemName: state.style.symbolName)
+                Text(state.style.displayName)
+                    .lineLimit(1)
+            }
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(controlForeground)
+            .padding(.horizontal, 16)
+            .frame(minWidth: 116, minHeight: Self.buttonDiameter)
+            .contentShape(Capsule())
         }
-        .modifier(GlassButtonModifier(id: "leadGlass", namespace: animationNamespace))
-        .accessibilityLabel("Language and style")
+        .buttonStyle(.plain)
+        .modifier(GlassCapsuleModifier())
+        .accessibilityLabel("Writing style")
+        .accessibilityValue(state.style.displayName)
+    }
+
+    private var compactLanguageButton: some View {
+        Menu {
+            ForEach(state.languageShortcuts, id: \.self) { lang in
+                languageButton(lang)
+            }
+            Menu("More languages") {
+                ForEach(state.remainingLanguages, id: \.self) { lang in
+                    languageButton(lang)
+                }
+            }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "globe")
+                Text(state.language.shortLabel)
+            }
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(controlForeground)
+            .padding(.horizontal, 12)
+            .frame(minHeight: Self.buttonDiameter)
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .modifier(GlassCapsuleModifier())
+        .accessibilityLabel("Transcription language")
+        .accessibilityValue(state.language.displayName)
+    }
+
+    /// The product mark reduced to the same two shapes as the app icon: brand
+    /// field and microphone. Drawing it here keeps the keyboard target from
+    /// carrying a second copy of the generated artwork.
+    private var compactLogo: some View {
+        ZStack {
+            Circle().fill(dashboardAccent)
+            Image(systemName: "mic.fill")
+                .font(.system(size: 12, weight: .bold))
+                .foregroundStyle(state.isDark ? Color(BrandPalette.ink) : .white)
+        }
+        .frame(width: 25, height: 25)
     }
 
     @ViewBuilder
@@ -782,24 +1005,17 @@ struct DictationSurfaceView: View {
             }
         } label: {
             ZStack {
-                // Glass rather than the brand circle, and a capsule rather than
-                // a circle: the extra width is what makes it read as the row's
-                // one action instead of a third icon. Fixed, because a button
-                // that grows with its glyph moves under the thumb every time
-                // the state changes the glyph.
+                // The compact row keeps the microphone at the trailing edge,
+                // matching the sketch and keeping its target fixed while the
+                // centre swaps between a style and suggestions.
                 if state.usesCompactControls {
-                    // Wide while it is the only thing on the row, round once
-                    // the suggestions have taken the middle: the same button
-                    // with the room it happens to have.
-                    Capsule()
+                    Circle()
                         .fill(.clear)
-                        .frame(
-                            width: centresAction
-                                ? Self.compactActionWidth
-                                : Self.buttonDiameter,
-                            height: Self.buttonDiameter
-                        )
-                        .modifier(GlassCapsuleModifier())
+                        .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
+                        .modifier(GlassButtonModifier(
+                            id: "compactPrimary",
+                            namespace: animationNamespace
+                        ))
                 } else {
                     Circle()
                         .fill(Self.brandGreen)

--- a/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
+++ b/ios/VocaPhoneKeyboard/DictationSurfaceView.swift
@@ -477,6 +477,7 @@ struct DictationSurfaceView: View {
     /// Layout springs stay off until the first real frame has landed. The
     /// keyboard restores a session in `viewDidLoad`; animating idle into
     /// recording is the blink after swiping back from vocaphone.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var layoutAnimationEnabled = false
     @State private var selectedDashboardPage = CompactDashboardPage.words
 
@@ -817,7 +818,7 @@ struct DictationSurfaceView: View {
             panelGlobeRow
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .transition(Self.panelTransition)
+        .transition(panelTransition)
     }
 
     private var controlForeground: Color {
@@ -826,6 +827,17 @@ struct DictationSurfaceView: View {
 
     private var dashboardAccent: Color {
         Color(BrandPalette.accent(isDark: state.isDark))
+    }
+
+    /// The keys' own palette, so a panel standing in their place is made of
+    /// the same material rather than of grey rectangles invented for it.
+    private var keyPalette: KeyboardPalette { KeyboardPalette(isDark: state.isDark) }
+
+    /// What is legible on an accent fill: white in light, near-black in dark.
+    private var onAccent: Color {
+        Color(BrandPalette.onAccent.resolvedColor(
+            with: UITraitCollection(userInterfaceStyle: state.isDark ? .dark : .light)
+        ))
     }
 
     @ViewBuilder
@@ -968,9 +980,16 @@ struct DictationSurfaceView: View {
 
     // MARK: - Pickers
 
-    /// The panels come and go the way the dashboard does.
-    private static let panelTransition = AnyTransition.opacity
-        .combined(with: .scale(scale: 0.97))
+    /// A panel rises into the room the keys leave, and fades going back.
+    ///
+    /// A rise rather than the scale this started with: scaling a panel that
+    /// fills the keyboard reads as the whole keyboard flexing, while eight
+    /// points of travel reads as one layer arriving over another.
+    private var panelTransition: AnyTransition {
+        reduceMotion
+            ? .opacity
+            : .asymmetric(insertion: .opacity.combined(with: .offset(y: 8)), removal: .opacity)
+    }
 
     @ViewBuilder
     private func panelContent(_ panel: SurfacePanel) -> some View {
@@ -1000,7 +1019,7 @@ struct DictationSurfaceView: View {
 
             Spacer(minLength: 0)
             Text(title)
-                .font(.system(size: 16, weight: .semibold))
+                .font(.system(size: 17, weight: .semibold))
                 .foregroundStyle(controlForeground)
                 .accessibilityAddTraits(.isHeader)
             Spacer(minLength: 0)
@@ -1008,6 +1027,15 @@ struct DictationSurfaceView: View {
             Color.clear
                 .frame(width: Self.buttonDiameter, height: Self.buttonDiameter)
                 .accessibilityHidden(true)
+        }
+        // The hairline a sheet has under its title: it says the row above is a
+        // header for what is below rather than the keyboard's own toolbar.
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(controlForeground.opacity(0.1))
+                .frame(height: 1 / max(UITraitCollection.current.displayScale, 1))
+                .padding(.horizontal, -Self.sideInset)
+                .offset(y: 6)
         }
     }
 
@@ -1035,20 +1063,29 @@ struct DictationSurfaceView: View {
                 }
                 .frame(maxHeight: 84)
             }
-            Text(state.style.detail)
+            // What the style does, done to a sentence, rather than described.
+            // "Sentence capitalization and a closing full stop" is a rule; the
+            // sentence itself is the answer to the question being asked.
+            Text("\u{201C}\(state.style.example)\u{201D}")
                 .font(.system(size: 13))
+                .italic()
                 .foregroundStyle(controlForeground.opacity(0.6))
                 .multilineTextAlignment(.center)
                 .lineLimit(2)
-                .frame(maxWidth: .infinity)
+                // Reserved, so swapping one example for a longer one does not
+                // move the tiles above it.
+                .frame(maxWidth: .infinity, minHeight: 34, alignment: .top)
                 .padding(.horizontal, 12)
-                .padding(.top, 4)
+                .padding(.top, 6)
+                .animation(nil, value: state.style)
             Spacer(minLength: 0)
             panelGlobeRow
         }
         .padding(.top, 10)
+        .padding(.horizontal, 2)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .transition(Self.panelTransition)
+        .transition(panelTransition)
+        .gesture(panelDismissGesture)
     }
 
     /// Automatic and the languages this person uses first, then every language
@@ -1082,11 +1119,26 @@ struct DictationSurfaceView: View {
                     }
                 }
                 .padding(.vertical, 10)
+                .padding(.horizontal, 2)
             }
+            // A list that runs off the bottom edge looks like a list that
+            // ends there. Fading the last few points says it carries on.
+            .mask(
+                LinearGradient(
+                    stops: [
+                        .init(color: .black, location: 0),
+                        .init(color: .black, location: 0.9),
+                        .init(color: .black.opacity(0), location: 1),
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
             panelGlobeRow
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .transition(Self.panelTransition)
+        .transition(panelTransition)
+        .gesture(panelDismissGesture)
     }
 
     private func languageSection(
@@ -1129,13 +1181,14 @@ struct DictationSurfaceView: View {
                     .minimumScaleFactor(0.75)
             }
             .font(.system(size: 14, weight: isSelected ? .semibold : .medium))
-            .foregroundStyle(isSelected ? dashboardAccent : controlForeground)
-            .padding(.horizontal, 8)
+            .foregroundStyle(isSelected ? onAccent : controlForeground)
+            .padding(.horizontal, 10)
             .frame(maxWidth: .infinity, minHeight: 38)
             .background(pickerFill(isSelected: isSelected), in: Capsule())
             .contentShape(Capsule())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(PickerTileButtonStyle())
+        .shadow(color: .black.opacity(state.isDark ? 0 : 0.16), radius: 0.75, y: 1.25)
         .disabled(!isSelectable)
         .opacity(isSelectable ? 1 : 0.35)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
@@ -1147,44 +1200,52 @@ struct DictationSurfaceView: View {
         isSelected: Bool,
         action: @escaping () -> Void
     ) -> some View {
-        Button(action: action) {
+        let shape = RoundedRectangle(cornerRadius: 13, style: .continuous)
+        return Button(action: action) {
             VStack(spacing: 6) {
                 // One height for every glyph, so the names line up across a
                 // row whatever shape the symbol above them is.
                 Image(systemName: symbol)
-                    .font(.system(size: 20, weight: .medium))
+                    .font(.system(size: 21, weight: .medium))
                     .frame(height: 24)
                 Text(title)
                     .font(.system(size: 14, weight: .semibold))
                     .lineLimit(1)
                     .minimumScaleFactor(0.8)
             }
-            .foregroundStyle(isSelected ? dashboardAccent : controlForeground)
+            .foregroundStyle(isSelected ? onAccent : controlForeground)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .frame(minHeight: 60)
-            .background(
-                pickerFill(isSelected: isSelected),
-                in: RoundedRectangle(cornerRadius: 14, style: .continuous)
-            )
-            .overlay {
-                if isSelected {
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .strokeBorder(dashboardAccent, lineWidth: 1.5)
-                }
-            }
-            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .frame(minHeight: 58)
+            .background(pickerFill(isSelected: isSelected), in: shape)
+            .contentShape(shape)
         }
         .buttonStyle(PickerTileButtonStyle())
+        // The keys' own contact shadow, so a tile sits on the keyboard the way
+        // the key it replaced did.
+        .shadow(color: .black.opacity(state.isDark ? 0 : 0.16), radius: 0.75, y: 1.25)
         .accessibilityLabel(title)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
-    /// The key colour's cousin: quiet on both backgrounds, and the accent's
-    /// tint for the choice in force.
+    /// A key when it is one of several, the accent when it is the one in force
+    /// — the same distinction the Return key makes on the keyboard behind it.
     private func pickerFill(isSelected: Bool) -> Color {
-        isSelected
-            ? dashboardAccent.opacity(state.isDark ? 0.22 : 0.14)
-            : controlForeground.opacity(state.isDark ? 0.12 : 0.07)
+        isSelected ? dashboardAccent : Color(keyPalette.standardKey)
+    }
+
+    /// A downward drag closes a panel, the way it closes a sheet.
+    ///
+    /// The keys are underneath and the finger is already there, so the gesture
+    /// somebody tries first is pushing the panel back down. Deliberately long
+    /// at 60 points: a list that scrolls is under the same finger.
+    private var panelDismissGesture: some Gesture {
+        DragGesture(minimumDistance: 24)
+            .onEnded { value in
+                guard value.translation.height > 60,
+                      abs(value.translation.width) < value.translation.height
+                else { return }
+                state.dismissPanel()
+            }
     }
 
     @ViewBuilder

--- a/ios/VocaPhoneKeyboard/KeyAlternatives.swift
+++ b/ios/VocaPhoneKeyboard/KeyAlternatives.swift
@@ -21,6 +21,15 @@ enum KeyAlternatives {
         "u": ["ú", "ù", "û", "ü", "ū"],
         "y": ["ý", "ÿ"],
         "z": ["ź", "ż", "ž"],
+        // Cyrillic. Thirty-three letters against thirty-one keys, and these are
+        // the two that iOS leaves off the grid: ё behind е, ъ behind ь. Both
+        // are real letters rather than accents, so unlike the Latin rows above
+        // this is not an ergonomic extra — it is the only way to type them.
+        "е": ["ё"],
+        "ь": ["ъ"],
+        // Ukrainian. є and ї are letters and have their own keys; ґ is rare
+        // enough that iOS puts it behind г, and so does this.
+        "г": ["ґ"],
     ]
 
     /// Alternates on the numbers and symbols planes.

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -742,7 +742,9 @@ final class KeyGridView: UIView {
     /// keyboard that takes a beat to appear. The next plane switch rebuilds
     /// what it needs in a few milliseconds.
     func discardHiddenPlanes() {
-        for key in planeCache.keys where key != activePlaneKey {
+        // Over a snapshot: the loop is removing entries from the dictionary it
+        // would otherwise be walking.
+        for key in Array(planeCache.keys) where key != activePlaneKey {
             evictPlane(key)
         }
         letterPlaneRecency.removeAll { $0 != activePlaneKey }

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -207,15 +207,34 @@ final class KeyGridView: UIView {
     /// Switching to digits and back is frequent, and rebuilding thirty-odd key
     /// views each time means re-resolving fonts and symbol images. Built planes
     /// are kept and simply hidden; only a metrics or palette change discards them.
-    /// Built rows and their views, kept per plane *and* per layout: switching
-    /// between two layouts is a gesture people repeat, and rebuilding thirty
-    /// key views each time is work the finger would feel.
+    ///
+    /// Only the letters depend on the layout, so only the letters are kept per
+    /// layout, and only for the current one and the one before it — the pair
+    /// somebody flips between. Each cached plane holds thirty-odd key bitmaps,
+    /// about 1.3 MB, and keyed by plane *and* layout the numbers and symbols
+    /// were built again for every language: cycling all seven left some seven
+    /// hundred hidden key views and 26 MB behind, in a process jetsam watches
+    /// at about sixty.
     private struct PlaneKey: Hashable {
         let plane: KeyPlane
-        let layout: TypingLayout
+        /// Only for `.letters`; `nil` for every plane the layout does not change.
+        let layoutID: String?
+
+        init(plane: KeyPlane, layout: TypingLayout) {
+            self.plane = plane
+            layoutID = plane == .letters ? layout.id : nil
+        }
     }
 
+    /// How many layouts' letters stay built. Two: the one in use and the one a
+    /// swipe goes back to.
+    static let cachedLetterLayouts = 2
+
     private var planeCache: [PlaneKey: (rows: [KeyRow], views: [KeyView])] = [:]
+    /// Letter planes, most recently shown first, for eviction.
+    private var letterPlaneRecency: [PlaneKey] = []
+    /// The plane on screen, which eviction never touches.
+    private var activePlaneKey: PlaneKey?
     private var previewPool: [KeyPreviewView] = []
     /// The fading stroke drawn under the finger while a swipe is in flight.
     /// Created once and kept above the keys; it never takes a touch.
@@ -662,6 +681,8 @@ final class KeyGridView: UIView {
             plane.views.forEach { $0.removeFromSuperview() }
         }
         planeCache.removeAll()
+        letterPlaneRecency.removeAll()
+        activePlaneKey = nil
         // Every balloon, not just the pooled ones. `releaseTouches` above starts
         // a *fade* rather than hiding outright, so a preview that is still
         // fading is in neither the pool nor any tracked touch — it used to
@@ -713,6 +734,25 @@ final class KeyGridView: UIView {
         measured("activatePlane") { activatePlaneBody() }
     }
 
+    /// Drops every plane that is not on screen.
+    ///
+    /// For when the keyboard leaves the screen or iOS asks for memory back. A
+    /// suspended extension is judged on its footprint like any other process,
+    /// and one killed in the background comes back cold — which is the
+    /// keyboard that takes a beat to appear. The next plane switch rebuilds
+    /// what it needs in a few milliseconds.
+    func discardHiddenPlanes() {
+        for key in planeCache.keys where key != activePlaneKey {
+            evictPlane(key)
+        }
+        letterPlaneRecency.removeAll { $0 != activePlaneKey }
+    }
+
+    private func evictPlane(_ key: PlaneKey) {
+        guard let entry = planeCache.removeValue(forKey: key) else { return }
+        entry.views.forEach { $0.removeFromSuperview() }
+    }
+
     private func activatePlaneBody() {
         // Cleared here and rebuilt before this method returns: never let a
         // touch resolve old target indices against the new plane's views.
@@ -747,6 +787,14 @@ final class KeyGridView: UIView {
             }
             entry = (built, views)
             planeCache[cacheKey] = entry
+        }
+        activePlaneKey = cacheKey
+        if cacheKey.layoutID != nil {
+            letterPlaneRecency.removeAll { $0 == cacheKey }
+            letterPlaneRecency.insert(cacheKey, at: 0)
+            while letterPlaneRecency.count > Self.cachedLetterLayouts {
+                evictPlane(letterPlaneRecency.removeLast())
+            }
         }
 
         rows = entry.rows

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -13,6 +13,17 @@ enum KeyboardOutput {
     /// move by *characters*: how many characters a line is worth is a question
     /// about the document, and only the controller can see it.
     case moveCursorLine(Int)
+    /// The space bar has become a trackpad, and has stopped being one.
+    ///
+    /// Split out because the expensive part of a cursor step was never the
+    /// step. It was the two hops into the host process for the document, and
+    /// the pass over the dictionary, that used to follow every one of them —
+    /// at up to a hundred and twenty steps a second. Nothing but this keyboard
+    /// is moving the cursor while the finger is down, so the controller reads
+    /// the document once here, counts against its own tally, and reconciles
+    /// when the finger lifts.
+    case beginCursorDrag
+    case endCursorDrag
     /// A traced word and the alternates that lost to it, for the strip.
     case swipeWord(String, alternates: [String])
     /// Hold the plane key to reach the emoji panel.
@@ -25,10 +36,39 @@ enum KeyboardOutput {
     case emojiPanel
     /// Carries the globe key itself so the keyboard picker can anchor to it.
     case nextInputMode(UIView, UIEvent?)
+    /// Step to the next enabled layout, forwards or back. The grid knows which
+    /// layout it is drawing but not which ones exist, so the controller
+    /// resolves it and hands the answer back.
+    case nextLayout(forward: Bool)
 }
 
+/// The space bar's cursor trackpad, as a rate rather than a ruler.
+///
+/// This used to quantise the *absolute* translation: one character per 10pt
+/// from wherever the finger landed. That reads well and behaves badly, in
+/// three separate ways. A fixed rate puts the far end of a seventy-character
+/// line off the glass, so reaching it costs a lift and another third of a
+/// second of holding. A boundary at exactly 10.0pt flips back and forth under
+/// a finger that is merely resting, because a resting finger still moves, and
+/// the cursor jitters while nobody is asking it to. And an origin fixed at
+/// touch-down cannot be corrected once the gesture is already under way.
+///
+/// So: take each frame's *increment*, convert it to a fraction of a character
+/// at a rate set by how fast the finger is going, and emit whole characters as
+/// they accumulate. Tremor below one character's worth never emits anything,
+/// which is the hysteresis; a flick crosses a line while a crawl still places
+/// the cursor between two specific letters.
 enum CursorTrackpad {
-    static let pointsPerCharacter: CGFloat = 10
+    /// Travel per character when the finger is barely moving.
+    static let slowPointsPerCharacter: CGFloat = 14
+    /// ...and when it is thrown across the line. Much below this the cursor
+    /// outruns the eye and lands by luck rather than by aim.
+    static let fastPointsPerCharacter: CGFloat = 4
+    /// The finger speeds those two rates belong to, in points per second.
+    /// Between them the rate is interpolated; outside, it is clamped.
+    static let slowSpeed: CGFloat = 90
+    static let fastSpeed: CGFloat = 1400
+
     /// How far the finger travels for one line.
     ///
     /// Deliberately more than twice the horizontal step. The gesture is mostly
@@ -37,12 +77,13 @@ enum CursorTrackpad {
     /// line — which loses the user the place they were trying to reach.
     static let pointsPerLine: CGFloat = 26
 
-    static func step(forHorizontalTranslation translation: CGFloat) -> Int {
-        Int(translation / pointsPerCharacter)
-    }
-
-    static func line(forVerticalTranslation translation: CGFloat) -> Int {
-        Int(translation / pointsPerLine)
+    /// What one character of travel is worth at this finger speed.
+    static func pointsPerCharacter(atSpeed speed: CGFloat) -> CGFloat {
+        guard speed > slowSpeed else { return slowPointsPerCharacter }
+        guard speed < fastSpeed else { return fastPointsPerCharacter }
+        let progress = (speed - slowSpeed) / (fastSpeed - slowSpeed)
+        return slowPointsPerCharacter
+            + progress * (fastPointsPerCharacter - slowPointsPerCharacter)
     }
 }
 
@@ -74,6 +115,36 @@ final class KeyGridView: UIView {
     var plane: KeyPlane = .letters {
         didSet { if plane != oldValue { activatePlane() } }
     }
+
+    /// Which letters are under the fingers. Changing it swaps the three letter
+    /// rows and leaves every other plane alone — the numbers and the symbols
+    /// are the same in both.
+    var layout: TypingLayout = .fallback {
+        didSet { if layout != oldValue { activatePlane() } }
+    }
+
+    /// Whether there is a second layout to reach at all. Everything the switch
+    /// costs the keyboard — a key on the bottom row, a label on the spacebar,
+    /// a gesture taken off it — is spent only when it buys something.
+    var showsLayoutSwitchKey = false {
+        didSet { if showsLayoutSwitchKey != oldValue { rebuild() } }
+    }
+
+    /// The name shown on the spacebar, chevrons included. `nil` blanks it.
+    ///
+    /// Blank is the resting state, as it is on the system keyboard. The name
+    /// is shown by ``flashSpaceTitle(_:)`` when it is worth reading and taken
+    /// away again — a caption that never leaves is a caption nobody sees.
+    var spaceTitle: String? {
+        didSet { if spaceTitle != oldValue { applySpaceTitle() } }
+    }
+
+    /// The two letters on the language key.
+    var layoutTitle: String? {
+        didSet { if layoutTitle != oldValue { applyLayoutTitle() } }
+    }
+
+    private var spaceTitleTimer: Timer?
 
     var showsGlobeKey = true {
         didSet { if showsGlobeKey != oldValue { rebuild() } }
@@ -142,7 +213,15 @@ final class KeyGridView: UIView {
     /// Switching to digits and back is frequent, and rebuilding thirty-odd key
     /// views each time means re-resolving fonts and symbol images. Built planes
     /// are kept and simply hidden; only a metrics or palette change discards them.
-    private var planeCache: [KeyPlane: (rows: [KeyRow], views: [KeyView])] = [:]
+    /// Built rows and their views, kept per plane *and* per layout: switching
+    /// between two layouts is a gesture people repeat, and rebuilding thirty
+    /// key views each time is work the finger would feel.
+    private struct PlaneKey: Hashable {
+        let plane: KeyPlane
+        let layout: TypingLayout
+    }
+
+    private var planeCache: [PlaneKey: (rows: [KeyRow], views: [KeyView])] = [:]
     private var previewPool: [KeyPreviewView] = []
     /// The fading stroke drawn under the finger while a swipe is in flight.
     /// Created once and kept above the keys; it never takes a touch.
@@ -177,6 +256,9 @@ final class KeyGridView: UIView {
     private var planeHoldPoint: CGPoint?
     private var deleteTimer: Timer?
     private var spaceTrackpadTimer: Timer?
+    /// Whether the keys are currently showing nothing, because a finger is
+    /// driving the cursor. See ``refreshCapsVisibility()``.
+    private var capsAreHidden = false
     private var deleteRepeatCount = 0
     private var lastShiftTapAt: Date?
     /// When the run of fast typing this keyboard is in last produced a letter,
@@ -223,9 +305,24 @@ final class KeyGridView: UIView {
         private let startedOnShift: Bool
         var preview: KeyPreviewView?
         let initialPoint: CGPoint
-        var lastCursorStep = 0
-        var lastCursorLine = 0
-        var isCursorTracking = false
+        /// Where the finger was at the last cursor sample, and when — `nil`
+        /// until the trackpad takes over.
+        ///
+        /// Deliberately not `initialPoint`. The trackpad arms a third of a
+        /// second after the finger lands and tolerates 14pt of drift in the
+        /// meantime, so measuring from where the finger *landed* handed the
+        /// gesture a head start nobody asked for: the cursor jumped a
+        /// character at the instant the mode engaged.
+        var cursorPoint: CGPoint?
+        var cursorTime: TimeInterval = 0
+        /// Characters and lines owed to the finger but not yet whole. Kept as
+        /// a fraction so that tremor never adds up to a move.
+        var cursorCarry: CGFloat = 0
+        var cursorLineCarry: CGFloat = 0
+        var isCursorTracking: Bool { cursorPoint != nil }
+        /// Set once this finger has changed the layout, so the lift that ends
+        /// the swipe does not also type the space it started on.
+        var didSwitchLayout = false
         /// Fires the accent popover if the finger is still on the key. Cancelled
         /// by movement, by lifting, and by anything that tears the grid down.
         var longPressTimer: Timer?
@@ -290,8 +387,12 @@ final class KeyGridView: UIView {
         swipeTrail.frame = bounds
         let available = bounds.width - 2 * metrics.sideInset
         // Every row resolves against the width of one letter column from the
-        // ten-key reference row, which is what keeps columns aligned vertically.
-        let unit = (available - 9 * metrics.columnGap) / 10
+        // widest reference row, which is what keeps columns aligned vertically.
+        let letterColumns = Self.referenceColumns(for: rows)
+        func unitWidth(columns: CGFloat) -> CGFloat {
+            (available - (columns - 1) * metrics.columnGap) / columns
+        }
+        let unit = unitWidth(columns: letterColumns)
         guard unit > 0 else {
             hitMap = KeyHitMap(targets: [])
             TouchTrace.note("layout ABANDONED, no width")
@@ -308,7 +409,12 @@ final class KeyGridView: UIView {
         targets.reserveCapacity(keyViews.count)
         var y: CGFloat = 0
         for (rowIndex, row) in rows.enumerated() {
-            let widths = resolvedWidths(for: row, unit: unit, available: available)
+            // A row that pins its own reference is measured against that and
+            // not against the alphabet: the bottom row must not shrink when a
+            // wider alphabet arrives, or the whole bottom of the keyboard
+            // moves under the thumb every time the language changes.
+            let rowUnit = row.columnReference.map(unitWidth(columns:)) ?? unit
+            let widths = resolvedWidths(for: row, unit: rowUnit, available: available)
             let span = widths.reduce(0, +)
                 + CGFloat(max(widths.count - 1, 0)) * metrics.columnGap
             var x = row.alignment == .centered
@@ -432,6 +538,26 @@ final class KeyGridView: UIView {
         return widths
     }
 
+    /// How many letter columns the current rows are measured against.
+    ///
+    /// This was the constant ten, which is QWERTY's top row and happened to be
+    /// true of every plane the keyboard had. ЙЦУКЕН puts eleven keys in a row,
+    /// and eleven keys a tenth of the width apiece run off the end of the
+    /// keyboard. So the reference is read off the rows themselves: the longest
+    /// run of single-column keys in any of them.
+    ///
+    /// Never fewer than ten, because a plane can be narrower than the letters —
+    /// the numeric keypads are three columns of `.multiple` keys and no
+    /// single-column keys at all — and letting those set the unit would blow
+    /// every key up to a third of the keyboard.
+    static func referenceColumns(for rows: [KeyRow]) -> CGFloat {
+        let widest = rows
+            .filter { $0.columnReference == nil }
+            .map { row in row.keys.filter { $0.width == .unit }.count }
+            .max() ?? 0
+        return CGFloat(max(widest, 10))
+    }
+
     /// How far above its own bounds the top row claims, so a finger reaching
     /// high for `q` through `p` still types. The touch arrives with its real
     /// location, which is outside the grid, and the hit map is what has to
@@ -552,6 +678,37 @@ final class KeyGridView: UIView {
         activatePlane()
     }
 
+    /// Puts the language name on whichever key is currently the spacebar.
+    ///
+    /// Per plane rather than once: every plane builds its own bottom row, and
+    /// the numbers plane's spacebar is a different view than the letters one.
+    private func applySpaceTitle() {
+        for key in keyViews where key.spec.cap == .space {
+            key.spaceTitle = spaceTitle
+        }
+    }
+
+    private func applyLayoutTitle() {
+        for key in keyViews where key.spec.cap == .layoutSwitch {
+            key.layoutTitle = layoutTitle
+        }
+    }
+
+    /// Shows the language on the spacebar, then takes it away.
+    ///
+    /// The moment somebody changes language is the one moment the caption is
+    /// worth the room — it confirms what just happened, and the chevrons round
+    /// it say that the bar itself is the other way to do it. A second later
+    /// that is all been read, and a permanent label is just something printed
+    /// on a key nobody is looking at.
+    func flashSpaceTitle(_ text: String) {
+        spaceTitleTimer?.invalidate()
+        spaceTitle = text
+        spaceTitleTimer = Self.scheduleTimer(after: 1.4) { [weak self] in
+            self?.spaceTitle = nil
+        }
+    }
+
     private func activatePlane() {
         measured("activatePlane") { activatePlaneBody() }
     }
@@ -565,12 +722,15 @@ final class KeyGridView: UIView {
         keyViews.forEach { $0.isHidden = true }
 
         let entry: (rows: [KeyRow], views: [KeyView])
-        if let cached = planeCache[plane] {
+        let cacheKey = PlaneKey(plane: plane, layout: layout)
+        if let cached = planeCache[cacheKey] {
             entry = cached
         } else {
             let built = KeyLayout.rows(
                 for: plane,
+                layout: layout,
                 includesGlobe: showsGlobeKey,
+                includesLayoutSwitch: showsLayoutSwitchKey,
                 returnIsProminent: returnKeyIsProminent,
                 punctuation: punctuation
             )
@@ -586,12 +746,14 @@ final class KeyGridView: UIView {
                 }
             }
             entry = (built, views)
-            planeCache[plane] = entry
+            planeCache[cacheKey] = entry
         }
 
         rows = entry.rows
         keyViews = entry.views
         keyViews.forEach { $0.isHidden = false }
+        applySpaceTitle()
+        applyLayoutTitle()
         // Re-added rather than merely kept: `addSubview` moves it back above the
         // keys this plane has just installed. Previews and the accent popover
         // still come out on top, because both bring themselves to the front.
@@ -644,6 +806,7 @@ final class KeyGridView: UIView {
             item.isSwiping = false
             item.swipePath = []
             item.isPinned = true
+            endCursorDrag(for: item)
             item.key.isHighlighted = false
             recycle(item.preview)
             item.preview = nil
@@ -659,6 +822,7 @@ final class KeyGridView: UIView {
         for item in tracked {
             item.longPressTimer?.invalidate()
             item.longPressTimer = nil
+            endCursorDrag(for: item)
             item.key.isHighlighted = false
             recycle(item.preview)
             item.preview = nil
@@ -926,7 +1090,10 @@ final class KeyGridView: UIView {
             }
             item.longPressTimer?.invalidate()
             item.longPressTimer = nil
-            var shouldCommit = commit && item.isEngaged && !item.isCursorTracking
+            var shouldCommit =
+                commit && item.isEngaged && !item.isCursorTracking && !item.didSwitchLayout
+            endCursorDrag(for: item)
+            refreshCapsVisibility()
             // A slide that began on Shift or the plane key tracks characters
             // only, so sliding back onto the modifier leaves `item.key` on the
             // letter it passed over. Lifting there must type nothing.
@@ -1024,6 +1191,8 @@ final class KeyGridView: UIView {
             plane = next
         case .globe:
             delegate?.keyGrid(self, didProduce: .nextInputMode(key, event))
+        case .layoutSwitch:
+            delegate?.keyGrid(self, didProduce: .nextLayout(forward: true))
         default:
             break
         }
@@ -1031,6 +1200,7 @@ final class KeyGridView: UIView {
 
     private func scheduleSpaceTrackpad(for item: TrackedTouch) {
         guard !UIAccessibility.isVoiceOverRunning else { return }
+        guard cursorTrackpadIsAvailable else { return }
         spaceTrackpadTimer?.invalidate()
         spaceTrackpadTimer = Self.scheduleTimer(after: 0.32) { [weak self, weak item] in
             guard let self,
@@ -1038,20 +1208,67 @@ final class KeyGridView: UIView {
                   self.tracked.contains(where: { $0 === item }),
                   item.isEngaged
             else { return }
-            item.isCursorTracking = true
-            item.lastCursorStep = 0
-            item.lastCursorLine = 0
+            item.cursorPoint = item.touch.location(in: self)
+            item.cursorTime = item.touch.timestamp
+            item.cursorCarry = 0
+            item.cursorLineCarry = 0
+            self.refreshCapsVisibility()
+            self.delegate?.keyGrid(self, didProduce: .beginCursorDrag)
             self.feedback.selectionChanged()
             UIAccessibility.post(notification: .announcement, argument: "Cursor control")
         }
     }
 
+    /// Whether the spacebar becomes a trackpad on this layout.
+    ///
+    /// Off on Cyrillic by request. The two gestures do not in fact collide —
+    /// the trackpad arms on a *still* finger and a moving one cancels it, which
+    /// is how every keyboard that has both keeps them apart — but the layout
+    /// that has just gained a swipe is not the one to prove that on.
+    private var cursorTrackpadIsAvailable: Bool {
+        layout.offersCursorTrackpad
+    }
+
+    /// How far a finger crosses the spacebar before it means the layout rather
+    /// than the cursor.
+    ///
+    /// A third of the bar, so it scales with the keyboard instead of being a
+    /// number that is right on one device. Well past the 14pt that disarms the
+    /// trackpad, because disarming is cheap and switching is not: a layout
+    /// changed by accident costs the sentence being typed.
+    private func layoutSwipeDistance(for item: TrackedTouch) -> CGFloat {
+        min(max(item.key.frame.width / 4, 28), 44)
+    }
+
     private func handleSpaceMovement(_ item: TrackedTouch, point: CGPoint) {
-        guard item.isCursorTracking else {
-            let distance = hypot(point.x - item.initialPoint.x, point.y - item.initialPoint.y)
+        guard let previous = item.cursorPoint else {
+            let travel = point.x - item.initialPoint.x
+            let rise = abs(point.y - item.initialPoint.y)
+            let distance = hypot(travel, point.y - item.initialPoint.y)
             if distance > 14 {
                 spaceTrackpadTimer?.invalidate()
                 spaceTrackpadTimer = nil
+            }
+            // Sideways, decisively, and only once per finger.
+            //
+            // The vertical test was `travel > rise * 2` and it is why the
+            // gesture worked some of the time: a thumb does not cross a
+            // spacebar along a ruler, it swings from a knuckle, and the arc
+            // that comes out of that spends most of a key's height on the way.
+            // Demanding twice the rise threw away exactly the swipes a thumb
+            // makes and kept the ones an index finger makes. Equal is enough
+            // to separate a sideways sweep from the roll up towards `b`, which
+            // is the movement this is actually guarding against.
+            if showsLayoutSwitchKey,
+               !item.didSwitchLayout,
+               abs(travel) > layoutSwipeDistance(for: item),
+               abs(travel) > rise
+            {
+                item.didSwitchLayout = true
+                setHighlight(false, on: item.key)
+                feedback.keyActionCommitted()
+                delegate?.keyGrid(self, didProduce: .nextLayout(forward: travel > 0))
+                return
             }
             item.isEngaged = stillHolds(item.key, at: point)
             setHighlight(item.isEngaged, on: item.key)
@@ -1061,26 +1278,55 @@ final class KeyGridView: UIView {
         item.isEngaged = true
         setHighlight(true, on: item.key)
 
+        let now = item.touch.timestamp
+        let elapsed = now - item.cursorTime
+        item.cursorPoint = point
+        item.cursorTime = now
+
         // Lines first. A drag that has crossed into another line is a drag about
         // *which* line, and applying the horizontal component in the same turn
         // would land the cursor a few characters away from the column the finger
         // is actually over.
-        let line = CursorTrackpad.line(
-            forVerticalTranslation: point.y - item.initialPoint.y
-        )
-        let lineDelta = line - item.lastCursorLine
-        if lineDelta != 0 {
-            item.lastCursorLine = line
-            delegate?.keyGrid(self, didProduce: .moveCursorLine(lineDelta))
+        item.cursorLineCarry += (point.y - previous.y) / CursorTrackpad.pointsPerLine
+        let lines = Int(item.cursorLineCarry.rounded(.towardZero))
+        if lines != 0 {
+            item.cursorLineCarry -= CGFloat(lines)
+            // The column the cursor keeps is the one it had before this frame,
+            // so whatever horizontal travel came with the same movement has
+            // already been spent on choosing the line.
+            item.cursorCarry = 0
+            delegate?.keyGrid(self, didProduce: .moveCursorLine(lines))
+            return
         }
 
-        let step = CursorTrackpad.step(
-            forHorizontalTranslation: point.x - item.initialPoint.x
-        )
-        let delta = step - item.lastCursorStep
-        guard delta != 0 else { return }
-        item.lastCursorStep = step
-        delegate?.keyGrid(self, didProduce: .moveCursor(delta))
+        let travel = point.x - previous.x
+        let speed = elapsed > 0 ? abs(travel) / CGFloat(elapsed) : 0
+        item.cursorCarry += travel / CursorTrackpad.pointsPerCharacter(atSpeed: speed)
+        let steps = Int(item.cursorCarry.rounded(.towardZero))
+        guard steps != 0 else { return }
+        item.cursorCarry -= CGFloat(steps)
+        delegate?.keyGrid(self, didProduce: .moveCursor(steps))
+    }
+
+    /// Hands the controller back the document it stopped reading while the
+    /// finger was travelling.
+    private func endCursorDrag(for item: TrackedTouch) {
+        guard item.isCursorTracking else { return }
+        item.cursorPoint = nil
+        delegate?.keyGrid(self, didProduce: .endCursorDrag)
+    }
+
+    /// The trackpad blanks the keys, as the system keyboard does.
+    ///
+    /// Without it the mode is invisible: a finger dragging across something
+    /// that still looks like a keyboard reads as a gesture that is not
+    /// working, and the usual response is to press harder and lift — which is
+    /// the one thing that ends it.
+    private func refreshCapsVisibility() {
+        let hidden = tracked.contains { $0.isCursorTracking }
+        guard hidden != capsAreHidden else { return }
+        capsAreHidden = hidden
+        for key in keyViews { key.capsAreHidden = hidden }
     }
 
     // MARK: - Fast typing
@@ -1598,7 +1844,7 @@ private extension KeyCap {
     /// lift so a slide can still correct the target.
     var actsOnTouchDown: Bool {
         switch self {
-        case .delete, .shift, .plane, .globe: true
+        case .delete, .shift, .plane, .globe, .layoutSwitch: true
         // A blank never reaches here — it owns no hit target — but saying so
         // explicitly is what stops the next cap added to the enum from
         // defaulting into firing on touch-down.

--- a/ios/VocaPhoneKeyboard/KeyGridView.swift
+++ b/ios/VocaPhoneKeyboard/KeyGridView.swift
@@ -7,12 +7,6 @@ enum KeyboardOutput {
     case deleteBackward
     case deleteWord
     case moveCursor(Int)
-    /// Move the cursor up or down whole lines, keeping its column.
-    ///
-    /// Separate from ``moveCursor(_:)`` because a keyboard extension can only
-    /// move by *characters*: how many characters a line is worth is a question
-    /// about the document, and only the controller can see it.
-    case moveCursorLine(Int)
     /// The space bar has become a trackpad, and has stopped being one.
     ///
     /// Split out because the expensive part of a cursor step was never the
@@ -60,22 +54,22 @@ enum KeyboardOutput {
 /// the cursor between two specific letters.
 enum CursorTrackpad {
     /// Travel per character when the finger is barely moving.
-    static let slowPointsPerCharacter: CGFloat = 14
+    static let slowPointsPerCharacter: CGFloat = 16
     /// ...and when it is thrown across the line. Much below this the cursor
     /// outruns the eye and lands by luck rather than by aim.
-    static let fastPointsPerCharacter: CGFloat = 4
+    static let fastPointsPerCharacter: CGFloat = 3
     /// The finger speeds those two rates belong to, in points per second.
     /// Between them the rate is interpolated; outside, it is clamped.
-    static let slowSpeed: CGFloat = 90
-    static let fastSpeed: CGFloat = 1400
-
-    /// How far the finger travels for one line.
     ///
-    /// Deliberately more than twice the horizontal step. The gesture is mostly
-    /// used to nudge along a line, and a vertical threshold close to the
-    /// horizontal one turns every slightly sloped drag into a jump to another
-    /// line — which loses the user the place they were trying to reach.
-    static let pointsPerLine: CGFloat = 26
+    /// These were 90 and 1400, and the range was the whole problem rather than
+    /// the rates at either end of it. A finger placing a cursor on a spacebar
+    /// does not go much faster than five hundred points a second — past that
+    /// it is a flick and not a drag — so the old span spent almost all of its
+    /// acceleration above the speeds a hand actually makes. Across the entire
+    /// useful range it moved from 14 points a character to 11.6: acceleration
+    /// that exists in the arithmetic and not in the fingers.
+    static let slowSpeed: CGFloat = 40
+    static let fastSpeed: CGFloat = 600
 
     /// What one character of travel is worth at this finger speed.
     static func pointsPerCharacter(atSpeed speed: CGFloat) -> CGFloat {
@@ -318,7 +312,13 @@ final class KeyGridView: UIView {
         /// Characters and lines owed to the finger but not yet whole. Kept as
         /// a fraction so that tremor never adds up to a move.
         var cursorCarry: CGFloat = 0
-        var cursorLineCarry: CGFloat = 0
+        /// Finger speed, smoothed. One frame's speed is a distance divided by
+        /// whatever interval UIKit happened to deliver — about eight
+        /// milliseconds at 120Hz, and not the same eight each time — so the raw
+        /// figure jitters and the rate would jitter with it. Starting at zero
+        /// also means a drag begins at its most precise, which is where a drag
+        /// wants to begin.
+        var cursorSpeed: CGFloat = 0
         var isCursorTracking: Bool { cursorPoint != nil }
         /// Set once this finger has changed the layout, so the lift that ends
         /// the swipe does not also type the space it started on.
@@ -754,6 +754,11 @@ final class KeyGridView: UIView {
         keyViews.forEach { $0.isHidden = false }
         applySpaceTitle()
         applyLayoutTitle()
+        // Caps visibility lives on the views, not on the plane. A trackpad
+        // that was still armed when this plane came up would otherwise leave
+        // the letters it just cached at alpha 0 forever — `update()` does not
+        // touch alpha, only ``capsAreHidden`` writes it.
+        for key in keyViews { key.capsAreHidden = capsAreHidden }
         // Re-added rather than merely kept: `addSubview` moves it back above the
         // keys this plane has just installed. Previews and the accent popover
         // still come out on top, because both bring themselves to the front.
@@ -811,6 +816,7 @@ final class KeyGridView: UIView {
             recycle(item.preview)
             item.preview = nil
         }
+        refreshCapsVisibility()
         dismissAlternatives()
     }
 
@@ -828,6 +834,7 @@ final class KeyGridView: UIView {
             item.preview = nil
         }
         tracked.removeAll()
+        refreshCapsVisibility()
         dismissAlternatives()
     }
 
@@ -1090,8 +1097,12 @@ final class KeyGridView: UIView {
             }
             item.longPressTimer?.invalidate()
             item.longPressTimer = nil
-            var shouldCommit =
-                commit && item.isEngaged && !item.isCursorTracking && !item.didSwitchLayout
+            var shouldCommit = Self.shouldCommitSpace(
+                isEngaged: item.isEngaged,
+                isCursorTracking: item.isCursorTracking,
+                didSwitchLayout: item.didSwitchLayout,
+                commit: commit
+            )
             endCursorDrag(for: item)
             refreshCapsVisibility()
             // A slide that began on Shift or the plane key tracks characters
@@ -1143,6 +1154,20 @@ final class KeyGridView: UIView {
             if didCommit, let origin = item.planeToRestore { planeToRestore = origin }
         }
         if let planeToRestore { plane = planeToRestore }
+    }
+
+    /// Whether lifting a spacebar finger types a space.
+    ///
+    /// A hold that became the cursor, or a swipe that changed the layout, has
+    /// already done its job; the lift must not add a space on top. Kept pure
+    /// so the three cases can be asserted without constructing a `UITouch`.
+    static func shouldCommitSpace(
+        isEngaged: Bool,
+        isCursorTracking: Bool,
+        didSwitchLayout: Bool,
+        commit: Bool
+    ) -> Bool {
+        commit && isEngaged && !isCursorTracking && !didSwitchLayout
     }
 
     /// The single completion boundary for ordinary taps and slide correction.
@@ -1201,6 +1226,11 @@ final class KeyGridView: UIView {
     private func scheduleSpaceTrackpad(for item: TrackedTouch) {
         guard !UIAccessibility.isVoiceOverRunning else { return }
         guard cursorTrackpadIsAvailable else { return }
+        // One drag at a time. A second finger on the spacebar would re-arm
+        // the timer, fire a second `.beginCursorDrag`, and then the first
+        // lift would `.endCursorDrag` while the other finger was still
+        // driving — after which every step re-reads the document.
+        guard !tracked.contains(where: { $0 !== item && $0.isCursorTracking }) else { return }
         spaceTrackpadTimer?.invalidate()
         spaceTrackpadTimer = Self.scheduleTimer(after: 0.32) { [weak self, weak item] in
             guard let self,
@@ -1211,7 +1241,7 @@ final class KeyGridView: UIView {
             item.cursorPoint = item.touch.location(in: self)
             item.cursorTime = item.touch.timestamp
             item.cursorCarry = 0
-            item.cursorLineCarry = 0
+            item.cursorSpeed = 0
             self.refreshCapsVisibility()
             self.delegate?.keyGrid(self, didProduce: .beginCursorDrag)
             self.feedback.selectionChanged()
@@ -1219,20 +1249,18 @@ final class KeyGridView: UIView {
         }
     }
 
-    /// Whether the spacebar becomes a trackpad on this layout.
-    ///
-    /// Off on Cyrillic by request. The two gestures do not in fact collide —
-    /// the trackpad arms on a *still* finger and a moving one cancels it, which
-    /// is how every keyboard that has both keeps them apart — but the layout
-    /// that has just gained a swipe is not the one to prove that on.
-    private var cursorTrackpadIsAvailable: Bool {
-        layout.offersCursorTrackpad
+    /// Whether the spacebar becomes a trackpad at all. A setting now, and the
+    /// same answer in every language.
+    var offersCursorTrackpad = true {
+        didSet { if offersCursorTrackpad != oldValue { releaseTouches() } }
     }
+
+    private var cursorTrackpadIsAvailable: Bool { offersCursorTrackpad }
 
     /// How far a finger crosses the spacebar before it means the layout rather
     /// than the cursor.
     ///
-    /// A third of the bar, so it scales with the keyboard instead of being a
+    /// A quarter of the bar, so it scales with the keyboard instead of being a
     /// number that is right on one device. Well past the 14pt that disarms the
     /// trackpad, because disarming is cheap and switching is not: a layout
     /// changed by accident costs the sentence being typed.
@@ -1240,25 +1268,34 @@ final class KeyGridView: UIView {
         min(max(item.key.frame.width / 4, 28), 44)
     }
 
+
     private func handleSpaceMovement(_ item: TrackedTouch, point: CGPoint) {
         guard let previous = item.cursorPoint else {
             let travel = point.x - item.initialPoint.x
             let rise = abs(point.y - item.initialPoint.y)
-            let distance = hypot(travel, point.y - item.initialPoint.y)
+            let distance = hypot(travel, rise)
             if distance > 14 {
                 spaceTrackpadTimer?.invalidate()
                 spaceTrackpadTimer = nil
             }
-            // Sideways, decisively, and only once per finger.
+
+            // The hold is what separates the two gestures on this key, and it
+            // does the whole job on its own.
             //
-            // The vertical test was `travel > rise * 2` and it is why the
-            // gesture worked some of the time: a thumb does not cross a
-            // spacebar along a ruler, it swings from a knuckle, and the arc
-            // that comes out of that spends most of a key's height on the way.
-            // Demanding twice the rise threw away exactly the swipes a thumb
-            // makes and kept the ones an index finger makes. Equal is enough
-            // to separate a sideways sweep from the roll up towards `b`, which
-            // is the movement this is actually guarding against.
+            // A version of this told them apart by speed, so that a slow slide
+            // could reach the cursor without waiting out the hold. It works,
+            // and it costs more than it saves: a gentle swipe then moves the
+            // cursor instead of changing the language, and the rule stops
+            // being "hold, then drag" — which is the one people already carry
+            // over from the system keyboard — and becomes a number that has to
+            // be tuned by feel. Once the trackpad has armed this branch is not
+            // reached at all, so nothing here can steal a cursor drag.
+            //
+            // Sideways is `abs(travel) > rise` rather than twice it: a thumb
+            // does not cross a spacebar along a ruler, it swings from a
+            // knuckle, and demanding twice the rise threw away exactly the
+            // swipes a thumb makes. Equal is enough to separate a sweep from
+            // the roll up towards `b`, which is what this guards against.
             if showsLayoutSwitchKey,
                !item.didSwitchLayout,
                abs(travel) > layoutSwipeDistance(for: item),
@@ -1270,6 +1307,7 @@ final class KeyGridView: UIView {
                 delegate?.keyGrid(self, didProduce: .nextLayout(forward: travel > 0))
                 return
             }
+
             item.isEngaged = stillHolds(item.key, at: point)
             setHighlight(item.isEngaged, on: item.key)
             return
@@ -1283,25 +1321,37 @@ final class KeyGridView: UIView {
         item.cursorPoint = point
         item.cursorTime = now
 
-        // Lines first. A drag that has crossed into another line is a drag about
-        // *which* line, and applying the horizontal component in the same turn
-        // would land the cursor a few characters away from the column the finger
-        // is actually over.
-        item.cursorLineCarry += (point.y - previous.y) / CursorTrackpad.pointsPerLine
-        let lines = Int(item.cursorLineCarry.rounded(.towardZero))
-        if lines != 0 {
-            item.cursorLineCarry -= CGFloat(lines)
-            // The column the cursor keeps is the one it had before this frame,
-            // so whatever horizontal travel came with the same movement has
-            // already been spent on choosing the line.
-            item.cursorCarry = 0
-            delegate?.keyGrid(self, didProduce: .moveCursorLine(lines))
-            return
-        }
-
+        // Sideways only, and that is the whole gesture.
+        //
+        // There used to be a vertical half that moved the cursor a line at a
+        // time. It was the only part of the drag that asked the host for the
+        // document — twice per line crossed, on the main thread, against a
+        // frame budget a single such read has been measured eating. It was also
+        // the only part that could be wrong: `documentContextBeforeInput` is a
+        // window of a few hundred characters rather than the document, and in
+        // the hosts that return only the current paragraph there is no line
+        // above to move to. A keyboard cannot see where the host wrapped text.
+        //
+        // Nothing is lost with it. The cursor moves by character offset and a
+        // newline is a character, so dragging on past the end of a line crosses
+        // into the next one and into the paragraph after that — at four points
+        // a character once the finger is moving, a line is a flick. What goes
+        // with it is a bug nobody had named: a sloped drag used to jump a line
+        // *and* discard the horizontal travel it arrived with.
         let travel = point.x - previous.x
-        let speed = elapsed > 0 ? abs(travel) / CGFloat(elapsed) : 0
-        item.cursorCarry += travel / CursorTrackpad.pointsPerCharacter(atSpeed: speed)
+        let sample = elapsed > 0 ? abs(travel) / CGFloat(elapsed) : 0
+        item.cursorSpeed = item.cursorSpeed * 0.6 + sample * 0.4
+        let rate = CursorTrackpad.pointsPerCharacter(atSpeed: item.cursorSpeed)
+        // What the finger is actually doing, so the two speeds the rate is
+        // interpolated between can be chosen from a hand rather than from a
+        // guess about one. Only while a drag is live, and only in a debug
+        // build: an instrument that runs during ordinary typing is the one
+        // that ends up producing the fault it was armed to find.
+        TouchTrace.note(String(
+            format: "cursor v=%4.0f pt/s  rate=%4.1f pt/ch  dx=%5.1f",
+            item.cursorSpeed, rate, travel
+        ))
+        item.cursorCarry += travel / rate
         let steps = Int(item.cursorCarry.rounded(.towardZero))
         guard steps != 0 else { return }
         item.cursorCarry -= CGFloat(steps)

--- a/ios/VocaPhoneKeyboard/KeyLayout.swift
+++ b/ios/VocaPhoneKeyboard/KeyLayout.swift
@@ -53,6 +53,10 @@ enum KeyCap: Equatable {
     case newline
     case plane(KeyPlane)
     case globe
+    /// Steps to the next enabled layout. Distinct from ``globe``, which leaves
+    /// for somebody else's keyboard: these are two different destinations and
+    /// sharing one key made the common one cost a long press.
+    case layoutSwitch
     /// A hole in the grid. The numeric keypads are a 3x4 block with one empty
     /// corner, and iOS leaves that corner genuinely empty rather than
     /// stretching its neighbours across it.
@@ -91,6 +95,7 @@ enum KeyCap: Equatable {
         case .space: return "Space"
         case .newline: return "Return"
         case .globe: return "Next keyboard"
+        case .layoutSwitch: return "Next language"
         case .blank: return ""
         case let .plane(plane):
             switch plane {
@@ -160,6 +165,16 @@ struct KeyRow: Equatable {
 
     let keys: [KeySpec]
     var alignment: Alignment = .fill
+    /// How many columns this row is measured against, when that is not the
+    /// alphabet's own count.
+    ///
+    /// The letter rows set the unit — ten for QWERTY, eleven for ЙЦУКЕН — and
+    /// every row that is *made of letters* should follow it, so the columns
+    /// line up. The bottom row is not made of letters: the spacebar, Return
+    /// and the plane key are the same keys in every language, and letting a
+    /// wider alphabet shrink them means the whole bottom of the keyboard moves
+    /// under the thumb when the language changes. It stays on ten.
+    var columnReference: CGFloat?
 }
 
 enum KeyLayout {
@@ -170,7 +185,9 @@ enum KeyLayout {
     /// URL (`/` and `.`).
     static func rows(
         for plane: KeyPlane,
+        layout: TypingLayout = .fallback,
         includesGlobe: Bool,
+        includesLayoutSwitch: Bool = false,
         returnIsProminent: Bool,
         punctuation: BottomRowPunctuation? = nil
     ) -> [KeyRow] {
@@ -178,16 +195,12 @@ enum KeyLayout {
         case .numberPad, .phonePad, .decimalPad:
             return keypadRows(for: plane, includesGlobe: includesGlobe)
         case .letters:
-            return [
-                KeyRow(keys: map("qwertyuiop")),
-                KeyRow(keys: map("asdfghjkl"), alignment: .centered),
-                KeyRow(keys: [KeySpec(cap: .shift, width: .fill, style: .function)]
-                    + map("zxcvbnm")
-                    + [KeySpec(cap: .delete, width: .fill, style: .function)]),
+            return letterRows(for: layout) + [
                 bottomRow(
                     planeSwitch: .numbers,
                     punctuation: punctuation,
                     includesGlobe: includesGlobe,
+                    includesLayoutSwitch: includesLayoutSwitch,
                     returnIsProminent: returnIsProminent
                 ),
             ]
@@ -204,6 +217,7 @@ enum KeyLayout {
                     planeSwitch: .letters,
                     punctuation: nil,
                     includesGlobe: includesGlobe,
+                    includesLayoutSwitch: includesLayoutSwitch,
                     returnIsProminent: returnIsProminent
                 ),
             ]
@@ -220,6 +234,7 @@ enum KeyLayout {
                     planeSwitch: .letters,
                     punctuation: nil,
                     includesGlobe: includesGlobe,
+                    includesLayoutSwitch: includesLayoutSwitch,
                     returnIsProminent: returnIsProminent
                 ),
             ]
@@ -230,6 +245,22 @@ enum KeyLayout {
     /// Besides matching its visual weight, this keeps longer return labels such
     /// as "Continue" from becoming a much smaller target than users expect.
     static let minimumReturnColumns: CGFloat = 2.5
+
+    /// Return's width once a language key has joined the row.
+    ///
+    /// Below Apple's 2.5, and deliberately: the spacebar is the key this row
+    /// exists to carry, and a Return that keeps a quarter of the row while the
+    /// spacebar shrinks to a thumb's width has the priorities backwards. At
+    /// 1.75 a "Continue" label still fits — it is the same width Return has on
+    /// the numbers plane, where nobody has ever called it small.
+    static let crowdedReturnColumns: CGFloat = 1.75
+
+    /// The width below which the spacebar stops reading as one.
+    ///
+    /// Apple's plain row gives it five columns of ten. Four is the point where
+    /// a thumb aiming for the middle of the bar can still miss by a column and
+    /// land on it, which is what the key is for; below that it is a wide comma.
+    static let minimumSpacebarColumns: CGFloat = 4
 
     /// Column widths that put the spacebar's visible centre on the keyboard's
     /// centre.
@@ -258,17 +289,27 @@ enum KeyLayout {
     struct BottomRowColumns: Equatable {
         var planeSwitch: CGFloat
         var globe: CGFloat?
+        var layoutSwitch: CGFloat?
         var punctuation: CGFloat?
         var period: CGFloat?
         var newline: CGFloat
 
-        var leading: CGFloat { planeSwitch + (globe ?? 0) + (punctuation ?? 0) }
+        var leading: CGFloat {
+            planeSwitch + (globe ?? 0) + (layoutSwitch ?? 0) + (punctuation ?? 0)
+        }
         var trailing: CGFloat { (period ?? 0) + newline }
         /// How far the spacebar's centre sits from the keyboard's, in columns.
         /// Zero is the goal; the sign says which way it leans.
         var centreOffset: CGFloat { (leading - trailing) / 2 }
+        /// What is left for the spacebar, which is the key this row exists to
+        /// carry and the only one whose width is decided by subtraction.
+        var spacebar: CGFloat { 10 - leading - trailing }
 
-        static func resolved(includesGlobe: Bool, includesPunctuation: Bool) -> BottomRowColumns {
+        static func resolved(
+            includesGlobe: Bool,
+            includesLayoutSwitch: Bool = false,
+            includesPunctuation: Bool
+        ) -> BottomRowColumns {
             // Measured on Apple's iOS 26 keyboard at the same 402pt width:
             //   plain:  2.5 |       5       | 2.5
             //   globe:  1.25 | 1.25 | 5     | 2.5
@@ -276,13 +317,82 @@ enum KeyLayout {
             // iOS sometimes supplies the globe in its own row below the
             // extension. In that case 123 occupies the two native leading
             // slots instead of leaving Space unnaturally wide.
-            let punctuation: CGFloat? = includesPunctuation ? 1.25 : nil
-            return BottomRowColumns(
-                planeSwitch: includesGlobe ? 1.25 : 2.5,
-                globe: includesGlobe ? 1.25 : nil,
-                punctuation: punctuation,
-                period: punctuation,
-                newline: minimumReturnColumns
+            // A language key is a fifth thing on a row Apple balances with
+            // four, and something has to give. The first attempt gave the
+            // same thing away every time — every function key trimmed to a
+            // column, Return to 1.75 — which on a row with no punctuation
+            // handed the spacebar six and a quarter columns against Apple's
+            // five, and left the keys either side of it visibly thin. Wrong
+            // in both directions at once.
+            //
+            // So nothing is trimmed until the row is actually short of room.
+            // Apple's widths are tried first; Return gives way before the
+            // function keys do, because Return has the most to spare and is
+            // the least often aimed at; and the trimming stops as soon as the
+            // spacebar is back above the width below which it stops reading
+            // as a spacebar.
+            guard includesLayoutSwitch else {
+                let punctuation: CGFloat? = includesPunctuation ? 1.25 : nil
+                return BottomRowColumns(
+                    planeSwitch: includesGlobe ? 1.25 : 2.5,
+                    globe: includesGlobe ? 1.25 : nil,
+                    layoutSwitch: nil,
+                    punctuation: punctuation,
+                    period: punctuation,
+                    newline: minimumReturnColumns
+                )
+            }
+            func row(function: CGFloat, newline: CGFloat) -> BottomRowColumns {
+                let punctuation: CGFloat? = includesPunctuation ? function : nil
+                return BottomRowColumns(
+                    planeSwitch: function,
+                    globe: includesGlobe ? function : nil,
+                    layoutSwitch: function,
+                    punctuation: punctuation,
+                    period: punctuation,
+                    newline: newline
+                )
+            }
+            let candidates = [
+                row(function: 1.25, newline: minimumReturnColumns),
+                row(function: 1.25, newline: crowdedReturnColumns),
+                row(function: 1, newline: minimumReturnColumns),
+                row(function: 1, newline: crowdedReturnColumns),
+            ]
+            // Of the rows that leave the spacebar wide enough, the one whose
+            // column totals either side of it come closest to equal — which is
+            // the identity that puts its visible centre on the keyboard's, and
+            // the thing a ladder of "trim this, then that" quietly destroys.
+            let roomy = candidates.filter { $0.spacebar >= minimumSpacebarColumns }
+            return roomy.min { abs($0.centreOffset) < abs($1.centreOffset) }
+                ?? candidates[candidates.count - 1]
+        }
+    }
+
+    /// The three letter rows of a layout, above the bottom row every plane
+    /// shares.
+    ///
+    /// The rows are the layout's own, and their *lengths* are what differs:
+    /// QWERTY is 10/9/7, ЙЦУКЕН is 11/11/9, AZERTY is 10/10/6. Nothing here
+    /// sets a width — ``KeyGridView`` reads its column unit off the rows it is
+    /// handed, so an eleven-key row simply produces narrower keys.
+    ///
+    /// The middle row centres itself only when it is shorter than the row above
+    /// it. That is the derivation behind QWERTY's familiar half-column indent,
+    /// and it is why Spanish, whose middle row is the longer one at ten keys
+    /// with ñ on the end, correctly does not indent.
+    private static func letterRows(for layout: TypingLayout) -> [KeyRow] {
+        let letters = layout.rows
+        let top = letters.first?.count ?? 0
+        return letters.enumerated().map { index, row in
+            if index == letters.count - 1 {
+                return KeyRow(keys: [KeySpec(cap: .shift, width: .fill, style: .function)]
+                    + map(row)
+                    + [KeySpec(cap: .delete, width: .fill, style: .function)])
+            }
+            return KeyRow(
+                keys: map(row),
+                alignment: row.count < top ? .centered : .fill
             )
         }
     }
@@ -291,10 +401,12 @@ enum KeyLayout {
         planeSwitch: KeyPlane,
         punctuation: BottomRowPunctuation?,
         includesGlobe: Bool,
+        includesLayoutSwitch: Bool,
         returnIsProminent: Bool
     ) -> KeyRow {
         let columns = BottomRowColumns.resolved(
             includesGlobe: includesGlobe,
+            includesLayoutSwitch: includesLayoutSwitch,
             includesPunctuation: punctuation != nil
         )
         var keys = [
@@ -306,6 +418,11 @@ enum KeyLayout {
         ]
         if let globe = columns.globe {
             keys.append(KeySpec(cap: .globe, width: .multiple(globe), style: .function))
+        }
+        if let layoutSwitch = columns.layoutSwitch {
+            keys.append(
+                KeySpec(cap: .layoutSwitch, width: .multiple(layoutSwitch), style: .function)
+            )
         }
         if let punctuation {
             keys.append(
@@ -331,7 +448,7 @@ enum KeyLayout {
                 style: returnIsProminent ? .accent : .function
             )
         )
-        return KeyRow(keys: keys)
+        return KeyRow(keys: keys, columnReference: 10)
     }
 
     /// The three-column numeric block iOS shows for a `.numberPad`,

--- a/ios/VocaPhoneKeyboard/KeyProximity.swift
+++ b/ios/VocaPhoneKeyboard/KeyProximity.swift
@@ -9,39 +9,58 @@ import Foundation
 /// in is most of what separates a correction that lands from one that reads as
 /// the keyboard guessing.
 ///
-/// Adjacency is taken from the QWERTY layout rather than from the live key
-/// frames on purpose. The rows are the same shape at every key height and on
-/// every device, so a static table gives the same answer as measured geometry
-/// while staying pure, cheap and testable — and it keeps working on the numbers
-/// and symbols planes, where the letters are not on screen at all.
+/// Adjacency is taken from the layout's letter rows rather than from the live
+/// key frames on purpose. The rows keep the same shape at every key height and
+/// on every device, so a table built from them gives the same answer as
+/// measured geometry while staying pure, cheap and testable — and it keeps
+/// working on the numbers and symbols planes, where the letters are not on
+/// screen at all.
 enum KeyProximity {
-    /// The three letter rows, as laid out by ``KeyLayout``.
-    private static let rows = ["qwertyuiop", "asdfghjkl", "zxcvbnm"]
+    private struct Table {
+        let adjacency: [Character: Set<Character>]
+    }
 
-    /// How far the lower rows are indented, in key columns. The home row sits
-    /// half a column in and the bottom row a full column, which is what makes
-    /// "s" a neighbour of both "w" and "x" but not of "q".
-    private static let rowOffsets: [Double] = [0, 0.5, 1.0]
-
-    /// Column position of every letter, so adjacency is measured rather than
-    /// enumerated by hand — a hand-written table of a hundred and some pairs is
-    /// a place for exactly one typo to hide forever.
-    private static let positions: [Character: (row: Int, column: Double)] = {
-        var positions: [Character: (row: Int, column: Double)] = [:]
-        for (rowIndex, row) in rows.enumerated() {
-            for (columnIndex, character) in row.enumerated() {
-                positions[character] = (rowIndex, Double(columnIndex) + rowOffsets[rowIndex])
-            }
+    /// Built once, for every layout the keyboard ships. `neighbours(of:)` is
+    /// asked several times per candidate word during a correction, and
+    /// rebuilding the set each time turned a cheap lookup into the most
+    /// expensive part of ranking.
+    private static let tables: [[String]: Table] = {
+        var tables: [[String]: Table] = [:]
+        for layout in TypingLayout.catalogue {
+            tables[layout.rows] = makeTable(for: layout.rows)
         }
-        return positions
+        return tables
     }()
 
-    /// Keys within one column and one row of each other.
+    /// How far each letter row is indented, in key columns.
     ///
-    /// Built once. `neighbours(of:)` is asked several times per candidate word
-    /// during a correction, and rebuilding the set each time turned a cheap
-    /// lookup into the most expensive part of ranking.
-    private static let adjacency: [Character: Set<Character>] = {
+    /// The same rule ``KeyLayout`` uses for the letters: a shorter row than the
+    /// one above centres itself, which is QWERTY's half-column home row. The
+    /// bottom letter row sits after a fill-width Shift, which is a full column
+    /// — that is why w neighbours x.
+    static func rowOffsets(for rows: [String]) -> [Double] {
+        let top = Double(rows.first?.count ?? 0)
+        return rows.enumerated().map { index, row in
+            if index == 0 { return 0 }
+            if index == rows.count - 1 { return 1 }
+            let count = Double(row.count)
+            return count < top ? (top - count) / 2 : 0
+        }
+    }
+
+    private static func table(for rows: [String]) -> Table {
+        tables[rows] ?? makeTable(for: rows)
+    }
+
+    private static func makeTable(for rows: [String]) -> Table {
+        let offsets = rowOffsets(for: rows)
+        var positions: [Character: (row: Int, column: Double)] = [:]
+        for (rowIndex, row) in rows.enumerated() {
+            let offset = rowIndex < offsets.count ? offsets[rowIndex] : 0
+            for (columnIndex, character) in row.enumerated() {
+                positions[character] = (rowIndex, Double(columnIndex) + offset)
+            }
+        }
         var adjacency: [Character: Set<Character>] = [:]
         for (character, position) in positions {
             var neighbours: Set<Character> = []
@@ -53,16 +72,24 @@ enum KeyProximity {
             }
             adjacency[character] = neighbours
         }
-        return adjacency
-    }()
-
-    static func neighbours(of character: Character) -> Set<Character> {
-        adjacency[Character(String(character).lowercased())] ?? []
+        return Table(adjacency: adjacency)
     }
 
-    static func areAdjacent(_ left: Character, _ right: Character) -> Bool {
+    static func neighbours(
+        of character: Character,
+        rows: [String] = TypingLayout.fallback.rows
+    ) -> Set<Character> {
+        table(for: rows).adjacency[Character(String(character).lowercased())] ?? []
+    }
+
+    static func areAdjacent(
+        _ left: Character,
+        _ right: Character,
+        rows: [String] = TypingLayout.fallback.rows
+    ) -> Bool {
         guard left != right else { return false }
-        return neighbours(of: left).contains(Character(String(right).lowercased()))
+        return neighbours(of: left, rows: rows)
+            .contains(Character(String(right).lowercased()))
     }
 
     /// What it costs to say the user meant `intended` where they typed `typed`.
@@ -71,12 +98,16 @@ enum KeyProximity {
     /// so it costs less than half a full substitution. Anything else is a
     /// different letter entirely, and paying full price for it is what stops
     /// "cat" being offered for "bat" as readily as "hello" for "hwllo".
-    static func substitutionCost(typed: Character, intended: Character) -> Double {
+    static func substitutionCost(
+        typed: Character,
+        intended: Character,
+        rows: [String] = TypingLayout.fallback.rows
+    ) -> Double {
         if typed == intended { return 0 }
         let lowerTyped = Character(String(typed).lowercased())
         let lowerIntended = Character(String(intended).lowercased())
         if lowerTyped == lowerIntended { return 0 }
-        return areAdjacent(lowerTyped, lowerIntended) ? 0.4 : 1
+        return areAdjacent(lowerTyped, lowerIntended, rows: rows) ? 0.4 : 1
     }
 
     /// Damerau-Levenshtein with the substitution cost above, bounded.
@@ -86,7 +117,12 @@ enum KeyProximity {
     /// at all" threshold should be measured against — but the costs are real
     /// numbers, so a two-key drift can rank ahead of a one-key change to a
     /// letter on the other side of the keyboard.
-    static func weightedDistance(_ left: String, _ right: String, maximum: Double) -> Double {
+    static func weightedDistance(
+        _ left: String,
+        _ right: String,
+        maximum: Double,
+        rows: [String] = TypingLayout.fallback.rows
+    ) -> Double {
         if left == right { return 0 }
         let a = Array(left)
         let b = Array(right)
@@ -104,7 +140,11 @@ enum KeyProximity {
             current[0] = Double(i)
             var rowMinimum = current[0]
             for j in 1...b.count {
-                let substitution = substitutionCost(typed: a[i - 1], intended: b[j - 1])
+                let substitution = substitutionCost(
+                    typed: a[i - 1],
+                    intended: b[j - 1],
+                    rows: rows
+                )
                 var value = min(
                     previous[j] + 1,
                     current[j - 1] + 1,

--- a/ios/VocaPhoneKeyboard/KeyView.swift
+++ b/ios/VocaPhoneKeyboard/KeyView.swift
@@ -176,7 +176,7 @@ final class KeyView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        titleLabel.frame = bounds.insetBy(dx: 2, dy: 0)
+        layoutTitleLabel()
         symbolView.frame = bounds
         layer.cornerRadius = metrics.cornerRadius
         // Without an explicit path every key forces an offscreen pass to derive
@@ -235,7 +235,40 @@ final class KeyView: UIView {
         }
     }
 
+    /// Sized to the text, not to the key.
+    ///
+    /// A label paints a bitmap the size of its bounds at screen scale, so one
+    /// that filled its key painted a key-sized bitmap around a glyph a fraction
+    /// of that — on every key of every cached plane, in an extension jetsam
+    /// watches at about sixty megabytes. Centred on the same point, the text
+    /// lands where the full-size label drew it; the origin is snapped to the
+    /// pixel grid so the smaller layer is not composited between pixels.
+    private func layoutTitleLabel() {
+        let available = bounds.insetBy(dx: 2, dy: 0)
+        let fitted = titleLabel.text?.isEmpty == false
+            ? titleLabel.sizeThatFits(available.size)
+            : .zero
+        let size = CGSize(
+            width: min(fitted.width.rounded(.up), available.width),
+            height: min(fitted.height.rounded(.up), available.height)
+        )
+        let scale = max(traitCollection.displayScale, 1)
+        func snapped(_ value: CGFloat) -> CGFloat { (value * scale).rounded() / scale }
+        // Immediate even inside the spacebar's crossfade, which runs `refresh`
+        // in an animation block: a frame animating up from nothing would read
+        // as the caption zooming in rather than fading.
+        UIView.performWithoutAnimation {
+            titleLabel.frame = CGRect(
+                x: snapped(available.midX - size.width / 2),
+                y: snapped(available.midY - size.height / 2),
+                width: size.width,
+                height: size.height
+            )
+        }
+    }
+
     private func refresh() {
+        defer { layoutTitleLabel() }
         let symbolFont = UIFont.systemFont(ofSize: metrics.letterFontSize - 3, weight: .medium)
         let symbolConfiguration = UIImage.SymbolConfiguration(font: symbolFont)
 

--- a/ios/VocaPhoneKeyboard/KeyView.swift
+++ b/ios/VocaPhoneKeyboard/KeyView.swift
@@ -112,6 +112,29 @@ final class KeyView: UIView {
     private var shift: ShiftState = .off
     private var returnTitle = "return"
 
+    /// What the spacebar says, or `nil` for the blank system spacebar.
+    ///
+    /// A keyboard with one layout keeps the bar blank, because there is nothing
+    /// to tell. With two, the name of the language is the only thing that makes
+    /// the swipe findable — an unlabelled gesture is one nobody performs, and
+    /// the HIG asks a custom gesture to be discoverable rather than folklore.
+    var spaceTitle: String? {
+        didSet {
+            guard spaceTitle != oldValue else { return }
+            // Crossfaded rather than swapped: the name arrives because the
+            // language just changed, and a caption that snaps in and out under
+            // a finger reads as a glitch rather than as an answer.
+            UIView.transition(with: titleLabel, duration: 0.2, options: .transitionCrossDissolve) {
+                self.refresh()
+            }
+        }
+    }
+
+    /// What the language key says — the current layout's two letters.
+    var layoutTitle: String? {
+        didSet { if layoutTitle != oldValue { refresh() } }
+    }
+
     init(spec: KeySpec, metrics: KeyboardMetrics, palette: KeyboardPalette) {
         self.spec = spec
         self.metrics = metrics
@@ -196,6 +219,22 @@ final class KeyView: UIView {
         spec.cap.resolvedText(shift: shift)
     }
 
+    /// Blanks the cap without forgetting what it says.
+    ///
+    /// The cursor trackpad empties the keyboard the way iOS does. Fading the
+    /// two layers rather than clearing their contents means coming back costs
+    /// nothing and cannot disagree with ``refresh()`` about what this key is.
+    var capsAreHidden = false {
+        didSet {
+            guard capsAreHidden != oldValue else { return }
+            let target: CGFloat = capsAreHidden ? 0 : 1
+            UIView.animate(withDuration: 0.14) {
+                self.titleLabel.alpha = target
+                self.symbolView.alpha = target
+            }
+        }
+    }
+
     private func refresh() {
         let symbolFont = UIFont.systemFont(ofSize: metrics.letterFontSize - 3, weight: .medium)
         let symbolConfiguration = UIImage.SymbolConfiguration(font: symbolFont)
@@ -226,10 +265,22 @@ final class KeyView: UIView {
                 systemName: "globe",
                 withConfiguration: symbolConfiguration
             )
+        case .layoutSwitch:
+            // Two letters rather than a glyph. Every symbol that means
+            // "language" is either the globe — which belongs to the key that
+            // leaves for another keyboard — or an abstract letterform that
+            // says "text" and not which text. The code says where you are, and
+            // it is the same two characters in the picker and on the key.
+            titleLabel.text = layoutTitle
+            titleLabel.font = planeFont
+            symbolView.image = nil
         case .space:
-            // The system spacebar is visually blank; its name remains available
-            // through the key's accessibility label.
-            titleLabel.text = nil
+            // Blank on a one-layout keyboard, as the system spacebar is; its
+            // name remains available through the key's accessibility label.
+            // Otherwise the language, between the two chevrons that say which
+            // way the finger goes.
+            titleLabel.text = spaceTitle
+            titleLabel.font = functionFont
             symbolView.image = nil
         case .newline:
             if returnTitle == "return" {

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -7,6 +7,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     private var activeSessionID: UUID?
     private var pollingTimer: Timer?
     private var pollingInterval: TimeInterval?
+    private var quickDictationReadinessTimer: Timer?
     private var darwinObservations: [VocaPhoneDarwinObservation] = []
     private var appLaunchFallbackTask: Task<Void, Never>?
     private var lastInsertedText: String?
@@ -18,6 +19,11 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     private var recordingStartedAt: Date?
     /// Whether the surface held the whole keyboard at the last layout pass.
     private var surfaceOwnedKeyboard = false
+    /// The compact dashboard owns the same full-height surface as a live
+    /// session. Keeping this at the controller level lets UIKit hide the grid
+    /// and hand its space to SwiftUI instead of clipping the dashboard into a
+    /// 54-point typing strip.
+    private var compactDashboardOwnsKeyboard = false
 
     /// How much of the recording's measured audio the meter has already drawn.
     /// The session the meter on screen belongs to.
@@ -212,6 +218,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // The app's settings screen writes the same two keys, and it may have
         // done so while another keyboard was on screen.
         dictationSurfaceState.refreshPreferences()
+        startQuickDictationReadinessPolling()
         // A new appearance is a new field as far as this keyboard can tell.
         //
         // The insertion target was previously kept for the life of the
@@ -285,6 +292,8 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         pollingTimer?.invalidate()
         pollingTimer = nil
         pollingInterval = nil
+        quickDictationReadinessTimer?.invalidate()
+        quickDictationReadinessTimer = nil
         darwinObservations.forEach { $0.invalidate() }
         darwinObservations.removeAll()
         appLaunchFallbackTask?.cancel()
@@ -334,6 +343,23 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             .keyboardShown,
             metadata: .fullAccess(hasFullAccess)
         )
+    }
+
+    /// The app's readiness lease expires when its heartbeat stops. An idle
+    /// keyboard has no session poll running, so without this lightweight check
+    /// force-quitting VocaPhone left the old ready badge on screen forever.
+    private func startQuickDictationReadinessPolling() {
+        quickDictationReadinessTimer?.invalidate()
+        quickDictationReadinessTimer = nil
+        guard dictationSurfaceState.usesCompactControls else { return }
+        let timer = Timer(timeInterval: 1, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self, self.isKeyboardVisible else { return }
+                self.dictationSurfaceState.refreshQuickDictationReadiness()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        quickDictationReadinessTimer = timer
     }
 
     override func textDidChange(_ textInput: (any UITextInput)?) {
@@ -1169,7 +1195,11 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         )
         darwinObservations.append(
             VocaPhoneDarwinCenter.observe(.quickDictationChanged) { [weak self] in
-                Task { @MainActor [weak self] in self?.refresh() }
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    self.dictationSurfaceState.refreshPreferences()
+                    self.refresh()
+                }
             }
         )
     }
@@ -1388,8 +1418,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // session to another layout: it stays where it was tapped, the line
         // under the bars becomes "Transcribing", and the check itself turns
         // into the spinner. Cancel keeps working throughout.
-        let isRecording = Self.surfaceOwnsKeyboard(state, hasFullAccess: hasFullAccess)
-        if isRecording {
+        let sessionOwnsKeyboard = Self.surfaceOwnsKeyboard(state, hasFullAccess: hasFullAccess)
+        let surfaceFillsKeyboard = sessionOwnsKeyboard || compactDashboardOwnsKeyboard
+        if surfaceFillsKeyboard {
             keyGrid.endActiveInteractions()
             keyGrid.isHidden = true
             // The panel is a second full-height view in the same stack. Left
@@ -1424,11 +1455,11 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // the state before, which is a stack taller than the keyboard.
         if model.isExpanded != isBarExpanded
             || model.layout != barLayout
-            || isRecording != surfaceOwnedKeyboard
+            || surfaceFillsKeyboard != surfaceOwnedKeyboard
         {
             isBarExpanded = model.isExpanded
             barLayout = model.layout
-            surfaceOwnedKeyboard = isRecording
+            surfaceOwnedKeyboard = surfaceFillsKeyboard
             applyLayoutMetrics(animated: hasRendered)
         }
         dictationBar.apply(model, animated: hasRendered)
@@ -1516,11 +1547,22 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         dictationSurfaceState.onFinish = { [weak self] in self?.perform(.finish) }
         dictationSurfaceState.onCancel = { [weak self] in self?.perform(.cancel) }
         dictationSurfaceState.onGlobe = { [weak self] in self?.advanceToNextInputMode() }
-        dictationSurfaceState.onStartQuickDictation = { [weak self] in
-            self?.openContainingAppAction("ready")
-        }
         dictationSurfaceState.onOpenSettings = { [weak self] in
             self?.openContainingAppAction("settings")
+        }
+        dictationSurfaceState.onDashboardVisibilityChanged = { [weak self] presented in
+            guard let self else { return }
+            compactDashboardOwnsKeyboard = presented
+            render(lastRecord)
+        }
+        dictationSurfaceState.onQuickDictationChanged = { [weak self] enabled in
+            KeyboardPreferences.quickDictationEnabled = enabled
+            if enabled {
+                KeyboardPreferences.quickDictationPausedUntilRelaunch = false
+                self?.openContainingAppAction("ready")
+            } else {
+                VocaPhoneDarwinCenter.post(.stopQuickDictationRequested)
+            }
         }
         dictationSurfaceState.onCandidate = { [weak self] candidate in
             guard let self, !isPerformingInsertion else { return }
@@ -1753,10 +1795,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         keyGrid.metrics = metrics
         dictationBar.metrics = barMetrics
 
-        let isRecording = Self.surfaceOwnsKeyboard(
+        let surfaceFillsKeyboard = Self.surfaceOwnsKeyboard(
             dictationSurfaceState.state,
             hasFullAccess: hasFullAccess
-        )
+        ) || compactDashboardOwnsKeyboard
         // Recording's own bar model is the *expanded status* layout — the tall
         // card the old bar used to draw — and asking it for a height is what
         // still made the keyboard grow, by about forty points, after the two
@@ -1764,8 +1806,8 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // all: it stands in the strip and then takes the keys' room from the
         // inside, so the height is the strip's, in every state.
         let barHeight = barMetrics.height(
-            for: isRecording ? .strip : barLayout,
-            expanded: isRecording ? false : isBarExpanded
+            for: surfaceFillsKeyboard ? .strip : barLayout,
+            expanded: surfaceFillsKeyboard ? false : isBarExpanded
         )
 
         // One height, and recording does not get a say in it: whatever the
@@ -1783,7 +1825,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             + KeyboardChrome.gapAboveKeys
             + metrics.gridHeight
 
-        let wantedBarHeight = isRecording
+        let wantedBarHeight = surfaceFillsKeyboard
             ? keyboardHeight - Self.chromeInset - Self.chromeBottomInset
             : barHeight
         // Nothing moved, so nothing is animated.

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -1555,9 +1555,8 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             compactDashboardOwnsKeyboard = presented
             render(lastRecord)
         }
-        dictationSurfaceState.onQuickDictationChanged = { [weak self] enabled in
-            KeyboardPreferences.quickDictationEnabled = enabled
-            if enabled {
+        dictationSurfaceState.onQuickDictationReadinessChanged = { [weak self] ready in
+            if ready {
                 KeyboardPreferences.quickDictationPausedUntilRelaunch = false
                 self?.openContainingAppAction("ready")
             } else {

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -304,6 +304,11 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // A held key or an open accent popover must not survive the keyboard
         // being dismissed; iOS does not reliably cancel those touches for us.
         keyGrid.endActiveInteractions()
+        // The instance is about to be suspended, and a suspended extension is
+        // killed on its footprint like anything else — after which the next
+        // field gets a cold start. Hidden planes are the part of that footprint
+        // this keyboard can give back for free.
+        keyGrid.discardHiddenPlanes()
 #if DEBUG
         FrameMonitor.stop()
 #endif
@@ -311,6 +316,13 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // A prepared generator keeps the Taptic Engine powered for a second or
         // two, which a dismissed keyboard has no business spending.
         KeyboardHaptics.shared.release()
+    }
+
+    /// The warning comes shortly before the kill, and a keyboard killed while
+    /// on screen is one that freezes and then vanishes mid-word.
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        keyGrid.discardHiddenPlanes()
     }
 
     /// The containing app has no API for whether this keyboard is installed or

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -19,11 +19,11 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     private var recordingStartedAt: Date?
     /// Whether the surface held the whole keyboard at the last layout pass.
     private var surfaceOwnedKeyboard = false
-    /// The compact dashboard owns the same full-height surface as a live
-    /// session. Keeping this at the controller level lets UIKit hide the grid
-    /// and hand its space to SwiftUI instead of clipping the dashboard into a
-    /// 54-point typing strip.
-    private var compactDashboardOwnsKeyboard = false
+    /// A panel — the compact dashboard or a picker — owns the same full-height
+    /// surface as a live session. Keeping this at the controller level lets
+    /// UIKit hide the grid and hand its space to SwiftUI instead of clipping
+    /// the panel into a 54-point typing strip.
+    private var panelOwnsKeyboard = false
 
     /// How much of the recording's measured audio the meter has already drawn.
     /// The session the meter on screen belongs to.
@@ -218,10 +218,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // The app's settings screen writes the same two keys, and it may have
         // done so while another keyboard was on screen.
         dictationSurfaceState.refreshPreferences()
-        // The dashboard belongs to the field it was opened in. A reused
-        // extension instance otherwise comes up in the next field with the
-        // stats page where the keys should be.
-        dictationSurfaceState.setCompactDashboardPresented(false)
+        // A panel belongs to the field it was opened in. A reused extension
+        // instance otherwise comes up in the next field with stats or a picker
+        // where the keys should be.
+        dictationSurfaceState.present(nil)
         startQuickDictationReadinessPolling()
         // A new appearance is a new field as far as this keyboard can tell.
         //
@@ -1435,7 +1435,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // under the bars becomes "Transcribing", and the check itself turns
         // into the spinner. Cancel keeps working throughout.
         let sessionOwnsKeyboard = Self.surfaceOwnsKeyboard(state, hasFullAccess: hasFullAccess)
-        let surfaceFillsKeyboard = sessionOwnsKeyboard || compactDashboardOwnsKeyboard
+        let surfaceFillsKeyboard = sessionOwnsKeyboard || panelOwnsKeyboard
         if surfaceFillsKeyboard {
             keyGrid.endActiveInteractions()
             keyGrid.isHidden = true
@@ -1566,9 +1566,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         dictationSurfaceState.onOpenSettings = { [weak self] in
             self?.openContainingAppAction("settings")
         }
-        dictationSurfaceState.onDashboardVisibilityChanged = { [weak self] presented in
+        dictationSurfaceState.onPanelVisibilityChanged = { [weak self] presented in
             guard let self else { return }
-            compactDashboardOwnsKeyboard = presented
+            panelOwnsKeyboard = presented
             render(lastRecord)
         }
         dictationSurfaceState.onVocaPhoneRunningChanged = { [weak self] running in
@@ -1818,7 +1818,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         let surfaceFillsKeyboard = Self.surfaceOwnsKeyboard(
             dictationSurfaceState.state,
             hasFullAccess: hasFullAccess
-        ) || compactDashboardOwnsKeyboard
+        ) || panelOwnsKeyboard
         // Recording's own bar model is the *expanded status* layout — the tall
         // card the old bar used to draw — and asking it for a height is what
         // still made the keyboard grow, by about forty points, after the two

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -541,20 +541,6 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             settleCursor()
         case let .moveCursor(offset):
             moveCursor(by: offset)
-        case let .moveCursorLine(lines):
-            moveCursorByLines(lines)
-            lastSpaceInsertedAt = nil
-            // A line move works out its offset from the document itself, so
-            // whatever the drag had counted no longer describes where the
-            // cursor is. Re-reading here is affordable: a line costs 26pt of
-            // travel, against 4 to 14 for a character.
-            let snapshot = refreshDocument()
-            if cursorDrag != nil {
-                cursorDrag = CursorDrag(document: snapshot)
-            } else {
-                typing.reconcile(document: snapshot)
-                releaseUndoIfDetached()
-            }
         case let .nextLayout(forward):
             guard let next = TypingLayout.next(
                 after: KeyboardPreferences.typingLayout,
@@ -904,52 +890,6 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         lastSpaceInsertedAt = nil
         typing.reconcile(document: refreshDocument())
         releaseUndoIfDetached()
-    }
-
-    private func moveCursorByLines(_ lines: Int) {
-        guard lines != 0 else { return }
-        let snapshot = document
-        let beforeLines = (snapshot.before ?? "").components(separatedBy: "\n")
-        let afterLines = (snapshot.after ?? "").components(separatedBy: "\n")
-        // How far into its own line the cursor sits. The last element of the
-        // leading context is the part of the current line behind the cursor.
-        let column = beforeLines.last?.count ?? 0
-        let proxy = textDocumentProxy
-
-        if lines < 0 {
-            // Nothing above in the visible context: the start of this line is
-            // the nearest thing to what was asked for, and it is where a finger
-            // dragged off the top is reaching anyway.
-            guard beforeLines.count > 1 else {
-                if column > 0 { proxy.adjustTextPosition(byCharacterOffset: -column) }
-                return
-            }
-            let steps = min(-lines, beforeLines.count - 1)
-            let target = beforeLines.count - 1 - steps
-            // Back to the start of the current line, then over each line
-            // skipped along with the break that ended it.
-            var offset = -column
-            for index in stride(from: beforeLines.count - 2, through: target, by: -1) {
-                offset -= 1 + beforeLines[index].count
-            }
-            // Forward into the target line, clamped to its end so a short line
-            // keeps the cursor on it rather than past it.
-            offset += min(column, beforeLines[target].count)
-            proxy.adjustTextPosition(byCharacterOffset: offset)
-        } else {
-            guard afterLines.count > 1 else {
-                let tail = afterLines.first?.count ?? 0
-                if tail > 0 { proxy.adjustTextPosition(byCharacterOffset: tail) }
-                return
-            }
-            let steps = min(lines, afterLines.count - 1)
-            var offset = afterLines[0].count
-            for index in 1..<steps {
-                offset += 1 + afterLines[index].count
-            }
-            offset += 1 + min(column, afterLines[steps].count)
-            proxy.adjustTextPosition(byCharacterOffset: offset)
-        }
     }
 
     private func deleteWordBackward() {
@@ -1893,6 +1833,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         keyGrid.layout = layout
         keyGrid.showsLayoutSwitchKey = switchable
         keyGrid.layoutTitle = switchable ? layout.shortName : nil
+        keyGrid.offersCursorTrackpad = KeyboardPreferences.spacebarCursorEnabled
         typing.layout = layout
         // Only when the language actually just changed. This method also runs
         // every time the keyboard arrives in a new field, and a caption that

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -1555,12 +1555,17 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             compactDashboardOwnsKeyboard = presented
             render(lastRecord)
         }
-        dictationSurfaceState.onQuickDictationReadinessChanged = { [weak self] ready in
-            if ready {
+        dictationSurfaceState.onVocaPhoneRunningChanged = { [weak self] running in
+            if running {
                 KeyboardPreferences.quickDictationPausedUntilRelaunch = false
                 self?.openContainingAppAction("ready")
             } else {
-                VocaPhoneDarwinCenter.post(.stopQuickDictationRequested)
+                // Off is the app switcher's swipe, not the Live Activity's
+                // pause: no preference is written. The marker goes first so
+                // this keyboard stops routing to a window that is ending even
+                // if VocaPhone has already died and nothing is listening.
+                try? self?.store.clearQuickDictationAvailability()
+                VocaPhoneDarwinCenter.post(.closeVocaPhoneRequested)
             }
         }
         dictationSurfaceState.onCandidate = { [weak self] candidate in

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -218,6 +218,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // The app's settings screen writes the same two keys, and it may have
         // done so while another keyboard was on screen.
         dictationSurfaceState.refreshPreferences()
+        // The dashboard belongs to the field it was opened in. A reused
+        // extension instance otherwise comes up in the next field with the
+        // stats page where the keys should be.
+        dictationSurfaceState.setCompactDashboardPresented(false)
         startQuickDictationReadinessPolling()
         // A new appearance is a new field as far as this keyboard can tell.
         //
@@ -1920,6 +1924,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // announced itself on every field would be an advertisement.
         if announce, switchable {
             keyGrid.flashSpaceTitle("‹ \(layout.displayName) ›")
+            // The caption is visual only; VoiceOver hears the letters change
+            // under its finger with no word of why.
+            UIAccessibility.post(notification: .announcement, argument: layout.displayName)
         }
     }
 

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -1882,6 +1882,11 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             && keyboardHeightConstraint?.constant == keyboardHeight
         guard !unchanged else { return }
 
+        // Whether the keyboard itself changes size, or only what is inside it.
+        // A panel opening over the keys is the second kind: the bar grows into
+        // the grid's room and the keyboard stays exactly as tall as it was.
+        let keyboardResizes = keyboardHeightConstraint?.constant != keyboardHeight
+
         barHeightConstraint?.constant = wantedBarHeight
         gridHeightConstraint?.constant = metrics.gridHeight
         emojiPanelHeightConstraint?.constant = metrics.gridHeight
@@ -1891,12 +1896,25 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             view.setNeedsLayout()
             return
         }
-        // The host app resizes around the keyboard, so the expansion has to be
-        // a settle rather than a jump.
+        // Two animations run over the same pixels when a panel opens: this one
+        // on the container, and the surface's own spring on the content inside
+        // it. They were 340 ms at 0.9 damping against 150 ms at 1, so the panel
+        // arrived and then kept settling for another fifth of a second, with
+        // SwiftUI re-laying its content against a frame that was still moving.
+        // That is the lag: not slow to start, slow to stop.
+        //
+        // The settle is still right when the *keyboard* resizes, because the
+        // host app resizes around it and a jump there moves the whole document.
+        let duration = keyboardResizes
+            ? 0.34
+            : KeyboardPreferences.surfaceAnimationResponse
+        let damping = keyboardResizes
+            ? 0.9
+            : KeyboardPreferences.surfaceAnimationDamping
         UIView.animate(
-            withDuration: 0.34,
+            withDuration: duration,
             delay: 0,
-            usingSpringWithDamping: 0.9,
+            usingSpringWithDamping: damping,
             initialSpringVelocity: 0,
             options: [.beginFromCurrentState, .allowUserInteraction]
         ) {

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -834,16 +834,6 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         releaseUndoIfDetached()
     }
 
-    /// Moves the cursor a whole line up or down, keeping its column.
-    ///
-    /// A keyboard extension can only `adjustTextPosition(byCharacterOffset:)`,
-    /// so "one line" has to be counted out in characters from the document
-    /// context — which is why this lives here rather than in the grid: the grid
-    /// knows the finger moved, and only the controller can see the text.
-    ///
-    /// Clamped to the ends. Off the top or bottom of the visible context the
-    /// cursor goes to the start or end of it rather than nowhere, which is what
-    /// the user is reaching for anyway.
     /// What the trackpad knows about the document while a finger is on it.
     ///
     /// A cursor step used to cost what a keystroke costs: `adjustTextPosition`,
@@ -857,12 +847,14 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         /// Characters either side of the cursor, in the UTF-16 units that
         /// `adjustTextPosition(byCharacterOffset:)` actually steps in.
         ///
-        /// A floor rather than the truth: iOS hands a keyboard a window onto
-        /// the document, not the document. It is the case at the edges that
-        /// has to be right, and there the window is not lying — an empty
-        /// `after` means there is genuinely nothing ahead.
-        var behind: Int
-        var ahead: Int
+        /// A floor rather than a ceiling. iOS hands a keyboard a window onto
+        /// the document, not the document — often the rest of the current
+        /// paragraph. `0` means that side of the window was empty, which is a
+        /// real end, so the cursor stops. `nil` means the finger has walked
+        /// off the window we were given, so the window is no longer a limit:
+        /// keep going, because the rest of the document is past it.
+        var behind: Int?
+        var ahead: Int?
 
         init(document: DocumentSnapshot) {
             behind = (document.before ?? "").utf16.count
@@ -872,18 +864,39 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
     private var cursorDrag: CursorDrag?
 
-    /// Moves the cursor, clamped to what the document has left.
+    /// Moves the cursor, stopping only at a known empty side of the document.
     ///
-    /// Without the clamp a finger that runs past the end of the field banks
+    /// Without any clamp a finger that runs past the end of the field banks
     /// every point of that overshoot, and the same travel has to be unwound
     /// before the cursor moves back at all — which is what "the cursor sticks
-    /// at the end of the box" is.
+    /// at the end of the box" is. The window iOS hands us is not the document,
+    /// though, so treating its length as a hard stop parks the cursor at a
+    /// paragraph boundary with text still ahead. Empty is the only case the
+    /// window is not lying about.
     private func moveCursor(by offset: Int) {
         var applied = offset
         if var drag = cursorDrag {
-            applied = offset > 0 ? min(offset, drag.ahead) : max(offset, -drag.behind)
-            drag.ahead -= applied
-            drag.behind += applied
+            if offset > 0 {
+                if drag.ahead == 0 {
+                    applied = 0
+                } else if let ahead = drag.ahead {
+                    let remaining = ahead - offset
+                    drag.ahead = remaining > 0 ? remaining : nil
+                    drag.behind = (drag.behind ?? 0) + offset
+                } else {
+                    drag.behind = (drag.behind ?? 0) + offset
+                }
+            } else {
+                if drag.behind == 0 {
+                    applied = 0
+                } else if let behind = drag.behind {
+                    let remaining = behind + offset
+                    drag.behind = remaining > 0 ? remaining : nil
+                    drag.ahead = (drag.ahead ?? 0) - offset
+                } else {
+                    drag.ahead = (drag.ahead ?? 0) - offset
+                }
+            }
             cursorDrag = drag
         }
         guard applied != 0 else { return }
@@ -1814,6 +1827,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // the character. Not in a field that has asked for no intelligence.
         keyGrid.traceNamesKeys = policy.allowsTypingIntelligence
         keyGrid.showsGlobeKey = needsInputModeSwitchKey
+        keyGrid.offersCursorTrackpad = KeyboardPreferences.spacebarCursorEnabled
         applyTypingLayout(KeyboardPreferences.typingLayout)
         let returnKeyType = proxy.returnKeyType ?? .default
         keyGrid.returnKeyTitle = Self.returnKeyTitle(for: returnKeyType)
@@ -1844,7 +1858,6 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         keyGrid.layout = layout
         keyGrid.showsLayoutSwitchKey = switchable
         keyGrid.layoutTitle = switchable ? layout.shortName : nil
-        keyGrid.offersCursorTrackpad = KeyboardPreferences.spacebarCursorEnabled
         typing.layout = layout
         // Only when the language actually just changed. This method also runs
         // every time the keyboard arrives in a new field, and a caption that

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -533,18 +533,38 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             lastSpaceInsertedAt = nil
             releaseUndoIfDetached()
             updateAutomaticShift()
+        case .beginCursorDrag:
+            let snapshot = refreshDocument()
+            cursorDrag = CursorDrag(document: snapshot)
+        case .endCursorDrag:
+            cursorDrag = nil
+            settleCursor()
         case let .moveCursor(offset):
-            textDocumentProxy.adjustTextPosition(byCharacterOffset: offset)
-            lastSpaceInsertedAt = nil
-            // The cursor is somewhere else now, so whatever was being composed
-            // belongs to a different part of the document.
-            typing.reconcile(document: refreshDocument())
-            releaseUndoIfDetached()
+            moveCursor(by: offset)
         case let .moveCursorLine(lines):
             moveCursorByLines(lines)
             lastSpaceInsertedAt = nil
+            // A line move works out its offset from the document itself, so
+            // whatever the drag had counted no longer describes where the
+            // cursor is. Re-reading here is affordable: a line costs 26pt of
+            // travel, against 4 to 14 for a character.
+            let snapshot = refreshDocument()
+            if cursorDrag != nil {
+                cursorDrag = CursorDrag(document: snapshot)
+            } else {
+                typing.reconcile(document: snapshot)
+                releaseUndoIfDetached()
+            }
+        case let .nextLayout(forward):
+            guard let next = TypingLayout.next(
+                after: KeyboardPreferences.typingLayout,
+                in: KeyboardPreferences.enabledTypingLayouts,
+                forward: forward
+            ) else { break }
+            KeyboardPreferences.typingLayout = next
+            applyTypingLayout(next, announce: true)
+            // The composition belonged to the alphabet that has just left.
             typing.reconcile(document: refreshDocument())
-            releaseUndoIfDetached()
         case let .nextInputMode(anchor, event):
             // `handleInputModeList` also drives the long-press keyboard picker,
             // which `advanceToNextInputMode` alone cannot offer.
@@ -827,6 +847,65 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// Clamped to the ends. Off the top or bottom of the visible context the
     /// cursor goes to the start or end of it rather than nowhere, which is what
     /// the user is reaching for anyway.
+    /// What the trackpad knows about the document while a finger is on it.
+    ///
+    /// A cursor step used to cost what a keystroke costs: `adjustTextPosition`,
+    /// then two properties read across into the host process, then a pass over
+    /// the dictionary — per step, at up to 120 steps a second, against a frame
+    /// budget of 8.3ms that a single one of those reads has already been
+    /// measured eating (see ``cachedSmartPunctuation``). Nothing else is moving
+    /// this cursor, so the document is read once when the finger arrives and
+    /// the drag counts for itself until it leaves.
+    private struct CursorDrag {
+        /// Characters either side of the cursor, in the UTF-16 units that
+        /// `adjustTextPosition(byCharacterOffset:)` actually steps in.
+        ///
+        /// A floor rather than the truth: iOS hands a keyboard a window onto
+        /// the document, not the document. It is the case at the edges that
+        /// has to be right, and there the window is not lying — an empty
+        /// `after` means there is genuinely nothing ahead.
+        var behind: Int
+        var ahead: Int
+
+        init(document: DocumentSnapshot) {
+            behind = (document.before ?? "").utf16.count
+            ahead = (document.after ?? "").utf16.count
+        }
+    }
+
+    private var cursorDrag: CursorDrag?
+
+    /// Moves the cursor, clamped to what the document has left.
+    ///
+    /// Without the clamp a finger that runs past the end of the field banks
+    /// every point of that overshoot, and the same travel has to be unwound
+    /// before the cursor moves back at all — which is what "the cursor sticks
+    /// at the end of the box" is.
+    private func moveCursor(by offset: Int) {
+        var applied = offset
+        if var drag = cursorDrag {
+            applied = offset > 0 ? min(offset, drag.ahead) : max(offset, -drag.behind)
+            drag.ahead -= applied
+            drag.behind += applied
+            cursorDrag = drag
+        }
+        guard applied != 0 else { return }
+        textDocumentProxy.adjustTextPosition(byCharacterOffset: applied)
+        lastSpaceInsertedAt = nil
+        // Mid-drag the document is deliberately not re-read; the finger lifting
+        // is what settles it. See ``CursorDrag``.
+        guard cursorDrag == nil else { return }
+        settleCursor()
+    }
+
+    /// The cursor is somewhere else now, so whatever was being composed belongs
+    /// to a different part of the document.
+    private func settleCursor() {
+        lastSpaceInsertedAt = nil
+        typing.reconcile(document: refreshDocument())
+        releaseUndoIfDetached()
+    }
+
     private func moveCursorByLines(_ lines: Int) {
         guard lines != 0 else { return }
         let snapshot = document
@@ -1784,6 +1863,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // the character. Not in a field that has asked for no intelligence.
         keyGrid.traceNamesKeys = policy.allowsTypingIntelligence
         keyGrid.showsGlobeKey = needsInputModeSwitchKey
+        applyTypingLayout(KeyboardPreferences.typingLayout)
         let returnKeyType = proxy.returnKeyType ?? .default
         keyGrid.returnKeyTitle = Self.returnKeyTitle(for: returnKeyType)
         keyGrid.returnKeyIsProminent = returnKeyType != .default
@@ -1799,6 +1879,27 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // A returning keyboard may already be at the end of "happy". Restore
         // its suggestions immediately instead of waiting for another key.
         if isKeyboardVisible { typing.reconcile(document: document) }
+    }
+
+    /// Puts a layout under the fingers, and tells everything that cares.
+    ///
+    /// Three things care and they are easy to leave behind one another: the
+    /// grid draws different letters, the spacebar carries the name that makes
+    /// the swipe findable, and typing intelligence corrects against a different
+    /// dictionary. A layout changed in only two of the three is a keyboard that
+    /// autocorrects Russian into English.
+    private func applyTypingLayout(_ layout: TypingLayout, announce: Bool = false) {
+        let switchable = KeyboardPreferences.enabledTypingLayouts.count > 1
+        keyGrid.layout = layout
+        keyGrid.showsLayoutSwitchKey = switchable
+        keyGrid.layoutTitle = switchable ? layout.shortName : nil
+        typing.layout = layout
+        // Only when the language actually just changed. This method also runs
+        // every time the keyboard arrives in a new field, and a caption that
+        // announced itself on every field would be an advertisement.
+        if announce, switchable {
+            keyGrid.flashSpaceTitle("‹ \(layout.displayName) ›")
+        }
     }
 
     /// Dims Return in the fields that asked for it.

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -485,6 +485,17 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
                 )
             )
         }
+        // The compact row moves its action button aside as soon as somebody
+        // types, and "as soon as" is the keystroke — not the suggestions it
+        // eventually produces. Latching on the candidates meant waiting for the
+        // spell checker to answer, which is a visible beat after the letter is
+        // already on screen.
+        switch output {
+        case .text, .space, .newline, .deleteBackward, .deleteWord, .swipeWord:
+            dictationSurfaceState.hasTypedThisSession = true
+        default:
+            break
+        }
         switch output {
         case let .text(text):
             if let substitution = SmartPunctuation.substitution(

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -485,17 +485,6 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
                 )
             )
         }
-        // The compact row moves its action button aside as soon as somebody
-        // types, and "as soon as" is the keystroke — not the suggestions it
-        // eventually produces. Latching on the candidates meant waiting for the
-        // spell checker to answer, which is a visible beat after the letter is
-        // already on screen.
-        switch output {
-        case .text, .space, .newline, .deleteBackward, .deleteWord, .swipeWord:
-            dictationSurfaceState.hasTypedThisSession = true
-        default:
-            break
-        }
         switch output {
         case let .text(text):
             if let substitution = SmartPunctuation.substitution(
@@ -1527,6 +1516,12 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         dictationSurfaceState.onFinish = { [weak self] in self?.perform(.finish) }
         dictationSurfaceState.onCancel = { [weak self] in self?.perform(.cancel) }
         dictationSurfaceState.onGlobe = { [weak self] in self?.advanceToNextInputMode() }
+        dictationSurfaceState.onStartQuickDictation = { [weak self] in
+            self?.openContainingAppAction("ready")
+        }
+        dictationSurfaceState.onOpenSettings = { [weak self] in
+            self?.openContainingAppAction("settings")
+        }
         dictationSurfaceState.onCandidate = { [weak self] candidate in
             guard let self, !isPerformingInsertion else { return }
             documentEvent { self.apply(candidate) }
@@ -1574,6 +1569,21 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // only part of that delay this code owns.
         hostView.setNeedsLayout()
         hostView.layoutIfNeeded()
+    }
+
+    /// Opens a user-requested destination in the containing app. These actions
+    /// carry no transcript or token; they only foreground VocaPhone so it can
+    /// arm its own microphone session or show its own Settings screen.
+    private func openContainingAppAction(_ action: String) {
+        guard let url = URL(string: "\(AppConfiguration.urlScheme)://\(action)") else { return }
+        openURLFromKeyboard(url) { [weak self] opened in
+            DispatchQueue.main.async {
+                guard let self, !opened else { return }
+                self.dictationSurfaceState.showRecoveryMessage(
+                    "Open vocaphone to continue."
+                )
+            }
+        }
     }
 
     private func configureUI() {

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -174,6 +174,33 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             .keyboardShown,
             metadata: .megabytesAvailable(availableMB)
         )
+        reportIfLowOnMemory(availableMB)
+    }
+
+    /// Below this, a keyboard is living on borrowed time: the measured launches
+    /// that ended in iOS killing the extension — and handing the user another
+    /// keyboard mid-sentence — reported four to eight megabytes, against the
+    /// sixty-five of an unpressured one.
+    private static let lowMemoryMegabytes = 25
+
+    /// Tells the app, which is the only process that can do anything about it.
+    ///
+    /// The keyboard's allowance is not the keyboard's to grow: iOS shrinks what
+    /// an extension may have when the *system* is under pressure, and on this
+    /// phone the pressure is the app's own speech model. So this is a request,
+    /// not a report — see `RecordingCoordinator.releaseLocalEnginesIfIdle`.
+    private func reportIfLowOnMemory(_ availableMB: Int) {
+        guard availableMB < Self.lowMemoryMegabytes else { return }
+        VocaPhoneDarwinCenter.post(.keyboardLowOnMemory)
+    }
+
+    /// The warning comes shortly before the kill, and a keyboard killed while
+    /// on screen is one that freezes and then vanishes mid-word. Hidden planes
+    /// are what this process can give back; the rest is the app's to give.
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        keyGrid.discardHiddenPlanes()
+        VocaPhoneDarwinCenter.post(.keyboardLowOnMemory)
     }
 
 #if DEBUG
@@ -316,13 +343,6 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // A prepared generator keeps the Taptic Engine powered for a second or
         // two, which a dismissed keyboard has no business spending.
         KeyboardHaptics.shared.release()
-    }
-
-    /// The warning comes shortly before the kill, and a keyboard killed while
-    /// on screen is one that freezes and then vanishes mid-word.
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        keyGrid.discardHiddenPlanes()
     }
 
     /// The containing app has no API for whether this keyboard is installed or

--- a/ios/VocaPhoneKeyboard/TypingCandidates.swift
+++ b/ios/VocaPhoneKeyboard/TypingCandidates.swift
@@ -136,6 +136,10 @@ enum TypingCandidates {
         var predictionEnabled = true
         var emojiEnabled = true
         var allowsTypingIntelligence = true
+        /// The letter rows under the fingers. Correction weights keys that sit
+        /// next to each other, and that neighbourhood is the layout's, not
+        /// QWERTY's.
+        var layoutRows: [String] = TypingLayout.fallback.rows
     }
 
     // MARK: - Strip
@@ -559,7 +563,8 @@ enum TypingCandidates {
         var cost = KeyProximity.weightedDistance(
             typed.lowercased(),
             candidate.lowercased(),
-            maximum: 3
+            maximum: 3,
+            rows: context.layoutRows
         )
         // The preceding word predicts this one. Worth about half an edit: enough
         // to settle a tie, never enough to beat a plainly closer spelling.

--- a/ios/VocaPhoneKeyboard/TypingEngine.swift
+++ b/ios/VocaPhoneKeyboard/TypingEngine.swift
@@ -622,6 +622,7 @@ final class TypingEngine {
         context.composition = composition
         context.origin = origin
         context.precedingWord = preceding
+        context.layoutRows = layout.rows
         let lowered = composition.lowercased()
         // One pass for both, over the folded copies: the prefix matches that
         // reach the strip, and the exact match that outranks it.

--- a/ios/VocaPhoneKeyboard/TypingEngine.swift
+++ b/ios/VocaPhoneKeyboard/TypingEngine.swift
@@ -136,6 +136,30 @@ final class TypingEngine {
     private var emojiTriggers: [String: String] = [:]
     private var precedingWord: String?
     private var hasDocumentContext = false
+
+    /// The layout under the fingers, which is what decides the dictionary.
+    ///
+    /// ``TypingLanguage`` was written expecting this: "the layout decides the
+    /// language, and the layout is English". It is no longer only English, so
+    /// the layout's own language now goes to the head of the preferred list and
+    /// the user's locales remain behind it as the fallback they always were.
+    var layout: TypingLayout = .fallback {
+        didSet {
+            guard layout != oldValue else { return }
+            // Resolving the system checker language can wake dictionaries, so
+            // leave it to the same quiet-period task that handles first use.
+            // The old layout's cached checks must not cross the switch.
+            hasResolvedLanguage = false
+            cache.removeAll()
+        }
+    }
+
+    private func resolvedLanguage() -> String {
+        TypingLanguage.resolve(
+            preferred: [layout.checkerLanguage] + Locale.preferredLanguages,
+            available: availableLanguages()
+        )
+    }
     private var customWords: [String] = []
     /// `customWords` folded once. See ``LexiconEntry/lowered``.
     private var loweredCustomWords: [String] = []
@@ -546,10 +570,7 @@ final class TypingEngine {
             try? await Task.sleep(for: Self.checkerQuietPeriod)
             guard !Task.isCancelled, let self, generation == self.generation else { return }
             if !self.hasResolvedLanguage {
-                self.language = TypingLanguage.resolve(
-                    preferred: Locale.preferredLanguages,
-                    available: self.availableLanguages()
-                )
+                self.language = self.resolvedLanguage()
                 self.hasResolvedLanguage = true
             }
             let key = SuggestionCache.Key(prefix: composition.lowercased(), language: self.language)

--- a/ios/VocaPhoneShared/DarwinNotifications.swift
+++ b/ios/VocaPhoneShared/DarwinNotifications.swift
@@ -9,6 +9,10 @@ enum VocaPhoneDarwinNotification: String, Sendable {
     case keyboardStatusChanged = "com.vocahq.vocaphone.keyboard-status-changed"
     case quickDictationChanged = "com.vocahq.vocaphone.quick-dictation-changed"
     case stopQuickDictationRequested = "com.vocahq.vocaphone.stop-quick-dictation"
+    /// The keyboard's VocaPhone switch turned off. Unlike the Live Activity's
+    /// stop, this is not a Quick Dictation pause: it ends the running app's
+    /// window the way the app switcher would, and changes no preference.
+    case closeVocaPhoneRequested = "com.vocahq.vocaphone.close-requested"
     /// The keyboard ran, and could not reach the shared container.
     ///
     /// The exception to the rule above: this one carries no durable record to

--- a/ios/VocaPhoneShared/DarwinNotifications.swift
+++ b/ios/VocaPhoneShared/DarwinNotifications.swift
@@ -13,6 +13,10 @@ enum VocaPhoneDarwinNotification: String, Sendable {
     /// stop, this is not a Quick Dictation pause: it ends the running app's
     /// window the way the app switcher would, and changes no preference.
     case closeVocaPhoneRequested = "com.vocahq.vocaphone.close-requested"
+    /// The keyboard came up with almost no room left. It cannot free what is
+    /// holding the memory — that is the app's loaded speech model, in another
+    /// process — so it says so, and the app answers by letting go.
+    case keyboardLowOnMemory = "com.vocahq.vocaphone.keyboard-low-memory"
     /// The keyboard ran, and could not reach the shared container.
     ///
     /// The exception to the rule above: this one carries no durable record to

--- a/ios/VocaPhoneShared/DiagnosticLog.swift
+++ b/ios/VocaPhoneShared/DiagnosticLog.swift
@@ -58,6 +58,9 @@ enum DiagnosticReason: String, Codable, Sendable {
     /// Quick Dictation was stopped from the Live Activity, which pauses the
     /// current window instead of changing the durable preference.
     case pausedUntilRelaunch
+    /// VocaPhone was switched off from the keyboard: the running window ended
+    /// as if the app had been closed, with every preference left alone.
+    case closedFromKeyboard
     case quickDictationOff
     case sessionFinished
     case processExit

--- a/ios/VocaPhoneShared/DiagnosticLog.swift
+++ b/ios/VocaPhoneShared/DiagnosticLog.swift
@@ -26,6 +26,8 @@ enum DiagnosticEvent: String, Codable, Sendable {
     case quickDictationArmed
     case quickDictationStopped
     case quickDictationStale
+    /// The loaded speech model was dropped, with how much room that left.
+    case localEngineReleased
     case stopQuickDictationRequested
     case audioInterruptionBegan
     case audioInterruptionEnded

--- a/ios/VocaPhoneShared/DiagnosticLog.swift
+++ b/ios/VocaPhoneShared/DiagnosticLog.swift
@@ -224,6 +224,30 @@ enum DiagnosticLog {
         return writeQueue.sync { coordinatedRead(from: fileURL) }
     }
 
+#if DEBUG
+    /// Copies the log where a Mac can fetch it with `devicectl`.
+    ///
+    /// The log itself lives at the root of the App Group container, and
+    /// `devicectl` refuses to transfer anything there — it lists only
+    /// `Library/` and answers a root path with "File paths cannot contain
+    /// '..'". The app's own Documents directory it will hand over, so a debug
+    /// build leaves a copy there and the diagnosing loop stops depending on the
+    /// user exporting and pasting a file that the clipboard expires in minutes.
+    static func mirrorForDeviceTransfer() {
+        guard let fileURL,
+              let documents = FileManager.default.urls(
+                  for: .documentDirectory,
+                  in: .userDomainMask
+              ).first
+        else { return }
+        let destination = documents.appendingPathComponent("diagnostics-latest.ndjson")
+        writeQueue.async {
+            guard let data = try? Data(contentsOf: fileURL) else { return }
+            try? data.write(to: destination, options: .atomic)
+        }
+    }
+#endif
+
     static func clear() {
         guard let fileURL else { return }
         writeQueue.sync { coordinatedWrite(Data(), to: fileURL) }

--- a/ios/VocaPhoneShared/DiagnosticLog.swift
+++ b/ios/VocaPhoneShared/DiagnosticLog.swift
@@ -233,6 +233,27 @@ enum DiagnosticLog {
     /// '..'". The app's own Documents directory it will hand over, so a debug
     /// build leaves a copy there and the diagnosing loop stops depending on the
     /// user exporting and pasting a file that the clipboard expires in minutes.
+    /// The keyboard's touch and frame trace, alongside this log.
+    ///
+    /// Written by the extension into the App Group, which `devicectl` will not
+    /// transfer; the app's Documents directory it will.
+    static func mirrorKeyboardTraceForDeviceTransfer() {
+        guard let group = FileManager.default.containerURL(
+                  forSecurityApplicationGroupIdentifier: AppConfiguration.appGroupIdentifier
+              ),
+              let documents = FileManager.default.urls(
+                  for: .documentDirectory,
+                  in: .userDomainMask
+              ).first
+        else { return }
+        let source = group.appendingPathComponent("touch-trace.txt")
+        let destination = documents.appendingPathComponent("touch-trace-latest.txt")
+        writeQueue.async {
+            guard let data = try? Data(contentsOf: source) else { return }
+            try? data.write(to: destination, options: .atomic)
+        }
+    }
+
     static func mirrorForDeviceTransfer() {
         guard let fileURL,
               let documents = FileManager.default.urls(

--- a/ios/VocaPhoneShared/DiagnosticLog.swift
+++ b/ios/VocaPhoneShared/DiagnosticLog.swift
@@ -225,14 +225,6 @@ enum DiagnosticLog {
     }
 
 #if DEBUG
-    /// Copies the log where a Mac can fetch it with `devicectl`.
-    ///
-    /// The log itself lives at the root of the App Group container, and
-    /// `devicectl` refuses to transfer anything there — it lists only
-    /// `Library/` and answers a root path with "File paths cannot contain
-    /// '..'". The app's own Documents directory it will hand over, so a debug
-    /// build leaves a copy there and the diagnosing loop stops depending on the
-    /// user exporting and pasting a file that the clipboard expires in minutes.
     /// The keyboard's touch and frame trace, alongside this log.
     ///
     /// Written by the extension into the App Group, which `devicectl` will not
@@ -254,6 +246,14 @@ enum DiagnosticLog {
         }
     }
 
+    /// Copies the log where a Mac can fetch it with `devicectl`.
+    ///
+    /// The log itself lives at the root of the App Group container, and
+    /// `devicectl` refuses to transfer anything there — it lists only
+    /// `Library/` and answers a root path with "File paths cannot contain
+    /// '..'". The app's own Documents directory it will hand over, so a debug
+    /// build leaves a copy there and the diagnosing loop stops depending on the
+    /// user exporting and pasting a file the clipboard expires in minutes.
     static func mirrorForDeviceTransfer() {
         guard let fileURL,
               let documents = FileManager.default.urls(

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -484,6 +484,10 @@ enum KeyboardPreferences {
     static let touchTraceKey = "touchTraceEnabled"
     /// Holding or sliding the spacebar to move the cursor.
     static let spacebarCursorKey = "spacebarCursorEnabled"
+    /// The compact dictation row: both left menus behind one ellipsis, and the
+    /// action button a glass capsule that stands in the middle until there is
+    /// something to type beside it.
+    static let compactControlsKey = "lab.usesCompactControls"
     /// The layout currently under the fingers.
     static let typingLayoutKey = "typingLayout"
     /// Every layout the user has turned on, in the order the space bar and the
@@ -727,6 +731,18 @@ enum KeyboardPreferences {
     static var spacebarCursorEnabled: Bool {
         get { boolean(spacebarCursorKey, default: true) }
         set { defaults?.set(newValue, forKey: spacebarCursorKey) }
+    }
+
+    /// Read by the keyboard itself, not only by the lab.
+    ///
+    /// This is the bug the flag was born with: the lab set it straight onto its
+    /// own preview object, so the switch changed the picture on the settings
+    /// screen and nothing else. Tapping into a real field brought up the
+    /// extension, which had never heard of it, and drew the old row — which
+    /// looks exactly like a switch that does not work.
+    static var compactControlsEnabled: Bool {
+        get { boolean(compactControlsKey, default: false) }
+        set { defaults?.set(newValue, forKey: compactControlsKey) }
     }
 
     /// The layouts the user has turned on, in the order the key and the swipe

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -302,6 +302,170 @@ enum KeyboardHeightPreference: String, CaseIterable, Codable, Identifiable, Send
     }
 }
 
+/// A letter arrangement the keyboard can put under the fingers.
+///
+/// Data, not cases. The first version of this was an enum with `qwerty` and
+/// `jcuken` in it, which meant every language after the second one was three
+/// `switch` statements and a recompile — and a keyboard whose answer to "add
+/// Ukrainian" is "add a case" will never have Ukrainian. A layout is its rows,
+/// its name and the dictionary it corrects against, so that is what it is.
+///
+/// The rows carry no widths. How wide eleven columns make a key is
+/// ``KeyGridView``'s question and it answers it from the rows it is handed;
+/// nothing here has to be kept in step with anything there.
+struct TypingLayout: Identifiable, Hashable, Sendable {
+    let id: String
+    /// What the language key says: two letters, written in the language's own
+    /// script.
+    ///
+    /// Cyrillic rather than a transliteration, because a Russian layout
+    /// labelled `RU` reads like a sticker somebody else put on it. Two letters
+    /// because the key is one column wide — the same column `123` fits in.
+    let shortName: String
+    /// Written in its own language, as iOS writes them: somebody reaching for
+    /// Russian is not looking for the word "Russian".
+    let displayName: String
+    /// Shown beside the name in the picker. A flag is a poor symbol for a
+    /// language and a good one for finding a row in a list of forty while
+    /// scrolling — which is the only job it has here.
+    let flag: String
+    /// The dictionary ``UITextChecker`` should answer in. It reads the user's
+    /// own installed dictionaries, so this is the whole of what a layout needs
+    /// for completion and correction — no shipped word list required.
+    let checkerLanguage: String
+    /// The three letter rows, top to bottom, unshifted.
+    let rows: [String]
+    /// Every letter the language writes, including the ones the rows have no
+    /// column for.
+    ///
+    /// Its only job is to be checked: a layout whose alphabet contains a letter
+    /// that is neither on a key nor behind one is a layout that cannot type its
+    /// own language, and that is a test rather than a code review.
+    let alphabet: String
+    /// Whether holding the spacebar turns it into a cursor trackpad here.
+    ///
+    /// Off on Russian by request. The two spacebar gestures do not in fact
+    /// collide — the trackpad arms on a *still* finger and a moving one
+    /// disarms it, which is how every keyboard carrying both keeps them
+    /// apart — but a layout that has just gained a swipe is not the one to
+    /// prove that on. Per layout rather than global, so turning it back on is
+    /// an edit to one line here and not a hunt through the grid.
+    var offersCursorTrackpad = true
+
+    /// The four arrangements almost every Latin layout in the catalogue is.
+    ///
+    /// Named rather than repeated, because the difference between Danish and
+    /// Swedish is two letters in the home row and nothing else, and a table
+    /// that spells all three rows out forty times hides that.
+    enum Arrangement {
+        static let qwerty = ["qwertyuiop", "asdfghjkl", "zxcvbnm"]
+        static let qwertz = ["qwertzuiop", "asdfghjkl", "yxcvbnm"]
+        static let azerty = ["azertyuiop", "qsdfghjklm", "wxcvbn"]
+    }
+
+    private static let latin = "abcdefghijklmnopqrstuvwxyz"
+
+    /// The layouts the keyboard knows.
+    ///
+    /// Seven, and deliberately not forty. A picker of forty languages is a
+    /// list somebody scrolls; seven is a list somebody reads. These are the
+    /// ones a keyboard is asked for first, and the shape of this table is what
+    /// makes the eighth a three-line addition rather than a project.
+    ///
+    /// Every entry is checked by ``KeyAlternativesTests`` for the only thing
+    /// that really matters here — that each letter of its alphabet is on a key
+    /// or behind one — so a wrong row is a failing test rather than a keyboard
+    /// that cannot spell its own language.
+    static let catalogue: [TypingLayout] = [
+        TypingLayout(
+            id: "en", shortName: "EN", displayName: "English", flag: "🇺🇸",
+            checkerLanguage: "en_US", rows: Arrangement.qwerty, alphabet: latin
+        ),
+        TypingLayout(
+            id: "es", shortName: "ES", displayName: "Español", flag: "🇪🇸",
+            checkerLanguage: "es_ES",
+            // ñ is on the grid rather than behind n: it is an ordinary letter
+            // in Spanish, reached as often as any other, and a hold per word
+            // is not typing. It is also why the home row here is the longer
+            // one, and why the middle row correctly does not indent.
+            rows: ["qwertyuiop", "asdfghjklñ", "zxcvbnm"],
+            alphabet: latin + "áéíóúüñ"
+        ),
+        TypingLayout(
+            id: "pt", shortName: "PT", displayName: "Português", flag: "🇧🇷",
+            checkerLanguage: "pt_BR", rows: Arrangement.qwerty,
+            alphabet: latin + "áâãàçéêíóôõú"
+        ),
+        TypingLayout(
+            id: "fr", shortName: "FR", displayName: "Français", flag: "🇫🇷",
+            checkerLanguage: "fr_FR", rows: Arrangement.azerty,
+            alphabet: latin + "àâçéèêëîïôùûü"
+        ),
+        TypingLayout(
+            id: "de", shortName: "DE", displayName: "Deutsch", flag: "🇩🇪",
+            checkerLanguage: "de_DE", rows: Arrangement.qwertz,
+            alphabet: latin + "äöüß"
+        ),
+        TypingLayout(
+            id: "ru", shortName: "РУ", displayName: "Русский", flag: "🇷🇺",
+            checkerLanguage: "ru_RU",
+            // Thirty-three letters over thirty-one keys: ё and ъ live behind е
+            // and ь, where iOS puts them and where ``KeyAlternatives`` has them.
+            rows: ["йцукенгшщзх", "фывапролджэ", "ячсмитьбю"],
+            alphabet: "абвгдеёжзийклмнопрстуфхцчшщъыьэюя",
+            offersCursorTrackpad: false
+        ),
+        TypingLayout(
+            id: "uk", shortName: "УК", displayName: "Українська", flag: "🇺🇦",
+            checkerLanguage: "uk_UA",
+            // Twelve on the top row, which is the widest the grid takes: ї is
+            // a letter here, not an accent on і. ґ is rare enough to sit
+            // behind г, which is where iOS puts it too.
+            rows: ["йцукенгшщзхї", "фівапролджє", "ячсмитьбю"],
+            alphabet: "абвгґдеєжзиіїйклмнопрстуфхцчшщьюя"
+        ),
+    ]
+
+    /// The layout every keyboard starts with, and the one that cannot be turned
+    /// off: a keyboard with no layouts types nothing.
+    static let fallback = catalogue[0]
+
+    static func layout(id: String) -> TypingLayout? {
+        catalogue.first { $0.id == id }
+    }
+
+    /// What a fresh install starts with: the layouts for the languages the
+    /// phone is already set up in, and English if none of them are known.
+    ///
+    /// The first version of this defaulted to the whole catalogue, which
+    /// handed somebody who only types English a language key, a labelled
+    /// spacebar and four languages they never asked for. Somebody whose phone
+    /// is set to Russian and English, meanwhile, should not have to go and
+    /// find the setting to get what iOS would have given them.
+    static func forPreferredLanguages(
+        _ preferred: [String] = Locale.preferredLanguages
+    ) -> [TypingLayout] {
+        let subtags = preferred.map { $0.split(separator: "-").first.map(String.init) ?? $0 }
+        let matched = catalogue.filter { subtags.contains($0.id) }
+        return matched.isEmpty ? [fallback] : matched
+    }
+
+    /// The layout after `current` in `enabled`, wrapping.
+    ///
+    /// `nil` when there is nowhere to go, which is also the answer to "should
+    /// the spacebar say anything" and "is the gesture available" — one question
+    /// asked once rather than three flags kept in agreement.
+    static func next(
+        after current: TypingLayout,
+        in enabled: [TypingLayout],
+        forward: Bool = true
+    ) -> TypingLayout? {
+        guard enabled.count > 1, let index = enabled.firstIndex(of: current) else { return nil }
+        let step = forward ? 1 : enabled.count - 1
+        return enabled[(index + step) % enabled.count]
+    }
+}
+
 enum KeyboardPreferences {
     static let autoInsertKey = "autoInsertTranscripts"
     static let keyboardHeightKey = "keyboardHeight"
@@ -328,6 +492,11 @@ enum KeyboardPreferences {
     /// Debug-only touch and frame instrumentation. Kept off unless a developer
     /// explicitly arms it in the keyboard lab.
     static let touchTraceKey = "touchTraceEnabled"
+    /// The layout currently under the fingers.
+    static let typingLayoutKey = "typingLayout"
+    /// Every layout the user has turned on, in the order the space bar and the
+    /// globe walk through them.
+    static let enabledTypingLayoutsKey = "enabledTypingLayouts"
     static let quickDictationKey = "quickDictationEnabled"
     static let quickDictationDurationKey = "quickDictationDuration"
     /// A stop from the Live Activity is a pause, not a preference change: the
@@ -557,6 +726,44 @@ enum KeyboardPreferences {
     static var touchTraceEnabled: Bool {
         get { boolean(touchTraceKey, default: false) }
         set { defaults?.set(newValue, forKey: touchTraceKey) }
+    }
+
+    /// The layouts the user has turned on, in the order the key and the swipe
+    /// walk through them. Never empty.
+    ///
+    /// Stored as ids rather than as indices into the catalogue, so reordering
+    /// or retiring a layout cannot silently point an existing install at a
+    /// different language than the one it chose.
+    static var enabledTypingLayouts: [TypingLayout] {
+        get {
+            let stored = defaults?.stringArray(forKey: enabledTypingLayoutsKey) ?? []
+            let resolved = stored.compactMap(TypingLayout.layout(id:))
+            return resolved.isEmpty ? TypingLayout.forPreferredLanguages() : resolved
+        }
+        set {
+            let unique = newValue.reduce(into: [TypingLayout]()) { list, layout in
+                if !list.contains(layout) { list.append(layout) }
+            }
+            let resolved = unique.isEmpty ? [TypingLayout.fallback] : unique
+            defaults?.set(resolved.map(\.id), forKey: enabledTypingLayoutsKey)
+            // A layout that has just been turned off cannot stay the current
+            // one, or the keyboard comes up on a language the settings say is
+            // not there.
+            if !resolved.contains(typingLayout) { typingLayout = resolved[0] }
+        }
+    }
+
+    /// The layout the keyboard shows, clamped to what is actually enabled.
+    static var typingLayout: TypingLayout {
+        get {
+            let enabled = enabledTypingLayouts
+            let stored = defaults?.string(forKey: typingLayoutKey)
+            guard let resolved = stored.flatMap(TypingLayout.layout(id:)),
+                  enabled.contains(resolved)
+            else { return enabled.first ?? .fallback }
+            return resolved
+        }
+        set { defaults?.set(newValue.id, forKey: typingLayoutKey) }
     }
 
     /// An absent key means "never set", which is the default — not `false`,

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -342,15 +342,6 @@ struct TypingLayout: Identifiable, Hashable, Sendable {
     /// that is neither on a key nor behind one is a layout that cannot type its
     /// own language, and that is a test rather than a code review.
     let alphabet: String
-    /// Whether holding the spacebar turns it into a cursor trackpad here.
-    ///
-    /// Off on Russian by request. The two spacebar gestures do not in fact
-    /// collide — the trackpad arms on a *still* finger and a moving one
-    /// disarms it, which is how every keyboard carrying both keeps them
-    /// apart — but a layout that has just gained a swipe is not the one to
-    /// prove that on. Per layout rather than global, so turning it back on is
-    /// an edit to one line here and not a hunt through the grid.
-    var offersCursorTrackpad = true
 
     /// The four arrangements almost every Latin layout in the catalogue is.
     ///
@@ -412,8 +403,7 @@ struct TypingLayout: Identifiable, Hashable, Sendable {
             // Thirty-three letters over thirty-one keys: ё and ъ live behind е
             // and ь, where iOS puts them and where ``KeyAlternatives`` has them.
             rows: ["йцукенгшщзх", "фывапролджэ", "ячсмитьбю"],
-            alphabet: "абвгдеёжзийклмнопрстуфхцчшщъыьэюя",
-            offersCursorTrackpad: false
+            alphabet: "абвгдеёжзийклмнопрстуфхцчшщъыьэюя"
         ),
         TypingLayout(
             id: "uk", shortName: "УК", displayName: "Українська", flag: "🇺🇦",
@@ -492,6 +482,8 @@ enum KeyboardPreferences {
     /// Debug-only touch and frame instrumentation. Kept off unless a developer
     /// explicitly arms it in the keyboard lab.
     static let touchTraceKey = "touchTraceEnabled"
+    /// Holding or sliding the spacebar to move the cursor.
+    static let spacebarCursorKey = "spacebarCursorEnabled"
     /// The layout currently under the fingers.
     static let typingLayoutKey = "typingLayout"
     /// Every layout the user has turned on, in the order the space bar and the
@@ -726,6 +718,15 @@ enum KeyboardPreferences {
     static var touchTraceEnabled: Bool {
         get { boolean(touchTraceKey, default: false) }
         set { defaults?.set(newValue, forKey: touchTraceKey) }
+    }
+
+    /// The spacebar's cursor trackpad. On by default: it is what the system
+    /// keyboard does, and somebody who has never heard of it loses nothing by
+    /// having it — the gesture that reaches it is one nobody performs by
+    /// accident.
+    static var spacebarCursorEnabled: Bool {
+        get { boolean(spacebarCursorKey, default: true) }
+        set { defaults?.set(newValue, forKey: spacebarCursorKey) }
     }
 
     /// The layouts the user has turned on, in the order the key and the swipe

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -484,9 +484,8 @@ enum KeyboardPreferences {
     static let touchTraceKey = "touchTraceEnabled"
     /// Holding or sliding the spacebar to move the cursor.
     static let spacebarCursorKey = "spacebarCursorEnabled"
-    /// The compact dictation row: both left menus behind one ellipsis, and the
-    /// action button a glass capsule that stands in the middle until there is
-    /// something to type beside it.
+    /// The compact dictation row: VocaPhone readiness, writing style and the
+    /// microphone at a glance, with an expandable local-stats dashboard.
     static let compactControlsKey = "lab.usesCompactControls"
     /// The layout currently under the fingers.
     static let typingLayoutKey = "typingLayout"

--- a/ios/VocaPhoneTests/KeyAlternativesTests.swift
+++ b/ios/VocaPhoneTests/KeyAlternativesTests.swift
@@ -2,6 +2,47 @@ import Testing
 import UIKit
 
 struct KeyAlternativesTests {
+    // MARK: - Every layout can type its own language
+
+    /// A layout whose alphabet contains a letter that is on no key and behind
+    /// no key cannot type its own language.
+    ///
+    /// This is the test the Russian layout was written against and the reason
+    /// ``TypingLayout/alphabet`` exists at all. Thirty-three letters do not fit
+    /// on thirty-one keys, so ё and ъ went behind е and ь — and the only thing
+    /// standing between that decision and a keyboard that silently cannot type
+    /// «объём» is this loop. It costs nothing and it guards every language
+    /// added after this one, which is the point: adding a layout is adding a
+    /// catalogue entry, and this is what makes that safe.
+    @Test func everyLayoutCanReachEveryLetterOfItsOwnAlphabet() {
+        for layout in TypingLayout.catalogue {
+            let onKeys = Set(layout.rows.joined())
+            for letter in layout.alphabet where !onKeys.contains(letter) {
+                let base = String(letter)
+                // Reachable by holding some key whose popover offers it.
+                let carriers = onKeys.filter { key in
+                    KeyAlternatives.options(for: String(key), shift: .off).contains(base)
+                }
+                #expect(
+                    !carriers.isEmpty,
+                    "\(layout.displayName): \(base) is on no key and behind no key"
+                )
+            }
+        }
+    }
+
+    /// ё and ъ are letters, not decorations.
+    ///
+    /// Everything else in the accent table is an ergonomic extra — a Latin
+    /// keyboard types "cafe" without ever opening a popover. These two are the
+    /// only way to type them at all, which is why they are asserted by name
+    /// rather than left to the loop above.
+    @Test func russianHidesItsTwoExtraLettersWhereIOSDoes() {
+        #expect(KeyAlternatives.options(for: "е", shift: .off).contains("ё"))
+        #expect(KeyAlternatives.options(for: "ь", shift: .off).contains("ъ"))
+        #expect(KeyAlternatives.options(for: "Е", shift: .on).contains("Ё"))
+    }
+
     /// Letters with accents and symbols with alternates; nothing else. A key
     /// that opens a popover offering only itself is a key that swallows a
     /// long press for no reason.

--- a/ios/VocaPhoneTests/KeyGridLayoutTests.swift
+++ b/ios/VocaPhoneTests/KeyGridLayoutTests.swift
@@ -23,6 +23,95 @@ struct KeyGridLayoutTests {
         return grid
     }
 
+    private static func makeGrid(layout: TypingLayout, switchKey: Bool = true) -> KeyGridView {
+        let grid = makeGrid()
+        grid.showsLayoutSwitchKey = switchKey
+        grid.layout = layout
+        grid.layoutIfNeeded()
+        return grid
+    }
+
+    // MARK: - Every layout, not just the one that fits
+
+    /// The column unit used to be the constant ten, which is QWERTY's top row.
+    /// ЙЦУКЕН is eleven, AZERTY's middle row is ten against a ten-key top —
+    /// and a unit that does not follow the rows puts the last key of an
+    /// eleven-key row off the side of the keyboard.
+    @Test func noLayoutRunsOffTheEdgeOfTheKeyboard() {
+        for layout in TypingLayout.catalogue {
+            let grid = Self.makeGrid(layout: layout)
+            let inset = grid.metrics.sideInset
+            for key in grid.keyViews {
+                #expect(
+                    key.frame.minX >= inset - 0.5,
+                    "\(layout.displayName): a key starts left of the margin"
+                )
+                #expect(
+                    key.frame.maxX <= Self.referenceWidth - inset + 0.5,
+                    "\(layout.displayName): a key runs past the right margin"
+                )
+            }
+        }
+    }
+
+    /// The property the ten-column constant was there to guarantee, now that it
+    /// is derived: within one layout every single-column key is the same width,
+    /// so the columns still line up between rows.
+    @Test func everyLayoutKeepsItsColumnsOneWidth() {
+        for layout in TypingLayout.catalogue {
+            let grid = Self.makeGrid(layout: layout)
+            let widths = Set(
+                grid.keyViews
+                    .filter { $0.spec.width == .unit }
+                    .map { ($0.frame.width * 100).rounded() }
+            )
+            #expect(widths.count == 1, "\(layout.displayName) has \(widths.count) column widths")
+        }
+    }
+
+    /// A wider alphabet makes narrower letters and must not make a narrower
+    /// bottom row: the spacebar, Return and the plane key are the same keys in
+    /// every language, and having them jump as the letters change is the sort
+    /// of thing a thumb notices before an eye does.
+    @Test func theBottomRowHoldsStillWhileTheLettersChange() {
+        let reference = Self.makeGrid(layout: .fallback)
+        let referenceRow = Self.rowsByPosition(in: reference)[3].map(\.frame)
+        for layout in TypingLayout.catalogue.dropFirst() {
+            let grid = Self.makeGrid(layout: layout)
+            let row = Self.rowsByPosition(in: grid)[3].map(\.frame)
+            #expect(row.count == referenceRow.count, "\(layout.displayName) bottom row differs")
+            for (moved, fixed) in zip(row, referenceRow) {
+                #expect(
+                    abs(moved.minX - fixed.minX) < 0.5 && abs(moved.width - fixed.width) < 0.5,
+                    "\(layout.displayName) moved a bottom-row key"
+                )
+            }
+        }
+    }
+
+    /// Ten stays the floor. The numeric keypads have no single-column keys at
+    /// all — three columns of `.multiple` — and letting the widest row speak
+    /// for them would blow every key up to a third of the keyboard.
+    @Test func theColumnReferenceFollowsTheRowsButNeverGoesBelowTen() {
+        for plane in [KeyPlane.numbers, .symbols, .numberPad, .phonePad] {
+            let rows = KeyLayout.rows(for: plane, includesGlobe: true, returnIsProminent: false)
+            #expect(KeyGridView.referenceColumns(for: rows) == 10, "\(plane)")
+        }
+        for layout in TypingLayout.catalogue {
+            let rows = KeyLayout.rows(
+                for: .letters,
+                layout: layout,
+                includesGlobe: true,
+                returnIsProminent: false
+            )
+            let widest = layout.rows.map(\.count).max() ?? 0
+            #expect(
+                KeyGridView.referenceColumns(for: rows) == CGFloat(max(widest, 10)),
+                "\(layout.displayName)"
+            )
+        }
+    }
+
     /// Rows used to be built from three separate hardcoded widths, so the
     /// columns visibly failed to line up. Every single-column key must now
     /// resolve to the same width.

--- a/ios/VocaPhoneTests/KeyGridLayoutTests.swift
+++ b/ios/VocaPhoneTests/KeyGridLayoutTests.swift
@@ -326,6 +326,47 @@ struct KeyGridLayoutTests {
             "spacebar ends at \(boundaryOnScreen) on screen, the system's at ~293"
         )
     }
+
+    /// Every cached plane keeps its key views, and their bitmaps, alive. Keyed
+    /// by plane and layout, cycling seven layouts once left some seven hundred
+    /// behind; the numbers and symbols are shared and only two layouts' letters
+    /// are kept.
+    @Test func cachedPlanesStayBoundedAcrossLayouts() {
+        let grid = Self.makeGrid(layout: .fallback)
+        for layout in TypingLayout.catalogue {
+            grid.layout = layout
+            for plane in [KeyPlane.letters, .numbers, .symbols] {
+                grid.plane = plane
+            }
+        }
+        grid.plane = .letters
+        func keyCount(_ plane: KeyPlane, _ layout: TypingLayout = .fallback) -> Int {
+            KeyLayout.rows(
+                for: plane,
+                layout: layout,
+                includesGlobe: grid.showsGlobeKey,
+                includesLayoutSwitch: true,
+                returnIsProminent: false
+            ).reduce(0) { $0 + $1.keys.count }
+        }
+        let widestLetters = TypingLayout.catalogue.map { keyCount(.letters, $0) }.max() ?? 0
+        let built = grid.subviews.filter { $0 is KeyView }.count
+        #expect(built <= 2 * widestLetters + keyCount(.numbers) + keyCount(.symbols))
+    }
+
+    @Test func discardingHiddenPlanesKeepsOnlyWhatIsOnScreen() {
+        let grid = Self.makeGrid(layout: .fallback)
+        grid.plane = .numbers
+        grid.plane = .symbols
+        grid.plane = .letters
+        grid.discardHiddenPlanes()
+        #expect(grid.subviews.filter { $0 is KeyView }.count == grid.keyViews.count)
+        #expect(grid.keyViews.allSatisfy { !$0.isHidden })
+
+        // And what was dropped comes back on demand.
+        grid.plane = .numbers
+        #expect(grid.keyViews.contains { $0.spec.cap == .character("1") })
+    }
 }
 
 /// The numeric keypads, which a `.numberPad` or `.phonePad` field used to be

--- a/ios/VocaPhoneTests/KeyboardHandoffPresentationTests.swift
+++ b/ios/VocaPhoneTests/KeyboardHandoffPresentationTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @MainActor
@@ -19,14 +20,37 @@ struct KeyboardHandoffPresentationTests {
         return record
     }
 
-    @Test func externalRecordingShowsTheRealReturnGestureAndFinishAction() {
+    @Test func externalRecordingAsksForTheReturnGestureAndNothingElse() {
         let presentation = KeyboardHandoffPresentation.make(record(state: .recording))
 
         #expect(presentation?.kind == .recording)
-        #expect(presentation?.title == "Recording")
-        #expect(presentation?.primaryAction == .finish)
-        #expect(presentation?.primaryTitle == "Finish & transcribe here")
-        #expect(presentation?.detail.contains("Swipe back") == true)
+        #expect(presentation?.title == "Swipe back to your app")
+        #expect(presentation?.detail == "Recording follows you there.")
+        #expect(presentation?.primaryAction == KeyboardHandoffPresentation.PrimaryAction.none)
+        #expect(presentation?.primaryTitle == nil)
+        #expect(presentation?.showsCancel == false)
+    }
+
+    /// The app is opened by the keyboard, so the screen it opens on has to be
+    /// the hand-off — not the home screen for the moment before the recorder
+    /// catches up.
+    @Test func theWaitForTheAppToOpenIsAlreadyTheHandoff() {
+        for state in [SessionState.launchingApp, .awaitingReturn] {
+            let pending = record(state: state)
+            #expect(KeyboardHandoffPresentation.shouldPresent(pending))
+            #expect(KeyboardHandoffPresentation.make(pending)?.kind == .recording)
+        }
+    }
+
+    /// But not on an ordinary launch days later, with a hand-off nobody claimed
+    /// still sitting in the store.
+    @Test func anAbandonedHandoffDoesNotTakeOverAnOrdinaryLaunch() {
+        var abandoned = record(state: .launchingApp)
+        abandoned.updatedAt = Date(
+            timeIntervalSinceNow: -SessionExpiryPolicy.handoffWindow - 1
+        )
+
+        #expect(!KeyboardHandoffPresentation.shouldPresent(abandoned))
     }
 
     @Test func processingKeepsTheHandoffStoryAndNamesTheConfirmedRoute() {

--- a/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
+++ b/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
@@ -48,22 +48,37 @@ struct KeyboardSurfaceTests {
         #expect(changes == [true, false])
     }
 
-    @Test func quickDictationToggleControlsOnlyTheLiveReadinessWindow() {
+    @Test func vocaPhoneSwitchClosesTheAppWithoutTouchingQuickDictation() {
+        let enabled = KeyboardPreferences.quickDictationEnabled
+        let duration = KeyboardPreferences.quickDictationDuration
+        let paused = KeyboardPreferences.quickDictationPausedUntilRelaunch
+        defer {
+            KeyboardPreferences.quickDictationEnabled = enabled
+            KeyboardPreferences.quickDictationDuration = duration
+            KeyboardPreferences.quickDictationPausedUntilRelaunch = paused
+        }
+        KeyboardPreferences.quickDictationEnabled = true
+        KeyboardPreferences.quickDictationDuration = .tenMinutes
+        KeyboardPreferences.quickDictationPausedUntilRelaunch = false
+
         let surface = DictationSurfaceState()
         surface.quickDictationReady = true
         surface.setCompactDashboardPresented(true)
         var changes: [Bool] = []
         var visibilityChanges: [Bool] = []
-        surface.onQuickDictationReadinessChanged = { changes.append($0) }
+        surface.onVocaPhoneRunningChanged = { changes.append($0) }
         surface.onDashboardVisibilityChanged = { visibilityChanges.append($0) }
 
-        surface.setQuickDictationReady(false)
-        surface.setQuickDictationReady(false)
+        surface.setVocaPhoneRunning(false)
+        surface.setVocaPhoneRunning(false)
 
         #expect(surface.quickDictationReady == false)
         #expect(surface.compactDashboardPresented == false)
         #expect(changes == [false])
         #expect(visibilityChanges == [false])
+        #expect(KeyboardPreferences.quickDictationEnabled)
+        #expect(KeyboardPreferences.quickDictationDuration == .tenMinutes)
+        #expect(KeyboardPreferences.quickDictationPausedUntilRelaunch == false)
     }
 
     @Test func recoveryGuidanceSurvivesPollingUntilTheStateChanges() {

--- a/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
+++ b/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
@@ -10,6 +10,25 @@ import UIKit
 /// attached to the value.
 @MainActor
 struct KeyboardSurfaceTests {
+    @Test func compactDashboardUsesOnlyRecordedUsageTotals() {
+        let now = Date(timeIntervalSince1970: 1_789_000_000)
+        let stats = UsageStats(
+            totalWords: 6_289,
+            totalDictations: 18,
+            totalSeconds: 4_239,
+            lastDayKey: UsageStats.dayKey(now),
+            currentStreak: 1,
+            bestStreak: 4
+        )
+
+        #expect(CompactDashboardPage.allCases.count == 4)
+        #expect(CompactDashboardPage.words.value(for: stats, now: now) == "6,289 words")
+        #expect(CompactDashboardPage.sessions.value(for: stats, now: now) == "18 sessions")
+        #expect(CompactDashboardPage.streak.value(for: stats, now: now) == "1 day")
+        #expect(CompactDashboardPage.streak.detail(for: stats) == "Best streak: 4 days")
+        #expect(CompactDashboardPage.speed.value(for: stats, now: now) == "89 WPM")
+    }
+
     @Test func recoveryGuidanceSurvivesPollingUntilTheStateChanges() {
         let surface = DictationSurfaceState()
         surface.state = .awaitingReturn

--- a/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
+++ b/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
@@ -284,15 +284,6 @@ struct KeyboardSurfaceTests {
         #expect(TypingLayout.next(after: stray, in: [first, all[2]]) == nil)
     }
 
-    /// Russian gives the spacebar to the swipe; everything else keeps its
-    /// trackpad. Asserted because it is a choice, not a fact — and a choice
-    /// that silently spread to every layout would be hard to notice.
-    @Test func onlyRussianGivesUpTheCursorTrackpad() {
-        for layout in TypingLayout.catalogue {
-            #expect(layout.offersCursorTrackpad == (layout.id != "ru"), "\(layout.id)")
-        }
-    }
-
     // MARK: - The press nobody could see
 
     /// A press is held long enough to be composited once, and no longer.
@@ -480,6 +471,28 @@ struct KeyboardSurfaceTests {
 
         // A one-character prefix is answered from its own bucket.
         #expect(list.completions(for: "q", limit: 2) == ["quixotic"])
+    }
+
+    // MARK: - Spacebar lift
+
+    /// A swipe that changed the layout, or a hold that became the cursor, has
+    /// already done its job. The lift must not type a space on top.
+    @Test func liftingTheSpacebarDoesNotTypeAfterAGesture() {
+        #expect(
+            KeyGridView.shouldCommitSpace(
+                isEngaged: true, isCursorTracking: false, didSwitchLayout: false, commit: true
+            )
+        )
+        #expect(
+            !KeyGridView.shouldCommitSpace(
+                isEngaged: true, isCursorTracking: true, didSwitchLayout: false, commit: true
+            )
+        )
+        #expect(
+            !KeyGridView.shouldCommitSpace(
+                isEngaged: true, isCursorTracking: false, didSwitchLayout: true, commit: true
+            )
+        )
     }
 }
 

--- a/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
+++ b/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
@@ -22,11 +22,44 @@ struct KeyboardSurfaceTests {
         )
 
         #expect(CompactDashboardPage.allCases.count == 4)
-        #expect(CompactDashboardPage.words.value(for: stats, now: now) == "6,289 words")
-        #expect(CompactDashboardPage.sessions.value(for: stats, now: now) == "18 sessions")
-        #expect(CompactDashboardPage.streak.value(for: stats, now: now) == "1 day")
+        #expect(CompactDashboardPage.words.value(for: stats, now: now) == "6,289")
+        #expect(CompactDashboardPage.words.label(for: stats, now: now) == "Words dictated")
+        #expect(CompactDashboardPage.words.detail(for: stats) == "Across 18 completed dictations")
+        #expect(CompactDashboardPage.sessions.value(for: stats, now: now) == "18")
+        #expect(CompactDashboardPage.streak.value(for: stats, now: now) == "1")
+        #expect(
+            CompactDashboardPage.streak.label(for: stats, now: now)
+                == "Day in your current streak"
+        )
         #expect(CompactDashboardPage.streak.detail(for: stats) == "Best streak: 4 days")
-        #expect(CompactDashboardPage.speed.value(for: stats, now: now) == "89 WPM")
+        #expect(CompactDashboardPage.speed.value(for: stats, now: now) == "89")
+        #expect(CompactDashboardPage.speed.label(for: stats, now: now) == "Average WPM")
+    }
+
+    @Test func compactDashboardReportsOnlyRealVisibilityChanges() {
+        let surface = DictationSurfaceState()
+        var changes: [Bool] = []
+        surface.onDashboardVisibilityChanged = { changes.append($0) }
+
+        surface.setCompactDashboardPresented(true)
+        surface.setCompactDashboardPresented(true)
+        surface.setCompactDashboardPresented(false)
+
+        #expect(changes == [true, false])
+    }
+
+    @Test func quickDictationToggleUpdatesReadinessAndReportsChanges() {
+        let surface = DictationSurfaceState()
+        surface.quickDictationEnabled = true
+        surface.quickDictationReady = true
+        var changes: [Bool] = []
+        surface.onQuickDictationChanged = { changes.append($0) }
+
+        surface.setQuickDictationEnabled(false)
+        surface.setQuickDictationEnabled(false)
+
+        #expect(surface.quickDictationReady == false)
+        #expect(changes == [false])
     }
 
     @Test func recoveryGuidanceSurvivesPollingUntilTheStateChanges() {

--- a/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
+++ b/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
@@ -86,6 +86,213 @@ struct KeyboardSurfaceTests {
         }
     }
 
+    // MARK: - Room for a language key
+
+    /// Apple's proportions, kept exactly, while the row is Apple's row.
+    ///
+    /// The language key is the only reason any of these numbers move. A change
+    /// that also moved them for everyone else would be a redesign of the
+    /// keyboard smuggled in behind a feature, so this is the test that says it
+    /// was not.
+    @Test func aKeyboardWithOneLayoutKeepsApplesBottomRowExactly() {
+        for globe in [true, false] {
+            for punctuation in [true, false] {
+                let columns = KeyLayout.BottomRowColumns.resolved(
+                    includesGlobe: globe,
+                    includesLayoutSwitch: false,
+                    includesPunctuation: punctuation
+                )
+                #expect(columns.layoutSwitch == nil)
+                #expect(columns.newline == KeyLayout.minimumReturnColumns)
+                #expect(columns.planeSwitch == (globe ? 1.25 : 2.5))
+                #expect(columns.punctuation == (punctuation ? 1.25 : nil))
+            }
+        }
+    }
+
+    /// A fifth key on a row balanced for four, at Apple's widths, leaves the
+    /// spacebar around two and a half columns — half a plain row's. That is the
+    /// arithmetic behind the note on ``KeyboardOutput/emojiPanel`` explaining
+    /// why there is no emoji key.
+    ///
+    /// Yandex's Russian keyboard carries the same five and answers the same
+    /// crowding by trimming the function keys to a column and Return to a
+    /// little over one. Measured off a screenshot: the spacebar comes back to
+    /// roughly four and a quarter columns of ten. These are those proportions,
+    /// and this is the number they were for.
+    @Test func aLanguageKeyBuysTheSpacebarBackInsteadOfHalvingIt() {
+        for globe in [true, false] {
+            for punctuation in [true, false] {
+                let label = "globe \(globe), punct \(punctuation)"
+                let apple = KeyLayout.BottomRowColumns.resolved(
+                    includesGlobe: globe,
+                    includesLayoutSwitch: false,
+                    includesPunctuation: punctuation
+                )
+                let crowded = KeyLayout.BottomRowColumns.resolved(
+                    includesGlobe: globe,
+                    includesLayoutSwitch: true,
+                    includesPunctuation: punctuation
+                )
+                // A sixth key does cost the spacebar something on a row that
+                // had room to spare — half a column where Apple's own gave it
+                // five. What it must never do is push it under the width below
+                // which it stops being a spacebar. And where Apple's row was
+                // already under that width, the trimming leaves it wider than
+                // Apple's: the crowded rows come out ahead, not behind.
+                #expect(
+                    crowded.spacebar >= min(KeyLayout.minimumSpacebarColumns, apple.spacebar),
+                    "\(label): \(crowded.spacebar) against Apple's \(apple.spacebar)"
+                )
+                if apple.spacebar < KeyLayout.minimumSpacebarColumns {
+                    #expect(
+                        crowded.spacebar > apple.spacebar,
+                        "\(label): \(crowded.spacebar) against Apple's \(apple.spacebar)"
+                    )
+                }
+            }
+        }
+    }
+
+    /// The spacebar's centre is the keyboard's centre exactly when the column
+    /// totals either side of it are equal — the identity the whole width
+    /// calculation rests on. Adding a key to the leading side is precisely the
+    /// way to break it.
+    @Test func theSpacebarStaysCentredWithALanguageKeyOnTheRow() {
+        for globe in [true, false] {
+            for punctuation in [true, false] {
+                let columns = KeyLayout.BottomRowColumns.resolved(
+                    includesGlobe: globe,
+                    includesLayoutSwitch: true,
+                    includesPunctuation: punctuation
+                )
+                #expect(
+                    abs(columns.centreOffset) <= 0.75,
+                    "off centre by \(columns.centreOffset) — globe \(globe), punct \(punctuation)"
+                )
+            }
+        }
+    }
+
+    /// The spacebar is never traded below the width it needs, and the keys
+    /// beside it are never trimmed further than that trade requires.
+    ///
+    /// The first version trimmed the same amount every time. On a row with no
+    /// punctuation that handed the spacebar six and a quarter columns against
+    /// Apple's five and left the keys either side visibly thin — reported from
+    /// a device as "you cut the side keys a lot and the space bar is big",
+    /// which is both halves of the same mistake.
+    @Test func theRowIsTrimmedOnlyAsFarAsTheSpacebarActuallyNeeds() {
+        for globe in [true, false] {
+            for punctuation in [true, false] {
+                let columns = KeyLayout.BottomRowColumns.resolved(
+                    includesGlobe: globe,
+                    includesLayoutSwitch: true,
+                    includesPunctuation: punctuation
+                )
+                let label = "globe \(globe), punct \(punctuation)"
+                // Six keys and a spacebar do not fit on ten columns at any
+                // width worth having: with both the globe and the punctuation
+                // pair the floor is out of reach even fully trimmed, and the
+                // row settles at 3.25 — still wider than the 2.5 Apple's own
+                // email row leaves. Every other configuration clears it.
+                if !(globe && punctuation) {
+                    #expect(
+                        columns.spacebar >= KeyLayout.minimumSpacebarColumns,
+                        "\(label): spacebar is \(columns.spacebar) columns"
+                    )
+                }
+                #expect(columns.spacebar >= 3.25, "\(label): \(columns.spacebar)")
+                // Never wider than Apple's plain row either: a spacebar that
+                // has eaten the row is not a fix for one that was too narrow.
+                #expect(columns.spacebar <= 5.5, "\(label): spacebar is \(columns.spacebar)")
+                #expect(columns.planeSwitch >= 1, "\(label): plane key is \(columns.planeSwitch)")
+                #expect(columns.newline >= KeyLayout.crowdedReturnColumns, "\(label)")
+                // Apple's Return survives wherever the spacebar did not need
+                // its width, which is the point of trimming by need.
+                if !globe, !punctuation {
+                    #expect(columns.newline == KeyLayout.minimumReturnColumns, "\(label)")
+                }
+            }
+        }
+        // An uncrowded row keeps Apple's widths untouched: there is nothing to
+        // buy back, so nothing is spent.
+        let plain = KeyLayout.BottomRowColumns.resolved(
+            includesGlobe: false,
+            includesLayoutSwitch: true,
+            includesPunctuation: false
+        )
+        #expect(plain.newline == KeyLayout.minimumReturnColumns)
+        #expect(plain.planeSwitch == 1.25)
+    }
+
+    /// A fresh install gets the languages the phone is already set up in.
+    ///
+    /// It used to get all five, which hands somebody who only types English a
+    /// language key, a labelled spacebar and four alphabets they never asked
+    /// for — and the gesture guarding against that is the whole reason the
+    /// count is checked in three places.
+    @Test func aNewInstallStartsWithTheLanguagesThePhoneAlreadyUses() {
+        #expect(TypingLayout.forPreferredLanguages(["en-US"]).map(\.id) == ["en"])
+        #expect(TypingLayout.forPreferredLanguages(["ru-RU", "en-GB"]).map(\.id) == ["en", "ru"])
+        // Order follows the catalogue, not the phone: the list in settings and
+        // the order the language key walks are the same order, and it should
+        // not silently differ between two phones set up the same way.
+        #expect(TypingLayout.forPreferredLanguages(["ru", "de"]).map(\.id) == ["de", "ru"])
+        // Nothing recognised still has to produce a keyboard.
+        #expect(TypingLayout.forPreferredLanguages(["ja-JP"]).map(\.id) == ["en"])
+        #expect(TypingLayout.forPreferredLanguages([]).map(\.id) == ["en"])
+    }
+
+    // MARK: - The catalogue
+
+    /// Adding a language is adding an entry, so what an entry must satisfy is
+    /// worth stating once rather than reviewing five times.
+    @Test func everyLayoutInTheCatalogueIsWellFormed() {
+        var seen = Set<String>()
+        for layout in TypingLayout.catalogue {
+            #expect(seen.insert(layout.id).inserted, "duplicate id \(layout.id)")
+            #expect(!layout.displayName.isEmpty)
+            #expect(!layout.checkerLanguage.isEmpty)
+            #expect(layout.rows.count == 3, "\(layout.displayName) has \(layout.rows.count) rows")
+            let letters = Array(layout.rows.joined())
+            #expect(
+                Set(letters).count == letters.count,
+                "\(layout.displayName) repeats a letter on the grid"
+            )
+            // Twelve is where a key stops being a target and starts being a
+            // sliver: at 393pt a twelve-column row is under 28pt of glass.
+            for row in layout.rows {
+                #expect(row.count <= 12, "\(layout.displayName) has a \(row.count)-key row")
+                #expect(!row.isEmpty)
+            }
+        }
+    }
+
+    /// The one question the spacebar label, the key and the gesture all ask.
+    @Test func steppingThroughLayoutsWrapsBothWaysAndStopsAtOne() {
+        let all = TypingLayout.catalogue
+        let first = all[0]
+        #expect(TypingLayout.next(after: first, in: [first]) == nil)
+        #expect(TypingLayout.next(after: first, in: []) == nil)
+        #expect(TypingLayout.next(after: first, in: all) == all[1])
+        #expect(TypingLayout.next(after: first, in: all, forward: false) == all[all.count - 1])
+        #expect(TypingLayout.next(after: all[all.count - 1], in: all) == first)
+        // A layout that is not in the list has no successor in it, which is the
+        // case a stale stored choice produces.
+        let stray = all[1]
+        #expect(TypingLayout.next(after: stray, in: [first, all[2]]) == nil)
+    }
+
+    /// Russian gives the spacebar to the swipe; everything else keeps its
+    /// trackpad. Asserted because it is a choice, not a fact — and a choice
+    /// that silently spread to every layout would be hard to notice.
+    @Test func onlyRussianGivesUpTheCursorTrackpad() {
+        for layout in TypingLayout.catalogue {
+            #expect(layout.offersCursorTrackpad == (layout.id != "ru"), "\(layout.id)")
+        }
+    }
+
     // MARK: - The press nobody could see
 
     /// A press is held long enough to be composited once, and no longer.

--- a/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
+++ b/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
@@ -52,14 +52,19 @@ struct KeyboardSurfaceTests {
         let surface = DictationSurfaceState()
         surface.quickDictationEnabled = true
         surface.quickDictationReady = true
+        surface.setCompactDashboardPresented(true)
         var changes: [Bool] = []
+        var visibilityChanges: [Bool] = []
         surface.onQuickDictationChanged = { changes.append($0) }
+        surface.onDashboardVisibilityChanged = { visibilityChanges.append($0) }
 
         surface.setQuickDictationEnabled(false)
         surface.setQuickDictationEnabled(false)
 
         #expect(surface.quickDictationReady == false)
+        #expect(surface.compactDashboardPresented == false)
         #expect(changes == [false])
+        #expect(visibilityChanges == [false])
     }
 
     @Test func recoveryGuidanceSurvivesPollingUntilTheStateChanges() {

--- a/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
+++ b/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
@@ -36,15 +36,53 @@ struct KeyboardSurfaceTests {
         #expect(CompactDashboardPage.speed.label(for: stats, now: now) == "Average WPM")
     }
 
-    @Test func compactDashboardReportsOnlyRealVisibilityChanges() {
+    @Test func panelsReportOnlyRealVisibilityChanges() {
         let surface = DictationSurfaceState()
         var changes: [Bool] = []
-        surface.onDashboardVisibilityChanged = { changes.append($0) }
+        surface.onPanelVisibilityChanged = { changes.append($0) }
 
-        surface.setCompactDashboardPresented(true)
-        surface.setCompactDashboardPresented(true)
-        surface.setCompactDashboardPresented(false)
+        surface.present(.dashboard)
+        surface.present(.dashboard)
+        surface.present(nil)
 
+        #expect(changes == [true, false])
+    }
+
+    /// Dashboard to language picker is one panel replacing another: the keys
+    /// must not be uncovered in between, and leaving the picker goes back to
+    /// the dashboard it was opened from.
+    @Test func aPickerOpenedFromTheDashboardReturnsToIt() {
+        let surface = DictationSurfaceState()
+        var changes: [Bool] = []
+        surface.onPanelVisibilityChanged = { changes.append($0) }
+
+        surface.present(.dashboard)
+        surface.present(.language, returningTo: .dashboard)
+        #expect(surface.panelReturnsToPrevious)
+        surface.dismissPanel()
+
+        #expect(surface.presentedPanel == .dashboard)
+        #expect(!surface.panelReturnsToPrevious)
+        #expect(changes == [true])
+
+        surface.dismissPanel()
+        #expect(surface.presentedPanel == nil)
+        #expect(changes == [true, false])
+    }
+
+    @Test func theStylePickerFromTheRowClosesBackToTheKeys() {
+        let style = KeyboardPreferences.writingStyle
+        defer { KeyboardPreferences.writingStyle = style }
+        let surface = DictationSurfaceState()
+        var changes: [Bool] = []
+        surface.onPanelVisibilityChanged = { changes.append($0) }
+
+        surface.present(.style)
+        surface.select(style: .formal)
+        surface.dismissPanel()
+
+        #expect(surface.presentedPanel == nil)
+        #expect(surface.style == .formal)
         #expect(changes == [true, false])
     }
 
@@ -63,17 +101,17 @@ struct KeyboardSurfaceTests {
 
         let surface = DictationSurfaceState()
         surface.quickDictationReady = true
-        surface.setCompactDashboardPresented(true)
+        surface.present(.dashboard)
         var changes: [Bool] = []
         var visibilityChanges: [Bool] = []
         surface.onVocaPhoneRunningChanged = { changes.append($0) }
-        surface.onDashboardVisibilityChanged = { visibilityChanges.append($0) }
+        surface.onPanelVisibilityChanged = { visibilityChanges.append($0) }
 
         surface.setVocaPhoneRunning(false)
         surface.setVocaPhoneRunning(false)
 
         #expect(surface.quickDictationReady == false)
-        #expect(surface.compactDashboardPresented == false)
+        #expect(surface.presentedPanel == nil)
         #expect(changes == [false])
         #expect(visibilityChanges == [false])
         #expect(KeyboardPreferences.quickDictationEnabled)

--- a/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
+++ b/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
@@ -48,18 +48,17 @@ struct KeyboardSurfaceTests {
         #expect(changes == [true, false])
     }
 
-    @Test func quickDictationToggleUpdatesReadinessAndReportsChanges() {
+    @Test func quickDictationToggleControlsOnlyTheLiveReadinessWindow() {
         let surface = DictationSurfaceState()
-        surface.quickDictationEnabled = true
         surface.quickDictationReady = true
         surface.setCompactDashboardPresented(true)
         var changes: [Bool] = []
         var visibilityChanges: [Bool] = []
-        surface.onQuickDictationChanged = { changes.append($0) }
+        surface.onQuickDictationReadinessChanged = { changes.append($0) }
         surface.onDashboardVisibilityChanged = { visibilityChanges.append($0) }
 
-        surface.setQuickDictationEnabled(false)
-        surface.setQuickDictationEnabled(false)
+        surface.setQuickDictationReady(false)
+        surface.setQuickDictationReady(false)
 
         #expect(surface.quickDictationReady == false)
         #expect(surface.compactDashboardPresented == false)

--- a/ios/VocaPhoneTests/ReliabilityFeatureTests.swift
+++ b/ios/VocaPhoneTests/ReliabilityFeatureTests.swift
@@ -301,12 +301,35 @@ struct ReliabilityFeatureTests {
         #expect(!availability.isReady(at: Date(timeIntervalSince1970: 1_800_000_000)))
     }
 
-    @Test func cursorTrackpadEmitsOnlyWholeCharacterSteps() {
-        #expect(CursorTrackpad.step(forHorizontalTranslation: 9.9) == 0)
-        #expect(CursorTrackpad.step(forHorizontalTranslation: 10) == 1)
-        #expect(CursorTrackpad.step(forHorizontalTranslation: 27) == 2)
-        #expect(CursorTrackpad.step(forHorizontalTranslation: -9.9) == 0)
-        #expect(CursorTrackpad.step(forHorizontalTranslation: -10) == -1)
+    /// The trackpad used to quantise the *absolute* translation at a fixed ten
+    /// points per character, and this test asserted that ruler. The ruler is
+    /// gone: a fixed rate puts the far end of a seventy-character line off the
+    /// glass, so reaching it cost a lift and another third of a second of
+    /// holding. What replaced it is a rate, and this is its contract.
+    @Test func cursorTravelPerCharacterFollowsHowFastTheFingerIsGoing() {
+        let slow = CursorTrackpad.pointsPerCharacter(atSpeed: 0)
+        let fast = CursorTrackpad.pointsPerCharacter(atSpeed: 10_000)
+        #expect(slow == CursorTrackpad.slowPointsPerCharacter)
+        #expect(fast == CursorTrackpad.fastPointsPerCharacter)
+        // A crawl places the cursor between two specific letters; a flick
+        // crosses a line. Anything else is one of them at the other's price.
+        #expect(slow > fast)
+
+        // Clamped outside the two speeds it interpolates between, so a fast
+        // flick cannot run away and a stationary finger cannot divide by zero.
+        #expect(CursorTrackpad.pointsPerCharacter(atSpeed: -50) == slow)
+        #expect(CursorTrackpad.pointsPerCharacter(atSpeed: CursorTrackpad.slowSpeed) == slow)
+        #expect(CursorTrackpad.pointsPerCharacter(atSpeed: CursorTrackpad.fastSpeed) == fast)
+
+        // Monotonic between them: no speed costs more travel per character than
+        // a slower one, which is the property that makes the gesture feel like
+        // a surface rather than a switch.
+        var previous = slow
+        for speed in stride(from: CGFloat(0), through: 2_000, by: 50) {
+            let rate = CursorTrackpad.pointsPerCharacter(atSpeed: speed)
+            #expect(rate <= previous + 0.001, "rate rose at \(speed) pt/s")
+            previous = rate
+        }
     }
 
     @Test func diagnosticsHaveNoPrivateContentFields() throws {

--- a/ios/VocaPhoneTests/TypingCandidatesTests.swift
+++ b/ios/VocaPhoneTests/TypingCandidatesTests.swift
@@ -256,6 +256,17 @@ struct TypingCandidatesTests {
         // keyboard: "w" is beside "e", "p" is not.
         #expect(KeyProximity.areAdjacent("w", "e"))
         #expect(!KeyProximity.areAdjacent("q", "p"))
+        #expect(KeyProximity.rowOffsets(for: TypingLayout.Arrangement.qwerty) == [0, 0.5, 1])
+        // AZERTY puts a and z next to each other on the top row. The QWERTY
+        // table used to call them two rows apart, and discount a/q instead.
+        let azerty = TypingLayout.Arrangement.azerty
+        // z and e sit next to each other on AZERTY's top row. QWERTY puts z
+        // on the bottom, two rows from e, so the old table missed this pair.
+        #expect(KeyProximity.areAdjacent("z", "e", rows: azerty))
+        #expect(!KeyProximity.areAdjacent("z", "e"))
+        let russian = TypingLayout.layout(id: "ru")!.rows
+        #expect(KeyProximity.areAdjacent("й", "ц", rows: russian))
+        #expect(!KeyProximity.areAdjacent("й", "ц"))
         #expect(
             KeyProximity.substitutionCost(typed: "w", intended: "e")
                 < KeyProximity.substitutionCost(typed: "q", intended: "p")


### PR DESCRIPTION
Four commits, in that order.

Languages: seven keyboard layouts, a sheet with search, flags and checkmarks, and a key that names the layout you are on. A fresh install turns on the ones that match the phone’s languages.

Spacebar: swipe left or right to change language. Hold and drag still moves the cursor between words — vertical is gone, and the rest is tightened because it was not working well.

Swipe back: a new screen — a drawn phone with the gesture looping as an animation, and one sentence. The app opens there.

Compact row: debug-only, a switch in the keyboard lab, not shipping. The big action button used to sit on the right and was too easy to hit. Open the keyboard to talk and it is large and in the middle; once you type, it moves to the corner and leaves the strip for autocomplete. If it feels better it can become the default later.

## Verification

- [x] `just ios ci` — 792 tests, 74 suites
- [ ] `just android ci` — not Android
- [ ] Gateway — not gateway
- [x] Physical iPhone 15. Languages, the spacebar (swipe / hold / lift), swipe-back, and both compact and the shipping row.

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [ ] Documentation — no data-flow, permission, retention, or network change