### PR TITLE
feat(ios): add usage statistics page

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -314,6 +314,29 @@ abused. It is unrelated
 to the gateway bearer token, which is a real secret and lives in the iOS
 Keychain and the Android Keystore.
 
+## Usage statistics (iOS)
+
+Counters for the Stats screen in Settings: total words, total dictations, total
+recorded seconds, a current and best streak, and word totals for the last seven
+days.
+
+- **Counts, not words.** No transcript text and no audio is stored. A dictation
+  contributes a number, and the number cannot be turned back into what was said.
+- **Never leaves the device.** Nothing here is sent to a gateway, reported as
+  telemetry, or included in the diagnostics export.
+- **Written where the dictation lands.** The keyboard extension appends one
+  small file per inserted dictation to the App Group; the app folds those into a
+  summary when the Stats screen is opened.
+- **Outside transcript retention, deliberately.** The files live in `usage/`,
+  beside `sessions/` rather than inside it, so deleting your transcripts — or
+  running a 7- or 30-day retention setting — keeps your lifetime totals. The
+  reverse also holds: resetting statistics does not touch your transcripts.
+- **Reset at any time**, from the Stats screen. This deletes the summary and any
+  pending events permanently.
+
+Only dictations that were actually inserted are counted. A transcript that is
+produced and then abandoned never becomes a statistic.
+
 ## Diagnostics export
 
 The authenticated WebUI Settings tab and `uv run vocaphone-diagnostics` can export a

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		28F0EDCC20383E5A9FEB5B42 /* WordComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9859ACCB32CD57E4F3E4D46A /* WordComposerTests.swift */; };
 		2912856F09ED7566DB955AF9 /* InsertionTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A53786C8D2346452C69A748 /* InsertionTargetTests.swift */; };
 		29D15EC565FE20FEE4FFE469 /* TranscriptRetention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6FFEA14B55E6F6C61FBAC /* TranscriptRetention.swift */; };
+		2AC2C1F94BB0CA1A60AB3856 /* UsageStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A5908FB5C22FDA5C22F947 /* UsageStatsStore.swift */; };
 		2B102E6B9DACF6787D86C68F /* QuickDictationRecoveryOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B433665FF81481E6CD0E1612 /* QuickDictationRecoveryOffer.swift */; };
 		2C1B81951562FBD7FF87662D /* TelemetryRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27748467103CFAD3F6A2F603 /* TelemetryRecord.swift */; };
 		2C362C9B71AA6A93A6D7E4DB /* SessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */; };
@@ -94,6 +95,7 @@
 		3655C2E063B7C9B8F286057B /* FinishRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B19321866AE8083C78C2B7F /* FinishRecordingIntent.swift */; };
 		366E7DFAD5B2666FC1FF9FB3 /* SetupStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342F2B3B437269514C969C77 /* SetupStatus.swift */; };
 		36A5F07E79173A14F240A47F /* local_model_pins.json in Resources */ = {isa = PBXBuildFile; fileRef = DBAE2B11D3A27A798D0F39ED /* local_model_pins.json */; };
+		36A8B74F656E9B17D367775A /* StatsShare.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2978D103DB7CEA2D29A546C1 /* StatsShare.swift */; };
 		387B6B6A0B0AE57B6324B55F /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F5D76EB1E944F3A323006D /* SettingsView.swift */; };
 		3948B010FEE4F51B8CE2074D /* TranscriptStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DBF47C7F5E5B13752056CB /* TranscriptStyler.swift */; };
 		396330316A5B80A3884BE142 /* LocalTranscriptionPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FF1A5ABC4220C886291309 /* LocalTranscriptionPreferences.swift */; };
@@ -150,11 +152,13 @@
 		5A151959ABCE2ADE4646A79D /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
 		5ADC4420E2E23403BFC8716D /* TranscriptRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */; };
 		5C0F524206C9335BC0C4C672 /* KeyboardStatusPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549656C750D0C8EF3F25E17C /* KeyboardStatusPublication.swift */; };
+		5C2D54A0C5B68220689428DB /* UsageStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93CC576887F75BD471DDDF8 /* UsageStats.swift */; };
 		5C558BDC79705E089820562F /* KeyLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87128326897BFA30E7B2038 /* KeyLayout.swift */; };
 		5D5A394AA7E8170CFE4E128B /* RecordingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF871FC84B4C6B2627A43C2 /* RecordingCoordinator.swift */; };
 		5E7C819783E63C4FC95E706B /* TelemetryFailureMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D81AEA9FD59906139F273D /* TelemetryFailureMapping.swift */; };
 		5FB6858C38350EC77F45EB62 /* BrandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9711C18238B39EA2E842C0F /* BrandPalette.swift */; };
 		5FD3264678E78B2F180A074A /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11816AC1A2219D15E870CE3E /* EmojiCatalog.swift */; };
+		602CD8CB5A40F80A23E5A4A9 /* UsageStatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD307AE75D5946FD5D016476 /* UsageStatsTests.swift */; };
 		612E02043BE5C4F9567D128E /* SwipeAlternatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CF82ECCA1F28AB94B4142DE /* SwipeAlternatesTests.swift */; };
 		6192C923119F158CCE94B48E /* QuickDictationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB84927D76F9C32C4BE1547 /* QuickDictationAvailability.swift */; };
 		61D705F2D38349B0A9667F2E /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */; };
@@ -188,6 +192,7 @@
 		79D51827CA805EB6D890699C /* SherpaLongAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */; };
 		7AE5598954918484EE8BB6B9 /* KeyboardHandoffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E5F9C1D93EF4EFB2AF5EA7 /* KeyboardHandoffView.swift */; };
 		7B0D3581B262BEB5AC561C23 /* TelemetryStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D9836F52892447650F0375 /* TelemetryStats.swift */; };
+		7B3A332D21DDF3608528D1BB /* UsageStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A5908FB5C22FDA5C22F947 /* UsageStatsStore.swift */; };
 		7B571D68CCB37D4C3FCEE258 /* KeyboardStatusPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549656C750D0C8EF3F25E17C /* KeyboardStatusPublication.swift */; };
 		7C304FFA51BC372F267CC729 /* Snippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69943FB61027DEE31DA51705 /* Snippet.swift */; };
 		7E26A729562A6F474635AFEC /* TranscriptStylerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45A3914F898AD0570486806 /* TranscriptStylerTests.swift */; };
@@ -212,11 +217,13 @@
 		85207216B77DE9C92D5E0519 /* AppGroupEntitlementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49565018533AF6A394F9C24 /* AppGroupEntitlementTests.swift */; };
 		867671B90E038F77BE36A4E6 /* DarwinNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3498C523755A678225152570 /* DarwinNotifications.swift */; };
 		86B74F487C94F9DBD1E691C4 /* SpokenEmoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1DAD70952939C37DE50F0B /* SpokenEmoji.swift */; };
+		878ED4FE5F11E43F16D27E44 /* StatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E522B238D0F1A138634161D /* StatsView.swift */; };
 		883C67CC3B4BBDA22771637A /* KeyProximity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B90ACCDCBABF9F7412EE906 /* KeyProximity.swift */; };
 		89E3D47D85EBD6AD5A093813 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */; };
 		8A69E16ABEF642C3D68FADD5 /* TranscriptHistoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A89F2BEC08F07614372D84D /* TranscriptHistoryModel.swift */; };
 		8A90D2390C756F9101AB251A /* SpeechAudioConditioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */; };
 		8A9E2E39C1371D1C12913813 /* EmojiTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA1B6FDE1A86C551FFCD094 /* EmojiTable.swift */; };
+		8CBF8AE3B848D419F8D584C9 /* UsageStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93CC576887F75BD471DDDF8 /* UsageStats.swift */; };
 		8DD5E5E2B734765883552523 /* DictationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3489C985467C23EB6A90AD /* DictationBarView.swift */; };
 		8F8E3C14AAC6A4F1DF144AD3 /* OnboardingPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D34E7E54437AFA69FDC2848 /* OnboardingPresentation.swift */; };
 		8FADF6C970427AFDEDCB45C4 /* KeyboardStatusPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549656C750D0C8EF3F25E17C /* KeyboardStatusPublication.swift */; };
@@ -332,6 +339,8 @@
 		D32F9FCE7750E51A69E56F10 /* DesignSystemPreviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71760E0F5AF9B1965E960E1 /* DesignSystemPreviews.swift */; };
 		D347613BCA81EB9BF9AAC2DD /* TranscriptionSourceStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5995603DDA33014FFA52B079 /* TranscriptionSourceStatus.swift */; };
 		D37101A845F65CA081F8B6E4 /* ProtectedSpans.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57FC525B204634FF41CDCDA /* ProtectedSpans.swift */; };
+		D47251260790D2922EF01E27 /* UsageStatsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D08D8869CBFAAE1BC37EAC /* UsageStatsStoreTests.swift */; };
+		D4851F415D2B9D01E291FDFC /* UsageStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A5908FB5C22FDA5C22F947 /* UsageStatsStore.swift */; };
 		D4CA018F48AA244D322B9156 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F3A6E7B826D1389D462944 /* ContentView.swift */; };
 		D4FEC9D26550CB1696FDF424 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */; };
 		D6533E4D830A06E9845CE624 /* KeyboardViewPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8E5D91EDE2C0E67DFC0250 /* KeyboardViewPreview.swift */; };
