### PR TITLE
feat(ios): add private usage statistics and sharing

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -317,8 +317,9 @@ Keychain and the Android Keystore.
 ## Usage statistics (iOS)
 
 Counters for the Stats screen in Settings: total words, total dictations, total
-recorded seconds, a current and best streak, and word totals for the last seven
-days.
+recorded seconds, a current and best streak, and words, sessions, and recorded
+time for each of the last seven active days. The screen fills quiet dates into
+its seven-calendar-day chart without storing additional events.
 
 - **Counts, not words.** No transcript text and no audio is stored. A dictation
   contributes a number, and the number cannot be turned back into what was said.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -314,6 +314,29 @@ abused. It is unrelated
 to the gateway bearer token, which is a real secret and lives in the iOS
 Keychain and the Android Keystore.
 
+## Usage statistics (iOS)
+
+Counters for the Stats screen in Settings: total words, total dictations, total
+recorded seconds, a current and best streak, and word totals for the last seven
+days.
+
+- **Counts, not words.** No transcript text and no audio is stored. A dictation
+  contributes a number, and the number cannot be turned back into what was said.
+- **Never leaves the device.** Nothing here is sent to a gateway, reported as
+  telemetry, or included in the diagnostics export.
+- **Written where the dictation lands.** The keyboard extension appends one
+  small file per inserted dictation to the App Group; the app folds those into a
+  summary when the Stats screen is opened.
+- **Outside transcript retention, deliberately.** The files live in `usage/`,
+  beside `sessions/` rather than inside it, so deleting your transcripts — or
+  running a 7- or 30-day retention setting — keeps your lifetime totals. The
+  reverse also holds: resetting statistics does not touch your transcripts.
+- **Reset at any time**, from the Stats screen. This deletes the summary and any
+  pending events permanently.
+
+Only dictations that were actually inserted are counted. A transcript that is
+produced and then abandoned never becomes a statistic.
+
 ## Diagnostics export
 
 The authenticated WebUI Settings tab and `uv run vocaphone-diagnostics` can export a

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		590AE5D90BD9113ABA4EEF3F /* BrandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9711C18238B39EA2E842C0F /* BrandPalette.swift */; };
 		594C4A6790AD798CA3A7D427 /* SpeechAudioConditioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */; };
 		5A151959ABCE2ADE4646A79D /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
+		5A724B25DE53408E57681DDE /* StatsPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E30393743BA32A747665278 /* StatsPresentationTests.swift */; };
 		5ADC4420E2E23403BFC8716D /* TranscriptRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */; };
 		5C0F524206C9335BC0C4C672 /* KeyboardStatusPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549656C750D0C8EF3F25E17C /* KeyboardStatusPublication.swift */; };
 		5C2D54A0C5B68220689428DB /* UsageStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93CC576887F75BD471DDDF8 /* UsageStats.swift */; };
@@ -177,6 +178,7 @@
 		6CEF2A686643F72F4BCDD51D /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
 		6E40FED503FAF66243463C4F /* KeyboardSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DC28A915553380C82653C9 /* KeyboardSurfaceTests.swift */; };
 		6EAFD2EC2E02A1270A140E47 /* TypingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B9027C03A87FBC74CE1130 /* TypingEngine.swift */; };
+		6F9B8A3AB8D1804639128BFA /* StatsPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105FC942932DAFE80242473E /* StatsPresentation.swift */; };
 		70232F18D7B4AA7F6BB15C64 /* TelemetrySink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E413C2A7ADDFE5C3B5F27C7 /* TelemetrySink.swift */; };
 		7118F0F04A2C3D94C65EC00D /* TelemetrySink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E413C2A7ADDFE5C3B5F27C7 /* TelemetrySink.swift */; };
 		7280B936E153A21AC6D75B27 /* WordComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A6EEE8C98BCBF8D1D70D44 /* WordComposer.swift */; };
@@ -195,6 +197,7 @@
 		7B3A332D21DDF3608528D1BB /* UsageStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A5908FB5C22FDA5C22F947 /* UsageStatsStore.swift */; };
 		7B571D68CCB37D4C3FCEE258 /* KeyboardStatusPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549656C750D0C8EF3F25E17C /* KeyboardStatusPublication.swift */; };
 		7C304FFA51BC372F267CC729 /* Snippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69943FB61027DEE31DA51705 /* Snippet.swift */; };
+		7D1B748A5FA30776EBB5F1A3 /* StatsPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105FC942932DAFE80242473E /* StatsPresentation.swift */; };
 		7E26A729562A6F474635AFEC /* TranscriptStylerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45A3914F898AD0570486806 /* TranscriptStylerTests.swift */; };
 		7E28776EDC2BD3E8A8AFCED9 /* TypingPrivacyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05735C847A47FF442B4FB21A /* TypingPrivacyTests.swift */; };
 		7E3D8E857A83184E74B15433 /* GatewayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0A752EC9784F6FD2274150 /* GatewayEndpoint.swift */; };
@@ -468,6 +471,7 @@
 		0B31528AA0DAB644EFBBE967 /* TypingCandidatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingCandidatesTests.swift; sourceTree = "<group>"; };
 		0BAEF22ED143D3569B005C88 /* SwipeBackCoach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeBackCoach.swift; sourceTree = "<group>"; };
 		0DFD83D2BCB84400E7981A4B /* SwipeTrailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeTrailTests.swift; sourceTree = "<group>"; };
+		105FC942932DAFE80242473E /* StatsPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPresentation.swift; sourceTree = "<group>"; };
 		11816AC1A2219D15E870CE3E /* EmojiCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCatalog.swift; sourceTree = "<group>"; };
 		1247ACC1CA43648BE4449042 /* SnippetExpander.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetExpander.swift; sourceTree = "<group>"; };
 		136E505E4C5668F9ACCD30C5 /* EmojiSuggestions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiSuggestions.swift; sourceTree = "<group>"; };
@@ -500,6 +504,7 @@
 		3BA012C76E8C374857732F67 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3C6B7EB27436670B0B1EB1D1 /* SpokenEmojiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpokenEmojiTests.swift; sourceTree = "<group>"; };
 		3D4BE75828FCA9C70DFEDC96 /* SpellChecking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpellChecking.swift; sourceTree = "<group>"; };
+		3E30393743BA32A747665278 /* StatsPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPresentationTests.swift; sourceTree = "<group>"; };
 		3E3E4382E021BE30F6D687A7 /* SherpaTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaTranscriptTests.swift; sourceTree = "<group>"; };
 		3EC2C1575D306E7683092FBA /* KeyGridLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyGridLayoutTests.swift; sourceTree = "<group>"; };
 		406B0C287866B36EF3109238 /* LocalModelPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelPicker.swift; sourceTree = "<group>"; };
@@ -959,6 +964,7 @@
 				A59DB522E7DFDE3B3E009AFD /* SpeechAudioConditioningTests.swift */,
 				3C6B7EB27436670B0B1EB1D1 /* SpokenEmojiTests.swift */,
 				8201161064874EF522DF3F70 /* SpokenNumbersTests.swift */,
+				3E30393743BA32A747665278 /* StatsPresentationTests.swift */,
 				1CF82ECCA1F28AB94B4142DE /* SwipeAlternatesTests.swift */,
 				924E5D73CB086A4210BF6052 /* SwipeRecognizerTests.swift */,
 				0DFD83D2BCB84400E7981A4B /* SwipeTrailTests.swift */,
@@ -1017,6 +1023,7 @@
 				342F2B3B437269514C969C77 /* SetupStatus.swift */,
 				346B6558EE5557A35C916067 /* SetupView.swift */,
 				55A7126FEDA473D8C112A397 /* StartDictationIntent.swift */,
+				105FC942932DAFE80242473E /* StatsPresentation.swift */,
 				2978D103DB7CEA2D29A546C1 /* StatsShare.swift */,
 				5E522B238D0F1A138634161D /* StatsView.swift */,
 				0BAEF22ED143D3569B005C88 /* SwipeBackCoach.swift */,
@@ -1381,6 +1388,7 @@
 				86B74F487C94F9DBD1E691C4 /* SpokenEmoji.swift in Sources */,
 				9C3766171C286926385A9F1E /* SpokenNumbers.swift in Sources */,
 				E9C82042A1155CC1E50BF2B6 /* StartDictationIntent.swift in Sources */,
+				6F9B8A3AB8D1804639128BFA /* StatsPresentation.swift in Sources */,
 				36A8B74F656E9B17D367775A /* StatsShare.swift in Sources */,
 				878ED4FE5F11E43F16D27E44 /* StatsView.swift in Sources */,
 				108C096B9C0FB4861FC26437 /* StopQuickDictationIntent.swift in Sources */,
@@ -1580,6 +1588,8 @@
 				F5468739AA5410076BE0C5EF /* SpokenEmojiTests.swift in Sources */,
 				AC222A4D19661A309FEC32C1 /* SpokenNumbers.swift in Sources */,
 				9418E647BE968A5FC2064D06 /* SpokenNumbersTests.swift in Sources */,
+				7D1B748A5FA30776EBB5F1A3 /* StatsPresentation.swift in Sources */,
+				5A724B25DE53408E57681DDE /* StatsPresentationTests.swift in Sources */,
 				939ADF1C236F670A3541ACAA /* SwipeAlternates.swift in Sources */,
 				612E02043BE5C4F9567D128E /* SwipeAlternatesTests.swift in Sources */,
 				33049B8AD2490B0F8D0A9E0F /* SwipeRecognizer.swift in Sources */,

--- a/ios/VocaPhone.xcodeproj/project.pbxproj
+++ b/ios/VocaPhone.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		28F0EDCC20383E5A9FEB5B42 /* WordComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9859ACCB32CD57E4F3E4D46A /* WordComposerTests.swift */; };
 		2912856F09ED7566DB955AF9 /* InsertionTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A53786C8D2346452C69A748 /* InsertionTargetTests.swift */; };
 		29D15EC565FE20FEE4FFE469 /* TranscriptRetention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6FFEA14B55E6F6C61FBAC /* TranscriptRetention.swift */; };
+		2AC2C1F94BB0CA1A60AB3856 /* UsageStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A5908FB5C22FDA5C22F947 /* UsageStatsStore.swift */; };
 		2B102E6B9DACF6787D86C68F /* QuickDictationRecoveryOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B433665FF81481E6CD0E1612 /* QuickDictationRecoveryOffer.swift */; };
 		2C1B81951562FBD7FF87662D /* TelemetryRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27748467103CFAD3F6A2F603 /* TelemetryRecord.swift */; };
 		2C362C9B71AA6A93A6D7E4DB /* SessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36767643E0E4AA29BBB3D4FD /* SessionRecord.swift */; };
@@ -94,6 +95,7 @@
 		3655C2E063B7C9B8F286057B /* FinishRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B19321866AE8083C78C2B7F /* FinishRecordingIntent.swift */; };
 		366E7DFAD5B2666FC1FF9FB3 /* SetupStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342F2B3B437269514C969C77 /* SetupStatus.swift */; };
 		36A5F07E79173A14F240A47F /* local_model_pins.json in Resources */ = {isa = PBXBuildFile; fileRef = DBAE2B11D3A27A798D0F39ED /* local_model_pins.json */; };
+		36A8B74F656E9B17D367775A /* StatsShare.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2978D103DB7CEA2D29A546C1 /* StatsShare.swift */; };
 		387B6B6A0B0AE57B6324B55F /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F5D76EB1E944F3A323006D /* SettingsView.swift */; };
 		3948B010FEE4F51B8CE2074D /* TranscriptStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DBF47C7F5E5B13752056CB /* TranscriptStyler.swift */; };
 		396330316A5B80A3884BE142 /* LocalTranscriptionPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FF1A5ABC4220C886291309 /* LocalTranscriptionPreferences.swift */; };
@@ -150,11 +152,13 @@
 		5A151959ABCE2ADE4646A79D /* SharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948F8C6C72A8D7A16C18562 /* SharedStore.swift */; };
 		5ADC4420E2E23403BFC8716D /* TranscriptRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */; };
 		5C0F524206C9335BC0C4C672 /* KeyboardStatusPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549656C750D0C8EF3F25E17C /* KeyboardStatusPublication.swift */; };
+		5C2D54A0C5B68220689428DB /* UsageStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93CC576887F75BD471DDDF8 /* UsageStats.swift */; };
 		5C558BDC79705E089820562F /* KeyLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87128326897BFA30E7B2038 /* KeyLayout.swift */; };
 		5D5A394AA7E8170CFE4E128B /* RecordingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF871FC84B4C6B2627A43C2 /* RecordingCoordinator.swift */; };
 		5E7C819783E63C4FC95E706B /* TelemetryFailureMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D81AEA9FD59906139F273D /* TelemetryFailureMapping.swift */; };
 		5FB6858C38350EC77F45EB62 /* BrandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9711C18238B39EA2E842C0F /* BrandPalette.swift */; };
 		5FD3264678E78B2F180A074A /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11816AC1A2219D15E870CE3E /* EmojiCatalog.swift */; };
+		602CD8CB5A40F80A23E5A4A9 /* UsageStatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD307AE75D5946FD5D016476 /* UsageStatsTests.swift */; };
 		612E02043BE5C4F9567D128E /* SwipeAlternatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CF82ECCA1F28AB94B4142DE /* SwipeAlternatesTests.swift */; };
 		6192C923119F158CCE94B48E /* QuickDictationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB84927D76F9C32C4BE1547 /* QuickDictationAvailability.swift */; };
 		61D705F2D38349B0A9667F2E /* KeyboardStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F34BD131F1AB394941AC87 /* KeyboardStatus.swift */; };
@@ -188,6 +192,7 @@
 		79D51827CA805EB6D890699C /* SherpaLongAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054B6576EFBD7797C0B0F433 /* SherpaLongAudio.swift */; };
 		7AE5598954918484EE8BB6B9 /* KeyboardHandoffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E5F9C1D93EF4EFB2AF5EA7 /* KeyboardHandoffView.swift */; };
 		7B0D3581B262BEB5AC561C23 /* TelemetryStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D9836F52892447650F0375 /* TelemetryStats.swift */; };
+		7B3A332D21DDF3608528D1BB /* UsageStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A5908FB5C22FDA5C22F947 /* UsageStatsStore.swift */; };
 		7B571D68CCB37D4C3FCEE258 /* KeyboardStatusPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549656C750D0C8EF3F25E17C /* KeyboardStatusPublication.swift */; };
 		7C304FFA51BC372F267CC729 /* Snippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69943FB61027DEE31DA51705 /* Snippet.swift */; };
 		7E26A729562A6F474635AFEC /* TranscriptStylerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45A3914F898AD0570486806 /* TranscriptStylerTests.swift */; };
@@ -212,11 +217,13 @@
 		85207216B77DE9C92D5E0519 /* AppGroupEntitlementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49565018533AF6A394F9C24 /* AppGroupEntitlementTests.swift */; };
 		867671B90E038F77BE36A4E6 /* DarwinNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3498C523755A678225152570 /* DarwinNotifications.swift */; };
 		86B74F487C94F9DBD1E691C4 /* SpokenEmoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1DAD70952939C37DE50F0B /* SpokenEmoji.swift */; };
+		878ED4FE5F11E43F16D27E44 /* StatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E522B238D0F1A138634161D /* StatsView.swift */; };
 		883C67CC3B4BBDA22771637A /* KeyProximity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B90ACCDCBABF9F7412EE906 /* KeyProximity.swift */; };
 		89E3D47D85EBD6AD5A093813 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */; };
 		8A69E16ABEF642C3D68FADD5 /* TranscriptHistoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A89F2BEC08F07614372D84D /* TranscriptHistoryModel.swift */; };
 		8A90D2390C756F9101AB251A /* SpeechAudioConditioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5508D34514C05BA0075667D5 /* SpeechAudioConditioning.swift */; };
 		8A9E2E39C1371D1C12913813 /* EmojiTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA1B6FDE1A86C551FFCD094 /* EmojiTable.swift */; };
+		8CBF8AE3B848D419F8D584C9 /* UsageStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93CC576887F75BD471DDDF8 /* UsageStats.swift */; };
 		8DD5E5E2B734765883552523 /* DictationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3489C985467C23EB6A90AD /* DictationBarView.swift */; };
 		8F8E3C14AAC6A4F1DF144AD3 /* OnboardingPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D34E7E54437AFA69FDC2848 /* OnboardingPresentation.swift */; };
 		8FADF6C970427AFDEDCB45C4 /* KeyboardStatusPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549656C750D0C8EF3F25E17C /* KeyboardStatusPublication.swift */; };
@@ -332,6 +339,8 @@
 		D32F9FCE7750E51A69E56F10 /* DesignSystemPreviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71760E0F5AF9B1965E960E1 /* DesignSystemPreviews.swift */; };
 		D347613BCA81EB9BF9AAC2DD /* TranscriptionSourceStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5995603DDA33014FFA52B079 /* TranscriptionSourceStatus.swift */; };
 		D37101A845F65CA081F8B6E4 /* ProtectedSpans.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57FC525B204634FF41CDCDA /* ProtectedSpans.swift */; };
+		D47251260790D2922EF01E27 /* UsageStatsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D08D8869CBFAAE1BC37EAC /* UsageStatsStoreTests.swift */; };
+		D4851F415D2B9D01E291FDFC /* UsageStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A5908FB5C22FDA5C22F947 /* UsageStatsStore.swift */; };
 		D4CA018F48AA244D322B9156 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F3A6E7B826D1389D462944 /* ContentView.swift */; };
 		D4FEC9D26550CB1696FDF424 /* TextInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBB0D1B0CD48BA2F8F22986 /* TextInsertion.swift */; };
 		D6533E4D830A06E9845CE624 /* KeyboardViewPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8E5D91EDE2C0E67DFC0250 /* KeyboardViewPreview.swift */; };
@@ -372,6 +381,7 @@
 		E79DE8AFCE199DDF7A77F176 /* SpokenEmoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1DAD70952939C37DE50F0B /* SpokenEmoji.swift */; };
 		E9C82042A1155CC1E50BF2B6 /* StartDictationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A7126FEDA473D8C112A397 /* StartDictationIntent.swift */; };
 		E9E86F6940BDB4381A8C9FF5 /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C304CF763960E5F1D8F76B2B /* LiveActivityManager.swift */; };
+		EAD46E947414FAB6F95B61F1 /* UsageStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93CC576887F75BD471DDDF8 /* UsageStats.swift */; };
 		ED04BFBB1AB30BB6226D77B3 /* TranscriptRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991F9CD996B90A4DF553DBE5 /* TranscriptRepair.swift */; };
 		EE7A49C4F95388AF42E1B30C /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
 		EF4B66CAC02A63D743384B49 /* DownloadReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF56F0E966D9AECA1DCFF65E /* DownloadReadiness.swift */; };
@@ -389,6 +399,7 @@
 		F3A845A38CC7840D2877FD26 /* KeyAlternatives.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0EBA8DE4056FCA3CB7F093C /* KeyAlternatives.swift */; };
 		F426CFBED733974D61FDB432 /* ModelLanguageSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41EF03C8A4F930315EFE77 /* ModelLanguageSupportTests.swift */; };
 		F43318EAC4CF26D8C46ECD19 /* FrameMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B973580E9433CC9EC9A76024 /* FrameMonitor.swift */; };
+		F4917037D6C4FCB243F7F7EA /* UsageStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A5908FB5C22FDA5C22F947 /* UsageStatsStore.swift */; };
 		F4E8B1A9D00B14184B01B223 /* SemanticPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C44F954E7A62974C66109 /* SemanticPalette.swift */; };
 		F50496BCCFCB73757D3DDF13 /* EmojiCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882F3122E12BD0F2BF44ADC9 /* EmojiCatalogTests.swift */; };
 		F5468739AA5410076BE0C5EF /* SpokenEmojiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6B7EB27436670B0B1EB1D1 /* SpokenEmojiTests.swift */; };
@@ -404,6 +415,7 @@
 		FCE1FDC346554C0EE93845F0 /* SherpaEmptyChunkRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF256CF6ED209E00193BF135 /* SherpaEmptyChunkRecovery.swift */; };
 		FD06CBDABE4EA9640EECF39C /* SherpaLongAudioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C2BEEA5195CB9CB5A38CA /* SherpaLongAudioTests.swift */; };
 		FDBB4DF9D4816CD646C1644D /* TypingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B9027C03A87FBC74CE1130 /* TypingEngine.swift */; };
+		FF7081607FBA7EFEC69C3560 /* UsageStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93CC576887F75BD471DDDF8 /* UsageStats.swift */; };
 		FF899AF5E59FAA55FDA261ED /* QuickDictationDuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783E7FC5F9553FD419487180 /* QuickDictationDuration.swift */; };
 /* End PBXBuildFile section */
 
