### PR TITLE
fix(android): rename "App" tile to "Settings" for clarity

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -1303,7 +1303,7 @@ private fun ToolbarMenuPanel(
                 listOf(
                     MenuTile("Speech", R.drawable.ic_connection) { onOpenSettings("connection") },
                     MenuTile("About", R.drawable.ic_about) { onOpenSettings("about") },
-                    MenuTile("App", R.drawable.ic_settings) { onOpenSettings("") },
+                    MenuTile("Settings", R.drawable.ic_settings) { onOpenSettings("") },
                 ),
             ).forEach { row ->
                 Row(


### PR DESCRIPTION
The tile in the Tiles menu that opens settings was labeled "App", which does not clearly communicate its function. Renamed to "Settings" to match its behavior (`onOpenSettings`).