### PR TITLE
fix(ios): improve keyboard startup, switching, and emoji suggestions

### DIFF
--- a/docs/device-setup.md
+++ b/docs/device-setup.md
@@ -162,6 +162,13 @@ supported one.
   keyboard haptics stop working, which is also stated there.
 - Type continuously for two minutes in a long document. The keyboard must not
   flicker, reset, or lose the composition — that is what a jetsam looks like.
+- After several hours away, open the keyboard in Notes and immediately type
+  and swipe. Repeat after switching from the Apple keyboard. Check first-key
+  responsiveness and that swipe becomes available without first typing a word.
+- Type part of a word, immediately switch keyboards or apps, and return to a
+  different field. Suggestions and touch prediction must describe the current
+  field. Repeat while a dictation finishes: hidden keyboards must not insert;
+  returning to vocaphone's keyboard should resume the pending session once.
 - Long-press `$`, `-`, `?` for symbol alternates, and `.` in a URL field for
   `.com`. Hold the `123` key to open the emoji panel; the keyboard's height must
   not change when it does.

--- a/docs/device-setup.md
+++ b/docs/device-setup.md
@@ -165,6 +165,11 @@ supported one.
 - After several hours away, open the keyboard in Notes and immediately type
   and swipe. Repeat after switching from the Apple keyboard. Check first-key
   responsiveness and that swipe becomes available without first typing a word.
+- With Suggestions and Emoji suggestions enabled, type `happy` or `sad` and
+  pause before pressing Space: 😊 or 😢 should appear even on the first word
+  after launch. Tap it and verify that it replaces only that word. Switch to
+  another keyboard and back with the cursor after `happy`; 😊 should return
+  without another keystroke. Turn Emoji suggestions off and repeat: no emoji.
 - Type part of a word, immediately switch keyboards or apps, and return to a
   different field. Suggestions and touch prediction must describe the current
   field. Repeat while a dictation finishes: hidden keyboards must not insert;

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -335,10 +335,10 @@ struct KeyboardSettingsView: View {
                 )
                 Text(
                     "Emoji suggestions offer one emoji beside the word candidates "
-                        + "when a word has an obvious one — typing “lol” offers 😂. "
-                        + "Tapping it replaces the word. It never takes a word "
-                        + "suggestion's place, and words without an obvious emoji "
-                        + "get none."
+                        + "when a word has an obvious one — “happy” offers 😊 "
+                        + "and “sad” offers 😢. Tap the emoji before adding a "
+                        + "space to replace the word. Words without an obvious "
+                        + "emoji get none."
                 )
                 Text(
                     "Typing haptics are off by default. Keyboard clicks follow "

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -1790,6 +1790,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         keyGrid.plane = Self.initialPlane(for: keyboardType)
         updateReturnKeyEnablement()
         applyTheme()
+        // A returning keyboard may already be at the end of "happy". Restore
+        // its suggestions immediately instead of waiting for another key.
+        if isKeyboardVisible { typing.reconcile(document: document) }
     }
 
     /// Dims Return in the fields that asked for it.

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -26,6 +26,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     private var lastRenderedState: SessionState?
     private var hasRendered = false
     private var announcesStateChanges = false
+    private var isKeyboardVisible = false
     private var lastPublishedAt: Date?
     private var lastPublishedFullAccess: Bool?
     private static let statusRepublishInterval: TimeInterval = 10
@@ -139,7 +140,6 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         typing.loadLexicon(from: self)
         KeyboardHaptics.shared.attach(to: view, hasFullAccess: hasFullAccess)
         render(nil)
-        refresh()
         noteAvailableMemory(.launched)
     }
 
@@ -201,6 +201,8 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         TouchTrace.beginSession("keyboard appeared")
 #endif
         super.viewWillAppear(animated)
+        isKeyboardVisible = true
+        lastSpaceInsertedAt = nil
         // Extension controllers can be reused across host fields and apps.
         hasDictationKey = true
         // A recreated extension instance can inherit a session the previous one
@@ -250,6 +252,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        typing.prepareResources()
         // UIKit can finalize a changed Full Access setting after the earlier
         // appearance callbacks. This is the last lifecycle point before guided
         // setup expects the extension to prove its state.
