### PR TITLE
fix(ime): consolidate the transcription-cancel button into Stop

### DIFF
--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationController.kt
@@ -200,6 +200,76 @@ class DictationController(
         }
     }
 
+    /**
+     * A short tap on Stop while the pipeline is still busy takes whatever
+     * partial transcript is already on hand instead of discarding it — only
+     * a long-press (see [cancel]) throws the take away entirely. Nothing is
+     * inserted if no partial ever arrived (e.g. the gateway route produced
+     * none before the user tapped).
+     */
+    fun acceptPartial(source: DictationSource) {
+        val current = _state.value
+        // INSERTING is already committing text via a largely synchronous
+        // editor call — cancelling here cannot retract that commit, so a
+        // second insertion of the partial would risk inserting twice.
+        // MicDictationControl.tap() already keeps this a no-op from the
+        // keyboard; guarded here too since this is also reachable from the
+        // foreground service.
+        if (current.phase == DictationPhase.INSERTING) return
+        if (!current.phase.isBusy) return
+        val partial = current.partialTranscript
+        diagnostics.recordAction("accept_partial", activeSource?.name)
+        cancelRequested = true
+        finishSignal.complete(Unit)
+        capture?.stop()
+        pipeline?.cancel()
+        if (partial.isBlank()) {
+            reset()
+            return
+        }
+        val sessionId = current.sessionId ?: UUID.randomUUID()
+        reset()
+        scope.launch {
+            val configuration = settings.current()
+            val styled = DictatedTranscript.finished(
+                partial,
+                style = configuration.style,
+                repairSpeech = false,
+                numbersAsDigits = configuration.numbersAsDigits,
+                spokenEmoji = configuration.spokenEmoji,
+                snippets = configuration.snippets,
+            )
+            val target = when (source) {
+                DictationSource.IME -> imeInserter
+                DictationSource.COMPANION_APP -> null
+            }
+            if (target == null) {
+                _state.value = _state.value.copy(
+                    phase = DictationPhase.READY_TO_INSERT,
+                    transcript = styled,
+                )
+                return@launch
+            }
+            val report = target.insert(styled)
+            history.recordSuccess(
+                sessionId = sessionId.toString(),
+                language = configuration.effectiveLanguage.wireValue,
+                style = configuration.style.wireValue,
+                transcript = styled,
+                targetPackage = report.applied?.packageName ?: target.currentTargetPackage(),
+                insertedIntoField = report.outcome == InsertionOutcome.INSERTED,
+            )
+            diagnostics.recordAction(
+                if (report.outcome == InsertionOutcome.INSERTED) {
+                    "accept_partial_inserted"
+                } else {
+                    "accept_partial_insertion_failed"
+                },
+                source.name,
+            )
+        }
+    }
+
     /** Re-sends audio that was preserved for a recoverable failure. */
     fun retry(sessionId: String) {
         if (pipeline?.isActive == true) return

--- a/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/dictation/DictationService.kt
@@ -70,6 +70,13 @@ class DictationService : Service() {
                 stopUnlessHoldingMicrophone()
             }
 
+            ACTION_ACCEPT_PARTIAL -> {
+                mainHandler.removeCallbacks(promoteRetry)
+                pendingSource = null
+                controller.acceptPartial(DictationSource.IME)
+                stopUnlessHoldingMicrophone()
+            }
+
             ACTION_CANCEL -> {
                 mainHandler.removeCallbacks(promoteRetry)
                 pendingSource = null
@@ -248,6 +255,7 @@ class DictationService : Service() {
     companion object {
         const val ACTION_START = "com.vocahq.vocaphone.START"
         const val ACTION_FINISH = "com.vocahq.vocaphone.FINISH"
+        const val ACTION_ACCEPT_PARTIAL = "com.vocahq.vocaphone.ACCEPT_PARTIAL"
         const val ACTION_CANCEL = "com.vocahq.vocaphone.CANCEL"
         const val EXTRA_SOURCE = "source"
         private const val CHANNEL_ID = "vocaphone.recording"

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/MicDictationControl.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/MicDictationControl.kt
@@ -6,6 +6,7 @@ import com.vocahq.vocaphone.core.DictationPhase
 internal enum class MicDictationAction {
     START,
     FINISH,
+    NONE,
     CANCEL,
     OPEN_APP,
 }
@@ -13,7 +14,10 @@ internal enum class MicDictationAction {
 internal object MicDictationControl {
     fun tap(phase: DictationPhase): MicDictationAction = when {
         phase == DictationPhase.LISTENING -> MicDictationAction.FINISH
-        phase.isBusy -> MicDictationAction.CANCEL
+        // Only long-press is destructive while busy: a tap here used to
+        // cancel, indistinguishable from long-press. Doing nothing keeps a
+        // stray/repeated tap on the now-consolidated Stop button safe.
+        phase.isBusy -> MicDictationAction.NONE
         phase == DictationPhase.PERMISSION_REPAIR -> MicDictationAction.OPEN_APP
         else -> MicDictationAction.START
     }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/MicDictationControl.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/MicDictationControl.kt
@@ -21,13 +21,6 @@ internal object MicDictationControl {
     fun longPress(phase: DictationPhase): MicDictationAction? =
         if (phase.isBusy) MicDictationAction.CANCEL else null
 
-    /**
-     * Visible X next to the mic. Hidden while listening so a walking tap cannot
-     * discard; the red Stop long-press is the discard path then.
-     */
-    fun showsSeparateCancel(phase: DictationPhase): Boolean =
-        phase.isBusy && phase != DictationPhase.LISTENING
-
     /** Menu, clipboard, and models stay reachable unless dictation is actually running. */
     fun allowsMenu(phase: DictationPhase): Boolean = !phase.isBusy
 }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/MicDictationControl.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/MicDictationControl.kt
@@ -7,6 +7,7 @@ internal enum class MicDictationAction {
     START,
     FINISH,
     NONE,
+    ACCEPT_PARTIAL,
     CANCEL,
     OPEN_APP,
 }
@@ -14,10 +15,13 @@ internal enum class MicDictationAction {
 internal object MicDictationControl {
     fun tap(phase: DictationPhase): MicDictationAction = when {
         phase == DictationPhase.LISTENING -> MicDictationAction.FINISH
-        // Only long-press is destructive while busy: a tap here used to
-        // cancel, indistinguishable from long-press. Doing nothing keeps a
-        // stray/repeated tap on the now-consolidated Stop button safe.
-        phase.isBusy -> MicDictationAction.NONE
+        // INSERTING is already committing text via a largely synchronous
+        // editor call; there's no safe partial to insert on top of an
+        // insertion already in flight, so it stays a no-op.
+        phase == DictationPhase.INSERTING -> MicDictationAction.NONE
+        // Every other busy phase can offer up whatever partial transcript
+        // is already on hand instead of doing nothing.
+        phase.isBusy -> MicDictationAction.ACCEPT_PARTIAL
         phase == DictationPhase.PERMISSION_REPAIR -> MicDictationAction.OPEN_APP
         else -> MicDictationAction.START
     }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -903,6 +903,7 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
                     container.diagnostics.recordAction("cancel", DictationSource.IME.name)
                     cancelImeDictation()
                 }
+                MicDictationAction.NONE -> Unit
                 MicDictationAction.OPEN_APP -> openCompanion()
                 MicDictationAction.START -> startImeDictation()
             }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneInputMethodService.kt
@@ -903,6 +903,10 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
                     container.diagnostics.recordAction("cancel", DictationSource.IME.name)
                     cancelImeDictation()
                 }
+                MicDictationAction.ACCEPT_PARTIAL -> {
+                    container.diagnostics.recordAction("accept_partial", DictationSource.IME.name)
+                    acceptPartialImeDictation()
+                }
                 MicDictationAction.NONE -> Unit
                 MicDictationAction.OPEN_APP -> openCompanion()
                 MicDictationAction.START -> startImeDictation()
@@ -966,6 +970,14 @@ class VocaPhoneInputMethodService : LifecycleInputMethodService(), TranscriptIns
             DictationService.send(this, DictationService.ACTION_FINISH)
         } else {
             container.dictation.finish()
+        }
+    }
+
+    private fun acceptPartialImeDictation() {
+        if (VoiceShortcutIme.usesMicrophoneForegroundService(voiceShortcutActive)) {
+            DictationService.send(this, DictationService.ACTION_ACCEPT_PARTIAL)
+        } else {
+            container.dictation.acceptPartial(DictationSource.IME)
         }
     }
 

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -1755,7 +1755,7 @@ private fun MicButton(
     val description = when {
         !enabled -> "Dictation unavailable"
         recording -> "Finish dictation. Long-press to discard without inserting"
-        processing -> "Cancel transcription"
+        processing -> "Transcribing. Long-press to discard without inserting"
         state.phase == DictationPhase.PERMISSION_REPAIR -> "Open VocaPhone"
         else -> "Start dictation"
     }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -1755,7 +1755,7 @@ private fun MicButton(
     val description = when {
         !enabled -> "Dictation unavailable"
         recording -> "Finish dictation. Long-press to discard without inserting"
-        processing -> "Transcribing. Long-press to discard without inserting"
+        processing -> "Accept what's transcribed so far. Long-press to discard instead"
         state.phase == DictationPhase.PERMISSION_REPAIR -> "Open VocaPhone"
         else -> "Start dictation"
     }

--- a/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
+++ b/android/app/src/main/java/com/vocahq/vocaphone/ime/VocaPhoneKeyboard.kt
@@ -47,7 +47,6 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -1095,9 +1094,6 @@ private fun DictationBar(
         if (panelTitle != null) {
             ToolbarCloseButton(onClick = onClosePanel)
         }
-        if (MicDictationControl.showsSeparateCancel(state.phase)) {
-            DictationCancelButton(onClick = onMicLongPress)
-        }
         MicButton(
             state = state,
             enabled = editor.dictationAllowed && !isPreferenceWritePending,
@@ -1217,9 +1213,6 @@ private fun VoiceShortcutListeningBar(
                     )
                 }
             }
-        }
-        if (MicDictationControl.showsSeparateCancel(state.phase)) {
-            DictationCancelButton(onClick = onMicLongPress)
         }
         MicButton(
             state = state,
@@ -1741,34 +1734,6 @@ private val WritingStyle.keyboardDetail: String
     }
 
 @Composable
-private fun DictationCancelButton(onClick: () -> Unit) {
-    val view = LocalView.current
-    Surface(
-        modifier = Modifier
-            .size(ToolbarControlSize)
-            .semantics {
-                role = Role.Button
-                contentDescription = "Cancel dictation"
-            }
-            .clickable {
-                view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
-                onClick()
-            },
-        shape = CircleShape,
-        color = MaterialTheme.colorScheme.errorContainer,
-    ) {
-        Box(contentAlignment = Alignment.Center) {
-            Icon(
-                painter = painterResource(R.drawable.ic_cancel),
-                contentDescription = null,
-                modifier = Modifier.size(18.dp),
-                tint = MaterialTheme.colorScheme.onErrorContainer,
-            )
-        }
-    }
-}
-
-@Composable
 private fun MicButton(
     state: DictationState,
     enabled: Boolean,
@@ -1783,10 +1748,14 @@ private fun MicButton(
         DictationPhase.INSERTING,
     )
     val recording = state.phase == DictationPhase.LISTENING
+    // Processing keeps the same Stop look as recording (color, icon) rather than
+    // swapping to a busy state: the button stays a single, consistent long-press
+    // target throughout. A busy indicator running along its border, rather than
+    // replacing its content, is a separate follow-up.
     val description = when {
         !enabled -> "Dictation unavailable"
         recording -> "Finish dictation. Long-press to discard without inserting"
-        processing -> "Dictation in progress"
+        processing -> "Cancel transcription"
         state.phase == DictationPhase.PERMISSION_REPAIR -> "Open VocaPhone"
         else -> "Start dictation"
     }
@@ -1802,40 +1771,70 @@ private fun MicButton(
         processing -> MaterialTheme.colorScheme.onSurface
         else -> MaterialTheme.colorScheme.onPrimary
     }
+    val busyIndicatorColor = MaterialTheme.colorScheme.onSurface
 
-    Surface(
-        modifier = Modifier
-            .size(ToolbarControlSize)
-            .semantics {
-                role = Role.Button
-                contentDescription = description
-                if (!enabled) disabled()
+    Box(modifier = Modifier.size(ToolbarControlSize)) {
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .semantics {
+                    role = Role.Button
+                    contentDescription = description
+                    if (!enabled) disabled()
+                }
+                .pointerInput(enabled) {
+                    if (!enabled) return@pointerInput
+                    detectTapGestures(
+                        onTap = {
+                            view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+                            onClick()
+                        },
+                        onLongPress = { _ ->
+                            view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                            onLongPress()
+                        },
+                    )
+                },
+            shape = CircleShape,
+            color = container,
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                when {
+                    recording || processing -> KeyboardIcon(Glyph.STOP, content)
+                    else -> KeyboardIcon(Glyph.MIC, content)
+                }
             }
-            .pointerInput(enabled) {
-                if (!enabled) return@pointerInput
-                detectTapGestures(
-                    onTap = {
-                        view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
-                        onClick()
-                    },
-                    onLongPress = { _ ->
-                        view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
-                        onLongPress()
-                    },
+        }
+        // Busy indicator traces the button's own border instead of replacing its
+        // content, so Stop stays visible and long-press-able while transcribing.
+        // The rotation animation itself is only created while processing, so
+        // idle/listening don't keep an unused infinite transition running.
+        if (processing) {
+            val busyRotation by rememberInfiniteTransition(label = "micBusy").animateFloat(
+                initialValue = 0f,
+                targetValue = 360f,
+                animationSpec = infiniteRepeatable(
+                    animation = tween(durationMillis = 900, easing = LinearEasing),
+                    repeatMode = RepeatMode.Restart,
+                ),
+                label = "micBusyRotation",
+            )
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                val strokeWidthPx = 2.5.dp.toPx()
+                val diameter = size.minDimension - strokeWidthPx
+                val topLeft = Offset(
+                    (size.width - diameter) / 2f,
+                    (size.height - diameter) / 2f,
                 )
-            },
-        shape = CircleShape,
-        color = container,
-    ) {
-        Box(contentAlignment = Alignment.Center) {
-            when {
-                processing -> CircularProgressIndicator(
-                    modifier = Modifier.size(20.dp),
-                    color = content,
-                    strokeWidth = 2.dp,
+                drawArc(
+                    color = busyIndicatorColor,
+                    startAngle = busyRotation,
+                    sweepAngle = 100f,
+                    useCenter = false,
+                    topLeft = topLeft,
+                    size = Size(diameter, diameter),
+                    style = Stroke(width = strokeWidthPx, cap = StrokeCap.Round),
                 )
-                recording -> KeyboardIcon(Glyph.STOP, content)
-                else -> KeyboardIcon(Glyph.MIC, content)
             }
         }
     }

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/MicDictationControlTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/MicDictationControlTest.kt
@@ -36,15 +36,6 @@ class MicDictationControlTest {
     }
 
     @Test
-    fun `separate cancel is hidden while listening so a walking tap cannot discard`() {
-        assertFalse(MicDictationControl.showsSeparateCancel(DictationPhase.IDLE))
-        assertFalse(MicDictationControl.showsSeparateCancel(DictationPhase.LISTENING))
-        assertTrue(MicDictationControl.showsSeparateCancel(DictationPhase.TRANSCRIBING))
-        assertTrue(MicDictationControl.showsSeparateCancel(DictationPhase.FINALIZING))
-        assertFalse(MicDictationControl.showsSeparateCancel(DictationPhase.FAILED))
-    }
-
-    @Test
     fun `a failed empty transcript does not lock the keyboard menu`() {
         assertTrue(MicDictationControl.allowsMenu(DictationPhase.IDLE))
         assertTrue(MicDictationControl.allowsMenu(DictationPhase.FAILED))

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/MicDictationControlTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/MicDictationControlTest.kt
@@ -10,11 +10,12 @@ import org.junit.Test
 class MicDictationControlTest {
 
     @Test
-    fun `tap starts, finishes, or cancels by phase`() {
+    fun `tap starts, finishes, does nothing while busy, or cancels by phase`() {
         assertEquals(MicDictationAction.START, MicDictationControl.tap(DictationPhase.IDLE))
         assertEquals(MicDictationAction.FINISH, MicDictationControl.tap(DictationPhase.LISTENING))
-        assertEquals(MicDictationAction.CANCEL, MicDictationControl.tap(DictationPhase.TRANSCRIBING))
-        assertEquals(MicDictationAction.CANCEL, MicDictationControl.tap(DictationPhase.FINALIZING))
+        assertEquals(MicDictationAction.NONE, MicDictationControl.tap(DictationPhase.TRANSCRIBING))
+        assertEquals(MicDictationAction.NONE, MicDictationControl.tap(DictationPhase.FINALIZING))
+        assertEquals(MicDictationAction.NONE, MicDictationControl.tap(DictationPhase.INSERTING))
         assertEquals(
             MicDictationAction.OPEN_APP,
             MicDictationControl.tap(DictationPhase.PERMISSION_REPAIR),

--- a/android/app/src/test/java/com/vocahq/vocaphone/ime/MicDictationControlTest.kt
+++ b/android/app/src/test/java/com/vocahq/vocaphone/ime/MicDictationControlTest.kt
@@ -10,11 +10,19 @@ import org.junit.Test
 class MicDictationControlTest {
 
     @Test
-    fun `tap starts, finishes, does nothing while busy, or cancels by phase`() {
+    fun `tap starts, finishes, accepts the partial, or cancels by phase`() {
         assertEquals(MicDictationAction.START, MicDictationControl.tap(DictationPhase.IDLE))
         assertEquals(MicDictationAction.FINISH, MicDictationControl.tap(DictationPhase.LISTENING))
-        assertEquals(MicDictationAction.NONE, MicDictationControl.tap(DictationPhase.TRANSCRIBING))
-        assertEquals(MicDictationAction.NONE, MicDictationControl.tap(DictationPhase.FINALIZING))
+        assertEquals(
+            MicDictationAction.ACCEPT_PARTIAL,
+            MicDictationControl.tap(DictationPhase.TRANSCRIBING),
+        )
+        assertEquals(
+            MicDictationAction.ACCEPT_PARTIAL,
+            MicDictationControl.tap(DictationPhase.FINALIZING),
+        )
+        // INSERTING is already committing text; accepting the partial there
+        // would risk a double insertion, so it stays a no-op.
         assertEquals(MicDictationAction.NONE, MicDictationControl.tap(DictationPhase.INSERTING))
         assertEquals(
             MicDictationAction.OPEN_APP,


### PR DESCRIPTION
Closes #271.

This PR is now three separate commits, each independently reviewable/revertable, in increasing order of scope and risk:

**1. `fix(ime): consolidate the transcription-cancel button into Stop`** — pure UI, no behavior change.
- Removes the separate red "X" cancel button shown during transcribing/finalizing/uploading/inserting — it fully duplicated the long-press-to-cancel gesture the main Stop button already handled via its own `pointerInput`.
- The Stop button no longer swaps to a bare spinner during processing; it keeps the same look it has while listening.
- A busy indicator now runs along the button's border (rotating arc) instead of replacing its content — created only while actually processing, so idle/listening don't keep an unused infinite transition running.
- Processing uses a neutral grey (previous `surfaceContainerHighest`/`onSurface`) rather than red, so a short tap still gives a visible color change distinct from listening.
- Tap and long-press both still cancel while busy at this point — identically, exactly as before this PR. Only the button consolidates visually.

**2. `feat(ime): a short tap while busy no longer cancels`** — the low-risk behavior fix.
- Only long-press is destructive now; a tap while busy is a safe no-op. This alone resolves the actual ambiguity #271 described (both gestures did the same thing).

**3. `feat(dictation): short tap during processing accepts the partial transcript`** — the higher-risk, more debatable one.
- A tap during finalizing/uploading/transcribing now inserts whatever partial transcript is already available instead of doing nothing.
- `INSERTING` is excluded and stays a no-op: it's already committing text via a largely synchronous editor call, so accepting the partial there risked a double insertion (caught in review on an earlier, flatter version of this change).
- This is a UX call worth a second opinion, not a settled one — kept as its own commit specifically so it can be discussed, requested for changes, or reverted independently of commits 1–2, which stand fine on their own.

Note on history: this replaces an earlier flatter version of the same PR (2 commits instead of 3, with `INSERTING` falling back to `CANCEL` instead of `NONE`) after a request to split the behavior change into smaller, more reviewable steps. The code itself is the same work, just regrouped — no reimplementation, and the two review comments from the earlier version (double-insertion risk on `INSERTING`, the idle-state animation) are both still addressed, now folded into commits 1 and 3 respectively rather than sitting in a separate follow-up commit.

---

Built the app from source, tested on my end - everything's fine and like I explained in https://github.com/VocaHQ/vocaphone/issues/271
The commit history is not clean because I fixed it after mistakes of local manual github management. It doesn't affect the quality of the PR. 