@@ -466,9 +478,11 @@
 		22AA42EFADB6B77B0C9A5E44 /* UsageReportingCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageReportingCopy.swift; sourceTree = "<group>"; };
 		22D68C853A7603A9B3224B3C /* KeyboardStatusPublicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardStatusPublicationTests.swift; sourceTree = "<group>"; };
 		2678D836274997421A54E901 /* AudioCaptureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCaptureTests.swift; sourceTree = "<group>"; };
+		26D08D8869CBFAAE1BC37EAC /* UsageStatsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageStatsStoreTests.swift; sourceTree = "<group>"; };
 		2730948940D555163E520926 /* SnippetExpanderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetExpanderTests.swift; sourceTree = "<group>"; };
 		27748467103CFAD3F6A2F603 /* TelemetryRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryRecord.swift; sourceTree = "<group>"; };
 		28ECEDA044D2B1021710F205 /* TranscriptHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptHistoryView.swift; sourceTree = "<group>"; };
+		2978D103DB7CEA2D29A546C1 /* StatsShare.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsShare.swift; sourceTree = "<group>"; };
 		2D34E7E54437AFA69FDC2848 /* OnboardingPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPresentation.swift; sourceTree = "<group>"; };
 		2E6C1FB17BFD787FDDCBBF82 /* SherpaOnnxBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SherpaOnnxBridge.h; sourceTree = "<group>"; };
 		2FABAD2700D5F00046349B21 /* TouchWitness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchWitness.swift; sourceTree = "<group>"; };
@@ -511,6 +525,7 @@
 		5995603DDA33014FFA52B079 /* TranscriptionSourceStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSourceStatus.swift; sourceTree = "<group>"; };
 		5A89F2BEC08F07614372D84D /* TranscriptHistoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptHistoryModel.swift; sourceTree = "<group>"; };
 		5B19321866AE8083C78C2B7F /* FinishRecordingIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishRecordingIntent.swift; sourceTree = "<group>"; };
+		5E522B238D0F1A138634161D /* StatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsView.swift; sourceTree = "<group>"; };
 		5FA135DE504590121F6D8843 /* DiagnosticLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticLog.swift; sourceTree = "<group>"; };
 		5FC91810C8F97443ECEF7FD1 /* VocaPhoneApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = VocaPhoneApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		629821E8C5C22C9824A13665 /* LocalModelIntegrity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelIntegrity.swift; sourceTree = "<group>"; };
@@ -608,7 +623,9 @@
 		C45D98EAFE18C689DC7551E9 /* LanguageMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageMenuTests.swift; sourceTree = "<group>"; };
 		C7842B22D05FB171B261101A /* DictationBarStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationBarStyle.swift; sourceTree = "<group>"; };
 		C8E491E7E805F47388A668E1 /* TranscriptSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSanitizerTests.swift; sourceTree = "<group>"; };
+		C93CC576887F75BD471DDDF8 /* UsageStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageStats.swift; sourceTree = "<group>"; };
 		CA4CAEF7B3212512BACDE655 /* TelemetryConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryConfig.swift; sourceTree = "<group>"; };
+		CD307AE75D5946FD5D016476 /* UsageStatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageStatsTests.swift; sourceTree = "<group>"; };
 		CDA1F0347FCF246193F6CF96 /* ModelTranslationSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTranslationSupportTests.swift; sourceTree = "<group>"; };
 		CDBE3CB8FFE4DDA7B459C2A7 /* TypingFieldPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingFieldPolicyTests.swift; sourceTree = "<group>"; };
 		CDCC7453FC149EBB02E3FB58 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
@@ -621,6 +638,7 @@
 		D57FC525B204634FF41CDCDA /* ProtectedSpans.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectedSpans.swift; sourceTree = "<group>"; };
 		D80C83295868E17F215D9382 /* TypingStripPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingStripPresentationTests.swift; sourceTree = "<group>"; };
 		D97C6225AC98D4FE053BDB13 /* KeyboardPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPreview.swift; sourceTree = "<group>"; };
+		D9A5908FB5C22FDA5C22F947 /* UsageStatsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageStatsStore.swift; sourceTree = "<group>"; };
 		DBAE2B11D3A27A798D0F39ED /* local_model_pins.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = local_model_pins.json; sourceTree = "<group>"; };
 		DBFB4BB0345784837C629340 /* PairingPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingPayload.swift; sourceTree = "<group>"; };
 		DC98427A2C06BE9FD63CACF1 /* en-bigrams.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "en-bigrams.txt"; sourceTree = "<group>"; };
@@ -799,6 +817,8 @@
 				56B6FFEA14B55E6F6C61FBAC /* TranscriptRetention.swift */,
 				B121356A503DF83BFA0E0D0C /* TranscriptSanitizer.swift */,
 				F0DBF47C7F5E5B13752056CB /* TranscriptStyler.swift */,
+				C93CC576887F75BD471DDDF8 /* UsageStats.swift */,
+				D9A5908FB5C22FDA5C22F947 /* UsageStatsStore.swift */,
 			);
 			path = VocaPhoneShared;
 			sourceTree = "<group>";
@@ -954,6 +974,8 @@
 				05735C847A47FF442B4FB21A /* TypingPrivacyTests.swift */,
 				D80C83295868E17F215D9382 /* TypingStripPresentationTests.swift */,
 				867A5BD6049E4D6788DB704C /* TypingWordListTests.swift */,
+				26D08D8869CBFAAE1BC37EAC /* UsageStatsStoreTests.swift */,
+				CD307AE75D5946FD5D016476 /* UsageStatsTests.swift */,
 				9859ACCB32CD57E4F3E4D46A /* WordComposerTests.swift */,
 			);
 			path = VocaPhoneTests;
@@ -995,6 +1017,8 @@
 				342F2B3B437269514C969C77 /* SetupStatus.swift */,
 				346B6558EE5557A35C916067 /* SetupView.swift */,
 				55A7126FEDA473D8C112A397 /* StartDictationIntent.swift */,
+				2978D103DB7CEA2D29A546C1 /* StatsShare.swift */,
+				5E522B238D0F1A138634161D /* StatsView.swift */,
 				0BAEF22ED143D3569B005C88 /* SwipeBackCoach.swift */,
 				5A89F2BEC08F07614372D84D /* TranscriptHistoryModel.swift */,
 				28ECEDA044D2B1021710F205 /* TranscriptHistoryView.swift */,
@@ -1265,6 +1289,8 @@
 				81BFE90A24876CEE127974AE /* TypingFieldPolicy.swift in Sources */,
 				D7038E651848C4EE6B0F722A /* TypingStripView.swift in Sources */,
 				E0450895D68708027C1BC77E /* TypingWordList.swift in Sources */,
+				5C2D54A0C5B68220689428DB /* UsageStats.swift in Sources */,
+				7B3A332D21DDF3608528D1BB /* UsageStatsStore.swift in Sources */,
 				D8EE8A829E13191046F3F183 /* WordComposer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1355,6 +1381,8 @@
 				86B74F487C94F9DBD1E691C4 /* SpokenEmoji.swift in Sources */,
 				9C3766171C286926385A9F1E /* SpokenNumbers.swift in Sources */,
 				E9C82042A1155CC1E50BF2B6 /* StartDictationIntent.swift in Sources */,
+				36A8B74F656E9B17D367775A /* StatsShare.swift in Sources */,
+				878ED4FE5F11E43F16D27E44 /* StatsView.swift in Sources */,
 				108C096B9C0FB4861FC26437 /* StopQuickDictationIntent.swift in Sources */,
 				A7216F1D388DBC1B95658666 /* SwipeBackCoach.swift in Sources */,
 				AD2CCDE7DC189E63810890BB /* SwipeRecognizer.swift in Sources */,
@@ -1383,6 +1411,8 @@
 				BA66A26AC92DB96524E13AF5 /* TypingWordList.swift in Sources */,
 				E6FDBF8529AEB00D2CFB245E /* UsageReportingCopy.swift in Sources */,
 				A86F678EFECCEA8BA246778C /* UsageReportingViews.swift in Sources */,
+				EAD46E947414FAB6F95B61F1 /* UsageStats.swift in Sources */,
+				F4917037D6C4FCB243F7F7EA /* UsageStatsStore.swift in Sources */,
 				E2C8F215E536CABB80623B3A /* VocaPhoneActivityAttributes.swift in Sources */,
 				4F24DEC1FC8411ACBDA6BC50 /* VocaPhoneApp.swift in Sources */,
 				7280B936E153A21AC6D75B27 /* WordComposer.swift in Sources */,
@@ -1436,6 +1466,8 @@
 				3D08A881E95118E5B57E9FCD /* TranscriptSanitizer.swift in Sources */,
 				95A08342703AE27BD09E08AC /* TranscriptStyler.swift in Sources */,
 				1935C96899E2437477303714 /* TranscriptionQuality.swift in Sources */,
+				FF7081607FBA7EFEC69C3560 /* UsageStats.swift in Sources */,
+				D4851F415D2B9D01E291FDFC /* UsageStatsStore.swift in Sources */,
 				07D7CA474CBB8812C0E83D1C /* VocaPhoneActivityAttributes.swift in Sources */,
 				A79BA8A795F60838D96EDFAA /* VocaPhoneLiveActivity.swift in Sources */,
 			);
@@ -1590,6 +1622,10 @@
 				E5595FE143CBC103B6DAE2C8 /* TypingWordList.swift in Sources */,
 				BAEC1D5BFECB17B9B28BD780 /* TypingWordListTests.swift in Sources */,
 				1301ECD8CCADCC436412B07A /* UsageReportingCopy.swift in Sources */,
+				8CBF8AE3B848D419F8D584C9 /* UsageStats.swift in Sources */,
+				2AC2C1F94BB0CA1A60AB3856 /* UsageStatsStore.swift in Sources */,
+				D47251260790D2922EF01E27 /* UsageStatsStoreTests.swift in Sources */,
+				602CD8CB5A40F80A23E5A4A9 /* UsageStatsTests.swift in Sources */,
 				114481F43D07358C285C76C3 /* WordComposer.swift in Sources */,
 				28F0EDCC20383E5A9FEB5B42 /* WordComposerTests.swift in Sources */,
 			);

--- a/ios/VocaPhoneApp/App/SettingsView.swift
+++ b/ios/VocaPhoneApp/App/SettingsView.swift
@@ -31,6 +31,9 @@ struct SettingsView: View {
         SnippetStore.key,
         store: SnippetStore.defaults
     ) private var snippetsData = Data()
