### PR TITLE
feat(ui): mention long-press cancel in the hint of training text field

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/ui/DictateScreen.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ui/DictateScreen.kt
@@ -56,7 +56,9 @@ internal object DictateCopy {
     const val MODEL = "Model"
     const val GATEWAY = "Gateway"
     const val NO_MODEL = "No model"
-    const val HINT = "Inserted at the cursor. Nothing here is uploaded."
+    const val HINT = "Inserted at the cursor. Nothing here is uploaded. " +
+        "Long-press the mic key in the keyboard below — not the Dictate " +
+        "button above — to cancel while listening or transcribing."
 }
 
 /**

--- a/android/app/src/test/java/com/vocahq/vocaphone/ui/DictateCopyTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ui/DictateCopyTest.kt
@@ -51,7 +51,9 @@ class DictateCopyTest {
     @Test
     fun scratchpadHintLeavesOnceThereIsTextOrARecording() {
         assertEquals(
-            "Inserted at the cursor. Nothing here is uploaded.",
+            "Inserted at the cursor. Nothing here is uploaded. " +
+                "Long-press the mic key in the keyboard below — not the Dictate " +
+                "button above — to cancel while listening or transcribing.",
             DictateCopy.HINT,
         )
         assertTrue(showScratchpadHint("", DictationPhase.IDLE))


### PR DESCRIPTION
The scratchpad hint shown before dictation starts now also tells the user that long-pressing Stop cancels, both during listening and during transcribing (per the gesture introduced for #113/#271).

Have fixed what GReptile was talking about, but I don't have the permission to manually re-trigger it.

Not dropping this — the gesture is real, just on a different control than the one reviewed here (the docked system keyboard's mic key, not this screen's own Dictate/Cancel/Finish row). Reworded to name both explicitly.

Screenshot with differentiation
<img width="864" height="1872" alt="image" src="https://github.com/user-attachments/assets/dee1a88e-dd7f-4ae5-8c5b-07ae8375a3ac" />