@@ -274,6 +277,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     }
 
     override func viewWillDisappear(_ animated: Bool) {
+        isKeyboardVisible = false
+        announcesStateChanges = false
+        typing.suspend()
         super.viewWillDisappear(animated)
         pollingTimer?.invalidate()
         pollingTimer = nil
@@ -331,6 +337,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
     override func textDidChange(_ textInput: (any UITextInput)?) {
         super.textDidChange(textInput)
+        guard isKeyboardVisible else { return }
         documentEvent { handleTextChange() }
     }
 
@@ -1040,7 +1047,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         ) else { return }
         openURLFromKeyboard(url) { [weak self] opened in
             DispatchQueue.main.async {
-                guard let self else { return }
+                guard let self, self.isKeyboardVisible else { return }
                 guard !opened, self.activeSessionID == sessionID,
                       let current = try? self.store.load(sessionID),
                       current.state == .launchingApp || current.state == .awaitingReturn
@@ -1134,7 +1141,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// which keeps ordinary typing free of a four-times-a-second directory scan
     /// inside a memory-constrained extension.
     private func updatePolling(for record: SessionRecord?) {
-        let needsUpdates = record.map { !$0.state.isTerminal } ?? false
+        let needsUpdates = isKeyboardVisible && (record.map { !$0.state.isTerminal } ?? false)
         guard needsUpdates else {
             pollingTimer?.invalidate()
             pollingTimer = nil
@@ -1163,6 +1170,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     }
 
     private func refresh() {
+        // Removing observers cannot recall callbacks already queued on the main
+        // actor. They must not insert text or restart polling after dismissal.
+        guard isKeyboardVisible else { return }
         if let id = activeSessionID, let record = try? store.load(id) {
             if ![.launchingApp, .awaitingReturn].contains(record.state) {
                 appLaunchFallbackTask?.cancel()

--- a/ios/VocaPhoneKeyboard/TypingEngine.swift
+++ b/ios/VocaPhoneKeyboard/TypingEngine.swift
@@ -129,6 +129,9 @@ final class TypingEngine {
         init(_ value: Value) { self.value = value }
     }
     private var language = TypingLanguage.fallback
+    private var hasResolvedLanguage = false
+    private let availableLanguages: @MainActor () -> [String]
+    private var emojiTableReady = false
     private var customWords: [String] = []
     /// `customWords` folded once. See ``LexiconEntry/lowered``.
     private var loweredCustomWords: [String] = []
@@ -136,13 +139,14 @@ final class TypingEngine {
     init(
         checker: any SpellChecking = SystemSpellChecker(),
         learned: LearnedWordStore = LearnedWordStore(),
-        wordList: TypingWordList? = nil
+        wordList: TypingWordList? = nil,
+        availableLanguages: @escaping @MainActor () -> [String] = SystemSpellChecker.availableLanguages
     ) {
         self.checker = checker
         self.learned = learned
-        // Nothing expensive here. Everything this subsystem needs is built the
-        // first time the user types, because a keyboard extension's whole memory
-        // budget has to survive *launch* first — see `ensureLoaded`.
+        self.availableLanguages = availableLanguages
+        // Bundled resources wait until the view appears; system dictionaries
+        // wait until a typing pause. Neither belongs in view construction.
         if let wordList {
             self.wordList = wordList
             hasLoaded = true
@@ -153,19 +157,11 @@ final class TypingEngine {
 
     private var hasLoaded = false
 
-    /// Pays for the dictionaries, once, on the first keystroke.
-    ///
-    /// Deliberately not in `init`: the engine is created while the keyboard is
-    /// still assembling its views, and loading ten thousand words plus the
-    /// system dictionaries there put the extension over the jetsam threshold
-    /// before it had drawn a key.
-    private func ensureLoaded() {
+    /// Starts only the bundled resources off-thread after the keyboard appears.
+    /// System dictionaries stay deferred until the checker quiet period.
+    func prepareResources() {
         guard !hasLoaded else { return }
         hasLoaded = true
-        language = TypingLanguage.resolve(
-            preferred: Locale.preferredLanguages,
-            available: SystemSpellChecker.availableLanguages()
-        )
         // Pure Swift, so unlike the checker this may leave the main actor.
         Task.detached(priority: .utility) {
             let loaded = TypingWordList.load(from: Bundle(for: TypingEngine.self))
@@ -176,7 +172,9 @@ final class TypingEngine {
             EmojiTable.warmUp()
             await MainActor.run { [weak self] in
                 self?.wordList = loaded
+                self?.emojiTableReady = true
                 self?.onWordListLoaded?(loaded)
+                self?.publishNextCharacters()
             }
         }
     }
@@ -206,6 +204,12 @@ final class TypingEngine {
         pendingRevert = nil
         cache.removeAll()
         publish(.none)
+        publishNextCharacters()
+    }
+
+    /// Retire field work before UIKit starts switching apps or keyboards.
+    func suspend() {
+        documentChanged(policy: policy)
     }
 
     /// Reconciles the composition against what the document says, then
@@ -442,7 +446,7 @@ final class TypingEngine {
 
         let generation = generation
         let composition = composer.text
-        if !composition.isEmpty { measured("ensureLoaded") { ensureLoaded() } }
+        if !composition.isEmpty { prepareResources() }
         let origin = composer.origin
         let preceding = measured("precedingWord") {
             PrecedingWord.lastWord(in: document.before)
@@ -489,6 +493,14 @@ final class TypingEngine {
         pendingCheck = Task { @MainActor [weak self] in
             try? await Task.sleep(for: Self.checkerQuietPeriod)
             guard !Task.isCancelled, let self, generation == self.generation else { return }
+            if !self.hasResolvedLanguage {
+                self.language = TypingLanguage.resolve(
+                    preferred: Locale.preferredLanguages,
+                    available: self.availableLanguages()
+                )
+                self.hasResolvedLanguage = true
+            }
+            let key = SuggestionCache.Key(prefix: composition.lowercased(), language: self.language)
             let value = SuggestionCache.Value(
                 completions: self.checker.completions(for: composition, language: self.language),
                 guesses: self.checker.guesses(for: composition, language: self.language),
@@ -608,7 +620,10 @@ final class TypingEngine {
         context.assertedWords = assertedWords
         // Exact word only, so nothing appears while the user is partway into a
         // different one.
-        context.emojiSuggestion = EmojiSuggestions.glyph(for: composition)
+        // A lazy static lookup can block behind its background initializer.
+        // Do not touch the table until that initializer has finished.
+        context.emojiSuggestion = emojiTableReady
+            ? EmojiSuggestions.glyph(for: composition) : nil
         context.emojiEnabled = KeyboardPreferences.emojiSuggestionsEnabled
         context.suggestionsEnabled = KeyboardPreferences.typingSuggestionsEnabled
         context.autocorrectEnabled = KeyboardPreferences.autocorrectIsActive

--- a/ios/VocaPhoneKeyboard/TypingEngine.swift
+++ b/ios/VocaPhoneKeyboard/TypingEngine.swift
@@ -131,7 +131,9 @@ final class TypingEngine {
     private var language = TypingLanguage.fallback
     private var hasResolvedLanguage = false
     private let availableLanguages: @MainActor () -> [String]
-    private var emojiTableReady = false
+    private var emojiTriggers: [String: String] = [:]
+    private var precedingWord: String?
+    private var hasDocumentContext = false
     private var customWords: [String] = []
     /// `customWords` folded once. See ``LexiconEntry/lowered``.
     private var loweredCustomWords: [String] = []
@@ -170,13 +172,33 @@ final class TypingEngine {
             // strip is no longer its only reader, so this warms what dictation
             // needs from it as well.
             EmojiTable.warmUp()
+            let emojiTriggers = EmojiTable.triggers
             await MainActor.run { [weak self] in
-                self?.wordList = loaded
-                self?.emojiTableReady = true
-                self?.onWordListLoaded?(loaded)
-                self?.publishNextCharacters()
+                self?.installResources(wordList: loaded, emojiTriggers: emojiTriggers)
             }
         }
+    }
+
+    /// Resource delivery is another reason to update the row, even if the user
+    /// has stopped typing. Rebuild from the current field, never from the word
+    /// that happened to start the background load.
+    func installResources(wordList: TypingWordList, emojiTriggers: [String: String]) {
+        self.wordList = wordList
+        self.emojiTriggers = emojiTriggers
+        onWordListLoaded?(wordList)
+        publishNextCharacters()
+        guard hasDocumentContext,
+              policy.allowsTypingIntelligence,
+              KeyboardPreferences.typingSuggestionsEnabled,
+              pendingSwipe == nil, pendingRevert == nil
+        else { return }
+        let key = SuggestionCache.Key(prefix: composer.text.lowercased(), language: language)
+        publishStrip(for: context(
+            composition: composer.text,
+            origin: composer.origin,
+            preceding: precedingWord,
+            checked: cache.value(for: key)
+        ))
     }
 
     var isPersistentLearningAvailable: Bool { learned.isPersistent }
@@ -200,6 +222,8 @@ final class TypingEngine {
         pendingSwipe = nil
         policy = newPolicy
         composer.reset()
+        precedingWord = nil
+        hasDocumentContext = false
         assertedWords.removeAll()
         pendingRevert = nil
         cache.removeAll()
@@ -451,6 +475,8 @@ final class TypingEngine {
         let preceding = measured("precedingWord") {
             PrecedingWord.lastWord(in: document.before)
         }
+        precedingWord = preceding
+        hasDocumentContext = true
 
         // Nothing being composed: prediction needs no checker, so it renders on
         // this turn rather than costing a hop.
@@ -620,10 +646,9 @@ final class TypingEngine {
         context.assertedWords = assertedWords
         // Exact word only, so nothing appears while the user is partway into a
         // different one.
-        // A lazy static lookup can block behind its background initializer.
-        // Do not touch the table until that initializer has finished.
-        context.emojiSuggestion = emojiTableReady
-            ? EmojiSuggestions.glyph(for: composition) : nil
+        // This snapshot arrives from the background loader, so the keystroke
+        // never waits on a lazy static initializer.
+        context.emojiSuggestion = emojiTriggers[composition.lowercased()]
         context.emojiEnabled = KeyboardPreferences.emojiSuggestionsEnabled
         context.suggestionsEnabled = KeyboardPreferences.typingSuggestionsEnabled
         context.autocorrectEnabled = KeyboardPreferences.autocorrectIsActive

--- a/ios/VocaPhoneTests/EmojiSuggestionsTests.swift
+++ b/ios/VocaPhoneTests/EmojiSuggestionsTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 /// The table is the feature. Matching is three lines; what decides whether the
@@ -6,6 +7,8 @@ import Testing
 /// emoji, but never ordinary prose.
 struct EmojiSuggestionsTests {
     @Test func theWordsPeopleExpectAreOffered() {
+        #expect(EmojiSuggestions.glyph(for: "happy") == "😊")
+        #expect(EmojiSuggestions.glyph(for: "sad") == "😢")
         #expect(EmojiSuggestions.glyph(for: "lol") == "😂")
         #expect(EmojiSuggestions.glyph(for: "pizza") == "🍕")
         #expect(EmojiSuggestions.glyph(for: "birthday") == "🎂")
@@ -94,5 +97,108 @@ struct EmojiSuggestionsTests {
         #expect(EmojiSuggestions.triggers.count > 2_000)
         let glyphs = Set(EmojiSuggestions.triggers.values)
         #expect(glyphs.count > 1_500)
+    }
+}
+
+@MainActor
+@Suite(.serialized)
+struct EmojiSuggestionLoadingTests {
+    private let triggers = ["happy": "😊", "sad": "😢"]
+
+    private func withEngine(_ body: (TypingEngine) -> Void) {
+        let suggestions = KeyboardPreferences.typingSuggestionsEnabled
+        let emoji = KeyboardPreferences.emojiSuggestionsEnabled
+        defer {
+            KeyboardPreferences.typingSuggestionsEnabled = suggestions
+            KeyboardPreferences.emojiSuggestionsEnabled = emoji
+        }
+        KeyboardPreferences.typingSuggestionsEnabled = true
+        KeyboardPreferences.emojiSuggestionsEnabled = true
+        let engine = TypingEngine(
+            learned: LearnedWordStore(containerURL: nil),
+            wordList: .empty
+        )
+        defer { engine.suspend() }
+        body(engine)
+    }
+
+    @Test(arguments: ["happy", "sad", "Happy", "SAD"])
+    func aFinishedWordGetsItsEmojiWhenLoadingCompletes(word: String) {
+        withEngine { engine in
+            engine.insert(word, document: DocumentSnapshot(before: word))
+            #expect(!engine.strip.candidates.contains { $0.kind == .emoji })
+            // Deliver the background result without another keystroke.
+            engine.installResources(wordList: .empty, emojiTriggers: triggers)
+            #expect(engine.strip.candidates.contains {
+                $0.kind == .emoji && $0.text == triggers[word.lowercased()]
+            })
+        }
+    }
+
+    @Test func returningToAFieldRestoresItsEmojiWithoutTyping() {
+        withEngine { engine in
+            engine.installResources(wordList: .empty, emojiTriggers: triggers)
+            engine.documentChanged(policy: .allowed)
+            engine.reconcile(document: DocumentSnapshot(before: "I am happy"))
+            #expect(engine.strip.candidates.contains { $0.text == "😊" && $0.kind == .emoji })
+            #expect(engine.strip.autocorrection == nil)
+        }
+    }
+
+    @Test func loadingUsesTheNewFieldsWord() {
+        withEngine { engine in
+            engine.insert("happy", document: DocumentSnapshot(before: "happy"))
+            engine.documentChanged(policy: .allowed)
+            engine.reconcile(document: DocumentSnapshot(before: "sad"))
+            engine.installResources(wordList: .empty, emojiTriggers: triggers)
+            #expect(engine.strip.candidates.contains { $0.text == "😢" && $0.kind == .emoji })
+            #expect(!engine.strip.candidates.contains { $0.text == "😊" })
+        }
+    }
+
+    @Test func loadingAfterDismissalDoesNotRestoreOldSuggestions() {
+        withEngine { engine in
+            engine.insert("happy", document: DocumentSnapshot(before: "happy"))
+            engine.suspend()
+            engine.installResources(wordList: .empty, emojiTriggers: triggers)
+            #expect(engine.strip.isEmpty)
+        }
+    }
+
+    @Test func disablingEmojiDuringLoadingIsRespected() {
+        withEngine { engine in
+            engine.insert("happy", document: DocumentSnapshot(before: "happy"))
+            KeyboardPreferences.emojiSuggestionsEnabled = false
+            engine.installResources(wordList: .empty, emojiTriggers: triggers)
+            #expect(!engine.strip.candidates.contains { $0.kind == .emoji })
+        }
+    }
+
+    @Test func loadingInASensitiveFieldKeepsSuggestionsHidden() {
+        withEngine { engine in
+            engine.insert("happy", document: DocumentSnapshot(before: "happy"))
+            engine.documentChanged(policy: TypingFieldPolicy(
+                allowsTypingIntelligence: false, reason: .secureEntry
+            ))
+            engine.reconcile(document: DocumentSnapshot(before: "sad"))
+            engine.installResources(wordList: .empty, emojiTriggers: triggers)
+            #expect(engine.strip.isEmpty)
+        }
+    }
+
+    @Test func loadingDoesNotReplaceSwipeAlternatesOrRevert() {
+        withEngine { engine in
+            engine.insert("happy", document: DocumentSnapshot(before: "happy"))
+            engine.noteSwipeWord("sad", alternates: ["sad", "said"])
+            let alternates = engine.strip
+            engine.installResources(wordList: .empty, emojiTriggers: triggers)
+            #expect(engine.strip == alternates)
+            engine.documentChanged(policy: .allowed)
+            engine.insert("the ", document: DocumentSnapshot(before: "the "))
+            engine.noteCorrection(typed: "teh", replacement: "the", boundary: " ")
+            let revert = engine.strip
+            engine.installResources(wordList: .empty, emojiTriggers: triggers)
+            #expect(engine.strip == revert)
+        }
     }
 }

--- a/ios/VocaPhoneTests/TypingCandidatesTests.swift
+++ b/ios/VocaPhoneTests/TypingCandidatesTests.swift
@@ -837,6 +837,55 @@ struct AppliedCorrectionArmingTests {
 @MainActor
 @Suite(.serialized)
 struct TypingEngineDocumentChangeTests {
+    @Test func firstKeyDefersSystemDictionariesUntilTheQuietPeriod() async throws {
+        let suggestions = KeyboardPreferences.typingSuggestionsEnabled
+        defer { KeyboardPreferences.typingSuggestionsEnabled = suggestions }
+        KeyboardPreferences.typingSuggestionsEnabled = true
+        var languageQueries = 0
+        let checker = RecordingSpellChecker()
+        let engine = TypingEngine(
+            checker: checker,
+            learned: LearnedWordStore(containerURL: nil),
+            availableLanguages: {
+                languageQueries += 1
+                return ["en_US"]
+            }
+        )
+        engine.insert("hel", document: DocumentSnapshot(before: "hel"))
+        #expect(languageQueries == 0)
+        #expect(checker.prefixesAsked.isEmpty)
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(languageQueries == 1)
+        #expect(checker.prefixesAsked == ["hel"])
+    }
+
+    @Test func hidingKeyboardCancelsCheckerAndClearsTouchPrediction() async throws {
+        let suggestions = KeyboardPreferences.typingSuggestionsEnabled
+        defer { KeyboardPreferences.typingSuggestionsEnabled = suggestions }
+        KeyboardPreferences.typingSuggestionsEnabled = true
+        let checker = RecordingSpellChecker()
+        let engine = TypingEngine(
+            checker: checker,
+            learned: LearnedWordStore(containerURL: nil),
+            wordList: TypingWordList(words: ["hello", "help"], bigrams: [:])
+        )
+        var weights: [Character: Double] = [:]
+        engine.onNextCharacters = { weights = $0 }
+        engine.insert("hel", document: DocumentSnapshot(before: "hel"))
+        #expect(!weights.isEmpty)
+        engine.suspend()
+        #expect(weights.isEmpty)
+        #expect(engine.composer.isEmpty)
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(checker.prefixesAsked.isEmpty)
+        #expect(engine.strip.isEmpty)
+        // The reused engine must still work when another field appears.
+        engine.documentChanged(policy: .allowed)
+        engine.insert("wo", document: DocumentSnapshot(before: "wo"))
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(checker.prefixesAsked == ["wo"])
+    }
+
     @Test func swipingRetiresThePreviousTypedWordsCheck() async throws {
         let suggestions = KeyboardPreferences.typingSuggestionsEnabled
         defer { KeyboardPreferences.typingSuggestionsEnabled = suggestions }


### PR DESCRIPTION
## Problem

The iOS keyboard synchronously enumerated system dictionary languages on the first composed word, and its swipe dictionary did not begin loading until a word was typed. During app or keyboard switching, deferred spelling work could outlive dismissal, and already-queued session notifications could refresh a hidden keyboard, including automatic insertion or restarting polling.

Emoji suggestions such as happy → 😊 and sad → 😢 also need to refresh when bundled resources finish loading, even when the user has stopped typing. Returning to an existing word previously cleared its composition without immediately restoring its suggestions.

## Summary

- Load bundled typing and emoji resources off the main thread after appearance. Defer system language enumeration until the existing spelling quiet period, and avoid blocking on the emoji table's lazy initializer before background loading completes.
- Cancel pending spelling work and clear composition/touch prediction on dismissal. Ignore hidden-keyboard session and text callbacks, stop hidden polling, and reset double-space timing and state announcements across appearances.
- Add regression coverage for first-key dictionary deferral, cancellation during dismissal, cleared touch prediction, and successful typing after a field switch. Document cold-start and rapid-switch device checks.
- Refresh the current field's candidates when emoji resources arrive and reconcile the visible field on keyboard return. Keep late delivery from reviving dismissed/sensitive-field suggestions or replacing swipe alternatives and correction undo. Cover happy/sad, case variants, settings, and switching during loading; clarify the emoji replacement behavior in Settings and device QA.

## Verification

- [x] `just ios ci`: passed; 785 tests in 75 suites, project freshness and preview isolation checks passed. Simulator: iPhone 17, iOS 26.5.
- [x] `git diff --check`
- [ ] `just android ci`: N/A, iOS-only changes.
- [ ] Gateway changes: N/A.
- [ ] Physical-device test: pending; paired iPhones were unavailable. No claim of measured latency improvement or reproduction of the hours-away symptom on hardware. Test Notes → type/swipe immediately after hours away; Apple keyboard → vocaphone keyboard; partial word → switch apps/fields → return; finish dictation while the keyboard is hidden → return and verify insertion once. Repeat in Messages and a third-party app, recording the device and OS.

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added.
- [x] Device QA instructions updated. No permission, audio routing, retention, or network changes; the visibility guard prevents background insertion through a hidden keyboard.