+    /// Read once when the hub appears rather than folded here: folding is the
+    /// app's job, and the Stats screen is where it happens.
+    @State private var usageStats = UsageStats()
 
     var body: some View {
         List {
@@ -46,6 +49,12 @@ struct SettingsView: View {
                     detail: language.displayName + " · " + writingStyle.displayName,
                     symbol: "mic"
                 ) { DictationSettingsView() }
+
+                destination(
+                    "Stats",
+                    detail: StatsCopy.menuDetail(usageStats, now: Date()),
+                    symbol: "chart.bar"
+                ) { StatsView() }
 
                 destination(
                     "Snippets",
@@ -87,6 +96,7 @@ struct SettingsView: View {
         }
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
+        .task { usageStats = UsageStatsStore.shared.current() }
     }
 
     private var keyboardHeight: KeyboardHeightPreference {

--- a/ios/VocaPhoneApp/App/StatsPresentation.swift
+++ b/ios/VocaPhoneApp/App/StatsPresentation.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+enum StatsCopy {
+    static let resetTitle = "Reset statistics?"
+    static let resetBody =
+        "This permanently deletes your usage totals. Your transcripts are not affected."
+    static let resetConfirm = "Reset"
+    static let speedCaption = "Average speaking speed"
+    static let shareTitle = "Share your progress"
+    static let shareSubtitle = "A private summary you choose where to post"
+    static let shareFootnote = "Social composers cannot attach images automatically. The card is copied so you can paste it into your post."
+
+    static func menuDetail(_ stats: UsageStats, now: Date) -> String {
+        guard stats.hasAny else { return "Words, speaking speed and streaks" }
+        return "\(StatsFormat.count(stats.totalWords)) words · "
+            + "\(StatsFormat.streak(stats.currentStreak(at: now))) streak"
+    }
+}
+
+enum StatsFormat {
+    static func count(_ value: Int) -> String {
+        value.formatted(.number.grouping(.automatic))
+    }
+
+    static func duration(_ seconds: Double) -> String {
+        let total = max(0, Int(seconds.rounded()))
+        if total < 60 { return "\(total)s" }
+        if total < 3_600 { return "\(total / 60)m" }
+        let hours = total / 3_600
+        let minutes = (total % 3_600) / 60
+        return minutes == 0 ? "\(hours)h" : "\(hours)h \(minutes)m"
+    }
+
+    static func wordsPerMinute(_ value: Double) -> String {
+        String(format: "%.1f", value)
+    }
+
+    static func streak(_ days: Int) -> String {
+        "\(days) \(days == 1 ? "day" : "days")"
+    }
+
+    static func words(_ count: Int) -> String {
+        "\(Self.count(count)) \(count == 1 ? "word" : "words")"
+    }
+
+    static func sessions(_ count: Int) -> String {
+        "\(Self.count(count)) \(count == 1 ? "session" : "sessions")"
+    }
+
+    static func dayLabel(_ key: String, now: Date, timeZone: TimeZone = .current) -> String {
+        let today = UsageStats.dayKey(now, timeZone: timeZone)
+        guard let elapsed = UsageStats.daysBetween(key, today) else { return key }
+        switch elapsed {
+        case 0: return "Today"
+        case 1: return "Yesterday"
+        default: return key
+        }
+    }
+
+    static func shortDayLabel(_ key: String) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        guard let date = formatter.date(from: key) else { return "–" }
+        formatter.dateFormat = "EEEEE"
+        return formatter.string(from: date)
+    }
+}
+
+enum StatsShareDestination: CaseIterable, Equatable, Sendable {
+    case x
+    case linkedIn
+
+    var label: String { self == .x ? "X" : "LinkedIn" }
+}
+
+enum StatsShareComposer {
+    static let site = "https://vocaphone.vocahq.com"
+
+    static func message(_ stats: UsageStats, now: Date) -> String {
+        var details = "📊 \(StatsFormat.sessions(stats.totalDictations))"
+        if stats.averageWordsPerMinute > 0 {
+            details += " · ⚡️ \(Int(stats.averageWordsPerMinute.rounded())) WPM"
+        }
+        let streak = stats.currentStreak(at: now)
+        if streak > 0 { details += " · 🔥 \(streak)-day streak" }
+        return [
+            "🎤 I've dictated \(StatsFormat.words(stats.totalWords)) with VocaPhone.",
+            details,
+            "Private voice typing — on my iPhone or through my own gateway. 🔒",
+            site,
+        ].joined(separator: "\n\n")
+    }
+
+    static func composerURL(_ destination: StatsShareDestination, message: String) -> URL? {
+        let base = destination == .x
+            ? "https://x.com/intent/post"
+            : "https://www.linkedin.com/feed/"
+        guard var components = URLComponents(string: base) else { return nil }
+        components.queryItems = destination == .x
+            ? [URLQueryItem(name: "text", value: message)]
+            : [
+                URLQueryItem(name: "shareActive", value: "true"),
+                URLQueryItem(name: "text", value: message),
+            ]
+        return components.url
+    }
+}

--- a/ios/VocaPhoneApp/App/StatsPresentation.swift
+++ b/ios/VocaPhoneApp/App/StatsPresentation.swift
@@ -8,7 +8,7 @@ enum StatsCopy {
     static let speedCaption = "Average speaking speed"
     static let shareTitle = "Share your progress"
     static let shareSubtitle = "A private summary you choose where to post"
-    static let shareFootnote = "Installed apps open first. We’ll copy anything the destination can’t receive automatically."
+    static let shareFootnote = "Installed apps open first. The card and post text are copied so you can paste them if needed."
 
     static func menuDetail(_ stats: UsageStats, now: Date) -> String {
         guard stats.hasAny else { return "Words, speaking speed and streaks" }
@@ -173,23 +173,17 @@ enum StatsShareComposer {
             components.queryItems = [URLQueryItem(name: "text", value: message)]
             return components.url
         case .linkedIn:
-            // LinkedIn's feed URL ignores the old shareActive/text query and
-            // can land on the ordinary feed. Its public web share dialog only
-            // accepts a URL, so the post text and card stay on the pasteboard.
-            guard var components = URLComponents(
-                string: "https://www.linkedin.com/sharing/share-offsite/"
-            ) else { return nil }
-            components.queryItems = [URLQueryItem(name: "url", value: site)]
+            // Match VocaMac's feed composer: share-offsite accepts only a URL,
+            // while this route carries the complete post body.
+            guard var components = URLComponents(string: "https://www.linkedin.com/feed/") else {
+                return nil
+            }
+            components.queryItems = [
+                URLQueryItem(name: "shareActive", value: "true"),
+                URLQueryItem(name: "text", value: message),
+            ]
             return components.url
         }
-    }
-
-    /// LinkedIn's public web dialog adds the shared URL itself and does not
-    /// accept post text. Copy the rest of the message for one clean paste.
-    static func linkedInWebPasteMessage(_ message: String) -> String {
-        let siteSuffix = "\n\n\(site)"
-        guard message.hasSuffix(siteSuffix) else { return message }
-        return String(message.dropLast(siteSuffix.count))
     }
 
     static func nativeURL(_ destination: StatsShareDestination, message: String) -> URL? {
@@ -205,7 +199,7 @@ enum StatsShareComposer {
         case .linkedIn:
             // LinkedIn exposes no supported deep link for a prefilled post.
             // Open the installed app and put both the card and text on the
-            // pasteboard; its browser fallback requires a guided text paste.
+            // pasteboard; the browser fallback receives the full post body.
             return URL(string: "linkedin://")
         }
     }

--- a/ios/VocaPhoneApp/App/StatsPresentation.swift
+++ b/ios/VocaPhoneApp/App/StatsPresentation.swift
@@ -165,17 +165,23 @@ enum StatsShareComposer {
     }
 
     static func composerURL(_ destination: StatsShareDestination, message: String) -> URL? {
-        let base = destination == .x
-            ? "https://x.com/intent/post"
-            : "https://www.linkedin.com/feed/"
-        guard var components = URLComponents(string: base) else { return nil }
-        components.queryItems = destination == .x
-            ? [URLQueryItem(name: "text", value: message)]
-            : [
-                URLQueryItem(name: "shareActive", value: "true"),
-                URLQueryItem(name: "text", value: message),
-            ]
-        return components.url
+        switch destination {
+        case .x:
+            guard var components = URLComponents(string: "https://x.com/intent/post") else {
+                return nil
+            }
+            components.queryItems = [URLQueryItem(name: "text", value: message)]
+            return components.url
+        case .linkedIn:
+            // LinkedIn's feed URL ignores the old shareActive/text query and
+            // can land on the ordinary feed. Its public web share dialog only
+            // accepts a URL, so the post text and card stay on the pasteboard.
+            guard var components = URLComponents(
+                string: "https://www.linkedin.com/sharing/share-offsite/"
+            ) else { return nil }
+            components.queryItems = [URLQueryItem(name: "url", value: site)]
+            return components.url
+        }
     }
 
     static func nativeURL(_ destination: StatsShareDestination, message: String) -> URL? {

--- a/ios/VocaPhoneApp/App/StatsPresentation.swift
+++ b/ios/VocaPhoneApp/App/StatsPresentation.swift
@@ -8,7 +8,7 @@ enum StatsCopy {
     static let speedCaption = "Average speaking speed"
     static let shareTitle = "Share your progress"
     static let shareSubtitle = "A private summary you choose where to post"
-    static let shareFootnote = "Installed apps open first. The card and post text are copied so you can paste them if needed."
+    static let shareFootnote = "Installed apps open first. We’ll copy anything the destination can’t receive automatically."
 
     static func menuDetail(_ stats: UsageStats, now: Date) -> String {
         guard stats.hasAny else { return "Words, speaking speed and streaks" }
@@ -184,6 +184,14 @@ enum StatsShareComposer {
         }
     }
 
+    /// LinkedIn's public web dialog adds the shared URL itself and does not
+    /// accept post text. Copy the rest of the message for one clean paste.
+    static func linkedInWebPasteMessage(_ message: String) -> String {
+        let siteSuffix = "\n\n\(site)"
+        guard message.hasSuffix(siteSuffix) else { return message }
+        return String(message.dropLast(siteSuffix.count))
+    }
+
     static func nativeURL(_ destination: StatsShareDestination, message: String) -> URL? {
         switch destination {
         case .x:
@@ -197,7 +205,7 @@ enum StatsShareComposer {
         case .linkedIn:
             // LinkedIn exposes no supported deep link for a prefilled post.
             // Open the installed app and put both the card and text on the
-            // pasteboard; the web fallback still receives prefilled text.
+            // pasteboard; its browser fallback requires a guided text paste.
             return URL(string: "linkedin://")
         }
     }

--- a/ios/VocaPhoneApp/App/StatsPresentation.swift
+++ b/ios/VocaPhoneApp/App/StatsPresentation.swift
@@ -8,7 +8,7 @@ enum StatsCopy {
     static let speedCaption = "Average speaking speed"
     static let shareTitle = "Share your progress"
     static let shareSubtitle = "A private summary you choose where to post"
-    static let shareFootnote = "Social composers cannot attach images automatically. The card is copied so you can paste it into your post."
+    static let shareFootnote = "Installed apps open first. The card and post text are copied so you can paste them if needed."
 
     static func menuDetail(_ stats: UsageStats, now: Date) -> String {
         guard stats.hasAny else { return "Words, speaking speed and streaks" }
@@ -20,6 +20,17 @@ enum StatsCopy {
 enum StatsFormat {
     static func count(_ value: Int) -> String {
         value.formatted(.number.grouping(.automatic))
+    }
+
+    static func compactCount(_ value: Int) -> String {
+        switch value {
+        case ..<1_000:
+            return count(value)
+        case ..<1_000_000:
+            return compact(Double(value) / 1_000, suffix: "K")
+        default:
+            return compact(Double(value) / 1_000_000, suffix: "M")
+        }
     }
 
     static func duration(_ seconds: Double) -> String {
@@ -53,17 +64,33 @@ enum StatsFormat {
         switch elapsed {
         case 0: return "Today"
         case 1: return "Yesterday"
-        default: return key
+        default:
+            return formattedDay(key, format: "EEE, MMM d", timeZone: timeZone) ?? key
         }
     }
 
-    static func shortDayLabel(_ key: String) -> String {
+    static func shortDayLabel(_ key: String, timeZone: TimeZone = .current) -> String {
+        formattedDay(key, format: "EEE", timeZone: timeZone) ?? "–"
+    }
+
+    private static func compact(_ value: Double, suffix: String) -> String {
+        let format = value < 10 && value.rounded() != value ? "%.1f%@" : "%.0f%@"
+        return String(format: format, value, suffix)
+    }
+
+    private static func formattedDay(
+        _ key: String,
+        format: String,
+        timeZone: TimeZone
+    ) -> String? {
         let formatter = DateFormatter()
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timeZone
         formatter.dateFormat = "yyyy-MM-dd"
-        guard let date = formatter.date(from: key) else { return "–" }
-        formatter.dateFormat = "EEEEE"
+        formatter.isLenient = false
+        guard let date = formatter.date(from: key) else { return nil }
+        formatter.dateFormat = format
         return formatter.string(from: date)
     }
 }
@@ -73,6 +100,16 @@ enum StatsShareDestination: CaseIterable, Equatable, Sendable {
     case linkedIn
 
     var label: String { self == .x ? "X" : "LinkedIn" }
+}
+
+enum StatsShareTarget: Equatable, Sendable {
+    case installedApp
+    case browser
+}
+
+struct StatsShareRoute: Equatable, Sendable {
+    let url: URL
+    let target: StatsShareTarget
 }
 
 enum StatsShareComposer {
@@ -105,5 +142,35 @@ enum StatsShareComposer {
                 URLQueryItem(name: "text", value: message),
             ]
         return components.url
+    }
+
+    static func nativeURL(_ destination: StatsShareDestination, message: String) -> URL? {
+        switch destination {
+        case .x:
+            var components = URLComponents()
+            // The renamed X app continues to register its long-standing
+            // twitter scheme. The post route opens its native composer.
+            components.scheme = "twitter"
+            components.host = "post"
+            components.queryItems = [URLQueryItem(name: "message", value: message)]
+            return components.url
+        case .linkedIn:
+            // LinkedIn exposes no supported deep link for a prefilled post.
+            // Open the installed app and put both the card and text on the
+            // pasteboard; the web fallback still receives prefilled text.
+            return URL(string: "linkedin://")
+        }
+    }
+
+    static func preferredRoute(
+        _ destination: StatsShareDestination,
+        message: String,
+        canOpen: (URL) -> Bool
+    ) -> StatsShareRoute? {
+        if let native = nativeURL(destination, message: message), canOpen(native) {
+            return StatsShareRoute(url: native, target: .installedApp)
+        }
+        guard let web = composerURL(destination, message: message) else { return nil }
+        return StatsShareRoute(url: web, target: .browser)
     }
 }

--- a/ios/VocaPhoneApp/App/StatsPresentation.swift
+++ b/ios/VocaPhoneApp/App/StatsPresentation.swift
@@ -100,6 +100,8 @@ enum StatsShareDestination: CaseIterable, Equatable, Sendable {
     case linkedIn
 
     var label: String { self == .x ? "X" : "LinkedIn" }
+
+    var handle: String? { self == .x ? "@vocahq" : nil }
 }
 
 enum StatsShareTarget: Equatable, Sendable {
@@ -115,19 +117,51 @@ struct StatsShareRoute: Equatable, Sendable {
 enum StatsShareComposer {
     static let site = "https://vocaphone.vocahq.com"
 
-    static func message(_ stats: UsageStats, now: Date) -> String {
-        var details = "📊 \(StatsFormat.sessions(stats.totalDictations))"
+    static func message(
+        _ stats: UsageStats,
+        now: Date,
+        destination: StatsShareDestination
+    ) -> String {
+        var details: [String] = []
+        if stats.totalDictations > 0 {
+            details.append("📊 \(pluralized(stats.totalDictations, "session"))")
+        }
+        if let duration = spokenDuration(stats.totalSeconds) {
+            details.append("⏱️ \(duration) of talking")
+        }
         if stats.averageWordsPerMinute > 0 {
-            details += " · ⚡️ \(Int(stats.averageWordsPerMinute.rounded())) WPM"
+            details.append("⚡️ \(Int(stats.averageWordsPerMinute.rounded())) WPM")
         }
         let streak = stats.currentStreak(at: now)
-        if streak > 0 { details += " · 🔥 \(streak)-day streak" }
-        return [
-            "🎤 I've dictated \(StatsFormat.words(stats.totalWords)) with VocaPhone.",
-            details,
-            "Private voice typing — on my iPhone or through my own gateway. 🔒",
-            site,
-        ].joined(separator: "\n\n")
+        if streak > 0 { details.append("🔥 \(streak)-day streak") }
+
+        var lines = [
+            "🎤 I’ve spoken \(pluralized(stats.totalWords, "word")) with VocaPhone.",
+            details.joined(separator: " · "),
+            "Private voice typing on my phone or my own self-hosted gateway. My audio stays mine. 🔒",
+            [destination.handle, site].compactMap { $0 }.joined(separator: " · "),
+        ]
+        lines.removeAll(where: \.isEmpty)
+        return lines.joined(separator: "\n\n")
+    }
+
+    static func pluralized(_ count: Int, _ noun: String) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.locale = Locale(identifier: "en_US")
+        let value = formatter.string(from: NSNumber(value: count)) ?? "\(count)"
+        return "\(value) \(count == 1 ? noun : noun + "s")"
+    }
+
+    static func spokenDuration(_ seconds: Double) -> String? {
+        let totalMinutes = max(0, Int(seconds) / 60)
+        guard totalMinutes > 0 else { return nil }
+        let hours = totalMinutes / 60
+        let minutes = totalMinutes % 60
+        var parts: [String] = []
+        if hours > 0 { parts.append("\(hours) \(hours == 1 ? "hour" : "hours")") }
+        if minutes > 0 { parts.append("\(minutes) \(minutes == 1 ? "minute" : "minutes")") }
+        return parts.joined(separator: ", ")
     }
 
     static func composerURL(_ destination: StatsShareDestination, message: String) -> URL? {

--- a/ios/VocaPhoneApp/App/StatsShare.swift
+++ b/ios/VocaPhoneApp/App/StatsShare.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+import UIKit
+
+enum StatsShareDestination: CaseIterable {
+    case x
+    case linkedIn
+
+    var label: String {
+        switch self {
+        case .x: "X"
+        case .linkedIn: "LinkedIn"
+        }
+    }
+}
+
+enum StatsShareComposer {
+    static let site = "https://vocaphone.vocahq.com"
+
+    static func message(_ stats: UsageStats, now: Date) -> String {
+        var lines = "🎤 I've dictated \(StatsFormat.count(stats.totalWords)) "
+        lines += stats.totalWords == 1 ? "word" : "words"
+        lines += " with VocaPhone.\n\n"
+        lines += "📊 \(StatsFormat.count(stats.totalDictations)) "
+        lines += stats.totalDictations == 1 ? "dictation" : "dictations"
+        if stats.averageWordsPerMinute > 0 {
+            lines += " · ⚡️ \(Int(stats.averageWordsPerMinute.rounded())) WPM"
+        }
+        let streak = stats.currentStreak(at: now)
+        if streak > 0 {
+            lines += " · 🔥 \(streak)-day streak"
+        }
+        lines += "\n\nRuns on my phone, privately. 🔒\n\(site)"
+        return lines
+    }
+
+    static func composerURL(_ destination: StatsShareDestination, message: String) -> URL? {
+        let encoded = message.addingPercentEncoding(
+            withAllowedCharacters: .alphanumerics
+        ) ?? ""
+        switch destination {
+        case .x:
+            return URL(string: "https://x.com/intent/post?text=\(encoded)")
+        case .linkedIn:
+            return URL(string: "https://www.linkedin.com/feed/?shareActive=true&text=\(encoded)")
+        }
+    }
+}
+
+struct StatsShareCard: View {
+    let stats: UsageStats
+    let now: Date
+
+    static let size = CGSize(width: 1_080, height: 720)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 36) {
+            Text("VOCAPHONE")
+                .font(.system(size: 30, weight: .semibold, design: .rounded))
+                .tracking(6)
+                .foregroundStyle(Color.brand)
+
+            Text(StatsFormat.count(stats.totalWords))
+                .font(.system(size: 190, weight: .bold, design: .rounded))
+                .foregroundStyle(Color.vocaPrimaryText)
+
+            Text(stats.totalWords == 1 ? "word dictated" : "words dictated")
+                .font(.system(size: 44, weight: .medium))
+                .foregroundStyle(Color.vocaSecondaryText)
+
+            Spacer(minLength: 0)
+
+            HStack(spacing: 56) {
+                cardStat(StatsFormat.count(stats.totalDictations), "dictations")
+                cardStat(StatsFormat.wordsPerMinute(stats.averageWordsPerMinute), "WPM")
+                cardStat(StatsFormat.count(stats.currentStreak(at: now)), "day streak")
+            }
+        }
+        .padding(72)
+        .frame(width: Self.size.width, height: Self.size.height, alignment: .leading)
+        .background(Color.vocaCanvas)
+    }
+
+    private func cardStat(_ value: String, _ label: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(value)
+                .font(.system(size: 58, weight: .semibold, design: .rounded))
+                .foregroundStyle(Color.vocaPrimaryText)
+            Text(label)
+                .font(.system(size: 30))
+                .foregroundStyle(Color.vocaSecondaryText)
+        }
+    }
+}
+
+@MainActor
+enum StatsShareExporter {
+    
+    static func renderCard(_ stats: UsageStats, now: Date, style: UIUserInterfaceStyle) -> UIImage? {
+        let renderer = ImageRenderer(content: StatsShareCard(stats: stats, now: now))
+        renderer.scale = 1
+        renderer.proposedSize = ProposedViewSize(StatsShareCard.size)
+        
+        var image: UIImage?
+        UITraitCollection(userInterfaceStyle: style).performAsCurrent {
+            image = renderer.uiImage
+        }
+        return image
+    }
+
+    @discardableResult
+    static func copyCard(_ stats: UsageStats, now: Date, style: UIUserInterfaceStyle) -> Bool {
+        guard let image = renderCard(stats, now: now, style: style) else { return false }
+        UIPasteboard.general.image = image
+        return true
+    }
+}

--- a/ios/VocaPhoneApp/App/StatsShare.swift
+++ b/ios/VocaPhoneApp/App/StatsShare.swift
@@ -120,14 +120,4 @@ enum StatsShareExporter {
             textCopied: UIPasteboard.general.hasStrings
         )
     }
-
-    /// Keep text as the only pasteboard item for browser text fields. If an
-    /// image item comes first, mobile Safari can offer the wrong paste value.
-    static func copyText(_ message: String) -> PayloadResult {
-        UIPasteboard.general.setItems(
-            [[UTType.utf8PlainText.identifier: message]],
-            options: [.localOnly: true]
-        )
-        return PayloadResult(cardCopied: false, textCopied: UIPasteboard.general.hasStrings)
-    }
 }

--- a/ios/VocaPhoneApp/App/StatsShare.swift
+++ b/ios/VocaPhoneApp/App/StatsShare.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import UniformTypeIdentifiers
 
 struct StatsShareCard: View {
     let stats: UsageStats
@@ -81,6 +82,11 @@ struct StatsShareCard: View {
 @MainActor
 enum StatsShareExporter {
 
+    struct PayloadResult: Equatable {
+        let cardCopied: Bool
+        let textCopied: Bool
+    }
+
     static func renderCard(_ stats: UsageStats, now: Date) -> UIImage? {
         let renderer = ImageRenderer(content: StatsShareCard(stats: stats, now: now))
         renderer.scale = 1
@@ -91,7 +97,27 @@ enum StatsShareExporter {
     @discardableResult
     static func copyCard(_ stats: UsageStats, now: Date) -> Bool {
         guard let image = renderCard(stats, now: now) else { return false }
+        return copyCard(image)
+    }
+
+    static func copyCard(_ image: UIImage) -> Bool {
         UIPasteboard.general.image = image
         return UIPasteboard.general.hasImages
+    }
+
+    /// Social deep links cannot carry an image attachment. Keep both pieces on
+    /// the local pasteboard so a native app can receive them with Paste, while
+    /// preventing private usage totals from syncing to another Apple device.
+    static func copySharePayload(image: UIImage?, message: String) -> PayloadResult {
+        var items: [[String: Any]] = []
+        if let image, let data = image.pngData() {
+            items.append([UTType.png.identifier: data])
+        }
+        items.append([UTType.utf8PlainText.identifier: message])
+        UIPasteboard.general.setItems(items, options: [.localOnly: true])
+        return PayloadResult(
+            cardCopied: image != nil && UIPasteboard.general.hasImages,
+            textCopied: UIPasteboard.general.hasStrings
+        )
     }
 }

--- a/ios/VocaPhoneApp/App/StatsShare.swift
+++ b/ios/VocaPhoneApp/App/StatsShare.swift
@@ -120,4 +120,14 @@ enum StatsShareExporter {
             textCopied: UIPasteboard.general.hasStrings
         )
     }
+
+    /// Keep text as the only pasteboard item for browser text fields. If an
+    /// image item comes first, mobile Safari can offer the wrong paste value.
+    static func copyText(_ message: String) -> PayloadResult {
+        UIPasteboard.general.setItems(
+            [[UTType.utf8PlainText.identifier: message]],
+            options: [.localOnly: true]
+        )
+        return PayloadResult(cardCopied: false, textCopied: UIPasteboard.general.hasStrings)
+    }
 }

--- a/ios/VocaPhoneApp/App/StatsShare.swift
+++ b/ios/VocaPhoneApp/App/StatsShare.swift
@@ -1,116 +1,97 @@
 import SwiftUI
 import UIKit
 
-enum StatsShareDestination: CaseIterable {
-    case x
-    case linkedIn
-
-    var label: String {
-        switch self {
-        case .x: "X"
-        case .linkedIn: "LinkedIn"
-        }
-    }
-}
-
-enum StatsShareComposer {
-    static let site = "https://vocaphone.vocahq.com"
-
-    static func message(_ stats: UsageStats, now: Date) -> String {
-        var lines = "🎤 I've dictated \(StatsFormat.count(stats.totalWords)) "
-        lines += stats.totalWords == 1 ? "word" : "words"
-        lines += " with VocaPhone.\n\n"
-        lines += "📊 \(StatsFormat.count(stats.totalDictations)) "
-        lines += stats.totalDictations == 1 ? "dictation" : "dictations"
-        if stats.averageWordsPerMinute > 0 {
-            lines += " · ⚡️ \(Int(stats.averageWordsPerMinute.rounded())) WPM"
-        }
-        let streak = stats.currentStreak(at: now)
-        if streak > 0 {
-            lines += " · 🔥 \(streak)-day streak"
-        }
-        lines += "\n\nRuns on my phone, privately. 🔒\n\(site)"
-        return lines
-    }
-
-    static func composerURL(_ destination: StatsShareDestination, message: String) -> URL? {
-        let encoded = message.addingPercentEncoding(
-            withAllowedCharacters: .alphanumerics
-        ) ?? ""
-        switch destination {
-        case .x:
-            return URL(string: "https://x.com/intent/post?text=\(encoded)")
-        case .linkedIn:
-            return URL(string: "https://www.linkedin.com/feed/?shareActive=true&text=\(encoded)")
-        }
-    }
-}
-
 struct StatsShareCard: View {
     let stats: UsageStats
     let now: Date
 
     static let size = CGSize(width: 1_080, height: 720)
+    private let background = Color(red: 0.07, green: 0.09, blue: 0.09)
+    private let surface = Color.white.opacity(0.07)
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 36) {
-            Text("VOCAPHONE")
-                .font(.system(size: 30, weight: .semibold, design: .rounded))
-                .tracking(6)
-                .foregroundStyle(Color.brand)
+        VStack(alignment: .leading, spacing: 38) {
+            HStack(spacing: 20) {
+                BrandMark(size: 72)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("VocaPhone")
+                        .font(.system(size: 34, weight: .bold, design: .rounded))
+                    Text("My voice, in numbers")
+                        .font(.system(size: 22, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.58))
+                }
+                Spacer()
+                Text("PRIVATE BY DESIGN")
+                    .font(.system(size: 15, weight: .bold, design: .rounded))
+                    .tracking(1.8)
+                    .foregroundStyle(Color.brand)
+            }
 
-            Text(StatsFormat.count(stats.totalWords))
-                .font(.system(size: 190, weight: .bold, design: .rounded))
-                .foregroundStyle(Color.vocaPrimaryText)
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(), spacing: 18), count: 3),
+                spacing: 18
+            ) {
+                cardStat("Words", StatsFormat.count(stats.totalWords), "text.word.spacing")
+                cardStat("Sessions", StatsFormat.count(stats.totalDictations), "waveform")
+                cardStat("Voice time", StatsFormat.duration(stats.totalSeconds), "timer")
+                cardStat("Speed", "\(Int(stats.averageWordsPerMinute.rounded())) WPM", "bolt.fill")
+                cardStat("Streak", "\(stats.currentStreak(at: now)) d", "flame.fill")
+                cardStat("Best", "\(stats.bestStreak) d", "trophy.fill")
+            }
 
-            Text(stats.totalWords == 1 ? "word dictated" : "words dictated")
-                .font(.system(size: 44, weight: .medium))
-                .foregroundStyle(Color.vocaSecondaryText)
-
-            Spacer(minLength: 0)
-
-            HStack(spacing: 56) {
-                cardStat(StatsFormat.count(stats.totalDictations), "dictations")
-                cardStat(StatsFormat.wordsPerMinute(stats.averageWordsPerMinute), "WPM")
-                cardStat(StatsFormat.count(stats.currentStreak(at: now)), "day streak")
+            HStack {
+                Capsule().fill(Color.brand).frame(width: 54, height: 7)
+                Text("Voice typing that stays yours.")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.55))
+                Spacer()
+                Text("vocaphone.vocahq.com")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.55))
             }
         }
-        .padding(72)
-        .frame(width: Self.size.width, height: Self.size.height, alignment: .leading)
-        .background(Color.vocaCanvas)
+        .foregroundStyle(.white)
+        .padding(56)
+        .frame(width: Self.size.width, height: Self.size.height)
+        .background(background)
+        .environment(\.colorScheme, .dark)
     }
 
-    private func cardStat(_ value: String, _ label: String) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
+    private func cardStat(_ title: String, _ value: String, _ symbol: String) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Image(systemName: symbol)
+                .font(.system(size: 23, weight: .semibold))
+                .foregroundStyle(Color.brand)
             Text(value)
-                .font(.system(size: 58, weight: .semibold, design: .rounded))
-                .foregroundStyle(Color.vocaPrimaryText)
-            Text(label)
-                .font(.system(size: 30))
-                .foregroundStyle(Color.vocaSecondaryText)
+                .font(.system(size: 34, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.55)
+            Text(title.uppercased())
+                .font(.system(size: 15, weight: .bold))
+                .tracking(1.4)
+                .foregroundStyle(.white.opacity(0.45))
         }
+        .frame(maxWidth: .infinity, minHeight: 138, alignment: .leading)
+        .padding(22)
+        .background(surface, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
     }
 }
 
 @MainActor
 enum StatsShareExporter {
-    
-    static func renderCard(_ stats: UsageStats, now: Date, style: UIUserInterfaceStyle) -> UIImage? {
+
+    static func renderCard(_ stats: UsageStats, now: Date) -> UIImage? {
         let renderer = ImageRenderer(content: StatsShareCard(stats: stats, now: now))
         renderer.scale = 1
         renderer.proposedSize = ProposedViewSize(StatsShareCard.size)
-        
-        var image: UIImage?
-        UITraitCollection(userInterfaceStyle: style).performAsCurrent {
-            image = renderer.uiImage
-        }
-        return image
+        return renderer.uiImage
     }
 
     @discardableResult
-    static func copyCard(_ stats: UsageStats, now: Date, style: UIUserInterfaceStyle) -> Bool {
-        guard let image = renderCard(stats, now: now, style: style) else { return false }
+    static func copyCard(_ stats: UsageStats, now: Date) -> Bool {
+        guard let image = renderCard(stats, now: now) else { return false }
         UIPasteboard.general.image = image
-        return true
+        return UIPasteboard.general.hasImages
     }
 }

--- a/ios/VocaPhoneApp/App/StatsView.swift
+++ b/ios/VocaPhoneApp/App/StatsView.swift
@@ -464,7 +464,14 @@ struct StatsView: View {
         cardCopied: Bool,
         textCopied: Bool
     ) -> (text: String, symbol: String, isError: Bool) {
-        let place = target == .installedApp ? "\(destination.label) app" : "web composer"
+        let place: String
+        if target == .installedApp {
+            place = "\(destination.label) app"
+        } else if destination == .linkedIn {
+            place = "LinkedIn share dialog"
+        } else {
+            place = "web composer"
+        }
         switch (cardCopied, textCopied) {
         case (true, true):
             return ("Opened the \(place). Card and post text copied for pasting.", "checkmark.circle.fill", false)

--- a/ios/VocaPhoneApp/App/StatsView.swift
+++ b/ios/VocaPhoneApp/App/StatsView.swift
@@ -4,6 +4,7 @@ struct StatsView: View {
     @State private var stats = UsageStats()
     @State private var now = Date()
     @State private var confirmingReset = false
+    @State private var pendingLinkedInWebShare: PendingLinkedInWebShare?
     @State private var shareState = ShareState.idle
     @State private var shareStateToken = 0
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
@@ -20,6 +21,12 @@ struct StatsView: View {
             textCopied: Bool
         )
         case failed(String)
+    }
+
+    private struct PendingLinkedInWebShare {
+        let route: StatsShareRoute
+        let message: String
+        let payload: StatsShareExporter.PayloadResult
     }
 
     var body: some View {
@@ -62,6 +69,22 @@ struct StatsView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text(StatsCopy.resetBody)
+        }
+        .alert(
+            "Your LinkedIn post is copied",
+            isPresented: Binding(
+                get: { pendingLinkedInWebShare != nil },
+                set: { if !$0 { pendingLinkedInWebShare = nil } }
+            )
+        ) {
+            Button("Open LinkedIn") { openPendingLinkedInWebShare() }
+            Button("Cancel", role: .cancel) { pendingLinkedInWebShare = nil }
+        } message: {
+            Text(
+                "LinkedIn’s browser only accepts the VocaPhone link automatically. "
+                    + "After the composer opens, tap the post field and choose Paste "
+                    + "to add your complete stats message."
+            )
         }
     }
 
@@ -418,6 +441,10 @@ struct StatsView: View {
             setShareState(.failed("Couldn’t prepare the \(destination.label) post."), clearingAfter: 6)
             return
         }
+        if destination == .linkedIn, route.target == .browser {
+            prepareLinkedInWebShare(route, message: message)
+            return
+        }
         let payload = StatsShareExporter.copySharePayload(
             image: StatsShareExporter.renderCard(stats, now: now),
             message: message
@@ -445,17 +472,47 @@ struct StatsView: View {
                     )
                 } else if route.target == .installedApp,
                           let web = StatsShareComposer.composerURL(destination, message: message) {
-                    open(
-                        StatsShareRoute(url: web, target: .browser),
-                        destination: destination,
-                        message: message,
-                        payload: payload
-                    )
+                    let webRoute = StatsShareRoute(url: web, target: .browser)
+                    if destination == .linkedIn {
+                        prepareLinkedInWebShare(webRoute, message: message)
+                    } else {
+                        open(
+                            webRoute,
+                            destination: destination,
+                            message: message,
+                            payload: payload
+                        )
+                    }
                 } else {
                     setShareState(.failed("Couldn’t open \(destination.label)."), clearingAfter: 6)
                 }
             }
         }
+    }
+
+    private func prepareLinkedInWebShare(_ route: StatsShareRoute, message: String) {
+        let pasteMessage = StatsShareComposer.linkedInWebPasteMessage(message)
+        let payload = StatsShareExporter.copyText(pasteMessage)
+        guard payload.textCopied else {
+            setShareState(.failed("Couldn’t copy the LinkedIn post text."), clearingAfter: 6)
+            return
+        }
+        pendingLinkedInWebShare = PendingLinkedInWebShare(
+            route: route,
+            message: message,
+            payload: payload
+        )
+    }
+
+    private func openPendingLinkedInWebShare() {
+        guard let pending = pendingLinkedInWebShare else { return }
+        pendingLinkedInWebShare = nil
+        open(
+            pending.route,
+            destination: .linkedIn,
+            message: pending.message,
+            payload: pending.payload
+        )
     }
 
     private func shareSuccessNote(
@@ -471,6 +528,13 @@ struct StatsView: View {
             place = "LinkedIn share dialog"
         } else {
             place = "web composer"
+        }
+        if destination == .linkedIn, target == .browser, textCopied {
+            return (
+                "Opened the LinkedIn share dialog. Tap the post field and choose Paste.",
+                "doc.on.clipboard.fill",
+                false
+            )
         }
         switch (cardCopied, textCopied) {
         case (true, true):

--- a/ios/VocaPhoneApp/App/StatsView.swift
+++ b/ios/VocaPhoneApp/App/StatsView.swift
@@ -1,0 +1,377 @@
+import SwiftUI
+
+enum StatsCopy {
+    static let empty = "Your dictation totals will appear here after your first dictation."
+    static let resetTitle = "Reset statistics?"
+    static let resetBody =
+        "This permanently deletes your usage totals. Your transcripts are not affected."
+    static let resetConfirm = "Reset"
+    static let speedCaption = "Speaking Speed"
+    static let shareTitle = "Share your progress"
+    static let shareSubtitle = "A polished card, ready to post"
+    static let shareFootnote = "The card is copied to your clipboard — paste it into your post."
+    static let shareCopied = "Card copied"
+
+    static func menuDetail(_ stats: UsageStats, now: Date) -> String {
+        guard stats.hasAny else { return "Words, speaking speed and streaks" }
+        let streak = stats.currentStreak(at: now)
+        return "\(StatsFormat.count(stats.totalWords)) words · \(StatsFormat.streak(streak)) streak"
+    }
+}
+
+enum StatsFormat {
+    static func count(_ value: Int) -> String {
+        value.formatted(.number.grouping(.automatic))
+    }
+
+    static func duration(_ seconds: Double) -> String {
+        let total = Int(seconds.rounded())
+        if total < 60 { return "\(total)s" }
+        if total < 3_600 { return "\(total / 60)m" }
+        let hours = total / 3_600
+        let minutes = (total % 3_600) / 60
+        return minutes == 0 ? "\(hours)h" : "\(hours)h \(minutes)m"
+    }
+
+    static func wordsPerMinute(_ value: Double) -> String {
+        String(format: "%.1f", value)
+    }
+
+    static func streak(_ days: Int) -> String {
+        "\(days) \(days == 1 ? "day" : "days")"
+    }
+
+    static func words(_ count: Int) -> String {
+        "\(Self.count(count)) \(count == 1 ? "word" : "words")"
+    }
+
+    static func dayLabel(_ key: String, now: Date, timeZone: TimeZone = .current) -> String {
+        let today = UsageStats.dayKey(now, timeZone: timeZone)
+        guard let elapsed = UsageStats.daysBetween(key, today) else { return key }
+        switch elapsed {
+        case 0: return "Today"
+        case 1: return "Yesterday"
+        default: return key
+        }
+    }
+}
+
+struct StatsView: View {
+    @State private var stats = UsageStats()
+    @State private var now = Date()
+    @State private var confirmingReset = false
+    @State private var copiedCard = false
+    @Environment(\.openURL) private var openURL
+    @Environment(\.colorScheme) private var colorScheme
+
+    private let store = UsageStatsStore.shared
+
+    var body: some View {
+        ScrollView {
+            if stats.hasAny {
+                content
+            } else {
+                Text(StatsCopy.empty)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(VocaMetrics.padding)
+            }
+        }
+        .navigationTitle("Stats")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { refresh(folding: true) }
+
+        .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
+            refresh(folding: false)
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: UIApplication.significantTimeChangeNotification)
+        ) { _ in
+            refresh(folding: false)
+        }
+        .confirmationDialog(
+            StatsCopy.resetTitle,
+            isPresented: $confirmingReset,
+            titleVisibility: .visible
+        ) {
+            Button(StatsCopy.resetConfirm, role: .destructive) { reset() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(StatsCopy.resetBody)
+        }
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: VocaMetrics.padding) {
+            speedCard
+            statGrid
+            recentActivityCard
+            shareCard
+
+            VocaDestructiveButton(title: "Reset statistics") { confirmingReset = true }
+                .frame(maxWidth: .infinity)
+                .padding(.top, VocaMetrics.related)
+        }
+        .padding(VocaMetrics.padding)
+    }
+
+
+    private var speedCard: some View {
+        VocaCard {
+            VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                StatChipLabel(symbol: "chart.line.uptrend.xyaxis", tint: .speed, title: "Speed")
+                HStack(alignment: .firstTextBaseline, spacing: VocaMetrics.tight) {
+                    Text(StatsFormat.wordsPerMinute(stats.averageWordsPerMinute))
+                        .font(.system(.largeTitle, design: .rounded).weight(.bold))
+                        .foregroundStyle(Color.vocaPrimaryText)
+                    Text("WPM")
+                        .font(.subheadline)
+                        .foregroundStyle(Color.vocaSecondaryText)
+                }
+                Text(StatsCopy.speedCaption)
+                    .font(.caption)
+                    .foregroundStyle(Color.vocaSecondaryText)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(
+                "Speaking speed, \(StatsFormat.wordsPerMinute(stats.averageWordsPerMinute)) words per minute"
+            )
+        }
+    }
+
+    private var statGrid: some View {
+        Grid(horizontalSpacing: VocaMetrics.padding, verticalSpacing: VocaMetrics.padding) {
+            GridRow {
+                statCard("text.alignleft", .words, StatsFormat.count(stats.totalWords), "Words")
+                statCard("mic.fill", .dictations, StatsFormat.count(stats.totalDictations), "Dictations")
+            }
+            GridRow {
+                statCard("clock", .time, StatsFormat.duration(stats.totalSeconds), "Time")
+                streakCard
+            }
+        }
+    }
+
+    private func statCard(
+        _ symbol: String,
+        _ tint: SemanticPalette.StatTint,
+        _ value: String,
+        _ label: String
+    ) -> some View {
+        VocaCard {
+            VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                StatChip(symbol: symbol, tint: tint)
+                Text(value)
+                    .font(.system(.title, design: .rounded).weight(.bold))
+                    .foregroundStyle(Color.vocaPrimaryText)
+                Text(label)
+                    .font(.caption)
+                    .foregroundStyle(Color.vocaSecondaryText)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(label), \(value)")
+        }
+    }
+
+    private var streakCard: some View {
+        let streak = stats.currentStreak(at: now)
+        return VocaCard {
+            VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                StatChip(symbol: "flame.fill", tint: .streak)
+                HStack(alignment: .firstTextBaseline, spacing: VocaMetrics.tight) {
+                    Text(StatsFormat.count(streak))
+                        .font(.system(.title, design: .rounded).weight(.bold))
+                        .foregroundStyle(Color.vocaPrimaryText)
+                    Text(streak == 1 ? "day" : "days")
+                        .font(.subheadline)
+                        .foregroundStyle(Color.vocaSecondaryText)
+                }
+                Text("Streak · Best \(StatsFormat.streak(stats.bestStreak))")
+                    .font(.caption)
+                    .foregroundStyle(Color.vocaSecondaryText)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(
+                "Streak, \(StatsFormat.streak(streak)). Best \(StatsFormat.streak(stats.bestStreak))"
+            )
+        }
+    }
+
+    private var recentActivityCard: some View {
+        let days = stats.recentDays()
+        return Group {
+            if days.isEmpty {
+                EmptyView()
+            } else {
+                VocaCard {
+                    VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                        StatChipLabel(
+                            symbol: "chart.line.uptrend.xyaxis",
+                            tint: .speed,
+                            title: "Recent activity"
+                        )
+                        ForEach(days, id: \.key) { day in
+                            LabeledContent {
+                                Text(StatsFormat.words(day.words))
+                                    .font(.subheadline)
+                                    .foregroundStyle(Color.vocaSecondaryText)
+                            } label: {
+                                Text(StatsFormat.dayLabel(day.key, now: now))
+                                    .font(.subheadline.weight(.medium))
+                                    .foregroundStyle(Color.vocaPrimaryText)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var shareCard: some View {
+        VocaCard {
+            VStack(alignment: .leading, spacing: VocaMetrics.padding) {
+                HStack(alignment: .top, spacing: VocaMetrics.related) {
+                    StatChip(symbol: "doc.on.clipboard", tint: .words)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(StatsCopy.shareTitle)
+                            .font(.headline)
+                            .foregroundStyle(Color.vocaPrimaryText)
+                        Text(StatsCopy.shareSubtitle)
+                            .font(.caption)
+                            .foregroundStyle(Color.vocaSecondaryText)
+                    }
+                }
+
+                HStack(spacing: VocaMetrics.related) {
+                    ShareButton(
+                        tint: Color.brand,
+                        label: copiedCard ? StatsCopy.shareCopied : "Copy"
+                    ) {
+                        Image(systemName: copiedCard ? "checkmark" : "doc.on.clipboard")
+                    } action: {
+                        copyCard()
+                    }
+
+                    ShareButton(tint: Color.vocaPrimaryText, label: "X") {
+                        Text("\u{1D54F}").font(.title3)
+                    } action: {
+                        share(to: .x)
+                    }
+
+                    ShareButton(tint: Self.linkedInBlue, label: "LinkedIn") {
+                        Text("in")
+                            .font(.subheadline.weight(.bold))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Self.linkedInBlue, in: RoundedRectangle(cornerRadius: 3))
+                    } action: {
+                        share(to: .linkedIn)
+                    }
+                }
+
+                Text(StatsCopy.shareFootnote)
+                    .font(.caption2)
+                    .foregroundStyle(Color.vocaSecondaryText)
+            }
+        }
+    }
+
+    private static let linkedInBlue = Color(red: 0.04, green: 0.40, blue: 0.71)
+
+    private func copyCard() {
+        StatsShareExporter.copyCard(stats, now: now, style: interfaceStyle)
+        withAnimation { copiedCard = true }
+    }
+
+    private func share(to destination: StatsShareDestination) {
+        StatsShareExporter.copyCard(stats, now: now, style: interfaceStyle)
+        let message = StatsShareComposer.message(stats, now: now)
+        guard let url = StatsShareComposer.composerURL(destination, message: message) else { return }
+        openURL(url)
+    }
+
+    private var interfaceStyle: UIUserInterfaceStyle {
+        colorScheme == .dark ? .dark : .light
+    }
+
+    private func refresh(folding: Bool) {
+        now = Date()
+        if folding, let folded = try? store.fold() {
+            stats = folded
+        } else {
+            stats = store.current()
+        }
+    }
+
+    private func reset() {
+        try? store.reset()
+        refresh(folding: false)
+    }
+}
+
+struct StatChip: View {
+    let symbol: String
+    let tint: SemanticPalette.StatTint
+    var size: CGFloat = 30
+
+    var body: some View {
+        Image(systemName: symbol)
+            .font(.system(size: size * 0.5, weight: .medium))
+            .foregroundStyle(Color.vocaStatSymbol(tint))
+            .frame(width: size, height: size)
+            .background(
+                Color.vocaStatChip(tint),
+                in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+            )
+            .accessibilityHidden(true)
+    }
+}
+
+struct StatChipLabel: View {
+    let symbol: String
+    let tint: SemanticPalette.StatTint
+    let title: String
+
+    var body: some View {
+        HStack(spacing: VocaMetrics.related) {
+            StatChip(symbol: symbol, tint: tint, size: 26)
+            Text(title)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(Color.vocaSecondaryText)
+        }
+    }
+}
+
+struct ShareButton<Mark: View>: View {
+    let tint: Color
+    let label: String
+    @ViewBuilder var mark: Mark
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: VocaMetrics.tight) {
+                mark
+                Text(label)
+                    .font(.caption.weight(.medium))
+            }
+            .frame(maxWidth: .infinity)
+            .frame(minHeight: VocaMetrics.minimumTarget + 12)
+            .foregroundStyle(tint)
+            .background(
+                tint.opacity(0.08),
+                in: RoundedRectangle(cornerRadius: VocaMetrics.fieldRadius, style: .continuous)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VocaMetrics.fieldRadius, style: .continuous)
+                    .strokeBorder(tint.opacity(0.25), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Share to \(label)")
+    }
+}

--- a/ios/VocaPhoneApp/App/StatsView.swift
+++ b/ios/VocaPhoneApp/App/StatsView.swift
@@ -4,7 +4,6 @@ struct StatsView: View {
     @State private var stats = UsageStats()
     @State private var now = Date()
     @State private var confirmingReset = false
-    @State private var pendingLinkedInWebShare: PendingLinkedInWebShare?
     @State private var shareState = ShareState.idle
     @State private var shareStateToken = 0
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
@@ -21,12 +20,6 @@ struct StatsView: View {
             textCopied: Bool
         )
         case failed(String)
-    }
-
-    private struct PendingLinkedInWebShare {
-        let route: StatsShareRoute
-        let message: String
-        let payload: StatsShareExporter.PayloadResult
     }
 
     var body: some View {
@@ -69,22 +62,6 @@ struct StatsView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text(StatsCopy.resetBody)
-        }
-        .alert(
-            "Your LinkedIn post is copied",
-            isPresented: Binding(
-                get: { pendingLinkedInWebShare != nil },
-                set: { if !$0 { pendingLinkedInWebShare = nil } }
-            )
-        ) {
-            Button("Open LinkedIn") { openPendingLinkedInWebShare() }
-            Button("Cancel", role: .cancel) { pendingLinkedInWebShare = nil }
-        } message: {
-            Text(
-                "LinkedIn’s browser only accepts the VocaPhone link automatically. "
-                    + "After the composer opens, tap the post field and choose Paste "
-                    + "to add your complete stats message."
-            )
         }
     }
 
@@ -441,10 +418,6 @@ struct StatsView: View {
             setShareState(.failed("Couldn’t prepare the \(destination.label) post."), clearingAfter: 6)
             return
         }
-        if destination == .linkedIn, route.target == .browser {
-            prepareLinkedInWebShare(route, message: message)
-            return
-        }
         let payload = StatsShareExporter.copySharePayload(
             image: StatsShareExporter.renderCard(stats, now: now),
             message: message
@@ -472,47 +445,17 @@ struct StatsView: View {
                     )
                 } else if route.target == .installedApp,
                           let web = StatsShareComposer.composerURL(destination, message: message) {
-                    let webRoute = StatsShareRoute(url: web, target: .browser)
-                    if destination == .linkedIn {
-                        prepareLinkedInWebShare(webRoute, message: message)
-                    } else {
-                        open(
-                            webRoute,
-                            destination: destination,
-                            message: message,
-                            payload: payload
-                        )
-                    }
+                    open(
+                        StatsShareRoute(url: web, target: .browser),
+                        destination: destination,
+                        message: message,
+                        payload: payload
+                    )
                 } else {
                     setShareState(.failed("Couldn’t open \(destination.label)."), clearingAfter: 6)
                 }
             }
         }
-    }
-
-    private func prepareLinkedInWebShare(_ route: StatsShareRoute, message: String) {
-        let pasteMessage = StatsShareComposer.linkedInWebPasteMessage(message)
-        let payload = StatsShareExporter.copyText(pasteMessage)
-        guard payload.textCopied else {
-            setShareState(.failed("Couldn’t copy the LinkedIn post text."), clearingAfter: 6)
-            return
-        }
-        pendingLinkedInWebShare = PendingLinkedInWebShare(
-            route: route,
-            message: message,
-            payload: payload
-        )
-    }
-
-    private func openPendingLinkedInWebShare() {
-        guard let pending = pendingLinkedInWebShare else { return }
-        pendingLinkedInWebShare = nil
-        open(
-            pending.route,
-            destination: .linkedIn,
-            message: pending.message,
-            payload: pending.payload
-        )
     }
 
     private func shareSuccessNote(
@@ -525,16 +468,9 @@ struct StatsView: View {
         if target == .installedApp {
             place = "\(destination.label) app"
         } else if destination == .linkedIn {
-            place = "LinkedIn share dialog"
+            place = "LinkedIn composer"
         } else {
             place = "web composer"
-        }
-        if destination == .linkedIn, target == .browser, textCopied {
-            return (
-                "Opened the LinkedIn share dialog. Tap the post field and choose Paste.",
-                "doc.on.clipboard.fill",
-                false
-            )
         }
         switch (cardCopied, textCopied) {
         case (true, true):

--- a/ios/VocaPhoneApp/App/StatsView.swift
+++ b/ios/VocaPhoneApp/App/StatsView.swift
@@ -409,7 +409,7 @@ struct StatsView: View {
     }
 
     private func share(to destination: StatsShareDestination) {
-        let message = StatsShareComposer.message(stats, now: now)
+        let message = StatsShareComposer.message(stats, now: now, destination: destination)
         guard let route = StatsShareComposer.preferredRoute(
             destination,
             message: message,

--- a/ios/VocaPhoneApp/App/StatsView.swift
+++ b/ios/VocaPhoneApp/App/StatsView.swift
@@ -6,7 +6,6 @@ struct StatsView: View {
     @State private var confirmingReset = false
     @State private var shareState = ShareState.idle
     @State private var shareStateToken = 0
-    @Environment(\.openURL) private var openURL
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     private let store = UsageStatsStore.shared
@@ -14,7 +13,12 @@ struct StatsView: View {
     private enum ShareState: Equatable {
         case idle
         case copied
-        case opened(StatsShareDestination)
+        case opened(
+            StatsShareDestination,
+            target: StatsShareTarget,
+            cardCopied: Bool,
+            textCopied: Bool
+        )
         case failed(String)
     }
 
@@ -205,10 +209,24 @@ struct StatsView: View {
 
     private var recentActivityCard: some View {
         let days = stats.lastSevenDays(endingAt: now)
+        let weeklyWords = days.reduce(0) { $0 + $1.words }
+        let weeklySessions = days.reduce(0) { $0 + $1.dictations }
         return VStack(alignment: .leading, spacing: VocaMetrics.related) {
             VocaSectionHeader(title: "Last 7 days")
             VocaCard {
                 VStack(alignment: .leading, spacing: VocaMetrics.padding) {
+                    HStack(spacing: VocaMetrics.related) {
+                        StatChip(symbol: "chart.bar.fill", tint: .speed, size: 34)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(StatsFormat.words(weeklyWords))
+                                .font(.headline)
+                                .foregroundStyle(Color.vocaPrimaryText)
+                            Text(StatsFormat.sessions(weeklySessions))
+                                .font(.caption)
+                                .foregroundStyle(Color.vocaSecondaryText)
+                        }
+                        Spacer()
+                    }
                     activityChart(days)
                     if stats.hasAny {
                         Divider()
@@ -233,13 +251,15 @@ struct StatsView: View {
         return HStack(alignment: .bottom, spacing: VocaMetrics.related) {
             ForEach(days) { day in
                 VStack(spacing: 7) {
-                    Text(day.words == 0 ? "" : StatsFormat.count(day.words))
+                    Text(day.words == 0 ? "" : StatsFormat.compactCount(day.words))
                         .font(.caption2.weight(.semibold))
                         .monospacedDigit()
                         .foregroundStyle(Color.vocaSecondaryText)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.65)
                         .frame(height: 16)
                     RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(day.words == 0 ? Color.vocaRecessedSurface : Color.brand)
+                        .fill(activityBarColor(day))
                         .frame(height: activityBarHeight(day.words, maximum: maximum))
                     Text(StatsFormat.shortDayLabel(day.key))
                         .font(.caption2.weight(day.key == UsageStats.dayKey(now) ? .bold : .regular))
@@ -260,24 +280,34 @@ struct StatsView: View {
     }
 
     private func activityRow(_ day: DailyUsage) -> some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text(StatsFormat.dayLabel(day.key, now: now))
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(Color.vocaPrimaryText)
-            Spacer()
-            Text(
-                "\(StatsFormat.words(day.words)) · \(StatsFormat.sessions(day.dictations)) · "
-                    + StatsFormat.duration(day.seconds)
-            )
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(StatsFormat.dayLabel(day.key, now: now))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.vocaPrimaryText)
+                Spacer()
+                Text(StatsFormat.words(day.words))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.vocaPrimaryText)
+            }
+            HStack(spacing: VocaMetrics.padding) {
+                Label(StatsFormat.sessions(day.dictations), systemImage: "waveform")
+                Label(StatsFormat.duration(day.seconds), systemImage: "timer")
+            }
             .font(.caption)
             .foregroundStyle(Color.vocaSecondaryText)
-            .multilineTextAlignment(.trailing)
         }
+        .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
     }
 
     private func activityBarHeight(_ words: Int, maximum: Int) -> CGFloat {
         words == 0 ? 8 : max(16, CGFloat(words) / CGFloat(maximum) * 94)
+    }
+
+    private func activityBarColor(_ day: DailyUsage) -> Color {
+        guard day.words > 0 else { return Color.vocaRecessedSurface }
+        return day.key == UsageStats.dayKey(now) ? Color.brand : Color.brand.opacity(0.58)
     }
 
     private var shareCard: some View {
@@ -295,24 +325,7 @@ struct StatsView: View {
                     }
                 }
 
-                HStack(spacing: VocaMetrics.related) {
-                    ShareButton(tint: Color.brand, label: "Copy", accessibilityLabel: "Copy stats card") {
-                        Image(systemName: shareState == .copied ? "checkmark" : "doc.on.clipboard")
-                    } action: { copyCard() }
-
-                    ShareButton(tint: Color.vocaPrimaryText, label: "X", accessibilityLabel: "Share stats on X") {
-                        Text("X").font(.headline.weight(.semibold))
-                    } action: { share(to: .x) }
-
-                    ShareButton(tint: Self.linkedInBlue, label: "LinkedIn", accessibilityLabel: "Share stats on LinkedIn") {
-                        Text("in")
-                            .font(.subheadline.weight(.bold))
-                            .foregroundStyle(.white)
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 1)
-                            .background(Self.linkedInBlue, in: RoundedRectangle(cornerRadius: 3))
-                    } action: { share(to: .linkedIn) }
-                }
+                shareActions
 
                 if let note = shareNote {
                     Label(note.text, systemImage: note.symbol)
@@ -326,6 +339,34 @@ struct StatsView: View {
                 }
             }
             .animation(.easeInOut(duration: 0.18), value: shareState)
+        }
+    }
+
+    private var shareActions: some View {
+        let layout = dynamicTypeSize.isAccessibilitySize
+            ? AnyLayout(VStackLayout(spacing: VocaMetrics.related))
+            : AnyLayout(HStackLayout(spacing: VocaMetrics.related))
+        return layout {
+            ShareButton(tint: Color.brand, label: "Copy", accessibilityLabel: "Copy stats card") {
+                Image(systemName: shareState == .copied ? "checkmark" : "doc.on.clipboard")
+            } action: { copyCard() }
+
+            ShareButton(tint: Color.vocaPrimaryText, label: "X", accessibilityLabel: "Share stats on X") {
+                Text("X").font(.headline.weight(.semibold))
+            } action: { share(to: .x) }
+
+            ShareButton(
+                tint: Self.linkedInBlue,
+                label: "LinkedIn",
+                accessibilityLabel: "Share stats on LinkedIn"
+            ) {
+                Text("in")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 1)
+                    .background(Self.linkedInBlue, in: RoundedRectangle(cornerRadius: 3))
+            } action: { share(to: .linkedIn) }
         }
     }
 
@@ -347,8 +388,13 @@ struct StatsView: View {
             nil
         case .copied:
             ("Card copied. Paste it wherever you’d like.", "checkmark.circle.fill", false)
-        case .opened(let destination):
-            ("Card copied. Paste it into your \(destination.label) post.", "doc.on.clipboard", false)
+        case .opened(let destination, let target, let cardCopied, let textCopied):
+            shareSuccessNote(
+                destination,
+                target: target,
+                cardCopied: cardCopied,
+                textCopied: textCopied
+            )
         case .failed(let message):
             (message, "exclamationmark.triangle.fill", true)
         }
@@ -363,23 +409,71 @@ struct StatsView: View {
     }
 
     private func share(to destination: StatsShareDestination) {
-        guard StatsShareExporter.copyCard(stats, now: now) else {
-            setShareState(.failed("Couldn’t copy the card image."), clearingAfter: 6)
-            return
-        }
         let message = StatsShareComposer.message(stats, now: now)
-        guard let url = StatsShareComposer.composerURL(destination, message: message) else {
+        guard let route = StatsShareComposer.preferredRoute(
+            destination,
+            message: message,
+            canOpen: UIApplication.shared.canOpenURL
+        ) else {
             setShareState(.failed("Couldn’t prepare the \(destination.label) post."), clearingAfter: 6)
             return
         }
-        openURL(url) { accepted in
+        let payload = StatsShareExporter.copySharePayload(
+            image: StatsShareExporter.renderCard(stats, now: now),
+            message: message
+        )
+        open(route, destination: destination, message: message, payload: payload)
+    }
+
+    private func open(
+        _ route: StatsShareRoute,
+        destination: StatsShareDestination,
+        message: String,
+        payload: StatsShareExporter.PayloadResult
+    ) {
+        UIApplication.shared.open(route.url) { accepted in
             Task { @MainActor in
                 if accepted {
-                    setShareState(.opened(destination), clearingAfter: 5)
+                    setShareState(
+                        .opened(
+                            destination,
+                            target: route.target,
+                            cardCopied: payload.cardCopied,
+                            textCopied: payload.textCopied
+                        ),
+                        clearingAfter: 6
+                    )
+                } else if route.target == .installedApp,
+                          let web = StatsShareComposer.composerURL(destination, message: message) {
+                    open(
+                        StatsShareRoute(url: web, target: .browser),
+                        destination: destination,
+                        message: message,
+                        payload: payload
+                    )
                 } else {
                     setShareState(.failed("Couldn’t open \(destination.label)."), clearingAfter: 6)
                 }
             }
+        }
+    }
+
+    private func shareSuccessNote(
+        _ destination: StatsShareDestination,
+        target: StatsShareTarget,
+        cardCopied: Bool,
+        textCopied: Bool
+    ) -> (text: String, symbol: String, isError: Bool) {
+        let place = target == .installedApp ? "\(destination.label) app" : "web composer"
+        switch (cardCopied, textCopied) {
+        case (true, true):
+            return ("Opened the \(place). Card and post text copied for pasting.", "checkmark.circle.fill", false)
+        case (false, true):
+            return ("Opened the \(place). Post text copied, but the card was unavailable.", "exclamationmark.triangle.fill", true)
+        case (true, false):
+            return ("Opened the \(place). Card copied, but the post text was unavailable.", "exclamationmark.triangle.fill", true)
+        case (false, false):
+            return ("Opened the \(place), but nothing could be copied.", "exclamationmark.triangle.fill", true)
         }
     }
 
@@ -436,13 +530,26 @@ struct ShareButton<Mark: View>: View {
     let accessibilityLabel: String
     @ViewBuilder var mark: Mark
     let action: () -> Void
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     var body: some View {
         Button(action: action) {
-            VStack(spacing: VocaMetrics.tight) {
-                mark
-                Text(label)
-                    .font(.caption.weight(.medium))
+            Group {
+                if dynamicTypeSize.isAccessibilitySize {
+                    HStack(spacing: VocaMetrics.related) {
+                        mark
+                        Text(label)
+                            .font(.body.weight(.semibold))
+                        Spacer()
+                    }
+                    .padding(.horizontal, VocaMetrics.padding)
+                } else {
+                    VStack(spacing: VocaMetrics.tight) {
+                        mark
+                        Text(label)
+                            .font(.caption.weight(.medium))
+                    }
+                }
             }
             .frame(maxWidth: .infinity)
             .frame(minHeight: VocaMetrics.minimumTarget + 12)

--- a/ios/VocaPhoneApp/App/StatsView.swift
+++ b/ios/VocaPhoneApp/App/StatsView.swift
@@ -1,87 +1,46 @@
 import SwiftUI
 
-enum StatsCopy {
-    static let empty = "Your dictation totals will appear here after your first dictation."
-    static let resetTitle = "Reset statistics?"
-    static let resetBody =
-        "This permanently deletes your usage totals. Your transcripts are not affected."
-    static let resetConfirm = "Reset"
-    static let speedCaption = "Speaking Speed"
-    static let shareTitle = "Share your progress"
-    static let shareSubtitle = "A polished card, ready to post"
-    static let shareFootnote = "The card is copied to your clipboard — paste it into your post."
-    static let shareCopied = "Card copied"
-
-    static func menuDetail(_ stats: UsageStats, now: Date) -> String {
-        guard stats.hasAny else { return "Words, speaking speed and streaks" }
-        let streak = stats.currentStreak(at: now)
-        return "\(StatsFormat.count(stats.totalWords)) words · \(StatsFormat.streak(streak)) streak"
-    }
-}
-
-enum StatsFormat {
-    static func count(_ value: Int) -> String {
-        value.formatted(.number.grouping(.automatic))
-    }
-
-    static func duration(_ seconds: Double) -> String {
-        let total = Int(seconds.rounded())
-        if total < 60 { return "\(total)s" }
-        if total < 3_600 { return "\(total / 60)m" }
-        let hours = total / 3_600
-        let minutes = (total % 3_600) / 60
-        return minutes == 0 ? "\(hours)h" : "\(hours)h \(minutes)m"
-    }
-
-    static func wordsPerMinute(_ value: Double) -> String {
-        String(format: "%.1f", value)
-    }
-
-    static func streak(_ days: Int) -> String {
-        "\(days) \(days == 1 ? "day" : "days")"
-    }
-
-    static func words(_ count: Int) -> String {
-        "\(Self.count(count)) \(count == 1 ? "word" : "words")"
-    }
-
-    static func dayLabel(_ key: String, now: Date, timeZone: TimeZone = .current) -> String {
-        let today = UsageStats.dayKey(now, timeZone: timeZone)
-        guard let elapsed = UsageStats.daysBetween(key, today) else { return key }
-        switch elapsed {
-        case 0: return "Today"
-        case 1: return "Yesterday"
-        default: return key
-        }
-    }
-}
-
 struct StatsView: View {
     @State private var stats = UsageStats()
     @State private var now = Date()
     @State private var confirmingReset = false
-    @State private var copiedCard = false
+    @State private var shareState = ShareState.idle
+    @State private var shareStateToken = 0
     @Environment(\.openURL) private var openURL
-    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     private let store = UsageStatsStore.shared
 
+    private enum ShareState: Equatable {
+        case idle
+        case copied
+        case opened(StatsShareDestination)
+        case failed(String)
+    }
+
     var body: some View {
         ScrollView {
-            if stats.hasAny {
-                content
-            } else {
-                Text(StatsCopy.empty)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(VocaMetrics.padding)
+            VStack(alignment: .leading, spacing: VocaMetrics.grouping) {
+                hero
+                statGrid
+                recentActivityCard
+                if stats.hasAny { shareCard }
+                privacyNote
+                if stats.hasAny {
+                    VocaDestructiveButton(title: "Reset statistics") {
+                        confirmingReset = true
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, VocaMetrics.related)
+                }
             }
+            .padding(.horizontal, VocaMetrics.padding)
+            .padding(.vertical, VocaMetrics.grouping)
         }
+        .background(Color.vocaCanvas)
         .navigationTitle("Stats")
         .navigationBarTitleDisplayMode(.inline)
         .task { refresh(folding: true) }
-
         .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
             refresh(folding: false)
         }
@@ -102,55 +61,99 @@ struct StatsView: View {
         }
     }
 
-    private var content: some View {
-        VStack(alignment: .leading, spacing: VocaMetrics.padding) {
-            speedCard
-            statGrid
-            recentActivityCard
-            shareCard
+    private var hero: some View {
+        VocaCard(padding: VocaMetrics.grouping) {
+            VStack(alignment: .leading, spacing: VocaMetrics.padding) {
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: VocaMetrics.tight) {
+                        Text("YOUR VOICE, IN NUMBERS")
+                            .font(.caption.weight(.bold))
+                            .tracking(1.3)
+                            .foregroundStyle(Color.brand)
+                        Text(stats.hasAny ? "Keep the momentum" : "Start your story")
+                            .font(.title2.weight(.bold))
+                            .foregroundStyle(Color.vocaPrimaryText)
+                    }
+                    Spacer()
+                    Image(systemName: stats.hasAny ? "waveform.circle.fill" : "sparkles")
+                        .font(.system(size: 38))
+                        .foregroundStyle(Color.brand)
+                        .accessibilityHidden(true)
+                }
 
-            VocaDestructiveButton(title: "Reset statistics") { confirmingReset = true }
-                .frame(maxWidth: .infinity)
-                .padding(.top, VocaMetrics.related)
-        }
-        .padding(VocaMetrics.padding)
-    }
-
-
-    private var speedCard: some View {
-        VocaCard {
-            VStack(alignment: .leading, spacing: VocaMetrics.related) {
-                StatChipLabel(symbol: "chart.line.uptrend.xyaxis", tint: .speed, title: "Speed")
-                HStack(alignment: .firstTextBaseline, spacing: VocaMetrics.tight) {
-                    Text(StatsFormat.wordsPerMinute(stats.averageWordsPerMinute))
-                        .font(.system(.largeTitle, design: .rounded).weight(.bold))
-                        .foregroundStyle(Color.vocaPrimaryText)
-                    Text("WPM")
+                if stats.hasAny {
+                    ViewThatFits(in: .horizontal) {
+                        HStack(alignment: .firstTextBaseline, spacing: VocaMetrics.related) {
+                            speedValue
+                            Spacer()
+                            streakPill
+                        }
+                        VStack(alignment: .leading, spacing: VocaMetrics.related) {
+                            speedValue
+                            streakPill
+                        }
+                    }
+                    Text(StatsCopy.speedCaption)
                         .font(.subheadline)
                         .foregroundStyle(Color.vocaSecondaryText)
+                } else {
+                    Text("Complete a dictation from the VocaPhone keyboard and your private progress will appear here.")
+                        .font(.subheadline)
+                        .foregroundStyle(Color.vocaSecondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Label("Only inserted dictations count", systemImage: "checkmark.seal.fill")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Color.brand)
                 }
-                Text(StatsCopy.speedCaption)
-                    .font(.caption)
-                    .foregroundStyle(Color.vocaSecondaryText)
             }
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel(
-                "Speaking speed, \(StatsFormat.wordsPerMinute(stats.averageWordsPerMinute)) words per minute"
-            )
         }
+    }
+
+    private var speedValue: some View {
+        HStack(alignment: .firstTextBaseline, spacing: VocaMetrics.related) {
+            Text(StatsFormat.wordsPerMinute(stats.averageWordsPerMinute))
+                .font(.system(size: 48, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(Color.vocaPrimaryText)
+                .lineLimit(1)
+                .minimumScaleFactor(0.65)
+            Text("WPM")
+                .font(.headline)
+                .foregroundStyle(Color.vocaSecondaryText)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "Speaking speed, \(StatsFormat.wordsPerMinute(stats.averageWordsPerMinute)) words per minute"
+        )
+    }
+
+    private var streakPill: some View {
+        let streak = stats.currentStreak(at: now)
+        return Label(StatsFormat.streak(streak), systemImage: "flame.fill")
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(streak > 0 ? Color.vocaStatSymbol(.streak) : Color.vocaSecondaryText)
+            .padding(.horizontal, 12)
+            .frame(minHeight: VocaMetrics.minimumTarget)
+            .background(Color.vocaRecessedSurface, in: Capsule())
+            .accessibilityLabel("Current streak, \(StatsFormat.streak(streak))")
     }
 
     private var statGrid: some View {
-        Grid(horizontalSpacing: VocaMetrics.padding, verticalSpacing: VocaMetrics.padding) {
-            GridRow {
+        VStack(alignment: .leading, spacing: VocaMetrics.related) {
+            VocaSectionHeader(title: "Lifetime")
+            LazyVGrid(columns: statColumns, spacing: VocaMetrics.related) {
                 statCard("text.alignleft", .words, StatsFormat.count(stats.totalWords), "Words")
-                statCard("mic.fill", .dictations, StatsFormat.count(stats.totalDictations), "Dictations")
-            }
-            GridRow {
-                statCard("clock", .time, StatsFormat.duration(stats.totalSeconds), "Time")
+                statCard("waveform", .dictations, StatsFormat.count(stats.totalDictations), "Sessions")
+                statCard("clock", .time, StatsFormat.duration(stats.totalSeconds), "Voice time")
                 streakCard
             }
         }
+    }
+
+    private var statColumns: [GridItem] {
+        dynamicTypeSize.isAccessibilitySize
+            ? [GridItem(.flexible())]
+            : [GridItem(.flexible(), spacing: VocaMetrics.related), GridItem(.flexible())]
     }
 
     private func statCard(
@@ -163,10 +166,13 @@ struct StatsView: View {
             VStack(alignment: .leading, spacing: VocaMetrics.related) {
                 StatChip(symbol: symbol, tint: tint)
                 Text(value)
-                    .font(.system(.title, design: .rounded).weight(.bold))
+                    .font(.system(.title2, design: .rounded).weight(.bold))
                     .foregroundStyle(Color.vocaPrimaryText)
+                    .monospacedDigit()
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.65)
                 Text(label)
-                    .font(.caption)
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(Color.vocaSecondaryText)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -180,54 +186,98 @@ struct StatsView: View {
         return VocaCard {
             VStack(alignment: .leading, spacing: VocaMetrics.related) {
                 StatChip(symbol: "flame.fill", tint: .streak)
-                HStack(alignment: .firstTextBaseline, spacing: VocaMetrics.tight) {
-                    Text(StatsFormat.count(streak))
-                        .font(.system(.title, design: .rounded).weight(.bold))
-                        .foregroundStyle(Color.vocaPrimaryText)
-                    Text(streak == 1 ? "day" : "days")
-                        .font(.subheadline)
-                        .foregroundStyle(Color.vocaSecondaryText)
-                }
-                Text("Streak · Best \(StatsFormat.streak(stats.bestStreak))")
-                    .font(.caption)
+                Text(StatsFormat.streak(streak))
+                    .font(.system(.title2, design: .rounded).weight(.bold))
+                    .foregroundStyle(Color.vocaPrimaryText)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.65)
+                Text("Best \(StatsFormat.streak(stats.bestStreak))")
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(Color.vocaSecondaryText)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityElement(children: .combine)
             .accessibilityLabel(
-                "Streak, \(StatsFormat.streak(streak)). Best \(StatsFormat.streak(stats.bestStreak))"
+                "Current streak, \(StatsFormat.streak(streak)). Best, \(StatsFormat.streak(stats.bestStreak))"
             )
         }
     }
 
     private var recentActivityCard: some View {
-        let days = stats.recentDays()
-        return Group {
-            if days.isEmpty {
-                EmptyView()
-            } else {
-                VocaCard {
-                    VStack(alignment: .leading, spacing: VocaMetrics.related) {
-                        StatChipLabel(
-                            symbol: "chart.line.uptrend.xyaxis",
-                            tint: .speed,
-                            title: "Recent activity"
-                        )
-                        ForEach(days, id: \.key) { day in
-                            LabeledContent {
-                                Text(StatsFormat.words(day.words))
-                                    .font(.subheadline)
-                                    .foregroundStyle(Color.vocaSecondaryText)
-                            } label: {
-                                Text(StatsFormat.dayLabel(day.key, now: now))
-                                    .font(.subheadline.weight(.medium))
-                                    .foregroundStyle(Color.vocaPrimaryText)
+        let days = stats.lastSevenDays(endingAt: now)
+        return VStack(alignment: .leading, spacing: VocaMetrics.related) {
+            VocaSectionHeader(title: "Last 7 days")
+            VocaCard {
+                VStack(alignment: .leading, spacing: VocaMetrics.padding) {
+                    activityChart(days)
+                    if stats.hasAny {
+                        Divider()
+                        VStack(spacing: VocaMetrics.related + 2) {
+                            ForEach(days.reversed().filter { $0.dictations > 0 }) { day in
+                                activityRow(day)
                             }
                         }
+                    } else {
+                        Text("Your daily words and sessions will build a seven-day view here.")
+                            .font(.subheadline)
+                            .foregroundStyle(Color.vocaSecondaryText)
+                            .frame(maxWidth: .infinity, alignment: .center)
                     }
                 }
             }
         }
+    }
+
+    private func activityChart(_ days: [DailyUsage]) -> some View {
+        let maximum = max(days.map(\.words).max() ?? 0, 1)
+        return HStack(alignment: .bottom, spacing: VocaMetrics.related) {
+            ForEach(days) { day in
+                VStack(spacing: 7) {
+                    Text(day.words == 0 ? "" : StatsFormat.count(day.words))
+                        .font(.caption2.weight(.semibold))
+                        .monospacedDigit()
+                        .foregroundStyle(Color.vocaSecondaryText)
+                        .frame(height: 16)
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(day.words == 0 ? Color.vocaRecessedSurface : Color.brand)
+                        .frame(height: activityBarHeight(day.words, maximum: maximum))
+                    Text(StatsFormat.shortDayLabel(day.key))
+                        .font(.caption2.weight(day.key == UsageStats.dayKey(now) ? .bold : .regular))
+                        .foregroundStyle(
+                            day.key == UsageStats.dayKey(now)
+                                ? Color.vocaPrimaryText
+                                : Color.vocaSecondaryText
+                        )
+                }
+                .frame(maxWidth: .infinity)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(
+                    "\(StatsFormat.dayLabel(day.key, now: now)), \(StatsFormat.words(day.words)), \(StatsFormat.sessions(day.dictations))"
+                )
+            }
+        }
+        .frame(height: 154, alignment: .bottom)
+    }
+
+    private func activityRow(_ day: DailyUsage) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(StatsFormat.dayLabel(day.key, now: now))
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Color.vocaPrimaryText)
+            Spacer()
+            Text(
+                "\(StatsFormat.words(day.words)) · \(StatsFormat.sessions(day.dictations)) · "
+                    + StatsFormat.duration(day.seconds)
+            )
+            .font(.caption)
+            .foregroundStyle(Color.vocaSecondaryText)
+            .multilineTextAlignment(.trailing)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func activityBarHeight(_ words: Int, maximum: Int) -> CGFloat {
+        words == 0 ? 8 : max(16, CGFloat(words) / CGFloat(maximum) * 94)
     }
 
     private var shareCard: some View {
@@ -246,56 +296,101 @@ struct StatsView: View {
                 }
 
                 HStack(spacing: VocaMetrics.related) {
-                    ShareButton(
-                        tint: Color.brand,
-                        label: copiedCard ? StatsCopy.shareCopied : "Copy"
-                    ) {
-                        Image(systemName: copiedCard ? "checkmark" : "doc.on.clipboard")
-                    } action: {
-                        copyCard()
-                    }
+                    ShareButton(tint: Color.brand, label: "Copy", accessibilityLabel: "Copy stats card") {
+                        Image(systemName: shareState == .copied ? "checkmark" : "doc.on.clipboard")
+                    } action: { copyCard() }
 
-                    ShareButton(tint: Color.vocaPrimaryText, label: "X") {
-                        Text("\u{1D54F}").font(.title3)
-                    } action: {
-                        share(to: .x)
-                    }
+                    ShareButton(tint: Color.vocaPrimaryText, label: "X", accessibilityLabel: "Share stats on X") {
+                        Text("X").font(.headline.weight(.semibold))
+                    } action: { share(to: .x) }
 
-                    ShareButton(tint: Self.linkedInBlue, label: "LinkedIn") {
+                    ShareButton(tint: Self.linkedInBlue, label: "LinkedIn", accessibilityLabel: "Share stats on LinkedIn") {
                         Text("in")
                             .font(.subheadline.weight(.bold))
                             .foregroundStyle(.white)
                             .padding(.horizontal, 4)
                             .padding(.vertical, 1)
                             .background(Self.linkedInBlue, in: RoundedRectangle(cornerRadius: 3))
-                    } action: {
-                        share(to: .linkedIn)
-                    }
+                    } action: { share(to: .linkedIn) }
                 }
 
-                Text(StatsCopy.shareFootnote)
-                    .font(.caption2)
-                    .foregroundStyle(Color.vocaSecondaryText)
+                if let note = shareNote {
+                    Label(note.text, systemImage: note.symbol)
+                        .font(.caption)
+                        .foregroundStyle(note.isError ? Color.vocaError : Color.vocaSecondaryText)
+                        .transition(.opacity)
+                } else {
+                    Text(StatsCopy.shareFootnote)
+                        .font(.caption2)
+                        .foregroundStyle(Color.vocaSecondaryText)
+                }
             }
+            .animation(.easeInOut(duration: 0.18), value: shareState)
         }
     }
 
     private static let linkedInBlue = Color(red: 0.04, green: 0.40, blue: 0.71)
 
+    private var privacyNote: some View {
+        Label(
+            "Counts stay on this iPhone. Nothing is posted until you finish the post yourself.",
+            systemImage: "lock.fill"
+        )
+        .font(.footnote)
+        .foregroundStyle(Color.vocaSecondaryText)
+        .padding(.horizontal, VocaMetrics.tight)
+    }
+
+    private var shareNote: (text: String, symbol: String, isError: Bool)? {
+        switch shareState {
+        case .idle:
+            nil
+        case .copied:
+            ("Card copied. Paste it wherever you’d like.", "checkmark.circle.fill", false)
+        case .opened(let destination):
+            ("Card copied. Paste it into your \(destination.label) post.", "doc.on.clipboard", false)
+        case .failed(let message):
+            (message, "exclamationmark.triangle.fill", true)
+        }
+    }
+
     private func copyCard() {
-        StatsShareExporter.copyCard(stats, now: now, style: interfaceStyle)
-        withAnimation { copiedCard = true }
+        guard StatsShareExporter.copyCard(stats, now: now) else {
+            setShareState(.failed("Couldn’t copy the card image."), clearingAfter: 6)
+            return
+        }
+        setShareState(.copied, clearingAfter: 3)
     }
 
     private func share(to destination: StatsShareDestination) {
-        StatsShareExporter.copyCard(stats, now: now, style: interfaceStyle)
+        guard StatsShareExporter.copyCard(stats, now: now) else {
+            setShareState(.failed("Couldn’t copy the card image."), clearingAfter: 6)
+            return
+        }
         let message = StatsShareComposer.message(stats, now: now)
-        guard let url = StatsShareComposer.composerURL(destination, message: message) else { return }
-        openURL(url)
+        guard let url = StatsShareComposer.composerURL(destination, message: message) else {
+            setShareState(.failed("Couldn’t prepare the \(destination.label) post."), clearingAfter: 6)
+            return
+        }
+        openURL(url) { accepted in
+            Task { @MainActor in
+                if accepted {
+                    setShareState(.opened(destination), clearingAfter: 5)
+                } else {
+                    setShareState(.failed("Couldn’t open \(destination.label)."), clearingAfter: 6)
+                }
+            }
+        }
     }
 
-    private var interfaceStyle: UIUserInterfaceStyle {
-        colorScheme == .dark ? .dark : .light
+    private func setShareState(_ state: ShareState, clearingAfter seconds: Double) {
+        shareStateToken += 1
+        let token = shareStateToken
+        shareState = state
+        Task {
+            try? await Task.sleep(for: .seconds(seconds))
+            if shareStateToken == token { shareState = .idle }
+        }
     }
 
     private func refresh(folding: Bool) {
@@ -308,8 +403,12 @@ struct StatsView: View {
     }
 
     private func reset() {
-        try? store.reset()
-        refresh(folding: false)
+        do {
+            try store.reset()
+            refresh(folding: false)
+        } catch {
+            setShareState(.failed("Couldn’t reset statistics."), clearingAfter: 6)
+        }
     }
 }
 
@@ -331,24 +430,10 @@ struct StatChip: View {
     }
 }
 
-struct StatChipLabel: View {
-    let symbol: String
-    let tint: SemanticPalette.StatTint
-    let title: String
-
-    var body: some View {
-        HStack(spacing: VocaMetrics.related) {
-            StatChip(symbol: symbol, tint: tint, size: 26)
-            Text(title)
-                .font(.subheadline.weight(.medium))
-                .foregroundStyle(Color.vocaSecondaryText)
-        }
-    }
-}
-
 struct ShareButton<Mark: View>: View {
     let tint: Color
     let label: String
+    let accessibilityLabel: String
     @ViewBuilder var mark: Mark
     let action: () -> Void
 
@@ -372,6 +457,6 @@ struct ShareButton<Mark: View>: View {
             )
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Share to \(label)")
+        .accessibilityLabel(accessibilityLabel)
     }
 }

--- a/ios/VocaPhoneApp/Info.plist
+++ b/ios/VocaPhoneApp/Info.plist
@@ -31,6 +31,14 @@
   <string>$(CURRENT_PROJECT_VERSION)</string>
   <key>LSRequiresIPhoneOS</key>
   <true/>
+  <!-- VocaPhone checks the installed-app schemes for X and LinkedIn. iOS
+       returns false from canOpenURL for undeclared schemes, which otherwise
+       made the Stats buttons choose the browser even when an app was present. -->
+  <key>LSApplicationQueriesSchemes</key>
+  <array>
+    <string>twitter</string>
+    <string>linkedin</string>
+  </array>
   <key>NSMicrophoneUsageDescription</key>
   <string>vocaphone records dictation for your configured transcription gateway and, when Quick Dictation is enabled, keeps microphone input ready for up to 10 minutes. Standby audio is discarded.</string>
   <key>NSCameraUsageDescription</key>

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -986,6 +986,8 @@ final class RecordingCoordinator {
         // session claimed by an older build carries no route at all — either way
         // this is where the record stops being able to mislead.
         record.processingLocation = Self.selectedProcessingLocation()
+
+        record.recordedSeconds = lastRecordingDuration
         captureClaimedTranscriptionSettings()
         try? store.save(record)
 

--- a/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
+++ b/ios/VocaPhoneApp/Sessions/RecordingCoordinator.swift
@@ -940,8 +940,12 @@ final class RecordingCoordinator {
         ) ?? resolvedAudioURL(for: record)
         DiagnosticLog.record(.captureStopped)
         if let started = captureStartedAt {
-            lastRecordingDuration = Date().timeIntervalSince(started)
+            record.recordCaptureDuration(startedAt: started)
+            lastRecordingDuration = record.recordedSeconds ?? 0
             captureStartedAt = nil
+            // Only a capture made by this process may replace the duration.
+            // A retry has no microphone clock and must keep the value already
+            // persisted on its session instead of borrowing another session's.
         }
         if wasRecording {
             // Feedback is optional and should never sit in front of gateway work.
@@ -987,7 +991,6 @@ final class RecordingCoordinator {
         // this is where the record stops being able to mislead.
         record.processingLocation = Self.selectedProcessingLocation()
 
-        record.recordedSeconds = lastRecordingDuration
         captureClaimedTranscriptionSettings()
         try? store.save(record)
 

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -1012,11 +1012,12 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             try store.save(record)
             try record.transition(to: .completed)
             try store.save(record)
-            // A keyboard-started dictation inside vocaphone's own field is the
-            // one onboarding exercise that proves the whole loop: Dictate,
-            // record, transcribe and direct insertion. Do not set this for
-            // keyboard sessions started in another app or for the app's
-            // diagnostic microphone test.
+
+            try? UsageStatsStore.shared.record(
+                transcript: transcript,
+                seconds: record.recordedSeconds
+            )
+            
             if record.startedInContainingApp == true, record.sourceDocumentID != "in-app-test" {
                 KeyboardPreferences.hasCompletedKeyboardPractice = true
             }

--- a/ios/VocaPhoneKeyboard/KeyboardViewController.swift
+++ b/ios/VocaPhoneKeyboard/KeyboardViewController.swift
@@ -1004,6 +1004,15 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             try store.save(record)
             textDocumentProxy.insertText(prepared)
             lastInsertedText = prepared
+            // The session ID makes this append idempotent if the extension is
+            // interrupted after insertion. Recording here means an insertion
+            // that happened cannot be lost merely because saving the terminal
+            // session state is the next operation to be interrupted.
+            _ = try? UsageStatsStore.shared.record(
+                transcript: transcript,
+                seconds: record.recordedSeconds,
+                id: record.sessionID
+            )
             // A transcript arrives as finished text. It never becomes a
             // composition and is never autocorrected: the model that produced it
             // already had its say.
@@ -1013,11 +1022,6 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             try record.transition(to: .completed)
             try store.save(record)
 
-            try? UsageStatsStore.shared.record(
-                transcript: transcript,
-                seconds: record.recordedSeconds
-            )
-            
             if record.startedInContainingApp == true, record.sourceDocumentID != "in-app-test" {
                 KeyboardPreferences.hasCompletedKeyboardPractice = true
             }

--- a/ios/VocaPhoneShared/SemanticPalette.swift
+++ b/ios/VocaPhoneShared/SemanticPalette.swift
@@ -117,6 +117,70 @@ enum SemanticPalette {
         UIColor { traits in value(role, isDark: traits.userInterfaceStyle == .dark) }
     }
 
+    enum StatTint: CaseIterable {
+        case speed
+        case words
+        case dictations
+        case time
+        case streak
+    }
+
+    static func statChip(_ tint: StatTint) -> UIColor {
+        UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? darkChip(tint)
+                : lightChip(tint)
+        }
+    }
+
+    static func statSymbol(_ tint: StatTint) -> UIColor {
+        UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? darkSymbol(tint)
+                : lightSymbol(tint)
+        }
+    }
+
+    private static func lightChip(_ tint: StatTint) -> UIColor {
+        switch tint {
+        case .speed: hex(0xE1_F0_E7)
+        case .words: hex(0xDD_EF_EA)
+        case .dictations: hex(0xE0_E8_F7)
+        case .time: hex(0xE8_E3_F5)
+        case .streak: hex(0xFA_E4_DE)
+        }
+    }
+
+    private static func lightSymbol(_ tint: StatTint) -> UIColor {
+        switch tint {
+        case .speed: hex(0x2C_7A_55)
+        case .words: hex(0x1D_78_6A)
+        case .dictations: hex(0x39_60_A6)
+        case .time: hex(0x5D_49_A6)
+        case .streak: hex(0xC2_53_3A)
+        }
+    }
+
+    private static func darkChip(_ tint: StatTint) -> UIColor {
+        switch tint {
+        case .speed: hex(0x1C_38_2A)
+        case .words: hex(0x15_34_2D)
+        case .dictations: hex(0x1A_29_43)
+        case .time: hex(0x28_23_43)
+        case .streak: hex(0x3C_24_1E)
+        }
+    }
+
+    private static func darkSymbol(_ tint: StatTint) -> UIColor {
+        switch tint {
+        case .speed: hex(0x7F_D8_A6)
+        case .words: hex(0x5F_D3_BE)
+        case .dictations: hex(0x8F_B4_F0)
+        case .time: hex(0xB3_A3_F0)
+        case .streak: hex(0xF0_A1_8A)
+        }
+    }
+
     private static func hex(_ value: UInt32) -> UIColor {
         UIColor(
             red: CGFloat((value >> 16) & 0xFF) / 255,
@@ -143,6 +207,14 @@ extension Color {
     static let vocaWarning = Color(SemanticPalette.color(.warning))
     static let vocaError = Color(SemanticPalette.color(.error))
     static let vocaDisabled = Color(SemanticPalette.color(.disabled))
+
+    static func vocaStatChip(_ tint: SemanticPalette.StatTint) -> Color {
+        Color(SemanticPalette.statChip(tint))
+    }
+
+    static func vocaStatSymbol(_ tint: SemanticPalette.StatTint) -> Color {
+        Color(SemanticPalette.statSymbol(tint))
+    }
 }
 
 // MARK: - Contrast

--- a/ios/VocaPhoneShared/SessionRecord.swift
+++ b/ios/VocaPhoneShared/SessionRecord.swift
@@ -127,6 +127,8 @@ struct SessionRecord: Codable, Equatable, Identifiable, Sendable {
     /// ``SessionProcessingLocation``.
     var processingLocation: SessionProcessingLocation?
 
+    var recordedSeconds: Double?
+
     init(
         sessionID: UUID = UUID(),
         state: SessionState = .idle,
@@ -150,6 +152,7 @@ struct SessionRecord: Codable, Equatable, Identifiable, Sendable {
         prefersQuickDictation = nil
         claimedAt = nil
         processingLocation = nil
+        recordedSeconds = nil
     }
 
     mutating func transition(to next: SessionState, now: Date = Date()) throws {

--- a/ios/VocaPhoneShared/SessionRecord.swift
+++ b/ios/VocaPhoneShared/SessionRecord.swift
@@ -174,6 +174,11 @@ struct SessionRecord: Codable, Equatable, Identifiable, Sendable {
         updatedAt = Self.normalizedTimestamp(now)
     }
 
+    mutating func recordCaptureDuration(startedAt: Date?, endedAt: Date = Date()) {
+        guard let startedAt else { return }
+        recordedSeconds = max(0, endedAt.timeIntervalSince(startedAt))
+    }
+
     private static let retryableFailures: Set<SessionState> = [
         .serverUnavailable, .uploadFailedRecoverable, .transcriptionFailedRecoverable,
     ]

--- a/ios/VocaPhoneShared/SharedStore.swift
+++ b/ios/VocaPhoneShared/SharedStore.swift
@@ -300,7 +300,7 @@ final class SharedStore: @unchecked Sendable {
         try rootDirectory().appendingPathComponent("sessions", isDirectory: true)
     }
 
-    private func rootDirectory() throws -> URL {
+    func rootDirectory() throws -> URL {
         if let rootOverride { return rootOverride }
         guard let groupURL = fileManager.containerURL(
             forSecurityApplicationGroupIdentifier: AppConfiguration.appGroupIdentifier

--- a/ios/VocaPhoneShared/UsageStats.swift
+++ b/ios/VocaPhoneShared/UsageStats.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+struct UsageStats: Codable, Equatable, Sendable {
+    var totalWords: Int = 0
+    var totalDictations: Int = 0
+    var totalSeconds: Double = 0
+    var lastDayKey: String = ""
+    var currentStreak: Int = 0
+    var bestStreak: Int = 0
+    var dailyWords: [String: Int] = [:]
+
+    static let dailyLimit = 7
+
+    var hasAny: Bool { totalDictations > 0 }
+
+    var averageWordsPerMinute: Double {
+        guard totalSeconds > 0 else { return 0 }
+        return Double(totalWords) / (totalSeconds / 60)
+    }
+
+    func currentStreak(at now: Date, timeZone: TimeZone = .current) -> Int {
+        guard !lastDayKey.isEmpty else { return 0 }
+        guard let elapsed = Self.daysBetween(lastDayKey, Self.dayKey(now, timeZone: timeZone)) else {
+            return 0
+        }
+        if Self.isUnreconcilableFuture(elapsed) { return 0 }
+        return elapsed <= 1 ? currentStreak : 0
+    }
+
+    func recording(dayKey key: String, words: Int, seconds: Double) -> UsageStats {
+        guard words > 0 else { return self }
+        var next = self
+        next.totalWords += words
+        next.totalDictations += 1
+        next.totalSeconds += max(seconds, 0)
+        var daily = dailyWords
+        daily[key, default: 0] += words
+        next.dailyWords = Self.pruneDaily(daily)
+        let streak = Self.advanceStreak(currentStreak, lastDayKey: lastDayKey, todayKey: key)
+        next.currentStreak = streak
+        next.bestStreak = max(bestStreak, streak)
+        next.lastDayKey = Self.nextDayKey(lastDayKey, todayKey: key)
+        return next
+    }
+
+    private static func gregorian(_ timeZone: TimeZone) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        return calendar
+    }
+
+    static func dayKey(_ date: Date, timeZone: TimeZone = .current) -> String {
+        let parts = gregorian(timeZone).dateComponents([.year, .month, .day], from: date)
+        return String(
+            format: "%04d-%02d-%02d",
+            parts.year ?? 0,
+            parts.month ?? 0,
+            parts.day ?? 0
+        )
+    }
+
+    static func daysBetween(_ fromKey: String, _ toKey: String) -> Int? {
+        guard let from = epochDay(fromKey), let to = epochDay(toKey) else { return nil }
+        return to - from
+    }
+
+    static func isDayKey(_ value: String) -> Bool { epochDay(value) != nil }
+
+    private static func epochDay(_ key: String) -> Int? {
+        let parts = key.split(separator: "-", omittingEmptySubsequences: false)
+        guard key.count == 10, parts.count == 3,
+              let year = Int(parts[0]), let month = Int(parts[1]), let day = Int(parts[2]),
+              parts[0].count == 4, parts[1].count == 2, parts[2].count == 2
+        else { return nil }
+        let calendar = gregorian(TimeZone(secondsFromGMT: 0) ?? .current)
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        guard let date = calendar.date(from: components) else { return nil }
+        let back = calendar.dateComponents([.year, .month, .day], from: date)
+        guard back.year == year, back.month == month, back.day == day else { return nil }
+        return Int((date.timeIntervalSince1970 / 86_400).rounded(.down))
+    }
+
+    static func advanceStreak(_ current: Int, lastDayKey: String, todayKey: String) -> Int {
+        guard !lastDayKey.isEmpty else { return 1 }
+        guard let elapsed = daysBetween(lastDayKey, todayKey) else { return 1 }
+        if isUnreconcilableFuture(elapsed) { return 1 }
+        if elapsed <= 0 { return max(current, 1) }
+        if elapsed == 1 { return max(current, 0) + 1 }
+        return 1
+    }
+
+    static func nextDayKey(_ stored: String, todayKey: String) -> String {
+        guard isDayKey(stored) else { return todayKey }
+        if let elapsed = daysBetween(stored, todayKey), isUnreconcilableFuture(elapsed) {
+            return todayKey
+        }
+        return max(stored, todayKey)
+    }
+
+    private static func isUnreconcilableFuture(_ elapsed: Int) -> Bool {
+        elapsed < -dailyLimit
+    }
+
+    static func pruneDaily(_ daily: [String: Int]) -> [String: Int] {
+        guard daily.count > dailyLimit else { return daily }
+        let ranked = daily.keys.sorted { left, right in
+            let leftReadable = isDayKey(left)
+            let rightReadable = isDayKey(right)
+            if leftReadable != rightReadable { return leftReadable }
+            return left > right
+        }
+        return Dictionary(uniqueKeysWithValues: ranked.prefix(dailyLimit).map { ($0, daily[$0] ?? 0) })
+    }
+
+    func recentDays(limit: Int = dailyLimit) -> [(key: String, words: Int)] {
+        dailyWords
+            .filter { Self.isDayKey($0.key) }
+            .sorted { $0.key > $1.key }
+            .prefix(limit)
+            .map { (key: $0.key, words: $0.value) }
+    }
+
+    static func wordCount(_ text: String) -> Int {
+        var count = 0
+        text.enumerateSubstrings(
+            in: text.startIndex..<text.endIndex,
+            options: [.byWords, .localized]
+        ) { _, _, _, _ in
+            count += 1
+        }
+        return count
+    }
+
+    static func nextDayStart(after date: Date, timeZone: TimeZone = .current) -> Date {
+        let calendar = gregorian(timeZone)
+        let today = calendar.startOfDay(for: date)
+        guard let tomorrow = calendar.date(byAdding: .day, value: 1, to: today) else {
+            return date.addingTimeInterval(86_400)
+        }
+        return calendar.startOfDay(for: tomorrow)
+    }
+}

--- a/ios/VocaPhoneShared/UsageStats.swift
+++ b/ios/VocaPhoneShared/UsageStats.swift
@@ -8,6 +8,8 @@ struct UsageStats: Codable, Equatable, Sendable {
     var currentStreak: Int = 0
     var bestStreak: Int = 0
     var dailyWords: [String: Int] = [:]
+    var dailyDictations: [String: Int] = [:]
+    var dailySeconds: [String: Double] = [:]
 
     static let dailyLimit = 7
 
@@ -35,7 +37,14 @@ struct UsageStats: Codable, Equatable, Sendable {
         next.totalSeconds += max(seconds, 0)
         var daily = dailyWords
         daily[key, default: 0] += words
-        next.dailyWords = Self.pruneDaily(daily)
+        var dictations = dailyDictations
+        dictations[key, default: 0] += 1
+        var secondsByDay = dailySeconds
+        secondsByDay[key, default: 0] += max(seconds, 0)
+        let retained = Set(Self.rankedDayKeys(in: daily).prefix(Self.dailyLimit))
+        next.dailyWords = daily.filter { retained.contains($0.key) }
+        next.dailyDictations = dictations.filter { retained.contains($0.key) }
+        next.dailySeconds = secondsByDay.filter { retained.contains($0.key) }
         let streak = Self.advanceStreak(currentStreak, lastDayKey: lastDayKey, todayKey: key)
         next.currentStreak = streak
         next.bestStreak = max(bestStreak, streak)
@@ -106,21 +115,51 @@ struct UsageStats: Codable, Equatable, Sendable {
 
     static func pruneDaily(_ daily: [String: Int]) -> [String: Int] {
         guard daily.count > dailyLimit else { return daily }
-        let ranked = daily.keys.sorted { left, right in
+        let ranked = rankedDayKeys(in: daily)
+        return Dictionary(uniqueKeysWithValues: ranked.prefix(dailyLimit).map { ($0, daily[$0] ?? 0) })
+    }
+
+    private static func rankedDayKeys(in daily: [String: Int]) -> [String] {
+        daily.keys.sorted { left, right in
             let leftReadable = isDayKey(left)
             let rightReadable = isDayKey(right)
             if leftReadable != rightReadable { return leftReadable }
             return left > right
         }
-        return Dictionary(uniqueKeysWithValues: ranked.prefix(dailyLimit).map { ($0, daily[$0] ?? 0) })
     }
 
-    func recentDays(limit: Int = dailyLimit) -> [(key: String, words: Int)] {
+    func recentDays(limit: Int = dailyLimit) -> [DailyUsage] {
         dailyWords
             .filter { Self.isDayKey($0.key) }
             .sorted { $0.key > $1.key }
             .prefix(limit)
-            .map { (key: $0.key, words: $0.value) }
+            .map {
+                DailyUsage(
+                    key: $0.key,
+                    words: $0.value,
+                    dictations: dailyDictations[$0.key, default: 0],
+                    seconds: dailySeconds[$0.key, default: 0]
+                )
+            }
+    }
+
+    /// Seven consecutive calendar days, including quiet days, for a chart that
+    /// shows an actual trend rather than only the dates that have activity.
+    func lastSevenDays(endingAt now: Date, timeZone: TimeZone = .current) -> [DailyUsage] {
+        let calendar = Self.gregorian(timeZone)
+        let today = calendar.startOfDay(for: now)
+        return (0..<Self.dailyLimit).reversed().compactMap { offset in
+            guard let date = calendar.date(byAdding: .day, value: -offset, to: today) else {
+                return nil
+            }
+            let key = Self.dayKey(date, timeZone: timeZone)
+            return DailyUsage(
+                key: key,
+                words: dailyWords[key, default: 0],
+                dictations: dailyDictations[key, default: 0],
+                seconds: dailySeconds[key, default: 0]
+            )
+        }
     }
 
     static func wordCount(_ text: String) -> Int {
@@ -141,5 +180,36 @@ struct UsageStats: Codable, Equatable, Sendable {
             return date.addingTimeInterval(86_400)
         }
         return calendar.startOfDay(for: tomorrow)
+    }
+}
+
+struct DailyUsage: Equatable, Identifiable, Sendable {
+    var id: String { key }
+    let key: String
+    let words: Int
+    let dictations: Int
+    let seconds: Double
+}
+
+extension UsageStats {
+    /// New daily dimensions decode leniently so a build upgrade preserves a
+    /// summary written before sessions and voice time were tracked per day.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        totalWords = try container.decodeIfPresent(Int.self, forKey: .totalWords) ?? 0
+        totalDictations = try container.decodeIfPresent(Int.self, forKey: .totalDictations) ?? 0
+        totalSeconds = try container.decodeIfPresent(Double.self, forKey: .totalSeconds) ?? 0
+        lastDayKey = try container.decodeIfPresent(String.self, forKey: .lastDayKey) ?? ""
+        currentStreak = try container.decodeIfPresent(Int.self, forKey: .currentStreak) ?? 0
+        bestStreak = try container.decodeIfPresent(Int.self, forKey: .bestStreak) ?? 0
+        dailyWords = try container.decodeIfPresent([String: Int].self, forKey: .dailyWords) ?? [:]
+        dailyDictations = try container.decodeIfPresent(
+            [String: Int].self,
+            forKey: .dailyDictations
+        ) ?? [:]
+        dailySeconds = try container.decodeIfPresent(
+            [String: Double].self,
+            forKey: .dailySeconds
+        ) ?? [:]
     }
 }

--- a/ios/VocaPhoneShared/UsageStatsStore.swift
+++ b/ios/VocaPhoneShared/UsageStatsStore.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+struct UsageEvent: Codable, Equatable, Sendable {
+    let id: UUID
+    let dayKey: String
+    let words: Int
+    let seconds: Double
+}
+
+private struct StoredSummary: Codable {
+    var stats: UsageStats
+    var consumedIDs: [UUID]
+}
+
+final class UsageStatsStore: @unchecked Sendable {
+    static let shared = UsageStatsStore()
+
+    private let fileManager: FileManager
+    private let rootOverride: URL?
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(fileManager: FileManager = .default, rootOverride: URL? = nil) {
+        self.fileManager = fileManager
+        self.rootOverride = rootOverride
+        encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    @discardableResult
+    func record(
+        transcript: String,
+        seconds: Double?,
+        now: Date = Date(),
+        timeZone: TimeZone = .current
+    ) throws -> UsageEvent? {
+        let words = UsageStats.wordCount(transcript)
+        guard words > 0 else { return nil }
+        let event = UsageEvent(
+            id: UUID(),
+            dayKey: UsageStats.dayKey(now, timeZone: timeZone),
+            words: words,
+            seconds: max(seconds ?? 0, 0)
+        )
+        let directory = try eventsDirectory()
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let data = try encoder.encode(event)
+        try data.write(to: directory.appendingPathComponent("\(event.id.uuidString).json"), options: .atomic)
+        return event
+    }
+
+    @discardableResult
+    func fold() throws -> UsageStats {
+        var summary = loadSummary()
+        let pending = try eventsOnDisk()
+        guard !pending.isEmpty else { return summary.stats }
+
+        let alreadyCounted = Set(summary.consumedIDs)
+        let fresh = pending
+            .filter { !alreadyCounted.contains($0.event.id) }
+            .sorted { $0.event.dayKey < $1.event.dayKey }
+
+        var stats = summary.stats
+        for entry in fresh {
+            stats = stats.recording(
+                dayKey: entry.event.dayKey,
+                words: entry.event.words,
+                seconds: entry.event.seconds
+            )
+        }
+
+        summary.stats = stats
+        summary.consumedIDs = pending.map(\.event.id)
+        try writeSummary(summary)
+
+        for entry in pending {
+            try? fileManager.removeItem(at: entry.url)
+        }
+        return stats
+    }
+
+    func current() -> UsageStats {
+        let summary = loadSummary()
+        guard let pending = try? eventsOnDisk(), !pending.isEmpty else { return summary.stats }
+        let alreadyCounted = Set(summary.consumedIDs)
+        var stats = summary.stats
+        for entry in pending
+            .filter({ !alreadyCounted.contains($0.event.id) })
+            .sorted(by: { $0.event.dayKey < $1.event.dayKey }) {
+            stats = stats.recording(
+                dayKey: entry.event.dayKey,
+                words: entry.event.words,
+                seconds: entry.event.seconds
+            )
+        }
+        return stats
+    }
+
+    func reset() throws {
+        let directory = try usageDirectory()
+        guard fileManager.fileExists(atPath: directory.path) else { return }
+        try fileManager.removeItem(at: directory)
+    }
+
+
+    private func loadSummary() -> StoredSummary {
+        guard let url = try? summaryURL(),
+              let data = try? Data(contentsOf: url),
+              let stored = try? decoder.decode(StoredSummary.self, from: data)
+        else {
+            return StoredSummary(stats: UsageStats(), consumedIDs: [])
+        }
+        return stored
+    }
+
+    private func writeSummary(_ summary: StoredSummary) throws {
+        let directory = try usageDirectory()
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        try encoder.encode(summary).write(to: try summaryURL(), options: .atomic)
+    }
+
+    private func eventsOnDisk() throws -> [(url: URL, event: UsageEvent)] {
+        let directory = try eventsDirectory()
+        guard fileManager.fileExists(atPath: directory.path) else { return [] }
+        let urls = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        )
+        return urls.compactMap { url in
+            guard url.pathExtension == "json",
+                  let data = try? Data(contentsOf: url),
+                  let event = try? decoder.decode(UsageEvent.self, from: data)
+            else { return nil }
+            return (url: url, event: event)
+        }
+    }
+
+    private func summaryURL() throws -> URL {
+        try usageDirectory().appendingPathComponent("summary.json")
+    }
+
+    private func eventsDirectory() throws -> URL {
+        try usageDirectory().appendingPathComponent("events", isDirectory: true)
+    }
+
+    private func usageDirectory() throws -> URL {
+        let root = try rootOverride ?? SharedStore.shared.rootDirectory()
+        return root.appendingPathComponent("usage", isDirectory: true)
+    }
+}

--- a/ios/VocaPhoneShared/UsageStatsStore.swift
+++ b/ios/VocaPhoneShared/UsageStatsStore.swift
@@ -34,13 +34,14 @@ final class UsageStatsStore: @unchecked Sendable {
     func record(
         transcript: String,
         seconds: Double?,
+        id: UUID = UUID(),
         now: Date = Date(),
         timeZone: TimeZone = .current
     ) throws -> UsageEvent? {
         let words = UsageStats.wordCount(transcript)
         guard words > 0 else { return nil }
         let event = UsageEvent(
-            id: UUID(),
+            id: id,
             dayKey: UsageStats.dayKey(now, timeZone: timeZone),
             words: words,
             seconds: max(seconds ?? 0, 0)

--- a/ios/VocaPhoneTests/SessionRecordTests.swift
+++ b/ios/VocaPhoneTests/SessionRecordTests.swift
@@ -66,6 +66,27 @@ struct SessionRecordTests {
         #expect(finalizing.meterLevel == 0)
     }
 
+    @Test func retryWithoutANewCaptureKeepsTheOriginalDuration() {
+        var record = SessionRecord()
+        record.recordedSeconds = 12.5
+
+        record.recordCaptureDuration(startedAt: nil)
+
+        #expect(record.recordedSeconds == 12.5)
+    }
+
+    @Test func aNewCaptureReplacesThePreviousDuration() {
+        var record = SessionRecord()
+        record.recordedSeconds = 12.5
+
+        record.recordCaptureDuration(
+            startedAt: Date(timeIntervalSince1970: 100),
+            endedAt: Date(timeIntervalSince1970: 104.25)
+        )
+
+        #expect(record.recordedSeconds == 4.25)
+    }
+
     @Test func aParkedTranscriptSurvivesUntilTheOriginalFieldReturns() throws {
         var record = SessionRecord()
         for state in [

--- a/ios/VocaPhoneTests/StatsPresentationTests.swift
+++ b/ios/VocaPhoneTests/StatsPresentationTests.swift
@@ -31,6 +31,42 @@ struct StatsPresentationTests {
         #expect(items.first(where: { $0.name == "text" })?.value == message)
     }
 
+    @Test func xNativeComposerRoundTripsTheEntireMessage() throws {
+        let message = "words & sessions + streak; हिन्दी 🔒"
+        let url = try #require(StatsShareComposer.nativeURL(.x, message: message))
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        #expect(components.scheme == "twitter")
+        #expect(components.host == "post")
+        #expect(components.queryItems?.first(where: { $0.name == "message" })?.value == message)
+    }
+
+    @Test func linkedinNativeRouteOpensTheInstalledApp() throws {
+        let url = try #require(StatsShareComposer.nativeURL(.linkedIn, message: "hello"))
+        #expect(url.scheme == "linkedin")
+    }
+
+    @Test(arguments: StatsShareDestination.allCases)
+    func anInstalledAppIsPreferredOverTheBrowser(_ destination: StatsShareDestination) throws {
+        let route = try #require(
+            StatsShareComposer.preferredRoute(destination, message: "hello") { url in
+                url.scheme != "https"
+            }
+        )
+        #expect(route.target == .installedApp)
+        #expect(route.url.scheme != "https")
+    }
+
+    @Test(arguments: StatsShareDestination.allCases)
+    func theBrowserIsTheFallbackWithoutAnInstalledApp(
+        _ destination: StatsShareDestination
+    ) throws {
+        let route = try #require(
+            StatsShareComposer.preferredRoute(destination, message: "hello") { _ in false }
+        )
+        #expect(route.target == .browser)
+        #expect(route.url.scheme == "https")
+    }
+
     @Test func linkedinUsesTheFeedComposerContract() throws {
         let url = try #require(StatsShareComposer.composerURL(.linkedIn, message: "hello"))
         let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
@@ -52,5 +88,28 @@ struct StatsPresentationTests {
         #expect(message.contains("1 word"))
         #expect(message.contains("1 session"))
         #expect(!message.contains("1 sessions"))
+    }
+
+    @Test func chartLabelsStayDistinctAndLargeCountsStayCompact() {
+        let utc = TimeZone(secondsFromGMT: 0) ?? .current
+        #expect(StatsFormat.shortDayLabel("2026-09-08", timeZone: utc) == "Tue")
+        #expect(StatsFormat.shortDayLabel("2026-09-10", timeZone: utc) == "Thu")
+        #expect(StatsFormat.compactCount(1_200) == "1.2K")
+        #expect(StatsFormat.compactCount(12_000) == "12K")
+    }
+
+    @Test func appInfoAllowsInstalledSocialAppDetection() throws {
+        let infoURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("VocaPhoneApp/Info.plist")
+        let plist = try #require(
+            PropertyListSerialization.propertyList(
+                from: Data(contentsOf: infoURL),
+                format: nil
+            ) as? [String: Any]
+        )
+        let schemes = try #require(plist["LSApplicationQueriesSchemes"] as? [String])
+        #expect(Set(schemes).isSuperset(of: ["twitter", "linkedin"]))
     }
 }

--- a/ios/VocaPhoneTests/StatsPresentationTests.swift
+++ b/ios/VocaPhoneTests/StatsPresentationTests.swift
@@ -15,11 +15,59 @@ struct StatsPresentationTests {
         )
     }
 
+    private func xPostLength(_ message: String) -> Int {
+        let withoutURL = message.replacingOccurrences(of: StatsShareComposer.site, with: "")
+        let weighted = withoutURL.unicodeScalars.reduce(0) { total, scalar in
+            switch scalar.value {
+            case 0...4351, 8192...8205, 8208...8223, 8242...8247:
+                return total + 1
+            default:
+                return total + 2
+            }
+        }
+        return weighted + 23
+    }
+
     @Test func shareCopyNamesBothPrivateProcessingRoutes() {
-        let message = StatsShareComposer.message(stats, now: now)
-        #expect(message.contains("on my iPhone or through my own gateway"))
-        #expect(!message.contains("Runs on my phone"))
+        let message = StatsShareComposer.message(stats, now: now, destination: .x)
+        #expect(message.contains("I’ve spoken 12,500 words with VocaPhone"))
+        #expect(message.contains("1 hour of talking"))
+        #expect(message.contains("my phone or my own self-hosted gateway"))
+        #expect(message.contains("My audio stays mine"))
+        #expect(message.contains("@vocahq"))
         #expect(message.contains(StatsShareComposer.site))
+    }
+
+    @Test func linkedinCopyOmitsTheXHandle() {
+        let message = StatsShareComposer.message(stats, now: now, destination: .linkedIn)
+        #expect(!message.contains("@vocahq"))
+        #expect(message.hasSuffix(StatsShareComposer.site))
+    }
+
+    @Test func shareCopyFitsWithinTheXPostLimit() {
+        let large = UsageStats(
+            totalWords: 987_654_321,
+            totalDictations: 123_456,
+            totalSeconds: 9_000_000,
+            lastDayKey: UsageStats.dayKey(now),
+            currentStreak: 4_321,
+            bestStreak: 5_000
+        )
+        let message = StatsShareComposer.message(large, now: now, destination: .x)
+        #expect(xPostLength(message) <= 280)
+    }
+
+    @Test func shareCopyOmitsUnavailableDetailsAndShortDurations() {
+        let empty = UsageStats(totalWords: 1, totalDictations: 0, totalSeconds: 0)
+        let message = StatsShareComposer.message(empty, now: now, destination: .x)
+        #expect(message.contains("1 word"))
+        #expect(!message.contains("session"))
+        #expect(!message.contains("talking"))
+        #expect(!message.contains("WPM"))
+        #expect(!message.contains("streak"))
+        #expect(!message.contains("\n\n\n"))
+        #expect(StatsShareComposer.spokenDuration(59) == nil)
+        #expect(StatsShareComposer.spokenDuration(5_460) == "1 hour, 31 minutes")
     }
 
     @Test(arguments: StatsShareDestination.allCases)
@@ -84,7 +132,7 @@ struct StatsPresentationTests {
             currentStreak: 1,
             bestStreak: 1
         )
-        let message = StatsShareComposer.message(one, now: now)
+        let message = StatsShareComposer.message(one, now: now, destination: .x)
         #expect(message.contains("1 word"))
         #expect(message.contains("1 session"))
         #expect(!message.contains("1 sessions"))

--- a/ios/VocaPhoneTests/StatsPresentationTests.swift
+++ b/ios/VocaPhoneTests/StatsPresentationTests.swift
@@ -114,22 +114,14 @@ struct StatsPresentationTests {
         #expect(route.url.scheme == "https")
     }
 
-    @Test func linkedinUsesThePublicShareDialogContract() throws {
-        let url = try #require(StatsShareComposer.composerURL(.linkedIn, message: "hello"))
+    @Test func linkedinFeedComposerReceivesTheEntireMessage() throws {
+        let message = "words & sessions + streak; हिन्दी 🔒"
+        let url = try #require(StatsShareComposer.composerURL(.linkedIn, message: message))
         let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
         #expect(components.host == "www.linkedin.com")
-        #expect(components.path == "/sharing/share-offsite/")
-        #expect(components.queryItems == [URLQueryItem(name: "url", value: StatsShareComposer.site)])
-        #expect(components.queryItems?.contains(where: { $0.name == "text" }) == false)
-    }
-
-    @Test func linkedinWebPasteCopyDoesNotDuplicateTheSharedURL() {
-        let message = StatsShareComposer.message(stats, now: now, destination: .linkedIn)
-        let pasteMessage = StatsShareComposer.linkedInWebPasteMessage(message)
-        #expect(pasteMessage.contains("I’ve spoken 12,500 words with VocaPhone"))
-        #expect(pasteMessage.contains("My audio stays mine"))
-        #expect(!pasteMessage.contains(StatsShareComposer.site))
-        #expect(StatsShareComposer.linkedInWebPasteMessage("custom copy") == "custom copy")
+        #expect(components.path == "/feed/")
+        #expect(components.queryItems?.first(where: { $0.name == "shareActive" })?.value == "true")
+        #expect(components.queryItems?.first(where: { $0.name == "text" })?.value == message)
     }
 
     @Test func singularPublicCopyIsGrammatical() {

--- a/ios/VocaPhoneTests/StatsPresentationTests.swift
+++ b/ios/VocaPhoneTests/StatsPresentationTests.swift
@@ -70,10 +70,9 @@ struct StatsPresentationTests {
         #expect(StatsShareComposer.spokenDuration(5_460) == "1 hour, 31 minutes")
     }
 
-    @Test(arguments: StatsShareDestination.allCases)
-    func composerURLsRoundTripTheEntireMessage(_ destination: StatsShareDestination) throws {
+    @Test func xComposerURLRoundTripsTheEntireMessage() throws {
         let message = "words & sessions + streak; हिन्दी 🔒"
-        let url = try #require(StatsShareComposer.composerURL(destination, message: message))
+        let url = try #require(StatsShareComposer.composerURL(.x, message: message))
         let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
         let items = try #require(components.queryItems)
         #expect(items.first(where: { $0.name == "text" })?.value == message)
@@ -115,12 +114,13 @@ struct StatsPresentationTests {
         #expect(route.url.scheme == "https")
     }
 
-    @Test func linkedinUsesTheFeedComposerContract() throws {
+    @Test func linkedinUsesThePublicShareDialogContract() throws {
         let url = try #require(StatsShareComposer.composerURL(.linkedIn, message: "hello"))
         let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
         #expect(components.host == "www.linkedin.com")
-        #expect(components.path == "/feed/")
-        #expect(components.queryItems?.contains(URLQueryItem(name: "shareActive", value: "true")) == true)
+        #expect(components.path == "/sharing/share-offsite/")
+        #expect(components.queryItems == [URLQueryItem(name: "url", value: StatsShareComposer.site)])
+        #expect(components.queryItems?.contains(where: { $0.name == "text" }) == false)
     }
 
     @Test func singularPublicCopyIsGrammatical() {

--- a/ios/VocaPhoneTests/StatsPresentationTests.swift
+++ b/ios/VocaPhoneTests/StatsPresentationTests.swift
@@ -123,6 +123,15 @@ struct StatsPresentationTests {
         #expect(components.queryItems?.contains(where: { $0.name == "text" }) == false)
     }
 
+    @Test func linkedinWebPasteCopyDoesNotDuplicateTheSharedURL() {
+        let message = StatsShareComposer.message(stats, now: now, destination: .linkedIn)
+        let pasteMessage = StatsShareComposer.linkedInWebPasteMessage(message)
+        #expect(pasteMessage.contains("I’ve spoken 12,500 words with VocaPhone"))
+        #expect(pasteMessage.contains("My audio stays mine"))
+        #expect(!pasteMessage.contains(StatsShareComposer.site))
+        #expect(StatsShareComposer.linkedInWebPasteMessage("custom copy") == "custom copy")
+    }
+
     @Test func singularPublicCopyIsGrammatical() {
         let one = UsageStats(
             totalWords: 1,

--- a/ios/VocaPhoneTests/StatsPresentationTests.swift
+++ b/ios/VocaPhoneTests/StatsPresentationTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+
+struct StatsPresentationTests {
+    private let now = Date(timeIntervalSince1970: 1_778_457_600)
+
+    private var stats: UsageStats {
+        UsageStats(
+            totalWords: 12_500,
+            totalDictations: 42,
+            totalSeconds: 3_600,
+            lastDayKey: UsageStats.dayKey(now),
+            currentStreak: 4,
+            bestStreak: 9
+        )
+    }
+
+    @Test func shareCopyNamesBothPrivateProcessingRoutes() {
+        let message = StatsShareComposer.message(stats, now: now)
+        #expect(message.contains("on my iPhone or through my own gateway"))
+        #expect(!message.contains("Runs on my phone"))
+        #expect(message.contains(StatsShareComposer.site))
+    }
+
+    @Test(arguments: StatsShareDestination.allCases)
+    func composerURLsRoundTripTheEntireMessage(_ destination: StatsShareDestination) throws {
+        let message = "words & sessions + streak; हिन्दी 🔒"
+        let url = try #require(StatsShareComposer.composerURL(destination, message: message))
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let items = try #require(components.queryItems)
+        #expect(items.first(where: { $0.name == "text" })?.value == message)
+    }
+
+    @Test func linkedinUsesTheFeedComposerContract() throws {
+        let url = try #require(StatsShareComposer.composerURL(.linkedIn, message: "hello"))
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        #expect(components.host == "www.linkedin.com")
+        #expect(components.path == "/feed/")
+        #expect(components.queryItems?.contains(URLQueryItem(name: "shareActive", value: "true")) == true)
+    }
+
+    @Test func singularPublicCopyIsGrammatical() {
+        let one = UsageStats(
+            totalWords: 1,
+            totalDictations: 1,
+            totalSeconds: 1,
+            lastDayKey: UsageStats.dayKey(now),
+            currentStreak: 1,
+            bestStreak: 1
+        )
+        let message = StatsShareComposer.message(one, now: now)
+        #expect(message.contains("1 word"))
+        #expect(message.contains("1 session"))
+        #expect(!message.contains("1 sessions"))
+    }
+}

--- a/ios/VocaPhoneTests/UsageStatsStoreTests.swift
+++ b/ios/VocaPhoneTests/UsageStatsStoreTests.swift
@@ -59,6 +59,27 @@ struct UsageStatsStoreTests {
         #expect(store.current().totalWords == 3)
     }
 
+    @Test func recordingTheSameSessionTwiceIsIdempotent() throws {
+        let (store, _) = try makeStore()
+        let sessionID = UUID()
+        try store.record(
+            transcript: "one two three",
+            seconds: 6,
+            id: sessionID,
+            now: at(2026, 9, 10),
+            timeZone: utc
+        )
+        try store.record(
+            transcript: "one two three",
+            seconds: 6,
+            id: sessionID,
+            now: at(2026, 9, 10),
+            timeZone: utc
+        )
+        #expect(store.current().totalWords == 3)
+        #expect(store.current().totalDictations == 1)
+    }
+
     @Test func anInterruptedFoldDoesNotCountTwice() throws {
         let (store, root) = try makeStore()
         try store.record(transcript: "one two three", seconds: 6, now: at(2026, 9, 10), timeZone: utc)

--- a/ios/VocaPhoneTests/UsageStatsStoreTests.swift
+++ b/ios/VocaPhoneTests/UsageStatsStoreTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+
+struct UsageStatsStoreTests {
+    private func makeStore() throws -> (UsageStatsStore, URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return (UsageStatsStore(rootOverride: root), root)
+    }
+
+    private let utc = TimeZone(identifier: "UTC")!
+
+    private func at(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = utc
+        return calendar.date(from: DateComponents(year: year, month: month, day: day, hour: 12))!
+    }
+
+    private func eventFiles(in root: URL) -> [URL] {
+        (try? FileManager.default.contentsOfDirectory(
+            at: root.appendingPathComponent("usage/events"),
+            includingPropertiesForKeys: nil
+        )) ?? []
+    }
+
+    @Test func nothingIsCountedBeforeAnythingIsDictated() throws {
+        let (store, _) = try makeStore()
+        #expect(!store.current().hasAny)
+    }
+
+    @Test func aRecordedDictationShowsUpBeforeItIsEverFolded() throws {
+        let (store, _) = try makeStore()
+        try store.record(transcript: "one two three", seconds: 6, now: at(2026, 9, 10), timeZone: utc)
+
+        let stats = store.current()
+        #expect(stats.totalWords == 3)
+        #expect(stats.totalDictations == 1)
+        #expect(stats.totalSeconds == 6)
+    }
+
+    @Test func foldingTurnsEventsIntoASummaryAndClearsTheFiles() throws {
+        let (store, root) = try makeStore()
+        try store.record(transcript: "one two", seconds: 4, now: at(2026, 9, 10), timeZone: utc)
+        try store.record(transcript: "three four", seconds: 4, now: at(2026, 9, 10), timeZone: utc)
+
+        let folded = try store.fold()
+        #expect(folded.totalWords == 4)
+        #expect(folded.totalDictations == 2)
+        #expect(eventFiles(in: root).isEmpty, "folded events are removed")
+        #expect(store.current().totalWords == 4, "and the summary carries them")
+    }
+
+    @Test func foldingIsIdempotent() throws {
+        let (store, _) = try makeStore()
+        try store.record(transcript: "one two three", seconds: 6, now: at(2026, 9, 10), timeZone: utc)
+        _ = try store.fold()
+        _ = try store.fold()
+        #expect(store.current().totalWords == 3)
+    }
+
+    @Test func anInterruptedFoldDoesNotCountTwice() throws {
+        let (store, root) = try makeStore()
+        try store.record(transcript: "one two three", seconds: 6, now: at(2026, 9, 10), timeZone: utc)
+        let files = eventFiles(in: root)
+        let saved = try files.map { (url: $0, data: try Data(contentsOf: $0)) }
+
+        _ = try store.fold()
+
+        for file in saved { try file.data.write(to: file.url) }
+
+        #expect(store.current().totalWords == 3, "the read path skips them")
+        #expect(try store.fold().totalWords == 3, "and so does the next fold")
+    }
+
+    @Test func eventsFoldOldestDayFirstSoStreaksAreSequential() throws {
+        let (store, _) = try makeStore()
+        try store.record(transcript: "third day", seconds: 3, now: at(2026, 9, 12), timeZone: utc)
+        try store.record(transcript: "first day", seconds: 3, now: at(2026, 9, 10), timeZone: utc)
+        try store.record(transcript: "second day", seconds: 3, now: at(2026, 9, 11), timeZone: utc)
+
+        let stats = try store.fold()
+        #expect(stats.currentStreak == 3)
+        #expect(stats.lastDayKey == "2026-09-12")
+    }
+
+    @Test func aSilentDictationIsNotRecordedAtAll() throws {
+        let (store, root) = try makeStore()
+        try store.record(transcript: "   ", seconds: 4, now: at(2026, 9, 10), timeZone: utc)
+        #expect(eventFiles(in: root).isEmpty)
+        #expect(!store.current().hasAny)
+    }
+
+    @Test func aDictationWithNoRecordedDurationStillCountsItsWords() throws {
+        let (store, _) = try makeStore()
+        try store.record(transcript: "one two", seconds: nil, now: at(2026, 9, 10), timeZone: utc)
+        let stats = store.current()
+        #expect(stats.totalWords == 2)
+        #expect(stats.averageWordsPerMinute == 0, "no audio, no speed")
+    }
+
+    @Test func resettingRemovesTotalsAndPendingEventsAlike() throws {
+        let (store, root) = try makeStore()
+        try store.record(transcript: "one two", seconds: 4, now: at(2026, 9, 10), timeZone: utc)
+        _ = try store.fold()
+        try store.record(transcript: "three", seconds: 2, now: at(2026, 9, 10), timeZone: utc)
+
+        try store.reset()
+        #expect(!store.current().hasAny)
+        #expect(eventFiles(in: root).isEmpty)
+    }
+
+    @Test func totalsSurviveDeletingEveryTranscript() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let usage = UsageStatsStore(rootOverride: root)
+        let sessions = SharedStore(rootOverride: root)
+
+        try sessions.save(SessionRecord(state: .idle))
+        try usage.record(transcript: "one two three", seconds: 6, now: at(2026, 9, 10), timeZone: utc)
+        _ = try usage.fold()
+
+        _ = try sessions.deleteAllSessions()
+
+        #expect(usage.current().totalWords == 3)
+    }
+}

--- a/ios/VocaPhoneTests/UsageStatsTests.swift
+++ b/ios/VocaPhoneTests/UsageStatsTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import Testing
+
+struct UsageStatsTests {
+    private let utc = TimeZone(identifier: "UTC")!
+
+    private func at(_ year: Int, _ month: Int, _ day: Int, hour: Int = 12, zone: TimeZone? = nil) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = zone ?? utc
+        return calendar.date(from: DateComponents(year: year, month: month, day: day, hour: hour))!
+    }
+
+
+    @Test func aDayKeyIsTheLocalCalendarDate() {
+        #expect(UsageStats.dayKey(at(2026, 9, 10), timeZone: utc) == "2026-09-10")
+    }
+
+    @Test func dayKeysAreGregorianWhateverTheDeviceCalendarIs() {
+        #expect(UsageStats.dayKey(at(2026, 9, 10), timeZone: utc).hasPrefix("2026-"))
+    }
+
+    @Test func onlyRealDatesAreReadableAsDays() {
+        #expect(UsageStats.isDayKey("2026-09-10"))
+        #expect(!UsageStats.isDayKey(""))
+        #expect(!UsageStats.isDayKey("not-a-date"))
+        #expect(!UsageStats.isDayKey("2026-9-10"))
+        #expect(!UsageStats.isDayKey("2026-02-31"), "well-shaped but impossible")
+    }
+
+    @Test func daysBetweenCountsCalendarDaysNotHours() {
+        #expect(UsageStats.daysBetween("2026-09-09", "2026-09-10") == 1)
+        #expect(UsageStats.daysBetween("2026-09-10", "2026-09-09") == -1)
+        #expect(UsageStats.daysBetween("2026-02-28", "2026-03-01") == 1)
+        #expect(UsageStats.daysBetween("nonsense", "2026-09-10") == nil)
+    }
+
+
+    @Test func consecutiveDaysExtendTheRunAndAGapResetsIt() {
+        var stats = UsageStats()
+        stats = stats.recording(dayKey: "2026-09-08", words: 10, seconds: 5)
+        #expect(stats.currentStreak == 1)
+        stats = stats.recording(dayKey: "2026-09-09", words: 10, seconds: 5)
+        #expect(stats.currentStreak == 2)
+        stats = stats.recording(dayKey: "2026-09-11", words: 10, seconds: 5)
+        #expect(stats.currentStreak == 1, "a day was missed")
+        #expect(stats.bestStreak == 2, "the best run survives the reset")
+    }
+
+    @Test func twoDictationsOnOneDayAreOneStreakDay() {
+        var stats = UsageStats().recording(dayKey: "2026-09-10", words: 5, seconds: 2)
+        stats = stats.recording(dayKey: "2026-09-10", words: 5, seconds: 2)
+        #expect(stats.currentStreak == 1)
+        #expect(stats.totalDictations == 2)
+        #expect(stats.dailyWords["2026-09-10"] == 10)
+    }
+
+    @Test func aStreakExpiresWhenReadRatherThanWhenWritten() {
+        let stats = UsageStats(
+            totalWords: 50,
+            totalDictations: 5,
+            lastDayKey: "2026-09-10",
+            currentStreak: 5,
+            bestStreak: 5
+        )
+        #expect(stats.currentStreak(at: at(2026, 9, 10), timeZone: utc) == 5, "same day")
+        #expect(stats.currentStreak(at: at(2026, 9, 11), timeZone: utc) == 5, "yesterday, still savable")
+        #expect(stats.currentStreak(at: at(2026, 9, 12), timeZone: utc) == 0, "a day was missed")
+        #expect(stats.currentStreak(at: at(2026, 12, 25), timeZone: utc) == 0)
+    }
+
+    @Test func aStreakThatNeverStartedIsZero() {
+        #expect(UsageStats().currentStreak(at: at(2026, 9, 10), timeZone: utc) == 0)
+    }
+
+    @Test func aFutureDatedDayDoesNotFreezeTheRunForever() {
+        let stats = UsageStats(lastDayKey: "2099-01-01", currentStreak: 4, bestStreak: 4)
+        #expect(stats.currentStreak(at: at(2026, 9, 10), timeZone: utc) == 0)
+        #expect(UsageStats.nextDayKey("2099-01-01", todayKey: "2026-09-10") == "2026-09-10")
+    }
+
+    @Test func aClockNudgedBackwardsKeepsTheRun() {
+        let stats = UsageStats(lastDayKey: "2026-09-11", currentStreak: 3, bestStreak: 3)
+        #expect(stats.currentStreak(at: at(2026, 9, 10), timeZone: utc) == 3)
+    }
+
+    @Test func anUnreadableStoredDayIsRepairedRatherThanKept() {
+        #expect(UsageStats.nextDayKey("not-a-date", todayKey: "2026-09-10") == "2026-09-10")
+        let stats = UsageStats(lastDayKey: "not-a-date", currentStreak: 3)
+        #expect(stats.currentStreak(at: at(2026, 9, 10), timeZone: utc) == 0)
+    }
+
+    @Test func onlyTheSevenMostRecentDaysAreKept() {
+        var daily: [String: Int] = [:]
+        for day in 1...10 { daily[String(format: "2026-09-%02d", day)] = day }
+        let pruned = UsageStats.pruneDaily(daily)
+        #expect(pruned.count == 7)
+        #expect(pruned["2026-09-10"] == 10)
+        #expect(pruned["2026-09-03"] == nil, "the oldest went first")
+    }
+
+    @Test func anUnreadableLabelDoesNotEvictARealDay() {
+        var daily: [String: Int] = ["zzz-not-a-day": 99]
+        for day in 1...7 { daily[String(format: "2026-09-%02d", day)] = day }
+        let pruned = UsageStats.pruneDaily(daily)
+        #expect(pruned["zzz-not-a-day"] == nil)
+        #expect(pruned.count == 7)
+        #expect(pruned["2026-09-01"] == 1, "the real days all survived")
+    }
+
+    @Test func wordsAreCountedBySegmentationNotSpaces() {
+        #expect(UsageStats.wordCount("Meet me by the station at six") == 7)
+        #expect(UsageStats.wordCount("  ") == 0)
+        #expect(UsageStats.wordCount("") == 0)
+        #expect(UsageStats.wordCount("well-known") >= 1)
+    }
+
+    @Test func aDictationWithNoWordsChangesNothing() {
+        let stats = UsageStats().recording(dayKey: "2026-09-10", words: 0, seconds: 4)
+        #expect(!stats.hasAny)
+        #expect(stats.totalSeconds == 0)
+    }
+
+    @Test func speakingSpeedIsWordsOverRecordedMinutes() {
+        let stats = UsageStats(totalWords: 120, totalDictations: 2, totalSeconds: 60)
+        #expect(stats.averageWordsPerMinute == 120)
+    }
+
+    @Test func speakingSpeedIsZeroRatherThanInfiniteWithoutAudio() {
+        #expect(UsageStats(totalWords: 10).averageWordsPerMinute == 0)
+    }
+
+    @Test func theNextDayStartsAtTheNextLocalMidnight() {
+        let start = UsageStats.nextDayStart(after: at(2026, 9, 10, hour: 12), timeZone: utc)
+        #expect(start == at(2026, 9, 11, hour: 0))
+    }
+
+    @Test func theDayTheClocksChangeIsShorterOrLonger() {
+        let la = TimeZone(identifier: "America/Los_Angeles")!
+        let spring = at(2026, 3, 8, hour: 0, zone: la)
+        let fall = at(2026, 11, 1, hour: 0, zone: la)
+        #expect(UsageStats.nextDayStart(after: spring, timeZone: la).timeIntervalSince(spring) == 23 * 3_600)
+        #expect(UsageStats.nextDayStart(after: fall, timeZone: la).timeIntervalSince(fall) == 25 * 3_600)
+    }
+
+    @Test func anAmbiguousMidnightIsTheFirstOneNotTheSecond() {
+        let havana = TimeZone(identifier: "America/Havana")!
+        let noon = at(2026, 10, 31, hour: 12, zone: havana)
+        #expect(UsageStats.nextDayStart(after: noon, timeZone: havana).timeIntervalSince(noon) == 12 * 3_600)
+    }
+
+    @Test func theNextDayStartIsExactlyTheBoundaryInEveryZone() {
+        let zones = ["UTC", "America/Los_Angeles", "Asia/Kolkata", "America/Havana",
+                     "Atlantic/Azores", "Australia/Lord_Howe", "Asia/Kathmandu"]
+        for id in zones {
+            let zone = TimeZone(identifier: id)!
+            var moment = at(2026, 1, 1, hour: 0)
+            while moment < at(2026, 12, 31, hour: 0) {
+                let start = UsageStats.nextDayStart(after: moment, timeZone: zone)
+                let today = UsageStats.dayKey(moment, timeZone: zone)
+                #expect(start > moment, "\(id) did not move forward at \(today)")
+                #expect(
+                    UsageStats.dayKey(start, timeZone: zone) != today,
+                    "\(id) did not reach the next day at \(today)"
+                )
+                #expect(
+                    UsageStats.dayKey(start.addingTimeInterval(-1), timeZone: zone) == today,
+                    "\(id) overshot the boundary at \(today)"
+                )
+                moment = moment.addingTimeInterval(3_600 + 37)
+            }
+        }
+    }
+
+    @Test func aStoredSummaryRoundTrips() throws {
+        let stats = UsageStats(
+            totalWords: 900,
+            totalDictations: 31,
+            totalSeconds: 412.5,
+            lastDayKey: "2026-09-10",
+            currentStreak: 4,
+            bestStreak: 9,
+            dailyWords: ["2026-09-10": 120]
+        )
+        let data = try JSONEncoder().encode(stats)
+        #expect(try JSONDecoder().decode(UsageStats.self, from: data) == stats)
+    }
+}

--- a/ios/VocaPhoneTests/UsageStatsTests.swift
+++ b/ios/VocaPhoneTests/UsageStatsTests.swift
@@ -52,6 +52,18 @@ struct UsageStatsTests {
         #expect(stats.currentStreak == 1)
         #expect(stats.totalDictations == 2)
         #expect(stats.dailyWords["2026-09-10"] == 10)
+        #expect(stats.dailyDictations["2026-09-10"] == 2)
+        #expect(stats.dailySeconds["2026-09-10"] == 4)
+    }
+
+    @Test func sevenDayActivityIncludesQuietCalendarDays() {
+        let stats = UsageStats().recording(dayKey: "2026-09-10", words: 5, seconds: 3)
+        let days = stats.lastSevenDays(endingAt: at(2026, 9, 10), timeZone: utc)
+        #expect(days.count == 7)
+        #expect(days.last?.key == "2026-09-10")
+        #expect(days.last?.words == 5)
+        #expect(days.last?.dictations == 1)
+        #expect(days.dropLast().allSatisfy { $0.words == 0 && $0.dictations == 0 })
     }
 
     @Test func aStreakExpiresWhenReadRatherThanWhenWritten() {
@@ -183,5 +195,15 @@ struct UsageStatsTests {
         )
         let data = try JSONEncoder().encode(stats)
         #expect(try JSONDecoder().decode(UsageStats.self, from: data) == stats)
+    }
+
+    @Test func anOlderSummaryWithoutDailyDimensionsStillDecodes() throws {
+        let data = Data(
+            #"{"totalWords":3,"totalDictations":1,"dailyWords":{"2026-09-10":3}}"#.utf8
+        )
+        let stats = try JSONDecoder().decode(UsageStats.self, from: data)
+        #expect(stats.totalWords == 3)
+        #expect(stats.dailyDictations.isEmpty)
+        #expect(stats.dailySeconds.isEmpty)
     }
 }

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -241,6 +241,9 @@ targets:
       # Search, filter and day-grouping for the transcript library. The grouping
       # arithmetic is the part that goes wrong at midnight and across zones.
       - path: VocaPhoneApp/App/TranscriptHistoryModel.swift
+      # Pure formatting and social composer contracts for the Stats screen.
+      # The rendered card and clipboard exporter remain app-only UIKit code.
+      - path: VocaPhoneApp/App/StatsPresentation.swift
       # Same reason as the app target: the strip and the bar carry their
       # own previews, and this is what those previews are built from.
       - path: VocaPhoneKeyboard/KeyboardViewPreview.swift


### PR DESCRIPTION
Closes #265. Replaces #273.

## Problem

iOS does not currently match Android and VocaMac for private dictation statistics or shareable progress. The existing proposal also allowed retry sessions to overwrite recording duration, could lose or duplicate usage events around insertion, showed only active-day word totals, and used fragile social-composer URL encoding.

## Summary

- Adds a Stats screen with lifetime words, sessions, voice time, speaking speed, current streak, and best streak.
- Adds a real seven-calendar-day chart plus daily word, session, and voice-time logs, including quiet days.
- Stores count-only usage events in the App Group beside session data. Transcript text and audio are never stored in statistics.
- Records an event immediately after successful keyboard insertion and keys it by session ID for interruption-safe idempotency.
- Preserves the original recording duration when retrying saved audio; only a new microphone capture replaces it.
- Adds a responsive empty state, improved metric hierarchy, Dynamic Type layout, reset error feedback, and local-data privacy guidance.
- Adds a branded 1080 by 720 share card and explicit Copy, X, and LinkedIn success and failure states.
- Uses `URLComponents` for social composers so Unicode, punctuation, and reserved characters survive intact.
- Describes both private processing routes accurately: on-device or through a self-hosted gateway.
- Regenerates and commits the Xcode project and updates `docs/privacy.md`.

## Verification

- [x] `just ios ci` — passes; 830 tests in 79 suites, preview isolation, and project-staleness checks.
- [ ] `just android ci` — not run; the only newer base change is already-merged Android-only #275 and this PR changes no Android files.
- [x] Gateway changes: none.
- [ ] Physical-device test — still required because keyboard insertion is touched and clipboard/X/LinkedIn handoff needs a real-device pass.

Additional checks:

- Focused stats/session suite: 73 tests passed.
- Simulator build and launch passed.
- `git diff --check` passed.
- Existing summary payloads without the new daily dimensions have regression coverage.
- Retry duration preservation, event idempotency, quiet calendar days, share copy, and composer query round-tripping have regression coverage.

## Privacy and security

- [x] No secrets, signing material, recordings, transcripts, or private network details added.
- [x] Usage events store counts and duration only; no transcript text or audio.
- [x] Nothing is posted automatically. The card is copied locally and the user completes the social post.
- [x] `docs/privacy.md` documents storage, retention separation, and the added daily dimensions.

## Review notes

The two commits intentionally preserve the original implementation history and layer the review fixes on top. The branch is rebased onto current `upstream/main`. Updated screenshots should be captured during the remaining physical-device QA because the visuals differ substantially from the screenshots on #273.