### PR TITLE
fix(ios): prevent keyboard quality regressions

### DIFF
--- a/ios/VocaPhoneApp/App/KeyboardLab.swift
+++ b/ios/VocaPhoneApp/App/KeyboardLab.swift
@@ -19,6 +19,7 @@ struct KeyboardLabView: View {
     @State private var isSpeaking = true
     @State private var showsCandidates = false
     @State private var usesSurface = true
+    @State private var touchTrace = KeyboardPreferences.touchTraceEnabled
     @State private var hapticStyle = KeyboardPreferences.typingHapticStyle
     @State private var hapticIntensity = KeyboardPreferences.typingHapticIntensity
     @State private var keyReleaseFade = KeyboardPreferences.keyReleaseFade
@@ -92,8 +93,13 @@ struct KeyboardLabView: View {
                 Toggle("Dark keyboard", isOn: $isDark)
                 Toggle("Speaking", isOn: $isSpeaking)
                 Toggle("Suggestions", isOn: $showsCandidates)
+                Toggle("Touch trace", isOn: $touchTrace)
             } footer: {
-                Text("Tap the microphone in the preview to play the transition.")
+                Text(
+                    "Tap the microphone in the preview to play the transition. "
+                        + "Touch trace records finger and frame timing for `just ios trace`; "
+                        + "enable it only while measuring."
+                )
             }
             transitionSection
             hapticsSection
@@ -108,6 +114,7 @@ struct KeyboardLabView: View {
         .onChange(of: state) { syncSurface() }
         .onChange(of: isDark) { syncSurface() }
         .onChange(of: showsCandidates) { syncSurface() }
+        .onChange(of: touchTrace) { KeyboardPreferences.touchTraceEnabled = touchTrace }
         .onReceive(meterTick) { _ in
             guard usesSurface, state == .recording, isSpeaking else { return }
             surface.appendMeterLevels(Self.nextLevels())

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -194,10 +194,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // Coming back is the moment it can have changed under us.
         cachedSmartPunctuation = nil
 #if DEBUG
-        // Armed for the whole of a debug build: the fault it is here to catch
-        // only happens at full typing speed, which is not a thing anyone can
-        // reach for a switch in the middle of.
-        TouchTrace.isEnabled = true
+        // Diagnostics have measurable cost: the frame monitor ticks for every
+        // display refresh and the trace formats several lines per keystroke.
+        // Keep normal device QA representative and arm them only from the lab.
+        TouchTrace.isEnabled = KeyboardPreferences.touchTraceEnabled
         TouchTrace.beginSession("keyboard appeared")
 #endif
         super.viewWillAppear(animated)
@@ -207,6 +207,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         hasDictationKey = true
         // A recreated extension instance can inherit a session the previous one
         // started, so scan once on appear and let `render` decide about polling.
+        typing.installCustomVocabulary(LocalTranscriptionPreferences.customVocabulary)
         applyDocumentTraits()
         // The app's settings screen writes the same two keys, and it may have
         // done so while another keyboard was on screen.

--- a/ios/VocaPhoneKeyboard/TypingEngine.swift
+++ b/ios/VocaPhoneKeyboard/TypingEngine.swift
@@ -83,11 +83,13 @@ final class TypingEngine {
     /// every one of them put that block in every gap between two letters, which
     /// is exactly where the next finger lands.
     ///
-    /// Waiting 90 ms means a burst of typing asks nothing at all — the strip is
-    /// carried by the shipped word list, which answers in a quarter of a
-    /// millisecond — and one question is asked when the hand stops, which is
-    /// also when somebody starts reading the strip.
-    private static let checkerQuietPeriod: Duration = .milliseconds(90)
+    /// The pause has to be longer than the roughly 120 ms between brisk
+    /// keystrokes. At 90 ms the checker began its 50-135 ms main-actor block
+    /// just before the next finger landed, turning the debounce into a source of
+    /// dropped frames. The shipped word list keeps the strip responsive during
+    /// this pause; the system checker joins only after the hand has really
+    /// stopped.
+    private static let checkerQuietPeriod: Duration = .milliseconds(250)
     private var pendingCheck: Task<Void, Never>?
     private let learned: LearnedWordStore
     private var cache = SuggestionCache()
@@ -187,6 +189,29 @@ final class TypingEngine {
         self.emojiTriggers = emojiTriggers
         onWordListLoaded?(wordList)
         publishNextCharacters()
+        refreshCurrentCandidates()
+    }
+
+    /// Installs the user's replacements and contacts when UIKit delivers them.
+    /// Delivery is asynchronous and often arrives after a word has already been
+    /// typed, so it is itself a reason to rebuild the visible candidates.
+    func installLexicon(_ entries: [LexiconEntry]) {
+        guard entries != lexiconEntries else { return }
+        lexiconEntries = entries
+        refreshCurrentCandidates()
+    }
+
+    /// Picks up vocabulary edited in the containing app while this extension
+    /// instance was suspended. iOS commonly reuses the instance on return.
+    func installCustomVocabulary(_ rawValue: String) {
+        let words = CustomVocabulary.terms(rawValue)
+        guard words != customWords else { return }
+        customWords = words
+        loweredCustomWords = words.map { $0.lowercased() }
+        refreshCurrentCandidates()
+    }
+
+    private func refreshCurrentCandidates() {
         guard hasDocumentContext,
               policy.allowsTypingIntelligence,
               KeyboardPreferences.typingSuggestionsEnabled,
@@ -427,9 +452,10 @@ final class TypingEngine {
             // the main actor.
             let delivery = UncheckedBox(lexicon)
             Task { @MainActor [weak self] in
-                self?.lexiconEntries = delivery.value.entries.map {
+                let entries = delivery.value.entries.map {
                     LexiconEntry(userInput: $0.userInput, documentText: $0.documentText)
                 }
+                self?.installLexicon(entries)
             }
         }
         controller.requestSupplementaryLexicon(completion: handler)

--- a/ios/VocaPhoneShared/KeyboardPreferences.swift
+++ b/ios/VocaPhoneShared/KeyboardPreferences.swift
@@ -325,6 +325,9 @@ enum KeyboardPreferences {
     static let typingHapticsMigrationKey = "typingHapticsMigrationV1"
     static let swipeTypingKey = "swipeTypingEnabled"
     static let numberRowKey = "numberRowEnabled"
+    /// Debug-only touch and frame instrumentation. Kept off unless a developer
+    /// explicitly arms it in the keyboard lab.
+    static let touchTraceKey = "touchTraceEnabled"
     static let quickDictationKey = "quickDictationEnabled"
     static let quickDictationDurationKey = "quickDictationDuration"
     /// A stop from the Live Activity is a pause, not a preference change: the
@@ -549,6 +552,11 @@ enum KeyboardPreferences {
     static var numberRowEnabled: Bool {
         get { boolean(numberRowKey, default: false) }
         set { defaults?.set(newValue, forKey: numberRowKey) }
+    }
+
+    static var touchTraceEnabled: Bool {
+        get { boolean(touchTraceKey, default: false) }
+        set { defaults?.set(newValue, forKey: touchTraceKey) }
     }
 
     /// An absent key means "never set", which is the default — not `false`,

--- a/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
+++ b/ios/VocaPhoneTests/KeyboardSurfaceTests.swift
@@ -275,3 +275,26 @@ struct KeyboardSurfaceTests {
         #expect(list.completions(for: "q", limit: 2) == ["quixotic"])
     }
 }
+
+@MainActor
+@Suite(.serialized)
+struct KeyboardDiagnosticsPreferenceTests {
+    @Test func touchTracingIsOptIn() {
+        let defaults = KeyboardPreferences.defaults
+        let key = KeyboardPreferences.touchTraceKey
+        let saved = defaults?.object(forKey: key)
+        defer {
+            if let saved {
+                defaults?.set(saved, forKey: key)
+            } else {
+                defaults?.removeObject(forKey: key)
+            }
+        }
+
+        defaults?.removeObject(forKey: key)
+        #expect(!KeyboardPreferences.touchTraceEnabled)
+
+        KeyboardPreferences.touchTraceEnabled = true
+        #expect(KeyboardPreferences.touchTraceEnabled)
+    }
+}

--- a/ios/VocaPhoneTests/TypingCandidatesTests.swift
+++ b/ios/VocaPhoneTests/TypingCandidatesTests.swift
@@ -837,6 +837,33 @@ struct AppliedCorrectionArmingTests {
 @MainActor
 @Suite(.serialized)
 struct TypingEngineDocumentChangeTests {
+    /// The checker blocks the main actor for 50-135 ms on a cold prefix. A
+    /// debounce shorter than the interval between ordinary keystrokes starts
+    /// that block just before the next finger lands, which is exactly the lag
+    /// the debounce is meant to prevent.
+    @Test func briskTypingNeverRunsTheCheckerBetweenLetters() async throws {
+        let suggestions = KeyboardPreferences.typingSuggestionsEnabled
+        defer { KeyboardPreferences.typingSuggestionsEnabled = suggestions }
+        KeyboardPreferences.typingSuggestionsEnabled = true
+        let checker = RecordingSpellChecker()
+        let engine = TypingEngine(
+            checker: checker,
+            learned: LearnedWordStore(containerURL: nil),
+            wordList: .empty
+        )
+
+        var document = ""
+        for character in "hell" {
+            document.append(character)
+            engine.insert(String(character), document: DocumentSnapshot(before: document))
+            try await Task.sleep(for: .milliseconds(120))
+        }
+
+        #expect(checker.prefixesAsked.isEmpty)
+        try await Task.sleep(for: .milliseconds(300))
+        #expect(checker.prefixesAsked == ["hell"])
+    }
+
     @Test func firstKeyDefersSystemDictionariesUntilTheQuietPeriod() async throws {
         let suggestions = KeyboardPreferences.typingSuggestionsEnabled
         defer { KeyboardPreferences.typingSuggestionsEnabled = suggestions }
@@ -854,7 +881,7 @@ struct TypingEngineDocumentChangeTests {
         engine.insert("hel", document: DocumentSnapshot(before: "hel"))
         #expect(languageQueries == 0)
         #expect(checker.prefixesAsked.isEmpty)
-        try await Task.sleep(for: .milliseconds(200))
+        try await Task.sleep(for: .milliseconds(350))
         #expect(languageQueries == 1)
         #expect(checker.prefixesAsked == ["hel"])
     }
@@ -876,13 +903,13 @@ struct TypingEngineDocumentChangeTests {
         engine.suspend()
         #expect(weights.isEmpty)
         #expect(engine.composer.isEmpty)
-        try await Task.sleep(for: .milliseconds(200))
+        try await Task.sleep(for: .milliseconds(350))
         #expect(checker.prefixesAsked.isEmpty)
         #expect(engine.strip.isEmpty)
         // The reused engine must still work when another field appears.
         engine.documentChanged(policy: .allowed)
         engine.insert("wo", document: DocumentSnapshot(before: "wo"))
-        try await Task.sleep(for: .milliseconds(200))
+        try await Task.sleep(for: .milliseconds(350))
         #expect(checker.prefixesAsked == ["wo"])
     }
 
@@ -899,7 +926,7 @@ struct TypingEngineDocumentChangeTests {
         engine.insert("hel", document: DocumentSnapshot(before: "hel"))
         engine.noteSwipeWord("world", alternates: ["world", "word"])
         let alternates = engine.strip
-        try await Task.sleep(for: .milliseconds(200))
+        try await Task.sleep(for: .milliseconds(350))
         #expect(checker.prefixesAsked.isEmpty)
         #expect(engine.strip == alternates)
     }
@@ -916,7 +943,7 @@ struct TypingEngineDocumentChangeTests {
         engine.insert("hel", document: DocumentSnapshot(before: "hel"))
         KeyboardPreferences.typingSuggestionsEnabled = false
         engine.reconcile(document: DocumentSnapshot(before: "hel"))
-        try await Task.sleep(for: .milliseconds(200))
+        try await Task.sleep(for: .milliseconds(350))
         #expect(checker.prefixesAsked.isEmpty)
         #expect(engine.strip.isEmpty)
     }
@@ -965,9 +992,9 @@ struct TypingEngineDocumentChangeTests {
         #expect(engine.pendingSwipeWord == nil)
         let publishedThroughChange = published.count
 
-        // Longer than `checkerQuietPeriod` (~90 ms), so a task that was not
+        // Longer than `checkerQuietPeriod` (~250 ms), so a task that was not
         // cancelled would have asked the checker and published by now.
-        try await Task.sleep(for: .milliseconds(200))
+        try await Task.sleep(for: .milliseconds(350))
 
         #expect(checker.prefixesAsked.isEmpty)
         #expect(engine.strip.isEmpty)
@@ -975,5 +1002,44 @@ struct TypingEngineDocumentChangeTests {
         #expect(!published.contains { strip in
             strip.candidates.contains { $0.text == Self.staleCompletion }
         })
+    }
+
+    @Test func lateLexiconDeliveryRefreshesTheWordAlreadyOnScreen() {
+        let suggestions = KeyboardPreferences.typingSuggestionsEnabled
+        defer { KeyboardPreferences.typingSuggestionsEnabled = suggestions }
+        KeyboardPreferences.typingSuggestionsEnabled = true
+        let engine = TypingEngine(
+            learned: LearnedWordStore(containerURL: nil),
+            wordList: .empty
+        )
+        defer { engine.suspend() }
+
+        engine.insert("omw", document: DocumentSnapshot(before: "omw"))
+        #expect(engine.strip.autocorrection == nil)
+
+        engine.installLexicon([
+            TypingEngine.LexiconEntry(userInput: "omw", documentText: "On my way!"),
+        ])
+
+        #expect(engine.strip.autocorrection == "On my way!")
+    }
+
+    @Test func refreshedCustomVocabularyUpdatesTheWordAlreadyOnScreen() {
+        let suggestions = KeyboardPreferences.typingSuggestionsEnabled
+        defer { KeyboardPreferences.typingSuggestionsEnabled = suggestions }
+        KeyboardPreferences.typingSuggestionsEnabled = true
+        let engine = TypingEngine(
+            learned: LearnedWordStore(containerURL: nil),
+            wordList: .empty
+        )
+        defer { engine.suspend() }
+        engine.installCustomVocabulary("")
+
+        engine.insert("kani", document: DocumentSnapshot(before: "kani"))
+        #expect(!engine.strip.candidates.contains { $0.text == "Kanishk" })
+
+        engine.installCustomVocabulary("Kanishk")
+
+        #expect(engine.strip.candidates.contains { $0.text == "Kanishk" })
     }
 }


### PR DESCRIPTION
## Problem

The keyboard redesign put a 90 ms debounce in front of a `UITextChecker` call that can block the main actor for 50-135 ms, even though the same code records about 120 ms between brisk keystrokes. A regression test reproduced the result: typing `hell` at that cadence queried the checker for `h`, `he`, `hel`, and `hell`, placing the blocking work immediately before each next touch.

Debug device builds also enabled the frame monitor and per-touch trace unconditionally. That made normal on-device QA warmer and less representative. Separately, an asynchronously delivered UIKit lexicon and custom vocabulary edits made while the extension was suspended did not refresh the word already shown in the suggestion strip.

## Summary

- wait 250 ms of actual typing quiet before consulting the main-actor spell checker; bundled word-list candidates still update immediately
- make touch/frame tracing opt-in through Keyboard Lab, with an off default
- rebuild current candidates when UIKit delivers the supplementary lexicon
- reload custom vocabulary whenever the keyboard appears, including reused extension instances
- cover brisk typing, diagnostic defaults, late lexicon delivery, and suspended-instance vocabulary updates

## Verification

- [x] `just ios ci` — 789 tests in 76 suites passed
- [x] `just ios release-build`
- [ ] `just android ci` — N/A; no Android files changed
- [ ] Gateway changes — N/A; no gateway files changed
- [ ] Physical-device typing test — partial only: a personally signed Debug build installed and launched on an iPhone 14 Pro running iOS 26.6.2. Manual keyboard selection, Full Access, brisk typing, suggestion timing, and insertion still need a human pass.

The new brisk-typing regression test was also run against the old 90 ms debounce first and failed with checker calls for every prefix.

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet details added
- [x] No data-flow, permission, retention, or network behavior changed; documentation does not need an update