@@ -372,6 +381,7 @@
 		E79DE8AFCE199DDF7A77F176 /* SpokenEmoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1DAD70952939C37DE50F0B /* SpokenEmoji.swift */; };
 		E9C82042A1155CC1E50BF2B6 /* StartDictationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A7126FEDA473D8C112A397 /* StartDictationIntent.swift */; };
 		E9E86F6940BDB4381A8C9FF5 /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C304CF763960E5F1D8F76B2B /* LiveActivityManager.swift */; };
+		EAD46E947414FAB6F95B61F1 /* UsageStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93CC576887F75BD471DDDF8 /* UsageStats.swift */; };
 		ED04BFBB1AB30BB6226D77B3 /* TranscriptRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */; };
 		EE7A49C4F95388AF42E1B30C /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
 		EF4B66CAC02A63D743384B49 /* DownloadReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF56F0E966D9AECA1DCFF65E /* DownloadReadiness.swift */; };
@@ -389,6 +399,7 @@
 		F3A845A38CC7840D2877FD26 /* KeyAlternatives.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0EBA8DE4056FCA3CB7F093C /* KeyAlternatives.swift */; };
 		F426CFBED733974D61FDB432 /* ModelLanguageSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41EF03C8A4F930315EFE77 /* ModelLanguageSupportTests.swift */; };
 		F43318EAC4CF26D8C46ECD19 /* FrameMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B973580E9433CC9EC9A76024 /* FrameMonitor.swift */; };
+		F4917037D6C4FCB243F7F7EA /* UsageStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A5908FB5C22FDA5C22F947 /* UsageStatsStore.swift */; };
 		F4E8B1A9D00B14184B01B223 /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
 		F50496BCCFCB73757D3DDF13 /* EmojiCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882F3122E12BD0F2BF44ADC9 /* EmojiCatalogTests.swift */; };
 		F5468739AA5410076BE0C5EF /* SpokenEmojiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6B7EB27436670B0B1EB1D1 /* SpokenEmojiTests.swift */; };
@@ -404,6 +415,7 @@
 		FCE1FDC346554C0EE93845F0 /* SherpaEmptyChunkRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF256CF6ED209E00193BF135 /* SherpaEmptyChunkRecovery.swift */; };
 		FD06CBDABE4EA9640EECF39C /* SherpaLongAudioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C2BEEA5195CB9CB5A38CA /* SherpaLongAudioTests.swift */; };
 		FDBB4DF9D4816CD646C1644D /* TypingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B9027C03A87FBC74CE1130 /* TypingEngine.swift */; };
+		FF7081607FBA7EFEC69C3560 /* UsageStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93CC576887F75BD471DDDF8 /* UsageStats.swift */; };
 		FF899AF5E59FAA55FDA261ED /* QuickDictationDuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783E7FC5F9553FD419487180 /* QuickDictationDuration.swift */; };
 /* End PBXBuildFile section */
 
@@ -466,9 +478,11 @@
 		22AA42EFADB6B77B0C9A5E44 /* UsageReportingCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageReportingCopy.swift; sourceTree = "<group>"; };
 		22D68C853A7603A9B3224B3C /* KeyboardStatusPublicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardStatusPublicationTests.swift; sourceTree = "<group>"; };
 		2678D836274997421A54E901 /* AudioCaptureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCaptureTests.swift; sourceTree = "<group>"; };
+		26D08D8869CBFAAE1BC37EAC /* UsageStatsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageStatsStoreTests.swift; sourceTree = "<group>"; };
 		2730948940D555163E520926 /* SnippetExpanderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetExpanderTests.swift; sourceTree = "<group>"; };
 		27748467103CFAD3F6A2F603 /* TelemetryRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryRecord.swift; sourceTree = "<group>"; };
 		28ECEDA044D2B1021710F205 /* TranscriptHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptHistoryView.swift; sourceTree = "<group>"; };
+		2978D103DB7CEA2D29A546C1 /* StatsShare.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsShare.swift; sourceTree = "<group>"; };
 		2D34E7E54437AFA69FDC2848 /* OnboardingPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPresentation.swift; sourceTree = "<group>"; };
 		2E6C1FB17BFD787FDDCBBF82 /* SherpaOnnxBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SherpaOnnxBridge.h; sourceTree = "<group>"; };
 		2FABAD2700D5F00046349B21 /* TouchWitness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchWitness.swift; sourceTree = "<group>"; };
@@ -511,6 +525,7 @@
 		5995603DDA33014FFA52B079 /* TranscriptionSourceStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSourceStatus.swift; sourceTree = "<group>"; };
 		5A89F2BEC08F07614372D84D /* TranscriptHistoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptHistoryModel.swift; sourceTree = "<group>"; };
 		5B19321866AE8083C78C2B7F /* FinishRecordingIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishRecordingIntent.swift; sourceTree = "<group>"; };
+		5E522B238D0F1A138634161D /* StatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsView.swift; sourceTree = "<group>"; };
 		5FA135DE504590121F6D8843 /* DiagnosticLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticLog.swift; sourceTree = "<group>"; };
 		5FC91810C8F97443ECEF7FD1 /* VocaPhoneApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = VocaPhoneApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		629821E8C5C22C9824A13665 /* LocalModelIntegrity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelIntegrity.swift; sourceTree = "<group>"; };
@@ -608,7 +623,9 @@
 		C45D98EAFE18C689DC7551E9 /* LanguageMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageMenuTests.swift; sourceTree = "<group>"; };
 		C7842B22D05FB171B261101A /* DictationBarStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarStyle.swift; sourceTree = "<group>"; };
 		C8E491E7E805F47388A668E1 /* TranscriptSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSanitizerTests.swift; sourceTree = "<group>"; };
+		C93CC576887F75BD471DDDF8 /* UsageStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageStats.swift; sourceTree = "<group>"; };
 		CA4CAEF7B3212512BACDE655 /* TelemetryConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryConfig.swift; sourceTree = "<group>"; };
+		CD307AE75D5946FD5D016476 /* UsageStatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageStatsTests.swift; sourceTree = "<group>"; };
 		CDA1F0347FCF246193F6CF96 /* ModelTranslationSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTranslationSupportTests.swift; sourceTree = "<group>"; };
 		CDBE3CB8FFE4DDA7B459C2A7 /* TypingFieldPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingFieldPolicyTests.swift; sourceTree = "<group>"; };
 		CDCC7453FC149EBB02E3FB58 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
@@ -621,6 +638,7 @@
 		D57FC525B204634FF41CDCDA /* ProtectedSpans.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectedSpans.swift; sourceTree = "<group>"; };
 		D80C83295868E17F215D9382 /* TypingStripPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingStripPresentationTests.swift; sourceTree = "<group>"; };
 		D97C6225AC98D4FE053BDB13 /* KeyboardPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPreview.swift; sourceTree = "<group>"; };
+		D9A5908FB5C22FDA5C22F947 /* UsageStatsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageStatsStore.swift; sourceTree = "<group>"; };
 		DBAE2B11D3A27A798D0F39ED /* local_model_pins.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = local_model_pins.json; sourceTree = "<group>"; };
 		DBFB4BB0345784837C629340 /* PairingPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingPayload.swift; sourceTree = "<group>"; };
 		DC98427A2C06BE9FD63CACF1 /* en-bigrams.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "en-bigrams.txt"; sourceTree = "<group>"; };
@@ -799,6 +817,8 @@
 				56B6FFEA14B55E6F6C61FBAC /* TranscriptRetention.swift */,
 				B121356A503DF83BFA0E0D0C /* TranscriptSanitizer.swift */,
 				F0DBF47C7F5E5B13752056CB /* TranscriptStyler.swift */,
+				C93CC576887F75BD471DDDF8 /* UsageStats.swift */,
+				D9A5908FB5C22FDA5C22F947 /* UsageStatsStore.swift */,
 			);
 			path = VocaPhoneShared;
 			sourceTree = "<group>";
@@ -954,6 +974,8 @@
 				05735C847A47FF442B4FB21A /* TypingPrivacyTests.swift */,
 				D80C83295868E17F215D9382 /* TypingStripPresentationTests.swift */,
 				867A5BD6049E4D6788DB704C /* TypingWordListTests.swift */,
+				26D08D8869CBFAAE1BC37EAC /* UsageStatsStoreTests.swift */,
+				CD307AE75D5946FD5D016476 /* UsageStatsTests.swift */,
 				9859ACCB32CD57E4F3E4D46A /* WordComposerTests.swift */,
 			);
 			path = VocaPhoneTests;
@@ -995,6 +1017,8 @@
 				342F2B3B437269514C969C77 /* SetupStatus.swift */,
 				346B6558EE5557A35C916067 /* SetupView.swift */,
 				55A7126FEDA473D8C112A397 /* StartDictationIntent.swift */,
+				2978D103DB7CEA2D29A546C1 /* StatsShare.swift */,
+				5E522B238D0F1A138634161D /* StatsView.swift */,
 				0BAEF22ED143D3569B005C88 /* SwipeBackCoach.swift */,
 				5A89F2BEC08F07614372D84D /* TranscriptHistoryModel.swift */,
 				28ECEDA044D2B1021710F205 /* TranscriptHistoryView.swift */,
