### PR TITLE
docs: prohibit agent co-authors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,11 @@ to that optional self-hosted gateway.
 User-facing setup and store status live in [README.md](README.md). This file is
 the agent contract: worktrees, commands that exist, and what not to commit.
 
+## Commit attribution
+
+Agents must not add themselves as commit co-authors or add `Co-authored-by`
+trailers for agents.
+
 ## Critical: git worktrees for every branch and PR
 
 Never create a branch, commit, or open a pull request in the primary checkout. Always use a linked git worktree so the main working tree stays on `main` and stays clean. Do not `git switch` / `git checkout` a feature branch in the primary directory, and do not leave it dirty.


### PR DESCRIPTION
## Problem

Agent-added `Co-authored-by` trailers can make non-human agents appear in the repository contributor list.

## Summary

- add an agent rule prohibiting agent co-author attribution

## Verification

- `git diff --check`