@@ -1265,6 +1289,8 @@
 				81BFE90A24876CEE127974AE /* TypingFieldPolicy.swift in Sources */,
 				D7038E651848C4EE6B0F722A /* TypingStripView.swift in Sources */,
 				E0450895D68708027C1BC77E /* TypingWordList.swift in Sources */,
+				5C2D54A0C5B68220689428DB /* UsageStats.swift in Sources */,
+				7B3A332D21DDF3608528D1BB /* UsageStatsStore.swift in Sources */,
 				D8EE8A829E13191046F3F183 /* WordComposer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1355,6 +1381,8 @@
 				86B74F487C94F9DBD1E691C4 /* SpokenEmoji.swift in Sources */,
 				9C3766171C286926385A9F1E /* SpokenNumbers.swift in Sources */,
 				E9C82042A1155CC1E50BF2B6 /* StartDictationIntent.swift in Sources */,
+				36A8B74F656E9B17D367775A /* StatsShare.swift in Sources */,
+				878ED4FE5F11E43F16D27E44 /* StatsView.swift in Sources */,
 				108C096B9C0FB4861FC26437 /* StopQuickDictationIntent.swift in Sources */,
 				A7216F1D388DBC1B95658666 /* SwipeBackCoach.swift in Sources */,
 				AD2CCDE7DC189E63810890BB /* SwipeRecognizer.swift in Sources */,
@@ -1383,6 +1411,8 @@
 				BA66A26AC92DB96524E13AF5 /* TypingWordList.swift in Sources */,
 				E6FDBF8529AEB00D2CFB245E /* UsageReportingCopy.swift in Sources */,
 				A86F678EFECCEA8BA246778C /* UsageReportingViews.swift in Sources */,
+				EAD46E947414FAB6F95B61F1 /* UsageStats.swift in Sources */,
+				F4917037D6C4FCB243F7F7EA /* UsageStatsStore.swift in Sources */,
 				E2C8F215E536CABB80623B3A /* VocaPhoneActivityAttributes.swift in Sources */,
 				4F24DEC1FC8411ACBDA6BC50 /* VocaPhoneApp.swift in Sources */,
 				7280B936E153A21AC6D75B27 /* WordComposer.swift in Sources */,
@@ -1436,6 +1466,8 @@
 				3D08A881E95118E5B57E9FCD /* TranscriptSanitizer.swift in Sources */,
 				95A08342703AE27BD09E08AC /* TranscriptStyler.swift in Sources */,
 				1935C96899E2437477303714 /* TranscriptionQuality.swift in Sources */,
+				FF7081607FBA7EFEC69C3560 /* UsageStats.swift in Sources */,
+				D4851F415D2B9D01E291FDFC /* UsageStatsStore.swift in Sources */,
 				07D7CA474CBB8812C0E83D1C /* VocaPhoneActivityAttributes.swift in Sources */,
 				A79BA8A795F60838D96EDFAA /* VocaPhoneLiveActivity.swift in Sources */,
 			);
@@ -1590,6 +1622,10 @@
 				E5595FE143CBC103B6DAE2C8 /* TypingWordList.swift in Sources */,
 				BAEC1D5BFECB17B9B28BD780 /* TypingWordListTests.swift in Sources */,
 				1301ECD8CCADCC436412B07A /* UsageReportingCopy.swift in Sources */,
+				8CBF8AE3B848D419F8D584C9 /* UsageStats.swift in Sources */,
+				2AC2C1F94BB0CA1A60AB3856 /* UsageStatsStore.swift in Sources */,
+				D47251260790D2922EF01E27 /* UsageStatsStoreTests.swift in Sources */,
+				602CD8CB5A40F80A23E5A4A9 /* UsageStatsTests.swift in Sources */,
 				114481F43D07358C285C76C3 /* WordComposer.swift in Sources */,
 				28F0EDCC20383E5A9FEB5B42 /* WordComposerTests.swift in Sources */,
 			);

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -31,6 +31,9 @@ struct SettingsView: View {
         SnippetStore.key,
         store: SnippetStore.defaults
     ) private var snippetsData = Data()
+    /// Read once when the hub appears rather than folded here: folding is the
+    /// app's job, and the Stats screen is where it happens.
+    @State private var usageStats = UsageStats()
 
     var body: some View {
         List {
@@ -46,6 +49,12 @@ struct SettingsView: View {
                     detail: language.displayName + " · " + writingStyle.displayName,
                     symbol: "mic"
                 ) { DictationSettingsView() }
+
+                destination(
+                    "Stats",
+                    detail: StatsCopy.menuDetail(usageStats, now: Date()),
+                    symbol: "chart.bar"
+                ) { StatsView() }
 
                 destination(
                     "Snippets",
@@ -87,6 +96,7 @@ struct SettingsView: View {
         }
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
+        .task { usageStats = UsageStatsStore.shared.current() }
     }
 
     private var keyboardHeight: KeyboardHeightPreference {

--- a/ios/VocaPhoneApp/App/StatsShare.swift
+++ b/ios/VocaPhoneApp/App/StatsShare.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+import UIKit
+
+enum StatsShareDestination: CaseIterable {
+    case x
+    case linkedIn
+
+    var label: String {
+        switch self {
+        case .x: "X"
+        case .linkedIn: "LinkedIn"
+        }
+    }
+}
+
+enum StatsShareComposer {
+    static let site = "https://vocaphone.vocahq.com"
+
+    static func message(_ stats: UsageStats, now: Date) -> String {
+        var lines = "🎤 I've dictated \(StatsFormat.count(stats.totalWords)) "
+        lines += stats.totalWords == 1 ? "word" : "words"
+        lines += " with VocaPhone.\n\n"
+        lines += "📊 \(StatsFormat.count(stats.totalDictations)) "
+        lines += stats.totalDictations == 1 ? "dictation" : "dictations"
+        if stats.averageWordsPerMinute > 0 {
+            lines += " · ⚡️ \(Int(stats.averageWordsPerMinute.rounded())) WPM"
+        }
+        let streak = stats.currentStreak(at: now)
+        if streak > 0 {
+            lines += " · 🔥 \(streak)-day streak"
+        }
+        lines += "\n\nRuns on my phone, privately. 🔒\n\(site)"
+        return lines
+    }
+
+    static func composerURL(_ destination: StatsShareDestination, message: String) -> URL? {
+        let encoded = message.addingPercentEncoding(
+            withAllowedCharacters: .alphanumerics
+        ) ?? ""
+        switch destination {
+        case .x:
+            return URL(string: "https://x.com/intent/post?text=\(encoded)")
+        case .linkedIn:
+            return URL(string: "https://www.linkedin.com/feed/?shareActive=true&text=\(encoded)")
+        }
+    }
+}
+
+struct StatsShareCard: View {
+    let stats: UsageStats
+    let now: Date
+
+    static let size = CGSize(width: 1_080, height: 720)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 36) {
+            Text("VOCAPHONE")
+                .font(.system(size: 30, weight: .semibold, design: .rounded))
+                .tracking(6)
+                .foregroundStyle(Color.brand)
+
+            Text(StatsFormat.count(stats.totalWords))
+                .font(.system(size: 190, weight: .bold, design: .rounded))
+                .foregroundStyle(Color.vocaPrimaryText)
+
+            Text(stats.totalWords == 1 ? "word dictated" : "words dictated")
+                .font(.system(size: 44, weight: .medium))
+                .foregroundStyle(Color.vocaSecondaryText)
+
+            Spacer(minLength: 0)
+
+            HStack(spacing: 56) {
+                cardStat(StatsFormat.count(stats.totalDictations), "dictations")
+                cardStat(StatsFormat.wordsPerMinute(stats.averageWordsPerMinute), "WPM")
+                cardStat(StatsFormat.count(stats.currentStreak(at: now)), "day streak")
+            }
+        }
+        .padding(72)
+        .frame(width: Self.size.width, height: Self.size.height, alignment: .leading)
+        .background(Color.vocaCanvas)
+    }
+
+    private func cardStat(_ value: String, _ label: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(value)
+                .font(.system(size: 58, weight: .semibold, design: .rounded))
+                .foregroundStyle(Color.vocaPrimaryText)
+            Text(label)
+                .font(.system(size: 30))
+                .foregroundStyle(Color.vocaSecondaryText)
+        }
+    }
+}
+
+@MainActor
+enum StatsShareExporter {
+    
+    static func renderCard(_ stats: UsageStats, now: Date, style: UIUserInterfaceStyle) -> UIImage? {
+        let renderer = ImageRenderer(content: StatsShareCard(stats: stats, now: now))
+        renderer.scale = 1
+        renderer.proposedSize = ProposedViewSize(StatsShareCard.size)
+        
+        var image: UIImage?
+        UITraitCollection(userInterfaceStyle: style).performAsCurrent {
+            image = renderer.uiImage
+        }
+        return image
+    }
+
+    @discardableResult
+    static func copyCard(_ stats: UsageStats, now: Date, style: UIUserInterfaceStyle) -> Bool {
+        guard let image = renderCard(stats, now: now, style: style) else { return false }
+        UIPasteboard.general.image = image
+        return true
+    }
+}

--- a/ios/VocaPhoneApp/App/StatsView.swift
+++ b/ios/VocaPhoneApp/App/StatsView.swift
@@ -1,0 +1,377 @@
+import SwiftUI
+
+enum StatsCopy {
+    static let empty = "Your dictation totals will appear here after your first dictation."
+    static let resetTitle = "Reset statistics?"
+    static let resetBody =
+        "This permanently deletes your usage totals. Your transcripts are not affected."
+    static let resetConfirm = "Reset"
+    static let speedCaption = "Speaking Speed"
+    static let shareTitle = "Share your progress"
+    static let shareSubtitle = "A polished card, ready to post"
+    static let shareFootnote = "The card is copied to your clipboard — paste it into your post."
+    static let shareCopied = "Card copied"
+
+    static func menuDetail(_ stats: UsageStats, now: Date) -> String {
+        guard stats.hasAny else { return "Words, speaking speed and streaks" }
+        let streak = stats.currentStreak(at: now)
+        return "\(StatsFormat.count(stats.totalWords)) words · \(StatsFormat.streak(streak)) streak"
+    }
+}
+
+enum StatsFormat {
+    static func count(_ value: Int) -> String {
+        value.formatted(.number.grouping(.automatic))
+    }
+
+    static func duration(_ seconds: Double) -> String {
+        let total = Int(seconds.rounded())
+        if total < 60 { return "\(total)s" }
+        if total < 3_600 { return "\(total / 60)m" }
+        let hours = total / 3_600
+        let minutes = (total % 3_600) / 60
+        return minutes == 0 ? "\(hours)h" : "\(hours)h \(minutes)m"
+    }
+
+    static func wordsPerMinute(_ value: Double) -> String {
+        String(format: "%.1f", value)
+    }
+
+    static func streak(_ days: Int) -> String {
+        "\(days) \(days == 1 ? "day" : "days")"
+    }
+
+    static func words(_ count: Int) -> String {
+        "\(Self.count(count)) \(count == 1 ? "word" : "words")"
+    }
+
+    static func dayLabel(_ key: String, now: Date, timeZone: TimeZone = .current) -> String {
+        let today = UsageStats.dayKey(now, timeZone: timeZone)
+        guard let elapsed = UsageStats.daysBetween(key, today) else { return key }
+        switch elapsed {
+        case 0: return "Today"
+        case 1: return "Yesterday"
+        default: return key
+        }
+    }
+}
+
+struct StatsView: View {
+    @State private var stats = UsageStats()
+    @State private var now = Date()
+    @State private var confirmingReset = false
+    @State private var copiedCard = false
+    @Environment(\.openURL) private var openURL
+    @Environment(\.colorScheme) private var colorScheme
+
+    private let store = UsageStatsStore.shared
+
+    var body: some View {
+        ScrollView {
+            if stats.hasAny {
+                content
+            } else {
+                Text(StatsCopy.empty)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(VocaMetrics.padding)
+            }
+        }
+        .navigationTitle("Stats")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { refresh(folding: true) }
+
+        .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
+            refresh(folding: false)
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: UIApplication.significantTimeChangeNotification)
+        ) { _ in
+            refresh(folding: false)
+        }
+        .confirmationDialog(
+            StatsCopy.resetTitle,
+            isPresented: $confirmingReset,
+            titleVisibility: .visible
+        ) {
+            Button(StatsCopy.resetConfirm, role: .destructive) { reset() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(StatsCopy.resetBody)
+        }
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: VocaMetrics.padding) {
+            speedCard
+            statGrid
+            recentActivityCard
+            shareCard
+
+            VocaDestructiveButton(title: "Reset statistics") { confirmingReset = true }
+                .frame(maxWidth: .infinity)
+                .padding(.top, VocaMetrics.related)
+        }
+        .padding(VocaMetrics.padding)
+    }
+
+
+    private var speedCard: some View {
+        VocaCard {
+            VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                StatChipLabel(symbol: "chart.line.uptrend.xyaxis", tint: .speed, title: "Speed")
+                HStack(alignment: .firstTextBaseline, spacing: VocaMetrics.tight) {
+                    Text(StatsFormat.wordsPerMinute(stats.averageWordsPerMinute))
+                        .font(.system(.largeTitle, design: .rounded).weight(.bold))
+                        .foregroundStyle(Color.vocaPrimaryText)
+                    Text("WPM")
+                        .font(.subheadline)
+                        .foregroundStyle(Color.vocaSecondaryText)
+                }
+                Text(StatsCopy.speedCaption)
+                    .font(.caption)
+                    .foregroundStyle(Color.vocaSecondaryText)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(
+                "Speaking speed, \(StatsFormat.wordsPerMinute(stats.averageWordsPerMinute)) words per minute"
+            )
+        }
+    }
+
+    private var statGrid: some View {
+        Grid(horizontalSpacing: VocaMetrics.padding, verticalSpacing: VocaMetrics.padding) {
+            GridRow {
+                statCard("text.alignleft", .words, StatsFormat.count(stats.totalWords), "Words")
+                statCard("mic.fill", .dictations, StatsFormat.count(stats.totalDictations), "Dictations")
+            }
+            GridRow {
+                statCard("clock", .time, StatsFormat.duration(stats.totalSeconds), "Time")
+                streakCard
+            }
+        }
+    }
+
+    private func statCard(
+        _ symbol: String,
+        _ tint: SemanticPalette.StatTint,
+        _ value: String,
+        _ label: String
+    ) -> some View {
+        VocaCard {
+            VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                StatChip(symbol: symbol, tint: tint)
+                Text(value)
+                    .font(.system(.title, design: .rounded).weight(.bold))
+                    .foregroundStyle(Color.vocaPrimaryText)
+                Text(label)
+                    .font(.caption)
+                    .foregroundStyle(Color.vocaSecondaryText)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(label), \(value)")
+        }
+    }
+
+    private var streakCard: some View {
+        let streak = stats.currentStreak(at: now)
+        return VocaCard {
+            VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                StatChip(symbol: "flame.fill", tint: .streak)
+                HStack(alignment: .firstTextBaseline, spacing: VocaMetrics.tight) {
+                    Text(StatsFormat.count(streak))
+                        .font(.system(.title, design: .rounded).weight(.bold))
+                        .foregroundStyle(Color.vocaPrimaryText)
+                    Text(streak == 1 ? "day" : "days")
+                        .font(.subheadline)
+                        .foregroundStyle(Color.vocaSecondaryText)
+                }
+                Text("Streak · Best \(StatsFormat.streak(stats.bestStreak))")
+                    .font(.caption)
+                    .foregroundStyle(Color.vocaSecondaryText)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(
+                "Streak, \(StatsFormat.streak(streak)). Best \(StatsFormat.streak(stats.bestStreak))"
+            )
+        }
+    }
+
+    private var recentActivityCard: some View {
+        let days = stats.recentDays()
+        return Group {
+            if days.isEmpty {
+                EmptyView()
+            } else {
+                VocaCard {
+                    VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                        StatChipLabel(
+                            symbol: "chart.line.uptrend.xyaxis",
+                            tint: .speed,
+                            title: "Recent activity"
+                        )
+                        ForEach(days, id: \.key) { day in
+                            LabeledContent {
+                                Text(StatsFormat.words(day.words))
+                                    .font(.subheadline)
+                                    .foregroundStyle(Color.vocaSecondaryText)
+                            } label: {
+                                Text(StatsFormat.dayLabel(day.key, now: now))
+                                    .font(.subheadline.weight(.medium))
+                                    .foregroundStyle(Color.vocaPrimaryText)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var shareCard: some View {
+        VocaCard {
+            VStack(alignment: .leading, spacing: VocaMetrics.padding) {
+                HStack(alignment: .top, spacing: VocaMetrics.related) {
+                    StatChip(symbol: "doc.on.clipboard", tint: .words)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(StatsCopy.shareTitle)
+                            .font(.headline)
+                            .foregroundStyle(Color.vocaPrimaryText)
+                        Text(StatsCopy.shareSubtitle)
+                            .font(.caption)
+                            .foregroundStyle(Color.vocaSecondaryText)
+                    }
+                }
+
+                HStack(spacing: VocaMetrics.related) {
+                    ShareButton(
+                        tint: Color.brand,
+                        label: copiedCard ? StatsCopy.shareCopied : "Copy"
+                    ) {
+                        Image(systemName: copiedCard ? "checkmark" : "doc.on.clipboard")
+                    } action: {
+                        copyCard()
+                    }
+
+                    ShareButton(tint: Color.vocaPrimaryText, label: "X") {
+                        Text("\u{1D54F}").font(.title3)
+                    } action: {
+                        share(to: .x)
+                    }
+
+                    ShareButton(tint: Self.linkedInBlue, label: "LinkedIn") {
+                        Text("in")
+                            .font(.subheadline.weight(.bold))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Self.linkedInBlue, in: RoundedRectangle(cornerRadius: 3))
+                    } action: {
+                        share(to: .linkedIn)
+                    }
+                }
+
+                Text(StatsCopy.shareFootnote)
+                    .font(.caption2)
+                    .foregroundStyle(Color.vocaSecondaryText)
+            }
+        }
+    }
+
+    private static let linkedInBlue = Color(red: 0.04, green: 0.40, blue: 0.71)
+
+    private func copyCard() {
+        StatsShareExporter.copyCard(stats, now: now, style: interfaceStyle)
+        withAnimation { copiedCard = true }
+    }
+
+    private func share(to destination: StatsShareDestination) {
+        StatsShareExporter.copyCard(stats, now: now, style: interfaceStyle)
+        let message = StatsShareComposer.message(stats, now: now)
+        guard let url = StatsShareComposer.composerURL(destination, message: message) else { return }
+        openURL(url)
+    }
+
+    private var interfaceStyle: UIUserInterfaceStyle {
+        colorScheme == .dark ? .dark : .light
+    }
+
+    private func refresh(folding: Bool) {
+        now = Date()
+        if folding, let folded = try? store.fold() {
+            stats = folded
+        } else {
+            stats = store.current()
+        }
+    }
+
+    private func reset() {
+        try? store.reset()
+        refresh(folding: false)
+    }
+}
+
+struct StatChip: View {
+    let symbol: String
+    let tint: SemanticPalette.StatTint
+    var size: CGFloat = 30
+
+    var body: some View {
+        Image(systemName: symbol)
+            .font(.system(size: size * 0.5, weight: .medium))
+            .foregroundStyle(Color.vocaStatSymbol(tint))
+            .frame(width: size, height: size)
+            .background(
+                Color.vocaStatChip(tint),
+                in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+            )
+            .accessibilityHidden(true)
+    }
+}
+
+struct StatChipLabel: View {
+    let symbol: String
+    let tint: SemanticPalette.StatTint
+    let title: String
+
+    var body: some View {
+        HStack(spacing: VocaMetrics.related) {
+            StatChip(symbol: symbol, tint: tint, size: 26)
+            Text(title)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(Color.vocaSecondaryText)
+        }
+    }
+}
+
+struct ShareButton<Mark: View>: View {
+    let tint: Color
+    let label: String
+    @ViewBuilder var mark: Mark
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: VocaMetrics.tight) {
+                mark
+                Text(label)
+                    .font(.caption.weight(.medium))
+            }
+            .frame(maxWidth: .infinity)
+            .frame(minHeight: VocaMetrics.minimumTarget + 12)
+            .foregroundStyle(tint)
+            .background(
+                tint.opacity(0.08),
+                in: RoundedRectangle(cornerRadius: VocaMetrics.fieldRadius, style: .continuous)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VocaMetrics.fieldRadius, style: .continuous)
+                    .strokeBorder(tint.opacity(0.25), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Share to \(label)")
+    }
+}

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -986,6 +986,8 @@ final class RecordingCoordinator {
         // session claimed by an older build carries no route at all — either way
         // this is where the record stops being able to mislead.
         record.processingLocation = Self.selectedProcessingLocation()
+
+        record.recordedSeconds = lastRecordingDuration
         captureClaimedTranscriptionSettings()
         try? store.save(record)
 

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -1012,11 +1012,12 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             try store.save(record)
             try record.transition(to: .completed)
             try store.save(record)
-            // A keyboard-started dictation inside vocaphone's own field is the
-            // one onboarding exercise that proves the whole loop: Dictate,
-            // record, transcribe and direct insertion. Do not set this for
-            // keyboard sessions started in another app or for the app's
-            // diagnostic microphone test.
+
+            try? UsageStatsStore.shared.record(
+                transcript: transcript,
+                seconds: record.recordedSeconds
+            )
+            
             if record.startedInContainingApp == true, record.sourceDocumentID != "in-app-test" {
                 KeyboardPreferences.hasCompletedKeyboardPractice = true
             }

--- a/ios/VocaPhoneShared/SemanticPalette.swift
+++ b/ios/VocaPhoneShared/SemanticPalette.swift
@@ -117,6 +117,70 @@ enum SemanticPalette {
         UIColor { traits in value(role, isDark: traits.userInterfaceStyle == .dark) }
     }
 
+    enum StatTint: CaseIterable {
+        case speed
+        case words
+        case dictations
+        case time
+        case streak
+    }
+
+    static func statChip(_ tint: StatTint) -> UIColor {
+        UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? darkChip(tint)
+                : lightChip(tint)
+        }
+    }
+
+    static func statSymbol(_ tint: StatTint) -> UIColor {
+        UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? darkSymbol(tint)
+                : lightSymbol(tint)
+        }
+    }
+
+    private static func lightChip(_ tint: StatTint) -> UIColor {
+        switch tint {
+        case .speed: hex(0xE1_F0_E7)
+        case .words: hex(0xDD_EF_EA)
+        case .dictations: hex(0xE0_E8_F7)
+        case .time: hex(0xE8_E3_F5)
+        case .streak: hex(0xFA_E4_DE)
+        }
+    }
+
+    private static func lightSymbol(_ tint: StatTint) -> UIColor {
+        switch tint {
+        case .speed: hex(0x2C_7A_55)
+        case .words: hex(0x1D_78_6A)
+        case .dictations: hex(0x39_60_A6)
+        case .time: hex(0x5D_49_A6)
+        case .streak: hex(0xC2_53_3A)
+        }
+    }
+
+    private static func darkChip(_ tint: StatTint) -> UIColor {
+        switch tint {
+        case .speed: hex(0x1C_38_2A)
+        case .words: hex(0x15_34_2D)
+        case .dictations: hex(0x1A_29_43)
+        case .time: hex(0x28_23_43)
+        case .streak: hex(0x3C_24_1E)
+        }
+    }
+
+    private static func darkSymbol(_ tint: StatTint) -> UIColor {
+        switch tint {
+        case .speed: hex(0x7F_D8_A6)
+        case .words: hex(0x5F_D3_BE)
+        case .dictations: hex(0x8F_B4_F0)
+        case .time: hex(0xB3_A3_F0)
+        case .streak: hex(0xF0_A1_8A)
+        }
+    }
+
     private static func hex(_ value: UInt32) -> UIColor {
         UIColor(
             red: CGFloat((value >> 16) & 0xFF) / 255,
@@ -143,6 +207,14 @@ extension Color {
     static let vocaWarning = Color(SemanticPalette.color(.warning))
     static let vocaError = Color(SemanticPalette.color(.error))
     static let vocaDisabled = Color(SemanticPalette.color(.disabled))
+
+    static func vocaStatChip(_ tint: SemanticPalette.StatTint) -> Color {
+        Color(SemanticPalette.statChip(tint))
+    }
+
+    static func vocaStatSymbol(_ tint: SemanticPalette.StatTint) -> Color {
+        Color(SemanticPalette.statSymbol(tint))
+    }
 }
 
 // MARK: - Contrast

--- a/ios/VocaPhoneShared/SessionRecord.swift
+++ b/ios/VocaPhoneShared/SessionRecord.swift
@@ -127,6 +127,8 @@ struct SessionRecord: Codable, Equatable, Identifiable, Sendable {
     /// ``SessionProcessingLocation``.
     var processingLocation: SessionProcessingLocation?
 
+    var recordedSeconds: Double?
+
     init(
         sessionID: UUID = UUID(),
         state: SessionState = .idle,
@@ -150,6 +152,7 @@ struct SessionRecord: Codable, Equatable, Identifiable, Sendable {
         prefersQuickDictation = nil
         claimedAt = nil
         processingLocation = nil
+        recordedSeconds = nil
     }
 
     mutating func transition(to next: SessionState, now: Date = Date()) throws {

--- a/ios/VocaPhoneShared/SharedStore.swift
+++ b/ios/VocaPhoneShared/SharedStore.swift
@@ -300,7 +300,7 @@ final class SharedStore: @unchecked Sendable {
         try rootDirectory().appendingPathComponent("sessions", isDirectory: true)
     }
 
-    private func rootDirectory() throws -> URL {
+    func rootDirectory() throws -> URL {
         if let rootOverride { return rootOverride }
         guard let groupURL = fileManager.containerURL(
             forSecurityApplicationGroupIdentifier: AppConfiguration.appGroupIdentifier

--- a/ios/VocaPhoneShared/UsageStats.swift
+++ b/ios/VocaPhoneShared/UsageStats.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+struct UsageStats: Codable, Equatable, Sendable {
+    var totalWords: Int = 0
+    var totalDictations: Int = 0
+    var totalSeconds: Double = 0
+    var lastDayKey: String = ""
+    var currentStreak: Int = 0
+    var bestStreak: Int = 0
+    var dailyWords: [String: Int] = [:]
+
+    static let dailyLimit = 7
+
+    var hasAny: Bool { totalDictations > 0 }
+
+    var averageWordsPerMinute: Double {
+        guard totalSeconds > 0 else { return 0 }
+        return Double(totalWords) / (totalSeconds / 60)
+    }
+
+    func currentStreak(at now: Date, timeZone: TimeZone = .current) -> Int {
+        guard !lastDayKey.isEmpty else { return 0 }
+        guard let elapsed = Self.daysBetween(lastDayKey, Self.dayKey(now, timeZone: timeZone)) else {
+            return 0
+        }
+        if Self.isUnreconcilableFuture(elapsed) { return 0 }
+        return elapsed <= 1 ? currentStreak : 0
+    }
+
+    func recording(dayKey key: String, words: Int, seconds: Double) -> UsageStats {
+        guard words > 0 else { return self }
+        var next = self
+        next.totalWords += words
+        next.totalDictations += 1
+        next.totalSeconds += max(seconds, 0)
+        var daily = dailyWords
+        daily[key, default: 0] += words
+        next.dailyWords = Self.pruneDaily(daily)
+        let streak = Self.advanceStreak(currentStreak, lastDayKey: lastDayKey, todayKey: key)
+        next.currentStreak = streak
+        next.bestStreak = max(bestStreak, streak)
+        next.lastDayKey = Self.nextDayKey(lastDayKey, todayKey: key)
+        return next
+    }
+
+    private static func gregorian(_ timeZone: TimeZone) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        return calendar
+    }
+
+    static func dayKey(_ date: Date, timeZone: TimeZone = .current) -> String {
+        let parts = gregorian(timeZone).dateComponents([.year, .month, .day], from: date)
+        return String(
+            format: "%04d-%02d-%02d",
+            parts.year ?? 0,
+            parts.month ?? 0,
+            parts.day ?? 0
+        )
+    }
+
+    static func daysBetween(_ fromKey: String, _ toKey: String) -> Int? {
+        guard let from = epochDay(fromKey), let to = epochDay(toKey) else { return nil }
+        return to - from
+    }
+
+    static func isDayKey(_ value: String) -> Bool { epochDay(value) != nil }
+
+    private static func epochDay(_ key: String) -> Int? {
+        let parts = key.split(separator: "-", omittingEmptySubsequences: false)
+        guard key.count == 10, parts.count == 3,
+              let year = Int(parts[0]), let month = Int(parts[1]), let day = Int(parts[2]),
+              parts[0].count == 4, parts[1].count == 2, parts[2].count == 2
+        else { return nil }
+        let calendar = gregorian(TimeZone(secondsFromGMT: 0) ?? .current)
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        guard let date = calendar.date(from: components) else { return nil }
+        let back = calendar.dateComponents([.year, .month, .day], from: date)
+        guard back.year == year, back.month == month, back.day == day else { return nil }
+        return Int((date.timeIntervalSince1970 / 86_400).rounded(.down))
+    }
+
+    static func advanceStreak(_ current: Int, lastDayKey: String, todayKey: String) -> Int {
+        guard !lastDayKey.isEmpty else { return 1 }
+        guard let elapsed = daysBetween(lastDayKey, todayKey) else { return 1 }
+        if isUnreconcilableFuture(elapsed) { return 1 }
+        if elapsed <= 0 { return max(current, 1) }
+        if elapsed == 1 { return max(current, 0) + 1 }
+        return 1
+    }
+
+    static func nextDayKey(_ stored: String, todayKey: String) -> String {
+        guard isDayKey(stored) else { return todayKey }
+        if let elapsed = daysBetween(stored, todayKey), isUnreconcilableFuture(elapsed) {
+            return todayKey
+        }
+        return max(stored, todayKey)
+    }
+
+    private static func isUnreconcilableFuture(_ elapsed: Int) -> Bool {
+        elapsed < -dailyLimit
+    }
+
+    static func pruneDaily(_ daily: [String: Int]) -> [String: Int] {
+        guard daily.count > dailyLimit else { return daily }
+        let ranked = daily.keys.sorted { left, right in
+            let leftReadable = isDayKey(left)
+            let rightReadable = isDayKey(right)
+            if leftReadable != rightReadable { return leftReadable }
+            return left > right
+        }
+        return Dictionary(uniqueKeysWithValues: ranked.prefix(dailyLimit).map { ($0, daily[$0] ?? 0) })
+    }
+
+    func recentDays(limit: Int = dailyLimit) -> [(key: String, words: Int)] {
+        dailyWords
+            .filter { Self.isDayKey($0.key) }
+            .sorted { $0.key > $1.key }
+            .prefix(limit)
+            .map { (key: $0.key, words: $0.value) }
+    }
+
+    static func wordCount(_ text: String) -> Int {
+        var count = 0
+        text.enumerateSubstrings(
+            in: text.startIndex..<text.endIndex,
+            options: [.byWords, .localized]
+        ) { _, _, _, _ in
+            count += 1
+        }
+        return count
+    }
+
+    static func nextDayStart(after date: Date, timeZone: TimeZone = .current) -> Date {
+        let calendar = gregorian(timeZone)
+        let today = calendar.startOfDay(for: date)
+        guard let tomorrow = calendar.date(byAdding: .day, value: 1, to: today) else {
+            return date.addingTimeInterval(86_400)
+        }
+        return calendar.startOfDay(for: tomorrow)
+    }
+}

--- a/ios/VocaPhoneShared/UsageStatsStore.swift
+++ b/ios/VocaPhoneShared/UsageStatsStore.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+struct UsageEvent: Codable, Equatable, Sendable {
+    let id: UUID
+    let dayKey: String
+    let words: Int
+    let seconds: Double
+}
+
+private struct StoredSummary: Codable {
+    var stats: UsageStats
+    var consumedIDs: [UUID]
+}
+
+final class UsageStatsStore: @unchecked Sendable {
+    static let shared = UsageStatsStore()
+
+    private let fileManager: FileManager
+    private let rootOverride: URL?
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(fileManager: FileManager = .default, rootOverride: URL? = nil) {
+        self.fileManager = fileManager
+        self.rootOverride = rootOverride
+        encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    @discardableResult
+    func record(
+        transcript: String,
+        seconds: Double?,
+        now: Date = Date(),
+        timeZone: TimeZone = .current
+    ) throws -> UsageEvent? {
+        let words = UsageStats.wordCount(transcript)
+        guard words > 0 else { return nil }
+        let event = UsageEvent(
+            id: UUID(),
+            dayKey: UsageStats.dayKey(now, timeZone: timeZone),
+            words: words,
+            seconds: max(seconds ?? 0, 0)
+        )
+        let directory = try eventsDirectory()
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let data = try encoder.encode(event)
+        try data.write(to: directory.appendingPathComponent("\(event.id.uuidString).json"), options: .atomic)
+        return event
+    }
+
+    @discardableResult
+    func fold() throws -> UsageStats {
+        var summary = loadSummary()
+        let pending = try eventsOnDisk()
+        guard !pending.isEmpty else { return summary.stats }
+
+        let alreadyCounted = Set(summary.consumedIDs)
+        let fresh = pending
+            .filter { !alreadyCounted.contains($0.event.id) }
+            .sorted { $0.event.dayKey < $1.event.dayKey }
+
+        var stats = summary.stats
+        for entry in fresh {
+            stats = stats.recording(
+                dayKey: entry.event.dayKey,
+                words: entry.event.words,
+                seconds: entry.event.seconds
+            )
+        }
+
+        summary.stats = stats
+        summary.consumedIDs = pending.map(\.event.id)
+        try writeSummary(summary)
+
+        for entry in pending {
+            try? fileManager.removeItem(at: entry.url)
+        }
+        return stats
+    }
+
+    func current() -> UsageStats {
+        let summary = loadSummary()
+        guard let pending = try? eventsOnDisk(), !pending.isEmpty else { return summary.stats }
+        let alreadyCounted = Set(summary.consumedIDs)
+        var stats = summary.stats
+        for entry in pending
+            .filter({ !alreadyCounted.contains($0.event.id) })
+            .sorted(by: { $0.event.dayKey < $1.event.dayKey }) {
+            stats = stats.recording(
+                dayKey: entry.event.dayKey,
+                words: entry.event.words,
+                seconds: entry.event.seconds
+            )
+        }
+        return stats
+    }
+
+    func reset() throws {
+        let directory = try usageDirectory()
+        guard fileManager.fileExists(atPath: directory.path) else { return }
+        try fileManager.removeItem(at: directory)
+    }
+
+
+    private func loadSummary() -> StoredSummary {
+        guard let url = try? summaryURL(),
+              let data = try? Data(contentsOf: url),
+              let stored = try? decoder.decode(StoredSummary.self, from: data)
+        else {
+            return StoredSummary(stats: UsageStats(), consumedIDs: [])
+        }
+        return stored
+    }
+
+    private func writeSummary(_ summary: StoredSummary) throws {
+        let directory = try usageDirectory()
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        try encoder.encode(summary).write(to: try summaryURL(), options: .atomic)
+    }
+
+    private func eventsOnDisk() throws -> [(url: URL, event: UsageEvent)] {
+        let directory = try eventsDirectory()
+        guard fileManager.fileExists(atPath: directory.path) else { return [] }
+        let urls = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        )
+        return urls.compactMap { url in
+            guard url.pathExtension == "json",
+                  let data = try? Data(contentsOf: url),
+                  let event = try? decoder.decode(UsageEvent.self, from: data)
+            else { return nil }
+            return (url: url, event: event)
+        }
+    }
+
+    private func summaryURL() throws -> URL {
+        try usageDirectory().appendingPathComponent("summary.json")
+    }
+
+    private func eventsDirectory() throws -> URL {
+        try usageDirectory().appendingPathComponent("events", isDirectory: true)
+    }
+
+    private func usageDirectory() throws -> URL {
+        let root = try rootOverride ?? SharedStore.shared.rootDirectory()
+        return root.appendingPathComponent("usage", isDirectory: true)
+    }
+}

--- a/ios/VocaPhoneTests/UsageStatsStoreTests.swift
+++ b/ios/VocaPhoneTests/UsageStatsStoreTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+
+struct UsageStatsStoreTests {
+    private func makeStore() throws -> (UsageStatsStore, URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return (UsageStatsStore(rootOverride: root), root)
+    }
+
+    private let utc = TimeZone(identifier: "UTC")!
+
+    private func at(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = utc
+        return calendar.date(from: DateComponents(year: year, month: month, day: day, hour: 12))!
+    }
+
+    private func eventFiles(in root: URL) -> [URL] {
+        (try? FileManager.default.contentsOfDirectory(
+            at: root.appendingPathComponent("usage/events"),
+            includingPropertiesForKeys: nil
+        )) ?? []
+    }
+
+    @Test func nothingIsCountedBeforeAnythingIsDictated() throws {
+        let (store, _) = try makeStore()
+        #expect(!store.current().hasAny)
+    }
+
+    @Test func aRecordedDictationShowsUpBeforeItIsEverFolded() throws {
+        let (store, _) = try makeStore()
+        try store.record(transcript: "one two three", seconds: 6, now: at(2026, 9, 10), timeZone: utc)
+
+        let stats = store.current()
+        #expect(stats.totalWords == 3)
+        #expect(stats.totalDictations == 1)
+        #expect(stats.totalSeconds == 6)
+    }
+
+    @Test func foldingTurnsEventsIntoASummaryAndClearsTheFiles() throws {
+        let (store, root) = try makeStore()
+        try store.record(transcript: "one two", seconds: 4, now: at(2026, 9, 10), timeZone: utc)
+        try store.record(transcript: "three four", seconds: 4, now: at(2026, 9, 10), timeZone: utc)
+
+        let folded = try store.fold()
+        #expect(folded.totalWords == 4)
+        #expect(folded.totalDictations == 2)
+        #expect(eventFiles(in: root).isEmpty, "folded events are removed")
+        #expect(store.current().totalWords == 4, "and the summary carries them")
+    }
+
+    @Test func foldingIsIdempotent() throws {
+        let (store, _) = try makeStore()
+        try store.record(transcript: "one two three", seconds: 6, now: at(2026, 9, 10), timeZone: utc)
+        _ = try store.fold()
+        _ = try store.fold()
+        #expect(store.current().totalWords == 3)
+    }
+
+    @Test func anInterruptedFoldDoesNotCountTwice() throws {
+        let (store, root) = try makeStore()
+        try store.record(transcript: "one two three", seconds: 6, now: at(2026, 9, 10), timeZone: utc)
+        let files = eventFiles(in: root)
+        let saved = try files.map { (url: $0, data: try Data(contentsOf: $0)) }
+
+        _ = try store.fold()
+
+        for file in saved { try file.data.write(to: file.url) }
+
+        #expect(store.current().totalWords == 3, "the read path skips them")
+        #expect(try store.fold().totalWords == 3, "and so does the next fold")
+    }
+
+    @Test func eventsFoldOldestDayFirstSoStreaksAreSequential() throws {
+        let (store, _) = try makeStore()
+        try store.record(transcript: "third day", seconds: 3, now: at(2026, 9, 12), timeZone: utc)
+        try store.record(transcript: "first day", seconds: 3, now: at(2026, 9, 10), timeZone: utc)
+        try store.record(transcript: "second day", seconds: 3, now: at(2026, 9, 11), timeZone: utc)
+
+        let stats = try store.fold()
+        #expect(stats.currentStreak == 3)
+        #expect(stats.lastDayKey == "2026-09-12")
+    }
+
+    @Test func aSilentDictationIsNotRecordedAtAll() throws {
+        let (store, root) = try makeStore()
+        try store.record(transcript: "   ", seconds: 4, now: at(2026, 9, 10), timeZone: utc)
+        #expect(eventFiles(in: root).isEmpty)
+        #expect(!store.current().hasAny)
+    }
+
+    @Test func aDictationWithNoRecordedDurationStillCountsItsWords() throws {
+        let (store, _) = try makeStore()
+        try store.record(transcript: "one two", seconds: nil, now: at(2026, 9, 10), timeZone: utc)
+        let stats = store.current()
+        #expect(stats.totalWords == 2)
+        #expect(stats.averageWordsPerMinute == 0, "no audio, no speed")
+    }
+
+    @Test func resettingRemovesTotalsAndPendingEventsAlike() throws {
+        let (store, root) = try makeStore()
+        try store.record(transcript: "one two", seconds: 4, now: at(2026, 9, 10), timeZone: utc)
+        _ = try store.fold()
+        try store.record(transcript: "three", seconds: 2, now: at(2026, 9, 10), timeZone: utc)
+
+        try store.reset()
+        #expect(!store.current().hasAny)
+        #expect(eventFiles(in: root).isEmpty)
+    }
+
+    @Test func totalsSurviveDeletingEveryTranscript() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let usage = UsageStatsStore(rootOverride: root)
+        let sessions = SharedStore(rootOverride: root)
+
+        try sessions.save(SessionRecord(state: .idle))
+        try usage.record(transcript: "one two three", seconds: 6, now: at(2026, 9, 10), timeZone: utc)
+        _ = try usage.fold()
+
+        _ = try sessions.deleteAllSessions()
+
+        #expect(usage.current().totalWords == 3)
+    }
+}

--- a/ios/VocaPhoneTests/UsageStatsTests.swift
+++ b/ios/VocaPhoneTests/UsageStatsTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import Testing
+
+struct UsageStatsTests {
+    private let utc = TimeZone(identifier: "UTC")!
+
+    private func at(_ year: Int, _ month: Int, _ day: Int, hour: Int = 12, zone: TimeZone? = nil) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = zone ?? utc
+        return calendar.date(from: DateComponents(year: year, month: month, day: day, hour: hour))!
+    }
+
+
+    @Test func aDayKeyIsTheLocalCalendarDate() {
+        #expect(UsageStats.dayKey(at(2026, 9, 10), timeZone: utc) == "2026-09-10")
+    }
+
+    @Test func dayKeysAreGregorianWhateverTheDeviceCalendarIs() {
+        #expect(UsageStats.dayKey(at(2026, 9, 10), timeZone: utc).hasPrefix("2026-"))
+    }
+
+    @Test func onlyRealDatesAreReadableAsDays() {
+        #expect(UsageStats.isDayKey("2026-09-10"))
+        #expect(!UsageStats.isDayKey(""))
+        #expect(!UsageStats.isDayKey("not-a-date"))
+        #expect(!UsageStats.isDayKey("2026-9-10"))
+        #expect(!UsageStats.isDayKey("2026-02-31"), "well-shaped but impossible")
+    }
+
+    @Test func daysBetweenCountsCalendarDaysNotHours() {
+        #expect(UsageStats.daysBetween("2026-09-09", "2026-09-10") == 1)
+        #expect(UsageStats.daysBetween("2026-09-10", "2026-09-09") == -1)
+        #expect(UsageStats.daysBetween("2026-02-28", "2026-03-01") == 1)
+        #expect(UsageStats.daysBetween("nonsense", "2026-09-10") == nil)
+    }
+
+
+    @Test func consecutiveDaysExtendTheRunAndAGapResetsIt() {
+        var stats = UsageStats()
+        stats = stats.recording(dayKey: "2026-09-08", words: 10, seconds: 5)
+        #expect(stats.currentStreak == 1)
+        stats = stats.recording(dayKey: "2026-09-09", words: 10, seconds: 5)
+        #expect(stats.currentStreak == 2)
+        stats = stats.recording(dayKey: "2026-09-11", words: 10, seconds: 5)
+        #expect(stats.currentStreak == 1, "a day was missed")
+        #expect(stats.bestStreak == 2, "the best run survives the reset")
+    }
+
+    @Test func twoDictationsOnOneDayAreOneStreakDay() {
+        var stats = UsageStats().recording(dayKey: "2026-09-10", words: 5, seconds: 2)
+        stats = stats.recording(dayKey: "2026-09-10", words: 5, seconds: 2)
+        #expect(stats.currentStreak == 1)
+        #expect(stats.totalDictations == 2)
+        #expect(stats.dailyWords["2026-09-10"] == 10)
+    }
+
+    @Test func aStreakExpiresWhenReadRatherThanWhenWritten() {
+        let stats = UsageStats(
+            totalWords: 50,
+            totalDictations: 5,
+            lastDayKey: "2026-09-10",
+            currentStreak: 5,
+            bestStreak: 5
+        )
+        #expect(stats.currentStreak(at: at(2026, 9, 10), timeZone: utc) == 5, "same day")
+        #expect(stats.currentStreak(at: at(2026, 9, 11), timeZone: utc) == 5, "yesterday, still savable")
+        #expect(stats.currentStreak(at: at(2026, 9, 12), timeZone: utc) == 0, "a day was missed")
+        #expect(stats.currentStreak(at: at(2026, 12, 25), timeZone: utc) == 0)
+    }
+
+    @Test func aStreakThatNeverStartedIsZero() {
+        #expect(UsageStats().currentStreak(at: at(2026, 9, 10), timeZone: utc) == 0)
+    }
+
+    @Test func aFutureDatedDayDoesNotFreezeTheRunForever() {
+        let stats = UsageStats(lastDayKey: "2099-01-01", currentStreak: 4, bestStreak: 4)
+        #expect(stats.currentStreak(at: at(2026, 9, 10), timeZone: utc) == 0)
+        #expect(UsageStats.nextDayKey("2099-01-01", todayKey: "2026-09-10") == "2026-09-10")
+    }
+
+    @Test func aClockNudgedBackwardsKeepsTheRun() {
+        let stats = UsageStats(lastDayKey: "2026-09-11", currentStreak: 3, bestStreak: 3)
+        #expect(stats.currentStreak(at: at(2026, 9, 10), timeZone: utc) == 3)
+    }
+
+    @Test func anUnreadableStoredDayIsRepairedRatherThanKept() {
+        #expect(UsageStats.nextDayKey("not-a-date", todayKey: "2026-09-10") == "2026-09-10")
+        let stats = UsageStats(lastDayKey: "not-a-date", currentStreak: 3)
+        #expect(stats.currentStreak(at: at(2026, 9, 10), timeZone: utc) == 0)
+    }
+
+    @Test func onlyTheSevenMostRecentDaysAreKept() {
+        var daily: [String: Int] = [:]
+        for day in 1...10 { daily[String(format: "2026-09-%02d", day)] = day }
+        let pruned = UsageStats.pruneDaily(daily)
+        #expect(pruned.count == 7)
+        #expect(pruned["2026-09-10"] == 10)
+        #expect(pruned["2026-09-03"] == nil, "the oldest went first")
+    }
+
+    @Test func anUnreadableLabelDoesNotEvictARealDay() {
+        var daily: [String: Int] = ["zzz-not-a-day": 99]
+        for day in 1...7 { daily[String(format: "2026-09-%02d", day)] = day }
+        let pruned = UsageStats.pruneDaily(daily)
+        #expect(pruned["zzz-not-a-day"] == nil)
+        #expect(pruned.count == 7)
+        #expect(pruned["2026-09-01"] == 1, "the real days all survived")
+    }
+
+    @Test func wordsAreCountedBySegmentationNotSpaces() {
+        #expect(UsageStats.wordCount("Meet me by the station at six") == 7)
+        #expect(UsageStats.wordCount("  ") == 0)
+        #expect(UsageStats.wordCount("") == 0)
+        #expect(UsageStats.wordCount("well-known") >= 1)
+    }
+
+    @Test func aDictationWithNoWordsChangesNothing() {
+        let stats = UsageStats().recording(dayKey: "2026-09-10", words: 0, seconds: 4)
+        #expect(!stats.hasAny)
+        #expect(stats.totalSeconds == 0)
+    }
+
+    @Test func speakingSpeedIsWordsOverRecordedMinutes() {
+        let stats = UsageStats(totalWords: 120, totalDictations: 2, totalSeconds: 60)
+        #expect(stats.averageWordsPerMinute == 120)
+    }
+
+    @Test func speakingSpeedIsZeroRatherThanInfiniteWithoutAudio() {
+        #expect(UsageStats(totalWords: 10).averageWordsPerMinute == 0)
+    }
+
+    @Test func theNextDayStartsAtTheNextLocalMidnight() {
+        let start = UsageStats.nextDayStart(after: at(2026, 9, 10, hour: 12), timeZone: utc)
+        #expect(start == at(2026, 9, 11, hour: 0))
+    }
+
+    @Test func theDayTheClocksChangeIsShorterOrLonger() {
+        let la = TimeZone(identifier: "America/Los_Angeles")!
+        let spring = at(2026, 3, 8, hour: 0, zone: la)
+        let fall = at(2026, 11, 1, hour: 0, zone: la)
+        #expect(UsageStats.nextDayStart(after: spring, timeZone: la).timeIntervalSince(spring) == 23 * 3_600)
+        #expect(UsageStats.nextDayStart(after: fall, timeZone: la).timeIntervalSince(fall) == 25 * 3_600)
+    }
+
+    @Test func anAmbiguousMidnightIsTheFirstOneNotTheSecond() {
+        let havana = TimeZone(identifier: "America/Havana")!
+        let noon = at(2026, 10, 31, hour: 12, zone: havana)
+        #expect(UsageStats.nextDayStart(after: noon, timeZone: havana).timeIntervalSince(noon) == 12 * 3_600)
+    }
+
+    @Test func theNextDayStartIsExactlyTheBoundaryInEveryZone() {
+        let zones = ["UTC", "America/Los_Angeles", "Asia/Kolkata", "America/Havana",
+                     "Atlantic/Azores", "Australia/Lord_Howe", "Asia/Kathmandu"]
+        for id in zones {
+            let zone = TimeZone(identifier: id)!
+            var moment = at(2026, 1, 1, hour: 0)
+            while moment < at(2026, 12, 31, hour: 0) {
+                let start = UsageStats.nextDayStart(after: moment, timeZone: zone)
+                let today = UsageStats.dayKey(moment, timeZone: zone)
+                #expect(start > moment, "\(id) did not move forward at \(today)")
+                #expect(
+                    UsageStats.dayKey(start, timeZone: zone) != today,
+                    "\(id) did not reach the next day at \(today)"
+                )
+                #expect(
+                    UsageStats.dayKey(start.addingTimeInterval(-1), timeZone: zone) == today,
+                    "\(id) overshot the boundary at \(today)"
+                )
+                moment = moment.addingTimeInterval(3_600 + 37)
+            }
+        }
+    }
+
+    @Test func aStoredSummaryRoundTrips() throws {
+        let stats = UsageStats(
+            totalWords: 900,
+            totalDictations: 31,
+            totalSeconds: 412.5,
+            lastDayKey: "2026-09-10",
+            currentStreak: 4,
+            bestStreak: 9,
+            dailyWords: ["2026-09-10": 120]
+        )
+        let data = try JSONEncoder().encode(stats)
+        #expect(try JSONDecoder().decode(UsageStats.self, from: data) == stats)
+    }
+}


### PR DESCRIPTION
Closes #265

Settings gains a Stats screen: lifetime words, dictations and recorded time,
speaking speed, a daily streak, and recent activity. Counts only, never
transcript text, and nothing leaves the phone unless shared.

Storage is a ledger rather than a shared counter: the keyboard appends one file
per inserted dictation, the app alone folds them into a summary. No
cross-process locking, and an interrupted fold cannot double count because the
summary records the ids it counted before deleting them.

Recording length now rides SessionRecord, from the microphone clock
RecordingCoordinator already kept. It is optional and schemaVersion stays 1 —
SharedStore.load tests that for equality, so a bump would reject every record
the previous build wrote.

Counters live in usage/, beside sessions/ rather than inside it, so a 7-day
retention setting or a delete-everything leaves lifetime totals alone. Only
inserted dictations count.

Sharing copies a card to the clipboard and opens a web composer; neither X nor
LinkedIn offers a usable compose scheme on iOS.

Adds 32 tests. Verified on a simulator in both appearances with a real
dictation through the keyboard. The share actions and the rendered card still
need a device pass.

## Summary

**What changed?**

- New `UsageStats` (pure day/streak arithmetic) and `UsageStatsStore` (the
  ledger) in `VocaPhoneShared`.
- New `StatsView` and `StatsShare` in the app; a Stats row in `SettingsView`.
- `SessionRecord` gains an optional `recordedSeconds`, set by
  `RecordingCoordinator` where the route is already resolved and saved.
- `KeyboardViewController` records one usage event after `.completed`, wrapped
  in `try?` so bookkeeping can never fail an insertion.
- `SemanticPalette` gains five tile tints, each with light and dark values,
  kept as their own vocabulary rather than as new `Role` cases.
- `docs/privacy.md` documents the new local dataset.

**Why is it needed?**

Android shipped this in #267 and iOS had no equivalent. The arithmetic is
mirrored deliberately rather than reinvented — the same person may run both
apps, and two independent answers to "when does a streak break" disagree
exactly where users notice.

## Verification

- [x] `just ios ci` — passes; 821 tests, lint, and the project-staleness gate.
- [x] `just android ci` — passes. No Android files are touched by this branch;
      run anyway to confirm nothing regressed.
- [x] Gateway changes: none. No gateway, submodule, or network code in this
      branch.
- [ ] **Physical-device test: not done.** Insertion *is* touched — one
      non-throwing statement appended after the existing transition sequence in
      `KeyboardViewController` — so this box should not be ticked from a
      simulator. What was verified on a simulator, end to end with a real
      dictation through the keyboard extension: `recordedSeconds` written by
      the app, the event written by the extension, folded by the app, 10 words
      counted, and the screen correct in both appearances.

Also unverified: the share actions (whether the composer opens pre-filled), the
rendered card image when pasted, the empty state, and Dynamic Type. There is no
UI test infrastructure in this target.

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private tailnet
      details added. Usage events store word *counts*, never words, and nothing
      under `usage/` is reconstructible into transcript text.
- [x] Documentation updated for data-flow, permission, retention, or network
      changes. `docs/privacy.md` gains a "Usage statistics (iOS)" section
      covering what is stored, where, that it never leaves the device, and that
      it sits deliberately outside transcript retention.

Two things worth a reviewer's eye rather than a checkbox:

- **This is the first outbound surface in the app.** The share message carries
  counts, WPM, streak and the marketing URL — no transcripts — but it also
  asserts "Runs on my phone, privately 🔒" under the user's own name. Worth
  reading as copy, not just as code.
- **`usage/` sits beside `sessions/` on purpose.** If it ever moves inside,
  retention and delete-all silently start erasing lifetime totals.

## Note for the reviewer

`ios/VocaPhone.xcodeproj/project.pbxproj` is regenerated and included, because
`just ios ci` fails on a stale project.

## Screenshots

<img width="441" height="970" alt="Screenshot 2026-09-10 at 9 25 51 AM" src="https://github.com/user-attachments/assets/a777be71-1985-4561-8a1c-dd00303f4b59" />
<img width="451" height="978" alt="Screenshot 2026-09-10 at 9 29 00 AM" src="https://github.com/user-attachments/assets/e2241ba8-d954-49d6-bf13-632b7666a0fa" />
